### PR TITLE
Retry TodoEteTest on flakes

### DIFF
--- a/flake-rule/src/main/java/com/palantir/flake/FlakeRetryingRule.java
+++ b/flake-rule/src/main/java/com/palantir/flake/FlakeRetryingRule.java
@@ -96,7 +96,6 @@ public class FlakeRetryingRule implements TestRule {
                 if (Arrays.stream(retryAnnotation.retryableExceptions()).anyMatch(type -> type.isInstance(t))) {
                     logFailureAndThrowIfNeeded(retryAnnotation, description, attempt, t);
                 } else {
-                    // This covers other Errors, where it generally doesn't make sense to retry.
                     throw Throwables.propagate(t);
                 }
             }

--- a/flake-rule/src/main/java/com/palantir/flake/ShouldRetry.java
+++ b/flake-rule/src/main/java/com/palantir/flake/ShouldRetry.java
@@ -38,4 +38,10 @@ public @interface ShouldRetry {
      * Values provided should be strictly positive; behaviour when this value is zero or negative is undefined.
      */
     int numAttempts() default 5;
+
+    /**
+     * Array specifying which types of Throwables should be retried. The default value throws a very wide net, and
+     * should ideally be replaced by a more specific list.
+     */
+    Class<? extends Throwable>[] retryableExceptions() default {AssertionError.class, Exception.class};
 }

--- a/flake-rule/src/test/java/com/palantir/flake/FlakeRetryingRuleTest.java
+++ b/flake-rule/src/test/java/com/palantir/flake/FlakeRetryingRuleTest.java
@@ -84,6 +84,19 @@ public class FlakeRetryingRuleTest {
         // pass
     }
 
+    @Test
+    @ShouldRetry(retryableExceptions = {RuntimeException.class})
+    @ExpectedFailure
+    public void doesNotRetryIfNotRetryable() {
+        runTestFailingUntilSpecifiedAttempt(2);
+    }
+
+    @Test
+    @ShouldRetry(retryableExceptions = {Throwable.class})
+    public void retriesIfSuperOfRetriable() {
+        runTestFailingUntilSpecifiedAttempt(2);
+    }
+
     private void runTestFailingUntilSpecifiedAttempt(long expected) {
         AtomicLong counter = counters.getOrDefault(testName.getMethodName(), new AtomicLong());
         long value = counter.incrementAndGet();


### PR DESCRIPTION
**Goals (and why)**:
Retry TodoEteTest on flakes

**Implementation Description (bullets)**:
If we hit a SocketTimeoutException, retry the test.
Had to modify FlakeRetryingRule for this, so now we can retry in a more flexible way. 

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added tests for specifying allowedExceptions in ShouldRetry

**Priority (whenever / two weeks / yesterday)**:
This is the most annoying flake atm, so would be nice to get it in soon

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3634)
<!-- Reviewable:end -->
