### PR TITLE
Gozakdag/leadership observer

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/util/MetricsManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/util/MetricsManager.java
@@ -16,9 +16,11 @@
 package com.palantir.atlasdb.util;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
@@ -209,5 +211,13 @@ public class MetricsManager {
 
         registeredTaggedMetrics.forEach(taggedMetricRegistry::remove);
         registeredTaggedMetrics.clear();
+    }
+
+    public synchronized void deregisterTaggedMetrics(Predicate<MetricName> predicate) {
+        List<MetricName> metricsToRemove = taggedMetricRegistry.getMetrics().keySet().stream()
+                .filter(predicate)
+                .collect(Collectors.toList());
+
+        metricsToRemove.forEach(taggedMetricRegistry::remove);
     }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbMetricNames.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbMetricNames.java
@@ -62,4 +62,7 @@ public final class AtlasDbMetricNames {
 
     public static final String SWEEP_OUTCOME = "outcome";
     public static final String TAG_OUTCOME = "status";
+
+    public static final String TAG_CURRENT_SUSPECTED_LEADER = "isCurrentSuspectedLeader";
+    public static final String TAG_CLIENT = "client";
 }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
@@ -112,11 +112,9 @@ public final class Leaders {
             String userAgent) {
         UUID leaderUuid = UUID.randomUUID();
 
+        AsyncLeadershipObserver leadershipObserver = AsyncLeadershipObserver.create();
         PaxosLeadershipEventRecorder leadershipEventRecorder = PaxosLeadershipEventRecorder.create(
-                metricsManager.getRegistry(), leaderUuid.toString());
-
-        AsyncLeadershipObserver leadershipObserver = new AsyncLeadershipObserver();
-        leadershipEventRecorder.attachObserver(leadershipObserver);
+                metricsManager.getRegistry(), leaderUuid.toString(), leadershipObserver);
 
         PaxosAcceptor ourAcceptor = AtlasDbMetrics.instrument(metricsManager.getRegistry(),
                 PaxosAcceptor.class,

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
@@ -44,7 +44,9 @@ import com.palantir.atlasdb.http.UserAgents;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.common.concurrent.PTExecutors;
+import com.palantir.leader.AsyncLeadershipObserver;
 import com.palantir.leader.LeaderElectionService;
+import com.palantir.leader.LeadershipObserver;
 import com.palantir.leader.PaxosLeaderElectionService;
 import com.palantir.leader.PaxosLeaderElectionServiceBuilder;
 import com.palantir.leader.PaxosLeadershipEventRecorder;
@@ -112,6 +114,9 @@ public final class Leaders {
 
         PaxosLeadershipEventRecorder leadershipEventRecorder = PaxosLeadershipEventRecorder.create(
                 metricsManager.getRegistry(), leaderUuid.toString());
+
+        AsyncLeadershipObserver leadershipObserver = new AsyncLeadershipObserver();
+        leadershipEventRecorder.attachObserver(leadershipObserver);
 
         PaxosAcceptor ourAcceptor = AtlasDbMetrics.instrument(metricsManager.getRegistry(),
                 PaxosAcceptor.class,
@@ -182,6 +187,7 @@ public final class Leaders {
                 .ourLearner(ourLearner)
                 .leaderElectionService(leaderElectionService)
                 .pingableLeader(pingableLeader)
+                .leadershipObserver(leadershipObserver)
                 .build();
     }
 
@@ -233,6 +239,7 @@ public final class Leaders {
         PaxosLearner ourLearner();
         LeaderElectionService leaderElectionService();
         PingableLeader pingableLeader();
+        LeadershipObserver leadershipObserver();
     }
 
     @Value.Immutable

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -85,6 +85,10 @@ develop
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3488>`__)
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3504>`__)
 
+    *    - |fixed|
+         - Fixed and issue in timelock where followers were publishing metrics with ``isCurrentSuspectedLeader`` tag set to ``true``.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3509>`__)
+
 ========
 v0.103.0
 ========

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -86,7 +86,7 @@ develop
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3504>`__)
 
     *    - |fixed|
-         - Fixed and issue in timelock where followers were publishing metrics with ``isCurrentSuspectedLeader`` tag set to ``true``.
+         - Fixed an issue in timelock where followers were publishing metrics with ``isCurrentSuspectedLeader`` tag set to ``true``.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3509>`__)
 
 ========

--- a/leader-election-impl/src/main/java/com/palantir/leader/AsyncLeadershipObserver.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/AsyncLeadershipObserver.java
@@ -30,6 +30,10 @@ public class AsyncLeadershipObserver implements LeadershipObserver {
     private final List<Runnable> followerTasks = new CopyOnWriteArrayList<>();
 
     public static AsyncLeadershipObserver create() {
+        /**
+         * This executor should be kept single threaded to ensure ordered execution of tasks
+         * which is guaranteed by the API contract of {@link LeadershipObserver}
+         */
         return new AsyncLeadershipObserver(PTExecutors.newSingleThreadExecutor(true));
     }
 

--- a/leader-election-impl/src/main/java/com/palantir/leader/AsyncLeadershipObserver.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/AsyncLeadershipObserver.java
@@ -24,7 +24,7 @@ import com.palantir.common.concurrent.PTExecutors;
 
 public class AsyncLeadershipObserver implements LeadershipObserver {
 
-    private ExecutorService executorService = PTExecutors.newSingleThreadExecutor();
+    private ExecutorService executorService = PTExecutors.newSingleThreadExecutor(true);
     private List<Runnable> leaderTasks = new ArrayList<>();
     private List<Runnable> followerTasks = new ArrayList<>();
 

--- a/leader-election-impl/src/main/java/com/palantir/leader/AsyncLeadershipObserver.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/AsyncLeadershipObserver.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.leader;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+import com.palantir.common.concurrent.PTExecutors;
+
+public class AsyncLeadershipObserver implements LeadershipObserver {
+
+    private ExecutorService executorService = PTExecutors.newSingleThreadExecutor();
+    private List<Runnable> leaderTasks = new ArrayList<>();
+    private List<Runnable> followerTasks = new ArrayList<>();
+
+    @Override
+    public void gainedLeadership() {
+        executorService.execute(this::executeLeaderTasks);
+    }
+
+    @Override
+    public void lostLeadership() {
+        executorService.execute(this::executeFollowerTasks);
+    }
+
+    @Override
+    public synchronized void executeWhenGainedLeadership(Runnable task) {
+        leaderTasks.add(task);
+    }
+
+    @Override
+    public synchronized void executeWhenLostLeadership(Runnable task) {
+        followerTasks.add(task);
+    }
+
+    private void executeFollowerTasks() {
+        followerTasks.forEach(Runnable::run);
+    }
+
+    private void executeLeaderTasks() {
+        leaderTasks.forEach(Runnable::run);
+    }
+}

--- a/leader-election-impl/src/main/java/com/palantir/leader/LeadershipObserver.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/LeadershipObserver.java
@@ -20,6 +20,15 @@ public interface LeadershipObserver {
     void gainedLeadership();
     void lostLeadership();
 
+    /**
+     * Guarantees ordered execution of the submitted tasks.
+     * @param task to be executed after gaining leadership.
+     */
     void executeWhenGainedLeadership(Runnable task);
+
+    /**
+     * Guarantees ordered execution of the submitted tasks.
+     * @param task to be executed after losing leadership.
+     */
     void executeWhenLostLeadership(Runnable task);
 }

--- a/leader-election-impl/src/main/java/com/palantir/leader/LeadershipObserver.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/LeadershipObserver.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.leader;
+
+public interface LeadershipObserver {
+    void gainedLeadership();
+    void lostLeadership();
+
+    void executeWhenGainedLeadership(Runnable task);
+    void executeWhenLostLeadership(Runnable task);
+}

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionEventRecorder.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionEventRecorder.java
@@ -43,6 +43,8 @@ public interface PaxosLeaderElectionEventRecorder {
     /** Called when we successfully contacted the suspected leader, but it reported that it was not the leader. */
     void recordLeaderPingReturnedFalse();
 
+    void attachObserver(LeadershipObserver leadershipObserver);
+
     PaxosLeaderElectionEventRecorder NO_OP = new PaxosLeaderElectionEventRecorder() {
         @Override
         public void recordNotLeading(PaxosValue value) { }
@@ -64,6 +66,9 @@ public interface PaxosLeaderElectionEventRecorder {
 
         @Override
         public void recordLeaderPingReturnedFalse() { }
+
+        @Override
+        public void attachObserver(LeadershipObserver ignored) { }
     };
 
 }

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionEventRecorder.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionEventRecorder.java
@@ -43,8 +43,6 @@ public interface PaxosLeaderElectionEventRecorder {
     /** Called when we successfully contacted the suspected leader, but it reported that it was not the leader. */
     void recordLeaderPingReturnedFalse();
 
-    void attachObserver(LeadershipObserver leadershipObserver);
-
     PaxosLeaderElectionEventRecorder NO_OP = new PaxosLeaderElectionEventRecorder() {
         @Override
         public void recordNotLeading(PaxosValue value) { }
@@ -66,9 +64,6 @@ public interface PaxosLeaderElectionEventRecorder {
 
         @Override
         public void recordLeaderPingReturnedFalse() { }
-
-        @Override
-        public void attachObserver(LeadershipObserver ignored) { }
     };
 
 }

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeadershipEventRecorder.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeadershipEventRecorder.java
@@ -16,8 +16,6 @@
 
 package com.palantir.leader;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 
 import javax.annotation.concurrent.GuardedBy;

--- a/leader-election-impl/src/test/java/com/palantir/leader/AsyncLeadershipObserverTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/AsyncLeadershipObserverTest.java
@@ -16,12 +16,12 @@
 
 package com.palantir.leader;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 public class AsyncLeadershipObserverTest {
 
@@ -29,25 +29,40 @@ public class AsyncLeadershipObserverTest {
     private Runnable followerTask = mock(Runnable.class);
     private LeadershipObserver leadershipObserver;
 
-
     @Before
     public void setUp() {
         leadershipObserver = new AsyncLeadershipObserver();
-        leadershipObserver.executeWhenGainedLeadership(leaderTask);
-        leadershipObserver.executeWhenLostLeadership(followerTask);
     }
 
     @Test
     public void executeLeaderTasksAfterBecomingLeader() {
+        leadershipObserver.executeWhenGainedLeadership(leaderTask);
         gainLeadership();
+
         verify(leaderTask, times(1)).run();
-        verify(followerTask, times(0)).run();
     }
 
     @Test
     public void executeFollowerTasksAfterLosingLeadership() {
+        leadershipObserver.executeWhenLostLeadership(followerTask);
         loseLeadership();
+
         verify(followerTask, times(1)).run();
+    }
+
+    @Test
+    public void doNotRunFollowerTasksAfterBecomingLeader() {
+        leadershipObserver.executeWhenLostLeadership(followerTask);
+        gainLeadership();
+
+        verify(followerTask, times(0)).run();
+    }
+
+    @Test
+    public void doNotRunLeaderTasksAfterLosingLeadership() {
+        leadershipObserver.executeWhenGainedLeadership(leaderTask);
+        loseLeadership();
+
         verify(leaderTask, times(0)).run();
     }
 

--- a/leader-election-impl/src/test/java/com/palantir/leader/AsyncLeadershipObserverTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/AsyncLeadershipObserverTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.leader;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+public class AsyncLeadershipObserverTest {
+
+    private Runnable leaderTask = mock(Runnable.class);
+    private Runnable followerTask = mock(Runnable.class);
+    private LeadershipObserver leadershipObserver;
+
+
+    @Before
+    public void setUp() {
+        leadershipObserver = new AsyncLeadershipObserver();
+        leadershipObserver.executeWhenGainedLeadership(leaderTask);
+        leadershipObserver.executeWhenLostLeadership(followerTask);
+    }
+
+    @Test
+    public void executeLeaderTasksAfterBecomingLeader() {
+        gainLeadership();
+        verify(leaderTask, times(1)).run();
+        verify(followerTask, times(0)).run();
+    }
+
+    @Test
+    public void executeFollowerTasksAfterLosingLeadership() {
+        loseLeadership();
+        verify(followerTask, times(1)).run();
+        verify(leaderTask, times(0)).run();
+    }
+
+    private void gainLeadership() {
+        leadershipObserver.gainedLeadership();
+    }
+
+    private void loseLeadership() {
+        leadershipObserver.lostLeadership();
+    }
+}

--- a/leader-election-impl/src/test/java/com/palantir/leader/AsyncLeadershipObserverTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/AsyncLeadershipObserverTest.java
@@ -47,6 +47,7 @@ public class AsyncLeadershipObserverTest {
     public void executeLeaderTasksAfterBecomingLeader() {
         registerFollowerAndLeaderTasks();
         gainLeadership();
+        waitForTasksToFinish();
 
         verify(leaderTask).run();
     }
@@ -55,17 +56,19 @@ public class AsyncLeadershipObserverTest {
     public void executeFollowerTasksAfterLosingLeadership() {
         registerFollowerAndLeaderTasks();
         loseLeadership();
+        waitForTasksToFinish();
 
         verify(followerTask).run();
     }
 
     @Test
-    public void executesAllSubmittedTasks() {
+    public void executeAllSubmittedTasks() {
         Runnable secondLeaderTask = mock(Runnable.class);
 
         leadershipObserver.executeWhenGainedLeadership(leaderTask);
         leadershipObserver.executeWhenGainedLeadership(secondLeaderTask);
         gainLeadership();
+        waitForTasksToFinish();
 
         verify(leaderTask).run();
         verify(secondLeaderTask).run();
@@ -78,11 +81,13 @@ public class AsyncLeadershipObserverTest {
 
     private void gainLeadership() {
         leadershipObserver.gainedLeadership();
-        executorService.runUntilIdle();
     }
 
     private void loseLeadership() {
         leadershipObserver.lostLeadership();
+    }
+
+    private void waitForTasksToFinish() {
         executorService.runUntilIdle();
     }
 }

--- a/leader-election-impl/src/test/java/com/palantir/leader/LeadershipEventRecorderTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/LeadershipEventRecorderTest.java
@@ -192,6 +192,32 @@ public class LeadershipEventRecorderTest {
         verify(events).gainedLeadershipFor(ROUND_1_LEADING);
     }
 
+    @Test
+    public void notifiesObserverIfGainedLeadership() {
+        LeadershipObserver observer = mock(LeadershipObserver.class);
+
+        recorder.attachObserver(observer);
+        recorder.recordRound(ROUND_1_LEADING);
+
+        verify(events).gainedLeadershipFor(ROUND_1_LEADING);
+        verify(observer, times(1)).gainedLeadership();
+    }
+
+    @Test
+    public void notifiesObserverIfLostLeadership() {
+        LeadershipObserver observer = mock(LeadershipObserver.class);
+
+        recorder.attachObserver(observer);
+        recorder.recordRound(ROUND_1_LEADING);
+        recorder.recordRound(ROUND_2_NOT_LEADING);
+
+        verify(events).gainedLeadershipFor(ROUND_1_LEADING);
+        verify(events).lostLeadershipFor(ROUND_1_LEADING);
+
+        verify(observer, times(1)).gainedLeadership();
+        verify(observer, times(1)).lostLeadership();
+    }
+
     private static PaxosValue round(long sequence, boolean leading) {
         return new PaxosValue(leading ? LEADER_ID : "other-leader", sequence, null);
     }

--- a/leader-election-impl/src/test/java/com/palantir/leader/LeadershipEventRecorderTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/LeadershipEventRecorderTest.java
@@ -21,6 +21,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import java.util.Optional;
+
 import org.junit.After;
 import org.junit.Test;
 
@@ -32,7 +34,9 @@ public class LeadershipEventRecorderTest {
     private static final String LEADER_ID = "foo";
 
     private final LeadershipEvents events = mock(LeadershipEvents.class);
-    private final PaxosLeadershipEventRecorder recorder = new PaxosLeadershipEventRecorder(events, LEADER_ID);
+    private final LeadershipObserver observer = mock(LeadershipObserver.class);
+    private final PaxosLeadershipEventRecorder recorder =
+            new PaxosLeadershipEventRecorder(events, LEADER_ID, Optional.of(observer));
 
     private static final PaxosValue ROUND_1_LEADING = round(1, true);
     private static final PaxosValue ROUND_2_LEADING = round(2, true);
@@ -194,9 +198,6 @@ public class LeadershipEventRecorderTest {
 
     @Test
     public void notifiesObserverIfGainedLeadership() {
-        LeadershipObserver observer = mock(LeadershipObserver.class);
-
-        recorder.attachObserver(observer);
         recorder.recordRound(ROUND_1_LEADING);
 
         verify(events).gainedLeadershipFor(ROUND_1_LEADING);
@@ -205,9 +206,6 @@ public class LeadershipEventRecorderTest {
 
     @Test
     public void notifiesObserverIfLostLeadership() {
-        LeadershipObserver observer = mock(LeadershipObserver.class);
-
-        recorder.attachObserver(observer);
         recorder.recordRound(ROUND_1_LEADING);
         recorder.recordRound(ROUND_2_NOT_LEADING);
 

--- a/leader-election-impl/src/test/java/com/palantir/leader/LeadershipEventRecorderTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/LeadershipEventRecorderTest.java
@@ -201,7 +201,7 @@ public class LeadershipEventRecorderTest {
         recorder.recordRound(ROUND_1_LEADING);
 
         verify(events).gainedLeadershipFor(ROUND_1_LEADING);
-        verify(observer, times(1)).gainedLeadership();
+        verify(observer).gainedLeadership();
     }
 
     @Test
@@ -212,8 +212,8 @@ public class LeadershipEventRecorderTest {
         verify(events).gainedLeadershipFor(ROUND_1_LEADING);
         verify(events).lostLeadershipFor(ROUND_1_LEADING);
 
-        verify(observer, times(1)).gainedLeadership();
-        verify(observer, times(1)).lostLeadership();
+        verify(observer).gainedLeadership();
+        verify(observer).lostLeadership();
     }
 
     private static PaxosValue round(long sequence, boolean leading) {

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/AsyncTimeLockServicesCreator.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/AsyncTimeLockServicesCreator.java
@@ -101,8 +101,8 @@ public class AsyncTimeLockServicesCreator implements TimeLockServicesCreator {
     }
 
     private static Predicate<MetricName> withTagIsCurrentSuspectedLeader(boolean currentLeader) {
-        return metricName -> metricName.safeTags().containsKey(AtlasDbMetricNames.TAG_CURRENT_SUSPECTED_LEADER) &&
-                metricName.safeTags().get(AtlasDbMetricNames.TAG_CURRENT_SUSPECTED_LEADER)
+        return metricName -> metricName.safeTags().containsKey(AtlasDbMetricNames.TAG_CURRENT_SUSPECTED_LEADER)
+                && metricName.safeTags().get(AtlasDbMetricNames.TAG_CURRENT_SUSPECTED_LEADER)
                         .equals(String.valueOf(currentLeader));
     }
 

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/AsyncTimeLockServicesCreator.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/AsyncTimeLockServicesCreator.java
@@ -16,6 +16,7 @@
 
 package com.palantir.timelock.paxos;
 
+import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -101,9 +102,10 @@ public class AsyncTimeLockServicesCreator implements TimeLockServicesCreator {
     }
 
     private static Predicate<MetricName> withTagIsCurrentSuspectedLeader(boolean currentLeader) {
-        return metricName -> metricName.safeTags().containsKey(AtlasDbMetricNames.TAG_CURRENT_SUSPECTED_LEADER)
-                && metricName.safeTags().get(AtlasDbMetricNames.TAG_CURRENT_SUSPECTED_LEADER)
-                        .equals(String.valueOf(currentLeader));
+        return metricName ->
+                Optional.ofNullable(metricName.safeTags().get(AtlasDbMetricNames.TAG_CURRENT_SUSPECTED_LEADER))
+                        .filter(x -> x.equals(String.valueOf(currentLeader)))
+                        .isPresent();
     }
 
     private AsyncTimelockService createRawAsyncTimelockService(


### PR DESCRIPTION
**Goals (and why)**:
We observed that "isCurrentSuspectedLeader" tag is stuck to be 'true', even after losing leadership. This pr mainly aims to fix this issue.

**Implementation Description (bullets)**:
In a timelock cluster of A, B, C; let's pick A as the leader first. In that case, any request coming to timelockServices in A will be instrumented, causing to publish a metric with `isCurrentSuspectedLeader` set to `true`. If A loses leadership to B, B will start to publish those metrics, but A will continue to emit those metrics with `isCurrentSuspectedLeader`, and it will not set it to false (as we are only applying the tag function if request is successful, and requests coming to a follower will not succeed). Even if it was set to false, we would end up having two separate tags, one set to true, one set to false. So the solution is to deregister those metrics from the node, when it loses leadership.

This pr implements a `LeadershipObserver`, which is attached to `PaxosLeaderElectionEventsRecorder`. Any class having access to this observer can now submit tasks that will be executed on either losing or gaining leadership. Tasks are executed async in a separate thread; as I did not want to block paxos processes in case of having a long running task submitted to `LeadershipObserver`.

Currently we are only submitting the task that deregisters the leadership metrics when leadership is lost.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Unit tests for `AsyncLeadershipObserver`.
- Addition to unit tests for LeadershipEventRecorder to make sure observer is notified.

**Concerns (what feedback would you like?)**:
- Is the executorService used correctly? Is it an overkill to use separate thread for the observer.
- Can I have the same functionality with less change on public API's?

**Where should we start reviewing?**:
`LeadershipObserver`

**Priority (whenever / two weeks / yesterday)**:
A week.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3509)
<!-- Reviewable:end -->
