### PR TITLE
Actually use Refreshing and Exception Counting Wrappers for Live Reloading Proxies

### DIFF
--- a/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/AtlasDbFeignTargetFactory.java
+++ b/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/AtlasDbFeignTargetFactory.java
@@ -146,7 +146,7 @@ public final class AtlasDbFeignTargetFactory {
             String userAgent) {
         FailoverFeignTarget<T> failoverFeignTarget = new FailoverFeignTarget<>(endpointUris, maxBackoffMillis, type);
         Client client = failoverFeignTarget.wrapClient(
-                FeignOkHttpClients.newOkHttpClient(sslSocketFactory, proxySelector, userAgent));
+                FeignOkHttpClients.newRefreshingOkHttpClient(sslSocketFactory, proxySelector, userAgent));
         return Feign.builder()
                 .contract(contract)
                 .encoder(encoder)

--- a/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/FeignOkHttpClients.java
+++ b/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/FeignOkHttpClients.java
@@ -105,8 +105,10 @@ public final class FeignOkHttpClients {
     }
 
     /**
-     * Returns a Feign {@link Client} wrapping an {@link okhttp3.OkHttpClient}, which re-creates
-     * itself periodically (by default, every ScheduledRefreshingClient.STANDARD_REFRESH_INTERVAL time).
+     * Returns a Feign {@link Client} wrapping an {@link okhttp3.OkHttpClient}. This {@link Client} recreates
+     * itself in the event that either {@link CounterBackedRefreshingClient#DEFAULT_REQUEST_COUNT_BEFORE_REFRESH}
+     * requests have been made, or if {@link ExceptionCountingRefreshingClient#DEFAULT_EXCEPTION_COUNT_BEFORE_REFRESH}
+     * consecutive exceptions have been thrown by the underlying client.
      */
     public static Client newRefreshingOkHttpClient(
             Optional<SSLSocketFactory> sslSocketFactory,

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -133,12 +133,12 @@ develop
     *    - |improved|
          - The index cleanup task for stream stores now only fetches the first column for each stream ID when determining whether the stream is still in use.
            Previously, we would fetch the entire row which is unnecessary and causes read pressure on the key-value-service for highly referenced streams.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/qqqq>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3423>`__)
 
     *    - |fixed|
          - Live-reloading HTTP proxies and HTTP proxies with failover now refresh themselves after encountering a large number of cumulative requests or consecutive exceptions.
-           This was previously implemented to work around several issues with our usage of OkHttp, but was not implemented for the failover proxies.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/qqqq>`__)
+           This was previously implemented to work around several issues with our usage of OkHttp, but was not implemented for the proxies with failover (which includes proxies to TimeLock).
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3629>`__)
 
 ========
 v0.106.0

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -134,7 +134,12 @@ develop
          - The index cleanup task for stream stores now only fetches the first column for each stream ID when determining whether the stream is still in use.
            Previously, we would fetch the entire row which is unnecessary and causes read pressure on the key-value-service for highly referenced streams.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/qqqq>`__)
- 
+
+    *    - |fixed|
+         - Live-reloading HTTP proxies and HTTP proxies with failover now refresh themselves after encountering a large number of cumulative requests or consecutive exceptions.
+           This was previously implemented to work around several issues with our usage of OkHttp, but was not implemented for the failover proxies.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/qqqq>`__)
+
 ========
 v0.106.0
 ========


### PR DESCRIPTION
**Goals (and why)**:
- See PDS-76333 - avoid causing outages for users because timelock has served loads of requests
- Also our work on exception counting clients hasn't been applied to live-reloading proxies (basically users talking to timelock); enable this.

**Implementation Description (bullets)**:
- Make failover clients use the refreshing wrappers.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Timelock integration tests should catch these if there are any real problems.

**Concerns (what feedback would you like?)**:
- Does this introduce an unacceptable delay when re-creating the client after 500M requests?
- The refreshing logic is somewhat more complicated than what I've written in the Javadoc, but I think going into too much specifics there is messy and unnecessary.

**Where should we start reviewing?**: `AtlasDbFeignTargetFactory`

**Priority (whenever / two weeks / yesterday)**: this week

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3629)
<!-- Reviewable:end -->
