### PR TITLE
Prevent AutoDelegate AutoFootShooting

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
@@ -27,7 +27,7 @@ import com.palantir.processors.AutoDelegate;
 import com.palantir.timestamp.TimestampManagementService;
 import com.palantir.timestamp.TimestampService;
 
-@AutoDelegate(typeToExtend = TransactionManager.class)
+@AutoDelegate
 public interface TransactionManager extends AutoCloseable {
     /**
      * Whether this transaction manager has established a connection to the backing store and timestamp/lock services,

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -40,7 +40,7 @@ import com.palantir.remoting.api.config.ssl.SslConfiguration;
 @JsonDeserialize(as = ImmutableCassandraKeyValueServiceConfig.class)
 @JsonSerialize(as = ImmutableCassandraKeyValueServiceConfig.class)
 @JsonTypeName(CassandraKeyValueServiceConfig.TYPE)
-@AutoDelegate(typeToExtend = CassandraKeyValueServiceConfig.class)
+@AutoDelegate
 @Value.Immutable
 public abstract class CassandraKeyValueServiceConfig implements KeyValueServiceConfig {
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
@@ -45,7 +45,7 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.processors.AutoDelegate;
 
 @SuppressWarnings({"all"}) // thrift variable names.
-@AutoDelegate(typeToExtend = CassandraClient.class)
+@AutoDelegate
 public interface CassandraClient {
     /**
      * Checks if the client has a valid connection to Cassandra cluster. Can be used by a client pool

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.processors.AutoDelegate;
 
-@AutoDelegate(typeToExtend = CassandraClientPool.class)
+@AutoDelegate
 public interface CassandraClientPool {
     FunctionCheckedException<CassandraClient, Void, Exception> getValidatePartitioner();
     <V, K extends Exception> V runOnHost(InetSocketAddress specifiedHost,

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -18,7 +18,7 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.processors.AutoDelegate;
 
-@AutoDelegate(typeToExtend = CassandraKeyValueService.class)
+@AutoDelegate
 public interface CassandraKeyValueService extends KeyValueService {
     CassandraTables getCassandraTables();
     TracingQueryRunner getTracingQueryRunner();

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/PuncherStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/PuncherStore.java
@@ -23,7 +23,7 @@ import com.palantir.processors.AutoDelegate;
  *
  * @author jweel
  */
-@AutoDelegate(typeToExtend = PuncherStore.class)
+@AutoDelegate
 public interface PuncherStore {
     /**
      * Used for PuncherStores that can be initialized asynchronously (i.e. those extending

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/ScrubberStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/ScrubberStore.java
@@ -30,7 +30,7 @@ import com.palantir.processors.AutoDelegate;
  *
  * @author ejin
  */
-@AutoDelegate(typeToExtend = ScrubberStore.class)
+@AutoDelegate
 public interface ScrubberStore {
     default boolean isInitialized() {
         return true;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/persistentlock/LockStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/persistentlock/LockStore.java
@@ -18,7 +18,7 @@ package com.palantir.atlasdb.persistentlock;
 import com.palantir.atlasdb.keyvalue.api.CheckAndSetException;
 import com.palantir.processors.AutoDelegate;
 
-@AutoDelegate(typeToExtend = LockStore.class)
+@AutoDelegate
 public interface LockStore {
     LockEntry getLockEntryWithLockId(PersistentLockId lockId);
     void releaseLock(LockEntry lockEntry) throws CheckAndSetException;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/metadata/SchemaMetadataService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/metadata/SchemaMetadataService.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 import com.palantir.atlasdb.schema.SchemaMetadata;
 import com.palantir.processors.AutoDelegate;
 
-@AutoDelegate(typeToExtend = SchemaMetadataService.class)
+@AutoDelegate
 public interface SchemaMetadataService {
     /**
      * Returns {@link SchemaMetadata} for the given schema name, provided the service knows it exists.

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/priority/SweepPriorityStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/priority/SweepPriorityStore.java
@@ -22,7 +22,7 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.processors.AutoDelegate;
 
-@AutoDelegate(typeToExtend = SweepPriorityStore.class)
+@AutoDelegate
 public interface SweepPriorityStore {
     void delete(Transaction tx, Collection<TableReference> tableRefs);
     void update(Transaction tx, TableReference tableRef, UpdateSweepPriority update);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/progress/SweepProgressStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/progress/SweepProgressStore.java
@@ -20,7 +20,7 @@ import java.util.Optional;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.processors.AutoDelegate;
 
-@AutoDelegate(typeToExtend = SweepProgressStore.class)
+@AutoDelegate
 public interface SweepProgressStore {
     void clearProgress(TableReference tableRef);
 

--- a/atlasdb-processors-tests/src/main/java/com/palantir/processors/ChildClass.java
+++ b/atlasdb-processors-tests/src/main/java/com/palantir/processors/ChildClass.java
@@ -15,7 +15,7 @@
  */
 package com.palantir.processors;
 
-@AutoDelegate(typeToExtend = ChildClass.class)
+@AutoDelegate
 public class ChildClass extends TestClass {
     public ChildClass(int overridingParentsConstructor) {}
 

--- a/atlasdb-processors-tests/src/main/java/com/palantir/processors/ChildTestInterface.java
+++ b/atlasdb-processors-tests/src/main/java/com/palantir/processors/ChildTestInterface.java
@@ -15,7 +15,7 @@
  */
 package com.palantir.processors;
 
-@AutoDelegate(typeToExtend = ChildTestInterface.class)
+@AutoDelegate
 public interface ChildTestInterface extends TestInterface {
     @Override
     void overriddenMethod(Integer p1, Integer p2, Integer p3);

--- a/atlasdb-processors-tests/src/main/java/com/palantir/processors/PackagePrivateInterface.java
+++ b/atlasdb-processors-tests/src/main/java/com/palantir/processors/PackagePrivateInterface.java
@@ -15,6 +15,6 @@
  */
 package com.palantir.processors;
 
-@AutoDelegate(typeToExtend = PackagePrivateInterface.class)
+@AutoDelegate
 interface PackagePrivateInterface {
 }

--- a/atlasdb-processors-tests/src/main/java/com/palantir/processors/TestClass.java
+++ b/atlasdb-processors-tests/src/main/java/com/palantir/processors/TestClass.java
@@ -15,7 +15,7 @@
  */
 package com.palantir.processors;
 
-@AutoDelegate(typeToExtend = TestClass.class)
+@AutoDelegate
 public class TestClass {
     private static void privateStaticMethod() {}
     protected static int protectedStaticMethod() {

--- a/atlasdb-processors-tests/src/main/java/com/palantir/processors/TestInterface.java
+++ b/atlasdb-processors-tests/src/main/java/com/palantir/processors/TestInterface.java
@@ -15,7 +15,7 @@
  */
 package com.palantir.processors;
 
-@AutoDelegate(typeToExtend = TestInterface.class)
+@AutoDelegate
 public interface TestInterface {
     void methodWithNoParameters();
     void methodWithOneParameter(int p1);

--- a/atlasdb-processors/src/main/java/com/palantir/processors/AutoDelegate.java
+++ b/atlasdb-processors/src/main/java/com/palantir/processors/AutoDelegate.java
@@ -23,8 +23,4 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.SOURCE)
 public @interface AutoDelegate {
-    /**
-     * The type to be extended. Can be either a class or an interface.
-     */
-    Class typeToExtend();
 }

--- a/atlasdb-processors/src/main/java/com/palantir/processors/AutoDelegateProcessor.java
+++ b/atlasdb-processors/src/main/java/com/palantir/processors/AutoDelegateProcessor.java
@@ -147,19 +147,18 @@ public final class AutoDelegateProcessor extends AbstractProcessor {
                     annotatedElement, AutoDelegate.class.getSimpleName());
         }
 
-        TypeElement baseType = ProcessorUtils.extractTypeFromAnnotation(elementUtils, annotation);
-        PackageElement typePackage = elementUtils.getPackageOf(baseType);
+        PackageElement typePackage = elementUtils.getPackageOf(annotatedElement);
 
         if (typePackage.isUnnamed()) {
-            throw new ProcessingException(baseType, "Type %s doesn't have a package", baseType);
+            throw new ProcessingException(annotatedElement, "Type %s doesn't have a package", annotatedElement);
         }
 
-        if (baseType.getModifiers().contains(Modifier.FINAL)) {
-            throw new ProcessingException(annotatedElement, "Trying to extend final type %s", baseType);
+        if (annotatedElement.getModifiers().contains(Modifier.FINAL)) {
+            throw new ProcessingException(annotatedElement, "Trying to extend final type %s", annotatedElement);
         }
 
-        List<TypeElement> superTypes = fetchSuperTypes(baseType);
-        return new TypeToExtend(typePackage, baseType, superTypes.toArray(new TypeElement[0]));
+        List<TypeElement> superTypes = fetchSuperTypes(annotatedElement);
+        return new TypeToExtend(typePackage, annotatedElement, superTypes.toArray(new TypeElement[0]));
     }
 
     private List<TypeElement> fetchSuperTypes(TypeElement baseType) {

--- a/atlasdb-processors/src/main/java/com/palantir/processors/AutoDelegateProcessor.java
+++ b/atlasdb-processors/src/main/java/com/palantir/processors/AutoDelegateProcessor.java
@@ -109,8 +109,7 @@ public final class AutoDelegateProcessor extends AbstractProcessor {
                 validateAnnotatedElement(annotatedElement);
                 TypeElement typeElement = (TypeElement) annotatedElement;
 
-                AutoDelegate annotation = annotatedElement.getAnnotation(AutoDelegate.class);
-                TypeToExtend typeToExtend = validateAnnotationAndCreateTypeToExtend(annotation, typeElement);
+                TypeToExtend typeToExtend = createTypeToExtend(typeElement);
 
                 if (generatedTypes.contains(typeToExtend.getCanonicalName())) {
                     continue;
@@ -139,14 +138,7 @@ public final class AutoDelegateProcessor extends AbstractProcessor {
         }
     }
 
-    private TypeToExtend validateAnnotationAndCreateTypeToExtend(AutoDelegate annotation, TypeElement annotatedElement)
-            throws ProcessingException {
-
-        if (annotation == null) {
-            throw new ProcessingException(annotatedElement, "Type %s doesn't have annotation @%s",
-                    annotatedElement, AutoDelegate.class.getSimpleName());
-        }
-
+    private TypeToExtend createTypeToExtend(TypeElement annotatedElement) throws ProcessingException {
         PackageElement typePackage = elementUtils.getPackageOf(annotatedElement);
 
         if (typePackage.isUnnamed()) {

--- a/atlasdb-processors/src/main/java/com/palantir/processors/ProcessorUtils.java
+++ b/atlasdb-processors/src/main/java/com/palantir/processors/ProcessorUtils.java
@@ -23,24 +23,12 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.MirroredTypeException;
 import javax.lang.model.type.TypeMirror;
-import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 
 import com.squareup.javapoet.ParameterSpec;
 
 final class ProcessorUtils {
     private ProcessorUtils() {}
-
-    static TypeElement extractTypeFromAnnotation(Elements elementUtils, AutoDelegate annotation) {
-        try {
-            // Throws a MirroredTypeException if the type is not compiled.
-            Class typeClass = annotation.typeToExtend();
-            return elementUtils.getTypeElement(typeClass.getCanonicalName());
-        } catch (MirroredTypeException mte) {
-            DeclaredType typeMirror = (DeclaredType) mte.getTypeMirror();
-            return (TypeElement) typeMirror.asElement();
-        }
-    }
 
     static TypeElement extractType(Types typeUtils, TypeMirror typeToExtract) {
         try {

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,11 @@ develop
     *    - Type
          - Change
 
+    *    - |devbreak|
+         - The AutoDelegate annotation no longer supports a typeToExtend parameter.
+           Users should instead annotate the desired class or interface directly.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3579>`__)
+
     *    - |fixed|
          - Targeted sweep does better with missing tables, and also with the empty namespace.
            Previously, it would just cycle on the error and never sweep. A highly undesirable condition.

--- a/lock-api/src/main/java/com/palantir/lock/LockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/LockService.java
@@ -39,7 +39,7 @@ import com.palantir.processors.AutoDelegate;
  * @author jtamer
  */
 @Path("/lock")
-@AutoDelegate(typeToExtend = LockService.class)
+@AutoDelegate
 @Beta public interface LockService extends RemoteLockService {
     /**
      * Attempts to acquire the requested set of locks. The locks are

--- a/lock-api/src/main/java/com/palantir/lock/v2/TimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/v2/TimelockService.java
@@ -31,7 +31,7 @@ import com.palantir.timestamp.TimestampRange;
 @Path("/timelock")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
-@AutoDelegate(typeToExtend = TimelockService.class)
+@AutoDelegate
 public interface TimelockService {
     /**
      * Used for TimelockServices that can be initialized asynchronously (i.e. those extending

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/ManagedTimestampService.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/ManagedTimestampService.java
@@ -19,6 +19,6 @@ import com.palantir.processors.AutoDelegate;
 import com.palantir.timestamp.TimestampManagementService;
 import com.palantir.timestamp.TimestampService;
 
-@AutoDelegate(typeToExtend = ManagedTimestampService.class)
+@AutoDelegate
 public interface ManagedTimestampService extends TimestampService, TimestampManagementService {
 }

--- a/timestamp-api/src/main/java/com/palantir/timestamp/TimestampBoundStore.java
+++ b/timestamp-api/src/main/java/com/palantir/timestamp/TimestampBoundStore.java
@@ -17,7 +17,7 @@ package com.palantir.timestamp;
 
 import com.palantir.processors.AutoDelegate;
 
-@AutoDelegate(typeToExtend = TimestampBoundStore.class)
+@AutoDelegate
 public interface TimestampBoundStore {
     /**
      * This will be called when the timestamp server is first created.

--- a/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentTimestampService.java
+++ b/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentTimestampService.java
@@ -17,7 +17,7 @@ package com.palantir.timestamp;
 
 import com.palantir.processors.AutoDelegate;
 
-@AutoDelegate(typeToExtend = PersistentTimestampService.class)
+@AutoDelegate
 public interface PersistentTimestampService extends TimestampService, TimestampManagementService {
     @SuppressWarnings("unused") // used by product
     long getUpperLimitTimestampToHandOutInclusive();


### PR DESCRIPTION
**Goals (and why)**:
Remove the `typeToExtend` parameter and extend the class that is annotated. This definitely prevents people from accidentally extending the same class multiple times.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Existing tests pass

**Concerns (what feedback would you like?)**:
This prevents extending external classes, but we have no such usages in atlasdb.

**Priority (whenever / two weeks / yesterday)**:
not urgent but small

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3579)
<!-- Reviewable:end -->
