### PR TITLE
We should use the timestamp lower bound when performing the check.

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/TimestampCorroboratingTimelockService.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/TimestampCorroboratingTimelockService.java
@@ -97,8 +97,8 @@ public final class TimestampCorroboratingTimelockService implements AutoDelegate
         return timestampContainer;
     }
 
-    private void checkTimestamp(long timestampLowerBound, long freshTimestamp) {
-        if (freshTimestamp <= lowerBound.get()) {
+    private static void checkTimestamp(long timestampLowerBound, long freshTimestamp) {
+        if (freshTimestamp <= timestampLowerBound) {
             throw clocksWentBackwards(timestampLowerBound, freshTimestamp);
         }
     }

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/timelock/TimestampCorroboratingTimelockServiceTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/timelock/TimestampCorroboratingTimelockServiceTest.java
@@ -16,6 +16,8 @@
 
 package com.palantir.atlasdb.factory.timelock;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -23,9 +25,14 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import com.palantir.lock.v2.IdentifiedTimeLockRequest;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
@@ -93,6 +100,53 @@ public class TimestampCorroboratingTimelockServiceTest {
 
         assertThrowsOnSecondCall(() -> timelockService.startIdentifiedAtlasDbTransaction(
                 StartIdentifiedAtlasDbTransactionRequest.createForRequestor(UUID.randomUUID())));
+    }
+
+    @Test
+    public void resilientUnderMultipleThreads() throws InterruptedException {
+        BlockingTimestamp blockingTimestampReturning1 = new BlockingTimestamp(1);
+        when(rawTimelockService.getFreshTimestamp())
+                .thenAnswer(blockingTimestampReturning1)
+                .thenReturn(2L);
+
+        Future<Void> blockingGetFreshTimestampCall =
+                CompletableFuture.runAsync(timelockService::getFreshTimestamp);
+
+        blockingTimestampReturning1.waitForFirstCallToBlock();
+
+        assertThat(timelockService.getFreshTimestamp())
+                .as("This should have updated the lower bound to 2")
+                .isEqualTo(2L);
+
+        // we want to now resume the blocked call, which will return timestamp of 1 and not throw
+        blockingTimestampReturning1.countdown();
+        assertThatCode(blockingGetFreshTimestampCall::get)
+                .doesNotThrowAnyException();
+    }
+
+    private static class BlockingTimestamp implements Answer<Long> {
+        private final CountDownLatch returnTimestampLatch = new CountDownLatch(1);
+        private final CountDownLatch blockingLatch = new CountDownLatch(1);
+        private final long timestampToReturn;
+
+        private BlockingTimestamp(long timestampToReturn) {
+            this.timestampToReturn = timestampToReturn;
+        }
+
+        @Override
+        public Long answer(InvocationOnMock invocation) throws Throwable {
+            blockingLatch.countDown();
+            returnTimestampLatch.await();
+            return timestampToReturn;
+        }
+
+        void countdown() {
+            returnTimestampLatch.countDown();
+        }
+
+        void waitForFirstCallToBlock() throws InterruptedException {
+            blockingLatch.await();
+        }
     }
 
     private void assertThrowsOnSecondCall(Runnable runnable) {


### PR DESCRIPTION
**Goals (and why)**:
We were effectively relying on another thread to update the lower bound in order for the corroborating ts to do its check. Causing a lot of flakes in the etes.

**Implementation Description (bullets)**:
Don't refetch the lower bound when performing the check. But the cached lower bound that's already been retrieved.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Simple multi threaded test: have another thread update the lower bound and then see what happens.

**Priority (whenever / two weeks / yesterday)**:
ASAP, develop is effectively broken and builds are quite flaky.
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
