### PR TITLE
Change TransactionManagers.builder

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -215,7 +215,7 @@ public abstract class TransactionManagers {
     }
 
     public static Builder builder() {
-        return ImmutableTransactionManagers.builder();
+        return new Builder();
     }
 
     @VisibleForTesting

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -148,7 +148,6 @@ import com.palantir.util.JavaSuppliers;
 import com.palantir.util.OptionalResolver;
 
 @Value.Immutable
-@Value.Style(stagedBuilder = true)
 public abstract class TransactionManagers {
     private static final int LOGGING_INTERVAL = 60;
     private static final Logger log = LoggerFactory.getLogger(TransactionManagers.class);
@@ -205,7 +204,17 @@ public abstract class TransactionManagers {
         return Callback.noOp();
     }
 
-    public static ImmutableTransactionManagers.ConfigBuildStage builder() {
+    public interface Configurator<T extends TransactionManager> {
+        Supplier<T> configure(Builder builder);
+    }
+
+    public static class Builder extends ImmutableTransactionManagers.Builder {
+        <T extends TransactionManager> Supplier<T> serializable(Configurator<T> configurator) {
+            return configurator.configure(this);
+        }
+    }
+
+    public static Builder builder() {
         return ImmutableTransactionManagers.builder();
     }
 

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -252,7 +252,7 @@ public abstract class TransactionManagers {
     }
 
     @JsonIgnore
-    @Value.Derived
+    @Value.Lazy
     public TransactionManager serializable() {
         List<AutoCloseable> closeables = Lists.newArrayList();
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -89,6 +89,9 @@ develop
          - Fixed a bug where ``AwaitingLeadershipProxy`` stops trying to gain leadership, causing client calls to leader to throw ``NotCurrentLeaderException``.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3582>`__)
 
+    *    - |devbreak|
+         - ``TransactionManagers.builder()`` no longer returns a ``ConfigStage``, but a ``TransactionManagers.Builder``. If this is used in a fluent fashion, it should have no effect.
+
 ========
 v0.106.0
 ========


### PR DESCRIPTION
Two changes:
1) `TransactionManagers.builder()` is no longer a staged builder, so no longer returns a `ConfigStage`. 
2) `TransactionManagers.Builder` now has a `serializable(Configurator<T extends TransactionManager> configurator)` method allowing alternate forms of creating transaction managers e.g. delegating to a library a way to finalise creation of a `TransactionManager` without allowing the consumer to intervene.

**Goals (and why)**:
A library needs to wrap a `TransactionManager` in order to provide safety guarantees. However, a non-wrapped `TransactionManager` cannot run with a wrapped `TransactionManager`. Goal is to force the consumer to pick one and not ever be in a state where they have both.

**Concerns**:
It does have a dev break, but since it's a builder, it's usually used fluently, so it should be fine, unless people are storing intermediate builders into variables (in my mind shouldn't be necessary, so I'm okay with the break here).

**Priority (whenever / two weeks / yesterday)**:
ASAP
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3602)
<!-- Reviewable:end -->
