### PR TITLE
[no release notes] fix multiplexingCompletionService test flake

### DIFF
--- a/atlasdb-commons/src/test/java/com/palantir/common/concurrent/MultiplexingCompletionServiceTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/common/concurrent/MultiplexingCompletionServiceTest.java
@@ -160,9 +160,12 @@ public class MultiplexingCompletionServiceTest {
 
     @Test
     public void valuesMayBeRetrievedFromFuturesReturned() throws ExecutionException, InterruptedException {
+        DeterministicScheduler scheduler = new DeterministicScheduler();
         MultiplexingCompletionService<String, Integer> boundedService = MultiplexingCompletionService.create(
-                ImmutableMap.of(KEY_1, createBoundedExecutor(2)));
+                ImmutableMap.of(KEY_1, scheduler));
         Future<Integer> returnedFuture = boundedService.submit(KEY_1, () -> 1234567);
+
+        scheduler.runUntilIdle();
 
         assertThat(returnedFuture.get()).isEqualTo(1234567);
         assertThat(boundedService.poll().get()).isEqualTo(1234567);


### PR DESCRIPTION
**Goals (and why)**:
Fixing a test flake in MultiplexingCompletionServiceTest; which most probably occurred because of a reordering problem

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3514)
<!-- Reviewable:end -->
