### PR TITLE
Hotfix Publish + List of Canonical Product Dependencies To Ignore For Non-Standard Distributions

### DIFF
--- a/atlasdb-cli-distribution/build.gradle
+++ b/atlasdb-cli-distribution/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.palantir.sls-java-service-distribution'
 
 apply from: "../gradle/publish-dists.gradle"
 apply from: "../gradle/shared.gradle"
+apply from: "../gradle/non-client-dist.gradle"
 
 dependencies {
   runtime project(':atlasdb-cli')
@@ -18,6 +19,4 @@ dependencies {
 distribution {
   serviceName 'atlasdb-cli'
   mainClass 'com.palantir.atlasdb.cli.AtlasCli'
-  ignoredProductDependency('com.palantir.rescue', 'rescue')
-  ignoredProductDependency('com.palantir.timelock', 'timelock-server')
 }

--- a/atlasdb-cli-distribution/build.gradle
+++ b/atlasdb-cli-distribution/build.gradle
@@ -19,4 +19,5 @@ distribution {
   serviceName 'atlasdb-cli'
   mainClass 'com.palantir.atlasdb.cli.AtlasCli'
   ignoredProductDependency('com.palantir.rescue', 'rescue')
+  ignoredProductDependency('com.palantir.timelock', 'timelock-server')
 }

--- a/atlasdb-console-distribution/build.gradle
+++ b/atlasdb-console-distribution/build.gradle
@@ -18,4 +18,5 @@ distribution {
   serviceName 'atlasdb-console'
   mainClass 'com.palantir.atlasdb.console.AtlasConsoleMain'
   ignoredProductDependency('com.palantir.rescue', 'rescue')
+  ignoredProductDependency('com.palantir.timelock', 'timelock-server')
 }

--- a/atlasdb-console-distribution/build.gradle
+++ b/atlasdb-console-distribution/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.palantir.sls-java-service-distribution'
 
 apply from: "../gradle/publish-dists.gradle"
 apply from: "../gradle/shared.gradle"
+apply from: "../gradle/non-client-dist.gradle"
 
 dependencies {
   runtime project(':atlasdb-console')
@@ -17,6 +18,4 @@ dependencies {
 distribution {
   serviceName 'atlasdb-console'
   mainClass 'com.palantir.atlasdb.console.AtlasConsoleMain'
-  ignoredProductDependency('com.palantir.rescue', 'rescue')
-  ignoredProductDependency('com.palantir.timelock', 'timelock-server')
 }

--- a/atlasdb-ete-tests/build.gradle
+++ b/atlasdb-ete-tests/build.gradle
@@ -1,5 +1,6 @@
 apply from: "../gradle/publish-jars.gradle"
 apply from: "../gradle/shared.gradle"
+apply from: "../gradle/non-client-dist.gradle"
 
 apply plugin: 'com.palantir.sls-java-service-distribution'
 apply plugin: 'org.inferred.processors'
@@ -76,8 +77,6 @@ distribution {
     mainClass 'com.palantir.atlasdb.AtlasDbEteServer'
     args 'server', 'var/conf/atlasdb-ete.yml'
     defaultJvmOpts '-Xmx384M'
-    ignoredProductDependency('com.palantir.rescue', 'rescue')
-    ignoredProductDependency('com.palantir.timelock', 'timelock-server')
 }
 
 sourceCompatibility = '1.8'

--- a/gradle/non-client-dist.gradle
+++ b/gradle/non-client-dist.gradle
@@ -1,0 +1,8 @@
+// Used to ignore product dependencies for distributions we produce that aren't standard AtlasDB consumers.
+
+apply plugin: 'com.palantir.sls-java-service-distribution'
+
+distribution {
+    ignoredProductDependency('com.palantir.rescue', 'rescue')
+    ignoredProductDependency('com.palantir.timelock', 'timelock-server')
+}

--- a/timelock-server-benchmark-client/build.gradle
+++ b/timelock-server-benchmark-client/build.gradle
@@ -23,6 +23,7 @@ distribution {
     args 'server', 'var/conf/timelock.yml'
     defaultJvmOpts "-Xms4096m", "-Xmx4096m", "-javaagent:service/lib/jetty-alpn-agent-${libVersions.jetty_alpn_agent}.jar"
     ignoredProductDependency('com.palantir.rescue', 'rescue')
+    ignoredProductDependency('com.palantir.timelock', 'timelock-server')
 }
 
 configurations.all {

--- a/timelock-server-benchmark-client/build.gradle
+++ b/timelock-server-benchmark-client/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'org.inferred.processors'
 apply from: "../gradle/publish-dists.gradle"
 apply from: "../gradle/shared.gradle"
 apply from: "../gradle/timelock.gradle"
+apply from: "../gradle/non-client-dist.gradle"
 
 dependencies {
     compile project(":timelock-server")
@@ -22,8 +23,6 @@ distribution {
     mainClass 'com.palantir.atlasdb.timelock.benchmarks.TimelockBenchmarkClientLauncher'
     args 'server', 'var/conf/timelock.yml'
     defaultJvmOpts "-Xms4096m", "-Xmx4096m", "-javaagent:service/lib/jetty-alpn-agent-${libVersions.jetty_alpn_agent}.jar"
-    ignoredProductDependency('com.palantir.rescue', 'rescue')
-    ignoredProductDependency('com.palantir.timelock', 'timelock-server')
 }
 
 configurations.all {

--- a/timelock-server-benchmark-cluster/build.gradle
+++ b/timelock-server-benchmark-cluster/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.palantir.sls-java-service-distribution'
 apply from: "../gradle/publish-dists.gradle"
 apply from: "../gradle/shared.gradle"
 apply from: "../gradle/timelock.gradle"
+apply from: "../gradle/non-client-dist.gradle"
 
 dependencies {
     compile project(':timelock-server')
@@ -14,8 +15,6 @@ distribution {
     mainClass 'com.palantir.atlasdb.timelock.benchmarks.server.TimelockBenchmarkServerLauncher'
     args 'server', 'var/conf/timelock.yml'
     defaultJvmOpts "-Xms512m", "-Xmx4096m", "-javaagent:service/lib/jetty-alpn-agent-${libVersions.jetty_alpn_agent}.jar"
-    ignoredProductDependency('com.palantir.rescue', 'rescue')
-    ignoredProductDependency('com.palantir.timelock', 'timelock-server')
 }
 
 configurations.all {

--- a/timelock-server-distribution/build.gradle
+++ b/timelock-server-distribution/build.gradle
@@ -4,6 +4,7 @@ apply from: "../gradle/docker.gradle"
 apply from: "../gradle/publish-dists.gradle"
 apply from: "../gradle/shared.gradle"
 apply from: "../gradle/timelock.gradle"
+apply from: "../gradle/non-client-dist.gradle"
 
 dependencies {
     runtime project(':timelock-server')
@@ -15,8 +16,6 @@ distribution {
     mainClass 'com.palantir.atlasdb.timelock.TimeLockServerLauncher'
     args 'server', 'var/conf/timelock.yml'
     defaultJvmOpts "-Xms512m", "-Xmx512m", "-javaagent:service/lib/jetty-alpn-agent-${libVersions.jetty_alpn_agent}.jar"
-    ignoredProductDependency('com.palantir.rescue', 'rescue')
-    ignoredProductDependency('com.palantir.timelock', 'timelock-server')
 }
 
 task runTimeLock(type: JavaExec) {


### PR DESCRIPTION
**Goals (and why)**: fix 0.114.0

**Implementation Description (bullets)**:
- add the missing timelock exclude to a few projects where it was missing

**Testing (What was existing testing like?  What have you done to improve it?)**:
- I ran `./gradlew createManifest` locally and it passed

**Concerns (what feedback would you like?)**:
- nothing in particular, are there any unexpected consequences of the quick refactor?

**Where should we start reviewing?**: `non-client-dist.gradle`

**Priority (whenever / two weeks / yesterday)**: yesterday 🔥 
