### PR TITLE
Revert broken pr.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,6 @@ buildscript {
     }
 
     dependencies {
-        classpath 'gradle.plugin.com.palantir:gradle-circle-style:1.1.2'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.3'
         classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.7.5'
         classpath 'gradle.plugin.com.palantir.gradle.docker:gradle-docker:0.13.0'

--- a/gradle/idea.gradle
+++ b/gradle/idea.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java'
 apply plugin: 'idea'
-apply plugin: 'com.palantir.circle.style'
 
 assert sourceCompatibility instanceof JavaVersion;
 assert targetCompatibility instanceof JavaVersion;

--- a/gradle/shared.gradle
+++ b/gradle/shared.gradle
@@ -80,10 +80,6 @@ afterEvaluate {
 }
 
 tasks.withType(Test) {
-    if (System.env.CIRCLE_TEST_REPORTS) {
-        reports.junitXml.destination = new File(System.env.CIRCLE_TEST_REPORTS, it.getName())
-    }
-
     enableAssertions = true
 
     testLogging {


### PR DESCRIPTION
**Goals (and why)**:
Didn't realise but we had 2 versions of gradle-circle-style, there's one included in baseline and it was causing conflicts breaking `~/gradlew idea`. This should be fixed now.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3547)
<!-- Reviewable:end -->
