### PR TITLE
[do not merge] Demo for breaking wire-format of InternalSchemaMetadata

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/InternalSchemaMetadataInitializer.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/InternalSchemaMetadataInitializer.java
@@ -17,7 +17,6 @@
 package com.palantir.atlasdb.internalschema;
 
 import com.palantir.atlasdb.coordination.CoordinationService;
-import com.palantir.timestamp.TimestampService;
 
 /**
  * Writes an initial version of the {@link InternalSchemaMetadata} to the database.
@@ -26,13 +25,10 @@ public class InternalSchemaMetadataInitializer {
     private static final long ZERO_TIMESTAMP = 0;
 
     private final CoordinationService<InternalSchemaMetadata> coordinationService;
-    private final TimestampService timestampService;
 
     public InternalSchemaMetadataInitializer(
-            CoordinationService<InternalSchemaMetadata> coordinationService,
-            TimestampService timestampService) {
+            CoordinationService<InternalSchemaMetadata> coordinationService) {
         this.coordinationService = coordinationService;
-        this.timestampService = timestampService;
     }
 
     /**
@@ -49,7 +45,7 @@ public class InternalSchemaMetadataInitializer {
 
     private InternalSchemaMetadata getDefaultInternalSchemaMetadata() {
         return InternalSchemaMetadata.builder()
-                .timestampFromWhichWeShouldUseTransactions2(Long.MIN_VALUE)
+                .timestampFromWhichWeShouldUseTransactions2(Long.MAX_VALUE)
                 .build();
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/InternalSchemaMetadataInitializer.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/InternalSchemaMetadataInitializer.java
@@ -16,8 +16,6 @@
 
 package com.palantir.atlasdb.internalschema;
 
-import com.google.common.collect.ImmutableRangeMap;
-import com.google.common.collect.Range;
 import com.palantir.atlasdb.coordination.CoordinationService;
 import com.palantir.timestamp.TimestampService;
 
@@ -51,8 +49,7 @@ public class InternalSchemaMetadataInitializer {
 
     private InternalSchemaMetadata getDefaultInternalSchemaMetadata() {
         return InternalSchemaMetadata.builder()
-                .timestampToTransactionsTableSchemaVersion(
-                        TimestampPartitioningMap.of(ImmutableRangeMap.of(Range.atLeast(1L), 1)))
+                .timestampFromWhichWeShouldUseTransactions2(Long.MIN_VALUE)
                 .build();
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/TimestampPartitioningMap.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/TimestampPartitioningMap.java
@@ -62,7 +62,7 @@ public abstract class TimestampPartitioningMap<T> {
     abstract Set<RangeAndValue<T>> timestampMappings();
 
     @Value.Lazy
-    RangeMap<Long, T> rangeMapView() {
+    public RangeMap<Long, T> rangeMapView() {
         ImmutableRangeMap.Builder<Long, T> builder = new ImmutableRangeMap.Builder<>();
         timestampMappings()
                 .forEach(rangeAndValue -> builder.put(rangeAndValue.longRange(), rangeAndValue.value()));

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/legacy/InternalSchemaMetadataV1.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/legacy/InternalSchemaMetadataV1.java
@@ -14,23 +14,24 @@
  * limitations under the License.
  */
 
-package com.palantir.atlasdb.internalschema;
+package com.palantir.atlasdb.internalschema.legacy;
 
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.palantir.atlasdb.internalschema.TimestampPartitioningMap;
 
 /**
- * An {@link InternalSchemaMetadata} object controls how Atlas nodes carry out certain operations.
+ * An {@link InternalSchemaMetadataV1} object controls how Atlas nodes carry out certain operations.
  */
 @Value.Immutable
-@JsonSerialize(as = ImmutableInternalSchemaMetadata.class)
-@JsonDeserialize(as = ImmutableInternalSchemaMetadata.class)
-public interface InternalSchemaMetadata {
-    long timestampFromWhichWeShouldUseTransactions2();
+@JsonSerialize(as = ImmutableInternalSchemaMetadataV1.class)
+@JsonDeserialize(as = ImmutableInternalSchemaMetadataV1.class)
+public interface InternalSchemaMetadataV1 {
+    TimestampPartitioningMap<Integer> timestampToTransactionsTableSchemaVersion();
 
-    static ImmutableInternalSchemaMetadata.Builder builder() {
-        return ImmutableInternalSchemaMetadata.builder();
+    static ImmutableInternalSchemaMetadataV1.Builder builder() {
+        return ImmutableInternalSchemaMetadataV1.builder();
     }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/internalschema/TransactionSchemaManagerIntegrationTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/internalschema/TransactionSchemaManagerIntegrationTest.java
@@ -49,7 +49,7 @@ public class TransactionSchemaManagerIntegrationTest {
 
     @Before
     public void setUp() {
-        new InternalSchemaMetadataInitializer(actualCoordinationService, timestamps)
+        new InternalSchemaMetadataInitializer(actualCoordinationService)
                 .ensureInternalSchemaMetadataInitialized();
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/internalschema/persistence/InternalSchemaMetadataPayloadCodecTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/internalschema/persistence/InternalSchemaMetadataPayloadCodecTest.java
@@ -27,20 +27,13 @@ import java.util.Objects;
 
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableRangeMap;
-import com.google.common.collect.Range;
+import com.palantir.atlasdb.internalschema.ImmutableInternalSchemaMetadata;
 import com.palantir.atlasdb.internalschema.InternalSchemaMetadata;
-import com.palantir.atlasdb.internalschema.TimestampPartitioningMap;
 import com.palantir.remoting3.ext.jackson.ObjectMappers;
 
 public class InternalSchemaMetadataPayloadCodecTest {
     private static final InternalSchemaMetadata INTERNAL_SCHEMA_METADATA = InternalSchemaMetadata.builder()
-            .timestampToTransactionsTableSchemaVersion(
-                    TimestampPartitioningMap.of(
-                            ImmutableRangeMap.<Long, Integer>builder()
-                                    .put(Range.closedOpen(1L, 1000L), 1)
-                                    .put(Range.atLeast(1000L), 2)
-                                    .build()))
+            .timestampFromWhichWeShouldUseTransactions2(9999)
             .build();
 
     @Test
@@ -73,7 +66,10 @@ public class InternalSchemaMetadataPayloadCodecTest {
         VersionedInternalSchemaMetadata versionedInternalSchemaMetadata
                 = ObjectMappers.newServerObjectMapper().readValue(bytes, VersionedInternalSchemaMetadata.class);
         assertThat(InternalSchemaMetadataPayloadCodec.decode(versionedInternalSchemaMetadata))
-                .isEqualTo(INTERNAL_SCHEMA_METADATA);
+                .isEqualTo(
+                        ImmutableInternalSchemaMetadata.copyOf(INTERNAL_SCHEMA_METADATA)
+                            .withTimestampFromWhichWeShouldUseTransactions2(1000)
+                );
     }
 
     private static String getResourcePath(String subPath) throws URISyntaxException {


### PR DESCRIPTION
See #3657 for context - this is an illustration of how to use that framework to make a wire-format-incompatible change.

Note that this is generally speaking not the right way to do wire changes, as the v2 format here is strictly less expressive than the v1 format - so this change is unsound in terms of application layer logic. Though it does demonstrate how the framework works.