### PR TITLE
[no release notes] Lower CachingTransaction shortcut logic logging to debug

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/CachingTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/CachingTransaction.java
@@ -71,7 +71,7 @@ public class CachingTransaction extends ForwardingTransaction {
     public SortedMap<byte[], RowResult<byte[]>> getRows(TableReference tableRef, Iterable<byte[]> rows,
                                                         ColumnSelection columnSelection) {
         if (Iterables.isEmpty(rows)) {
-            log.info("Attempted getRows on '{}' table and {} with empty rows argument", tableRef, columnSelection);
+            log.debug("Attempted getRows on '{}' table and {} with empty rows argument", tableRef, columnSelection);
             return AbstractTransaction.EMPTY_SORTED_ROWS;
         }
 
@@ -114,7 +114,7 @@ public class CachingTransaction extends ForwardingTransaction {
     @Override
     public Map<Cell, byte[]> get(TableReference tableRef, Set<Cell> cells) {
         if (cells.isEmpty()) {
-            log.info("Attempted get on '{}' table with empty cells argument", tableRef);
+            log.debug("Attempted get on '{}' table with empty cells argument", tableRef);
             return ImmutableMap.of();
         }
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/CachingTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/CachingTransaction.java
@@ -72,7 +72,7 @@ public class CachingTransaction extends ForwardingTransaction {
                                                         ColumnSelection columnSelection) {
         if (Iterables.isEmpty(rows)) {
             if (log.isTraceEnabled()) {
-                log.trace(String.format("Attempted getRows on %s table and %s with empty rows argument", tableRef, columnSelection), new Exception());
+                log.trace("Attempted getRows on '{}' table and {} with empty rows argument", tableRef, columnSelection, new Exception());
             } else if (log.isDebugEnabled()) {
                 log.debug("Attempted getRows on '{}' table and {} with empty rows argument", tableRef, columnSelection);
             }
@@ -119,7 +119,7 @@ public class CachingTransaction extends ForwardingTransaction {
     public Map<Cell, byte[]> get(TableReference tableRef, Set<Cell> cells) {
         if (cells.isEmpty()) {
             if (log.isTraceEnabled()) {
-                log.trace(String.format("Attempted get on %s table with empty cells argument", tableRef), new Exception());
+                log.trace("Attempted get on '{}' table with empty cells argument", tableRef, new Exception());
             } else if (log.isDebugEnabled()) {
                 log.debug("Attempted get on '{}' table with empty cells argument", tableRef);
             }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/CachingTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/CachingTransaction.java
@@ -71,7 +71,11 @@ public class CachingTransaction extends ForwardingTransaction {
     public SortedMap<byte[], RowResult<byte[]>> getRows(TableReference tableRef, Iterable<byte[]> rows,
                                                         ColumnSelection columnSelection) {
         if (Iterables.isEmpty(rows)) {
-            log.debug("Attempted getRows on '{}' table and {} with empty rows argument", tableRef, columnSelection);
+            if (log.isTraceEnabled()) {
+                log.trace(String.format("Attempted getRows on %s table and %s with empty rows argument", tableRef, columnSelection), new Exception());
+            } else if (log.isDebugEnabled()) {
+                log.debug("Attempted getRows on '{}' table and {} with empty rows argument", tableRef, columnSelection);
+            }
             return AbstractTransaction.EMPTY_SORTED_ROWS;
         }
 
@@ -114,7 +118,11 @@ public class CachingTransaction extends ForwardingTransaction {
     @Override
     public Map<Cell, byte[]> get(TableReference tableRef, Set<Cell> cells) {
         if (cells.isEmpty()) {
-            log.debug("Attempted get on '{}' table with empty cells argument", tableRef);
+            if (log.isTraceEnabled()) {
+                log.trace(String.format("Attempted get on %s table with empty cells argument", tableRef), new Exception());
+            } else if (log.isDebugEnabled()) {
+                log.debug("Attempted get on '{}' table with empty cells argument", tableRef);
+            }
             return ImmutableMap.of();
         }
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/CachingTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/CachingTransaction.java
@@ -71,11 +71,6 @@ public class CachingTransaction extends ForwardingTransaction {
     public SortedMap<byte[], RowResult<byte[]>> getRows(TableReference tableRef, Iterable<byte[]> rows,
                                                         ColumnSelection columnSelection) {
         if (Iterables.isEmpty(rows)) {
-            if (log.isTraceEnabled()) {
-                log.trace("Attempted getRows on '{}' table and {} with empty rows argument", tableRef, columnSelection, new Exception());
-            } else if (log.isDebugEnabled()) {
-                log.debug("Attempted getRows on '{}' table and {} with empty rows argument", tableRef, columnSelection);
-            }
             return AbstractTransaction.EMPTY_SORTED_ROWS;
         }
 
@@ -118,11 +113,6 @@ public class CachingTransaction extends ForwardingTransaction {
     @Override
     public Map<Cell, byte[]> get(TableReference tableRef, Set<Cell> cells) {
         if (cells.isEmpty()) {
-            if (log.isTraceEnabled()) {
-                log.trace("Attempted get on '{}' table with empty cells argument", tableRef, new Exception());
-            } else if (log.isDebugEnabled()) {
-                log.debug("Attempted get on '{}' table with empty cells argument", tableRef);
-            }
             return ImmutableMap.of();
         }
 


### PR DESCRIPTION
Large internal product just increased logging to info by default. Given this code will shortcut the call anyways, there's no need for so much log spew.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3463)
<!-- Reviewable:end -->
