### PR TITLE
include javax.anntations-api for java 8 backwards compatibility

### DIFF
--- a/atlasdb-client/build.gradle
+++ b/atlasdb-client/build.gradle
@@ -84,6 +84,7 @@ dependencies {
     exclude (group: 'org.hdrhistogram', module: 'HdrHistogram')
   }
   compile group: 'com.squareup', name:'javapoet', version: '1.9.0'
+  compile group: 'javax.annotation' name: 'javax.annotation-api'
   compile group: 'org.hdrhistogram', name: 'HdrHistogram'
 
   processor group: 'org.immutables', name: 'value'

--- a/versions.props
+++ b/versions.props
@@ -37,6 +37,7 @@ io.dropwizard.metrics:metrics-* = 3.2.3
 io.dropwizard.modules:* = 0.9.0-1
 io.dropwizard:* = 0.9.3
 io.reactivex.rxjava2:rxjava = 2.1.1
+javax.annotation:javax.annotation-api = 1.3.2
 javax.validation:validation-api = 1.1.0.Final
 javax.ws.rs:javax.ws.rs-api = 2.0.1
 joda-time:joda-time = 2.9


### PR DESCRIPTION
**Goals (and why)**:
We want to upgrade our java to a more modern version than 8, atlasdb TableRenderer relies on javax.annotation.Generated which got moved in java 9.
