### PR TITLE
Fix CqlQuery leak and make it (more) foolproof

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
@@ -76,6 +76,7 @@ import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.keyvalue.impl.AbstractKeyValueServiceTest;
 import com.palantir.atlasdb.keyvalue.impl.TableSplittingKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.TracingPrefsConfig;
+import com.palantir.atlasdb.logging.LoggingArgs;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
 import com.palantir.atlasdb.table.description.ColumnMetadataDescription;
 import com.palantir.atlasdb.table.description.NameMetadataDescription;
@@ -85,6 +86,8 @@ import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.atlasdb.util.MetricsManagers;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
 
 public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueServiceTest {
     @ClassRule
@@ -440,15 +443,18 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
             throws TException {
         CassandraKeyValueServiceImpl ckvs = (CassandraKeyValueServiceImpl) keyValueService;
         ckvs.getClientPool().runWithRetry(input -> {
-            CqlQuery cqlQuery = new CqlQuery(String.format("INSERT INTO \"%s\".\"%s\" (key, column1, column2, value)"
-                            + " VALUES (%s, %s, %s, %s) USING TIMESTAMP %s;",
-                    CassandraContainer.KVS_CONFIG.getKeyspaceOrThrow(),
-                    tableReference.getQualifiedName().replaceAll("\\.", "__"),
-                    convertBytesToHexString(cell.getRowName()),
-                    convertBytesToHexString(cell.getColumnName()),
-                    ~atlasTimestamp,
-                    convertBytesToHexString(PtBytes.toBytes("testtesttest")),
-                    cassandraTimestamp));
+            CqlQuery cqlQuery = CqlQuery.builder()
+                    .safeQueryFormat("INSERT INTO \"%s\".\"%s\" (key, column1, column2, value)"
+                            + " VALUES (%s, %s, %s, %s) USING TIMESTAMP %s;")
+                    .addArgs(
+                            SafeArg.of("keyspace", CassandraContainer.KVS_CONFIG.getKeyspaceOrThrow()),
+                            LoggingArgs.internalTableName(tableReference),
+                            UnsafeArg.of("row", convertBytesToHexString(cell.getRowName())),
+                            UnsafeArg.of("column", convertBytesToHexString(cell.getColumnName())),
+                            SafeArg.of("atlasTimestamp", ~atlasTimestamp),
+                            UnsafeArg.of("value", convertBytesToHexString(PtBytes.toBytes("testtesttest"))),
+                            SafeArg.of("cassandraTimestamp", cassandraTimestamp))
+                    .build();
             return input.execute_cql3_query(
                     cqlQuery,
                     Compression.NONE,

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTestTools.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTestTools.java
@@ -50,8 +50,10 @@ public final class SchemaMutationLockTestTools {
 
     public CqlResult truncateLocksTable() throws TException {
         return clientPool.run(client -> {
-            CqlQuery truncateQuery = new CqlQuery("TRUNCATE \"%s\";",
-                    SafeArg.of("lockTable", lockTable.getOnlyTable().getQualifiedName()));
+            CqlQuery truncateQuery = CqlQuery.builder()
+                    .safeQueryFormat("TRUNCATE \"%s\";")
+                    .addArgs(SafeArg.of("lockTable", lockTable.getOnlyTable().getQualifiedName()))
+                    .build();
             return runCqlQuery(truncateQuery, client, ConsistencyLevel.ALL);
         });
     }
@@ -60,11 +62,13 @@ public final class SchemaMutationLockTestTools {
         return clientPool.run(client -> {
             String lockRowName = getHexEncodedBytes(CassandraConstants.GLOBAL_DDL_LOCK_ROW_NAME);
             String lockColName = getHexEncodedBytes(CassandraConstants.GLOBAL_DDL_LOCK_COLUMN_NAME);
-            CqlQuery selectCql = new CqlQuery(
-                    "SELECT \"value\" FROM \"%s\" WHERE key = %s AND column1 = %s AND column2 = -1;",
-                    SafeArg.of("lockTable", lockTable.getOnlyTable().getQualifiedName()),
-                    SafeArg.of("lockRow", lockRowName),
-                    SafeArg.of("lockColumn", lockColName));
+            CqlQuery selectCql = CqlQuery.builder()
+                    .safeQueryFormat("SELECT \"value\" FROM \"%s\" WHERE key = %s AND column1 = %s AND column2 = -1;")
+                    .addArgs(
+                            SafeArg.of("lockTable", lockTable.getOnlyTable().getQualifiedName()),
+                            SafeArg.of("lockRow", lockRowName),
+                            SafeArg.of("lockColumn", lockColName))
+                    .build();
             return runCqlQuery(selectCql, client, ConsistencyLevel.LOCAL_QUORUM);
         });
     }
@@ -86,12 +90,14 @@ public final class SchemaMutationLockTestTools {
             String lockRowName = getHexEncodedBytes(CassandraConstants.GLOBAL_DDL_LOCK_ROW_NAME);
             String lockColName = getHexEncodedBytes(CassandraConstants.GLOBAL_DDL_LOCK_COLUMN_NAME);
             String lockTableName = lockTable.getOnlyTable().getQualifiedName();
-            CqlQuery updateCql = new CqlQuery(
-                    "UPDATE \"%s\" SET value = %s WHERE key = %s AND column1 = %s AND column2 = -1;",
-                    SafeArg.of("lockTable", lockTableName),
-                    SafeArg.of("hexLockValue", hexLockValue),
-                    SafeArg.of("lockRow", lockRowName),
-                    SafeArg.of("lockCol", lockColName));
+            CqlQuery updateCql = CqlQuery.builder()
+                    .safeQueryFormat("UPDATE \"%s\" SET value = %s WHERE key = %s AND column1 = %s AND column2 = -1;")
+                    .addArgs(
+                            SafeArg.of("lockTable", lockTableName),
+                            SafeArg.of("hexLockValue", hexLockValue),
+                            SafeArg.of("lockRow", lockRowName),
+                            SafeArg.of("lockCol", lockColName))
+                    .build();
             return runCqlQuery(updateCql, client, ConsistencyLevel.EACH_QUORUM);
         });
     }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtils.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtils.java
@@ -47,6 +47,7 @@ import com.palantir.atlasdb.table.description.NamedColumnDescription;
 import com.palantir.atlasdb.table.description.TableMetadata;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
+import com.palantir.logsafe.SafeArg;
 import com.palantir.util.Pair;
 
 public final class CassandraTimestampUtils {
@@ -93,7 +94,13 @@ public final class CassandraTimestampUtils {
             builder.append(constructCheckAndSetQuery(columnName, expected, target));
         });
         builder.append("APPLY BATCH;");
-        return new CqlQuery(builder.toString());
+
+        // This looks awkward. However, we know that all expressions in this String pertain to timestamps and known
+        // table references, hence this is actually safe. Doing this quickly owing to priority.
+        // TODO (jkong): Build up a query by passing around legitimate formats and args.
+        return CqlQuery.builder()
+                .safeQueryFormat(builder.toString())
+                .build();
     }
 
     public static boolean isValidTimestampData(byte[] data) {
@@ -101,12 +108,15 @@ public final class CassandraTimestampUtils {
     }
 
     public static CqlQuery constructSelectFromTimestampTableQuery() {
-        return new CqlQuery(String.format(
-                "SELECT %s, %s FROM %s WHERE key=%s;",
-                COLUMN_NAME_COLUMN,
-                VALUE_COLUMN,
-                wrapInQuotes(AtlasDbConstants.TIMESTAMP_TABLE.getQualifiedName()),
-                ROW_AND_COLUMN_NAME_HEX_STRING));
+        // Timestamps are safe.
+        return ImmutableCqlQuery.builder()
+                .safeQueryFormat("SELECT %s, %s FROM %s WHERE key=%s;")
+                .addArgs(
+                        SafeArg.of("columnName", COLUMN_NAME_COLUMN),
+                        SafeArg.of("valueColumnName", VALUE_COLUMN),
+                        SafeArg.of("tableRef", wrapInQuotes(AtlasDbConstants.TIMESTAMP_TABLE.getQualifiedName())),
+                        SafeArg.of("rowAndColumnValue", ROW_AND_COLUMN_NAME_HEX_STRING))
+                .build();
     }
 
     public static Map<String, byte[]> getValuesFromSelectionResult(CqlResult result) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutorImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutorImpl.java
@@ -176,13 +176,15 @@ public class CqlExecutorImpl implements CqlExecutor {
             int limit) {
         long invertedTimestamp = ~startTimestampExclusive;
         String selQuery = "SELECT column1, column2 FROM %s WHERE key = %s AND (column1, column2) > (%s, %s) LIMIT %s;";
-        CqlQuery query = new CqlQuery(
-                selQuery,
-                quotedTableName(tableRef),
-                key(row),
-                column1(startColumnInclusive),
-                column2(invertedTimestamp),
-                limit(limit));
+        CqlQuery query = CqlQuery.builder()
+                .safeQueryFormat(selQuery)
+                .addArgs(
+                        quotedTableName(tableRef),
+                        key(row),
+                        column1(startColumnInclusive),
+                        column2(invertedTimestamp),
+                        limit(limit))
+                .build();
 
         return executeAndGetCells(query, row,
                 result -> CqlExecutorImpl.getCellFromKeylessRow(result, row));

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CqlQuery.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CqlQuery.java
@@ -16,8 +16,10 @@
 
 package com.palantir.atlasdb.keyvalue.cassandra;
 
-import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Collectors;
+
+import org.immutables.value.Value;
 
 import com.google.common.base.Stopwatch;
 import com.palantir.atlasdb.logging.KvsProfilingLogger;
@@ -26,26 +28,26 @@ import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 
-public class CqlQuery {
-    final String queryFormat;
-    final Arg<?>[] queryArgs;
-
-    public CqlQuery(String queryFormat, Arg<?>... args) {
-        this.queryFormat = queryFormat;
-        this.queryArgs = args;
-    }
+@Value.Immutable
+public abstract class CqlQuery {
+    public abstract String safeQueryFormat();
+    public abstract List<Arg<?>> args();
 
     @Override
     public String toString() {
-        return String.format(queryFormat, (Object[]) queryArgs);
+        return String.format(safeQueryFormat(), args().toArray());
+    }
+
+    public static ImmutableCqlQuery.Builder builder() {
+        return ImmutableCqlQuery.builder();
     }
 
     public void logSlowResult(KvsProfilingLogger.LoggingFunction log, Stopwatch timer) {
-        Object[] allArgs = new Object[queryArgs.length + 3];
-        allArgs[0] = SafeArg.of("queryFormat", queryFormat);
+        Object[] allArgs = new Object[args().size() + 3];
+        allArgs[0] = SafeArg.of("queryFormat", safeQueryFormat());
         allArgs[1] = UnsafeArg.of("fullQuery", toString());
         allArgs[2] = LoggingArgs.durationMillis(timer);
-        System.arraycopy(queryArgs, 0, allArgs, 3, queryArgs.length);
+        System.arraycopy(args().toArray(), 0, allArgs, 3, args().size());
 
         log.log("A CQL query was slow: queryFormat = [{}], fullQuery = [{}], durationMillis = {}", allArgs);
     }
@@ -58,12 +60,12 @@ public class CqlQuery {
         return new Object() {
             @Override
             public String toString() {
-                String argsString = Arrays.stream(queryArgs)
+                String argsString = args().stream()
                         .filter(Arg::isSafeForLogging)
                         .map(arg -> String.format("%s = %s", arg.getName(), arg.getValue()))
                         .collect(Collectors.joining(", "));
 
-                return queryFormat + ": " + argsString;
+                return safeQueryFormat() + ": " + argsString;
             }
         };
     }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTables.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTables.java
@@ -100,10 +100,13 @@ public class SchemaMutationLockTables {
                 + "    PRIMARY KEY (key, column1, column2)\n"
                 + ") WITH COMPACT STORAGE\n"
                 + "    AND id = '%s'";
-        CqlQuery query = new CqlQuery(createTableStatement,
-                SafeArg.of("keyspace", keyspace),
-                SafeArg.of("internalTableName", internalTableName),
-                SafeArg.of("cfId", uuid));
+        CqlQuery query = CqlQuery.builder()
+                .safeQueryFormat(createTableStatement)
+                .addArgs(
+                        SafeArg.of("keyspace", keyspace),
+                        SafeArg.of("internalTableName", internalTableName),
+                        SafeArg.of("cfId", uuid))
+                .build();
 
         clientPool.runWithRetry(client -> {
             try {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/cas/CheckAndSetQueries.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/cas/CheckAndSetQueries.java
@@ -20,7 +20,9 @@ import com.google.common.base.Preconditions;
 import com.google.common.io.BaseEncoding;
 import com.palantir.atlasdb.keyvalue.api.CheckAndSetRequest;
 import com.palantir.atlasdb.keyvalue.cassandra.CqlQuery;
-import com.palantir.atlasdb.keyvalue.impl.AbstractKeyValueService;
+import com.palantir.atlasdb.logging.LoggingArgs;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
 
 final class CheckAndSetQueries {
     private static final long CASSANDRA_TIMESTAMP = -1L;
@@ -37,26 +39,26 @@ final class CheckAndSetQueries {
     private static CqlQuery insertIfNotExists(CheckAndSetRequest request) {
         Preconditions.checkState(!request.oldValue().isPresent(),
                 "insertIfNotExists queries should only be made if we don't have an old value");
-        return new CqlQuery(String.format(
+        return new CqlQuery(
                 "INSERT INTO \"%s\" (key, column1, column2, value) VALUES (%s, %s, %s, %s) IF NOT EXISTS;",
-                AbstractKeyValueService.internalTableName(request.table()),
-                encodeCassandraHexString(request.cell().getRowName()),
-                encodeCassandraHexString(request.cell().getColumnName()),
-                CASSANDRA_TIMESTAMP,
-                encodeCassandraHexString(request.newValue())));
+                LoggingArgs.internalTableName(request.table()),
+                UnsafeArg.of("row", encodeCassandraHexString(request.cell().getRowName())),
+                UnsafeArg.of("column", encodeCassandraHexString(request.cell().getColumnName())),
+                SafeArg.of("cassandraTimestamp", CASSANDRA_TIMESTAMP),
+                UnsafeArg.of("newValue", encodeCassandraHexString(request.newValue())));
     }
 
     private static CqlQuery updateIfMatching(CheckAndSetRequest request) {
         Preconditions.checkState(request.oldValue().isPresent(),
                 "updateIfMatching queries should only be made if we do have an old value");
-        return new CqlQuery(String.format(
+        return new CqlQuery(
                 "UPDATE \"%s\" SET value=%s WHERE key=%s AND column1=%s AND column2=%s IF value=%s;",
-                AbstractKeyValueService.internalTableName(request.table()),
-                encodeCassandraHexString(request.newValue()),
-                encodeCassandraHexString(request.cell().getRowName()),
-                encodeCassandraHexString(request.cell().getColumnName()),
-                CASSANDRA_TIMESTAMP,
-                encodeCassandraHexString(request.oldValue().get())));
+                LoggingArgs.internalTableName(request.table()),
+                UnsafeArg.of("newValue", encodeCassandraHexString(request.newValue())),
+                UnsafeArg.of("row", encodeCassandraHexString(request.cell().getRowName())),
+                UnsafeArg.of("column", encodeCassandraHexString(request.cell().getColumnName())),
+                SafeArg.of("cassandraTimestamp", CASSANDRA_TIMESTAMP),
+                UnsafeArg.of("oldValue", encodeCassandraHexString(request.oldValue().get())));
     }
 
     private static String encodeCassandraHexString(byte[] data) {

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/ProfilingCassandraClientTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/ProfilingCassandraClientTest.java
@@ -44,7 +44,9 @@ import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 
 public class ProfilingCassandraClientTest {
-    private static final CqlQuery CQL_QUERY = new CqlQuery("SELECT * FROM atlasdb.foo LIMIT 1;");
+    private static final CqlQuery CQL_QUERY = CqlQuery.builder()
+            .safeQueryFormat("SELECT * FROM atlasdb.foo LIMIT 1;")
+            .build();
 
     private final CassandraClient delegate = mock(CassandraClient.class);
     private final CassandraClient profilingClient = new ProfilingCassandraClient(delegate);

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/QosCassandraClientTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/QosCassandraClientTest.java
@@ -78,7 +78,9 @@ public class QosCassandraClientTest {
 
     @Test
     public void executeCqlQueryChecksLimit() throws TException, LimitExceededException {
-        CqlQuery query = new CqlQuery("SELECT * FROM test_table LIMIT 1");
+        CqlQuery query = CqlQuery.builder()
+                .safeQueryFormat("SELECT * FROM test_table LIMIT 1")
+                .build();
         client.execute_cql3_query(query, Compression.NONE, ConsistencyLevel.ANY);
 
         verify(qosClient, times(1)).executeRead(any(), any());

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/cas/CheckAndSetQueriesTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/cas/CheckAndSetQueriesTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra.cas;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.Maps;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.CheckAndSetRequest;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.cassandra.CqlQuery;
+import com.palantir.logsafe.Arg;
+
+public class CheckAndSetQueriesTest {
+    private static final TableReference TABLE_REFERENCE = TableReference.createFromFullyQualifiedName("ns.table");
+    private static final Cell CELL = Cell.create(PtBytes.toBytes("abc"), PtBytes.toBytes("123"));
+    private static final CheckAndSetRequest NEW_CELL_REQUEST = CheckAndSetRequest.newCell(
+            TABLE_REFERENCE,
+            CELL,
+            PtBytes.toBytes("ptpt"));
+    private static final CheckAndSetRequest UPDATE_REQUEST = CheckAndSetRequest.singleCell(
+            TABLE_REFERENCE,
+            CELL,
+            PtBytes.toBytes("aaa"),
+            PtBytes.toBytes("bbb"));
+
+    @Test
+    public void valuesCreatedAtCorrectLogSafetyLevelsForNewCells() {
+        CqlQuery query = CheckAndSetQueries.getQueryForRequest(NEW_CELL_REQUEST);
+        AtomicReference<Object[]> objects = new AtomicReference<>();
+        query.logSlowResult((format, args) -> objects.set(args), Stopwatch.createStarted());
+
+        Object[] loggedObjects = objects.get();
+        Map<String, Boolean> argumentSafety = Maps.newHashMap();
+        Arrays.stream(loggedObjects)
+                .forEach(object -> {
+                    Arg<?> arg = (Arg) object;
+                    argumentSafety.put(arg.getName(), arg.isSafeForLogging());
+                });
+
+        assertThat(argumentSafety)
+                .containsEntry("row", false)
+                .containsEntry("column", false)
+                .containsEntry("cassandraTimestamp", true)
+                .containsEntry("newValue", false)
+                .containsEntry("tableRef", false); // the table wasn't marked as safe
+        assertThat(query.toString())
+                .isEqualTo("INSERT INTO \"ns__table\" (key, column1, column2, value)"
+                        + " VALUES (0x616263, 0x313233, -1, 0x70747074) IF NOT EXISTS;");
+    }
+
+    @Test
+    public void valuesCreatedAtCorrectLogSafetyLevelsForUpdates() {
+        CqlQuery query = CheckAndSetQueries.getQueryForRequest(UPDATE_REQUEST);
+        AtomicReference<Object[]> objects = new AtomicReference<>();
+        query.logSlowResult((format, args) -> objects.set(args), Stopwatch.createStarted());
+
+        Object[] loggedObjects = objects.get();
+        Map<String, Boolean> argumentSafety = Maps.newHashMap();
+        Arrays.stream(loggedObjects)
+                .forEach(object -> {
+                    Arg<?> arg = (Arg) object;
+                    argumentSafety.put(arg.getName(), arg.isSafeForLogging());
+                });
+
+        assertThat(argumentSafety)
+                .containsEntry("row", false)
+                .containsEntry("column", false)
+                .containsEntry("cassandraTimestamp", true)
+                .containsEntry("oldValue", false)
+                .containsEntry("newValue", false)
+                .containsEntry("tableRef", false); // the table wasn't marked as safe
+        assertThat(query.toString())
+                .isEqualTo("UPDATE \"ns__table\" SET value=0x626262"
+                        + " WHERE key=0x616263 AND column1=0x313233 AND column2=-1 IF value=0x616161;");
+    }
+}

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/cas/CheckAndSetQueriesTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/cas/CheckAndSetQueriesTest.java
@@ -65,7 +65,8 @@ public class CheckAndSetQueriesTest {
                 .containsEntry("column", false)
                 .containsEntry("cassandraTimestamp", true)
                 .containsEntry("newValue", false)
-                .containsEntry("tableRef", false); // the table wasn't marked as safe
+                .containsEntry("unsafeTableRef", false)
+                .doesNotContainKey("tableRef"); // the table wasn't marked as safe
         assertThat(query.toString())
                 .isEqualTo("INSERT INTO \"ns__table\" (key, column1, column2, value)"
                         + " VALUES (0x616263, 0x313233, -1, 0x70747074) IF NOT EXISTS;");
@@ -91,7 +92,8 @@ public class CheckAndSetQueriesTest {
                 .containsEntry("cassandraTimestamp", true)
                 .containsEntry("oldValue", false)
                 .containsEntry("newValue", false)
-                .containsEntry("tableRef", false); // the table wasn't marked as safe
+                .containsEntry("unsafeTableRef", false)
+                .doesNotContainKey("tableRef"); // the table wasn't marked as safe
         assertThat(query.toString())
                 .isEqualTo("UPDATE \"ns__table\" SET value=0x626262"
                         + " WHERE key=0x616263 AND column1=0x313233 AND column2=-1 IF value=0x616161;");

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/logging/LoggingArgs.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/logging/LoggingArgs.java
@@ -73,10 +73,7 @@ public final class LoggingArgs {
     }
 
     public static Arg<String> internalTableName(TableReference tableReference) {
-        return getArg(
-                "tableRef",
-                AbstractKeyValueService.internalTableName(tableReference),
-                logArbitrator.isTableReferenceSafe(tableReference));
+        return safeInternalTableName(AbstractKeyValueService.internalTableName(tableReference));
     }
 
     public static SafeAndUnsafeTableReferences tableRefs(Collection<TableReference> tableReferences) {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/logging/LoggingArgs.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/logging/LoggingArgs.java
@@ -33,6 +33,7 @@ import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
 import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.impl.AbstractKeyValueService;
 import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
@@ -69,6 +70,13 @@ public final class LoggingArgs {
     @VisibleForTesting
     static synchronized void setLogArbitrator(KeyValueServiceLogArbitrator arbitrator) {
         logArbitrator = arbitrator;
+    }
+
+    public static Arg<String> internalTableName(TableReference tableReference) {
+        return getArg(
+                "tableRef",
+                AbstractKeyValueService.internalTableName(tableReference),
+                logArbitrator.isTableReferenceSafe(tableReference));
     }
 
     public static SafeAndUnsafeTableReferences tableRefs(Collection<TableReference> tableReferences) {

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -60,6 +60,12 @@ develop
            Previously, trying to refresh a larger number of locks could trigger the 50MB limit in payload size.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3450>`__)
 
+    *    - |fixed|
+         - CQL queries are now logged correctly (with safe and unsafe arguments respected).
+           Previously, these versions would log all arguments as part of the format string as it eagerly did the string substitution.
+           AtlasDB versions 0.95.0 through 0.101.0 (inclusive both ends) are affected.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/abcd>`__)
+
     *    - |logs|
          - Reduce logging level for locks not being refreshed.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3458>`__)

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -66,6 +66,11 @@ develop
            AtlasDB versions 0.95.0 through 0.101.0 (inclusive both ends) are affected.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/abcd>`__)
 
+    *    - |devbreak| |improved|
+         - CqlQuery is now an abstract class and must now be created through its builder.
+           This makes the intention that the query string provided is safe considerably more explicit.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/abcd>`__)
+
     *    - |logs|
          - Reduce logging level for locks not being refreshed.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3458>`__)

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,17 @@ develop
     *    - Type
          - Change
 
+    *    - |fixed|
+         - CQL queries are now logged correctly (with safe and unsafe arguments respected).
+           Previously, these versions would log all arguments as part of the format string as it eagerly did the string substitution.
+           AtlasDB versions 0.95.0 through 0.101.0 (inclusive both ends) are affected.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3469>`__)
+
+    *    - |devbreak| |improved|
+         - CqlQuery is now an abstract class and must now be created through its builder.
+           This makes the intention that the query string provided is safe considerably more explicit.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3469>`__)
+
     *    - |improved|
          - DbKvs now implements its own version of ``deleteAllTimestamps`` instead of using the default AbstractKvs implementation.
            This facilitates better performance of targeted sweep on DbKvs.
@@ -59,17 +70,6 @@ develop
          - LockRefreshingLockService now batches calls to refresh locks in batches of 650K.
            Previously, trying to refresh a larger number of locks could trigger the 50MB limit in payload size.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3450>`__)
-
-    *    - |fixed|
-         - CQL queries are now logged correctly (with safe and unsafe arguments respected).
-           Previously, these versions would log all arguments as part of the format string as it eagerly did the string substitution.
-           AtlasDB versions 0.95.0 through 0.101.0 (inclusive both ends) are affected.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/abcd>`__)
-
-    *    - |devbreak| |improved|
-         - CqlQuery is now an abstract class and must now be created through its builder.
-           This makes the intention that the query string provided is safe considerably more explicit.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/abcd>`__)
 
     *    - |logs|
          - Reduce logging level for locks not being refreshed.

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -53,7 +53,7 @@ develop
     *    - |fixed|
          - CQL queries are now logged correctly (with safe and unsafe arguments respected).
            Previously, these versions would log all arguments as part of the format string as it eagerly did the string substitution.
-           AtlasDB versions 0.95.0 through 0.101.0 (inclusive both ends) are affected.
+           AtlasDB versions 0.100.0 through 0.101.0 (inclusive both ends) are affected.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3469>`__)
 
     *    - |devbreak| |improved|


### PR DESCRIPTION
**Goals (and why)**:
- Internal ref PDS-73313

**Implementation Description (bullets)**:
- Make CqlQuery foolproof
- Fix the specific leak
- Fix other benign but incorrect usages

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Non-existent for CqlQuery; now present including checks on log levels
- New methods are tested

**Concerns (what feedback would you like?)**:
- The unlogged batch for timestamp service is snowflaky right now
- Are the safety levels correct?
- Did I break anything when moving CqlQuery to use immutables? This isn't the smallest change but I want to improve that class.

**Where should we start reviewing?**: CqlQuery

**Priority (whenever / two weeks / yesterday)**: several weeks ago 🔥 🔥 🔥

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3469)
<!-- Reviewable:end -->
