### PR TITLE
Improve visibility of inter-lock comms errors

### DIFF
--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosQuorumChecker.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosQuorumChecker.java
@@ -172,7 +172,7 @@ public final class PaxosQuorumChecker {
                     if (onlyLogOnQuorumFailure) {
                         toLog.add(e.getCause());
                     } else {
-                        log.warn(PAXOS_MESSAGE_ERROR, e.getCause());
+                        log.error(PAXOS_MESSAGE_ERROR, e.getCause());
                     }
                 }
             }
@@ -187,7 +187,7 @@ public final class PaxosQuorumChecker {
                     interrupted = true;
                     break;
                 } catch (ExecutionException e) {
-                    log.warn(PAXOS_MESSAGE_ERROR, e.getCause());
+                    log.error(PAXOS_MESSAGE_ERROR, e.getCause());
                 }
             }
 
@@ -202,7 +202,7 @@ public final class PaxosQuorumChecker {
 
             if (onlyLogOnQuorumFailure && acksRecieved < quorumSize) {
                 for (Throwable throwable : toLog) {
-                    log.warn(PAXOS_MESSAGE_ERROR, throwable);
+                    log.error(PAXOS_MESSAGE_ERROR, throwable);
                 }
             }
         }


### PR DESCRIPTION
Make it easier to identify when remote exceptions have prevented quorum
by logging the exception at ERROR rather than WARN.

**Goals (and why)**:

We hit an issue in the field recently (PDS-71980) where a non-timelock lock server in a three-node cluster hit a thread leak. We suspect, but can't fully prove, that `PaxosLeaderElectionService.blockOnBecomingLeader` got stuck in a tight loop due to remote exceptions causing `PaxosQuorumChecker.collectResponses` to repeatedly immediately bail out with `NO_QUORUM`, leaking executor threads for the requests that didn't fail out.

However, WARN logging from external dependencies doesn't get picked up by default in the product in question, so we don't have any record of what the error might have been. I think remote exceptions probably deserve to be logged at ERROR anyway, so I think the correct minimal change here is to bump up the log level in Atlas.

I'll submit a separate PR for ensuring `blockOnBecomingLeader` backs off rather than tight-looping when quorum isn't achieved; this one is just for the logging change.

**Implementation Description (bullets)**:

* Bump a couple of log lines to ERROR that were previously at WARN.

**Testing (What was existing testing like?  What have you done to improve it?)**:

* N/A

**Concerns (what feedback would you like?)**:

* If you feel strongly that this log shouldn't be at ERROR, I guess that's the only real point of contention. 

**Where should we start reviewing?**:

* It's a very short diff.

**Priority (whenever / two weeks / yesterday)**:

* No specific deadline, but I'd hate to hit this again without the logging. Order of a week or so?

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3465)
<!-- Reviewable:end -->
