### PR TITLE
move start-transaction implementations

### DIFF
--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/AsyncTimeLockServicesCreator.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/AsyncTimeLockServicesCreator.java
@@ -70,14 +70,14 @@ public class AsyncTimeLockServicesCreator implements TimeLockServicesCreator {
             Supplier<ManagedTimestampService> rawTimestampServiceSupplier,
             Supplier<LockService> rawLockServiceSupplier) {
         log.info("Creating async timelock services for client {}", SafeArg.of("client", client));
-        AsyncOrLegacyTimelockService asyncOrLegacyTimelockService;
         AsyncTimelockService asyncTimelockService = instrumentInLeadershipProxy(
                 metricsManager.getTaggedRegistry(),
                 AsyncTimelockService.class,
                 () -> createRawAsyncTimelockService(client, rawTimestampServiceSupplier),
                 client);
-        asyncOrLegacyTimelockService = AsyncOrLegacyTimelockService.createFromAsyncTimelock(
-                new AsyncTimelockResource(lockLog, asyncTimelockService));
+        AsyncOrLegacyTimelockService asyncOrLegacyTimelockService =
+                AsyncOrLegacyTimelockService.createFromAsyncTimelock(
+                        new AsyncTimelockResource(lockLog, asyncTimelockService));
 
         LockService lockService = instrumentInLeadershipProxy(
                 metricsManager.getTaggedRegistry(),

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockResource.java
@@ -29,7 +29,6 @@ import javax.ws.rs.core.MediaType;
 import com.palantir.atlasdb.timelock.lock.AsyncResult;
 import com.palantir.atlasdb.timelock.lock.LockLog;
 import com.palantir.lock.v2.IdentifiedTimeLockRequest;
-import com.palantir.lock.v2.ImmutableIdentifiedTimeLockRequest;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
 import com.palantir.lock.v2.LockRequest;
 import com.palantir.lock.v2.LockResponse;
@@ -75,18 +74,14 @@ public class AsyncTimelockResource {
     @POST
     @Path("start-atlasdb-transaction")
     public StartAtlasDbTransactionResponse startAtlasDbTransaction(IdentifiedTimeLockRequest request) {
-        return StartAtlasDbTransactionResponse.of(
-                timelock.lockImmutableTimestamp(request),
-                timelock.getFreshTimestamp());
+        return timelock.startAtlasDbTransaction(request);
     }
 
     @POST
     @Path("start-identified-atlasdb-transaction")
     public StartIdentifiedAtlasDbTransactionResponse startIdentifiedAtlasDbTransaction(
             StartIdentifiedAtlasDbTransactionRequest request) {
-        return StartIdentifiedAtlasDbTransactionResponse.of(
-                timelock.lockImmutableTimestamp(ImmutableIdentifiedTimeLockRequest.of(request.requestId())),
-                timelock.getFreshTimestampForClient(request.requestorId()));
+        return timelock.startIdentifiedAtlasDbTransaction(request);
     }
 
     @POST

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockService.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockService.java
@@ -24,6 +24,9 @@ import com.palantir.lock.v2.IdentifiedTimeLockRequest;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
 import com.palantir.lock.v2.LockRequest;
 import com.palantir.lock.v2.LockToken;
+import com.palantir.lock.v2.StartAtlasDbTransactionResponse;
+import com.palantir.lock.v2.StartIdentifiedAtlasDbTransactionRequest;
+import com.palantir.lock.v2.StartIdentifiedAtlasDbTransactionResponse;
 import com.palantir.lock.v2.WaitForLocksRequest;
 
 public interface AsyncTimelockService extends ClientAwareManagedTimestampService, Closeable {
@@ -41,5 +44,10 @@ public interface AsyncTimelockService extends ClientAwareManagedTimestampService
     long getImmutableTimestamp();
 
     LockImmutableTimestampResponse lockImmutableTimestamp(IdentifiedTimeLockRequest request);
+
+    StartAtlasDbTransactionResponse startAtlasDbTransaction(IdentifiedTimeLockRequest request);
+
+    StartIdentifiedAtlasDbTransactionResponse startIdentifiedAtlasDbTransaction(
+            StartIdentifiedAtlasDbTransactionRequest request);
 
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceImpl.java
@@ -26,9 +26,13 @@ import com.palantir.atlasdb.timelock.paxos.ManagedTimestampService;
 import com.palantir.atlasdb.timelock.transaction.timestamp.ClientAwareManagedTimestampService;
 import com.palantir.atlasdb.timelock.transaction.timestamp.DelegatingClientAwareManagedTimestampService;
 import com.palantir.lock.v2.IdentifiedTimeLockRequest;
+import com.palantir.lock.v2.ImmutableIdentifiedTimeLockRequest;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
 import com.palantir.lock.v2.LockRequest;
 import com.palantir.lock.v2.LockToken;
+import com.palantir.lock.v2.StartAtlasDbTransactionResponse;
+import com.palantir.lock.v2.StartIdentifiedAtlasDbTransactionRequest;
+import com.palantir.lock.v2.StartIdentifiedAtlasDbTransactionResponse;
 import com.palantir.lock.v2.TimestampAndPartition;
 import com.palantir.lock.v2.WaitForLocksRequest;
 import com.palantir.timestamp.TimestampRange;
@@ -106,6 +110,21 @@ public class AsyncTimelockServiceImpl implements AsyncTimelockService {
     @Override
     public Set<LockToken> unlock(Set<LockToken> tokens) {
         return lockService.unlock(tokens);
+    }
+
+    @Override
+    public StartAtlasDbTransactionResponse startAtlasDbTransaction(IdentifiedTimeLockRequest request) {
+        return StartAtlasDbTransactionResponse.of(
+                lockImmutableTimestamp(request),
+                getFreshTimestamp());
+    }
+
+    @Override
+    public StartIdentifiedAtlasDbTransactionResponse startIdentifiedAtlasDbTransaction(
+            StartIdentifiedAtlasDbTransactionRequest request) {
+        return StartIdentifiedAtlasDbTransactionResponse.of(
+                lockImmutableTimestamp(ImmutableIdentifiedTimeLockRequest.of(request.requestId())),
+                getFreshTimestampForClient(request.requestorId()));
     }
 
     @Override


### PR DESCRIPTION
**Goals (and why)**:
- Instrument start-atlasdb-transaction calls

**Implementation Description (bullets)**:
- Move startAtlasDbTrasaction implementation from `AsyncTimelockResource` to `AsyncTimelockServiceImpl`.

**Priority (whenever / two weeks / yesterday)**:
Pretty short pr, would be nice if we can merge it today or early next week.
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3641)
<!-- Reviewable:end -->
