### PR TITLE
The targeted sweep queue no longer contains json encoded data

### DIFF
--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/api/WriteReferenceTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/api/WriteReferenceTest.java
@@ -16,6 +16,8 @@
 
 package com.palantir.atlasdb.keyvalue.api;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 import java.io.IOException;
 
 import org.assertj.core.api.Assertions;
@@ -34,5 +36,19 @@ public class WriteReferenceTest {
 
         byte[] valueAsBytes = writeRef.persistToBytes();
         Assertions.assertThat(WriteReference.BYTES_HYDRATOR.hydrateFromBytes(valueAsBytes)).isEqualTo(writeRef);
+    }
+
+    @Test
+    public void throwsIfDecodingLegacyOnNewValue() {
+        TableReference tableReference = TableReference.createFromFullyQualifiedName("abc.def");
+        Cell cell = Cell.create(new byte[] {0, 0}, new byte[] {1, 1});
+        WriteReference writeRef = ImmutableWriteReference.builder()
+                .tableRef(tableReference)
+                .cell(cell)
+                .isTombstone(false)
+                .build();
+
+        byte[] valueAsBytes = writeRef.persistToBytes();
+        assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> WriteReference.decodeLegacy(valueAsBytes));
     }
 }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -55,6 +55,11 @@ develop
            and was deleted by a different host while this host was online and sweeping.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3516>`__)
 
+    *    - |fixed|
+         - Targeted sweep now stores much less data in the sweepable cells table due
+           to more efficient encoding.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3516>`__)
+
 ========
 v0.105.0
 ========


### PR DESCRIPTION
This leads to additional space being used than necessary. In practice as
I understand Atlas, this is safe to be rolling upgraded around; older
nodes will start failing to sweep but once the cluster is upgraded
everything will be fine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3520)
<!-- Reviewable:end -->
