### PR TITLE
Add backoff when leadership check hits NO_QUORUM

### DIFF
--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionServiceBuilder.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionServiceBuilder.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.net.HostAndPort;
 import com.palantir.paxos.PaxosAcceptor;
@@ -34,6 +35,7 @@ public class PaxosLeaderElectionServiceBuilder {
     private ExecutorService executor;
     private long pingRateMs;
     private long randomWaitBeforeProposingLeadershipMs;
+    private long noQuorumMaxDelayMs = PaxosLeaderElectionService.DEFAULT_NO_QUORUM_MAX_DELAY_MS;
     private long leaderPingResponseWaitMs;
     private PaxosLeaderElectionEventRecorder eventRecorder = PaxosLeaderElectionEventRecorder.NO_OP;
 
@@ -84,12 +86,19 @@ public class PaxosLeaderElectionServiceBuilder {
         return this;
     }
 
+    public PaxosLeaderElectionServiceBuilder noQuorumMaxDelayMs(long noQuorumMaxDelayMs) {
+        this.noQuorumMaxDelayMs = noQuorumMaxDelayMs;
+        return this;
+    }
+
     public PaxosLeaderElectionServiceBuilder eventRecorder(PaxosLeaderElectionEventRecorder eventRecorder) {
         this.eventRecorder = eventRecorder;
         return this;
     }
 
     public PaxosLeaderElectionService build() {
+        Preconditions.checkState(randomWaitBeforeProposingLeadershipMs >= 0, "randomWaitBeforeProposingLeadershipMs should be positive; was " + randomWaitBeforeProposingLeadershipMs);
+        Preconditions.checkState(noQuorumMaxDelayMs >= 0, "noQuorumMaxDelayMs should be positive; was " + noQuorumMaxDelayMs);
         return new PaxosLeaderElectionService(
                 proposer,
                 knowledge,
@@ -99,6 +108,7 @@ public class PaxosLeaderElectionServiceBuilder {
                 executor,
                 pingRateMs,
                 randomWaitBeforeProposingLeadershipMs,
+                noQuorumMaxDelayMs,
                 leaderPingResponseWaitMs,
                 eventRecorder);
     }


### PR DESCRIPTION
When calling determineLeadershipStatus during blockOnBecomingLeader results in a NO_QUORUM response, wait for a randomly chosen period before re-requesting.

**Goals (and why)**:

We recently encountered an issue where a deployment on legacy clustered lock server hit a thread leak – two of the three lock servers spun up to 30k+ threads and then OOMed. See PDS-71980.

I think it's possible for this to happen as follows:
* blockOnBecomingLeader calls determineLeadershipStatus
* Ultimately this calls PaxosLatestRoundVerifierImpl.isLatestRound
* This calls PaxosQuorumChecker.collectResponses, which spins up a new thread on the executor service for each verifier to be contacted.
* collectResponses blocks until either a quorum of results is obtained, or enough failures occur that no quorum can be achieved.
* In the latter case, we try to reap any outstanding request threads by interrupting them, but this is no guarantee that the interrupt is actually respected (in the case of PDS-71980 the many threads were blocking on obtaining a socket from a socket pool).
* These failures can potentially occur rapidly – if the nack occurs because we received a serialised exception from the remote server, this short-circuit might happen right away.
* This results in a NO_QUORUM return value within blockOnBecomingLeader. At present, when this happens we immediately `continue` in the while loop and call determineLeadershipStatus again.
* So I think potentially we could be hard looping through this code path and leaking request threads each round. At the least, in this case we'd be spamming the other nodes in the cluster.
* So I think backing off makes sense.

**Implementation Description (bullets)**:

* Add a noQuorumMaxDelay parameter to PaxosLeadershipElectionService. 
* Default to 2s but allow this to be configured in PaxosLeadershipElectionServiceBuilder.
* When we hit a NO_QUORUM response, wait for a uniform period between 0s and noQuorumMaxDelay.

**Testing (What was existing testing like?  What have you done to improve it?)**:

* I haven't added any tests here. I'm not sure there's an easy way to test this, and it feels relatively trivial. Happy to add some UTs if the reviewer disagrees and has suggestions for sensible tests.

**Concerns (what feedback would you like?)**:

* Is there anywhere else I should pipe the noQuorumMaxDelay value through from? Or is the builder the right entry point?

**Where should we start reviewing?**:

* It's pretty short – I think it's self explanatory.

**Priority (whenever / two weeks / yesterday)**:

* A week or so should be fine :) Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3496)
<!-- Reviewable:end -->
