### PR TITLE
default oracle config migration state to FINISHED to match docs

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfig.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfig.java
@@ -53,7 +53,10 @@ public abstract class OracleDdlConfig extends DdlConfig {
     @JsonIgnore
     public abstract Optional<Supplier<Long>> overflowIds();
 
-    public abstract OverflowMigrationState overflowMigrationState();
+    @Value.Default
+    public OverflowMigrationState overflowMigrationState() {
+        return OverflowMigrationState.FINISHED;
+    }
 
     @Value.Default
     public boolean enableOracleEnterpriseFeatures() {

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -63,6 +63,10 @@ develop
          - Bumps com.palantir.remoting3 dependency to 3.41.1 from 3.22.0.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3482>`__)
 
+    *    - |changed|
+         - Introduces FINISHED as the default for OracleDdlConfig's overflowMigrationState which matches the documentation specification for new clients.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3500>`__)
+
 ========
 v0.103.0
 ========


### PR DESCRIPTION
**Goals (and why)**:

Introduce a default for OracleDdlConfig's overflowMigrationState which matches the documentation specification for new clients ([here](https://github.com/palantir/atlasdb/blob/f61dde689afb75281b97299751359f973f3ed259/docs/source/configuration/key_value_service_configs/oracle_key_value_service_config.rst#configuration-parameters)).

This will keep new clients from needing to specify something that only matters for legacy clients, and will decrease confusion around Oracle config overrides.

**Concerns (what feedback would you like?)**:

Is there concern around old clients upgrading and inheriting the incorrect value? My thought is that there's been sufficient time to upgrade/I'm not sure if anybody relies on this anymore.


**Priority (whenever / two weeks / yesterday)**:

Eventually

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3500)
<!-- Reviewable:end -->
