### PR TITLE
Excavator: Enable org.gradle.parallel by default

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 enableErrorProne=false
+org.gradle.parallel=true


### PR DESCRIPTION
Ported from #3518

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3540)
<!-- Reviewable:end -->
