### PR TITLE
[_transactions2] Coordination, Part 3: Internal Schema Metadata & Timestamp->Schema RangeMap

### DIFF
--- a/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/CoordinationService.java
+++ b/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/CoordinationService.java
@@ -58,5 +58,5 @@ public interface CoordinationService<T> {
      * @param transform transformation to apply to the existing value and bound the coordination service agrees on
      * @return a {@link CheckAndSetResult} indicating whether the transform was applied and the current value
      */
-    CheckAndSetResult<ValueAndBound<T>> tryTransformCurrentValue(Function<Optional<T>, T> transform);
+    CheckAndSetResult<ValueAndBound<T>> tryTransformCurrentValue(Function<ValueAndBound<T>, T> transform);
 }

--- a/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/CoordinationServiceImpl.java
+++ b/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/CoordinationServiceImpl.java
@@ -42,7 +42,7 @@ public class CoordinationServiceImpl<T> implements CoordinationService<T> {
     }
 
     @Override
-    public CheckAndSetResult<ValueAndBound<T>> tryTransformCurrentValue(Function<Optional<T>, T> transform) {
+    public CheckAndSetResult<ValueAndBound<T>> tryTransformCurrentValue(Function<ValueAndBound<T>, T> transform) {
         CheckAndSetResult<ValueAndBound<T>> transformResult = store.transformAgreedValue(transform);
         ValueAndBound<T> existingValue = Iterables.getOnlyElement(transformResult.existingValues());
         accumulateCachedValue(Optional.of(existingValue));

--- a/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/CoordinationStore.java
+++ b/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/CoordinationStore.java
@@ -36,10 +36,12 @@ public interface CoordinationStore<T> {
 
     /**
      * Proposes a new value to be stored in this {@link CoordinationStore} based on applying the transform passed
-     * to an existing bound. It is the responsibility of users to confirm whether their transform succeeded or not.
+     * to an existing {@link ValueAndBound}. It is the responsibility of users to confirm whether their transform
+     * succeeded or not.
      *
      * @param transform transformation of the original value passed
      * @return a {@link CheckAndSetResult} indicating if the proposal was successful and the current value
      */
-    CheckAndSetResult<ValueAndBound<T>> transformAgreedValue(Function<Optional<T>, T> transform);
+    CheckAndSetResult<ValueAndBound<T>> transformAgreedValue(
+            Function<ValueAndBound<T>, T> transform);
 }

--- a/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/SequenceAndBound.java
+++ b/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/SequenceAndBound.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 @JsonSerialize(as = ImmutableSequenceAndBound.class)
 @JsonDeserialize(as = ImmutableSequenceAndBound.class)
 public interface SequenceAndBound {
+    long INVALID_BOUND = -1;
+
     @Value.Parameter
     long sequence();
 

--- a/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/ValueAndBound.java
+++ b/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/ValueAndBound.java
@@ -33,4 +33,8 @@ public interface ValueAndBound<T> {
     static <T> ValueAndBound<T> of(Optional<T> value, long bound) {
         return ImmutableValueAndBound.of(value, bound);
     }
+
+    static <T> ValueAndBound<T> of(T value, long bound) {
+        return ImmutableValueAndBound.of(Optional.of(value), bound);
+    }
 }

--- a/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/keyvalue/KeyValueServiceCoordinationStore.java
+++ b/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/keyvalue/KeyValueServiceCoordinationStore.java
@@ -17,7 +17,6 @@
 package com.palantir.atlasdb.coordination.keyvalue;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
@@ -36,6 +35,7 @@ import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.coordination.CoordinationStore;
 import com.palantir.atlasdb.coordination.SequenceAndBound;
 import com.palantir.atlasdb.coordination.ValueAndBound;
+import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.CheckAndSetException;
 import com.palantir.atlasdb.keyvalue.api.CheckAndSetRequest;
@@ -228,7 +228,7 @@ public final class KeyValueServiceCoordinationStore<T> implements CoordinationSt
         } catch (IOException e) {
             log.error("Error encountered when deserializing {}: {}",
                     SafeArg.of("safeDescriptionOfItemToDeserialize", safeDescriptionOfItemToDeserialize),
-                    SafeArg.of("coordinationData", Arrays.toString(data)));
+                    SafeArg.of("coordinationData", PtBytes.toString(data)));
             throw new RuntimeException(e);
         }
     }

--- a/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/keyvalue/KeyValueServiceCoordinationStore.java
+++ b/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/keyvalue/KeyValueServiceCoordinationStore.java
@@ -123,10 +123,12 @@ public final class KeyValueServiceCoordinationStore<T> implements CoordinationSt
     }
 
     @Override
-    public CheckAndSetResult<ValueAndBound<T>> transformAgreedValue(Function<Optional<T>, T> transform) {
+    public CheckAndSetResult<ValueAndBound<T>> transformAgreedValue(Function<ValueAndBound<T>, T> transform) {
         Optional<SequenceAndBound> coordinationValue = getCoordinationValue();
-        T targetValue = transform.apply(coordinationValue.flatMap(
-                sequenceAndBound -> getValue(sequenceAndBound.sequence())));
+        T targetValue = transform.apply(
+                ValueAndBound.of(coordinationValue.flatMap(
+                        sequenceAndBound -> getValue(sequenceAndBound.sequence())),
+                        coordinationValue.map(SequenceAndBound::bound).orElse(SequenceAndBound.INVALID_BOUND)));
 
         long sequenceNumber = sequenceNumberSupplier.getAsLong();
         putUnlessValueExists(sequenceNumber, targetValue);

--- a/atlasdb-impl-shared/build.gradle
+++ b/atlasdb-impl-shared/build.gradle
@@ -13,12 +13,13 @@ repositories {
 libsDirName = file('build/artifacts')
 
 dependencies {
+  compile project(":atlasdb-client")
   compile project(":atlasdb-commons")
+  compile project(":atlasdb-coordination-impl")
   compile project(":atlasdb-persistent-lock-api")
   compile project(":lock-impl")
   compile project(":timestamp-api")
   compile project(":timestamp-client")
-  compile project(":atlasdb-client")
 
   compile 'com.palantir.patches.sourceforge:trove3:' + libVersions.trove
   compile group: 'com.palantir.common', name: 'streams'

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/InternalSchemaMetadata.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/InternalSchemaMetadata.java
@@ -21,7 +21,6 @@ import org.immutables.value.Value;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.google.common.collect.RangeMap;
 
 /**
  * An {@link InternalSchemaMetadata} object controls how Atlas nodes carry out certain operations.
@@ -37,5 +36,9 @@ public interface InternalSchemaMetadata {
     /**
      * Mapping of ranges of timestamps to schema versions for the transactions table.
      */
-    RangeMap<Long, Integer> timestampToTransactionsTableSchemaVersion();
+    TimestampToTransactionSchemaMap timestampToTransactionsTableSchemaVersion();
+
+    static ImmutableInternalSchemaMetadata.Builder builder() {
+        return ImmutableInternalSchemaMetadata.builder();
+    }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/InternalSchemaMetadata.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/InternalSchemaMetadata.java
@@ -1,0 +1,41 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.internalschema;
+
+import org.immutables.value.Value;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.collect.RangeMap;
+
+/**
+ * An {@link InternalSchemaMetadata} object controls how Atlas nodes carry out certain operations.
+ *
+ * This object may concurrently be read across nodes on multiple versions of AtlasDB, and thus it is important
+ * to ensure backwards compatibility.
+ */
+@Value.Immutable
+@JsonSerialize(as = ImmutableInternalSchemaMetadata.class)
+@JsonDeserialize(as = ImmutableInternalSchemaMetadata.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public interface InternalSchemaMetadata {
+    /**
+     * Mapping of ranges of timestamps to schema versions for the transactions table.
+     */
+    RangeMap<Long, Integer> timestampToTransactionsTableSchemaVersion();
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/InternalSchemaMetadataInitializer.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/InternalSchemaMetadataInitializer.java
@@ -1,0 +1,63 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.internalschema;
+
+import com.google.common.collect.BoundType;
+import com.google.common.collect.ImmutableRangeMap;
+import com.google.common.collect.Range;
+import com.palantir.atlasdb.coordination.CoordinationService;
+import com.palantir.atlasdb.coordination.ValueAndBound;
+import com.palantir.timestamp.TimestampService;
+
+/**
+ * Writes an initial version of the {@link InternalSchemaMetadata} to the database.
+ */
+public class InternalSchemaMetadataInitializer {
+    private static final long ZERO_TIMESTAMP = 0;
+    private static final long ADVANCEMENT_QUANTUM = 5_000_000;
+
+    private final CoordinationService<InternalSchemaMetadata> coordinationService;
+    private final TimestampService timestampService;
+
+    public InternalSchemaMetadataInitializer(
+            CoordinationService<InternalSchemaMetadata> coordinationService,
+            TimestampService timestampService) {
+        this.coordinationService = coordinationService;
+        this.timestampService = timestampService;
+    }
+
+    /**
+     * Once this method returns, it can be guaranteed that the {@link CoordinationService} associated with this
+     * {@link InternalSchemaMetadataInitializer} will contain a value. This may not necessarily be the initial
+     * value.
+     */
+    public void ensureInternalSchemaMetadataInitialized() {
+        long initialTimestamp = timestampService.getFreshTimestamp() + ADVANCEMENT_QUANTUM;
+        while (!coordinationService.getValueForTimestamp(ZERO_TIMESTAMP).isPresent()) {
+            coordinationService.tryTransformCurrentValue(optionalValueAndBound ->
+                    optionalValueAndBound
+                            .orElseGet(() -> ValueAndBound.of(getDefaultInternalSchemaMetadata(), initialTimestamp)));
+        }
+    }
+
+    private InternalSchemaMetadata getDefaultInternalSchemaMetadata() {
+        return ImmutableInternalSchemaMetadata.builder()
+                .timestampToTransactionsTableSchemaVersion(
+                        ImmutableRangeMap.of(Range.range(0L, BoundType.OPEN, Long.MAX_VALUE, BoundType.CLOSED), 1))
+                .build();
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/InternalSchemaMetadataInitializer.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/InternalSchemaMetadataInitializer.java
@@ -20,7 +20,6 @@ import com.google.common.collect.BoundType;
 import com.google.common.collect.ImmutableRangeMap;
 import com.google.common.collect.Range;
 import com.palantir.atlasdb.coordination.CoordinationService;
-import com.palantir.atlasdb.coordination.ValueAndBound;
 import com.palantir.timestamp.TimestampService;
 
 /**
@@ -46,11 +45,9 @@ public class InternalSchemaMetadataInitializer {
      * value.
      */
     public void ensureInternalSchemaMetadataInitialized() {
-        long initialTimestamp = timestampService.getFreshTimestamp() + ADVANCEMENT_QUANTUM;
         while (!coordinationService.getValueForTimestamp(ZERO_TIMESTAMP).isPresent()) {
-            coordinationService.tryTransformCurrentValue(optionalValueAndBound ->
-                    optionalValueAndBound
-                            .orElseGet(() -> ValueAndBound.of(getDefaultInternalSchemaMetadata(), initialTimestamp)));
+            coordinationService.tryTransformCurrentValue(valueAndBound -> valueAndBound.value()
+                    .orElseGet(this::getDefaultInternalSchemaMetadata));
         }
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/InternalSchemaMetadataInitializer.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/InternalSchemaMetadataInitializer.java
@@ -16,9 +16,6 @@
 
 package com.palantir.atlasdb.internalschema;
 
-import com.google.common.collect.BoundType;
-import com.google.common.collect.ImmutableRangeMap;
-import com.google.common.collect.Range;
 import com.palantir.atlasdb.coordination.CoordinationService;
 import com.palantir.timestamp.TimestampService;
 
@@ -53,8 +50,7 @@ public class InternalSchemaMetadataInitializer {
 
     private InternalSchemaMetadata getDefaultInternalSchemaMetadata() {
         return ImmutableInternalSchemaMetadata.builder()
-                .timestampToTransactionsTableSchemaVersion(
-                        ImmutableRangeMap.of(Range.range(0L, BoundType.OPEN, Long.MAX_VALUE, BoundType.CLOSED), 1))
+                .timestampToTransactionsTableSchemaVersion(TimestampToTransactionSchemaMap.initialValue())
                 .build();
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/InternalSchemaMetadataInitializer.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/InternalSchemaMetadataInitializer.java
@@ -24,7 +24,6 @@ import com.palantir.timestamp.TimestampService;
  */
 public class InternalSchemaMetadataInitializer {
     private static final long ZERO_TIMESTAMP = 0;
-    private static final long ADVANCEMENT_QUANTUM = 5_000_000;
 
     private final CoordinationService<InternalSchemaMetadata> coordinationService;
     private final TimestampService timestampService;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/TimestampToTransactionSchemaMap.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/TimestampToTransactionSchemaMap.java
@@ -1,0 +1,136 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.internalschema;
+
+import java.util.Map;
+
+import org.immutables.value.Value;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.collect.ImmutableRangeMap;
+import com.google.common.collect.Range;
+import com.google.common.collect.RangeMap;
+import com.google.common.collect.RangeSet;
+import com.google.common.collect.TreeRangeSet;
+import com.palantir.common.annotation.Output;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+
+/**
+ * A {@link TimestampToTransactionSchemaMap} keeps track of a mapping of timestamp ranges to transactions schema
+ * versions. The reason for using such a mapping is that clients may switch between mappings over time for various
+ * reasons.
+ *
+ * {@link TimestampToTransactionSchemaMap#timestampToTransactionsTableSchemaVersion()} is always expected to cover
+ * all timestamps. That is, it should span the range [1, +∞) and be connected.
+ */
+@Value.Immutable
+@JsonSerialize(as = ImmutableTimestampToTransactionSchemaMap.class)
+@JsonDeserialize(as = ImmutableTimestampToTransactionSchemaMap.class)
+public abstract class TimestampToTransactionSchemaMap {
+    private static final Range<Long> ALL_TIMESTAMPS = Range.atLeast(1L);
+
+    @Value.Parameter
+    abstract RangeMap<Long, Integer> timestampToTransactionsTableSchemaVersion();
+
+    public static TimestampToTransactionSchemaMap initialValue() {
+        return of(ImmutableRangeMap.of(ALL_TIMESTAMPS, 1));
+    }
+
+    public static TimestampToTransactionSchemaMap of(RangeMap<Long, Integer> initialState) {
+        return ImmutableTimestampToTransactionSchemaMap.of(initialState);
+    }
+
+    public int getVersionForTimestamp(long timestamp) {
+        return timestampToTransactionsTableSchemaVersion().get(timestamp);
+    }
+
+    public TimestampToTransactionSchemaMap copyInstallingNewVersion(
+            long lowerBoundForNewVersion,
+            int newSchemaVersion) {
+        Map.Entry<Range<Long>, Integer> latestEntry = getLatestEntry();
+        validateInstallationIsCurrent(lowerBoundForNewVersion, newSchemaVersion, latestEntry);
+
+        ImmutableRangeMap.Builder<Long, Integer> builder = ImmutableRangeMap.builder();
+        copyOldRangesFromPreviousMap(latestEntry, builder);
+        addNewRanges(lowerBoundForNewVersion, newSchemaVersion, latestEntry, builder);
+        return ImmutableTimestampToTransactionSchemaMap.of(builder.build());
+    }
+
+    private static void validateInstallationIsCurrent(long lowerBoundForNewVersion, int newSchemaVersion,
+            Map.Entry<Range<Long>, Integer> latestEntry) {
+        if (lowerBoundForNewVersion < latestEntry.getKey().lowerEndpoint()) {
+            throw new SafeIllegalArgumentException("Cannot install a new schema version at an earlier timestamp;"
+                    + " attempted to install version {} at {}, but the newest interval is at {}.",
+                    SafeArg.of("attemptedNewVersion", newSchemaVersion),
+                    SafeArg.of("attemptedLowerBound", lowerBoundForNewVersion),
+                    SafeArg.of("existingInterval", latestEntry));
+        }
+    }
+
+    private void addNewRanges(
+            long lowerBoundForNewVersion,
+            int newSchemaVersion,
+            Map.Entry<Range<Long>, Integer> latestEntry,
+            @Output ImmutableRangeMap.Builder<Long, Integer> builder) {
+        builder.put(Range.closedOpen(latestEntry.getKey().lowerEndpoint(), lowerBoundForNewVersion),
+                latestEntry.getValue());
+        builder.put(Range.atLeast(lowerBoundForNewVersion), newSchemaVersion);
+    }
+
+    private void copyOldRangesFromPreviousMap(
+            Map.Entry<Range<Long>, Integer> latestEntry,
+            @Output ImmutableRangeMap.Builder<Long, Integer> builder) {
+        timestampToTransactionsTableSchemaVersion()
+                .asMapOfRanges()
+                .entrySet()
+                .stream()
+                .filter(entry -> !entry.equals(latestEntry))
+                .forEach(entry -> builder.put(entry.getKey(), entry.getValue()));
+    }
+
+    private Map.Entry<Range<Long>, Integer> getLatestEntry() {
+        return timestampToTransactionsTableSchemaVersion()
+                .asDescendingMapOfRanges()
+                .entrySet()
+                .iterator()
+                .next();
+    }
+
+    @Value.Check
+    public void check() {
+        validateCoversPreciselyAllTimestamps(timestampToTransactionsTableSchemaVersion());
+    }
+
+    private static void validateCoversPreciselyAllTimestamps(RangeMap<Long, Integer> initialState) {
+        if (initialState.equals(ImmutableRangeMap.of()) || !initialState.span().equals(ALL_TIMESTAMPS)) {
+            throw new SafeIllegalArgumentException("Attempted to initialize a timestamp to transaction schema map"
+                    + " of {}; its span does not cover precisely all timestamps.",
+                    SafeArg.of("timestampToTransactionSchemaMap", initialState));
+        }
+
+        RangeSet<Long> rangesCovered = TreeRangeSet.create(initialState.asMapOfRanges().keySet());
+        if (rangesCovered.asRanges().size() != 1) {
+            throw new SafeIllegalArgumentException("Attempted to initialize a timestamp to transaction schema map"
+                    + " of {}. While the span covers all timestamps, some are missing. The disconnected ranges"
+                    + " of the provided map were {}.",
+                    SafeArg.of("timestampToTransactionSchemaMap", initialState),
+                    SafeArg.of("disconnectedRanges", rangesCovered));
+        }
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/TimestampToTransactionSchemaMap.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/TimestampToTransactionSchemaMap.java
@@ -39,7 +39,7 @@ import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
  * reasons.
  *
  * {@link TimestampToTransactionSchemaMap#timestampToTransactionsTableSchemaVersion()} is always expected to cover
- * all timestamps. That is, it should span the range [1, +∞) and be connected.
+ * all timestamps. That is, the ranges present should span the range [1, +∞) and be connected.
  */
 @Value.Immutable
 @JsonSerialize(as = ImmutableTimestampToTransactionSchemaMap.class)
@@ -47,6 +47,13 @@ import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 public abstract class TimestampToTransactionSchemaMap {
     private static final Range<Long> ALL_TIMESTAMPS = Range.atLeast(1L);
 
+    /**
+     * Mapping of timestamp ranges to transactions table schema versions, represented as a set.
+     *
+     * This representation is for serialisation, because a {@link Range} serializes to an object, so it's not
+     * permissible for them to be used as keys in a Map; {@link RangeMap} doesn't seem to be supported in Jackson at
+     * time of writing.
+     */
     @Value.Parameter
     abstract Set<RangeAndValue> timestampToTransactionsTableSchemaVersion();
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/TransactionSchemaManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/TransactionSchemaManager.java
@@ -57,6 +57,7 @@ public class TransactionSchemaManager {
                 throw new IllegalStateException("Cannot install a new transactions schema version"
                         + " if we don't have any old versions known.");
             }
+            ValueAndBound<InternalSchemaMetadata> existingSchema = optionalValueAndBound.get();
 
         });
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/TransactionSchemaManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/TransactionSchemaManager.java
@@ -1,0 +1,94 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.internalschema;
+
+import java.util.Optional;
+
+import com.google.common.collect.BoundType;
+import com.google.common.collect.ImmutableRangeMap;
+import com.google.common.collect.Range;
+import com.palantir.atlasdb.coordination.CoordinationService;
+import com.palantir.atlasdb.coordination.ImmutableValueAndBound;
+import com.palantir.atlasdb.coordination.ValueAndBound;
+import com.palantir.atlasdb.keyvalue.impl.CheckAndSetResult;
+import com.palantir.timestamp.TimestampService;
+
+public class TransactionSchemaManager {
+    private static final int ADVANCEMENT_QUANTUM = 5_000_000;
+
+    private final CoordinationService<InternalSchemaMetadata> coordinationService;
+    private final TimestampService timestampService;
+
+    public TransactionSchemaManager(
+            CoordinationService<InternalSchemaMetadata> coordinationService,
+            TimestampService timestampService) {
+        this.coordinationService = coordinationService;
+        this.timestampService = timestampService;
+    }
+
+    public int getTransactionsSchemaVersion(long timestamp) {
+        Optional<Integer> possibleVersion =
+                extractTimestampVersion(coordinationService.getValueForTimestamp(timestamp), timestamp);
+        while (!possibleVersion.isPresent()) {
+            CheckAndSetResult<ValueAndBound<InternalSchemaMetadata>> casResult = tryPerpetuateExistingState(timestamp);
+            possibleVersion = extractTimestampVersion(casResult.existingValues()
+                    .stream()
+                    .filter(valueAndBound -> valueAndBound.bound() >= timestamp)
+                    .findAny(),
+                    timestamp);
+        }
+        return possibleVersion.get();
+    }
+
+    public void putInitialState() {
+        long timestamp = timestampService.getFreshTimestamp();
+        while (!coordinationService.getValueForTimestamp(timestamp).isPresent()) {
+            coordinationService.tryTransformCurrentValue(optionalValueAndBound -> {
+                if (!optionalValueAndBound.isPresent()) {
+                    return ValueAndBound.of(
+                            ImmutableInternalSchemaMetadata.builder().timestampToTransactionsTableSchemaVersion(
+                                    ImmutableRangeMap.of(
+                                            Range.range(0L, BoundType.OPEN, timestamp, BoundType.CLOSED), 1))
+                                    .build(),
+                            timestamp);
+                }
+                return optionalValueAndBound.get();
+            });
+        }
+    }
+
+    private CheckAndSetResult<ValueAndBound<InternalSchemaMetadata>> tryPerpetuateExistingState(long timestamp) {
+        return coordinationService.tryTransformCurrentValue(optionalValueAndBound -> {
+            if (!optionalValueAndBound.isPresent()) {
+                throw new IllegalStateException("Cannot perpetuate an existing state when none was available!");
+            }
+            ValueAndBound<InternalSchemaMetadata> valueAndBound = optionalValueAndBound.get();
+            if (valueAndBound.bound() >= timestamp) {
+                return valueAndBound;
+            }
+            return ImmutableValueAndBound.of(valueAndBound.value(), timestamp + ADVANCEMENT_QUANTUM);
+        });
+    }
+
+    private static Optional<Integer> extractTimestampVersion(
+            Optional<ValueAndBound<InternalSchemaMetadata>> valueAndBound, long timestamp) {
+        return valueAndBound
+                .flatMap(ValueAndBound::value)
+                .map(InternalSchemaMetadata::timestampToTransactionsTableSchemaVersion)
+                .map(rangeMap -> rangeMap.get(timestamp));
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/TransactionSchemaManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/TransactionSchemaManager.java
@@ -59,6 +59,11 @@ public class TransactionSchemaManager {
             }
             ValueAndBound<InternalSchemaMetadata> existingSchema = optionalValueAndBound.get();
 
+            if (!existingSchema.value().isPresent()) {
+                throw new IllegalStateException("Persisted value is empty, which is unexpected.");
+            }
+
+            InternalSchemaMetadata presentMetadata = existingSchema.value().get();
         });
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/internalschema/TimestampToTransactionSchemaMapTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/internalschema/TimestampToTransactionSchemaMapTest.java
@@ -1,0 +1,94 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.internalschema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableRangeMap;
+import com.google.common.collect.Range;
+
+public class TimestampToTransactionSchemaMapTest {
+    private static final TimestampToTransactionSchemaMap DEFAULT_INITIAL_MAPPING
+            = TimestampToTransactionSchemaMap.of(ImmutableRangeMap.of(Range.atLeast(1L), 1));
+
+    private static final long TIMESTAMP_1 = 77L;
+    private static final long TIMESTAMP_2 = 777L;
+
+    @Test
+    public void throwsIfInitialMapIsEmpty() {
+        assertThatThrownBy(() -> TimestampToTransactionSchemaMap.of(ImmutableRangeMap.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("its span does not cover precisely all timestamps");
+    }
+
+    @Test
+    public void throwsIfInitialMapDoesNotCoverFullRange() {
+        assertThatThrownBy(() -> TimestampToTransactionSchemaMap.of(ImmutableRangeMap.of(Range.atLeast(42L), 1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("its span does not cover precisely all timestamps");
+    }
+
+    @Test
+    public void throwsIfInitialMapHasGapsInRange() {
+        assertThatThrownBy(() -> TimestampToTransactionSchemaMap.of(
+                ImmutableRangeMap.<Long, Integer>builder()
+                        .put(Range.closed(1L, 6L), 1)
+                        .put(Range.atLeast(8L), 2)
+                        .build()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("While the span covers all timestamps, some are missing.");
+    }
+
+    @Test
+    public void throwsIfInitialMapExceedsTimestampRange() {
+        assertThatThrownBy(() -> TimestampToTransactionSchemaMap.of(ImmutableRangeMap.of(Range.atLeast(-42L), 1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("its span does not cover precisely all timestamps");
+    }
+
+    @Test
+    public void getsVersionForTimestamp() {
+        assertThat(DEFAULT_INITIAL_MAPPING.getVersionForTimestamp(68)).isEqualTo(1);
+    }
+
+    @Test
+    public void copiesWithNewVersions() {
+        TimestampToTransactionSchemaMap newMap = DEFAULT_INITIAL_MAPPING.copyInstallingNewVersion(TIMESTAMP_1, 2);
+        assertThat(newMap.getVersionForTimestamp(TIMESTAMP_1 - 1)).isEqualTo(1);
+        assertThat(newMap.getVersionForTimestamp(TIMESTAMP_2)).isEqualTo(2);
+    }
+
+    @Test
+    public void supportsRevertingVersions() {
+        TimestampToTransactionSchemaMap newMap = DEFAULT_INITIAL_MAPPING
+                .copyInstallingNewVersion(TIMESTAMP_1, 2)
+                .copyInstallingNewVersion(TIMESTAMP_2, 1);
+        assertThat(newMap.getVersionForTimestamp(TIMESTAMP_2 - 1)).isEqualTo(2);
+        assertThat(newMap.getVersionForTimestamp(TIMESTAMP_2)).isEqualTo(1);
+    }
+
+    @Test
+    public void throwsWhenInstallingVersionInThePast() {
+        TimestampToTransactionSchemaMap newMap = DEFAULT_INITIAL_MAPPING.copyInstallingNewVersion(TIMESTAMP_2, 2);
+        assertThatThrownBy(() -> newMap.copyInstallingNewVersion(TIMESTAMP_1, 2))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Cannot install a new schema version at an earlier timestamp");
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/internalschema/TransactionSchemaManagerIntegrationTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/internalschema/TransactionSchemaManagerIntegrationTest.java
@@ -1,0 +1,77 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.internalschema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.palantir.atlasdb.coordination.CoordinationServiceImpl;
+import com.palantir.atlasdb.coordination.keyvalue.KeyValueServiceCoordinationStore;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
+import com.palantir.remoting3.ext.jackson.ObjectMappers;
+import com.palantir.timestamp.InMemoryTimestampService;
+
+public class TransactionSchemaManagerIntegrationTest {
+    private static final long ONE_HUNDRED_MILLION = 100_000_000;
+
+    private final InMemoryTimestampService timestamps = new InMemoryTimestampService();
+    private final CoordinationServiceImpl<InternalSchemaMetadata> coordinationService = new CoordinationServiceImpl<>(
+            KeyValueServiceCoordinationStore.create(
+                    ObjectMappers.newServerObjectMapper().registerModule(new GuavaModule()),
+                    new InMemoryKeyValueService(true),
+                    PtBytes.toBytes("blablabla"),
+                    timestamps::getFreshTimestamp,
+                    InternalSchemaMetadata.class));
+    private final TransactionSchemaManager manager = new TransactionSchemaManager(coordinationService);
+
+    @Before
+    public void setUp() {
+        new InternalSchemaMetadataInitializer(coordinationService, timestamps)
+                .ensureInternalSchemaMetadataInitialized();
+    }
+
+    @Test
+    public void canForceCoordinations() {
+        assertThat(manager.getTransactionsSchemaVersion(337)).isEqualTo(1);
+    }
+
+    @Test
+    public void newSchemaVersionsCanBeInstalledWithinOneHundredMillionTimestamps() {
+        manager.installNewTransactionsSchemaVersion(2);
+        fastForwardTimestampByOneHundredMillion();
+        assertThat(manager.getTransactionsSchemaVersion(timestamps.getFreshTimestamp())).isEqualTo(2);
+    }
+
+    @Test
+    public void canSwitchBetweenSchemaVersions() {
+        manager.installNewTransactionsSchemaVersion(2);
+        fastForwardTimestampByOneHundredMillion();
+        assertThat(manager.getTransactionsSchemaVersion(timestamps.getFreshTimestamp())).isEqualTo(2);
+        manager.installNewTransactionsSchemaVersion(1);
+        fastForwardTimestampByOneHundredMillion();
+        assertThat(manager.getTransactionsSchemaVersion(timestamps.getFreshTimestamp())).isEqualTo(1);
+    }
+
+    private void fastForwardTimestampByOneHundredMillion() {
+        long currentTimestamp = timestamps.getFreshTimestamp();
+        timestamps.fastForwardTimestamp(currentTimestamp + ONE_HUNDRED_MILLION);
+    }
+}


### PR DESCRIPTION
**Goals (and why)**:
- Have a data structure that can be persisted into the KVS representing the things Atlas needs to coordinate amongst its nodes.
- Have a representation of the timestamp -> schema version rangemap that is persistable.

**Implementation Description (bullets)**:
- `InternalSchemaMetadata` is the object that'll be persisted in the `CoordinationService`, and it has a `timestampToTransactionsTableSchemaVersion` map. This is set to *ignore unknown properties* - is this what we want, or should we fail if we see unknown ones?
- `TimestampToTransactionSchemaMap` is a map of long ranges to integer (the transaction schema version). Effectively, this is a `RangeMap<Long, Integer>` which satisfies some additional invariants; the ranges span `[1, +inf)` completely.

**Testing (What was existing testing like?  What have you done to improve it?)**:
PR is mainly new. There are tests for the new code.

**Concerns (what feedback would you like?)**:
- Should we fail on unknown properties as far as `InternalSchemaMetadata` is concerned? This can be useful for ensuring no one is on too old of a version, but might make blue-green deployments non-HA if the new node updates the internal schema metadata.
- Is the way `TimestampToTransactionSchemaMap` evolves reasonable? The reason this was chosen was so that extensions of the current version as well as changes to other properties in `InternalSchemaMetadata` will not need to update the data structure. It is a little more complex.
- Iis there an easier way to manage the serialisation of the `TimestampToTransactionSchemaMap`?

**Where should we start reviewing?**: `TimestampToTransactionSchemaMap`

**Priority (whenever / two weeks / yesterday)**: this week, or maybe early next - I'm on support so iteration may be slightly slower than normal.