### PR TITLE
[PDS-75716] Finer grained DbKVS connection manager profiling

### DIFF
--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/HikariCPConnectionManager.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/HikariCPConnectionManager.java
@@ -368,7 +368,7 @@ public class HikariCPConnectionManager extends BaseConnectionManager {
     private class ConnectionAcquisitionProfiler {
         private static final String PROFILING_MESSAGE_FORMAT = "[{}] Waited {}ms for connection"
                 + " (acquisition: {}, statement creation: {}, execution: {})";
-        
+
         private final Stopwatch globalStopwatch;
         private final Stopwatch trialStopwatch;
 
@@ -413,7 +413,7 @@ public class HikariCPConnectionManager extends BaseConnectionManager {
                         queryExecutionMillis);
                 logPoolStats();
             } else {
-                log.warn(PROFILING_MESSAGE_FORMAT,
+                log.debug(PROFILING_MESSAGE_FORMAT,
                         connConfig.getConnectionPoolName(),
                         elapsedMillis,
                         acquisitionMillis,

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/HikariCPConnectionManager.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/HikariCPConnectionManager.java
@@ -108,7 +108,7 @@ public class HikariCPConnectionManager extends BaseConnectionManager {
             profiler.logAcquisitionAndRestart();
 
             try {
-                testConnection(conn);
+                testConnection(conn, Optional.of(profiler));
                 return conn;
             } catch (SQLException e) {
                 log.error("[{}] Dropping connection which failed validation",


### PR DESCRIPTION
**Goals (and why)**: 
See PDS-75716; this aims to help some investigation concerning slow execution of queries.

**Implementation Description (bullets)**:
- Time creating a statement and executing it separately.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- admittedly nonexistent 😞 

**Concerns (what feedback would you like?)**:
- Can creating the statement ever be slow? My guess would be yes based on reading the JavaDoc (it can throw a SQLException "if a database access error occurs"), but not sure.

**Where should we start reviewing?**: the one file

**Priority (whenever / two weeks / yesterday)**: P2; this week/early next.
