### PR TITLE
Reduce startup independence test execution time

### DIFF
--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/StartupIndependenceMultipleCassandraEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/StartupIndependenceMultipleCassandraEteTest.java
@@ -49,15 +49,6 @@ public class StartupIndependenceMultipleCassandraEteTest {
     }
 
     @Test
-    public void atlasStartsWithCassandraDownAndInitializesWithAllNodes()
-            throws IOException, InterruptedException {
-        StartupIndependenceUtils.restartAtlasWithChecks();
-        StartupIndependenceUtils.assertNotInitializedExceptionIsThrownAndMappedCorrectly();
-        StartupIndependenceUtils.startCassandraNodes(ALL_CASSANDRA_NODES);
-        StartupIndependenceUtils.assertSatisfiedWithin(240, StartupIndependenceUtils::canPerformTransaction);
-    }
-
-    @Test
     public void atlasStartsWithCassandraDownAndInitializesWithQuorum()
             throws IOException, InterruptedException {
         StartupIndependenceUtils.restartAtlasWithChecks();
@@ -70,8 +61,6 @@ public class StartupIndependenceMultipleCassandraEteTest {
     public void atlasInitializesSynchronouslyIfCassandraIsInGoodState() throws InterruptedException, IOException {
         StartupIndependenceUtils.startCassandraNodes(ALL_CASSANDRA_NODES);
         StartupIndependenceUtils.verifyCassandraIsSettled();
-        StartupIndependenceUtils.restartAtlasWithChecks();
-        assertTrue(StartupIndependenceUtils.canPerformTransaction());
 
         StartupIndependenceUtils.killCassandraNodes(ONE_CASSANDRA_NODE);
         StartupIndependenceUtils.restartAtlasWithChecks();

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/StartupIndependenceUtils.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/StartupIndependenceUtils.java
@@ -143,6 +143,7 @@ public final class StartupIndependenceUtils {
         executorService.invokeAll(nodes.stream()
                 .map(cassandraContainer -> Executors.callable(() -> operator.nodeOperation(cassandraContainer)))
                 .collect(Collectors.toList()));
+        executorService.shutdown();
     }
 
     private interface CassandraContainerOperator {


### PR DESCRIPTION
**Goals (and why)**:
They are very long and sometimes also flake. This removes the all nodes test that is basically subsumed by the quorum test, and simplifies the third test in a similar way.

**Priority (whenever / two weeks / yesterday)**:
let's get it in asap to make everyone's life easier

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3506)
<!-- Reviewable:end -->
