### PR TITLE
Shuffle Sweep Priority Overrides

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/priority/NextTableToSweepProvider.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/priority/NextTableToSweepProvider.java
@@ -87,7 +87,7 @@ public class NextTableToSweepProvider {
 
         List<TableReference> tablesOrderedByPriority = orderTablesByPriority(tablesWithNonZeroPriority);
 
-        Optional<TableToSweep> chosenTable = attemptToChooseTableFromList(tablesOrderedByPriority,
+        Optional<TableToSweep> chosenTable = attemptToChooseTableFromPrioritisedList(tablesOrderedByPriority,
                 "it has a high priority score");
 
         return logDecision(chosenTable, scores, overrideConfig);
@@ -103,10 +103,11 @@ public class NextTableToSweepProvider {
         // exists, but the priority table reference list is expected to be small.
         Collections.shuffle(priorityTableRefs);
 
-        return attemptToChooseTableFromList(priorityTableRefs, "it is on the sweep priority list");
+        return attemptToChooseTableFromPrioritisedList(priorityTableRefs, "it is on the sweep priority list");
     }
 
-    private Optional<TableToSweep> attemptToChooseTableFromList(List<TableReference> priorityTables, String reason) {
+    private Optional<TableToSweep> attemptToChooseTableFromPrioritisedList(
+            List<TableReference> priorityTables, String reason) {
         for (TableReference tableRefToSweep : priorityTables) {
             SingleLockService sweepLockForTable = SingleLockService.createNamedLockServiceForTable(
                     lockService, BackgroundSweepThread.TABLE_LOCK_PREFIX, tableRefToSweep);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/priority/NextTableToSweepProvider.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/priority/NextTableToSweepProvider.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.sweep.priority;
 
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -96,6 +97,12 @@ public class NextTableToSweepProvider {
         List<TableReference> priorityTableRefs = overrideConfig.priorityTablesAsList().stream()
                 .map(TableReference::createFromFullyQualifiedName)
                 .collect(Collectors.toList());
+
+        // If there are multiple priority tables, we don't want to consistently use the same ordering.
+        // It is true that this operation is O(list length) while an O(min(list length, cluster size)) algorithm
+        // exists, but the priority table reference list is expected to be small.
+        Collections.shuffle(priorityTableRefs);
+
         return attemptToChooseTableFromList(priorityTableRefs, "it is on the sweep priority list");
     }
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -89,6 +89,11 @@ develop
          - Targeted sweep threads will no longer die if Timelock unlock calls fail.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3510>`__)
 
+    *    - |fixed|
+         - Background sweep will now choose between priority tables uniform randomly if there are multiple priority tables.
+           Previously, if multiple priority tables were specified, background sweep would repeatedly pick the same table to be swept, meaning that the other priority tables would all never be swept.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3510>`__)
+
 ========
 v0.103.0
 ========


### PR DESCRIPTION
**Goals (and why)**:
- Address a bug found in PDS-74117
- Fix #3511 

**Implementation Description (bullets)**:
- Shuffle the list of tables before trying to lock them.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Existing testing did not have any tests that cover interactions between _multiple_ calls to the priority table. This change adds one test that used to fail but now passes.

**Concerns (what feedback would you like?)**:
- Shuffle is not an efficient algorithm (O(priority list size) instead of likely O(min(priority list size, number of sweep threads))) but I think it's fine as the priority list should be small anyway

**Where should we start reviewing?**: NextTableToSweepProviderTest

**Priority (whenever / two weeks / yesterday)**: this week

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3512)
<!-- Reviewable:end -->
