### PR TITLE
Fix upgrading shards issue

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/ShardProgress.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/ShardProgress.java
@@ -39,11 +39,11 @@ import com.palantir.util.PersistableBoolean;
 
 public class ShardProgress {
     private static final Logger log = LoggerFactory.getLogger(ShardProgress.class);
-    private static final TableReference TABLE_REF = TargetedSweepTableFactory.of()
+    static final TableReference TABLE_REF = TargetedSweepTableFactory.of()
             .getSweepShardProgressTable(null).getTableRef();
 
     private static final int SHARD_COUNT_INDEX = -1;
-    private static final ShardAndStrategy SHARD_COUNT_SAS = ShardAndStrategy.conservative(SHARD_COUNT_INDEX);
+    static final ShardAndStrategy SHARD_COUNT_SAS = ShardAndStrategy.conservative(SHARD_COUNT_INDEX);
 
     private final KeyValueService kvs;
 
@@ -101,7 +101,7 @@ public class ShardProgress {
         return kvs.get(TABLE_REF, ImmutableMap.of(cellForShard(shardAndStrategy), SweepQueueUtils.READ_TS));
     }
 
-    private Cell cellForShard(ShardAndStrategy shardAndStrategy) {
+    Cell cellForShard(ShardAndStrategy shardAndStrategy) {
         SweepShardProgressTable.SweepShardProgressRow row = SweepShardProgressTable.SweepShardProgressRow.of(
                 shardAndStrategy.shard(),
                 PersistableBoolean.of(shardAndStrategy.isConservative()).persistToBytes());
@@ -116,27 +116,31 @@ public class ShardProgress {
     }
 
     private long increaseValueFromToAtLeast(ShardAndStrategy shardAndStrategy, long oldVal, long newVal) {
-        byte[] colValNew = SweepShardProgressTable.Value.of(newVal).persistValue();
+        byte[] colValNew = createColumnValue(newVal);
 
         long currentValue = oldVal;
         while (currentValue < newVal) {
-            CheckAndSetRequest casRequest = createRequest(shardAndStrategy, currentValue, colValNew);
+            CheckAndSetRequest casRequest = createRequest(shardAndStrategy, oldVal, colValNew);
             try {
                 kvs.checkAndSet(casRequest);
                 return newVal;
             } catch (CheckAndSetException e) {
                 log.info("Failed to check and set from expected old value {} to new value {}. Retrying if the old "
-                        + "value changed under us.",
+                                + "value changed under us.",
                         SafeArg.of("old value", oldVal),
                         SafeArg.of("new value", newVal));
-                currentValue = updateOrRethrowIfNoChange(shardAndStrategy, currentValue, e);
+                currentValue = rethrowIfUnchanged(shardAndStrategy, oldVal, e);
             }
         }
         return currentValue;
     }
 
-    private long updateOrRethrowIfNoChange(ShardAndStrategy shardAndStrategy, long oldVal, CheckAndSetException ex) {
-        long updatedOldVal = getValue(getEntry(shardAndStrategy));
+    static byte[] createColumnValue(long newVal) {
+        return SweepShardProgressTable.Value.of(newVal).persistValue();
+    }
+
+    private long rethrowIfUnchanged(ShardAndStrategy shardStrategy, long oldVal, CheckAndSetException ex) {
+        long updatedOldVal = getValue(getEntry(shardStrategy));
         if (updatedOldVal == oldVal) {
             throw ex;
         }
@@ -144,11 +148,27 @@ public class ShardProgress {
     }
 
     private CheckAndSetRequest createRequest(ShardAndStrategy shardAndStrategy, long oldVal, byte[] colValNew) {
-        if (oldVal == SweepQueueUtils.INITIAL_TIMESTAMP
-                || (shardAndStrategy == SHARD_COUNT_SAS && oldVal == AtlasDbConstants.DEFAULT_SWEEP_QUEUE_SHARDS)) {
-            return CheckAndSetRequest.newCell(TABLE_REF, cellForShard(shardAndStrategy), colValNew);
+        if (isDefaultValue(shardAndStrategy, oldVal)) {
+            return maybeGet(shardAndStrategy)
+                    .map(persistedValue -> createSingleCellRequest(shardAndStrategy, persistedValue, colValNew))
+                    .orElse(createNewCellRequest(shardAndStrategy, colValNew));
+        } else {
+            return createSingleCellRequest(shardAndStrategy, oldVal, colValNew);
         }
-        byte[] colValOld = SweepShardProgressTable.Value.of(oldVal).persistValue();
+    }
+
+    private boolean isDefaultValue(ShardAndStrategy shardAndStrategy, long oldVal) {
+        return oldVal == SweepQueueUtils.INITIAL_TIMESTAMP
+                || (shardAndStrategy == SHARD_COUNT_SAS && oldVal == AtlasDbConstants.DEFAULT_SWEEP_QUEUE_SHARDS);
+    }
+
+    CheckAndSetRequest createNewCellRequest(ShardAndStrategy shardAndStrategy, byte[] colValNew) {
+        return CheckAndSetRequest.newCell(TABLE_REF, cellForShard(shardAndStrategy), colValNew);
+    }
+
+    private CheckAndSetRequest createSingleCellRequest(ShardAndStrategy shardAndStrategy, long oldVal,
+            byte[] colValNew) {
+        byte[] colValOld = createColumnValue(oldVal);
         return CheckAndSetRequest.singleCell(TABLE_REF, cellForShard(shardAndStrategy), colValOld, colValNew);
     }
 }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -52,7 +52,7 @@ develop
 
     *    - |fixed|
          - Fixed an issue where targeted sweep would fail to increase the number of shards and error out if the default number of shards was ever persisted into the progress table.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/34??>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3473>`__)
 
 
     *    - |fixed|

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -54,6 +54,7 @@ develop
          - Fixed an issue where targeted sweep would fail to increase the number of shards and error out if the default number of shards was ever persisted into the progress table.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3473>`__)
 
+    *    - |fixed|
          - Several exceptions (such as when creating cells with overly long names or executors in illegal configurations) now contain numerical parameters correctly.
            Previously, the exceptions thrown would erroneously contain ``{}`` values.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3468>`__)

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -51,6 +51,11 @@ develop
          - Change
 
     *    - |fixed|
+         - Fixed an issue where targeted sweep would fail to increase the number of shards and error out if the default number of shards was ever persisted into the progress table.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/34??>`__)
+
+
+    *    - |fixed|
          - CQL queries are now logged correctly (with safe and unsafe arguments respected).
            Previously, these versions would log all arguments as part of the format string as it eagerly did the string substitution.
            AtlasDB versions 0.100.0 through 0.101.0 (inclusive both ends) are affected.


### PR DESCRIPTION
**Goals (and why)**:
Fix a bug where we would repeatedly fail to CAS to update the number of shards from the default value causing targeted sweep to error out.

This would only hit the early adopters as in the very first release with TS we were persisting the default number of shards (1) due to defaulting a missing entry to -1:
https://github.com/palantir/atlasdb/blob/0bd6dbd4969bc2e57ebd0df0a6b92774e4d4da83/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/ShardProgress.java#L118

However, this could hit other users as well if we ever changed the default value.
 
**Implementation Description (bullets)**:
If we determine that we are changing from the default value, we check again to make sure if there is an existing entry. Could have avoided this extra lookup at the cost of making the code harder to read, but decided its not worth it.

**Testing (What was existing testing like?  What have you done to improve it?)**:
The new test, which fails on develop.

**Concerns (what feedback would you like?)**:
Are there any other corner cases we might have missed?

**Where should we start reviewing?**:
Small

**Priority (whenever / two weeks / yesterday)**:
ASAP

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3473)
<!-- Reviewable:end -->
