### PR TITLE
Fix warning from errorprone in generated code.

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
@@ -271,7 +271,7 @@ public class StreamStoreRenderer {
                     line(StreamMetadataRow, " row = ", StreamMetadataRow, ".of(id);");
                     line("StreamMetadata metadata = metaTable.getMetadatas(ImmutableSet.of(row)).values().iterator().next();");
                     line("Preconditions.checkState(metadata.getStatus() == Status.STORING, \"This stream is being cleaned up while storing blocks: %s\", id);");
-                    line("Builder builder = StreamMetadata.newBuilder(metadata);");
+                    line("StreamMetadata.Builder builder = StreamMetadata.newBuilder(metadata);");
                     line("builder.setLength(blockNumber * BLOCK_SIZE_IN_BYTES + 1);");
                     line("metaTable.putMetadata(row, builder.build());");
                 } line("}");
@@ -825,7 +825,6 @@ public class StreamStoreRenderer {
         ByteString.class,
         Status.class,
         StreamMetadata.class,
-        StreamMetadata.Builder.class,
         Throwables.class,
         ConcatenatedInputStream.class,
         Cell.class,

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -73,6 +73,10 @@ develop
            which would cause other hooks to not run.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3654>`__)
 
+    *    - |fixed|
+         - Fix warning in stream-store generated code.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3667>`__)
+
 ========
 v0.111.0
 ========


### PR DESCRIPTION
**Goals (and why)**:

This warning is blocking upgrading to newer gradle-baseline in an internal product. For some reason errorprone is not recognising the @Generated annotation on atlasdb generated code; that is to be figured out, but fixing the warning is lowest lift fix.

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
