### PR TITLE
[TS] Hard throw if unable to read table metadata

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/WriteInfoPartitioner.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/WriteInfoPartitioner.java
@@ -33,6 +33,7 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.logging.LoggingArgs;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
 import com.palantir.atlasdb.table.description.TableMetadata;
+import com.palantir.common.base.Throwables;
 
 public class WriteInfoPartitioner {
     private static final Logger log = LoggerFactory.getLogger(WriteInfoPartitioner.class);
@@ -88,10 +89,10 @@ public class WriteInfoPartitioner {
     private TableMetadataPersistence.SweepStrategy getStrategyFromKvs(TableReference tableRef) {
         try {
             return TableMetadata.BYTES_HYDRATOR.hydrateFromBytes(kvs.getMetadataForTable(tableRef)).getSweepStrategy();
-        } catch (Throwable th) {
-            log.warn("Failed to obtain sweep strategy for table {}. Assuming sweep strategy is CONSERVATIVE.",
-                    LoggingArgs.tableRef(tableRef), th);
-            return TableMetadataPersistence.SweepStrategy.CONSERVATIVE;
+        } catch (Exception e) {
+            log.warn("Failed to obtain sweep strategy for table {}.",
+                    LoggingArgs.tableRef(tableRef), e);
+            throw Throwables.rewrapAndThrowUncheckedException(e);
         }
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/WriteInfoPartitionerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/WriteInfoPartitionerTest.java
@@ -76,9 +76,11 @@ public class WriteInfoPartitionerTest {
 
     @Test
     public void getStrategyThrowsOnUncheckedException() {
-        when(mockKvs.getMetadataForTable(any())).thenThrow(new RuntimeException());
+        RuntimeException cause = new RuntimeException("cause");
+        when(mockKvs.getMetadataForTable(any())).thenThrow(cause);
         assertThatThrownBy(() -> partitioner.getStrategy(getWriteInfoWithFixedCellHash(getTableRef("a"), 0)))
-                .isInstanceOf(UncheckedExecutionException.class);
+                .isInstanceOf(UncheckedExecutionException.class)
+                .hasCause(cause);
     }
 
     @Test

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/WriteInfoPartitionerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/WriteInfoPartitionerTest.java
@@ -17,6 +17,7 @@
 package com.palantir.atlasdb.sweep.queue;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -36,6 +37,7 @@ import org.junit.Test;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.Cell;
@@ -66,10 +68,17 @@ public class WriteInfoPartitionerTest {
     }
 
     @Test
-    public void getStrategyReturnsConservativeForIllegalMetadata() {
+    public void getStrategyThrowsForIllegalMetadata() {
         when(mockKvs.getMetadataForTable(any())).thenReturn(AtlasDbConstants.EMPTY_TABLE_METADATA);
-        assertThat(partitioner.getStrategy(getWriteInfoWithFixedCellHash(getTableRef("a"), 0)))
-                .isEqualTo(TableMetadataPersistence.SweepStrategy.CONSERVATIVE);
+        assertThatThrownBy(() -> partitioner.getStrategy(getWriteInfoWithFixedCellHash(getTableRef("a"), 0)))
+                .isInstanceOf(UncheckedExecutionException.class);
+    }
+
+    @Test
+    public void getStrategyThrowsOnUncheckedException() {
+        when(mockKvs.getMetadataForTable(any())).thenThrow(new RuntimeException());
+        assertThatThrownBy(() -> partitioner.getStrategy(getWriteInfoWithFixedCellHash(getTableRef("a"), 0)))
+                .isInstanceOf(UncheckedExecutionException.class);
     }
 
     @Test
@@ -132,7 +141,7 @@ public class WriteInfoPartitionerTest {
         Map<PartitionInfo, List<WriteInfo>> partitions = partitioner.partitionWritesByShardStrategyTimestamp(writes);
         assertThat(partitions.keySet())
                 .containsExactly(PartitionInfo.of(writes.get(0).toShard(numShards), true, 1L));
-        assertThat(partitions.values()).containsExactly(writes);
+        assertThat(Iterables.getOnlyElement(partitions.values())).isEqualTo(writes);
     }
 
     @Test

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -53,7 +53,7 @@ develop
     *    - |improved|
          - Targeted sweep queue now hard fails if it is unable to read table metadata to determine sweep strategy.
            Previously, we assumed the strategy was conservative, which could result in sweeping that should never be swept.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/3476>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3477>`__)
 
     *    - |fixed|
          - CQL queries are now logged correctly (with safe and unsafe arguments respected).

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -52,7 +52,7 @@ develop
 
     *    - |improved|
          - Targeted sweep queue now hard fails if it is unable to read table metadata to determine sweep strategy.
-           Previously, we assumed the strategy was conservative, which could result in sweeping that should never be swept.
+           Previously, we assumed the strategy was conservative, which could result in sweeping tables that should never be swept.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3477>`__)
 
     *    - |fixed|

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,11 @@ develop
     *    - Type
          - Change
 
+    *    - |improved|
+         - Targeted sweep queue now hard fails if it is unable to read table metadata to determine sweep strategy.
+           Previously, we assumed the strategy was conservative, which could result in sweeping that should never be swept.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3476>`__)
+
     *    - |fixed|
          - CQL queries are now logged correctly (with safe and unsafe arguments respected).
            Previously, these versions would log all arguments as part of the format string as it eagerly did the string substitution.


### PR DESCRIPTION
**Goals (and why)**:
Instead of assuming default CONSERVATIVE sweep strategy, throw if unable to read from the KVS

**Concerns (what feedback would you like?)**:
If metadata is malformed, no transactions writing to that table will be able to commit

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:
small

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3477)
<!-- Reviewable:end -->
