### PR TITLE
Delete metadata properly when dropping tables

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -373,8 +373,8 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         this.checkAndSetRunner = new CheckAndSetRunner(queryRunner);
         this.cassandraTableCreator = new CassandraTableCreator(clientPool, config);
         this.cassandraTableTruncator = new CassandraTableTruncator(queryRunner, clientPool);
-        this.cassandraTableDropper = new CassandraTableDropper(config, clientPool, cellValuePutter,
-                wrappingQueryRunner, cassandraTableTruncator);
+        this.cassandraTableDropper = new CassandraTableDropper(config, clientPool, wrappingQueryRunner,
+                cassandraTableTruncator);
     }
 
     private static ExecutorService createInstrumentedFixedThreadPool(CassandraKeyValueServiceConfig config,

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,8 +50,12 @@ develop
     *    - Type
          - Change
 
-    *    -
-         -
+    *    - |fixed|
+         - Cassandra KVS `getAllTimestamps` method no longer returns entries for tables that were dropped.
+           Previously, when a table was dropped, an empty byte array would be written into the _metadata table to mark it as deleted.
+           Now we place a ranged tombstone deleting all historical versions of the table's metadata instead.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/TBD>`__)
+
 
 ========
 v0.111.0

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -51,7 +51,7 @@ develop
          - Change
 
     *    - |fixed|
-         - Cassandra KVS `getAllTimestamps` method no longer returns entries for tables that were dropped.
+         - Cassandra KVS `getMetadataForTables` method no longer returns entries for tables that were dropped.
            Previously, when a table was dropped, an empty byte array would be written into the _metadata table to mark it as deleted.
            Now we place a ranged tombstone deleting all historical versions of the table's metadata instead.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/TBD>`__)


### PR DESCRIPTION
**Goals (and why)**:
Fix https://github.com/palantir/atlasdb/issues/3625

**Implementation Description (bullets)**:
Instead of writing an empty byte array to the metadata cell, just nuke both the current and the legacy metadata cells using a ranged timestamp.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Diff shows that the behaviour is now as expected, added a test showing that it works for tables that have metadata in the legacy cell as well.

**Concerns (what feedback would you like?)**:
Technically introduces a race condition if we lose a node after truncating the table and before deleting the metadata where before we would have placed the empty byte array before erroring out.

