### PR TITLE
Targeted sweep now immediately cleans up dedicated rows

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -42,7 +42,7 @@ import com.palantir.util.paging.TokenBackedBasicResultsPage;
  * A service which stores key-value pairs.
  */
 @Path("/keyvalue")
-@AutoDelegate(typeToExtend = KeyValueService.class)
+@AutoDelegate
 public interface KeyValueService extends AutoCloseable {
     /**
      * Performs non-destructive cleanup when the KVS is no longer needed.

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/DedicatedRows.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/DedicatedRows.java
@@ -13,31 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.palantir.atlasdb.sweep.queue;
 
-import java.util.Collection;
 import java.util.List;
 
 import org.immutables.value.Value;
 
-/**
- * Contains information on a batch to sweep: a possibly empty list of WriteInfos to sweep for and the maximum timestamp
- * guaranteed to have been swept once the batch is processed.
- */
+import com.palantir.atlasdb.schema.generated.SweepableCellsTable.SweepableCellsRow;
+
 @Value.Immutable
-public interface SweepBatch {
-    List<WriteInfo> writes();
-    DedicatedRows dedicatedRows();
-    long lastSweptTimestamp();
+public interface DedicatedRows {
+    @Value.Parameter
+    List<SweepableCellsRow> getDedicatedRows();
 
-    default boolean isEmpty() {
-        return writes().isEmpty();
-    }
-
-    static SweepBatch of(Collection<WriteInfo> writes, DedicatedRows dedicatedRows, long timestamp) {
-        return ImmutableSweepBatch.builder()
-                .writes(writes)
-                .dedicatedRows(dedicatedRows)
-                .lastSweptTimestamp(timestamp).build();
+    static DedicatedRows of(List<SweepableCellsRow> dedicatedRows) {
+        return ImmutableDedicatedRows.of(dedicatedRows);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueue.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueue.java
@@ -118,7 +118,7 @@ public final class SweepQueue implements MultiTableSweepQueueWriter {
                     SafeArg.of("shardStrategy", shardStrategy.toText()));
         }
 
-        cleaner.clean(shardStrategy, lastSweptTs, sweepBatch.lastSweptTimestamp());
+        cleaner.clean(shardStrategy, lastSweptTs, sweepBatch.lastSweptTimestamp(), sweepBatch.dedicatedRows());
 
         metrics.updateNumberOfTombstones(shardStrategy, sweepBatch.writes().size());
         metrics.updateProgressForShard(shardStrategy, sweepBatch.lastSweptTimestamp());

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueCleaner.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueCleaner.java
@@ -56,6 +56,8 @@ public class SweepQueueCleaner {
         long lastSweptPartitionPreviously = SweepQueueUtils.tsPartitionFine(oldProgress);
         long minimumSweepPartitionNextIteration = SweepQueueUtils.tsPartitionFine(newProgress + 1);
         if (minimumSweepPartitionNextIteration > lastSweptPartitionPreviously) {
+            // This is present for backcompat; we now clean up dedicated rows early, but this is
+            cleanDedicatedRows(shardStrategy, lastSweptPartitionPreviously);
             cleanNonDedicatedRow(shardStrategy, lastSweptPartitionPreviously);
             log.info("Deleted persisted sweep queue information in table {} for partition {}.",
                     LoggingArgs.tableRef(TargetedSweepTableFactory.of().getSweepableCellsTable(null).getTableRef()),
@@ -65,6 +67,10 @@ public class SweepQueueCleaner {
 
     private void cleanDedicatedRows(DedicatedRows dedicatedRows) {
         sweepableCells.deleteDedicatedRows(dedicatedRows);
+    }
+
+    private void cleanDedicatedRows(ShardAndStrategy shardStrategy, long partitionToDelete) {
+        sweepableCells.deleteDedicatedRows(shardStrategy, partitionToDelete);
     }
 
     private void cleanNonDedicatedRow(ShardAndStrategy shardStrategy, long partitionToDelete) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueReader.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueReader.java
@@ -30,6 +30,6 @@ class SweepQueueReader {
     SweepBatch getNextBatchToSweep(ShardAndStrategy shardStrategy, long lastSweptTs, long sweepTs) {
         return sweepableTimestamps.nextSweepableTimestampPartition(shardStrategy, lastSweptTs, sweepTs)
                 .map(fine -> sweepableCells.getBatchForPartition(shardStrategy, fine, lastSweptTs, sweepTs))
-                .orElse(SweepBatch.of(ImmutableList.of(), sweepTs - 1L));
+                .orElse(SweepBatch.of(ImmutableList.of(), DedicatedRows.of(ImmutableList.of()), sweepTs - 1L));
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableCells.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableCells.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -30,11 +29,11 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.PeekingIterator;
+import com.google.common.collect.Streams;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.CellReference;
 import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
@@ -52,6 +51,7 @@ import com.palantir.atlasdb.keyvalue.api.WriteReferencePersister;
 import com.palantir.atlasdb.logging.LoggingArgs;
 import com.palantir.atlasdb.schema.generated.SweepableCellsTable;
 import com.palantir.atlasdb.schema.generated.SweepableCellsTable.SweepableCellsColumnValue;
+import com.palantir.atlasdb.schema.generated.SweepableCellsTable.SweepableCellsRow;
 import com.palantir.atlasdb.schema.generated.TargetedSweepTableFactory;
 import com.palantir.atlasdb.sweep.CommitTsCache;
 import com.palantir.atlasdb.sweep.metrics.TargetedSweepMetrics;
@@ -107,12 +107,12 @@ public class SweepableCells extends SweepQueueTable {
 
     private Map<Cell, byte[]> addCell(PartitionInfo info, WriteReference writeRef, boolean isDedicatedRow,
             long dedicatedRowNumber, long writeIndex) {
-        SweepableCellsTable.SweepableCellsRow row = computeRow(info, isDedicatedRow, dedicatedRowNumber);
+        SweepableCellsRow row = computeRow(info, isDedicatedRow, dedicatedRowNumber);
         SweepableCellsColumnValue colVal = createColVal(info.timestamp(), writeIndex, writeRef);
         return ImmutableMap.of(SweepQueueUtils.toCell(row, colVal), colVal.persistValue());
     }
 
-    private SweepableCellsTable.SweepableCellsRow computeRow(PartitionInfo info, boolean isDedicatedRow,
+    private SweepableCellsRow computeRow(PartitionInfo info, boolean isDedicatedRow,
             long dedicatedRowNumber) {
         TargetedSweepMetadata metadata = ImmutableTargetedSweepMetadata.builder()
                 .conservative(info.isConservative().isTrue())
@@ -122,10 +122,10 @@ public class SweepableCells extends SweepQueueTable {
                 .build();
 
         long tsOrPartition = getTimestampOrPartition(info, isDedicatedRow);
-        return SweepableCellsTable.SweepableCellsRow.of(tsOrPartition, metadata.persistToBytes());
+        return SweepableCellsRow.of(tsOrPartition, metadata.persistToBytes());
     }
 
-    private SweepableCellsTable.SweepableCellsRow computeRow(long partitionFine, ShardAndStrategy shardStrategy) {
+    private SweepableCellsRow computeRow(long partitionFine, ShardAndStrategy shardStrategy) {
         TargetedSweepMetadata metadata = ImmutableTargetedSweepMetadata.builder()
                 .conservative(shardStrategy.isConservative())
                 .dedicatedRow(false)
@@ -133,7 +133,7 @@ public class SweepableCells extends SweepQueueTable {
                 .dedicatedRowNumber(0)
                 .build();
 
-        return SweepableCellsTable.SweepableCellsRow.of(partitionFine, metadata.persistToBytes());
+        return SweepableCellsRow.of(partitionFine, metadata.persistToBytes());
     }
 
     private long getTimestampOrPartition(PartitionInfo info, boolean isDedicatedRow) {
@@ -151,32 +151,32 @@ public class SweepableCells extends SweepQueueTable {
 
     SweepBatch getBatchForPartition(ShardAndStrategy shardStrategy, long partitionFine, long minTsExclusive,
             long sweepTs) {
-        SweepableCellsTable.SweepableCellsRow row = computeRow(partitionFine, shardStrategy);
+        SweepableCellsRow row = computeRow(partitionFine, shardStrategy);
         RowColumnRangeIterator resultIterator = getRowColumnRange(row, partitionFine, minTsExclusive, sweepTs);
         PeekingIterator<Map.Entry<Cell, Value>> peekingResultIterator = Iterators.peekingIterator(resultIterator);
-        Multimap<Long, WriteInfo> writesByStartTs = getBatchOfWrites(row, peekingResultIterator, sweepTs);
+        WriteBatch writeBatch = getBatchOfWrites(row, peekingResultIterator, sweepTs);
+        Multimap<Long, WriteInfo> writesByStartTs = writeBatch.writesByStartTs;
         maybeMetrics.ifPresent(metrics -> metrics.updateEntriesRead(shardStrategy, writesByStartTs.size()));
         log.debug("Read {} entries from the sweep queue.", SafeArg.of("number", writesByStartTs.size()));
-        TimestampsToSweep tsToSweep = getTimestampsToSweepDescendingAndCleanupAborted(shardStrategy,
-                minTsExclusive, sweepTs, writesByStartTs);
+        TimestampsToSweep tsToSweep = getTimestampsToSweepDescendingAndCleanupAborted(
+                shardStrategy, minTsExclusive, sweepTs, writesByStartTs);
         Collection<WriteInfo> writes = getWritesToSweep(writesByStartTs, tsToSweep.timestampsDescending());
         long lastSweptTs = getLastSweptTs(tsToSweep, peekingResultIterator, partitionFine, sweepTs);
-        return SweepBatch.of(writes, lastSweptTs);
+        return SweepBatch.of(writes, DedicatedRows.of(writeBatch.dedicatedRows), lastSweptTs);
     }
 
-    private Multimap<Long, WriteInfo> getBatchOfWrites(SweepableCellsTable.SweepableCellsRow row,
+    private WriteBatch getBatchOfWrites(SweepableCellsRow row,
             PeekingIterator<Map.Entry<Cell, Value>> resultIterator, long sweepTs) {
-        Multimap<Long, WriteInfo> writesByStartTs = HashMultimap.create();
-        while (resultIterator.hasNext() && writesByStartTs.size() < SweepQueueUtils.SWEEP_BATCH_SIZE) {
+        WriteBatch writeBatch = new WriteBatch();
+        while (resultIterator.hasNext() && writeBatch.writesByStartTs.size() < SweepQueueUtils.SWEEP_BATCH_SIZE) {
             Map.Entry<Cell, Value> entry = resultIterator.next();
             SweepableCellsTable.SweepableCellsColumn col = computeColumn(entry);
             long startTs = getTimestamp(row, col);
             if (knownToBeCommittedAfterSweepTs(startTs, sweepTs)) {
-                writesByStartTs.put(startTs, getWriteInfo(startTs, entry.getValue()));
-                // at this point we know any writes with a greater start timestamp will be filtered out, so we stop
-                return writesByStartTs;
+                writeBatch.add(ImmutableList.of(getWriteInfo(startTs, entry.getValue())));
+                return writeBatch;
             }
-            writesByStartTs.putAll(startTs, getWrites(row, col, entry.getValue()));
+            writeBatch.merge(getWrites(row, col, entry.getValue()));
         }
         // there may be entries remaining with the same start timestamp as the last processed one. If that is the case
         // we want to include these ones as well. This is OK since there are at most MAX_CELLS_GENERIC - 1 of them.
@@ -184,17 +184,43 @@ public class SweepableCells extends SweepQueueTable {
             Map.Entry<Cell, Value> entry = resultIterator.peek();
             SweepableCellsTable.SweepableCellsColumn col = computeColumn(entry);
             long timestamp = getTimestamp(row, col);
-            if (writesByStartTs.containsKey(timestamp)) {
-                writesByStartTs.putAll(timestamp, getWrites(row, col, entry.getValue()));
+            if (writeBatch.writesByStartTs.containsKey(timestamp)) {
+                writeBatch.merge(getWrites(row, col, entry.getValue()));
                 resultIterator.next();
             } else {
                 break;
             }
         }
-        return writesByStartTs;
+        return writeBatch;
     }
 
-    private RowColumnRangeIterator getRowColumnRange(SweepableCellsTable.SweepableCellsRow row, long partitionFine,
+    private static class WriteBatch {
+        private final Multimap<Long, WriteInfo> writesByStartTs = HashMultimap.create();
+        private final List<SweepableCellsRow> dedicatedRows = new ArrayList<>();
+
+        WriteBatch merge(WriteBatch other) {
+            writesByStartTs.putAll(other.writesByStartTs);
+            dedicatedRows.addAll(other.dedicatedRows);
+            return this;
+        }
+
+        static WriteBatch single(WriteInfo writeInfo) {
+            WriteBatch batch = new WriteBatch();
+            return batch.add(ImmutableList.of(writeInfo));
+        }
+
+        WriteBatch add(List<SweepableCellsRow> newDedicatedRows, List<WriteInfo> writeInfos) {
+            dedicatedRows.addAll(newDedicatedRows);
+            return add(writeInfos);
+        }
+
+        WriteBatch add(List<WriteInfo> writeInfos) {
+            writeInfos.forEach(info -> writesByStartTs.put(info.timestamp(), info));
+            return this;
+        }
+    }
+
+    private RowColumnRangeIterator getRowColumnRange(SweepableCellsRow row, long partitionFine,
             long minTsExclusive, long maxTsExclusive) {
         return getRowsColumnRange(ImmutableList.of(row.persistToBytes()),
                 columnsBetween(minTsExclusive + 1, maxTsExclusive, partitionFine), SweepQueueUtils.BATCH_SIZE_KVS);
@@ -255,35 +281,36 @@ public class SweepableCells extends SweepQueueTable {
         }
     }
 
-    private List<WriteInfo> getWrites(SweepableCellsTable.SweepableCellsRow row,
+    private WriteBatch getWrites(SweepableCellsRow row,
             SweepableCellsTable.SweepableCellsColumn col, Value value) {
-        List<WriteInfo> writes = new ArrayList<>();
         if (isReferenceToDedicatedRows(col)) {
-            writes = addWritesFromDedicated(row, col, writes);
+            return writesFromDedicated(row, col);
         } else {
-            writes.add(getWriteInfo(getTimestamp(row, col), value));
+            return WriteBatch.single(getWriteInfo(getTimestamp(row, col), value));
         }
-        return writes;
     }
 
     private boolean isReferenceToDedicatedRows(SweepableCellsTable.SweepableCellsColumn col) {
         return col.getWriteIndex() < 0;
     }
 
-    private List<WriteInfo> addWritesFromDedicated(SweepableCellsTable.SweepableCellsRow row,
-            SweepableCellsTable.SweepableCellsColumn col, List<WriteInfo> writes) {
-        List<byte[]> dedicatedRows = computeDedicatedRows(row, col);
-        RowColumnRangeIterator iterator = getWithColumnRangeAll(dedicatedRows);
-        iterator.forEachRemaining(entry -> writes.add(getWriteInfo(getTimestamp(row, col), entry.getValue())));
-        return writes;
+    private WriteBatch writesFromDedicated(SweepableCellsRow row,
+            SweepableCellsTable.SweepableCellsColumn col) {
+        List<SweepableCellsRow> dedicatedRows = computeDedicatedRows(row, col);
+        RowColumnRangeIterator iterator = getWithColumnRangeAll(
+                Lists.transform(dedicatedRows, SweepableCellsRow::persistToBytes));
+        WriteBatch batch = new WriteBatch();
+        return batch.add(dedicatedRows, Streams.stream(iterator)
+                .map(entry -> getWriteInfo(getTimestamp(row, col), entry.getValue()))
+                .collect(Collectors.toList()));
     }
 
-    private List<byte[]> computeDedicatedRows(SweepableCellsTable.SweepableCellsRow row,
+    private List<SweepableCellsRow> computeDedicatedRows(SweepableCellsRow row,
             SweepableCellsTable.SweepableCellsColumn col) {
         TargetedSweepMetadata metadata = TargetedSweepMetadata.BYTES_HYDRATOR.hydrateFromBytes(row.getMetadata());
         long timestamp = getTimestamp(row, col);
         int numberOfDedicatedRows = writeIndexToNumberOfDedicatedRows(col.getWriteIndex());
-        List<byte[]> dedicatedRows = new ArrayList<>();
+        List<SweepableCellsRow> dedicatedRows = new ArrayList<>();
 
         for (int i = 0; i < numberOfDedicatedRows; i++) {
             byte[] dedicatedMetadata = ImmutableTargetedSweepMetadata.builder()
@@ -292,12 +319,12 @@ public class SweepableCells extends SweepQueueTable {
                     .dedicatedRowNumber(i)
                     .build()
                     .persistToBytes();
-            dedicatedRows.add(SweepableCellsTable.SweepableCellsRow.of(timestamp, dedicatedMetadata).persistToBytes());
+            dedicatedRows.add(SweepableCellsRow.of(timestamp, dedicatedMetadata));
         }
         return dedicatedRows;
     }
 
-    private long getTimestamp(SweepableCellsTable.SweepableCellsRow row, SweepableCellsTable.SweepableCellsColumn col) {
+    private long getTimestamp(SweepableCellsRow row, SweepableCellsTable.SweepableCellsColumn col) {
         return row.getTimestampPartition() * SweepQueueUtils.TS_FINE_GRANULARITY + col.getTimestampModulus();
     }
 
@@ -327,8 +354,11 @@ public class SweepableCells extends SweepQueueTable {
         return Math.min(SweepQueueUtils.maxTsForFinePartition(partitionFine), maxTsExclusive - 1);
     }
 
-    void deleteDedicatedRows(ShardAndStrategy shardAndStrategy, long partitionFine) {
-        rangeRequestsDedicatedRows(shardAndStrategy, partitionFine).forEach(this::deleteRange);
+    void deleteDedicatedRows(DedicatedRows dedicatedRows) {
+        dedicatedRows.getDedicatedRows().stream()
+                .map(SweepableCellsRow::persistToBytes)
+                .map(dedicatedRow -> computeRangeRequestForRows(dedicatedRow, dedicatedRow))
+                .forEach(this::deleteRange);
     }
 
     void deleteNonDedicatedRow(ShardAndStrategy shardAndStrategy, long partitionFine) {
@@ -338,24 +368,6 @@ public class SweepableCells extends SweepQueueTable {
     private Map<Cell, byte[]> addWrite(PartitionInfo info, WriteInfo write, boolean dedicate, long index) {
         return addCell(info, write.writeRef(), dedicate, index / SweepQueueUtils.MAX_CELLS_DEDICATED,
                 index % SweepQueueUtils.MAX_CELLS_DEDICATED);
-    }
-
-    private List<RangeRequest> rangeRequestsDedicatedRows(ShardAndStrategy shardAndStrategy, long partitionFine) {
-        SweepableCellsTable.SweepableCellsRow row = computeRow(partitionFine, shardAndStrategy);
-        RowColumnRangeIterator rowIterator = getWithColumnRangeAllForRow(row);
-        List<RangeRequest> requests = new ArrayList<>();
-        rowIterator.forEachRemaining(entry -> requests.addAll(rangeRequestsIfDedicated(row, computeColumn(entry))));
-        return requests;
-    }
-
-    private Set<RangeRequest> rangeRequestsIfDedicated(SweepableCellsTable.SweepableCellsRow row,
-            SweepableCellsTable.SweepableCellsColumn col) {
-        if (!isReferenceToDedicatedRows(col)) {
-            return ImmutableSet.of();
-        }
-        return computeDedicatedRows(row, col).stream()
-                .map(bytes -> computeRangeRequestForRows(bytes, bytes))
-                .collect(Collectors.toSet());
     }
 
     private RangeRequest rangeRequestNonDedicatedRow(ShardAndStrategy shardAndStrategy, long partitionFine) {
@@ -374,10 +386,6 @@ public class SweepableCells extends SweepQueueTable {
     private SweepableCellsTable.SweepableCellsColumn computeColumn(Map.Entry<Cell, Value> entry) {
         return SweepableCellsTable.SweepableCellsColumn.BYTES_HYDRATOR
                 .hydrateFromBytes(entry.getKey().getColumnName());
-    }
-
-    private RowColumnRangeIterator getWithColumnRangeAllForRow(SweepableCellsTable.SweepableCellsRow row) {
-        return getWithColumnRangeAll(ImmutableList.of(row.persistToBytes()));
     }
 
     private ColumnRangeSelection columnsBetween(long startTsInclusive, long endTsExclusive, long partitionFine) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/TimestampsToSweep.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/TimestampsToSweep.java
@@ -15,17 +15,17 @@
  */
 package com.palantir.atlasdb.sweep.queue;
 
-import java.util.List;
+import java.util.SortedSet;
 
 import org.immutables.value.Value;
 
 @Value.Immutable
 public interface TimestampsToSweep {
-    List<Long> timestampsDescending();
+    SortedSet<Long> timestampsDescending();
     long maxSwept();
     boolean processedAll();
 
-    static TimestampsToSweep of(List<Long> list, long max, boolean processedAll) {
+    static TimestampsToSweep of(SortedSet<Long> list, long max, boolean processedAll) {
         return ImmutableTimestampsToSweep.builder()
                 .timestampsDescending(list)
                 .maxSwept(max)

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepableCellsTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepableCellsTest.java
@@ -47,7 +47,7 @@ import com.palantir.atlasdb.keyvalue.api.ImmutableTargetedSweepMetadata;
 import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.RangeRequests;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
-import com.palantir.atlasdb.schema.generated.SweepableCellsTable;
+import com.palantir.atlasdb.schema.generated.SweepableCellsTable.SweepableCellsRow;
 import com.palantir.atlasdb.schema.generated.TargetedSweepTableFactory;
 import com.palantir.atlasdb.sweep.metrics.SweepMetricsAssert;
 import com.palantir.atlasdb.sweep.metrics.TargetedSweepMetrics;
@@ -343,7 +343,7 @@ public class SweepableCellsTest extends AbstractSweepQueueTest {
         writeCommittedConservativeRowForTimestamp(TS + 5, MAX_CELLS_GENERIC);
 
         sweepableCells.deleteNonDedicatedRow(ShardAndStrategy.conservative(0), TS_FINE_PARTITION);
-        SweepableCellsTable.SweepableCellsRow row = SweepableCellsTable.SweepableCellsRow.of(TS_FINE_PARTITION,
+        SweepableCellsRow row = SweepableCellsRow.of(TS_FINE_PARTITION,
                 ImmutableTargetedSweepMetadata.builder()
                         .conservative(true)
                         .dedicatedRow(false)
@@ -358,11 +358,9 @@ public class SweepableCellsTest extends AbstractSweepQueueTest {
     @Test
     public void cleanupMultipleDedicatedRows() {
         useSingleShard();
-        writeCommittedConservativeRowForTimestamp(TS + 1, MAX_CELLS_DEDICATED * 2 + 1);
 
-        sweepableCells.deleteDedicatedRows(ShardAndStrategy.conservative(0), TS_FINE_PARTITION);
-
-        List<SweepableCellsTable.SweepableCellsRow> expectedRangesToDelete = LongStream.range(0, 3)
+        long timestamp = TS + 1;
+        DedicatedRows dedicatedRows = DedicatedRows.of(LongStream.range(0, 3)
                 .mapToObj(rowNumber -> ImmutableTargetedSweepMetadata.builder()
                         .conservative(true)
                         .dedicatedRow(true)
@@ -370,12 +368,40 @@ public class SweepableCellsTest extends AbstractSweepQueueTest {
                         .shard(0)
                         .build()
                         .persistToBytes())
-                .map(metadata -> SweepableCellsTable.SweepableCellsRow.of(TS + 1, metadata))
-                .collect(Collectors.toList());
-        verifyRowsDeletedFromSweepQueue(expectedRangesToDelete);
+                .map(metadata -> SweepableCellsRow.of(timestamp, metadata))
+                .collect(Collectors.toList()));
+
+        writeCommittedConservativeRowForTimestamp(timestamp, MAX_CELLS_DEDICATED * 2 + 1);
+
+        sweepableCells.deleteDedicatedRows(dedicatedRows);
+
+        verifyRowsDeletedFromSweepQueue(dedicatedRows.getDedicatedRows());
     }
 
-    private void verifyRowsDeletedFromSweepQueue(List<SweepableCellsTable.SweepableCellsRow> rows) {
+    @Test
+    public void getBatchReturnsDedicatedRowsSeen() {
+        useSingleShard();
+
+        long timestamp = TS + 1;
+
+        writeCommittedConservativeRowForTimestamp(timestamp, MAX_CELLS_DEDICATED * 2 + 1);
+
+        DedicatedRows expectedDedicatedRows = DedicatedRows.of(LongStream.range(0, 3)
+                .mapToObj(rowNumber -> ImmutableTargetedSweepMetadata.builder()
+                        .conservative(true)
+                        .dedicatedRow(true)
+                        .dedicatedRowNumber(rowNumber)
+                        .shard(0)
+                        .build()
+                        .persistToBytes())
+                .map(metadata -> SweepableCellsRow.of(timestamp, metadata))
+                .collect(Collectors.toList()));
+
+        assertThat(readConservative(0, TS_FINE_PARTITION, TS - 1, SMALL_SWEEP_TS).dedicatedRows())
+                .isEqualTo(expectedDedicatedRows);
+    }
+
+    private void verifyRowsDeletedFromSweepQueue(List<SweepableCellsRow> rows) {
         ArgumentCaptor<RangeRequest> captor = ArgumentCaptor.forClass(RangeRequest.class);
         verify(spiedKvs, atLeast(0)).deleteRange(eq(SWEEP_QUEUE_TABLE), captor.capture());
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
@@ -773,7 +773,7 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
 
         // we now read all to the end
         sweepQueue.sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
-        assertThat(metricsManager).hasEntriesReadConservativeEqualTo(4 + writesInDedicated + 3 + writesInDedicated + 2);
+        assertThat(metricsManager).hasEntriesReadConservativeEqualTo(4 + 3 + writesInDedicated + 2);
     }
 
     @Test

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,11 @@ develop
     *    - Type
          - Change
 
+    *    - |fixed|
+         - Targeted sweep now deletes certain sweep queue rows faster than before, which should
+           reduce table bloat (particularly on space constrained systems).
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3581>`__)
+
     *    - |devbreak|
          - The AutoDelegate annotation no longer supports a typeToExtend parameter.
            Users should instead annotate the desired class or interface directly.

--- a/timestamp-api/src/main/java/com/palantir/timestamp/TimestampService.java
+++ b/timestamp-api/src/main/java/com/palantir/timestamp/TimestampService.java
@@ -25,7 +25,7 @@ import com.palantir.logsafe.Safe;
 import com.palantir.processors.AutoDelegate;
 
 @Path("/timestamp")
-@AutoDelegate(typeToExtend = TimestampService.class)
+@AutoDelegate
 public interface TimestampService {
     /**
      * Used for TimestampServices that can be initialized asynchronously; other TimestampServices can keep the default


### PR DESCRIPTION
Don't dilly dally waiting for dedicated rows to be cleaned up; instead
just delete them immediately after sweeping them (since once we start
loading the contents of a dedicated row, we just delete all the
contents).

Notable gaps: Testing. I'm not sure I'm convinced it works. Is there
actually a test that the dedicated rows get cleaned up @gmaretic?
I couldn't really find one.

Making progress here is dependent on David's internal testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3581)
<!-- Reviewable:end -->
