### PR TITLE
Clean up TimeLockClient

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -388,7 +388,7 @@ public abstract class TransactionManagers {
         TransactionManager instrumentedTransactionManager =
                 AtlasDbMetrics.instrument(metricsManager.getRegistry(), TransactionManager.class, transactionManager);
 
-        instrumentedTransactionManager.registerClosingCallback(lockAndTimestampServices::close);
+        instrumentedTransactionManager.registerClosingCallback(lockAndTimestampServices.close());
         instrumentedTransactionManager.registerClosingCallback(targetedSweep::close);
 
         PersistentLockManager persistentLockManager = initializeCloseable(

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -72,6 +72,9 @@ develop
          - PaxosQuorumChecker now takes an ExecutorService as opposed to an Executor.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3596>`__)
 
+    *    - |fixed|
+         - Fixed a bug where lock and timestamp services were not closed when transaction managers were closed.
+
 =======
 0.108.0
 =======

--- a/lock-api/src/main/java/com/palantir/lock/client/TimeLockClient.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/TimeLockClient.java
@@ -170,6 +170,7 @@ public class TimeLockClient implements AutoCloseable, TimelockService {
     public void close() {
         lockRefresher.close();
         unlocker.close();
+        timestampService.close();
     }
 
     private static LockRefresher createLockRefresher(TimelockService timelockService) {


### PR DESCRIPTION
This is a bug - the actual timestamp-and-lock close method was not getting registered as a close callback of its transaction manager. That close method closes `TimeLockClient`. Failing to do this causes thread leaks, especially in test scenarios where many transaction managers can be created and destroyed. I'm surprised the type checker allowed this bug to exist.

**Priority (whenever / two weeks / yesterday)**:
This week, please
