### PR TITLE
Fds/test coverage 3148

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -30,6 +30,8 @@ import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ExecutorService;
 
+import javax.annotation.Nullable;
+
 import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,6 +45,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
@@ -253,23 +256,13 @@ public class SerializableTransaction extends SnapshotTransaction {
     }
 
     private ConcurrentNavigableMap<Cell, byte[]> getReadsForTable(TableReference table) {
-        ConcurrentNavigableMap<Cell, byte[]> reads = readsByTable.get(table);
-        if (reads == null) {
-            ConcurrentNavigableMap<Cell, byte[]> newMap = new ConcurrentSkipListMap<>();
-            readsByTable.putIfAbsent(table, newMap);
-            reads = readsByTable.get(table);
-        }
-        return reads;
+        return readsByTable.computeIfAbsent(table, $ -> new ConcurrentSkipListMap<>());
     }
 
     private void setRangeEnd(TableReference table, RangeRequest range, byte[] maxRow) {
         Validate.notNull(maxRow, "maxRow cannot be null");
-        ConcurrentMap<RangeRequest, byte[]> rangeEnds = rangeEndByTable.get(table);
-        if (rangeEnds == null) {
-            ConcurrentMap<RangeRequest, byte[]> newMap = Maps.newConcurrentMap();
-            rangeEndByTable.putIfAbsent(table, newMap);
-            rangeEnds = rangeEndByTable.get(table);
-        }
+        ConcurrentMap<RangeRequest, byte[]> rangeEnds =
+                rangeEndByTable.computeIfAbsent(table, $ -> Maps.newConcurrentMap());
 
         if (maxRow.length == 0) {
             rangeEnds.put(range, maxRow);
@@ -293,14 +286,14 @@ public class SerializableTransaction extends SnapshotTransaction {
         Validate.notNull(maxCol, "maxCol cannot be null");
         ByteBuffer row = ByteBuffer.wrap(unwrappedRow);
         columnRangeEndsByTable.computeIfAbsent(table, unused -> new ConcurrentHashMap<>());
-        ConcurrentMap<BatchColumnRangeSelection, byte[]> rangeEnds =
+        ConcurrentMap<BatchColumnRangeSelection, byte[]> rangeEndsForRow =
                 columnRangeEndsByTable.get(table).computeIfAbsent(row, unused -> new ConcurrentHashMap<>());
 
         if (maxCol.length == 0) {
-            rangeEnds.put(columnRangeSelection, maxCol);
+            rangeEndsForRow.put(columnRangeSelection, maxCol);
         }
 
-        rangeEnds.compute(columnRangeSelection, (range, curVal) -> {
+        rangeEndsForRow.compute(columnRangeSelection, (range, curVal) -> {
             if (curVal == null) {
                 return maxCol;
             } else if (curVal.length == 0) {
@@ -330,11 +323,7 @@ public class SerializableTransaction extends SnapshotTransaction {
             return;
         }
         getReadsForTable(table).putAll(transformGetsForTesting(result));
-        Set<Cell> cellsForTable = cellsRead.get(table);
-        if (cellsForTable == null) {
-            cellsRead.putIfAbsent(table, Sets.newConcurrentHashSet());
-            cellsForTable = cellsRead.get(table);
-        }
+        Set<Cell> cellsForTable = cellsRead.computeIfAbsent(table, $ -> Sets.newConcurrentHashSet());
         cellsForTable.addAll(searched);
     }
 
@@ -361,12 +350,11 @@ public class SerializableTransaction extends SnapshotTransaction {
         }
         ConcurrentNavigableMap<Cell, byte[]> reads = getReadsForTable(table);
         Map<Cell, byte[]> map = Maps2.fromEntries(result);
-        map = transformGetsForTesting(map);
-        reads.putAll(map);
+        reads.putAll(transformGetsForTesting(map));
         setColumnRangeEnd(table, row, range, Iterables.getLast(result).getKey().getColumnName());
     }
 
-    static class RowRead {
+    private static class RowRead {
         final ImmutableList<byte[]> rows;
         final ColumnSelection cols;
 
@@ -387,14 +375,10 @@ public class SerializableTransaction extends SnapshotTransaction {
         ConcurrentNavigableMap<Cell, byte[]> reads = getReadsForTable(table);
         for (RowResult<byte[]> row : result) {
             Map<Cell, byte[]> map = Maps2.fromEntries(row.getCells());
-            map = transformGetsForTesting(map);
-            reads.putAll(map);
+            reads.putAll(transformGetsForTesting(map));
         }
-        Set<RowRead> rowReads = rowsRead.get(table);
-        if (rowReads == null) {
-            rowsRead.putIfAbsent(table, Sets.<RowRead>newConcurrentHashSet());
-            rowReads = rowsRead.get(table);
-        }
+
+        Set<RowRead> rowReads = rowsRead.computeIfAbsent(table, $ -> Sets.newConcurrentHashSet());
         rowReads.add(new RowRead(rows, cols));
     }
 
@@ -569,9 +553,10 @@ public class SerializableTransaction extends SnapshotTransaction {
         }
     }
 
-    private NavigableMap<Cell, byte[]> getReadsInColumnRange(TableReference table,
-                                                             byte[] row,
-                                                             BatchColumnRangeSelection range) {
+    private NavigableMap<Cell, byte[]> getReadsInColumnRangeSkippingWrites(
+            TableReference table,
+            byte[] row,
+            BatchColumnRangeSelection range) {
         NavigableMap<Cell, byte[]> reads = getReadsForTable(table);
         Cell startCell = Cells.createSmallestCellForRow(row);
         if ((range.getStartCol() != null) && (range.getStartCol().length > 0)) {
@@ -581,11 +566,9 @@ public class SerializableTransaction extends SnapshotTransaction {
         if ((range.getEndCol() != null) && (range.getEndCol().length > 0)) {
             Cell endCell = Cell.create(row, range.getEndCol());
             reads = reads.headMap(endCell, false);
-        } else {
-            if (!RangeRequests.isLastRowName(row)) {
-                Cell endCell = Cells.createSmallestCellForRow(RangeRequests.nextLexicographicName(row));
-                reads = reads.headMap(endCell, false);
-            }
+        } else if (!RangeRequests.isLastRowName(row)) {
+            Cell endCell = Cells.createSmallestCellForRow(RangeRequests.nextLexicographicName(row));
+            reads = reads.headMap(endCell, false);
         }
         ConcurrentNavigableMap<Cell, byte[]> writes = writesByTable.get(table);
         if (writes != null) {
@@ -597,55 +580,66 @@ public class SerializableTransaction extends SnapshotTransaction {
     private void verifyColumnRanges(Transaction readOnlyTransaction) {
         // verify each set of reads to ensure they are the same.
         for (Entry<TableReference,
-                ConcurrentMap<ByteBuffer, ConcurrentMap<BatchColumnRangeSelection, byte[]>>> tableAndRange :
+                ConcurrentMap<ByteBuffer, ConcurrentMap<BatchColumnRangeSelection, byte[]>>> tableAndColumnRangeEnds :
                 columnRangeEndsByTable.entrySet()) {
-            TableReference table = tableAndRange.getKey();
-            Map<ByteBuffer, ConcurrentMap<BatchColumnRangeSelection, byte[]>> columnRangeEnds =
-                    tableAndRange.getValue();
 
-            Map<Cell, byte[]> writes = writesByTable.get(table);
-            Map<BatchColumnRangeSelection, List<byte[]>> rangesToRows = Maps.newHashMap();
+            Map<ByteBuffer, ConcurrentMap<BatchColumnRangeSelection, byte[]>> columnRangeEnds =
+                    tableAndColumnRangeEnds.getValue();
+
+            Multimap<BatchColumnRangeSelection, byte[]> rangesToRows = LinkedListMultimap.create();
             for (Entry<ByteBuffer, ConcurrentMap<BatchColumnRangeSelection, byte[]>> rowAndRangeEnds :
                     columnRangeEnds.entrySet()) {
                 byte[] row = rowAndRangeEnds.getKey().array();
                 Map<BatchColumnRangeSelection, byte[]> rangeEnds = rowAndRangeEnds.getValue();
-
                 for (Entry<BatchColumnRangeSelection, byte[]> e : rangeEnds.entrySet()) {
                     BatchColumnRangeSelection range = e.getKey();
                     byte[] rangeEnd = e.getValue();
-                    if (rangeEnd.length != 0 && !RangeRequests.isTerminalRow(false, rangeEnd)) {
-                        range = BatchColumnRangeSelection.create(
-                                range.getStartCol(),
-                                RangeRequests.getNextStartRow(false, rangeEnd),
-                                range.getBatchHint());
-                    }
-                    rangesToRows.computeIfAbsent(range, ignored -> Lists.newArrayList()).add(row);
+                    rangesToRows.put(nextLexicographicalRangeEnd(range, rangeEnd), row);
                 }
             }
-            for (Entry<BatchColumnRangeSelection, List<byte[]>> e : rangesToRows.entrySet()) {
-                BatchColumnRangeSelection range = e.getKey();
-                List<byte[]> rows = e.getValue();
+
+            TableReference table = tableAndColumnRangeEnds.getKey();
+            rangesToRows.asMap().forEach((columnRange, rows) -> {
                 Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> result =
-                        readOnlyTransaction.getRowsColumnRange(table, rows, range);
-                for (Entry<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> res : result.entrySet()) {
-                    byte[] row = res.getKey();
-                    BatchingVisitableView<Entry<Cell, byte[]>> bv = BatchingVisitableView.of(res.getValue());
+                        readOnlyTransaction.getRowsColumnRange(table, rows, columnRange);
+
+                for (Entry<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> cellValuesForRow : result.entrySet()) {
+                    byte[] row = cellValuesForRow.getKey();
+                    BatchingVisitableView<Entry<Cell, byte[]>> visitable =
+                            BatchingVisitableView.of(cellValuesForRow.getValue());
                     NavigableMap<Cell, ByteBuffer> readsInRange = Maps.transformValues(
-                            getReadsInColumnRange(table, row, range),
-                            input -> ByteBuffer.wrap(input));
-                    boolean isEqual = bv.transformBatch(input -> filterWritesFromCells(input, writes))
+                            getReadsInColumnRangeSkippingWrites(table, row, columnRange),
+                            ByteBuffer::wrap);
+                    boolean isEqual = visitable.transformBatch(cellValues -> filterWritesFromCells(cellValues, table))
                             .isEqual(readsInRange.entrySet());
                     if (!isEqual) {
                         handleTransactionConflict(table);
                     }
                 }
-            }
+            });
+        }
+    }
+
+    private static BatchColumnRangeSelection nextLexicographicalRangeEnd(BatchColumnRangeSelection currentRange, byte[] rangeEnd) {
+        if (rangeEnd.length != 0 && !RangeRequests.isTerminalRow(false, rangeEnd)) {
+            return BatchColumnRangeSelection.create(
+                    currentRange.getStartCol(),
+                    RangeRequests.getNextStartRow(false, rangeEnd),
+                    currentRange.getBatchHint());
+        } else {
+            return currentRange;
         }
     }
 
     private List<Entry<Cell, ByteBuffer>> filterWritesFromCells(
             Iterable<Entry<Cell, byte[]>> cells,
-            Map<Cell, byte[]> writes) {
+            TableReference table) {
+        return filterWritesFromCells(cells, writesByTable.get(table));
+    }
+
+    private static List<Entry<Cell, ByteBuffer>> filterWritesFromCells(
+            Iterable<Entry<Cell, byte[]>> cells,
+            @Nullable Map<Cell, byte[]> writes) {
         List<Entry<Cell, ByteBuffer>> cellsWithoutWrites = Lists.newArrayList();
         for (Entry<Cell, byte[]> cell : cells) {
             // NB: We filter our write set out here because our normal SI
@@ -659,7 +653,7 @@ public class SerializableTransaction extends SnapshotTransaction {
 
     private List<Entry<Cell, ByteBuffer>> filterWritesFromRows(
             Iterable<RowResult<byte[]>> rows,
-            Map<Cell, byte[]> writes) {
+            @Nullable Map<Cell, byte[]> writes) {
         List<Entry<Cell, ByteBuffer>> rowsWithoutWrites = Lists.newArrayList();
         for (RowResult<byte[]> row : rows) {
             rowsWithoutWrites.addAll(filterWritesFromCells(row.getCells(), writes));

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -262,7 +262,7 @@ public class SerializableTransaction extends SnapshotTransaction {
     private void setRangeEnd(TableReference table, RangeRequest range, byte[] maxRow) {
         Validate.notNull(maxRow, "maxRow cannot be null");
         ConcurrentMap<RangeRequest, byte[]> rangeEnds =
-                rangeEndByTable.computeIfAbsent(table, $ -> Maps.newConcurrentMap());
+                rangeEndByTable.computeIfAbsent(table, unused -> Maps.newConcurrentMap());
 
         if (maxRow.length == 0) {
             rangeEnds.put(range, maxRow);
@@ -620,7 +620,9 @@ public class SerializableTransaction extends SnapshotTransaction {
         }
     }
 
-    private static BatchColumnRangeSelection nextLexicographicalRangeEnd(BatchColumnRangeSelection currentRange, byte[] rangeEnd) {
+    private static BatchColumnRangeSelection nextLexicographicalRangeEnd(
+            BatchColumnRangeSelection currentRange,
+            byte[] rangeEnd) {
         if (rangeEnd.length != 0 && !RangeRequests.isTerminalRow(false, rangeEnd)) {
             return BatchColumnRangeSelection.create(
                     currentRange.getStartCol(),

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -256,7 +256,7 @@ public class SerializableTransaction extends SnapshotTransaction {
     }
 
     private ConcurrentNavigableMap<Cell, byte[]> getReadsForTable(TableReference table) {
-        return readsByTable.computeIfAbsent(table, $ -> new ConcurrentSkipListMap<>());
+        return readsByTable.computeIfAbsent(table, unused -> new ConcurrentSkipListMap<>());
     }
 
     private void setRangeEnd(TableReference table, RangeRequest range, byte[] maxRow) {
@@ -323,7 +323,7 @@ public class SerializableTransaction extends SnapshotTransaction {
             return;
         }
         getReadsForTable(table).putAll(transformGetsForTesting(result));
-        Set<Cell> cellsForTable = cellsRead.computeIfAbsent(table, $ -> Sets.newConcurrentHashSet());
+        Set<Cell> cellsForTable = cellsRead.computeIfAbsent(table, unused -> Sets.newConcurrentHashSet());
         cellsForTable.addAll(searched);
     }
 
@@ -378,7 +378,7 @@ public class SerializableTransaction extends SnapshotTransaction {
             reads.putAll(transformGetsForTesting(map));
         }
 
-        Set<RowRead> rowReads = rowsRead.computeIfAbsent(table, $ -> Sets.newConcurrentHashSet());
+        Set<RowRead> rowReads = rowsRead.computeIfAbsent(table, unused -> Sets.newConcurrentHashSet());
         rowReads.add(new RowRead(rows, cols));
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -54,7 +54,6 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
-import com.google.common.base.Stopwatch;
 import com.google.common.base.Supplier;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.Collections2;
@@ -209,7 +208,6 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     private final TransactionReadSentinelBehavior readSentinelBehavior;
     private volatile long commitTsForScrubbing = TransactionConstants.FAILED_COMMIT_TS;
     protected final boolean allowHiddenTableAccess;
-    protected final Stopwatch transactionTimer = Stopwatch.createStarted();
     protected final TimestampCache timestampValidationReadCache;
     protected final ExecutorService getRangesExecutor;
     protected final int defaultGetRangesConcurrency;
@@ -292,10 +290,6 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     @Override
     public TransactionReadSentinelBehavior getReadSentinelBehavior() {
         return readSentinelBehavior;
-    }
-
-    public Stopwatch getTrasactionTimer() {
-        return transactionTimer;
     }
 
     protected void checkGetPreconditions(TableReference tableRef) {
@@ -939,15 +933,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     }
 
     private ConcurrentNavigableMap<Cell, byte[]> getLocalWrites(TableReference tableRef) {
-        ConcurrentNavigableMap<Cell, byte[]> writes = writesByTable.get(tableRef);
-        if (writes == null) {
-            writes = new ConcurrentSkipListMap<Cell, byte[]>();
-            ConcurrentNavigableMap<Cell, byte[]> previous = writesByTable.putIfAbsent(tableRef, writes);
-            if (previous != null) {
-                writes = previous;
-            }
-        }
-        return writes;
+        return writesByTable.computeIfAbsent(tableRef, unused -> new ConcurrentSkipListMap<>());
     }
 
     /**
@@ -1460,14 +1446,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     }
 
     private boolean hasWrites() {
-        boolean hasWrites = false;
-        for (SortedMap<?, ?> map : writesByTable.values()) {
-            if (!map.isEmpty()) {
-                hasWrites = true;
-                break;
-            }
-        }
-        return hasWrites;
+        return writesByTable.values().stream().anyMatch(writesForTable -> !writesForTable.isEmpty());
     }
 
     protected boolean hasReads() {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/SimpleTransactionService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/SimpleTransactionService.java
@@ -82,7 +82,7 @@ public final class SimpleTransactionService implements TransactionService {
                 ImmutableMap.of(key, value));
     }
 
-    private Cell getTransactionCell(long startTimestamp) {
+    private static Cell getTransactionCell(long startTimestamp) {
         return Cell.create(
                 TransactionConstants.getValueForTimestamp(startTimestamp),
                 TransactionConstants.COMMIT_TS_COLUMN);

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
@@ -704,19 +704,19 @@ public abstract class AbstractSerializableTransactionTest extends AbstractTransa
 
     @Test
     public void testMultipleReadsToSameColumnRangeAcrossRows() {
-        byte[] aRow = PtBytes.toBytes("aRow");
-        byte[] aDifferentRow = PtBytes.toBytes("aDifferentRow");
+        byte[] row = PtBytes.toBytes("row");
+        byte[] differentRow = PtBytes.toBytes("differentRow");
 
         Transaction transaction = startTransaction();
         BatchColumnRangeSelection sameColumnRangeSelection =
                 BatchColumnRangeSelection.create(PtBytes.toBytes("col"), PtBytes.toBytes("col0"), 1);
 
         Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> columnRangeResultForRow =
-                transaction.getRowsColumnRange(TEST_TABLE, ImmutableList.of(aRow), sameColumnRangeSelection);
+                transaction.getRowsColumnRange(TEST_TABLE, ImmutableList.of(row), sameColumnRangeSelection);
         columnRangeResultForRow.values().forEach(visitable -> visitable.batchAccept(10, t -> true));
 
         Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> columnRangeResultForDifferentRow =
-                transaction.getRowsColumnRange(TEST_TABLE, ImmutableList.of(aDifferentRow), sameColumnRangeSelection);
+                transaction.getRowsColumnRange(TEST_TABLE, ImmutableList.of(differentRow), sameColumnRangeSelection);
         columnRangeResultForDifferentRow.values().forEach(visitable -> visitable.batchAccept(10, t -> true));
         put(transaction, "mutation to ensure", "conflict", "handling");
         transaction.commit();

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
@@ -704,21 +704,22 @@ public abstract class AbstractSerializableTransactionTest extends AbstractTransa
 
     @Test
     public void testMultipleReadsToSameColumnRangeAcrossRows() {
-        byte[] row1 = PtBytes.toBytes("row1");
-        byte[] row2 = PtBytes.toBytes("row2");
+        byte[] aRow = PtBytes.toBytes("aRow");
+        byte[] aDifferentRow = PtBytes.toBytes("aDifferentRow");
 
         Transaction transaction = startTransaction();
-        Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> columnRange =
-                transaction.getRowsColumnRange(TEST_TABLE, ImmutableList.of(row1),
-                        BatchColumnRangeSelection.create(PtBytes.toBytes("col"), PtBytes.toBytes("col0"), 1));
-        columnRange.values().forEach(visitable -> visitable.batchAccept(10, t -> true));
-        Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> columnRangeDifferentRow =
-                transaction.getRowsColumnRange(TEST_TABLE, ImmutableList.of(row2),
-                        BatchColumnRangeSelection.create(PtBytes.toBytes("col"), PtBytes.toBytes("col0"), 1));
-        columnRangeDifferentRow.values().forEach(visitable -> visitable.batchAccept(10, t -> true));
+        BatchColumnRangeSelection sameColumnRangeSelection =
+                BatchColumnRangeSelection.create(PtBytes.toBytes("col"), PtBytes.toBytes("col0"), 1);
+
+        Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> columnRangeResultForRow =
+                transaction.getRowsColumnRange(TEST_TABLE, ImmutableList.of(aRow), sameColumnRangeSelection);
+        columnRangeResultForRow.values().forEach(visitable -> visitable.batchAccept(10, t -> true));
+
+        Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> columnRangeResultForDifferentRow =
+                transaction.getRowsColumnRange(TEST_TABLE, ImmutableList.of(aDifferentRow), sameColumnRangeSelection);
+        columnRangeResultForDifferentRow.values().forEach(visitable -> visitable.batchAccept(10, t -> true));
         put(transaction, "mutation to ensure", "conflict", "handling");
         transaction.commit();
-
     }
 
     private void writeColumns() {


### PR DESCRIPTION
**Goals (and why)**:
Fixes #3148. If the fix to #3148 is reverted, the added test will fail. Also cleaned up some things in this class and neighbouring classes.

**Implementation Description (bullets)**:
Opted to use `Multimap` as opposed to a map with a collection value. Cleaner semantics and less null checks, happy to revert if necessary.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added a test that reads from a second row. Should we amend all our tests to read from at least 2 rows/cols?

**Concerns (what feedback would you like?)**:
Conversions to `computeIfAbsent`, `Stream`-ifying, etc.

**Where should we start reviewing?**:
`AbstractSerializationTransactionTest`

**Priority (whenever / two weeks / yesterday)**:
Whenever.
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3535)
<!-- Reviewable:end -->
