### PR TITLE
increase threshold for logging large numbers of transaction lookups

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -80,7 +80,7 @@ public final class AtlasDbConstants {
     public static final long MAX_TS = Long.MAX_VALUE;
 
     public static final long DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS = 60_000;
-    public static final int THRESHOLD_FOR_LOGGING_LARGE_NUMBER_OF_TRANSACTION_LOOKUPS = 10_000;
+    public static final int THRESHOLD_FOR_LOGGING_LARGE_NUMBER_OF_TRANSACTION_LOOKUPS = 10_000_000;
 
     public static final Set<TableReference> hiddenTables = ImmutableSet.of(
             TransactionConstants.TRANSACTION_TABLE,

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -70,6 +70,7 @@ develop
          - Improved visibility into sources of high DB load.
            We log when a query returns a high number of timestamps that need to be looked up in the database, and tag some additional metrics with the tablename we were querying.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3488>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3504>`__)
 
 ========
 v0.103.0


### PR DESCRIPTION
increase threshold for logging large numbers of transaction table lookups so it doesn't normally fire.

**Goals (and why)**: Concerned that we will log too often at large users.

**Implementation Description (bullets)**: Increase the threshold to something we should never hit, we can then decrease the value if we want to enable the logging (it is live reloaded).

**Testing (What was existing testing like?  What have you done to improve it?)**: No testing before, I've not added any.

**Concerns (what feedback would you like?)**: Is the value high enough.

**Where should we start reviewing?**: 4 character change, start there.

**Priority (whenever / two weeks / yesterday)**: today (we don't want to release with the smaller value)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3504)
<!-- Reviewable:end -->
