### PR TITLE
Cassandra KVS Startup Metadata Check Must Be Case-Insensitive

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.startsWith;
 import static org.mockito.Mockito.mock;
@@ -436,6 +437,32 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
         keyValueService.createTable(userTable, tableMetadataUpdate);
 
         assertThat(Arrays.equals(keyValueService.getMetadataForTable(userTable), tableMetadataUpdate), is(true));
+    }
+
+    @Test
+    public void upgradeFromOlderInternalSchemaDoesNotErrorOnTablesWithUpperCaseCharacters() {
+        TableReference tableRef = TableReference.createFromFullyQualifiedName("test.uPgrAdefRomolDerintErnalscHema");
+        keyValueService.put(
+                AtlasDbConstants.DEFAULT_METADATA_TABLE,
+                ImmutableMap.of(CassandraKeyValueServices.getMetadataCell(tableRef), originalMetadata),
+                System.currentTimeMillis());
+        keyValueService.createTable(tableRef, originalMetadata);
+
+        ((CassandraKeyValueServiceImpl) keyValueService).upgradeFromOlderInternalSchema();
+        verify(logger, never()).error(anyString(), any(Object.class));
+    }
+
+    @Test
+    public void upgradeFromOlderInternalSchemaDoesNotErrorOnTablesWithOldMetadata() {
+        TableReference tableRef = TableReference.createFromFullyQualifiedName("test.oldTimeyTable");
+        keyValueService.put(
+                AtlasDbConstants.DEFAULT_METADATA_TABLE,
+                ImmutableMap.of(CassandraKeyValueServices.getOldMetadataCell(tableRef), originalMetadata),
+                System.currentTimeMillis());
+        keyValueService.createTable(tableRef, originalMetadata);
+
+        ((CassandraKeyValueServiceImpl) keyValueService).upgradeFromOlderInternalSchema();
+        verify(logger, never()).error(anyString(), any(Object.class));
     }
 
     private void putDummyValueAtCellAndTimestamp(

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
@@ -440,6 +440,7 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
     }
 
     @Test
+    @SuppressWarnings("Slf4jConstantLogMessage")
     public void upgradeFromOlderInternalSchemaDoesNotErrorOnTablesWithUpperCaseCharacters() {
         TableReference tableRef = TableReference.createFromFullyQualifiedName("test.uPgrAdefRomolDerintErnalscHema");
         keyValueService.put(
@@ -453,6 +454,7 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
     }
 
     @Test
+    @SuppressWarnings("Slf4jConstantLogMessage")
     public void upgradeFromOlderInternalSchemaDoesNotErrorOnTablesWithOldMetadata() {
         TableReference tableRef = TableReference.createFromFullyQualifiedName("test.oldTimeyTable");
         keyValueService.put(

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -431,7 +431,8 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                 .orElse(LockLeader.I_AM_THE_LOCK_LEADER);
     }
 
-    private void upgradeFromOlderInternalSchema() {
+    @VisibleForTesting
+    void upgradeFromOlderInternalSchema() {
         try {
             Map<TableReference, byte[]> metadataForTables = getMetadataForTables();
             final Collection<CfDef> updatedCfs = Lists.newArrayListWithExpectedSize(metadataForTables.size());

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -55,6 +55,10 @@ develop
            Previously, the exceptions thrown would erroneously contain ``{}`` values.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3468>`__)
 
+    *    - |fixed|
+         - Cassandra Key Value Service now no longer logs spurious ERROR warning messages when failing to read new-format table metadata.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3nnn>`__)
+
 ========
 v0.102.0
 ========

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -57,7 +57,7 @@ develop
 
     *    - |fixed|
          - Cassandra Key Value Service now no longer logs spurious ERROR warning messages when failing to read new-format table metadata.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/3nnn>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3478>`__)
 
 ========
 v0.102.0


### PR DESCRIPTION
- [x] Add a test that captures precisely this

**Goals (and why)**:
- Fix PDS-73442 which has caused some alarm internally
- In recent versions of Atlas the Cassandra KVS writes metadata as lower-case to allow for faster look-ups, but I think we missed this call-site

**Implementation Description (bullets)**:
- Have a fallback mechanism for looking up table metadata given a map of available table metadata, and use it

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Not great which is why we didn't catch this. I plan to add a test tomorrow.

**Concerns (what feedback would you like?)**:
- This is unlikely to be the most performant way to implement this method (it is worst-case quadratic; a linear solution exists by pre-processing the map and deciding on a standard form). Is this a problem?

**Where should we start reviewing?**: CassandraKeyValueServiceImpl

**Priority (whenever / two weeks / yesterday)**: tomorrow ideally

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3478)
<!-- Reviewable:end -->
