### PR TITLE
remove wrapper for lockImmutableTs

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/TimestampCorroboratingTimelockService.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/TimestampCorroboratingTimelockService.java
@@ -22,7 +22,6 @@ import java.util.function.ToLongFunction;
 
 import com.palantir.lock.v2.AutoDelegate_TimelockService;
 import com.palantir.lock.v2.IdentifiedTimeLockRequest;
-import com.palantir.lock.v2.LockImmutableTimestampResponse;
 import com.palantir.lock.v2.StartAtlasDbTransactionResponse;
 import com.palantir.lock.v2.StartIdentifiedAtlasDbTransactionRequest;
 import com.palantir.lock.v2.StartIdentifiedAtlasDbTransactionResponse;

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/TimestampCorroboratingTimelockService.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/TimestampCorroboratingTimelockService.java
@@ -72,13 +72,6 @@ public final class TimestampCorroboratingTimelockService implements AutoDelegate
     }
 
     @Override
-    public LockImmutableTimestampResponse lockImmutableTimestamp(IdentifiedTimeLockRequest request) {
-        return checkAndUpdateLowerBound(() -> delegate.lockImmutableTimestamp(request),
-                LockImmutableTimestampResponse::getImmutableTimestamp,
-                LockImmutableTimestampResponse::getImmutableTimestamp);
-    }
-
-    @Override
     public StartIdentifiedAtlasDbTransactionResponse startIdentifiedAtlasDbTransaction(
             StartIdentifiedAtlasDbTransactionRequest request) {
         return checkAndUpdateLowerBound(() -> delegate.startIdentifiedAtlasDbTransaction(request),

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/timelock/TimestampCorroboratingTimelockServiceTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/timelock/TimestampCorroboratingTimelockServiceTest.java
@@ -83,13 +83,6 @@ public class TimestampCorroboratingTimelockServiceTest {
     }
 
     @Test
-    public void lockImmutableTimestampShouldFail() {
-        when(rawTimelockService.lockImmutableTimestamp(any())).thenReturn(LOCK_IMMUTABLE_TIMESTAMP_RESPONSE);
-
-        assertThrowsOnSecondCall(() -> timelockService.lockImmutableTimestamp(IDENTIFIED_TIME_LOCK_REQUEST));
-    }
-
-    @Test
     public void startIdentifiedAtlasDbTransactionShouldFail() {
         StartIdentifiedAtlasDbTransactionResponse startIdentifiedAtlasDbTransactionResponse =
                 StartIdentifiedAtlasDbTransactionResponse.of(LOCK_IMMUTABLE_TIMESTAMP_RESPONSE,


### PR DESCRIPTION
**Goals (and why)**:
Don't wrap `lockImmutableTs` as contract does not guarantee it will be always higher than the previous fresh timestamp.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3618)
<!-- Reviewable:end -->
