### PR TITLE
LockServerSync State Logging to Develop

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -51,34 +51,49 @@ develop
          - Change
 
     *    - |improved|
-         - Targeted sweep now stores even less data in the sweepable cells table due to dictionary encoding table references instead
-           of storing them as strings.
+         - Targeted sweep now stores even less data in the sweepable cells table due to dictionary encoding table references instead of storing them as strings.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3533>`__)
+
+    *    - |improved|
+         - The legacy lock service's lock state logger now logs additional information about the lock service's internal synchronization state.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3554>`__)
+
+
+========
+v0.106.0
+========
+
+2 Oct 2018
+
+.. list-table::
+    :widths: 5 40
+    :header-rows: 1
+
+    *    - Type
+         - Change
+
+    *    - |fixed| |devbreak|
+         - Reverted the PR #3505, which was modifying PaxosLeaderElectionService to utilise distinct bounded thread pools, as this PR uncovered some resiliency issues with PaxosLeaderElectionService.
+           It will be re-merged after fixing those issues.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3536>`__)
+
+    *    - |fixed|
+         - Targeted sweep now stores much less data in the sweepable cells table due to more efficient encoding.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3516>`__)
 
     *    - |new|
          - ``TransactionManager``s now expose a ``TimestampManagementService``, allowing clients to fast-forward timestamps when necessary.
-           This functionality is intended for libraries that extend AtlasDB functionality; it is unlikely that users should
-           directly require the TimestampManagementService.
+           This functionality is intended for libraries that extend AtlasDB functionality; it is unlikely that users should directly require the TimestampManagementService.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3524>`__)
 
     *    - |fixed|
-         - Targeted sweep no longer chokes if a table in the queue no longer exists,
-           and was deleted by a different host while this host was online and sweeping.
+         - Targeted sweep no longer chokes if a table in the queue no longer exists, and was deleted by a different host while this host was online and sweeping.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3516>`__)
 
-    *    - |fixed|
-         - Targeted sweep now stores much less data in the sweepable cells table due
-           to more efficient encoding.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/3516>`__)
-    
     *    - |improved|
          - Add versionId to SimpleTokenInfo to improve logging for troubleshooting.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/3521>`__)           
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3521>`__)
 
-    *    - |fixed| |devbreak|
-         - Reverted the PR #3505, which was modifying PaxosLeaderElectionService to utilise distinct bounded thread pools, as this PR uncovered some resiliency issues with PaxosLeaderElectionService. It will be re-merged after fixing those issues.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/3536>`__)           
-        
 ========
 v0.105.0
 ========

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockServerLock.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockServerLock.java
@@ -66,6 +66,12 @@ public class LockServerLock implements ClientAwareReadWriteLock {
                 .toString();
     }
 
+    public String toSanitizedString() {
+        return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("sync", sync)
+                .toString();
+    }
+
     static IllegalMonitorStateException throwIllegalMonitorStateException(String message) {
         IllegalMonitorStateException ex = new IllegalMonitorStateException(message);
         log.error("Illegal monitor state exception: {}", message, ex);

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
@@ -1033,6 +1033,7 @@ public final class LockServiceImpl
         LockServiceStateLogger lockServiceStateLogger = new LockServiceStateLogger(
                 heldLocksTokenMap,
                 outstandingLockRequestMultimap,
+                descriptorToLockMap.asMap(),
                 lockStateLoggerDir);
         lockServiceStateLogger.logLocks();
     }

--- a/lock-impl/src/test/java/com/palantir/lock/logger/LockServiceStateLoggerTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/logger/LockServiceStateLoggerTest.java
@@ -15,13 +15,16 @@
  */
 package com.palantir.lock.logger;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -30,6 +33,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import org.assertj.core.util.Strings;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -38,6 +42,7 @@ import org.yaml.snakeyaml.Yaml;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.MapMaker;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
@@ -50,6 +55,9 @@ import com.palantir.lock.LockRequest;
 import com.palantir.lock.SimpleTimeDuration;
 import com.palantir.lock.SortedLockCollection;
 import com.palantir.lock.StringLockDescriptor;
+import com.palantir.lock.impl.ClientAwareReadWriteLock;
+import com.palantir.lock.impl.LockClientIndices;
+import com.palantir.lock.impl.LockServerLock;
 import com.palantir.lock.impl.LockServiceImpl;
 
 public class LockServiceStateLoggerTest {
@@ -60,6 +68,12 @@ public class LockServiceStateLoggerTest {
     private static final SetMultimap<LockClient, LockRequest> outstandingLockRequestMultimap =
             Multimaps.synchronizedSetMultimap(HashMultimap.<LockClient, LockRequest>create());
 
+    private static final Map<LockDescriptor, ClientAwareReadWriteLock> syncStateMap =
+            Maps.newHashMap();
+
+    private static final LockDescriptor DESCRIPTOR_1 = StringLockDescriptor.of("logger-lock");
+    private static final LockDescriptor DESCRIPTOR_2 = StringLockDescriptor.of("logger-AAA");
+
     @BeforeClass
     public static void setUp() throws Exception {
         LockServiceTestUtils.cleanUpLogStateDir();
@@ -67,15 +81,12 @@ public class LockServiceStateLoggerTest {
         LockClient clientA = LockClient.of("Client A");
         LockClient clientB = LockClient.of("Client B");
 
-        LockDescriptor descriptor1 = StringLockDescriptor.of("logger-lock");
-        LockDescriptor descriptor2 = StringLockDescriptor.of("logger-AAA");
-
         LockRequest request1 = LockRequest.builder(
-                LockCollections.of(ImmutableSortedMap.of(descriptor1, LockMode.WRITE)))
+                LockCollections.of(ImmutableSortedMap.of(DESCRIPTOR_1, LockMode.WRITE)))
                 .blockForAtMost(SimpleTimeDuration.of(1000, TimeUnit.MILLISECONDS))
                 .build();
         LockRequest request2 = LockRequest.builder(
-                LockCollections.of(ImmutableSortedMap.of(descriptor2, LockMode.WRITE)))
+                LockCollections.of(ImmutableSortedMap.of(DESCRIPTOR_2, LockMode.WRITE)))
                 .blockForAtMost(SimpleTimeDuration.of(1000, TimeUnit.MILLISECONDS))
                 .build();
 
@@ -93,9 +104,16 @@ public class LockServiceStateLoggerTest {
         heldLocksTokenMap.putIfAbsent(token, LockServiceImpl.HeldLocks.of(token, LockCollections.of()));
         heldLocksTokenMap.putIfAbsent(token2, LockServiceImpl.HeldLocks.of(token2, LockCollections.of()));
 
+        LockServerLock lock1 = new LockServerLock(DESCRIPTOR_1, new LockClientIndices());
+        syncStateMap.put(DESCRIPTOR_1, lock1);
+        LockServerLock lock2 = new LockServerLock(DESCRIPTOR_2, new LockClientIndices());
+        lock2.get(clientA, LockMode.WRITE).lock();
+        syncStateMap.put(DESCRIPTOR_2, lock2);
+
         LockServiceStateLogger logger = new LockServiceStateLogger(
                 heldLocksTokenMap,
                 outstandingLockRequestMultimap,
+                syncStateMap,
                 LockServiceTestUtils.TEST_LOG_STATE_DIR);
         logger.logLocks();
     }
@@ -110,6 +128,10 @@ public class LockServiceStateLoggerTest {
 
         assertEquals("Unexpected number of lock state files", files.stream()
                 .filter(file -> file.getName().startsWith(LockServiceStateLogger.LOCKSTATE_FILE_PREFIX))
+                .count(), 1);
+
+        assertEquals("Unexpected number of lock sync state files", files.stream()
+                .filter(file -> file.getName().startsWith(LockServiceStateLogger.SYNC_STATE_FILE_PREFIX))
                 .count(), 1);
     }
 
@@ -149,14 +171,53 @@ public class LockServiceStateLoggerTest {
                 assertEquals(getOutstandingDescriptors().size(), ((List) arrayObj).size());
             } else if (map.containsKey(LockServiceStateLogger.HELD_LOCKS_TITLE)) {
                 Object mapObj = map.get(LockServiceStateLogger.HELD_LOCKS_TITLE);
-                assertTrue("Held locks is not a list", mapObj instanceof Map);
+                assertTrue("Held locks is not a map", mapObj instanceof Map);
 
                 assertEquals(getHeldDescriptors().size(), ((Map) mapObj).size());
             } else {
                 throw new IllegalStateException("Map found in YAML document without an expected key");
             }
         }
+    }
 
+    @Test
+    public void testSyncState() throws Exception {
+        List<File> files = LockServiceTestUtils.logStateDirFiles();
+
+        Optional<File> syncStateFile = files.stream().filter(
+                file -> file.getName().startsWith(LockServiceStateLogger.SYNC_STATE_FILE_PREFIX)).findFirst();
+
+        assertThat(syncStateFile).isPresent();
+        assertSyncStateStructureCorrect(syncStateFile.get());
+        assertDescriptorsNotPresentInSyncFile(syncStateFile.get());
+    }
+
+    private void assertDescriptorsNotPresentInSyncFile(File syncStateFile) {
+        try {
+            List<String> contents = Files.readAllLines(syncStateFile.toPath());
+            String result = Strings.join(contents).with("\n");
+            assertThat(result).doesNotContain(DESCRIPTOR_1.getLockIdAsString());
+            assertThat(result).doesNotContain(DESCRIPTOR_2.getLockIdAsString());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void assertSyncStateStructureCorrect(File syncStateFile) throws FileNotFoundException {
+        Iterable<Object> syncState = new Yaml().loadAll(new FileInputStream(syncStateFile));
+
+        for (Object ymlMap : syncState) {
+            assertTrue("Sync state contains unrecognizable object", ymlMap instanceof Map);
+            Map map = (Map) ymlMap;
+            if (map.containsKey(LockServiceStateLogger.SYNC_STATE_TITLE)) {
+                Object mapObj = map.get(LockServiceStateLogger.SYNC_STATE_TITLE);
+                assertTrue("Sync state is not a map", mapObj instanceof Map);
+
+                assertEquals(getSyncStateDescriptors().size(), ((Map) mapObj).size());
+            } else {
+                throw new IllegalStateException("Map found in YAML document without an expected key");
+            }
+        }
     }
 
     @AfterClass
@@ -186,5 +247,9 @@ public class LockServiceStateLoggerTest {
                 .map(LockRequest::getLockDescriptors)
                 .flatMap(SortedLockCollection::stream)
                 .collect(Collectors.toSet());
+    }
+
+    private Set<LockDescriptor> getSyncStateDescriptors() {
+        return syncStateMap.keySet();
     }
 }


### PR DESCRIPTION
**Goals (and why)**:
- Forward port of #3550 
- Getting information about the internal sync state can be useful when debugging, especially with pending requests (since AFAIK locks aren't written to the held locks map until a request actually completes)

**Implementation Description (bullets)**:
- Dump information about the synchronizers
- Sanitize this to get rid of lock descriptors and keep them in the reference file
- Drive-by cleaning up of release notes to make sense

**Testing (What was existing testing like?  What have you done to improve it?)**:
- There were tests for checking the dumper. I added one more which also checks that the descriptors weren't logged in the 'safe' file.

**Concerns (what feedback would you like?)**:
- The RN part: is that right?
- Did we accidentally leak the descriptors anywhere?
- Not too much; the first commit is a clean cherry pick from 0.61.x and the 2nd is release notes

**Where should we start reviewing?**: LockServiceImpl

**Priority (whenever / two weeks / yesterday)**: whenever

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3554)
<!-- Reviewable:end -->
