### PR TITLE
Issue 2559 - AtlasConsole getRange can OOM

### DIFF
--- a/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/module/Table.groovy
+++ b/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/module/Table.groovy
@@ -30,6 +30,8 @@ class Table {
     boolean mutationsEnabled
 
     private static int DEFAULT_JOIN_BATCH_SIZE = 10000;
+    private static final int DEFAULT_RANGE_BATCH_SIZE = 100;
+    private static final String[] DEFAULT_LIST_QUERY_PARAMS = ["start", "end"];
 
     Table(String name, AtlasConsoleServiceWrapper service, boolean mutationsEnabled) {
         this.name = name
@@ -211,9 +213,14 @@ class Table {
      */
     Range getRange(Map rangeInfo = null, TransactionToken token = service.getTransactionToken()) {
         rangeInfo = (rangeInfo == null ? [:] : rangeInfo)
-        def query = [table:name as Object]
+        def query = [table:name as Object, 'batch_size':DEFAULT_RANGE_BATCH_SIZE]
         rangeInfo.each { key, value ->
-            query.put(key as String, convertToListIfNotAlreadyList(value))
+            String keyAsString = (key as String);
+            if (keyAsString in DEFAULT_LIST_QUERY_PARAMS) {
+                query.put(keyAsString, convertToListIfNotAlreadyList(value))
+            } else {
+                query.put(keyAsString, value);
+            }
         }
         return new Range(service, service.getRange(query, token) as Map, token)
     }


### PR DESCRIPTION
**Goals (and why)**:

This PR is a speculative fix to https://github.com/palantir/atlasdb/issues/2559 – table(xyz).getRange() can OOM AtlasConsole.

I have a theory that this is issue is caused because the default batch size of queries
is 2000, which feels a little wide. It's also unfortunate that the batch size isn't configurable.

This commit brings that default down to 100, and adds a configurable batch size
for when we want to trade memory for performance. In future the user can simply pass `batch_size` into the range map.

**Implementation Description (bullets)**:

* Table.getRange actually already passes all the range parameters through to atlas.
* batch_size is a parameter that Atlas will expect and handle.
* However the existing Table.getRange code will convert all range parameters to lists, because `start` and `end` need to be lists but AtlasConsole allows the user to give a singleton.
* This doesn't make sense for `batch_size` – so if the user provides it, atlas console will crash because Atlas doesn't want a list.
* I've added a list of parameters which `Table.getRange` _should_ uplift to lists. The rest will be passed unaltered.
* I've also modified `Table.getRange` to pass a default batch size of 100, which feel safer.

**Testing (What was existing testing like?  What have you done to improve it?)**:

*** I haven't tested this at all. I would really appreciate a conversation around how best to test this, either in code or on a test rig. :) ***

**Concerns (what feedback would you like?)**:

Primarily testing, or maybe alternative methods for providing a batch size if folks have better suggestions.

**Where should we start reviewing?**:

It's a one-class change

**Priority (whenever / two weeks / yesterday)**:

At your convenience.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3502)
<!-- Reviewable:end -->
