### PR TITLE
Remove usages of Runtime#addShutdownHook to cleanup resources.

### DIFF
--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -423,5 +423,11 @@
         </module>
 
         <!-- Stricter checks end -->
+
+        <module name="RegexpSinglelineJava">
+            <property name="id" value="DoNotUseShutdownHooks"/>
+            <property name="format" value=".*addShutdownHook\("/>
+            <property name="message" value="Shutdown hooks should not be used in AtlasDB, it is a library. Products using AtlasDB might be creating and destroying many instances of AtlasDB, therefore relying on shutdown hooks for cleaning up resources can lead to memory leaks."/>
+        </module>
     </module>
 </module>

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -395,6 +395,8 @@ public abstract class TransactionManagers {
                 () -> new PersistentLockManager(
                         metricsManager, persistentLockService, config().getSweepPersistentLockWaitMillis()),
                 closeables);
+        instrumentedTransactionManager.registerClosingCallback(persistentLockManager::close);
+
         initializeCloseable(
                 () -> initializeSweepEndpointAndBackgroundProcess(
                         metricsManager,

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/Containers.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/Containers.java
@@ -44,6 +44,7 @@ import com.palantir.docker.compose.logging.LogCollector;
 import com.palantir.docker.compose.logging.LogDirectory;
 import com.palantir.docker.proxy.DockerProxyRule;
 
+@SuppressWarnings("DoNotUseShutdownHooks")
 public class Containers extends ExternalResource {
     private static final ProjectName PROJECT_NAME = ProjectName.fromString("atlasdbcontainers");
     @VisibleForTesting

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweeperImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweeperImpl.java
@@ -121,21 +121,6 @@ public final class BackgroundSweeperImpl implements BackgroundSweeper, AutoClose
 
             daemons.add(daemon);
         }
-
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            log.info("Shutting down persistent lock manager");
-            try {
-                persistentLockManager.shutdown();
-                log.info("Shutdown complete!");
-            } catch (Exception e) {
-                log.warn("An exception occurred while shutting down. This means that we had the backup lock out when"
-                         + "the shutdown was triggered, but failed to release it. If this is the case, sweep or backup"
-                         + "may fail to take out the lock in future. If this happens consistently, "
-                         + "consult the following documentation on how to release the dead lock: "
-                         + "https://palantir.github.io/atlasdb/html/troubleshooting/index.html#clearing-the-backup-lock",
-                        e);
-            }
-        }));
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/PersistentLockManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/PersistentLockManager.java
@@ -180,7 +180,7 @@ public class PersistentLockManager implements AutoCloseable {
     }
 
     private void logFailedShutdown(Exception exception) {
-        log.warn("An exception occurred while shutting down. This means that we had the backup lock out when"
+        log.warn("An exception occurred while shutting down. This means that we had the backup lock out when "
                         + "the shutdown was triggered, but failed to release it. If this is the case, sweep "
                         + "or backup may fail to take out the lock in future. If this happens consistently, "
                         + "consult the following documentation on how to release the dead lock: "

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/PersistentLockManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/PersistentLockManager.java
@@ -81,12 +81,18 @@ public class PersistentLockManager implements AutoCloseable {
 
     public synchronized void shutdown() {
         log.info("Shutting down...");
-        isShutDown = true;
-        while (lockId != null) {
-            releasePersistentLock();
+
+        try {
+            isShutDown = true;
+            while (lockId != null) {
+                releasePersistentLock();
+            }
+            log.info("Shutdown completed!");
+        } catch (Exception e) {
+            logFailedShutdown(e);
         }
-        log.info("Shutdown completed!");
     }
+
 
     // We don't synchronize this method, to avoid deadlocking if {@link #shutdown} is called while attempting
     // to acquire a lock.
@@ -171,5 +177,14 @@ public class PersistentLockManager implements AutoCloseable {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         }
+    }
+
+    private void logFailedShutdown(Exception exception) {
+        log.warn("An exception occurred while shutting down. This means that we had the backup lock out when"
+                        + "the shutdown was triggered, but failed to release it. If this is the case, sweep "
+                        + "or backup may fail to take out the lock in future. If this happens consistently, "
+                        + "consult the following documentation on how to release the dead lock: "
+                        + "https://palantir.github.io/atlasdb/html/troubleshooting/index.html#clearing-the-backup-lock",
+                exception);
     }
 }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,8 +50,9 @@ develop
     *    - Type
          - Change
 
-    *    -
-         -
+    *    - |fixed|
+         - Remove a memory leak due to usages of Runtime#addShutdownHook to cleanup resources.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3653>`__)
 
 ========
 v0.111.0

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -52,6 +52,8 @@ develop
 
     *    - |fixed|
          - Remove a memory leak due to usages of Runtime#addShutdownHook to cleanup resources.
+           This only applies where multiple `TransactionManager` s might exist in a single VM
+           and they are created an shutdown repeatedly.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3653>`__)
 
 ========


### PR DESCRIPTION
**Goals (and why)**:

Remove a memory leak due to usages of Runtime#addShutdownHook.

**Implementation Description (bullets)**:

* Use TransactionManager#registerClosingCallback to shutdown PersistentLockManager instead of Runtime#addShutdownHook.
* Add checkstyle check to prohibit this use in the future.

**Testing (What was existing testing like?  What have you done to improve it?)**:

I created and shutdown TransactionManagers in a loop in a small (500M) JVM. Pre-fix it was able to fill up OldGen pretty quickly and start CMSing all the time, with this fix it seems stable.

**Concerns (what feedback would you like?)**:

The only thing that the old code was doing was making sure that PersistentLockManager gets closed after BackgroundSweeperImpl. I believe this invariant should hold with the new code.

**Where should we start reviewing?**:

TransactionManagers

**Priority (whenever / two weeks / yesterday)**:

High, caused production problems.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
