### PR TITLE
Move javax.anntations-api dependency to atlasdb-api

### DIFF
--- a/atlasdb-api/build.gradle
+++ b/atlasdb-api/build.gradle
@@ -10,6 +10,7 @@ dependencies {
   compile group: 'org.apache.commons', name: 'commons-lang3'
   compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations'
   compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
+  compile group: 'javax.annotation', name: 'javax.annotation-api'
   compile group: 'javax.validation', name: 'validation-api'
 
   compile group: 'com.palantir.remoting-api', name: 'ssl-config'

--- a/atlasdb-client/build.gradle
+++ b/atlasdb-client/build.gradle
@@ -83,7 +83,6 @@ dependencies {
     exclude (group: 'org.hdrhistogram', module: 'HdrHistogram')
   }
   compile group: 'com.squareup', name:'javapoet'
-  compile group: 'javax.annotation', name: 'javax.annotation-api'
   compile group: 'org.hdrhistogram', name: 'HdrHistogram'
   compile group: 'com.palantir.common', name: 'streams'
 


### PR DESCRIPTION
**Goals (and why)**:
Only `atlasdb-config` is needed to generate schemas. The generated schema classes contain the `Generated` annotation but the dependency is missing from `atlasdb-config`.

cc @robert3005 