### PR TITLE
Upgrade GBJ / Fix incorrect %s vs {}

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/Cell.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/Cell.java
@@ -65,7 +65,7 @@ public final class Cell implements Serializable, Comparable<Cell> {
         try {
             Preconditions.checkArgument(
                     name.length <= MAX_NAME_LENGTH,
-                    "name must be no longer than {}.",
+                    "name must be no longer than %s.",
                     MAX_NAME_LENGTH);
         } catch (IllegalArgumentException e) {
             log.error("Cell name length exceeded. Name must be no longer than {}. "

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.3'
         classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.7.5'
         classpath 'gradle.plugin.com.palantir.gradle.docker:gradle-docker:0.13.0'
-        classpath 'com.palantir.baseline:gradle-baseline-java:0.18.0'
+        classpath 'com.palantir.baseline:gradle-baseline-java:0.30.0'
         classpath 'com.palantir.sls-packaging:gradle-sls-packaging:2.11.0'
         classpath 'com.netflix.nebula:nebula-dependency-recommender:5.2.0'
         classpath 'com.netflix.nebula:nebula-publishing-plugin:5.1.4'
@@ -44,7 +44,7 @@ apply plugin: 'com.palantir.baseline-config'
 dependencies {
     // Adds a dependency on the Baseline configuration files. Typically use
     // the same version as the plugin itself.
-    baseline "com.palantir.baseline:gradle-baseline-java-config:0.18.0@zip"
+    baseline "com.palantir.baseline:gradle-baseline-java-config:0.30.0@zip"
 }
 
 apply from: 'gradle/versions.gradle'

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,6 @@ buildscript {
 
 plugins {
     id 'com.github.johnrengelman.shadow' version '2.0.0'
-    id 'com.palantir.circle.style' version '1.0.0'
     id 'com.palantir.configuration-resolver' version '0.2.0'
     id 'com.palantir.git-version' version '0.5.2'
     id 'org.inferred.processors' version '1.2.12'

--- a/commons-executors/src/main/java/com/palantir/common/concurrent/PTExecutors.java
+++ b/commons-executors/src/main/java/com/palantir/common/concurrent/PTExecutors.java
@@ -41,7 +41,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
-import com.palantir.logsafe.SafeArg;
 import com.palantir.remoting3.tracing.Tracers;
 
 /**
@@ -438,8 +437,8 @@ public final class PTExecutors {
     public static ScheduledThreadPoolExecutor newScheduledThreadPoolExecutor(int corePoolSize,
             ThreadFactory threadFactory, RejectedExecutionHandler handler) {
         Preconditions.checkArgument(corePoolSize >= 0,
-                "Cannot create a ScheduledThreadPoolExecutor with {} threads - thread count must not be negative!",
-                SafeArg.of("corePoolSize", corePoolSize));
+                "Cannot create a ScheduledThreadPoolExecutor with %s threads - thread count must not be negative!",
+                corePoolSize);
         int positiveCorePoolSize = corePoolSize > 0 ? corePoolSize : 1;
         ScheduledThreadPoolExecutor ret = new ScheduledThreadPoolExecutor(positiveCorePoolSize, threadFactory,
                 handler) {

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -60,6 +60,11 @@ develop
            Previously, trying to refresh a larger number of locks could trigger the 50MB limit in payload size.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3450>`__)
 
+    *    - |fixed|
+         - Several exceptions (such as when creating cells with overly long names or executors in illegal configurations) now contain numerical parameters correctly.
+           Previously, the exceptions thrown would erroneously contain ``{}`` values
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3450>`__)
+
     *    - |logs|
          - Reduce logging level for locks not being refreshed.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3458>`__)

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -62,8 +62,8 @@ develop
 
     *    - |fixed|
          - Several exceptions (such as when creating cells with overly long names or executors in illegal configurations) now contain numerical parameters correctly.
-           Previously, the exceptions thrown would erroneously contain ``{}`` values
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/3450>`__)
+           Previously, the exceptions thrown would erroneously contain ``{}`` values.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3468>`__)
 
     *    - |logs|
          - Reduce logging level for locks not being refreshed.

--- a/gradle/baseline.gradle
+++ b/gradle/baseline.gradle
@@ -6,10 +6,6 @@ if (enableErrorProne.toBoolean()) {
     // installs the "processor" configuration needed for baseline-error-prone
     apply plugin: 'com.palantir.baseline-error-prone'
 
-    configurations.errorprone {
-        resolutionStrategy { force('com.google.guava:guava:21.0') }
-    }
-
     tasks.withType(JavaCompile) {
         options.compilerArgs += ['-XepDisableWarningsInGeneratedCode']
     }
@@ -17,12 +13,18 @@ if (enableErrorProne.toBoolean()) {
     compileJava {
         options.compilerArgs += ['-Xep:PreconditionsConstantMessage:OFF']
         options.compilerArgs += ['-Xep:ValidateConstantMessage:OFF']
+
+        // I'd like to change this, but preserving log message format for now
+        options.compilerArgs += ['-Xep:CatchBlockLogException:OFF']
     }
 
     compileTestJava {
         // CheckReturnValue can be problematic for tests asserting that various Immutable objects may or may not
         // be created.
         options.compilerArgs += ['-Xep:CheckReturnValue:OFF']
+
+        // ReturnValueIgnored can be problematic for tests asserting a call to some method throws an exception.
+        options.compilerArgs += ['-Xep:ReturnValueIgnored:OFF']
     }
 }
 


### PR DESCRIPTION
**Goals (and why)**:
- Update gradle-baseline-java so that we can use the baseline circleci plugin
- This was meant to be a part of #3461 but I thought it was best done separately. Turned out there were fewer changes than I was hoping.

**Implementation Description (bullets)**:
- Update the plugin version
- Fix several errorprone errors, mainly around the usage of %s vs {} in log messages
- Blacklist two specific checks.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- I didn't add any here. Uncertain about whether testing for messages containing specific strings is a good practice.

**Concerns (what feedback would you like?)**:
- I made two new suppressions. Do we agree with these? I think for tests ignoring return value in some cases is not contentious; the log message one is a bit more so.

**Where should we start reviewing?**:
- build.gradle?

**Priority (whenever / two weeks / yesterday)**: soon. Blocks #3461

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3468)
<!-- Reviewable:end -->
