### PR TITLE
fix leader election dead end

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -76,6 +76,9 @@ develop
            (`Pull Request 1 <https://github.com/palantir/atlasdb/pull/3554>`__ and
            `Pull Request 2 <https://github.com/palantir/atlasdb/pull/3565>`__)
 
+    *    - |fixed|
+         - Fixed a bug where ``AwaitingLeadershipProxy`` stops trying to gain leadership, causing client calls to leader to throw ``NotCurrentLeaderException``.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3582>`__)
 
 ========
 v0.106.0

--- a/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
@@ -19,10 +19,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -211,7 +211,7 @@ public class AwaitingLeadershipProxyTest {
         Thread.sleep(1000); //wait for retrying on gaining leadership
 
         proxy.run();
-        verify(leaderElectionService, times(2)).blockOnBecomingLeader();
+        verify(leaderElectionService, atLeast(2)).blockOnBecomingLeader();
     }
 
     @SuppressWarnings("IllegalThrows")


### PR DESCRIPTION
**Goals (and why)**:
`AwaitingLeadershipProxy` assumes a node would either be a leader or try to become a leader (which is a valid assumption). But it somehow fall into a state where it is not the leader and it is not trying to become a leader; then there is no way that it can get out of that state.

Currently, if `blockOnBecomingLeader()` throws, `gainLeadershipBlocking()` will fail silently, leaving `leadershipToken` empty. In that case, node won't be the leader, and it won't try to become the leader -> getting stuck in the follower state forever. (or until someone restarts the service)

**Implementation Description (bullets)**:
Wrapping `gainLeadershipBlocking()` with `gainLeadershipWithRetry()`, which checks if leadership token is set after `gainLeadershipBlocking()` returns. If it is not set, retries.

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:
`AwaitingLeadershipProxy`

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3582)
<!-- Reviewable:end -->
