### PR TITLE
Catch unlock failures in targeted sweep

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/TargetedSweeper.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/TargetedSweeper.java
@@ -255,10 +255,10 @@ public class TargetedSweeper implements MultiTableSweepQueueWriter, BackgroundSw
 
         private void logUnlockException(Throwable th, Optional<TargetedSweeperLock> maybeLock) {
             if (maybeLock.isPresent()) {
-                log.warn("Failed to unlock targeted sweep lock for {}.",
+                log.info("Failed to unlock targeted sweep lock for {}.",
                         SafeArg.of("shardStrategy", maybeLock.get().getShardAndStrategy().toText()), th);
             } else {
-                log.warn("Failed to unlock targeted sweep lock for sweep strategy {}.",
+                log.info("Failed to unlock targeted sweep lock for sweep strategy {}.",
                         SafeArg.of("sweepStrategy", sweepStrategy), th);
             }
         }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/TargetedSweeper.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/TargetedSweeper.java
@@ -222,7 +222,11 @@ public class TargetedSweeper implements MultiTableSweepQueueWriter, BackgroundSw
                 metrics.registerOccurrenceOf(SweepOutcome.ERROR);
                 logException(th, maybeLock);
             } finally {
-                maybeLock.ifPresent(TargetedSweeperLock::unlock);
+                try {
+                    maybeLock.ifPresent(TargetedSweeperLock::unlock);
+                } catch (Throwable th) {
+                    logUnlockException(th, maybeLock);
+                }
             }
         }
 
@@ -245,6 +249,16 @@ public class TargetedSweeper implements MultiTableSweepQueueWriter, BackgroundSw
                         SafeArg.of("shardStrategy", maybeLock.get().getShardAndStrategy().toText()), th);
             } else {
                 log.warn("Targeted sweep for sweep strategy {} failed and will be retried later.",
+                        SafeArg.of("sweepStrategy", sweepStrategy), th);
+            }
+        }
+
+        private void logUnlockException(Throwable th, Optional<TargetedSweeperLock> maybeLock) {
+            if (maybeLock.isPresent()) {
+                log.warn("Failed to unlock targeted sweep lock for {}.",
+                        SafeArg.of("shardStrategy", maybeLock.get().getShardAndStrategy().toText()), th);
+            } else {
+                log.warn("Failed to unlock targeted sweep lock for sweep strategy {}.",
                         SafeArg.of("sweepStrategy", sweepStrategy), th);
             }
         }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -85,6 +85,10 @@ develop
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3488>`__)
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3504>`__)
 
+    *    - |fixed|
+         - Targeted sweep threads will no longer die if Timelock unlock calls fail.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3510>`__)
+
 ========
 v0.103.0
 ========


### PR DESCRIPTION
**Goals (and why)**:
Fix potentially observed issue where Timelock downtime/issues can lead to targeted sweep threads dying. Exceptions thrown in a finally block do get thrown, and we've seen cases where unlock failures were logged by background sweep threads right around the time that some targeted sweep threads disappeared.

**Implementation Description (bullets)**:
Try/catch around the unlock statement

**Testing (What was existing testing like?  What have you done to improve it?)**:
No tests exist for this specific method, but they wouldn't have caught this issue without the correct test being written. I believe that this is sufficiently simple to just rely on code inspection, but can refactor things to add a `DeterministicScheduler` if preferred. This existing issue could already have been caught with a careful review.

**Priority (whenever / two weeks / yesterday)**:
Soon

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3510)
<!-- Reviewable:end -->
