### PR TITLE
[WIP][DO NOT MERGE] Compare against existing client pool when refreshing pool

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -278,6 +278,7 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
             sanityCheckRingConsistency();
         }
 
+        //TODO(achow): Log some kind of placeholder for addresses detected in token range refresh
         log.debug("Cassandra pool refresh added hosts {}, removed hosts {}.",
                 SafeArg.of("serversToAdd", CassandraLogHelper.collectionOfHosts(serversToAdd)),
                 SafeArg.of("serversToRemove", CassandraLogHelper.collectionOfHosts(serversToRemove)));


### PR DESCRIPTION
**Goals (and why)**:

Refactor of refreshPool() method in CassandraClientPoolImpl where servers added/removed are identified by comparing against servers in the current token range with the servers in the current (un-updated) client pool. This allows decommissioned c* nodes to be removed from the client pool without restarting the client.

**Implementation Description (bullets)**:

The current behavior is:
- If auto-refresh is on, find all servers in the config or token range. Add servers not already in the client pool.
- If auto-refresh is off, remove servers in the client pool that are not in the config.

Behavior with this PR is:
- If auto-refresh is off:
	- Add all servers from the config to the client pool, if not there already
	- Remove any servers in the client pool that aren't in the config
- If auto-refresh is on:
	- Add to client pool all servers from the current token range that aren't already in the client pool
	- Remove from client pool any servers that aren't in the current token range.

**Testing (What was existing testing like?  What have you done to improve it?)**:

Tested on an old branch I had: https://github.com/amandachow/atlasdb/tree/achow/refresh-remove-nodes
What I did was:
- Try a migration workflow to reproduce existing issue:
	- Create c* nodes 1, 2, 3
	- Add to cluster c* nodes 4, 5, 6
	- Decom 1, 2, 3 -- At this stage atlas client starts spewing errors
- Do same workflow with client running my branch (built locally)

Started a new branch (this one) because the change was so simple and my branch was so old/full of annoying logging I added, haven't done the same workflow with this branch but it doesn't look like this function has been touched since then anyway

**Concerns (what feedback would you like?)**:

Not sure how to approach writing tests. Also not sure if my understanding of the current behavior is correct. Also would like to walk through weird edge cases (such as create nodes 1, 2, 3, 4, then remove node 4, then spin up a new node on same host as node 4, or start atlasdb client with nodes 1, 2, 3, 4 in the config when actually the token range is 1, 2, 3, etc etc), especially around initialization

**Where should we start reviewing?**:

CassandraClientPoolImpl.refreshPool()

**Priority (whenever / two weeks / yesterday)**:

Two weeks

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3599)
<!-- Reviewable:end -->
