### PR TITLE
Never use the 'getActualValues' method

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/id/IdsToNames.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/id/IdsToNames.java
@@ -58,10 +58,7 @@ class IdsToNames {
             kvs.checkAndSet(request);
             return true;
         } catch (CheckAndSetException e) {
-            byte[] currentValue = Iterables.getOnlyElement(e.getActualValues());
-            TableReference currentTableRef =
-                    TableReference.fromString(SweepIdToNameColumnValue.hydrateValue(currentValue));
-            return currentTableRef.equals(table);
+            return get(id).get().equals(table);
         }
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/id/NamesToIds.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/id/NamesToIds.java
@@ -21,7 +21,6 @@ import static com.google.common.base.Preconditions.checkState;
 import java.util.Collections;
 import java.util.Optional;
 
-import com.google.common.collect.Iterables;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.CheckAndSetException;
 import com.palantir.atlasdb.keyvalue.api.CheckAndSetRequest;
@@ -51,7 +50,7 @@ class NamesToIds {
             kvs.checkAndSet(cas);
             return newValue;
         } catch (CheckAndSetException e) {
-            return SweepTableIdentifier.BYTES_HYDRATOR.hydrateFromBytes(Iterables.getOnlyElement(e.getActualValues()));
+            return currentMapping(table).get();
         }
     }
 
@@ -81,8 +80,7 @@ class NamesToIds {
         try {
             kvs.checkAndSet(request);
         } catch (CheckAndSetException e) {
-            SweepTableIdentifier actual = SweepTableIdentifier.BYTES_HYDRATOR.hydrateFromBytes(
-                    Iterables.getOnlyElement(e.getActualValues()));
+            SweepTableIdentifier actual = currentMapping(table).get();
             checkState(newValue.equals(actual), "Unexpectedly we state changed from pending(id) to "
                     + "not(identified(id)) after identifying id as the correct value");
         }


### PR DESCRIPTION
DbKvs behaves differently to the other KVSes, and it's non-trivial to
unify the behaviour. I'm going to file the issue, but this is the
easiest workaround.

Explicitly, if you use CAS to do a PUE, all C* and InMemory will set the
'current values', whereas DbKVS will not. Changing this would require
some fairly exciting SQL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3559)
<!-- Reviewable:end -->
