### PR TITLE
TargetedSweepMetrics#millisSinceLastSweptTs updates at least every 5 …

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/metrics/TargetedSweepMetrics.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/metrics/TargetedSweepMetrics.java
@@ -142,7 +142,8 @@ public class TargetedSweepMetrics {
                     new AggregatingVersionedMetric<>(lastSweptTsSupplier), tag);
 
             Supplier<Long> millisSinceLastSweptTs = new CachedComposedSupplier<>(
-                    sweptTs -> estimateMillisSinceTs(sweptTs, wallClock, tsToMillis), lastSweptTs::getVersionedValue);
+                    sweptTs -> estimateMillisSinceTs(sweptTs, wallClock, tsToMillis), lastSweptTs::getVersionedValue,
+                    recomputeMillis, wallClock);
 
             register(AtlasDbMetricNames.LAG_MILLIS, millisSinceLastSweptTs::get, tag);
         }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/metrics/TargetedSweepMetricsTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/metrics/TargetedSweepMetricsTest.java
@@ -245,7 +245,7 @@ public class TargetedSweepMetricsTest {
     @Test
     public void millisSinceLastSweptDoesNotUpdateWithoutWaiting() {
         metricsManager = MetricsManagers.createForTests();
-        metrics = TargetedSweepMetrics.createWithClock(metricsManager, kvs, () -> clockTime, 1_000_000);
+        metrics = TargetedSweepMetrics.createWithClock(metricsManager, kvs, () -> clockTime, 1_000);
 
         metrics.updateEnqueuedWrites(CONS_ZERO, 1, 200);
         metrics.updateProgressForShard(CONS_ZERO, 100);
@@ -258,6 +258,9 @@ public class TargetedSweepMetricsTest {
         assertThat(metricsManager).hasMillisSinceLastSweptConservativeEqualTo(50L);
         clockTime += 100;
         assertThat(metricsManager).hasMillisSinceLastSweptConservativeEqualTo(50L);
+
+        clockTime += 1000; // clock is now 1201
+        assertThat(metricsManager).hasMillisSinceLastSweptConservativeEqualTo(1151L);
     }
 
     @Test

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -51,6 +51,10 @@ develop
          - Change
 
     *    - |fixed|
+         - TargetedSweepMetrics#millisSinceLastSweptTs updates periodically, even if targeted sweep is failing to successfully run.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3507>`__)
+
+    *    - |fixed|
          - The Jepsen tests no longer assume that users have installed Python or DateUtil, and will install these itself if needed.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3461>`__)
 


### PR DESCRIPTION
…minutes

Because if sweep isn't successfully running the lag should still increase.

**Goals (and why)**:

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3507)
<!-- Reviewable:end -->
