### PR TITLE
Add another fix for targeted sweep when another service has deleted t…

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueDeleter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueDeleter.java
@@ -70,13 +70,14 @@ public class SweepQueueDeleter {
                             }
                         });
             } catch (IllegalArgumentException e) {
-                // hack because InMemoryKVS doesn't throw a TableMappingNotFoundException...
-                if (e.getCause() instanceof TableMappingNotFoundException
-                        || e.getMessage().endsWith("does not exist")) {
-                    log.warn("Could not resolve full name for table reference {}, "
+                // TODO we don't have a centralized error for when a table doesn't exist...
+                if (e.getCause() instanceof TableMappingNotFoundException // exception thrown through TableRemappingKVS
+                        || (e.getMessage().startsWith("table")
+                            && (e.getMessage().endsWith("does not exist") // exception thrown through InMemoryKVS
+                                || e.getMessage().endsWith("not found")))) { // exception thrown through DbKvs
+                    log.warn("Could not find table for table reference {}, "
                             + "assuming table has been deleted and therefore relevant cells as well.",
-                            LoggingArgs.tableRef(entry.getKey()));
-                    log.debug("Stack trace follows:", e);
+                            LoggingArgs.tableRef(entry.getKey()), e);
                 } else {
                     throw e;
                 }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,11 @@ develop
     *    - Type
          - Change
 
+    *    - |fixed|
+         - Targeted sweep no longer chokes if a table in the queue no longer exists,
+           and was deleted by a different host while this host was online and sweeping.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3516>`__)
+
     *    - |improved|
          - A few timelock ops edge cases have been removed. Timelock users must now indicate whether they are booting their
            servers for the first time or subsequent times, to avoid the situation where a timelock node becomes newly


### PR DESCRIPTION
…he table.

And therefore the TableMapper has a reference to the table name, but the
underlying kvs can't actually find it.

**Goals (and why)**:

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3516)
<!-- Reviewable:end -->
