### PR TITLE
fix off by one error for quorum healthcheck

### DIFF
--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/LeaderPingHealthCheck.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/LeaderPingHealthCheck.java
@@ -57,7 +57,7 @@ public class LeaderPingHealthCheck {
     }
 
     private int getQuorumSize() {
-        return (leaders.size() + 1) / 2;
+        return PaxosRemotingUtils.getQuorumSize(leaders);
     }
 
     private int getCountPingResults(PingResult value, Map<PingResult, Long> pingResults) {


### PR DESCRIPTION
**Goals (and why)**:
Fix off by one error in Leadership health check. Previous one was returning quorum size one less than it should for even number of servers; such as 2 for 4 timelock servers. Though it is highly unlikely to hit this bug (As no one should have even number of timelock servers).

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
