### PR TITLE
Fix the stupid sweep things.

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/WriteReferencePersister.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/WriteReferencePersister.java
@@ -51,7 +51,7 @@ public final class WriteReferencePersister {
             public WriteReference visitTableNameAsStringBinary(byte[] ref) {
                 int offset = 1;
                 String tableReferenceString = EncodingUtils.decodeVarString(ref, offset);
-                TableReference tableReference = TableReference.createFromFullyQualifiedName(tableReferenceString);
+                TableReference tableReference = TableReference.fromString(tableReferenceString);
                 offset += EncodingUtils.sizeOfVarString(tableReferenceString);
                 byte[] row = EncodingUtils.decodeSizedBytes(ref, offset);
                 offset += EncodingUtils.sizeOfSizedBytes(row);


### PR DESCRIPTION
Unfortunately, it looks like there's no good way to
1. test for writes to empty namespace tables enqueued for targeted sweep
   before the table mapping migration.
2. test for oracle or postgres missing tables in this repo
So I guess I'm going to have to just fix this and hope

