### PR TITLE
Fix quorum calculation for waiting on schema versions

### DIFF
--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServicesSchemaConsensusTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServicesSchemaConsensusTest.java
@@ -16,126 +16,200 @@
 package com.palantir.atlasdb.keyvalue.cassandra;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
+import org.apache.cassandra.thrift.EndpointDetails;
+import org.apache.cassandra.thrift.KsDef;
+import org.apache.cassandra.thrift.TokenRange;
 import org.apache.thrift.TException;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 
 public class CassandraKeyValueServicesSchemaConsensusTest {
-    private static CassandraKeyValueServiceConfig config = mock(CassandraKeyValueServiceConfig.class);
-    private static CassandraKeyValueServiceConfig waitingConfig = mock(CassandraKeyValueServiceConfig.class);
-    private static CassandraClient client = mock(CassandraClient.class);
+    private CassandraKeyValueServiceConfig config = mock(CassandraKeyValueServiceConfig.class);
+    private CassandraClient client = mock(CassandraClient.class);
 
-    private static final Set<InetSocketAddress> FIVE_SERVERS = ImmutableSet.of(
-            new InetSocketAddress("1", 0),
-            new InetSocketAddress("2", 0),
-            new InetSocketAddress("3", 0),
-            new InetSocketAddress("4", 0),
-            new InetSocketAddress("5", 0));
     private static final String TABLE = "table";
+    private static final String DC1 = "dc1";
+    private static final String DC2 = "dc2";
     private static final String VERSION_1 = "v1";
     private static final String VERSION_2 = "v2";
     private static final String VERSION_UNREACHABLE = "UNREACHABLE";
-    private static final List<String> QUORUM_OF_NODES = ImmutableList.of("1", "2", "3");
-    private static final List<String> REST_OF_NODES = ImmutableList.of("4", "5");
-    private static final List<String> ALL_NODES = ImmutableList.of("1", "2", "3", "4", "5");
 
-    @BeforeClass
-    public static void initializeMocks() {
+
+    private Map<String, List<String>> versionToHostDc1 = new HashMap<>();
+    private Map<String, List<String>> versionToHostDc2 = new HashMap<>();
+    private Map<String, List<String>> allVersions = new HashMap<>();
+
+    @Before
+    public void initializeMocks() throws TException {
         when(config.schemaMutationTimeoutMillis()).thenReturn(0);
-        when(config.servers()).thenReturn(FIVE_SERVERS);
-        when(waitingConfig.schemaMutationTimeoutMillis()).thenReturn(10_000);
-        when(waitingConfig.servers()).thenReturn(FIVE_SERVERS);
     }
 
     @Test
-    public void waitSucceedsForSameSchemaVersion() throws TException {
-        when(client.describe_schema_versions()).thenReturn(ImmutableMap.of(VERSION_1, ALL_NODES));
+    public void waitSucceedsWhenAllHostsOnSameSchemaVersion() throws TException {
+        setNumberOfNodesForVersionPerDatacenter(VERSION_1, 3, 3);
+        finalizeSchemaVersions();
         assertWaitForSchemaVersionsDoesNotThrow();
     }
 
     @Test
-    public void waitThrowsForAllUnknownSchemaVersion() throws TException {
-        when(client.describe_schema_versions()).thenReturn(ImmutableMap.of());
+    public void waitThrowsWhenHostsDivergen() throws TException {
+        setNumberOfNodesForVersionPerDatacenter(VERSION_1, 3, 3);
+        setNumberOfNodesForVersionPerDatacenter(VERSION_2, 0, 1);
+        finalizeSchemaVersions();
         assertWaitForSchemaVersionsThrowsAndContainsConfigNodesInformation();
     }
 
     @Test
-    public void waitThrowsForAllUnreachableSchemaVersion() throws TException {
-        when(client.describe_schema_versions()).thenReturn(ImmutableMap.of(VERSION_UNREACHABLE, ALL_NODES));
-        assertWaitForSchemaVersionsThrowsAndContainsConfigNodesInformation();
-    }
-
-    @Test
-    public void waitThrowsForFewerThanQuorumOnSameVersion() throws TException {
-        when(client.describe_schema_versions()).thenReturn(ImmutableMap.of(VERSION_1, REST_OF_NODES));
-        assertWaitForSchemaVersionsThrowsAndContainsConfigNodesInformation();
-    }
-
-    @Test
-    public void waitThrowsForQuorumOfUnreachableNodes() throws TException {
-        when(client.describe_schema_versions())
-                .thenReturn(ImmutableMap.of(VERSION_UNREACHABLE, QUORUM_OF_NODES, VERSION_1, REST_OF_NODES));
-        assertWaitForSchemaVersionsThrowsAndContainsConfigNodesInformation();
-    }
-
-    @Test
-    public void waitSucceedsForQuorumOnlyWithUnknownSchemaVersion() throws TException {
-        when(client.describe_schema_versions()).thenReturn(ImmutableMap.of(VERSION_1, QUORUM_OF_NODES));
+    public void waitSucceedsWhenQuorumIsAvailablePerDatacenterAndRestUnreachable() throws TException {
+        setNumberOfNodesForVersionPerDatacenter(VERSION_1, 3, 2);
+        setNumberOfNodesForVersionPerDatacenter(VERSION_UNREACHABLE, 1, 1);
+        finalizeSchemaVersions();
+        setRfPerDatacenter(3, 3);
         assertWaitForSchemaVersionsDoesNotThrow();
     }
 
     @Test
-    public void waitSucceedsForQuorumOnlyWithUnreachableSchemaVersion() throws TException {
-        when(client.describe_schema_versions())
-                .thenReturn(ImmutableMap.of(VERSION_1, QUORUM_OF_NODES, VERSION_UNREACHABLE, REST_OF_NODES));
-        assertWaitForSchemaVersionsDoesNotThrow();
-    }
-
-    @Test
-    public void waitThrowsForDifferentSchemaVersion() throws TException {
-        when(client.describe_schema_versions())
-                .thenReturn(ImmutableMap.of(VERSION_1, QUORUM_OF_NODES, VERSION_2, REST_OF_NODES));
+    public void waitThrowsWhenLessThanQuorumForSomeDatacenter() throws TException {
+        setNumberOfNodesForVersionPerDatacenter(VERSION_1, 3, 4);
+        setNumberOfNodesForVersionPerDatacenter(VERSION_UNREACHABLE, 1, 2);
+        finalizeSchemaVersions();
+        setRfPerDatacenter(3, 3);
         assertWaitForSchemaVersionsThrowsAndContainsConfigNodesInformation();
     }
 
     @Test
-    public void waitSucceedsForQuorumOnlyWithUnknownAndUnreachableSchemaVersion() throws TException {
-        when(client.describe_schema_versions()).thenReturn(
-                ImmutableMap.of(VERSION_1, QUORUM_OF_NODES, VERSION_UNREACHABLE, ImmutableList.of("5")));
-        assertWaitForSchemaVersionsDoesNotThrow();
+    public void waitThrowsWhenExactlyHalfOfTheNodesIsUnreachableForSomeTokenRange() throws TException {
+        setNumberOfNodesForVersionPerDatacenter(VERSION_1, 3, 2);
+        setNumberOfNodesForVersionPerDatacenter(VERSION_UNREACHABLE, 1, 1);
+        finalizeSchemaVersions();
+        setRfPerDatacenter(2, 2);
+        assertWaitForSchemaVersionsThrowsAndContainsConfigNodesInformation();
+    }
+
+    @Test
+    public void waitSucceedsWhenQuorumIsAvailableForAllTokenRanges() throws TException {
+        setNumberOfNodesForVersionPerDatacenter(VERSION_1, 2, 2);
+        setNumberOfNodesForVersionPerDatacenter(VERSION_UNREACHABLE, 3, 3);
+        finalizeSchemaVersions();
+        setRfPerDatacenter(3, 3);
+        setOnlyTokenRangeToIncludeQuorumFromEachDc();
     }
 
     @Test
     public void waitWaitsForSchemaVersions() throws TException {
-        CassandraClient waitingClient = mock(CassandraClient.class);
-        when(waitingClient.describe_schema_versions()).thenReturn(
-                ImmutableMap.of(),
-                ImmutableMap.of(VERSION_UNREACHABLE, QUORUM_OF_NODES, VERSION_1, REST_OF_NODES),
-                ImmutableMap.of(VERSION_1, QUORUM_OF_NODES, VERSION_UNREACHABLE, REST_OF_NODES),
-                ImmutableMap.of(VERSION_1, ALL_NODES));
+        when(client.describe_schema_versions())
+                .thenAnswer(invocation -> {
+                    setNumberOfNodesForVersionPerDatacenter(VERSION_1, 3, 4);
+                    setNumberOfNodesForVersionPerDatacenter(VERSION_UNREACHABLE, 1, 2);
+                    setRfPerDatacenter(3, 3);
+                    return allVersions;
+                })
+                .thenAnswer(invocation1 -> {
+                    cleanupVersions();
+                    setNumberOfNodesForVersionPerDatacenter(VERSION_1, 3, 3);
+                    setNumberOfNodesForVersionPerDatacenter(VERSION_2, 0, 1);
+                    return allVersions;
+                })
+                .thenAnswer(invocation -> {
+                    cleanupVersions();
+                    setNumberOfNodesForVersionPerDatacenter(VERSION_1, 3, 2);
+                    setNumberOfNodesForVersionPerDatacenter(VERSION_UNREACHABLE, 1, 1);
+                    setRfPerDatacenter(3, 3);
+                    return allVersions;
+                });
 
-        CassandraKeyValueServices.waitForSchemaVersions(waitingConfig, waitingClient, TABLE);
-        verify(waitingClient, times(3)).describe_schema_versions();
+        when(config.schemaMutationTimeoutMillis()).thenReturn(10_000);
+        assertWaitForSchemaVersionsDoesNotThrow();
+        verify(client, times(3)).describe_schema_versions();
+    }
+
+    private void cleanupVersions() {
+        versionToHostDc1 = new HashMap<>();
+        versionToHostDc2 = new HashMap<>();
+    }
+
+    private void setOnlyTokenRangeToIncludeQuorumFromEachDc() throws TException {
+        when(client.describe_ring(any())).thenReturn(ImmutableList.of(
+                createTokenRange(
+                        Lists.newArrayList(Iterables.concat(
+                                versionToHostDc1.get(VERSION_1).subList(0, 2),
+                                versionToHostDc1.get(VERSION_UNREACHABLE).subList(0, 1))),
+                        Lists.newArrayList(Iterables.concat(
+                                versionToHostDc2.get(VERSION_1).subList(0, 2),
+                                versionToHostDc2.get(VERSION_UNREACHABLE).subList(0, 1))))));
+    }
+
+    private void setNumberOfNodesForVersionPerDatacenter(String version, int dc1, int dc2) throws TException {
+        versionToHostDc1.put(version, createHostList(DC1, version, dc1));
+        versionToHostDc2.put(version, createHostList(DC2, version, dc2));
+
+        allVersions = new HashMap<>(versionToHostDc1);
+        versionToHostDc2.forEach((ver, hosts) -> allVersions
+                .merge(ver, hosts, (hosts1, hosts2) -> Lists.newArrayList(Iterables.concat(hosts1, hosts2))));
+    }
+
+    private void finalizeSchemaVersions() throws TException {
+        when(client.describe_schema_versions()).thenReturn(allVersions);
+    }
+
+    private void setRfPerDatacenter(int rf1, int rf2) throws TException {
+        Set<Set<String>> dc1Combs = Sets.combinations(getHosts(versionToHostDc1), rf1);
+        Set<Set<String>> dc2Combs = Sets.combinations(getHosts(versionToHostDc2), rf2);
+        Set<List<Set<String>>> allCombinations = Sets.cartesianProduct(ImmutableList.of(dc1Combs, dc2Combs));
+
+        when(client.describe_ring(any())).thenReturn(allCombinations.stream()
+                .map(hostList -> createTokenRange(hostList.get(0), hostList.get(1))).collect(Collectors.toList()));
+
+        KsDef ksDef = new KsDef();
+        ksDef.setStrategy_options(ImmutableMap.of(DC1, Integer.toString(rf1), DC2, Integer.toString(rf2)));
+        when(client.describe_keyspace(any())).thenReturn(ksDef);
+    }
+
+    private Set<String> getHosts(Map<String, List<String>> versionToHost) {
+        return versionToHost.values()
+                .stream()
+                .flatMap(List::stream)
+                .collect(Collectors.toSet());
+    }
+
+    private List<String> createHostList(String datacenter, String version, int number) {
+        return IntStream.range(0, number)
+                .mapToObj(num -> datacenter + version + num)
+                .collect(Collectors.toList());
+    }
+
+    private TokenRange createTokenRange(Collection<String> dc1Nodes, Collection<String> dc2Nodes) {
+        List<EndpointDetails> endpointDetails = new ArrayList<>();
+        dc1Nodes.forEach(host -> endpointDetails.add(new EndpointDetails(host, DC1)));
+        dc2Nodes.forEach(host -> endpointDetails.add(new EndpointDetails(host, DC2)));
+        return new TokenRange().setEndpoint_details(endpointDetails);
     }
 
     private void assertWaitForSchemaVersionsThrowsAndContainsConfigNodesInformation() {
         assertThatThrownBy(() -> CassandraKeyValueServices.waitForSchemaVersions(config, client, TABLE))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining(FIVE_SERVERS.iterator().next().getHostName());
+                .isInstanceOf(IllegalStateException.class);
     }
 
     private void assertWaitForSchemaVersionsDoesNotThrow() throws TException {

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,12 @@ develop
     *    - Type
          - Change
 
+    *    - |fixed|
+         - Cassandra KVS now correctly determines if enough nodes agree on schema versions when waiting for schema changes to propagate.
+           Previously, we would proceed if a majority of the nodes were on the same schema version and the rest were unreachable.
+           Now, we require that a quorum of nodes for each datacenter and for each token range satisfies the condition, and the rest are unreachable.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3664>`__)
+
     *    - |improved|
          - Read transactions on thoroughly swept tables requires one less RPC to timelock now.
            This improves the read performance and reduces load on timelock.


### PR DESCRIPTION
**Goals (and why)**:
After we do Cassandra schema mutations, we wait for the nodes to agree on schema versions. Ideally, we'd want all nodes to agree, but in order to be HA, we allow some nodes to be unreachable.

Historically, this was hardcoded to allow at most one node to be unreachable, and later changed to less than half. The first is very restrictive, and the latter doesn't give us the guarantees we want. This PR is to check that the available nodes guarantee write consistency, i.e. EACH_QUORUM. 

**Implementation Description (bullets)**:
If we hit the interesting case of some nodes being unreachable and others on the same version, we request the necessary information from Cassandra and then check for each TokenRange that each datacenter has a quorum of available nodes.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added a few tests for the different cases.

**Concerns (what feedback would you like?)**:
Is this actually what we want? Is this a reasonable way to do it? I'd like your feedback, @tpetracca @amandachow @ashrayjain

**Where should we start reviewing?**:
Probably from the tests
