### PR TITLE
Shorten TodoEteTest for sweeping streams

### DIFF
--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TodoEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TodoEteTest.java
@@ -65,8 +65,8 @@ public class TodoEteTest {
         assertThat(valueSweep.getCellTsPairsExamined(), equalTo(9L));
         assertThat(valueSweep.getStaleValuesDeleted(), equalTo(4L));
 
-        // Stores five larger streams, which take 19 blocks each
-        StreamTestUtils.storeFiveStreams(todoClient, 7654321);
+        // Stores five larger streams, which take 3 blocks each
+        StreamTestUtils.storeFiveStreams(todoClient, 1254321);
 
         // The index table now contains ten rows:
         // 4 rows with a sentinel and a delete (sweep sees the delete, but doesn't sweep it - 4 examined, 0 deleted)
@@ -81,12 +81,12 @@ public class TodoEteTest {
         // The value table now contains ten rows:
         // 4 rows with a sentinel and a delete (sweep sees the delete, but doesn't sweep it - 4 E, 0 D)
         // 1 single-block row with one block and a delete (sweep sees both, and sweeps the value - 2 E, 1 D)
-        // 4 rows with 19 blocks and 19 deletes (38 E, 19 D per row = 152 E, 76 D)
-        // 1 row (the most recent) with 19 blocks (19 E, 0 D)
-        // The total cells examined is thus 4 + 2 + 4*2*19 + 19 = 177
-        // And the total cells deleted is 1 + 4*19 = 77
+        // 4 rows with 3 blocks and 3 deletes (6 E, 3 D per row = 24 E, 12 D)
+        // 1 row (the most recent) with 3 blocks (3 E, 0 D)
+        // The total cells examined is thus 4 + 2 + 4*2*3 + 3 = 33
+        // And the total cells deleted is 1 + 4*3 = 13
         SweepResults secondValueSweep = todoClient.sweepSnapshotValues();
-        assertThat(secondValueSweep.getCellTsPairsExamined(), equalTo(177L));
-        assertThat(secondValueSweep.getStaleValuesDeleted(), equalTo(1L + 19 * 4L));
+        assertThat(secondValueSweep.getCellTsPairsExamined(), equalTo(33L));
+        assertThat(secondValueSweep.getStaleValuesDeleted(), equalTo(13L));
     }
 }


### PR DESCRIPTION
**Goals (and why)**:
This test was flaking because of timeouts. There is no reason why this test needed to put in that much data, so this will make it faster and should stop flaking

**Priority (whenever / two weeks / yesterday)**:
asap

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3607)
<!-- Reviewable:end -->
