### PR TITLE
 Use correct bounds for InMemoryKeyValueService column range

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/InMemoryKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/InMemoryKeyValueService.java
@@ -17,6 +17,7 @@ package com.palantir.atlasdb.keyvalue.impl;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -334,15 +335,15 @@ public class InMemoryKeyValueService extends AbstractKeyValueService {
         } else {
             rowBegin = Cells.createSmallestCellForRow(row);
         }
-        // Inclusive last cell.
         Cell rowEnd;
         if (columnRangeSelection.getEndCol().length > 0) {
-            rowEnd = Cell.create(row, RangeRequests.previousLexicographicName(columnRangeSelection.getEndCol()));
+            rowEnd = Cell.create(row, columnRangeSelection.getEndCol());
         } else {
             rowEnd = Cells.createLargestCellForRow(row);
         }
+
         PeekingIterator<Entry<Key, byte[]>> entries = Iterators.peekingIterator(table.subMap(
-                new Key(rowBegin, Long.MIN_VALUE), new Key(rowEnd, timestamp)).entrySet().iterator());
+                new Key(rowBegin, Long.MIN_VALUE), new Key(rowEnd, Long.MIN_VALUE)).entrySet().iterator());
         Map<Cell, Value> rowResults = new LinkedHashMap<>();
         while (entries.hasNext()) {
             Entry<Key, byte[]> entry = entries.peek();

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
@@ -238,6 +238,12 @@ public abstract class AbstractKeyValueServiceTest {
         assertEquals(0, getValuesForRow(values, row(1), 1).size());
         values = keyValueService.getRowsColumnRange(TEST_TABLE,
                 ImmutableList.of(row(1)),
+                BatchColumnRangeSelection.create(column(0), column(0), 1),
+                TEST_TIMESTAMP + 1);
+        assertEquals(1, values.size());
+        assertEquals(0, getValuesForRow(values, row(1), 1).size());
+        values = keyValueService.getRowsColumnRange(TEST_TABLE,
+                ImmutableList.of(row(1)),
                 BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, Integer.MAX_VALUE),
                 TEST_TIMESTAMP + 1);
         assertEquals(1, values.size());


### PR DESCRIPTION
**Goals (and why)**:

When calling `InMemoryKeyValueService#getRowsColumnRange` with a column selection in which `startCol` equals `endCol` the call would throw the following exception:
```
java.lang.IllegalArgumentException: inconsistent range
    at java.util.concurrent.ConcurrentSkipListMap$SubMap.<init>(ConcurrentSkipListMap.java:2603)
    at java.util.concurrent.ConcurrentSkipListMap.subMap(ConcurrentSkipListMap.java:2061)
    at java.util.concurrent.ConcurrentSkipListMap.subMap(ConcurrentSkipListMap.java:2097)
    at com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService.getColumnRangeForSingleRow(InMemoryKeyValueService.java:344)
    at com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService.lambda$getRowsColumnRange$2(InMemoryKeyValueService.java:323)
    at com.google.common.collect.Iterators$6.transform(Iterators.java:788)
    at com.google.common.collect.TransformedIterator.next(TransformedIterator.java:47)
    at com.google.common.collect.Iterators$ConcatenatedIterator.hasNext(Iterators.java:1340)
    at com.palantir.atlasdb.keyvalue.impl.LocalRowColumnRangeIterator.hasNext(LocalRowColumnRangeIterator.java:34)
    at com.palantir.atlasdb.transaction.impl.SnapshotTransaction.getRowsColumnRange(SnapshotTransaction.java:380)
    at com.palantir.atlasdb.transaction.impl.SerializableTransaction.getRowsColumnRange(SerializableTransaction.java:207)
    ...
``` 

This is because calling `RangeRequests#previousLexicographicName` will result in `rowEnd` being less than `rowBegin`.

**Implementation Description (bullets)**:

Using an inclusive `toKey` is incorrect when calling this variant of `NavigableMap#subMap`. This PR changes the implementation to use the correct exclusive key, which resolves the above issue.

**Testing (What was existing testing like?  What have you done to improve it?)**:

Updated key value services tests to test a column range request when `startCol` equals `endCol`.