### PR TITLE
[_transactions2] Coordination, Part 4: Reuse Existing Values in the Coordination Store

### DIFF
--- a/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/keyvalue/KeyValueServiceCoordinationStore.java
+++ b/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/keyvalue/KeyValueServiceCoordinationStore.java
@@ -186,7 +186,8 @@ public final class KeyValueServiceCoordinationStore<T> implements CoordinationSt
         }
     }
 
-    private Optional<SequenceAndBound> getCoordinationValue() {
+    @VisibleForTesting
+    Optional<SequenceAndBound> getCoordinationValue() {
         return readFromCoordinationTable(getCoordinationValueCell())
                 .map(Value::getContents)
                 .map(this::deserializeSequenceAndBound);

--- a/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/keyvalue/KeyValueServiceCoordinationStore.java
+++ b/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/keyvalue/KeyValueServiceCoordinationStore.java
@@ -162,8 +162,8 @@ public final class KeyValueServiceCoordinationStore<T> implements CoordinationSt
             Optional<SequenceAndBound> coordinationValue,
             Optional<T> extantValue,
             T targetValue) {
-        return coordinationValue.isPresent() &&
-                extantValue.map(presentValue -> presentValue.equals(targetValue)).orElse(false);
+        return coordinationValue.isPresent()
+                && extantValue.map(presentValue -> presentValue.equals(targetValue)).orElse(false);
     }
 
     private CheckAndSetResult<ValueAndBound<T>> extractRelevantValues(T targetValue, long newBound,

--- a/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/keyvalue/KeyValueServiceCoordinationStore.java
+++ b/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/keyvalue/KeyValueServiceCoordinationStore.java
@@ -179,8 +179,8 @@ public final class KeyValueServiceCoordinationStore<T> implements CoordinationSt
                         .collect(Collectors.toList()));
     }
 
-    private long getNewBound(long sequenceNumber) {
-        return sequenceNumber + ADVANCEMENT_QUANTUM;
+    private long getNewBound(long pointInTime) {
+        return pointInTime + ADVANCEMENT_QUANTUM;
     }
 
     @VisibleForTesting


### PR DESCRIPTION
**Goals (and why)**:
- Most of the time, coordination involves perpetuating existing values. When this happens, we don't want to have to re-write existing values that are already stored there, to avoid unnecessarily bloating disk.

**Implementation Description (bullets)**:
- If a transform transforms a valueAndBound to the value that's present, advance the bound, but don't actually write a new value. Previously if the latest version was `v3` and bound was `10M`, we might have done a CAS to `(v4, 15M)` while now we do it to `(v3, 15M)`.

**Testing (What was existing testing like?  What have you done to improve it?)**:
`valuePreservingTransformationsDoNotWriteTheSameValueAgain` is a new test that verifies this behaviour (and would have failed on the previous branch).
Other tests should sanity check that things aren't horribly broken.

**Concerns (what feedback would you like?)**:
- There's an extra object equality check here on the objects stored in the coordination store. Is this reasonable?
- Might this optimisation be broken in a way I haven't thought of?

**Where should we start reviewing?**: KVSCoordinationStoreTest

**Priority (whenever / two weeks / yesterday)**: this week
