### PR TITLE
LockServiceStateLogger: Finding the next lock

### DIFF
--- a/lock-impl/src/main/java/com/palantir/lock/impl/KnownClientLock.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/KnownClientLock.java
@@ -92,4 +92,9 @@ public interface KnownClientLock {
      *         anonymous or if this is a read lock instead of a write lock.
      */
     void unlockAndFreeze();
+
+    /**
+     * Returns true if and only if the lock is believed to be held by this lock client.
+     */
+    boolean isHeld();
 }

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockServerLock.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockServerLock.java
@@ -146,6 +146,11 @@ public class LockServerLock implements ClientAwareReadWriteLock {
         }
 
         @Override
+        public boolean isHeld() {
+            return sync.holdsReadLock(clientIndex);
+        }
+
+        @Override
         public String toString() {
             return MoreObjects.toStringHelper(getClass().getSimpleName())
                     .add("mode", getMode())
@@ -220,6 +225,11 @@ public class LockServerLock implements ClientAwareReadWriteLock {
         @Override
         public void unlockAndFreeze() {
             sync.unlockAndFreeze(clientIndex);
+        }
+
+        @Override
+        public boolean isHeld() {
+            return sync.safeHoldsWriteLock(clientIndex);
         }
 
         @Override

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockServerSync.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockServerSync.java
@@ -46,6 +46,10 @@ class LockServerSync extends AbstractQueuedSynchronizer {
         return clientIndex < 0;
     }
 
+    synchronized boolean safeHoldsWriteLock(int clientIndex) {
+        return getState() > 0 && clientIndex == writeLockHolder && !isAnonymous(clientIndex);
+    }
+
     private synchronized boolean holdsWriteLock(int clientIndex) {
         Preconditions.checkState(getState() > 0);
         return clientIndex == writeLockHolder && !isAnonymous(clientIndex);
@@ -245,7 +249,7 @@ class LockServerSync extends AbstractQueuedSynchronizer {
         return readLockHolders != null && !readLockHolders.isEmpty();
     }
 
-    private synchronized boolean holdsReadLock(int clientIndex) {
+    synchronized boolean holdsReadLock(int clientIndex) {
         return !isAnonymous(clientIndex) && readLockHolders != null && readLockHolders.get(clientIndex) > 0;
     }
 

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceStateDebugger.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceStateDebugger.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.impl;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.immutables.value.Value;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.palantir.lock.LockClient;
+import com.palantir.lock.LockDescriptor;
+import com.palantir.lock.LockMode;
+import com.palantir.lock.LockRequest;
+
+/**
+ * Note: This class does NOT strictly guarantee that state returned is up to date across all requests.
+ */
+public class LockServiceStateDebugger {
+    private final Map<LockClient, Set<LockRequest>> outstandingLockRequests;
+    private final Map<LockDescriptor, ClientAwareReadWriteLock> descriptorToLockMap;
+
+    public LockServiceStateDebugger(
+            Map<LockClient, Set<LockRequest>> outstandingLockRequests,
+            Map<LockDescriptor, ClientAwareReadWriteLock> descriptorToLockMap) {
+        this.outstandingLockRequests = outstandingLockRequests;
+        this.descriptorToLockMap = descriptorToLockMap;
+    }
+
+    public Multimap<LockClient, LockRequestProgress> getSuspectedLockProgress() {
+        Multimap<LockClient, LockRequestProgress> result = Multimaps.newListMultimap(
+                Maps.newHashMap(),
+                Lists::newArrayList);
+        for (Map.Entry<LockClient, Set<LockRequest>> entry : outstandingLockRequests.entrySet()) {
+            for (LockRequest lockRequest : entry.getValue()) {
+                result.put(entry.getKey(), getSuspectedLockProgress(entry.getKey(), lockRequest));
+            }
+        }
+        return result;
+    }
+
+    private LockRequestProgress getSuspectedLockProgress(
+            LockClient client,
+            LockRequest request) {
+        int locksHeld = 0;
+        for (Map.Entry<LockDescriptor, LockMode> entry : request.getLockDescriptors().entries()) {
+            ClientAwareReadWriteLock clientAwareLock = descriptorToLockMap.get(entry.getKey());
+            KnownClientLock knownClientLock = clientAwareLock.get(client, entry.getValue());
+            if (!knownClientLock.isHeld()) {
+                return ImmutableLockRequestProgress.builder()
+                        .request(request)
+                        .nextLock(entry.getKey())
+                        .numLocksAcquired(locksHeld)
+                        .totalNumLocks(request.getLockDescriptors().size())
+                        .build();
+            }
+            locksHeld++;
+        }
+        // This means that it looks like we hold ALL of the locks
+        return ImmutableLockRequestProgress.builder()
+                .request(request)
+                .numLocksAcquired(locksHeld)
+                .totalNumLocks(request.getLockDescriptors().size())
+                .build();
+    }
+
+    @Value.Immutable
+    @JsonSerialize(as = ImmutableLockRequestProgress.class)
+    @JsonDeserialize(as = ImmutableLockRequestProgress.class)
+    public interface LockRequestProgress {
+        LockRequest getRequest();
+        Optional<LockDescriptor> getNextLock();
+        int getNumLocksAcquired();
+        int getTotalNumLocks();
+    }
+}

--- a/lock-impl/src/main/java/com/palantir/lock/logger/LockServiceStateLogger.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/LockServiceStateLogger.java
@@ -37,6 +37,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.SetMultimap;
 import com.palantir.lock.HeldLocksToken;
@@ -46,6 +47,7 @@ import com.palantir.lock.LockRequest;
 import com.palantir.lock.impl.ClientAwareReadWriteLock;
 import com.palantir.lock.impl.LockServerLock;
 import com.palantir.lock.impl.LockServiceImpl;
+import com.palantir.lock.impl.LockServiceStateDebugger;
 
 public class LockServiceStateLogger {
     private static Logger log = LoggerFactory.getLogger(LockServiceStateLogger.class);
@@ -56,6 +58,8 @@ public class LockServiceStateLogger {
     static final String DESCRIPTORS_FILE_PREFIX = "descriptors-";
     @VisibleForTesting
     static final String SYNC_STATE_FILE_PREFIX = "sync-state-";
+    @VisibleForTesting
+    static final String SYNTHESIZED_REQUEST_STATE_FILE_PREFIX = "synthesized-requests-";
 
     @VisibleForTesting
     static final String OUTSTANDING_LOCK_REQUESTS_TITLE = "OutstandingLockRequests";
@@ -63,10 +67,12 @@ public class LockServiceStateLogger {
     static final String HELD_LOCKS_TITLE = "HeldLocks";
     @VisibleForTesting
     static final String SYNC_STATE_TITLE = "SyncState";
+    @VisibleForTesting
+    static final String SYNTHESIZED_REQUEST_STATE_TITLE = "SynthesizedLockRequestState";
 
     private static final String WARNING_LOCK_DESCRIPTORS = "WARNING: Lock descriptors may contain sensitive information";
     private static final String FILE_NOT_CREATED_LOG_ERROR = "Destination file [{}] either already exists"
-            + "or can't be created. This is a very unlikely scenario."
+            + "or can't be created. This is a very unlikely scenario. "
             + "Retrigger logging or check if process has permissions on the folder";
 
     private final LockDescriptorMapper lockDescriptorMapper = new LockDescriptorMapper();
@@ -93,11 +99,30 @@ public class LockServiceStateLogger {
         Map<String, Object> generatedOutstandingRequests = generateOutstandingLocksYaml(outstandingLockRequests);
         Map<String, Object> generatedHeldLocks = generateHeldLocks(heldLocks);
         Map<String, Object> generatedSyncState = generateSyncState(descriptorToLockMap);
+        Map<String, Object> synthesizedRequestState
+                = synthesizeRequestState(outstandingLockRequests, descriptorToLockMap);
 
         Path outputDirPath = Paths.get(outputDir);
         Files.createDirectories(outputDirPath);
 
-        dumpYamlsInNewFiles(generatedOutstandingRequests, generatedHeldLocks, generatedSyncState);
+        dumpYamlsInNewFiles(
+                generatedOutstandingRequests, generatedHeldLocks, generatedSyncState, synthesizedRequestState);
+    }
+
+    private Map<String, Object> synthesizeRequestState(
+            Map<LockClient, Set<LockRequest>> outstandingLockRequests,
+            Map<LockDescriptor, ClientAwareReadWriteLock> descriptorToLockMap) {
+        LockServiceStateDebugger debugger = new LockServiceStateDebugger(outstandingLockRequests, descriptorToLockMap);
+        Multimap<LockClient, LockServiceStateDebugger.LockRequestProgress> progressMultimap
+                = debugger.getSuspectedLockProgress();
+
+        return nameObjectForYamlConversion(SYNTHESIZED_REQUEST_STATE_TITLE, progressMultimap.asMap().entrySet().stream()
+                .collect(Collectors.toMap(
+                        entry -> entry.getKey().toString(),
+                        entry -> entry.getValue().stream().map(
+                                lockRequestProgress -> SanitizedLockRequestProgress.create(
+                                        lockRequestProgress, lockDescriptorMapper, entry.getKey().toString()))
+                                .collect(Collectors.toList()))));
     }
 
     private Map<String, Object> generateOutstandingLocksYaml(Map<LockClient, Set<LockRequest>> outstandingLockRequestsMap) {
@@ -176,13 +201,16 @@ public class LockServiceStateLogger {
     private void dumpYamlsInNewFiles(
             Map<String, Object> generatedOutstandingRequests,
             Map<String, Object> generatedHeldLocks,
-            Map<String, Object> generatedSyncState) throws IOException {
+            Map<String, Object> generatedSyncState,
+            Map<String, Object> synthesizedRequestState) throws IOException {
         File lockStateFile = createNewFile(LOCKSTATE_FILE_PREFIX);
         File descriptorsFile = createNewFile(DESCRIPTORS_FILE_PREFIX);
         File syncStateFile = createNewFile(SYNC_STATE_FILE_PREFIX);
+        File synthesizedRequestStateFile = createNewFile(SYNTHESIZED_REQUEST_STATE_FILE_PREFIX);
 
         dumpYaml(ImmutableList.of(generatedOutstandingRequests, generatedHeldLocks), lockStateFile);
         dumpYaml(ImmutableList.of(generatedSyncState), syncStateFile);
+        dumpYaml(ImmutableList.of(synthesizedRequestState), synthesizedRequestStateFile);
         dumpDescriptorsYaml(descriptorsFile);
     }
 

--- a/lock-impl/src/main/java/com/palantir/lock/logger/LockServiceStateLogger.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/LockServiceStateLogger.java
@@ -74,6 +74,8 @@ public class LockServiceStateLogger {
     private static final String FILE_NOT_CREATED_LOG_ERROR = "Destination file [{}] either already exists"
             + "or can't be created. This is a very unlikely scenario. "
             + "Retrigger logging or check if process has permissions on the folder";
+    private static final String WARNING_SYNTHESIZE_ANONYMOUS = "WARNING: For LockClient.ANONYMOUS this method"
+            + " may not return accurate results.";
 
     private final LockDescriptorMapper lockDescriptorMapper = new LockDescriptorMapper();
     private final long startTimestamp = System.currentTimeMillis();
@@ -210,7 +212,7 @@ public class LockServiceStateLogger {
 
         dumpYaml(ImmutableList.of(generatedOutstandingRequests, generatedHeldLocks), lockStateFile);
         dumpYaml(ImmutableList.of(generatedSyncState), syncStateFile);
-        dumpYaml(ImmutableList.of(synthesizedRequestState), synthesizedRequestStateFile);
+        dumpYaml(ImmutableList.of(synthesizedRequestState), synthesizedRequestStateFile, WARNING_SYNTHESIZE_ANONYMOUS);
         dumpDescriptorsYaml(descriptorsFile);
     }
 
@@ -229,6 +231,15 @@ public class LockServiceStateLogger {
 
     private void dumpYaml(List<Map<String, Object>> objects, File file) throws IOException {
         try (LockStateYamlWriter writer = LockStateYamlWriter.create(file)) {
+            for (Map<String, Object> object : objects) {
+                writer.dumpObject(object);
+            }
+        }
+    }
+
+    private void dumpYaml(List<Map<String, Object>> objects, File file, String prefix) throws IOException {
+        try (LockStateYamlWriter writer = LockStateYamlWriter.create(file)) {
+            writer.appendComment(prefix);
             for (Map<String, Object> object : objects) {
                 writer.dumpObject(object);
             }

--- a/lock-impl/src/main/java/com/palantir/lock/logger/LockServiceTestUtils.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/LockServiceTestUtils.java
@@ -35,13 +35,13 @@ public class LockServiceTestUtils {
     public static final String TEST_LOG_STATE_DIR = "log-state";
 
     public static void cleanUpLogStateDir() throws IOException {
-        File rootDir = new File(TEST_LOG_STATE_DIR);
-        if (rootDir.isDirectory()) {
-            for (File file : rootDir.listFiles()) {
-                file.delete();
-            }
-        }
-        rootDir.delete();
+//        File rootDir = new File(TEST_LOG_STATE_DIR);
+//        if (rootDir.isDirectory()) {
+//            for (File file : rootDir.listFiles()) {
+//                file.delete();
+//            }
+//        }
+//        rootDir.delete();
     }
 
     static List<File> logStateDirFiles() {

--- a/lock-impl/src/main/java/com/palantir/lock/logger/LockServiceTestUtils.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/LockServiceTestUtils.java
@@ -35,13 +35,13 @@ public class LockServiceTestUtils {
     public static final String TEST_LOG_STATE_DIR = "log-state";
 
     public static void cleanUpLogStateDir() throws IOException {
-//        File rootDir = new File(TEST_LOG_STATE_DIR);
-//        if (rootDir.isDirectory()) {
-//            for (File file : rootDir.listFiles()) {
-//                file.delete();
-//            }
-//        }
-//        rootDir.delete();
+        File rootDir = new File(TEST_LOG_STATE_DIR);
+        if (rootDir.isDirectory()) {
+            for (File file : rootDir.listFiles()) {
+                file.delete();
+            }
+        }
+        rootDir.delete();
     }
 
     static List<File> logStateDirFiles() {

--- a/lock-impl/src/main/java/com/palantir/lock/logger/LockStateYamlWriter.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/LockStateYamlWriter.java
@@ -69,6 +69,7 @@ class LockStateYamlWriter implements Closeable {
         Representer representer = new LockDescriptorAwareRepresenter();
         representer.addClassTag(ImmutableSimpleTokenInfo.class, Tag.MAP);
         representer.addClassTag(ImmutableSimpleLockRequest.class, Tag.MAP);
+        representer.addClassTag(ImmutableSanitizedLockRequestProgress.class, Tag.MAP);
         representer.addClassTag(SimpleLockRequestsWithSameDescriptor.class, Tag.MAP);
         representer.addClassTag(LockDescriptor.class, Tag.MAP);
         return representer;

--- a/lock-impl/src/main/java/com/palantir/lock/logger/SanitizedLockRequestProgress.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/SanitizedLockRequestProgress.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.logger;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.immutables.value.Value;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.palantir.lock.impl.LockServiceStateDebugger;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableSanitizedLockRequestProgress.class)
+@JsonDeserialize(as = ImmutableSanitizedLockRequestProgress.class)
+public interface SanitizedLockRequestProgress {
+    String UNKNOWN_NEXT_LOCK_MESSAGE = "<unknown; this may have happened if the request has been serviced,"
+            + " but we have not cleared it from the map>";
+
+    List<SimpleLockRequest> getRequests();
+    String getNextLock();
+    int getNumLocksAcquired();
+    int getTotalNumLocks();
+
+    static SanitizedLockRequestProgress create(LockServiceStateDebugger.LockRequestProgress progress,
+            LockDescriptorMapper descriptorMapper,
+            String clientId) {
+        return ImmutableSanitizedLockRequestProgress.builder()
+                .totalNumLocks(progress.getTotalNumLocks())
+                .numLocksAcquired(progress.getNumLocksAcquired())
+                .nextLock(progress.getNextLock().map(descriptorMapper::getDescriptorMapping)
+                        .orElse(UNKNOWN_NEXT_LOCK_MESSAGE))
+                .requests(
+                        StreamSupport.stream(progress.getRequest().getLockDescriptors().entries().spliterator(), false)
+                                .map(descriptor -> SimpleLockRequest.of(
+                                        progress.getRequest(),
+                                        descriptorMapper.getDescriptorMapping(descriptor.getKey()),
+                                        descriptor.getValue(),
+                                        clientId))
+                        .collect(Collectors.toList()))
+                .build();
+    }
+}


### PR DESCRIPTION
**Goals (and why)**:
- The lock service state logger should be able to tell, for each outstanding request, what the next lock it needs to acquire is.
- Runtime performance of the lock service should not be affected if no dumps are taken.

**Implementation Description (bullets)**:
- Expose an ability on a `KnownClientLock` to check if a lock is being held by an individual client in the read or write mode.
- The algorithm iterates through the locks in order, stopping at the first lock that we do not hold. That is reported as the next lock.
- We also report progress information (e.g. this is lock number 55 of 77).

Sample output could look like this:

```
# WARNING: For LockClient.ANONYMOUS this method may not return accurate results.
---
SynthesizedLockRequestState:
    Client B:
    -   nextLock: Lock-1
        numLocksAcquired: 0
        requests:
        -   blockingDuration: 1000
            blockingMode: BLOCK_UNTIL_TIMEOUT
            clientId: Client B
            creatingThread: main
            lockCount: 1
            lockDescriptor: Lock-1
            lockGroupBehavior: LOCK_ALL_OR_NONE
            lockMode: WRITE
            lockTimeout: 120000
            versionId: null
        totalNumLocks: 1
```

**Testing (What was existing testing like?  What have you done to improve it?)**:
Lock service state logger is tested, I added a test for the new file.

**Concerns (what feedback would you like?)**:
- This approach seems pretty complicated. An easier approach is to maintain state for each request in a map and update it as we go, but that violates my second goal of not normally adding overhead. Is there a way to manage the complexity here, or is my second goal misguided?
- This method does not work for ANONYMOUS lock clients. Internal use cases we were debugging use named lock clients, so this should be fine, but is this a broader problem?
- Are there any threading / synchronization landmines I'm stepping on? There are race conditions everywhere, but I think this is still useful - if there's a legit deadlock things should settle.
- Do we leak lock descriptors anywhere in the synthesized file? I don't think so, but should be worth a check.

**Where should we start reviewing?**: LockServiceStateDebugger

**Priority (whenever / two weeks / yesterday)**: early next week. I'm not sure it's as critical for the PDS ticket any more (as you can reconstruct this information from what's already available if I'm not wrong), but this may make things easier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3557)
<!-- Reviewable:end -->
