### PR TITLE
Better profiling for HikariCPConnectionPools

### DIFF
--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/HikariCPConnectionManager.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/HikariCPConnectionManager.java
@@ -22,6 +22,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.TimeZone;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 
 import javax.management.JMX;
 import javax.management.MBeanServer;
@@ -34,6 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Stopwatch;
 import com.palantir.nexus.db.DBType;
 import com.palantir.nexus.db.pool.config.ConnectionConfig;
 import com.palantir.nexus.db.sql.ExceptionCheck;
@@ -84,27 +86,30 @@ public class HikariCPConnectionManager extends BaseConnectionManager {
 
     @Override
     public Connection getConnection() throws SQLException {
-        long start = System.currentTimeMillis();
+        ConnectionAcquisitionProfiler profiler = new ConnectionAcquisitionProfiler(
+                Stopwatch.createStarted(), Stopwatch.createStarted());
         try {
-            return acquirePooledConnection(start);
+            return acquirePooledConnection(profiler);
         } finally {
-            logConnectionAcquisitionTiming(start);
+            profiler.logQueryDuration();
         }
     }
 
     /**
      * Attempts to acquire a valid database connection from the pool.
-     * @param startMillis start milliseconds
+     * @param profiler Connection acquisition profiler for this attempt to acquire a connection
      * @return valid pooled connection
      * @throws SQLException if a connection cannot be acquired within the {@link ConnectionConfig#getCheckoutTimeout()}
      */
-    private Connection acquirePooledConnection(long startMillis) throws SQLException {
+    private Connection acquirePooledConnection(ConnectionAcquisitionProfiler profiler) throws SQLException {
         while (true) {
             HikariDataSource dataSourcePool = checkAndGetDataSourcePool();
             Connection conn = dataSourcePool.getConnection();
+            profiler.logAcquisitionAndRestart();
 
             try {
                 testConnection(conn);
+                profiler.logConnectionTest();
                 return conn;
             } catch (SQLException e) {
                 log.error("[{}] Dropping connection which failed validation",
@@ -112,25 +117,13 @@ public class HikariCPConnectionManager extends BaseConnectionManager {
                         e);
                 dataSourcePool.evictConnection(conn);
 
-                if (System.currentTimeMillis() > startMillis + connConfig.getCheckoutTimeout()) {
+                if (profiler.trialStopwatch.elapsed(TimeUnit.MILLISECONDS) > connConfig.getCheckoutTimeout()) {
                     // It's been long enough that had hikari been
                     // validating internally it would have given up rather
                     // than retry
                     throw e;
                 }
             }
-        }
-    }
-
-    private void logConnectionAcquisitionTiming(long startMillis) {
-        long elapsedMillis = System.currentTimeMillis() - startMillis;
-        if (elapsedMillis > 1000) {
-            log.warn("[{}] Waited {}ms for connection",
-                    connConfig.getConnectionPoolName(),
-                    elapsedMillis);
-            logPoolStats();
-        } else {
-            log.debug("Waited {}ms for connection", elapsedMillis);
         }
     }
 
@@ -353,5 +346,47 @@ public class HikariCPConnectionManager extends BaseConnectionManager {
     @Override
     public DBType getDbType() {
         return connConfig.getDbType();
+    }
+
+    private class ConnectionAcquisitionProfiler {
+        private final Stopwatch globalStopwatch;
+        private final Stopwatch trialStopwatch;
+
+        private long acquisitionMillis;
+        private long connectionTestMillis;
+
+        private ConnectionAcquisitionProfiler(Stopwatch globalStopwatch, Stopwatch trialStopwatch) {
+            this.globalStopwatch = globalStopwatch;
+            this.trialStopwatch = trialStopwatch;
+        }
+
+        private void logAcquisitionAndRestart() {
+            trialStopwatch.stop();
+            acquisitionMillis = trialStopwatch.elapsed(TimeUnit.MILLISECONDS);
+            trialStopwatch.reset().start();
+        }
+
+        private void logConnectionTest() {
+            trialStopwatch.stop();
+            connectionTestMillis = trialStopwatch.elapsed(TimeUnit.MILLISECONDS);
+        }
+
+        private void logQueryDuration() {
+            long elapsedMillis = globalStopwatch.elapsed(TimeUnit.MILLISECONDS);
+            if (elapsedMillis > 1000) {
+                log.warn("[{}] Waited {}ms for connection (acquisition: {}, connectionTest: {})",
+                        connConfig.getConnectionPoolName(),
+                        elapsedMillis,
+                        acquisitionMillis,
+                        connectionTestMillis);
+                logPoolStats();
+            } else {
+                log.debug("[{}] Waited {}ms for connection (acquisition: {}, connectionTest: {})",
+                        connConfig.getConnectionPoolName(),
+                        elapsedMillis,
+                        acquisitionMillis,
+                        connectionTestMillis);
+            }
+        }
     }
 }

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/HikariCPConnectionManager.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/HikariCPConnectionManager.java
@@ -86,8 +86,7 @@ public class HikariCPConnectionManager extends BaseConnectionManager {
 
     @Override
     public Connection getConnection() throws SQLException {
-        ConnectionAcquisitionProfiler profiler = new ConnectionAcquisitionProfiler(
-                Stopwatch.createStarted(), Stopwatch.createStarted());
+        ConnectionAcquisitionProfiler profiler = new ConnectionAcquisitionProfiler();
         try {
             return acquirePooledConnection(profiler);
         } finally {
@@ -117,7 +116,7 @@ public class HikariCPConnectionManager extends BaseConnectionManager {
                         e);
                 dataSourcePool.evictConnection(conn);
 
-                if (profiler.trialStopwatch.elapsed(TimeUnit.MILLISECONDS) > connConfig.getCheckoutTimeout()) {
+                if (profiler.globalStopwatch.elapsed(TimeUnit.MILLISECONDS) > connConfig.getCheckoutTimeout()) {
                     // It's been long enough that had hikari been
                     // validating internally it would have given up rather
                     // than retry
@@ -354,6 +353,10 @@ public class HikariCPConnectionManager extends BaseConnectionManager {
 
         private long acquisitionMillis;
         private long connectionTestMillis;
+
+        private ConnectionAcquisitionProfiler() {
+            this(Stopwatch.createStarted(), Stopwatch.createStarted());
+        }
 
         private ConnectionAcquisitionProfiler(Stopwatch globalStopwatch, Stopwatch trialStopwatch) {
             this.globalStopwatch = globalStopwatch;

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
@@ -101,6 +101,20 @@ public abstract class ConnectionConfig {
         return 45;
     }
 
+    @Value.Default
+    public String getConnectionPoolIdentifier() {
+        return "db-pool";
+    }
+
+    @Value.Derived
+    public String getConnectionPoolName() {
+        return String.format(
+                "%s-%s-%s",
+                getConnectionPoolIdentifier(),
+                getConnId(),
+                getDbLogin());
+    }
+
     /**
      * This is JsonIgnore'd because it doesn't serialise. Serialisation is needed for atlasdb-dropwizard-bundle.
      */
@@ -123,7 +137,7 @@ public abstract class ConnectionConfig {
 
         Properties props = getHikariProperties();
 
-        config.setPoolName("db-pool-" + getConnId() + "-" + getDbLogin());
+        config.setPoolName(getConnectionPoolName());
         config.setRegisterMbeans(true);
         config.setMetricRegistry(SharedMetricRegistries.getOrCreate("com.palantir.metrics"));
 

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
@@ -106,6 +106,7 @@ public abstract class ConnectionConfig {
         return "db-pool";
     }
 
+    @JsonIgnore
     @Value.Derived
     public String getConnectionPoolName() {
         return String.format(


### PR DESCRIPTION
**Goals (and why)**: See PDS-75716

**Implementation Description (bullets)**:
- Allow configs to include a pool identifier
- Split out timing of getting the connection and running the subsequent query

**Testing (What was existing testing like?  What have you done to improve it?)**:
Nonexistent, and nothing since high priority and high lift

**Concerns (what feedback would you like?)**:
Does it work, and are there any blatant pitfalls this misses?

**Where should we start reviewing?**: the one file

**Priority (whenever / two weeks / yesterday)**: 0-1 days ideally

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3585)
<!-- Reviewable:end -->
