### PR TITLE
Gozakdag/commit time read validation removal

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -1363,7 +1363,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
 
                 // if there are no writes, we must still make sure the immutable timestamp lock is still valid,
                 // to ensure that sweep hasn't thoroughly deleted cells we tried to read
-                if (validationNecessaryForInvolvedTables()) {
+                if (validationNecessaryForInvolvedTablesOnCommit()) {
                     throwIfImmutableTsOrCommitLocksExpired(null);
                 }
                 return;
@@ -2061,7 +2061,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         involvedTables.add(tableRef);
     }
 
-    private boolean validationNecessaryForInvolvedTables() {
+    private boolean validationNecessaryForInvolvedTablesOnCommit() {
         return involvedTables.stream().anyMatch(this::isValidationNecessaryOnCommit);
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -755,14 +755,14 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     }
 
     private boolean isValidationNecessaryOnReads(TableReference tableRef) {
-        return validateLocksOnReads && isThoroughSwept(tableRef);
+        return validateLocksOnReads && isThoroughlySwept(tableRef);
     }
 
     private boolean isValidationNecessaryOnCommit(TableReference tableRef) {
-        return !validateLocksOnReads && isThoroughSwept(tableRef);
+        return !validateLocksOnReads && isThoroughlySwept(tableRef);
     }
 
-    private boolean isThoroughSwept(TableReference tableRef) {
+    private boolean isThoroughlySwept(TableReference tableRef) {
         return sweepStrategyManager.get().get(tableRef) == SweepStrategy.THOROUGH;
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -755,10 +755,14 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     }
 
     private boolean isValidationNecessaryOnReads(TableReference tableRef) {
-        return validateLocksOnReads && isValidationNecessary(tableRef);
+        return validateLocksOnReads && isThoroughSwept(tableRef);
     }
 
-    private boolean isValidationNecessary(TableReference tableRef) {
+    private boolean isValidationNecessaryOnCommit(TableReference tableRef) {
+        return !validateLocksOnReads && isThoroughSwept(tableRef);
+    }
+
+    private boolean isThoroughSwept(TableReference tableRef) {
         return sweepStrategyManager.get().get(tableRef) == SweepStrategy.THOROUGH;
     }
 
@@ -2058,7 +2062,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     }
 
     private boolean validationNecessaryForInvolvedTables() {
-        return involvedTables.stream().anyMatch(this::isValidationNecessary);
+        return involvedTables.stream().anyMatch(this::isValidationNecessaryOnCommit);
     }
 
     private long getStartTimestamp() {

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -1163,6 +1163,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
 
         transaction.get(TABLE_SWEPT_THOROUGH, ImmutableSet.of(TEST_CELL));
         transaction.commit();
+        timelockService.unlock(ImmutableSet.of(res.getLock()));
+        
         verify(timelockService).refreshLockLeases(ImmutableSet.of(res.getLock()));
     }
 
@@ -1182,6 +1184,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
 
         transaction.get(TABLE_SWEPT_THOROUGH, ImmutableSet.of(TEST_CELL));
         transaction.commit();
+        timelockService.unlock(ImmutableSet.of(res.getLock()));
+
         verify(timelockService).refreshLockLeases(ImmutableSet.of(res.getLock()));
     }
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -68,7 +68,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.runners.Parameterized;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Supplier;

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,11 @@ develop
     *    - Type
          - Change
 
+    *    - |improved|
+         - Read transactions on thoroughly swept tables requires one less RPC to timelock now.
+           This improves the read performance and reduces load on timelock.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3651>`__)
+
     *    - |fixed|
          - Remove a memory leak due to usages of Runtime#addShutdownHook to cleanup resources.
            This only applies where multiple `TransactionManager` s might exist in a single VM


### PR DESCRIPTION
**Goals (and why)**:
One less RPC to timelock. (Affects only read-only transactions on thorough swept tables)

**Implementation Description (bullets)**:
If we are checking validity of immutable timestamp lock after every read, then at commit time we can guarantee that we have a consistent snapshot view without checking immutable timestamp lock once more.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Using existing tests.

**Concerns (what feedback would you like?)**:
Is there an edge case that I am missing?

**Where should we start reviewing?**:
`SnapshotTransaction.java`

**Priority (whenever / two weeks / yesterday)**:
Early next week?

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
