### PR TITLE
TimeLock Migration Docs Clarifications

### DIFF
--- a/docs/source/services/timelock_service/migration.rst
+++ b/docs/source/services/timelock_service/migration.rst
@@ -15,10 +15,15 @@ Automated Migration
 -------------------
 
 .. warning::
-    Automated migrations are only implemented for Cassandra.
+    Automated migrations are only implemented for Cassandra. If you are using any other KVS, please follow the
+    instructions at :ref:`manual-timelock-migration`.
 
-1. If you are using the Cassandra key value service and have added the :ref:`Timelock client configuration <timelock-client-configuration>`, then starting/re-starting the service will automatically migrate the service.
-2. If you are using any other KVS, please follow the instructions at :ref:`manual-timelock-migration`.
+1. Confirm that your AtlasDB installation is backed by Cassandra KVS.
+2. (Optional) Take a fresh timestamp from your AtlasDB services, using the fresh timestamp CLI or the
+   ``/timestamp/fresh-timestamp`` endpoint. This step is not strictly required, but may be useful for verification.
+3. Add the :ref:`Timelock client configuration <timelock-client-configuration>` to your service.
+4. Starting/re-starting the service will automatically migrate the service.
+   Note that the service may not elect a leader until a timestamp or lock request for some client is actually made.
 
 Verification
 ~~~~~~~~~~~~


### PR DESCRIPTION
**Goals (and why)**:
- See PDS-74088. There was some friction around two main points: (1) the instructions ask you to validate a value against a timestamp from before that you were never actually asked to get, and (2) timelock did not elect a leader when it was bounced for quite a long time (you actually need to call get fresh timestamp / lock to trigger an election)

**Implementation Description (bullets)**:
- Add a step before the actual upgrade that says to get a verification timestamp
- Mention that the service may not elect a leader until a request is made.

**Testing (What was existing testing like?  What have you done to improve it?)**: N/A, docs change. The docs build.

**Concerns (what feedback would you like?)**: Nothing too much.

**Where should we start reviewing?**: `migration.rst`

**Priority (whenever / two weeks / yesterday)**: this week, it's small

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3601)
<!-- Reviewable:end -->
