### PR TITLE
Don't retry schema mutation requests...

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -1504,7 +1504,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     }
 
     private void createTablesInternal(final Map<TableReference, byte[]> tableNamesToTableMetadata) throws Exception {
-        clientPool.runWithRetry(client -> {
+        clientPool.run(client -> {
             for (Entry<TableReference, byte[]> tableEntry : tableNamesToTableMetadata.entrySet()) {
                 try {
                     client.system_add_column_family(ColumnFamilyDefinitions.getCfDef(

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,11 @@ develop
     *    - Type
          - Change
 
+    *    - |fixed|
+         - We no longer retry failed Cassandra  schema mutations; these can cause concurrent schema mutations
+           while holding the schema mutation lock.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3613>`__)
+
     *    - |userbreak|
          - Qos Service: The experimental QosService for rate-limiting clients has been removed.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3586>`__)


### PR DESCRIPTION
This is a little silly. We shouldn't be retrying schema mutation
requests because they re-introduce the race condition the schema
mutation lock is supposed to solve in the presence of timeouts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3613)
<!-- Reviewable:end -->
