### PR TITLE
Fix postgres utility table creation race condition

### DIFF
--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbkvsPostgresTestSuite.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbkvsPostgresTestSuite.java
@@ -40,14 +40,14 @@ import com.palantir.remoting.api.config.service.HumanReadableDuration;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-        DbkvsPostgresTargetedSweepIntegrationTest.class,
+//        DbkvsPostgresTargetedSweepIntegrationTest.class,
         DbkvsPostgresKeyValueServiceTest.class,
-        DbkvsPostgresSerializableTransactionTest.class,
-        DbkvsPostgresSweepTaskRunnerTest.class,
-        DbkvsBackgroundSweeperIntegrationTest.class,
-        PostgresDbTimestampBoundStoreTest.class,
-        DbKvsPostgresGetCandidateCellsForSweepingTest.class,
-        DbKvsSweepProgressStoreIntegrationTest.class
+//        DbkvsPostgresSerializableTransactionTest.class,
+//        DbkvsPostgresSweepTaskRunnerTest.class,
+//        DbkvsBackgroundSweeperIntegrationTest.class,
+//        PostgresDbTimestampBoundStoreTest.class,
+//        DbKvsPostgresGetCandidateCellsForSweepingTest.class,
+//        DbKvsSweepProgressStoreIntegrationTest.class
         })
 public final class DbkvsPostgresTestSuite {
     private static final int POSTGRES_PORT_NUMBER = 5432;

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbkvsPostgresTestSuite.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbkvsPostgresTestSuite.java
@@ -40,14 +40,14 @@ import com.palantir.remoting.api.config.service.HumanReadableDuration;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-//        DbkvsPostgresTargetedSweepIntegrationTest.class,
+        DbkvsPostgresTargetedSweepIntegrationTest.class,
         DbkvsPostgresKeyValueServiceTest.class,
-//        DbkvsPostgresSerializableTransactionTest.class,
-//        DbkvsPostgresSweepTaskRunnerTest.class,
-//        DbkvsBackgroundSweeperIntegrationTest.class,
-//        PostgresDbTimestampBoundStoreTest.class,
-//        DbKvsPostgresGetCandidateCellsForSweepingTest.class,
-//        DbKvsSweepProgressStoreIntegrationTest.class
+        DbkvsPostgresSerializableTransactionTest.class,
+        DbkvsPostgresSweepTaskRunnerTest.class,
+        DbkvsBackgroundSweeperIntegrationTest.class,
+        PostgresDbTimestampBoundStoreTest.class,
+        DbKvsPostgresGetCandidateCellsForSweepingTest.class,
+        DbKvsSweepProgressStoreIntegrationTest.class
         })
 public final class DbkvsPostgresTestSuite {
     private static final int POSTGRES_PORT_NUMBER = 5432;

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresTableInitializer.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresTableInitializer.java
@@ -35,12 +35,13 @@ public class PostgresTableInitializer implements DbTableInitializer {
     @Override
     public void createUtilityTables() {
         executeIgnoringError(
-                "CREATE TABLE dual (id BIGINT)",
+                "CREATE TABLE dual (id BIGINT, CONSTRAINT pk_dual PRIMARY KEY (id))",
                 "already exists"
         );
 
-        connectionSupplier.get().executeUnregisteredQuery(
-                "INSERT INTO dual (id) SELECT 1 WHERE NOT EXISTS ( SELECT id FROM dual WHERE id = 1 )"
+        executeIgnoringError(
+                "INSERT INTO dual (id) VALUES (1)",
+                "duplicate key"
         );
     }
 

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresTableInitializer.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresTableInitializer.java
@@ -40,7 +40,7 @@ public class PostgresTableInitializer implements DbTableInitializer {
         );
 
         executeIgnoringError(
-                "INSERT INTO dual (id) VALUES (1)",
+                "INSERT INTO dual (id) SELECT 1 WHERE NOT EXISTS ( SELECT id FROM dual WHERE id = 1 )",
                 "duplicate key"
         );
     }


### PR DESCRIPTION
**Goals (and why)**:
Fix bug that was causing TodoEteTest flakes.

**Implementation Description (bullets)**:
Due to a race condition, it was possible to insert multiple entries into the dual table at initialization time (see https://www.postgresql.org/docs/7.2/xact-read-committed.html). This would permanently break some functionality such as cause an infinite loop when we try to write a garbage deletion sentinel.
The simple fix is to simply create the dual table with a pk constraint so that we cannot end up in this situation. Kept the old query not to break existing dual tables without the constraint (everyone who had the table correctly initialized the first time atlas started on postgres is fine).
 
**Testing (What was existing testing like?  What have you done to improve it?)**:
Some manual tests, but as long as existing tests pass, there shouldn't be anything to worry about.

**Concerns (what feedback would you like?)**:
What am I doing with my life?

**Priority (whenever / two weeks / yesterday)**:
Fixes really annoying flake, so asap
