### PR TITLE
More fixes for getMetadataForTables()

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
@@ -28,9 +28,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import static com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyvalueServiceTestUtils.clearOutMetadataTable;
-import static com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyvalueServiceTestUtils.insertMetadataIntoLegacyCell;
-import static com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyvalueServiceTestUtils.originalMetadata;
+import static com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServiceTestUtils.clearOutMetadataTable;
+import static com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServiceTestUtils.insertGenericMetadataIntoLegacyCell;
+import static com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServiceTestUtils.originalMetadata;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -295,7 +295,7 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
         TableReference userTable = TableReference.createFromFullyQualifiedName("test.cAsEsEnSiTiVe");
         keyValueService.createTable(userTable, AtlasDbConstants.GENERIC_TABLE_METADATA);
         clearOutMetadataTable(keyValueService);
-        insertMetadataIntoLegacyCell(keyValueService, userTable, originalMetadata());
+        insertGenericMetadataIntoLegacyCell(keyValueService, userTable, originalMetadata());
 
         assertThat(
                 Arrays.equals(keyValueService.getMetadataForTable(userTable), originalMetadata()),
@@ -303,7 +303,7 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
     }
 
     @Test
-    public void metadataForNewTableIsNotLowerCased() {
+    public void metadataForNewTableMatchesCase() {
         TableReference userTable = TableReference.createFromFullyQualifiedName("test.xXcOoLtAbLeNaMeXx");
 
         keyValueService.createTable(userTable, originalMetadata());

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTestUtils.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTestUtils.java
@@ -27,8 +27,8 @@ import com.palantir.atlasdb.table.description.NameMetadataDescription;
 import com.palantir.atlasdb.table.description.TableMetadata;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
 
-public final class CassandraKeyvalueServiceTestUtils {
-    private CassandraKeyvalueServiceTestUtils() {
+public final class CassandraKeyValueServiceTestUtils {
+    private CassandraKeyValueServiceTestUtils() {
         // utility
     }
 
@@ -36,11 +36,11 @@ public final class CassandraKeyvalueServiceTestUtils {
         kvs.truncateTable(AtlasDbConstants.DEFAULT_METADATA_TABLE);
     }
 
-    public static void insertMetadataIntoLegacyCell(KeyValueService kvs, TableReference tableRef) {
-        insertMetadataIntoLegacyCell(kvs, tableRef, AtlasDbConstants.GENERIC_TABLE_METADATA);
+    public static void insertGenericMetadataIntoLegacyCell(KeyValueService kvs, TableReference tableRef) {
+        insertGenericMetadataIntoLegacyCell(kvs, tableRef, AtlasDbConstants.GENERIC_TABLE_METADATA);
     }
 
-    public static void insertMetadataIntoLegacyCell(KeyValueService kvs, TableReference tableRef, byte[] data) {
+    public static void insertGenericMetadataIntoLegacyCell(KeyValueService kvs, TableReference tableRef, byte[] data) {
         Cell legacyMetadataCell = CassandraKeyValueServices.getOldMetadataCell(tableRef);
         kvs.put(AtlasDbConstants.DEFAULT_METADATA_TABLE, ImmutableMap.of(legacyMetadataCell, data),
                 System.currentTimeMillis());

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyvalueServiceTestUtils.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyvalueServiceTestUtils.java
@@ -1,0 +1,59 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import com.google.common.collect.ImmutableMap;
+import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
+import com.palantir.atlasdb.table.description.ColumnMetadataDescription;
+import com.palantir.atlasdb.table.description.NameMetadataDescription;
+import com.palantir.atlasdb.table.description.TableMetadata;
+import com.palantir.atlasdb.transaction.api.ConflictHandler;
+
+public class CassandraKeyvalueServiceTestUtils {
+    private CassandraKeyvalueServiceTestUtils() {
+        // utility
+    }
+
+    public static void clearOutMetadataTable(KeyValueService kvs) {
+        kvs.truncateTable(AtlasDbConstants.DEFAULT_METADATA_TABLE);
+    }
+
+    public static void insertMetadataIntoLegacyCell(KeyValueService kvs, TableReference tableRef) {
+        insertMetadataIntoLegacyCell(kvs, tableRef, AtlasDbConstants.GENERIC_TABLE_METADATA);
+    }
+
+    public static void insertMetadataIntoLegacyCell(KeyValueService kvs, TableReference tableRef, byte[] data) {
+        Cell legacyMetadataCell = CassandraKeyValueServices.getOldMetadataCell(tableRef);
+        kvs.put(AtlasDbConstants.DEFAULT_METADATA_TABLE, ImmutableMap.of(legacyMetadataCell, data),
+                System.currentTimeMillis());
+    }
+
+    // notably, this metadata is different from the default AtlasDbConstants.GENERIC_TABLE_METADATA
+    // to make sure the tests are actually exercising the correct retrieval codepaths
+    public static byte[] originalMetadata() {
+        return new TableMetadata(
+                new NameMetadataDescription(),
+                new ColumnMetadataDescription(),
+                ConflictHandler.RETRY_ON_VALUE_CHANGED,
+                TableMetadataPersistence.LogSafety.SAFE)
+                .persistToBytes();
+    }
+}

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyvalueServiceTestUtils.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyvalueServiceTestUtils.java
@@ -27,7 +27,7 @@ import com.palantir.atlasdb.table.description.NameMetadataDescription;
 import com.palantir.atlasdb.table.description.TableMetadata;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
 
-public class CassandraKeyvalueServiceTestUtils {
+public final class CassandraKeyvalueServiceTestUtils {
     private CassandraKeyvalueServiceTestUtils() {
         // utility
     }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraStrangeBehaviourTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraStrangeBehaviourTest.java
@@ -77,16 +77,16 @@ public class CassandraStrangeBehaviourTest {
         kvs.createTable(UPPER_UPPER, AtlasDbConstants.GENERIC_TABLE_METADATA);
 
         assertThat(kvs.getMetadataForTables().keySet())
-                .contains(LOWER_LOWER)
-                .doesNotContain(UPPER_UPPER);
+                .contains(UPPER_UPPER)
+                .doesNotContain(LOWER_LOWER);
     }
 
     @Test
-    public void droppedTableMetadataShowsUpInGetMetadataForTables() {
-        kvs.createTable(LOWER_LOWER, AtlasDbConstants.GENERIC_TABLE_METADATA);
-        kvs.dropTable(LOWER_LOWER);
+    public void droppedTableMetadataDoesNotShowUpInGetMetadataForTables() {
+        kvs.createTable(LOWER_UPPER, AtlasDbConstants.GENERIC_TABLE_METADATA);
+        kvs.dropTable(LOWER_UPPER);
 
-        assertThat(kvs.getMetadataForTables().keySet()).contains(LOWER_LOWER);
+        assertThat(kvs.getMetadataForTables().keySet()).isEmpty();
     }
 
     @Test

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraStrangeBehaviourTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraStrangeBehaviourTest.java
@@ -19,9 +19,9 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import static com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyvalueServiceTestUtils.clearOutMetadataTable;
-import static com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyvalueServiceTestUtils.insertMetadataIntoLegacyCell;
-import static com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyvalueServiceTestUtils.originalMetadata;
+import static com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServiceTestUtils.clearOutMetadataTable;
+import static com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServiceTestUtils.insertGenericMetadataIntoLegacyCell;
+import static com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServiceTestUtils.originalMetadata;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -88,7 +88,7 @@ public class CassandraStrangeBehaviourTest {
     @Test
     public void getMetadataReturnsResultFromNewMetadataCellOnConflict() {
         kvs.createTable(LOWER_UPPER, originalMetadata());
-        insertMetadataIntoLegacyCell(kvs, LOWER_UPPER);
+        insertGenericMetadataIntoLegacyCell(kvs, LOWER_UPPER);
 
         assertThat(kvs.getMetadataForTables().get(LOWER_UPPER)).contains(originalMetadata());
         assertThat(kvs.getMetadataForTable(LOWER_UPPER)).contains(originalMetadata());
@@ -106,10 +106,10 @@ public class CassandraStrangeBehaviourTest {
         clearOutMetadataTable(kvs);
 
         insertMetadataIntoNewCell(LOWER_UPPER);
-        insertMetadataIntoLegacyCell(kvs, LOWER_UPPER);
-        insertMetadataIntoLegacyCell(kvs, UPPER_UPPER);
-        insertMetadataIntoLegacyCell(kvs, longerInRange);
-        insertMetadataIntoLegacyCell(kvs, shorterInRange);
+        insertGenericMetadataIntoLegacyCell(kvs, LOWER_UPPER);
+        insertGenericMetadataIntoLegacyCell(kvs, UPPER_UPPER);
+        insertGenericMetadataIntoLegacyCell(kvs, longerInRange);
+        insertGenericMetadataIntoLegacyCell(kvs, shorterInRange);
 
         kvs.dropTable(LOWER_UPPER);
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -1467,19 +1467,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
 
         // if unsuccessful with fast code-path, we need to check if this table exists but was written at a key
         // before we started enforcing only writing lower-case canonicalised versions of keys
-        java.util.Optional<Entry<TableReference, byte[]>> match =
-                getMetadataForTables().entrySet().stream().filter(
-                        entry -> matchingIgnoreCase(entry.getKey(), tableRef))
-                .findFirst();
-
-        if (!match.isPresent()) {
-            log.debug("Couldn't find table metadata for {}", LoggingArgs.tableRef(tableRef));
-            return AtlasDbConstants.EMPTY_TABLE_METADATA;
-        } else {
-            log.debug("Found table metadata for {} at matching name {}", LoggingArgs.tableRef(tableRef),
-                    LoggingArgs.tableRef("matchingTable", match.get().getKey()));
-            return match.get().getValue();
-        }
+        return getMetadataForTables().get(tableRef);
     }
 
     private boolean matchingIgnoreCase(TableReference t1, TableReference t2) {
@@ -1528,27 +1516,6 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                             (fst, snd) -> fst));
         }
 
-//            while (range.hasNext()) {
-//                Iterables.getOnlyElement(range.next().getCells());
-//                Iterable<Entry<Cell, Value>> cells = valueRow.getCells();
-//
-//                for (Entry<Cell, Value> entry : cells) {
-//                    Value value = entry.getValue();
-//                    TableReference tableRef = CassandraKeyValueServices.lowerCaseTableReferenceFromBytes(
-//                            entry.getKey().getRowName());
-//                    byte[] contents;
-//                    if (value == null) {
-//                        contents = AtlasDbConstants.EMPTY_TABLE_METADATA;
-//                    } else {
-//                        contents = value.getContents();
-//                    }
-//                    if (!HiddenTables.isHidden(tableRef)) {
-//                        tableToMetadataContents.put(tableRef, contents);
-//                    }
-//                }
-//            }
-//        }
-
         for (TableReference tableRef: allTableRefs) {
             if (HiddenTables.isHidden(tableRef)) {
                 continue;
@@ -1558,12 +1525,6 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                 result.put(tableRef, tableToMetadataContents.get(lowercaseTableRef).getContents());
             }
         }
-
-//        allTableRefs.stream()
-//                .filter(tableRef -> !HiddenTables.isHidden(tableRef))
-//                .filter(tableRef -> tableToMetadataContents.containsKey(TableReference.createLowerCased(tableRef)))
-//                .collect(Collectors.toMap(tableRef -> tableRef, tableRef -> tableToMetadataContents.get(TableReference.createLowerCased(tableRef)).getContents()));
-
 
         return result;
     }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
@@ -70,7 +70,7 @@ public final class CassandraKeyValueServices {
     }
 
     /**
-     * Attempt to wait until nodes' schema versions.
+     * Attempt to wait until nodes' schema versions match.
      *
      * @param config the KVS configuration.
      * @param client Cassandra client.

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
@@ -332,8 +332,8 @@ public final class CassandraKeyValueServices {
     }
 
     @SuppressWarnings("checkstyle:RegexpSinglelineJava")
-    static TableReference tableReferenceFromBytes(byte[] name) {
-        return TableReference.createUnsafe(new String(name, Charset.defaultCharset()));
+    static TableReference lowerCaseTableReferenceFromBytes(byte[] name) {
+        return TableReference.createUnsafe(new String(name, Charset.defaultCharset()).toLowerCase());
     }
 
     static TableReference tableReferenceFromCfDef(CfDef cf) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTableDropper.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTableDropper.java
@@ -61,7 +61,7 @@ class CassandraTableDropper {
                         CassandraKeyValueServices.runWithWaitingForSchemas(
                                 () -> truncateThenDrop(table, client), config, client,
                                 "dropping the column family for table " + table + " in a call to drop tables");
-                        cassandraTableMetadata.deleteAllRowsForTable(table);
+                        cassandraTableMetadata.deleteAllMetadataRowsForTable(table);
                     } else {
                         log.warn("Ignored call to drop a table ({}) that did not exist.", LoggingArgs.tableRef(table));
                     }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -57,6 +57,11 @@ develop
            (`Pull Request <https://github.com/palantir/atlasdb/pull/TBD>`__)
 
     *    - |fixed|
+         - Cassandra KVS `getMetadataForTables` method now does not contain entries for tables that do not exist in Cassandra.
+           Furthermore, the table reference keys of the returned map have capitalisation matching the table names in Cassandra.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/TBD>`__)
+
+    *    - |fixed|
          - Remove a memory leak due to usages of Runtime#addShutdownHook to cleanup resources.
            This only applies where multiple `TransactionManager` s might exist in a single VM
            and they are created an shutdown repeatedly.


### PR DESCRIPTION
**Goals (and why)**:
Cleanup all existing metadata on table drop, fix getMetadataForTables so that it returns only tables that actually exist and with correct capitalisation.

**Implementation Description (bullets)**:
For dropping, we find all the rows in the possible range and do ranged deletes. For getMetadataForTables, we filter out nonexistent tables, and only get the most relevant entry -- the new metadata cell if it exists, otherwise any entry (actually it's the lexicographical latest, but no guarantees this won't change).

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added tests to cover some edge cases, is this enough?

**Concerns (what feedback would you like?)**:
Dropping can be expensive, but I think we should do this. The request should be faster giving we can just look in a single column (why haven't we been doing this before?)
The new logic for getMetadataForTables can obviously return different results than before. The only case where the result is different and it was not a bug was when there was no entry in the new metadata cell, but the behaviour in that case was nondeterministic, so we should be ok.

**Where should we start reviewing?**:
CassandraTableMetadata.getMetadataForTables?
The diff is not as large as it appears, mostly code was moved around.
