### PR TITLE
Do not break cassandra when creating and dropping tables

### DIFF
--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/OneNodeDownTableManipulationTest.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/OneNodeDownTableManipulationTest.java
@@ -17,6 +17,7 @@ package com.palantir.cassandra.multinode;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableMap;
@@ -37,6 +38,7 @@ public class OneNodeDownTableManipulationTest extends AbstractDegradedClusterTes
     }
 
     @Test
+    @Ignore // until we rework table creation
     public void canCreateTable() {
         TableReference tableToCreate = TableReference.createWithEmptyNamespace("new_table");
         getTestKvs().createTable(tableToCreate, AtlasDbConstants.GENERIC_TABLE_METADATA);
@@ -47,6 +49,7 @@ public class OneNodeDownTableManipulationTest extends AbstractDegradedClusterTes
     }
 
     @Test
+    @Ignore // until we rework table creation
     public void canCreateTables() {
         TableReference tableToCreate = TableReference.createWithEmptyNamespace("new_table2");
         getTestKvs().createTables(ImmutableMap.of(tableToCreate, AtlasDbConstants.GENERIC_TABLE_METADATA));
@@ -57,6 +60,23 @@ public class OneNodeDownTableManipulationTest extends AbstractDegradedClusterTes
     }
 
     @Test
+    public void createTableThrowsAndDoesNotChangeCassandraSchema() {
+        TableReference tableToCreate = TableReference.createWithEmptyNamespace("new_table");
+        assertThrowsAtlasDbDependencyExceptionAndDoesNotChangeCassandraSchema(() ->
+                getTestKvs().createTable(tableToCreate, AtlasDbConstants.GENERIC_TABLE_METADATA));
+
+    }
+
+    @Test
+    public void createTablesThrowsAndDoesNotChangeCassandraSchema() {
+        TableReference tableToCreate = TableReference.createWithEmptyNamespace("new_table");
+        assertThrowsAtlasDbDependencyExceptionAndDoesNotChangeCassandraSchema(() ->
+                getTestKvs().createTables(ImmutableMap.of(tableToCreate, AtlasDbConstants.GENERIC_TABLE_METADATA)));
+
+    }
+
+    @Test
+    @Ignore // until we rework table dropping
     public void canDropTable() {
         getTestKvs().dropTable(TABLE_TO_DROP);
 
@@ -66,12 +86,25 @@ public class OneNodeDownTableManipulationTest extends AbstractDegradedClusterTes
     }
 
     @Test
+    @Ignore // until we rework table dropping
     public void canDropTables() {
         getTestKvs().dropTables(ImmutableSet.of(TABLE_TO_DROP_2));
 
         assertThat(getTestKvs().getAllTableNames()).doesNotContain(TABLE_TO_DROP_2);
         assertKvsReturnsEmptyMetadata(TABLE_TO_DROP_2);
         assertCassandraSchemaChanged();
+    }
+
+    @Test
+    public void dropTableThrowsAndDoesNotChangeCassandraSchema() {
+        assertThrowsAtlasDbDependencyExceptionAndDoesNotChangeCassandraSchema(() ->
+                getTestKvs().dropTable(TEST_TABLE));
+    }
+
+    @Test
+    public void dropTablesThrowsAndDoesNotChangeCassandraSchema() {
+        assertThrowsAtlasDbDependencyExceptionAndDoesNotChangeCassandraSchema(() ->
+                getTestKvs().dropTables(ImmutableSet.of(TEST_TABLE)));
     }
 
     @Test

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/TwoNodesDownCleanCassLockStateTest.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/TwoNodesDownCleanCassLockStateTest.java
@@ -15,9 +15,6 @@
  */
 package com.palantir.cassandra.multinode;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import org.apache.thrift.TException;
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +28,6 @@ import com.palantir.atlasdb.keyvalue.cassandra.CassandraSchemaLockCleaner;
 import com.palantir.atlasdb.keyvalue.cassandra.SchemaMutationLockTables;
 import com.palantir.atlasdb.keyvalue.cassandra.TracingQueryRunner;
 import com.palantir.atlasdb.keyvalue.impl.TracingPrefsConfig;
-import com.palantir.common.exception.AtlasDbDependencyException;
 
 public class TwoNodesDownCleanCassLockStateTest extends AbstractDegradedClusterTest {
 
@@ -47,7 +43,7 @@ public class TwoNodesDownCleanCassLockStateTest extends AbstractDegradedClusterT
     }
 
     @Test
-    public void cleanUpSchemaMutationLockTablesStateThrowsButCleansUpExtraTables() throws TException {
+    public void cleanUpSchemaMutationLockTablesStateThrows() {
         CassandraKeyValueServiceConfig config = TwoNodesDownTestSuite.getConfig(getClass());
         CassandraClientPool clientPool = getTestKvs().getClientPool();
         SchemaMutationLockTables lockTables = new SchemaMutationLockTables(clientPool, config);
@@ -56,8 +52,7 @@ public class TwoNodesDownCleanCassLockStateTest extends AbstractDegradedClusterT
         CassandraSchemaLockCleaner cleaner = CassandraSchemaLockCleaner.create(config, clientPool, lockTables,
                 queryRunner);
 
-        assertThatThrownBy(cleaner::cleanLocksState).isInstanceOf(AtlasDbDependencyException.class);
-        // Note this behaviour
-        assertCassandraSchemaChanged();
+
+        assertThrowsAtlasDbDependencyExceptionAndDoesNotChangeCassandraSchema(cleaner::cleanLocksState);
     }
 }

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/TwoNodesDownTableManipulationTest.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/TwoNodesDownTableManipulationTest.java
@@ -15,9 +15,9 @@
  */
 package com.palantir.cassandra.multinode;
 
-import org.apache.thrift.TException;
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
@@ -31,7 +31,7 @@ public class TwoNodesDownTableManipulationTest extends AbstractDegradedClusterTe
     }
 
     @Test
-    public void createTableThrowsAndDoesNotChangeCassandraSchema() throws TException {
+    public void createTableThrowsAndDoesNotChangeCassandraSchema() {
         TableReference tableToCreate = TableReference.createWithEmptyNamespace("new_table");
         assertThrowsAtlasDbDependencyExceptionAndDoesNotChangeCassandraSchema(() ->
                 getTestKvs().createTable(tableToCreate, AtlasDbConstants.GENERIC_TABLE_METADATA));
@@ -39,13 +39,21 @@ public class TwoNodesDownTableManipulationTest extends AbstractDegradedClusterTe
     }
 
     @Test
-    public void dropTableThrowsAndDoesNotChangeCassandraSchema() throws TException {
+    public void createTablesThrowsAndDoesNotChangeCassandraSchema() {
+        TableReference tableToCreate = TableReference.createWithEmptyNamespace("new_table");
+        assertThrowsAtlasDbDependencyExceptionAndDoesNotChangeCassandraSchema(() ->
+                getTestKvs().createTables(ImmutableMap.of(tableToCreate, AtlasDbConstants.GENERIC_TABLE_METADATA)));
+
+    }
+
+    @Test
+    public void dropTableThrowsAndDoesNotChangeCassandraSchema() {
         assertThrowsAtlasDbDependencyExceptionAndDoesNotChangeCassandraSchema(() ->
                 getTestKvs().dropTable(TEST_TABLE));
     }
 
     @Test
-    public void dropTablesThrowsAndDoesNotChangeCassandraSchema() throws TException {
+    public void dropTablesThrowsAndDoesNotChangeCassandraSchema() {
         assertThrowsAtlasDbDependencyExceptionAndDoesNotChangeCassandraSchema(() ->
                 getTestKvs().dropTables(ImmutableSet.of(TEST_TABLE)));
     }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTableDropper.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTableDropper.java
@@ -58,6 +58,8 @@ class CassandraTableDropper {
         try {
             clientPool.runWithRetry(
                     (FunctionCheckedException<CassandraClient, Void, Exception>) client -> {
+                        CassandraKeyValueServices.waitForSchemaAgreementOnAllNodes(config, client, "before dropping the"
+                                + " column family for tables " + tablesToDrop + " in a call to drop tables");
                         KsDef ks = client.describe_keyspace(
                                 config.getKeyspaceOrThrow());
                         Set<TableReference> existingTables = Sets.newHashSet();
@@ -78,8 +80,8 @@ class CassandraTableDropper {
                                         LoggingArgs.tableRef(table));
                             }
                         }
-                        CassandraKeyValueServices.waitForSchemaVersions(config, client, "after dropping the column "
-                                + "family for tables " + tablesToDrop + " in a call to drop tables");
+                        CassandraKeyValueServices.waitForSchemaAgreementOnAllNodes(config, client, "after dropping the "
+                                + "column family for tables " + tablesToDrop + " in a call to drop tables");
                         return null;
                     });
         } catch (Exception e) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTables.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTables.java
@@ -76,8 +76,8 @@ class CassandraTables {
     private Set<String> getTableNames(CassandraClient client, String keyspace,
             Function<CfDef, String> nameGetter) throws TException {
         try {
-            CassandraKeyValueServices
-                    .waitForSchemaVersions(config, client, "before making a call to get all table names.");
+            CassandraKeyValueServices.waitForSchemaAgreementOnQuorumOfNodes(
+                    config, client, "before making a call to get all table names.");
         } catch (IllegalStateException e) {
             throw new InsufficientConsistencyException("Could not reach a quorum of nodes agreeing on schema versions "
                     + "before making a call to get all table names.", e);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -208,7 +208,7 @@ public final class CassandraVerifier {
         try {
             CassandraClient client = CassandraClientFactory.getClientInternal(host, config);
             client.describe_keyspace(config.getKeyspaceOrThrow());
-            CassandraKeyValueServices.waitForSchemaVersions(config, client,
+            CassandraKeyValueServices.waitForSchemaAgreementOnQuorumOfNodes(config, client,
                     "while checking if schemas diverged on startup");
             return true;
         } catch (NotFoundException e) {
@@ -223,7 +223,7 @@ public final class CassandraVerifier {
             KsDef ksDef = createKsDefForFresh(client, config);
             client.system_add_keyspace(ksDef);
             log.info("Created keyspace: {}", SafeArg.of("keyspace", config.getKeyspaceOrThrow()));
-            CassandraKeyValueServices.waitForSchemaVersions(config, client,
+            CassandraKeyValueServices.waitForSchemaAgreementOnQuorumOfNodes(config, client,
                     "after adding the initial empty keyspace");
             return true;
         } catch (InvalidRequestException e) {
@@ -247,7 +247,7 @@ public final class CassandraVerifier {
                 // Can't call system_update_keyspace to update replication factor if CfDefs are set
                 modifiedKsDef.setCf_defs(ImmutableList.of());
                 client.system_update_keyspace(modifiedKsDef);
-                CassandraKeyValueServices.waitForSchemaVersions(config, client,
+                CassandraKeyValueServices.waitForSchemaAgreementOnQuorumOfNodes(config, client,
                         "after updating the existing keyspace");
             }
             return null;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTables.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTables.java
@@ -111,7 +111,7 @@ public class SchemaMutationLockTables {
             try {
                 client.execute_cql3_query(query, Compression.NONE, ConsistencyLevel.QUORUM);
 
-                CassandraKeyValueServices.waitForSchemaVersions(config, client,
+                CassandraKeyValueServices.waitForSchemaAgreementOnQuorumOfNodes(config, client,
                         "creating the lock table " + tableRef.getQualifiedName());
                 return null;
             } catch (TException ex) {

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,12 @@ develop
     *    - Type
          - Change
 
+    *    - |fixed|
+         - Fixed a bug in Cassandra KVS that could result in issuing a request to create the same table to two different Cassandra nodes, requiring manual intervention to correct the resulting schema versions state in Cassandra.
+           We now require all nodes to agree on schema versions after we obtain the schema mutation lock and before we create or drop tables.
+           This temporarily reverts some of the changes in https://github.com/palantir/atlasdb/pull/3480 until we rework table creation and dropping.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3614>`__)
+
     *    - |userbreak|
          - Qos Service: The experimental QosService for rate-limiting clients has been removed.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3586>`__)


### PR DESCRIPTION
**Goals (and why)**:
See internal ticket 76619. Prevent breaking your cassandra schema that can happen when a task requiring schema mutation locks is retried. 

**Implementation Description (bullets)**:
This is a bit heavy-handed because it forces all nodes to be available before we allow table creation and dropping, but that is comparable to previous behaviour.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Existing tests have been updated to reflect the sotw

**Concerns (what feedback would you like?)**:
The following could have happened in atlas 0.107.0 and before, which was a bug, but may have increased availability:
We have quorum up, try to create table -> this requests the schema mutation then fails on waiting for versions to settle
We restart atlas, still only have quorum but now the table exists and we happily start since we only need a quorum of nodes to agree on schema versions if others are unavailable.

Now, we will never issue the request in the first place, so you will not be able to start atlas if you need to create a table and not all nodes are up. We should follow up next week with a fix where we supply the cfId ourselves as @j-baker suggested.

**Where should we start reviewing?**:
Small

**Priority (whenever / two weeks / yesterday)**:
Today & release

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3614)
<!-- Reviewable:end -->
