### PR TITLE
Actually fix the sweep things

### DIFF
--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbkvsPostgresTargetedSweepIntegrationTest.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbkvsPostgresTargetedSweepIntegrationTest.java
@@ -21,11 +21,11 @@ import org.junit.ClassRule;
 import com.palantir.atlasdb.keyvalue.impl.TestResourceManager;
 import com.palantir.atlasdb.sweep.AbstractTargetedSweepTest;
 
-public class DbkvsTargetedSweepIntegrationTest extends AbstractTargetedSweepTest {
+public class DbkvsPostgresTargetedSweepIntegrationTest extends AbstractTargetedSweepTest {
     @ClassRule
     public static final TestResourceManager TRM = new TestResourceManager(DbkvsPostgresTestSuite::createKvs);
 
-    public DbkvsTargetedSweepIntegrationTest() {
+    public DbkvsPostgresTargetedSweepIntegrationTest() {
         super(TRM, TRM);
     }
 }

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbkvsPostgresTestSuite.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbkvsPostgresTestSuite.java
@@ -40,6 +40,7 @@ import com.palantir.remoting.api.config.service.HumanReadableDuration;
 
 @RunWith(Suite.class)
 @SuiteClasses({
+        DbkvsTargetedSweepIntegrationTest.class
         DbkvsPostgresKeyValueServiceTest.class,
         DbkvsPostgresSerializableTransactionTest.class,
         DbkvsPostgresSweepTaskRunnerTest.class,

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbkvsPostgresTestSuite.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbkvsPostgresTestSuite.java
@@ -40,7 +40,7 @@ import com.palantir.remoting.api.config.service.HumanReadableDuration;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-        DbkvsTargetedSweepIntegrationTest.class
+        DbkvsPostgresTargetedSweepIntegrationTest.class,
         DbkvsPostgresKeyValueServiceTest.class,
         DbkvsPostgresSerializableTransactionTest.class,
         DbkvsPostgresSweepTaskRunnerTest.class,

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbkvsTargetedSweepIntegrationTest.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbkvsTargetedSweepIntegrationTest.java
@@ -13,23 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.palantir.atlasdb.keyvalue.cassandra;
+
+package com.palantir.atlasdb.keyvalue.dbkvs;
 
 import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.rules.RuleChain;
 
-import com.palantir.atlasdb.containers.CassandraResource;
+import com.palantir.atlasdb.keyvalue.impl.TestResourceManager;
 import com.palantir.atlasdb.sweep.AbstractTargetedSweepTest;
 
-public class CassandraTargetedSweepIntegrationTest extends AbstractTargetedSweepTest {
+public class DbkvsTargetedSweepIntegrationTest extends AbstractTargetedSweepTest {
     @ClassRule
-    public static final CassandraResource CASSANDRA = new CassandraResource();
+    public static final TestResourceManager TRM = new TestResourceManager(DbkvsPostgresTestSuite::createKvs);
 
-    @Rule
-    public final RuleChain ruleChain = SchemaMutationLockReleasingRule.createChainedReleaseAndRetry(CASSANDRA);
-
-    public CassandraTargetedSweepIntegrationTest() {
-        super(CASSANDRA, CASSANDRA);
+    public DbkvsTargetedSweepIntegrationTest() {
+        super(TRM, TRM);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueDeleter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueDeleter.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.sweep.queue;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 import java.util.function.Function;
@@ -24,13 +25,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Iterables;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
-import com.palantir.atlasdb.keyvalue.impl.TableMappingNotFoundException;
 import com.palantir.atlasdb.logging.LoggingArgs;
 import com.palantir.atlasdb.sweep.Sweeper;
-import com.palantir.exception.PalantirSqlException;
 
 public class SweepQueueDeleter {
     private static final Logger log = LoggerFactory.getLogger(SweepQueueDeleter.class);
@@ -69,19 +69,18 @@ public class SweepQueueDeleter {
                                 kvs.deleteAllTimestamps(entry.getKey(), maxTimestampByCellPartition, true);
                             }
                         });
-            } catch (IllegalArgumentException | PalantirSqlException e) {
-                // TODO we don't have a centralized error for when a table doesn't exist...
-                if (e.getCause() instanceof TableMappingNotFoundException // exception thrown by TableRemappingKVS
-                        || e.getMessage().endsWith("does not exist") // exception thrown by InMemory, Oracle, Postgres
-                        || e.getMessage().endsWith("not found")) { // exception thrown by TableValueStyleCache
-                    log.warn("Could not find table for table reference {}, "
-                            + "assuming table has been deleted and therefore relevant cells as well.",
-                            LoggingArgs.tableRef(entry.getKey()), e);
+            } catch (Exception e) {
+                if (tableWasDropped(entry.getKey())) {
+                    log.info("The table {} has been deleted.", LoggingArgs.tableRef(entry.getKey()), e);
                 } else {
                     throw e;
                 }
             }
         }
+    }
+
+    private boolean tableWasDropped(TableReference tableRef) {
+        return Arrays.equals(kvs.getMetadataForTable(tableRef), AtlasDbConstants.EMPTY_TABLE_METADATA);
     }
 
     private Map<TableReference, Map<Cell, Long>> writesPerTable(Collection<WriteInfo> writes, Sweeper sweeper) {

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractTargetedSweepTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractTargetedSweepTest.java
@@ -1,0 +1,104 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.SweepResults;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.keyvalue.impl.KvsManager;
+import com.palantir.atlasdb.keyvalue.impl.TransactionManagerManager;
+import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
+import com.palantir.atlasdb.sweep.queue.ShardAndStrategy;
+import com.palantir.atlasdb.sweep.queue.SpecialTimestampsSupplier;
+import com.palantir.atlasdb.sweep.queue.TargetedSweepFollower;
+import com.palantir.atlasdb.sweep.queue.TargetedSweeper;
+import com.palantir.atlasdb.table.description.TableMetadata;
+import com.palantir.lock.v2.TimelockService;
+
+public class AbstractTargetedSweepTest extends AbstractSweepTest {
+    private static final TableReference TABLE_TO_BE_DROPPED = TableReference.createFromFullyQualifiedName("ts.drop");
+    private static final Cell TEST_CELL = Cell.create(PtBytes.toBytes("r"), PtBytes.toBytes("c"));
+    private static final String OLD_VALUE = "old_value";
+    private static final String NEW_VALUE = "new_value";
+    private SpecialTimestampsSupplier timestampsSupplier = mock(SpecialTimestampsSupplier.class);
+    private TargetedSweeper sweepQueue;
+
+    protected AbstractTargetedSweepTest(KvsManager kvsManager, TransactionManagerManager tmManager) {
+        super(kvsManager, tmManager);
+    }
+
+    @Before
+    public void setup() {
+        super.setup();
+
+        sweepQueue = TargetedSweeper.createUninitializedForTest(() -> 1);
+        sweepQueue.initializeWithoutRunning(
+                timestampsSupplier, mock(TimelockService.class), kvs, mock(TargetedSweepFollower.class));
+    }
+
+    @Override
+    protected Optional<SweepResults> completeSweep(TableReference ignored, long ts) {
+        when(timestampsSupplier.getUnreadableTimestamp()).thenReturn(ts);
+        when(timestampsSupplier.getImmutableTimestamp()).thenReturn(ts);
+        sweepQueue.sweepNextBatch(ShardAndStrategy.conservative(0));
+        sweepQueue.sweepNextBatch(ShardAndStrategy.thorough(0));
+        return Optional.empty();
+    }
+
+    @Override
+    protected void put(final TableReference tableRef, Cell cell, final String val, final long ts) {
+        super.put(tableRef, cell, val, ts);
+        sweepQueue.enqueue(ImmutableMap.of(tableRef, ImmutableMap.of(cell, val.getBytes(StandardCharsets.UTF_8))), ts);
+    }
+
+    @Test
+    public void targetedSweepIgnoresDroppedTables() {
+        createTable(TableMetadataPersistence.SweepStrategy.CONSERVATIVE);
+        kvs.createTable(TABLE_TO_BE_DROPPED, new TableMetadata().persistToBytes());
+
+        put(TABLE_NAME, TEST_CELL, OLD_VALUE, 50);
+        put(TABLE_NAME, TEST_CELL, NEW_VALUE, 150);
+        put(TABLE_TO_BE_DROPPED, TEST_CELL, OLD_VALUE, 100);
+
+        kvs.dropTable(TABLE_TO_BE_DROPPED);
+        completeSweep(null, 90);
+        assertThat(getValue(TABLE_NAME, 110)).isEqualTo(Value.create(PtBytes.toBytes(OLD_VALUE), 50));
+        assertThat(getValue(TABLE_NAME, 160)).isEqualTo(Value.create(PtBytes.toBytes(NEW_VALUE), 150));
+
+        completeSweep(null, 160);
+        assertThat(getValue(TABLE_NAME, 110))
+                .isEqualTo(Value.create(PtBytes.EMPTY_BYTE_ARRAY, Value.INVALID_VALUE_TIMESTAMP));
+        assertThat(getValue(TABLE_NAME, 160)).isEqualTo(Value.create(PtBytes.toBytes(NEW_VALUE), 150));
+    }
+
+    private Value getValue(TableReference tableRef, long ts) {
+        return kvs.get(tableRef, ImmutableMap.of(TEST_CELL, ts)).get(TEST_CELL);
+    }
+}

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractTargetedSweepTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractTargetedSweepTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 import org.junit.Before;
@@ -75,7 +74,7 @@ public class AbstractTargetedSweepTest extends AbstractSweepTest {
     @Override
     protected void put(final TableReference tableRef, Cell cell, final String val, final long ts) {
         super.put(tableRef, cell, val, ts);
-        sweepQueue.enqueue(ImmutableMap.of(tableRef, ImmutableMap.of(cell, val.getBytes(StandardCharsets.UTF_8))), ts);
+        sweepQueue.enqueue(ImmutableMap.of(tableRef, ImmutableMap.of(cell, PtBytes.toBytes(val))), ts);
     }
 
     @Test


### PR DESCRIPTION
**Goals (and why)**:
Originally, write tests for postgres targeted sweep and cassandra ts with dropped table. Both implementations were actually throwing, so then fixed the problem in a less brittle way.
 
**Implementation Description (bullets)**:
Instead of juggling all these different and undocumented exceptions (KVS interface claims ISE should be thrown), call getMetadata to verify if the table is there.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Comes with tests.

**Concerns (what feedback would you like?)**:
Another KVS call, but I think it's preferable to parsing exception messages

**Priority (whenever / two weeks / yesterday)**:
Blocked on the base branch being merged

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3584)
<!-- Reviewable:end -->
