### PR TITLE
Refactor Cassandra multinode tests

### DIFF
--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/AbstractDegradedClusterTest.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/AbstractDegradedClusterTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.cassandra.multinode;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueService;
+
+public abstract class AbstractDegradedClusterTest {
+    static final TableReference TEST_TABLE = TableReference.createWithEmptyNamespace("test_table");
+    static final byte[] FIRST_ROW = PtBytes.toBytes("row1");
+    static final byte[] SECOND_ROW = PtBytes.toBytes("row2");
+    static final byte[] FIRST_COLUMN = PtBytes.toBytes("col1");
+    static final byte[] SECOND_COLUMN = PtBytes.toBytes("col2");
+    static final Cell CELL_1_1 = Cell.create(FIRST_ROW, FIRST_COLUMN);
+    static final Cell CELL_1_2 = Cell.create(FIRST_ROW, SECOND_COLUMN);
+    static final Cell CELL_2_1 = Cell.create(SECOND_ROW, FIRST_COLUMN);
+    static final Cell CELL_2_2 = Cell.create(SECOND_ROW, SECOND_COLUMN);
+    static final byte[] CONTENTS = PtBytes.toBytes("default_value");
+    static final long TIMESTAMP = 2L;
+    static final Value VALUE = Value.create(CONTENTS, TIMESTAMP);
+
+    private static final Map<Class<? extends AbstractDegradedClusterTest>, CassandraKeyValueService> testKvs =
+            new HashMap<>();
+
+    public void initialize(CassandraKeyValueService kvs) {
+        testKvs.put(getClass(), kvs);
+        testSetup(kvs);
+    }
+
+    abstract void testSetup(CassandraKeyValueService kvs);
+
+    CassandraKeyValueService getTestKvs() {
+        return testKvs.get(getClass());
+    }
+
+    static void closeAll() {
+        testKvs.values().forEach(KeyValueService::close);
+        testKvs.clear();
+    }
+}

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/AbstractNodeAvailabilityTest.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/AbstractNodeAvailabilityTest.java
@@ -15,21 +15,24 @@
  */
 package com.palantir.cassandra.multinode;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 
 import com.palantir.atlasdb.keyvalue.api.ClusterAvailabilityStatus;
-import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueService;
 
-public abstract class AbstractNodeAvailabilityTest {
+public abstract class AbstractNodeAvailabilityTest extends AbstractDegradedClusterTest {
+
+    @Override
+    void testSetup(CassandraKeyValueService kvs) {
+        // noop
+    }
 
     @Test
     public void nodeAvailabilityStatusShouldBeAsExpected() {
-        assertEquals(expectedNodeAvailabilityStatus(), getKeyValueService().getClusterAvailabilityStatus());
+        assertThat(getTestKvs().getClusterAvailabilityStatus()).isEqualTo(expectedNodeAvailabilityStatus());
     }
 
     protected abstract ClusterAvailabilityStatus expectedNodeAvailabilityStatus();
-
-    protected abstract KeyValueService getKeyValueService();
 }

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/LessThanQuorumNodeAvailabilityTest.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/LessThanQuorumNodeAvailabilityTest.java
@@ -16,17 +16,11 @@
 package com.palantir.cassandra.multinode;
 
 import com.palantir.atlasdb.keyvalue.api.ClusterAvailabilityStatus;
-import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 
 public class LessThanQuorumNodeAvailabilityTest extends AbstractNodeAvailabilityTest {
 
     @Override
     protected ClusterAvailabilityStatus expectedNodeAvailabilityStatus() {
         return ClusterAvailabilityStatus.NO_QUORUM_AVAILABLE;
-    }
-
-    @Override
-    protected KeyValueService getKeyValueService() {
-        return NodesDownTestSetup.kvs;
     }
 }

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/NodesDownTestSetup.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/NodesDownTestSetup.java
@@ -12,11 +12,8 @@
  */
 package com.palantir.cassandra.multinode;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.awaitility.Awaitility;
@@ -24,81 +21,47 @@ import org.junit.AfterClass;
 import org.junit.ClassRule;
 
 import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableMap;
-import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.containers.Containers;
 import com.palantir.atlasdb.containers.ThreeNodeCassandraCluster;
-import com.palantir.atlasdb.encoding.PtBytes;
-import com.palantir.atlasdb.keyvalue.api.Cell;
-import com.palantir.atlasdb.keyvalue.api.TableReference;
-import com.palantir.atlasdb.keyvalue.api.Value;
-import com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolImpl;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueService;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServiceImpl;
-import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.docker.compose.connection.DockerPort;
 
 public abstract class NodesDownTestSetup {
 
     private static final int CASSANDRA_THRIFT_PORT = 9160;
-
-    static final TableReference TEST_TABLE = TableReference.createWithEmptyNamespace("test_table");
-    static final TableReference TEST_TABLE_TO_DROP = TableReference.createWithEmptyNamespace("test_table_to_drop");
-    static final TableReference TEST_TABLE_TO_DROP_2 = TableReference.createWithEmptyNamespace("test_table_to_drop_2");
-
-    static final byte[] FIRST_ROW = PtBytes.toBytes("row1");
-    static final byte[] SECOND_ROW = PtBytes.toBytes("row2");
-    static final byte[] FIRST_COLUMN = PtBytes.toBytes("col1");
-    static final byte[] SECOND_COLUMN = PtBytes.toBytes("col2");
-    static final Cell CELL_1_1 = Cell.create(FIRST_ROW, FIRST_COLUMN);
-    static final Cell CELL_1_2 = Cell.create(FIRST_ROW, SECOND_COLUMN);
-    static final Cell CELL_2_1 = Cell.create(SECOND_ROW, FIRST_COLUMN);
-    static final Cell CELL_2_2 = Cell.create(SECOND_ROW, SECOND_COLUMN);
-    static final Cell CELL_3_1 = Cell.create(PtBytes.toBytes("row3"), FIRST_COLUMN);
-    static final Cell CELL_4_1 = Cell.create(PtBytes.toBytes("row4"), FIRST_COLUMN);
-
-    static final byte[] DEFAULT_CONTENTS = PtBytes.toBytes("default_value");
-    static final long DEFAULT_TIMESTAMP = 2L;
-    static final long OLD_TIMESTAMP = 1L;
-    static final Value DEFAULT_VALUE = Value.create(DEFAULT_CONTENTS, DEFAULT_TIMESTAMP);
-    static final ImmutableCassandraKeyValueServiceConfig CONFIG = ImmutableCassandraKeyValueServiceConfig
+    private static final CassandraKeyValueServiceConfig CONFIG = ImmutableCassandraKeyValueServiceConfig
             .copyOf(ThreeNodeCassandraCluster.KVS_CONFIG)
             .withSchemaMutationTimeoutMillis(3_000);
-
-    static CassandraKeyValueService kvs;
 
     @ClassRule
     public static final Containers CONTAINERS = new Containers(NodesDownTestSetup.class)
             .with(new ThreeNodeCassandraCluster());
 
-    public static void initializeKvsAndDegradeCluster(List<String> nodesToKill) {
-        setupTestTable();
-        kvs = createCassandraKvs();
+    @AfterClass
+    public static void closeKvs() {
+        AbstractDegradedClusterTest.closeAll();
+    }
+
+    static void initializeKvsAndDegradeCluster(List<Class<?>> tests, List<String> nodesToKill) throws Exception {
+        for (Class<?> test : tests) {
+            test.getMethod("initialize", CassandraKeyValueService.class).invoke(test.newInstance(), createKvs(test));
+        }
         degradeCassandraCluster(nodesToKill);
     }
 
-    @AfterClass
-    public static void closeKvs() throws IOException, InterruptedException {
-        kvs.close();
+    private static CassandraKeyValueService createKvs(Class<?> testClass) {
+        return CassandraKeyValueServiceImpl
+                .createForTesting(getConfig(testClass), ThreeNodeCassandraCluster.LEADER_CONFIG);
     }
 
-    private static void setupTestTable() {
-        CassandraKeyValueService setupDb = createCassandraKvs();
-        setupDb.createTable(TEST_TABLE, AtlasDbConstants.GENERIC_TABLE_METADATA);
-        setupDb.put(TEST_TABLE, ImmutableMap.of(CELL_1_1, PtBytes.toBytes("old_value")), OLD_TIMESTAMP);
-        setupDb.put(TEST_TABLE, ImmutableMap.of(CELL_1_1, DEFAULT_CONTENTS), DEFAULT_TIMESTAMP);
-        setupDb.put(TEST_TABLE, ImmutableMap.of(CELL_1_2, DEFAULT_CONTENTS), DEFAULT_TIMESTAMP);
-        setupDb.put(TEST_TABLE, ImmutableMap.of(CELL_2_1, DEFAULT_CONTENTS), DEFAULT_TIMESTAMP);
-
-        setupDb.createTable(TEST_TABLE_TO_DROP, AtlasDbConstants.GENERIC_TABLE_METADATA);
-        setupDb.createTable(TEST_TABLE_TO_DROP_2, AtlasDbConstants.GENERIC_TABLE_METADATA);
-
-        setupDb.close();
-    }
-
-    protected static CassandraKeyValueService createCassandraKvs() {
-        return CassandraKeyValueServiceImpl.createForTesting(CONFIG, ThreeNodeCassandraCluster.LEADER_CONFIG);
+    static CassandraKeyValueServiceConfig getConfig(Class<?> testClass) {
+        return ImmutableCassandraKeyValueServiceConfig.builder()
+                .from(CONFIG)
+                .keyspace(testClass.getSimpleName())
+                .build();
     }
 
     private static void degradeCassandraCluster(List<String> nodesToKill) {
@@ -110,11 +73,6 @@ public abstract class NodesDownTestSetup {
             }
         });
 
-        // startup checks aren't guaranteed to pass immediately after killing the node, so we wait until
-        // they do. unclear if this is an AtlasDB product problem. see #1154
-        if (nodesToKill.size() < 2) {
-            waitUntilStartupChecksPass();
-        }
     }
 
     private static void killCassandraContainer(String containerName) throws IOException, InterruptedException {
@@ -122,33 +80,5 @@ public abstract class NodesDownTestSetup {
         DockerPort containerPort = new DockerPort(containerName, CASSANDRA_THRIFT_PORT, CASSANDRA_THRIFT_PORT);
         Awaitility.waitAtMost(10, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(
                 () -> !containerPort.isListeningNow());
-    }
-
-    private static void waitUntilStartupChecksPass() {
-        Awaitility.await()
-                .atMost(180, TimeUnit.SECONDS)
-                .pollInterval(1, TimeUnit.SECONDS)
-                .until(NodesDownTestSetup::startupChecksPass);
-    }
-
-    private static boolean startupChecksPass() {
-        try {
-            // startup checks are done implicitly in the constructor
-            CassandraClientPoolImpl.create(
-                    MetricsManagers.createForTests(),
-                    ThreeNodeCassandraCluster.KVS_CONFIG);
-            return true;
-        } catch (Exception e) {
-            return false;
-        }
-    }
-
-    protected static void verifyValue(Cell cell, Value value) {
-        Map<Cell, Value> result = kvs.get(TEST_TABLE, ImmutableMap.of(cell, Long.MAX_VALUE));
-        assertThat(value).isEqualTo(result.get(cell));
-    }
-
-    protected static boolean tableExists(TableReference tableReference) {
-        return NodesDownTestSetup.kvs.getAllTableNames().contains(tableReference);
     }
 }

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/OneNodeDownDeleteTest.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/OneNodeDownDeleteTest.java
@@ -21,24 +21,27 @@ import org.junit.Test;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
-import com.palantir.atlasdb.keyvalue.api.InsufficientConsistencyException;
+import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueService;
+import com.palantir.common.exception.AtlasDbDependencyException;
 
-public class OneNodeDownDeleteTest {
-    private static final String REQUIRES_ALL_CASSANDRA_NODES = "requires ALL Cassandra nodes to be up and available.";
+public class OneNodeDownDeleteTest extends AbstractDegradedClusterTest {
+
+    @Override
+    void testSetup(CassandraKeyValueService kvs) {
+        kvs.createTable(TEST_TABLE, AtlasDbConstants.GENERIC_TABLE_METADATA);
+    }
 
     @Test
     public void deletingThrows() {
-        assertThatThrownBy(() -> OneNodeDownTestSuite.kvs.delete(OneNodeDownTestSuite.TEST_TABLE,
-                ImmutableMultimap.of(OneNodeDownTestSuite.CELL_1_1, OneNodeDownTestSuite.DEFAULT_TIMESTAMP)))
-                .isExactlyInstanceOf(InsufficientConsistencyException.class)
-                .hasMessageContaining(REQUIRES_ALL_CASSANDRA_NODES);
+        assertThatThrownBy(() -> getTestKvs().delete(TEST_TABLE, ImmutableMultimap.of(CELL_1_1, TIMESTAMP)))
+                .isInstanceOf(AtlasDbDependencyException.class);
     }
 
     @Test
     public void deleteAllTimestampsThrows() {
-        assertThatThrownBy(() -> OneNodeDownTestSuite.kvs.deleteAllTimestamps(OneNodeDownTestSuite.TEST_TABLE,
-                ImmutableMap.of(OneNodeDownTestSuite.CELL_1_1, OneNodeDownTestSuite.DEFAULT_TIMESTAMP), false))
-                .isExactlyInstanceOf(InsufficientConsistencyException.class)
-                .hasMessageContaining(REQUIRES_ALL_CASSANDRA_NODES);
+        assertThatThrownBy(() -> getTestKvs().deleteAllTimestamps(TEST_TABLE,
+                ImmutableMap.of(CELL_1_1, TIMESTAMP), false))
+                .isInstanceOf(AtlasDbDependencyException.class);
     }
 }

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/OneNodeDownGetTest.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/OneNodeDownGetTest.java
@@ -17,117 +17,108 @@ package com.palantir.cassandra.multinode;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
 
-import org.junit.Rule;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.Iterables;
 import com.google.common.primitives.UnsignedBytes;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
-import com.palantir.atlasdb.keyvalue.api.InsufficientConsistencyException;
 import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.RowColumnRangeIterator;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueService;
 import com.palantir.common.base.ClosableIterator;
-import com.palantir.flake.FlakeRetryingRule;
-import com.palantir.flake.ShouldRetry;
+import com.palantir.common.exception.AtlasDbDependencyException;
 
-@ShouldRetry
-public class OneNodeDownGetTest {
-    private static final String REQUIRES_ALL_CASSANDRA_NODES = "requires ALL Cassandra nodes to be up and available.";
+public class OneNodeDownGetTest extends AbstractDegradedClusterTest {
+    private static final Set<Map.Entry<Cell, Value>> expectedRowEntries = ImmutableMap
+            .of(CELL_1_1, VALUE, CELL_1_2, VALUE).entrySet();
 
-    @Rule
-    public final FlakeRetryingRule flakeRetryingRule = new FlakeRetryingRule();
-
-    ImmutableMap<Cell, Value> expectedRow = ImmutableMap.of(
-            OneNodeDownTestSuite.CELL_1_1, OneNodeDownTestSuite.DEFAULT_VALUE,
-            OneNodeDownTestSuite.CELL_1_2, OneNodeDownTestSuite.DEFAULT_VALUE);
+    @Override
+    void testSetup(CassandraKeyValueService kvs) {
+        kvs.createTable(TEST_TABLE, AtlasDbConstants.GENERIC_TABLE_METADATA);
+        kvs.put(TEST_TABLE, ImmutableMap.of(CELL_1_1, PtBytes.toBytes("old_value")), TIMESTAMP - 1);
+        kvs.put(TEST_TABLE, ImmutableMap.of(CELL_1_1, CONTENTS), TIMESTAMP);
+        kvs.put(TEST_TABLE, ImmutableMap.of(CELL_1_2, CONTENTS), TIMESTAMP);
+        kvs.put(TEST_TABLE, ImmutableMap.of(CELL_2_1, CONTENTS), TIMESTAMP);
+    }
 
     @Test
     public void canGet() {
-        OneNodeDownTestSuite.verifyValue(OneNodeDownTestSuite.CELL_1_1,
-                OneNodeDownTestSuite.DEFAULT_VALUE);
+        assertLatestValueInCellEquals(CELL_1_1, VALUE);
     }
 
     @Test
     public void canGetRows() {
-        Map<Cell, Value> row = OneNodeDownTestSuite.kvs.getRows(OneNodeDownTestSuite.TEST_TABLE,
-                ImmutableList.of(OneNodeDownTestSuite.FIRST_ROW), ColumnSelection.all(), Long.MAX_VALUE);
+        Map<Cell, Value> row = getTestKvs()
+                .getRows(TEST_TABLE, ImmutableList.of(FIRST_ROW), ColumnSelection.all(), Long.MAX_VALUE);
 
-        assertThat(row).containsAllEntriesOf(expectedRow);
+        assertThat(row.entrySet()).hasSameElementsAs(expectedRowEntries);
     }
 
     @Test
     public void canGetRange() {
-        final RangeRequest range = RangeRequest.builder().endRowExclusive(OneNodeDownTestSuite.SECOND_ROW).build();
-        ClosableIterator<RowResult<Value>> it = OneNodeDownTestSuite.kvs.getRange(OneNodeDownTestSuite.TEST_TABLE,
-                range, Long.MAX_VALUE);
+        RangeRequest range = RangeRequest.builder().endRowExclusive(SECOND_ROW).build();
+        ClosableIterator<RowResult<Value>> resultIterator = getTestKvs().getRange(TEST_TABLE, range, Long.MAX_VALUE);
 
-        ImmutableMap<byte[], Value> expectedColumns = ImmutableMap.of(
-                OneNodeDownTestSuite.FIRST_COLUMN, OneNodeDownTestSuite.DEFAULT_VALUE,
-                OneNodeDownTestSuite.SECOND_COLUMN, OneNodeDownTestSuite.DEFAULT_VALUE);
-        RowResult<Value> expectedRowResult = RowResult.create(OneNodeDownTestSuite.FIRST_ROW,
+        Map<byte[], Value> expectedColumns = ImmutableMap.of(FIRST_COLUMN, VALUE, SECOND_COLUMN, VALUE);
+        RowResult<Value> expectedRowResult = RowResult.create(FIRST_ROW,
                 ImmutableSortedMap.copyOf(expectedColumns, UnsignedBytes.lexicographicalComparator()));
 
-        assertThat(it).containsExactly(expectedRowResult);
+        assertThat(resultIterator).containsExactlyElementsOf(ImmutableList.of(expectedRowResult));
     }
 
     @Test
     public void canGetRowsColumnRange() {
-        BatchColumnRangeSelection rangeSelection = BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY,
-                PtBytes.EMPTY_BYTE_ARRAY, 1);
-        Map<byte[], RowColumnRangeIterator> rowsColumnRange = OneNodeDownTestSuite.kvs.getRowsColumnRange(
-                OneNodeDownTestSuite.TEST_TABLE, ImmutableList.of(OneNodeDownTestSuite.FIRST_ROW),
-                rangeSelection, Long.MAX_VALUE);
+        BatchColumnRangeSelection rangeSelection = BatchColumnRangeSelection.create(null, null, 1);
+        Map<byte[], RowColumnRangeIterator> rowsColumnRange = getTestKvs()
+                .getRowsColumnRange(TEST_TABLE, ImmutableList.of(FIRST_ROW), rangeSelection, Long.MAX_VALUE);
 
-        assertEquals(1, rowsColumnRange.size());
-        byte[] rowName = rowsColumnRange.entrySet().iterator().next().getKey();
-        assertTrue(Arrays.equals(OneNodeDownTestSuite.FIRST_ROW, rowName));
-
-        RowColumnRangeIterator it = rowsColumnRange.get(rowName);
-        assertThat(it).containsExactlyElementsOf(expectedRow.entrySet());
+        assertThat(Iterables.getOnlyElement(rowsColumnRange.keySet())).isEqualTo(FIRST_ROW);
+        assertThat(rowsColumnRange.get(FIRST_ROW)).containsExactlyElementsOf(expectedRowEntries);
     }
 
     @Test
     public void canGetAllTableNames() {
-        assertTrue(OneNodeDownTestSuite.tableExists(OneNodeDownTestSuite.TEST_TABLE));
+        assertThat(getTestKvs().getAllTableNames()).contains(TEST_TABLE);
     }
 
     @Test
     public void canGetLatestTimestamps() {
-        Map<Cell, Long> latest = OneNodeDownTestSuite.kvs.getLatestTimestamps(OneNodeDownTestSuite.TEST_TABLE,
-                ImmutableMap.of(OneNodeDownTestSuite.CELL_1_1, Long.MAX_VALUE));
-        assertEquals(OneNodeDownTestSuite.DEFAULT_TIMESTAMP, latest.get(OneNodeDownTestSuite.CELL_1_1).longValue());
+        Map<Cell, Long> latestTs = getTestKvs()
+                .getLatestTimestamps(TEST_TABLE, ImmutableMap.of(CELL_1_1, Long.MAX_VALUE));
+        assertThat(latestTs.get(CELL_1_1).longValue()).isEqualTo(TIMESTAMP);
     }
 
     @Test
     public void getRangeOfTimestampsThrows() {
-        RangeRequest range = RangeRequest.builder().endRowExclusive(OneNodeDownTestSuite.SECOND_ROW).build();
-        ClosableIterator<RowResult<Set<Long>>> it = OneNodeDownTestSuite.kvs.getRangeOfTimestamps(
-                OneNodeDownTestSuite.TEST_TABLE, range, Long.MAX_VALUE);
-        assertThatThrownBy(() -> it.next())
-                .isExactlyInstanceOf(InsufficientConsistencyException.class)
-                .hasMessageContaining(REQUIRES_ALL_CASSANDRA_NODES);
+        RangeRequest range = RangeRequest.builder().endRowExclusive(SECOND_ROW).build();
+        try (ClosableIterator<RowResult<Set<Long>>> resultIterator = getTestKvs()
+                .getRangeOfTimestamps(TEST_TABLE, range, Long.MAX_VALUE)) {
+            assertThatThrownBy(resultIterator::next).isInstanceOf(AtlasDbDependencyException.class);
+        }
     }
 
     @Test
     public void getAllTimestampsThrows() {
-        assertThatThrownBy(() -> OneNodeDownTestSuite.kvs.getAllTimestamps(OneNodeDownTestSuite.TEST_TABLE,
-                ImmutableSet.of(OneNodeDownTestSuite.CELL_1_1), Long.MAX_VALUE))
-                .isExactlyInstanceOf(InsufficientConsistencyException.class)
-                .hasMessageContaining(REQUIRES_ALL_CASSANDRA_NODES);
+        assertThatThrownBy(() -> getTestKvs().getAllTimestamps(TEST_TABLE, ImmutableSet.of(CELL_1_1), Long.MAX_VALUE))
+                .isInstanceOf(AtlasDbDependencyException.class);
+    }
+
+    private void assertLatestValueInCellEquals(Cell cell, Value value) {
+        Map<Cell, Value> result = getTestKvs().get(TEST_TABLE, ImmutableMap.of(cell, Long.MAX_VALUE));
+        assertThat(result.get(cell)).isEqualTo(value);
     }
 }

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/OneNodeDownNodeAvailabilityTest.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/OneNodeDownNodeAvailabilityTest.java
@@ -16,17 +16,11 @@
 package com.palantir.cassandra.multinode;
 
 import com.palantir.atlasdb.keyvalue.api.ClusterAvailabilityStatus;
-import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 
 public class OneNodeDownNodeAvailabilityTest extends AbstractNodeAvailabilityTest {
 
     @Override
     protected ClusterAvailabilityStatus expectedNodeAvailabilityStatus() {
         return ClusterAvailabilityStatus.QUORUM_AVAILABLE;
-    }
-
-    @Override
-    protected KeyValueService getKeyValueService() {
-        return NodesDownTestSetup.kvs;
     }
 }

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/OneNodeDownTableManipulationTest.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/OneNodeDownTableManipulationTest.java
@@ -57,7 +57,7 @@ public class OneNodeDownTableManipulationTest extends AbstractDegradedClusterTes
     public void canCreateTables() {
         TableReference tableToCreate = TableReference.createWithEmptyNamespace("new_table2");
         getTestKvs().createTables(ImmutableMap.of(tableToCreate, AtlasDbConstants.GENERIC_TABLE_METADATA));
-        
+
         assertThat(getTestKvs().getAllTableNames()).contains(tableToCreate);
     }
 

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/OneNodeDownTableManipulationTest.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/OneNodeDownTableManipulationTest.java
@@ -23,75 +23,66 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.palantir.atlasdb.AtlasDbConstants;
-import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
-import com.palantir.atlasdb.keyvalue.api.InsufficientConsistencyException;
+import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool;
+import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueService;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraSchemaLockCleaner;
 import com.palantir.atlasdb.keyvalue.cassandra.SchemaMutationLockTables;
 import com.palantir.atlasdb.keyvalue.cassandra.TracingQueryRunner;
 import com.palantir.atlasdb.keyvalue.impl.TracingPrefsConfig;
 import com.palantir.common.exception.AtlasDbDependencyException;
 
-public class OneNodeDownTableManipulationTest {
-    private static final TableReference NEW_TABLE = TableReference.createWithEmptyNamespace("new_table");
-    private static final TableReference NEW_TABLE2 = TableReference.createWithEmptyNamespace("new_table2");
+public class OneNodeDownTableManipulationTest extends AbstractDegradedClusterTest {
+    private static final TableReference TABLE_TO_DROP = TableReference.createWithEmptyNamespace("table_to_drop");
+    private static final TableReference TABLE_TO_DROP_2 = TableReference.createWithEmptyNamespace("table_to_drop_2");
+
+    @Override
+    void testSetup(CassandraKeyValueService kvs) {
+        kvs.createTable(TEST_TABLE, AtlasDbConstants.GENERIC_TABLE_METADATA);
+        kvs.createTable(TABLE_TO_DROP, AtlasDbConstants.GENERIC_TABLE_METADATA);
+        kvs.createTable(TABLE_TO_DROP_2, AtlasDbConstants.GENERIC_TABLE_METADATA);
+    }
 
     @Test
     public void canCreateTable() {
-        assertThat(OneNodeDownTestSuite.kvs.getAllTableNames()).doesNotContain(NEW_TABLE);
-        OneNodeDownTestSuite.kvs.createTable(NEW_TABLE, AtlasDbConstants.GENERIC_TABLE_METADATA);
+        TableReference tableToCreate = TableReference.createWithEmptyNamespace("new_table");
+        getTestKvs().createTable(tableToCreate, AtlasDbConstants.GENERIC_TABLE_METADATA);
 
-        // This documents and verifies the current behaviour, creating the table in spite of the exception
-        // Seems to be inconsistent with the API
-        assertThat(OneNodeDownTestSuite.kvs.getAllTableNames()).contains(NEW_TABLE);
+        assertThat(getTestKvs().getAllTableNames()).contains(tableToCreate);
     }
 
     @Test
     public void canCreateTables() {
-        assertThat(OneNodeDownTestSuite.kvs.getAllTableNames()).doesNotContain(NEW_TABLE2);
-        OneNodeDownTestSuite.kvs.createTables(ImmutableMap.of(NEW_TABLE2, AtlasDbConstants.GENERIC_TABLE_METADATA));
-
-        // This documents and verifies the current behaviour, creating the table in spite of the exception
-        // Seems to be inconsistent with the API
-        assertThat(OneNodeDownTestSuite.kvs.getAllTableNames()).contains(NEW_TABLE2);
+        TableReference tableToCreate = TableReference.createWithEmptyNamespace("new_table2");
+        getTestKvs().createTables(ImmutableMap.of(tableToCreate, AtlasDbConstants.GENERIC_TABLE_METADATA));
+        
+        assertThat(getTestKvs().getAllTableNames()).contains(tableToCreate);
     }
 
     @Test
     public void dropTableThrows() {
-        assertThat(OneNodeDownTestSuite.kvs.getAllTableNames()).contains(OneNodeDownTestSuite.TEST_TABLE_TO_DROP);
-        assertThatThrownBy(() -> OneNodeDownTestSuite.kvs.dropTable(OneNodeDownTestSuite.TEST_TABLE_TO_DROP))
-                .isExactlyInstanceOf(AtlasDbDependencyException.class)
-                .hasCauseInstanceOf(UncheckedExecutionException.class);
+        assertThatThrownBy(() -> getTestKvs().dropTable(TABLE_TO_DROP))
+                .isInstanceOf(AtlasDbDependencyException.class);
         // This documents and verifies the current behaviour, dropping the table in spite of the exception
         // Seems to be inconsistent with the API
-        assertThat(OneNodeDownTestSuite.kvs.getAllTableNames()).doesNotContain(OneNodeDownTestSuite.TEST_TABLE_TO_DROP);
+        assertThat(getTestKvs().getAllTableNames()).doesNotContain(TABLE_TO_DROP);
     }
 
     @Test
     public void dropTablesThrows() {
-        assertThat(OneNodeDownTestSuite.kvs.getAllTableNames()).contains(OneNodeDownTestSuite.TEST_TABLE_TO_DROP_2);
-        assertThatThrownBy(() -> OneNodeDownTestSuite.kvs.dropTables(
-                ImmutableSet.of(OneNodeDownTestSuite.TEST_TABLE_TO_DROP_2)))
-                .isExactlyInstanceOf(AtlasDbDependencyException.class)
-                .hasCauseInstanceOf(UncheckedExecutionException.class);
+        assertThatThrownBy(() -> getTestKvs().dropTables(ImmutableSet.of(TABLE_TO_DROP_2)))
+                .isInstanceOf(AtlasDbDependencyException.class);
         // This documents and verifies the current behaviour, dropping the table in spite of the exception
         // Seems to be inconsistent with the API
-        assertThat(OneNodeDownTestSuite.kvs.getAllTableNames())
-                .doesNotContain(OneNodeDownTestSuite.TEST_TABLE_TO_DROP_2);
-    }
-
-    @Test
-    public void canCompactInternally() {
-        OneNodeDownTestSuite.kvs.compactInternally(OneNodeDownTestSuite.TEST_TABLE);
+        assertThat(getTestKvs().getAllTableNames()).doesNotContain(TABLE_TO_DROP_2);
     }
 
     @Test
     public void canCleanUpSchemaMutationLockTablesState() throws Exception {
-        ImmutableCassandraKeyValueServiceConfig config = OneNodeDownTestSuite.CONFIG;
-        CassandraClientPool clientPool = OneNodeDownTestSuite.kvs.getClientPool();
+        CassandraKeyValueServiceConfig config = OneNodeDownTestSuite.getConfig(getClass());
+        CassandraClientPool clientPool = getTestKvs().getClientPool();
         SchemaMutationLockTables lockTables = new SchemaMutationLockTables(clientPool, config);
         TracingQueryRunner queryRunner = new TracingQueryRunner(LoggerFactory.getLogger(TracingQueryRunner.class),
                 new TracingPrefsConfig());
@@ -103,16 +94,14 @@ public class OneNodeDownTableManipulationTest {
 
     @Test
     public void truncateTableThrows() {
-        assertThatThrownBy(() -> OneNodeDownTestSuite.kvs.truncateTable(OneNodeDownTestSuite.TEST_TABLE))
-                .isExactlyInstanceOf(InsufficientConsistencyException.class)
-                .hasMessage("Truncating tables requires all Cassandra nodes to be up and available.");
+        assertThatThrownBy(() -> getTestKvs().truncateTable(TEST_TABLE))
+                .isInstanceOf(AtlasDbDependencyException.class);
+
     }
 
     @Test
     public void truncateTablesThrows() {
-        assertThatThrownBy(() -> OneNodeDownTestSuite.kvs.truncateTables(
-                ImmutableSet.of(OneNodeDownTestSuite.TEST_TABLE)))
-                .isExactlyInstanceOf(InsufficientConsistencyException.class)
-                .hasMessage("Truncating tables requires all Cassandra nodes to be up and available.");
+        assertThatThrownBy(() -> getTestKvs().truncateTables(ImmutableSet.of(TEST_TABLE)))
+                .isInstanceOf(AtlasDbDependencyException.class);
     }
 }

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/OneNodeDownTestSuite.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/OneNodeDownTestSuite.java
@@ -15,17 +15,14 @@
  */
 package com.palantir.cassandra.multinode;
 
+import java.util.Arrays;
+
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 import com.google.common.collect.ImmutableList;
-import com.palantir.atlasdb.containers.Containers;
 import com.palantir.atlasdb.containers.ThreeNodeCassandraCluster;
-import com.palantir.atlasdb.keyvalue.cassandra.SchemaMutationLockReleasingRule;
-import com.palantir.flake.ShouldRetry;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -36,20 +33,12 @@ import com.palantir.flake.ShouldRetry;
         OneNodeDownTableManipulationTest.class,
         OneNodeDownNodeAvailabilityTest.class
         })
-@ShouldRetry(numAttempts = 3)
 public final class OneNodeDownTestSuite extends NodesDownTestSetup {
 
-    // Reusing containers when the FlakeRule kicks in.
-    @ClassRule
-    public static final RuleChain ruleChain = RuleChain
-            .outerRule(new Containers(NodesDownTestSetup.class)
-                    .with(new ThreeNodeCassandraCluster()))
-            .around(SchemaMutationLockReleasingRule.createChainedReleaseAndRetry(
-                    NodesDownTestSetup::createCassandraKvs, CONFIG));
-
     @BeforeClass
-    public static void setup() {
-        NodesDownTestSetup.initializeKvsAndDegradeCluster(
+    public static void setup() throws Exception {
+        initializeKvsAndDegradeCluster(
+                Arrays.asList(OneNodeDownTestSuite.class.getAnnotation(Suite.SuiteClasses.class).value()),
                 ImmutableList.of(ThreeNodeCassandraCluster.FIRST_CASSANDRA_CONTAINER_NAME));
     }
 }

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/ThreeNodeDownTestSuite.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/ThreeNodeDownTestSuite.java
@@ -15,26 +15,23 @@
  */
 package com.palantir.cassandra.multinode;
 
+import java.util.Arrays;
+
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 import com.google.common.collect.ImmutableList;
-import com.palantir.atlasdb.containers.Containers;
 import com.palantir.atlasdb.containers.ThreeNodeCassandraCluster;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses(LessThanQuorumNodeAvailabilityTest.class)
 public final class ThreeNodeDownTestSuite extends NodesDownTestSetup {
 
-    @ClassRule
-    public static final Containers CONTAINERS = new Containers(NodesDownTestSetup.class)
-            .with(new ThreeNodeCassandraCluster());
-
     @BeforeClass
-    public static void setup() {
-        NodesDownTestSetup.initializeKvsAndDegradeCluster(
+    public static void setup() throws Exception {
+        initializeKvsAndDegradeCluster(
+                Arrays.asList(ThreeNodeDownTestSuite.class.getAnnotation(Suite.SuiteClasses.class).value()),
                 ImmutableList.of(ThreeNodeCassandraCluster.FIRST_CASSANDRA_CONTAINER_NAME,
                         ThreeNodeCassandraCluster.SECOND_CASSANDRA_CONTAINER_NAME,
                         ThreeNodeCassandraCluster.THIRD_CASSANDRA_CONTAINER_NAME)

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/TwoNodeDownTestSuite.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/TwoNodeDownTestSuite.java
@@ -15,26 +15,23 @@
  */
 package com.palantir.cassandra.multinode;
 
+import java.util.Arrays;
+
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 import com.google.common.collect.ImmutableList;
-import com.palantir.atlasdb.containers.Containers;
 import com.palantir.atlasdb.containers.ThreeNodeCassandraCluster;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses(LessThanQuorumNodeAvailabilityTest.class)
 public final class TwoNodeDownTestSuite extends NodesDownTestSetup {
 
-    @ClassRule
-    public static final Containers CONTAINERS = new Containers(NodesDownTestSetup.class)
-            .with(new ThreeNodeCassandraCluster());
-
     @BeforeClass
-    public static void setup() {
+    public static void setup() throws Exception {
         NodesDownTestSetup.initializeKvsAndDegradeCluster(
+                Arrays.asList(TwoNodeDownTestSuite.class.getAnnotation(Suite.SuiteClasses.class).value()),
                 ImmutableList.of(ThreeNodeCassandraCluster.FIRST_CASSANDRA_CONTAINER_NAME,
                         ThreeNodeCassandraCluster.SECOND_CASSANDRA_CONTAINER_NAME));
     }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
@@ -132,7 +131,6 @@ import com.palantir.common.base.Throwables;
 import com.palantir.common.exception.AtlasDbDependencyException;
 import com.palantir.common.exception.PalantirRuntimeException;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.UnsafeArg;
 import com.palantir.util.paging.AbstractPagingIterable;
 import com.palantir.util.paging.SimpleTokenBackedResultsPage;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
@@ -1123,11 +1121,14 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     }
 
     private void runTruncateInternal(final Set<TableReference> tablesToTruncate) throws TException {
-        clientPool.run(new FunctionCheckedException<CassandraClient, Void, TException>() {
+        clientPool.runWithRetry(new FunctionCheckedException<CassandraClient, Void, TException>() {
             @Override
             public Void apply(CassandraClient client) throws TException {
                 for (TableReference tableRef : tablesToTruncate) {
-                    truncateInternal(client, tableRef);
+                    queryRunner.run(client, tableRef, () -> {
+                        client.truncate(internalTableName(tableRef));
+                        return true;
+                    });
                 }
                 return null;
             }
@@ -1137,37 +1138,6 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                 return "truncateTables(" + tablesToTruncate.size() + " tables)";
             }
         });
-    }
-
-    private void truncateInternal(CassandraClient client, TableReference tableRef) throws TException {
-        for (int tries = 1; tries <= CassandraConstants.MAX_TRUNCATION_ATTEMPTS; tries++) {
-            boolean successful = true;
-            try {
-                queryRunner.run(client, tableRef, () -> {
-                    client.truncate(internalTableName(tableRef));
-                    return true;
-                });
-            } catch (TException e) {
-                log.error("Cluster was unavailable while we attempted a truncate for table "
-                        + "{}; we will try {} additional time(s).",
-                        UnsafeArg.of("table", tableRef.getQualifiedName()),
-                        SafeArg.of("retries", CassandraConstants.MAX_TRUNCATION_ATTEMPTS - tries),
-                        e);
-                if (CassandraConstants.MAX_TRUNCATION_ATTEMPTS - tries == 0) {
-                    throw e;
-                }
-                successful = false;
-                try {
-                    Thread.sleep(new Random()
-                            .nextInt((1 << (CassandraConstants.MAX_TRUNCATION_ATTEMPTS - tries)) - 1) * 1000);
-                } catch (InterruptedException e1) {
-                    Thread.currentThread().interrupt();
-                }
-            }
-            if (successful) {
-                break;
-            }
-        }
     }
 
     /**
@@ -2065,7 +2035,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     }
 
     private boolean doesConfigReplicationFactorMatchWithCluster() {
-        return clientPool.run(client -> {
+        return clientPool.runWithRetry(client -> {
             try {
                 CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client, config);
                 return true;


### PR DESCRIPTION
**Goals (and why)**:
Need to write some new tests for the quorum schema changes, but the existing tests were in bad shape. Also, fix https://github.com/palantir/atlasdb/issues/3390

**Implementation Description (bullets)**:
Each test class gets its own namespace so there is no pollution across tests. Initialization needs to be done before the cluster is degraded, so we use a bit of reflection to do that. 

**Concerns (what feedback would you like?)**:
Along the way noticed that table truncation uses its own retrying strategy for no discernable reason, so refactored that as well -- any concerns there? Also, removed the flake retrying -- if it still flakes,  might be fixed in the follow-up PR, and if not we can reintroduce it (but the old way we did it was broken). 

**Priority (whenever / two weeks / yesterday)**:
Not critical but would be nice

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3495)
<!-- Reviewable:end -->
