### PR TITLE
@AutoDelegate: Support Interface Statics and Generics

### DIFF
--- a/atlasdb-processors-tests/build.gradle
+++ b/atlasdb-processors-tests/build.gradle
@@ -9,6 +9,7 @@ repositories {
 
 dependencies {
     processor project(":atlasdb-processors")
+    testCompile group: 'org.assertj', name: 'assertj-core'
     testCompile group: 'org.hamcrest', name: 'hamcrest-library'
     testCompile group: 'org.mockito', name: 'mockito-core'
 }

--- a/atlasdb-processors-tests/build.gradle
+++ b/atlasdb-processors-tests/build.gradle
@@ -9,6 +9,8 @@ repositories {
 
 dependencies {
     processor project(":atlasdb-processors")
+
+    testCompile group: 'com.google.guava', name: 'guava'
     testCompile group: 'org.assertj', name: 'assertj-core'
     testCompile group: 'org.hamcrest', name: 'hamcrest-library'
     testCompile group: 'org.mockito', name: 'mockito-core'

--- a/atlasdb-processors-tests/src/main/java/com/palantir/processors/GenericsTester.java
+++ b/atlasdb-processors-tests/src/main/java/com/palantir/processors/GenericsTester.java
@@ -21,6 +21,8 @@ import java.util.Set;
 
 @AutoDelegate
 public interface GenericsTester<A, B extends List<C>, C> {
+    A processItems(A first, B second, C third);
+
     List<B> getListOfLists(A comparison);
 
     default Set<C> hello() {

--- a/atlasdb-processors-tests/src/main/java/com/palantir/processors/GenericsTester.java
+++ b/atlasdb-processors-tests/src/main/java/com/palantir/processors/GenericsTester.java
@@ -1,0 +1,33 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.processors;
+
+import java.util.List;
+import java.util.Set;
+
+@AutoDelegate
+public interface GenericsTester<A, B extends List<C>, C> {
+    List<B> getListOfLists(A comparison);
+
+    default Set<C> hello() {
+        throw new UnsupportedOperationException("This class doesn't know how to say hello.");
+    }
+
+    static <A, D> D hidingParameter(A argument) {
+        return null;
+    }
+}

--- a/atlasdb-processors-tests/src/main/java/com/palantir/processors/TestInterface.java
+++ b/atlasdb-processors-tests/src/main/java/com/palantir/processors/TestInterface.java
@@ -35,7 +35,5 @@ public interface TestInterface {
 
     void overriddenMethod(Integer p1, Integer p2, Integer p3);
 
-    static void staticMethod() {
-        // do nothing
-    }
+    static void staticMethod() {}
 }

--- a/atlasdb-processors-tests/src/main/java/com/palantir/processors/TestInterface.java
+++ b/atlasdb-processors-tests/src/main/java/com/palantir/processors/TestInterface.java
@@ -34,4 +34,8 @@ public interface TestInterface {
     default void defaultMethod() {}
 
     void overriddenMethod(Integer p1, Integer p2, Integer p3);
+
+    static void staticMethod() {
+        // do nothing
+    }
 }

--- a/atlasdb-processors-tests/src/test/java/com/palantir/processors/AutoDelegateGenericTests.java
+++ b/atlasdb-processors-tests/src/test/java/com/palantir/processors/AutoDelegateGenericTests.java
@@ -38,7 +38,6 @@ public class AutoDelegateGenericTests {
         Set<String> generatedMethods = TestingUtils.extractMethods(AutoDelegate_GenericsTester.class);
         Set<String> originalMethods = TestingUtils.extractNonStaticMethods(GenericsTester.class);
 
-        generatedMethods.removeAll(originalMethods);
         assertThat(Sets.difference(generatedMethods, originalMethods)).containsOnly("delegate");
     }
 }

--- a/atlasdb-processors-tests/src/test/java/com/palantir/processors/AutoDelegateGenericTests.java
+++ b/atlasdb-processors-tests/src/test/java/com/palantir/processors/AutoDelegateGenericTests.java
@@ -1,0 +1,53 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.processors;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.lang.reflect.Modifier;
+import java.util.Set;
+
+import org.junit.Test;
+
+public class AutoDelegateGenericTests {
+    @Test
+    public void generatedInterfaceHasInterfaceMethods() {
+        Set<String> generatedMethods = TestingUtils.extractMethods(AutoDelegate_GenericsTester.class);
+        Set<String> originalMethods = extractNonStaticMethods(GenericsTester.class);
+
+        assertThat(generatedMethods, hasItems(originalMethods.toArray(new String[0])));
+    }
+
+    @Test
+    public void generatedInterfaceHasDelegateMethod() {
+        Set<String> generatedMethods = TestingUtils.extractMethods(AutoDelegate_GenericsTester.class);
+        Set<String> originalMethods = extractNonStaticMethods(GenericsTester.class);
+
+        generatedMethods.removeAll(originalMethods);
+        assertThat(generatedMethods.size(), is(1));
+        assertThat(generatedMethods.iterator().next(), containsString("delegate"));
+    }
+
+    private Set<String> extractNonStaticMethods(Class klass) {
+        return TestingUtils.extractMethodsSatisfyingPredicate(
+                klass,
+                method -> !Modifier.isStatic(method.getModifiers()));
+    }
+}

--- a/atlasdb-processors-tests/src/test/java/com/palantir/processors/AutoDelegateGenericTests.java
+++ b/atlasdb-processors-tests/src/test/java/com/palantir/processors/AutoDelegateGenericTests.java
@@ -16,38 +16,29 @@
 
 package com.palantir.processors;
 
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import java.lang.reflect.Modifier;
 import java.util.Set;
 
 import org.junit.Test;
+
+import com.google.common.collect.Sets;
 
 public class AutoDelegateGenericTests {
     @Test
     public void generatedInterfaceHasInterfaceMethods() {
         Set<String> generatedMethods = TestingUtils.extractMethods(AutoDelegate_GenericsTester.class);
-        Set<String> originalMethods = extractNonStaticMethods(GenericsTester.class);
+        Set<String> originalMethods = TestingUtils.extractNonStaticMethods(GenericsTester.class);
 
-        assertThat(generatedMethods, hasItems(originalMethods.toArray(new String[0])));
+        assertThat(generatedMethods).containsAll(originalMethods);
     }
 
     @Test
     public void generatedInterfaceHasDelegateMethod() {
         Set<String> generatedMethods = TestingUtils.extractMethods(AutoDelegate_GenericsTester.class);
-        Set<String> originalMethods = extractNonStaticMethods(GenericsTester.class);
+        Set<String> originalMethods = TestingUtils.extractNonStaticMethods(GenericsTester.class);
 
         generatedMethods.removeAll(originalMethods);
-        assertThat(generatedMethods.size(), is(1));
-        assertThat(generatedMethods.iterator().next(), containsString("delegate"));
-    }
-
-    private Set<String> extractNonStaticMethods(Class klass) {
-        return TestingUtils.extractMethodsSatisfyingPredicate(
-                klass,
-                method -> !Modifier.isStatic(method.getModifiers()));
+        assertThat(Sets.difference(generatedMethods, originalMethods)).containsOnly("delegate");
     }
 }

--- a/atlasdb-processors-tests/src/test/java/com/palantir/processors/AutoDelegateGenericTests.java
+++ b/atlasdb-processors-tests/src/test/java/com/palantir/processors/AutoDelegateGenericTests.java
@@ -16,10 +16,12 @@
 
 package com.palantir.processors;
 
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Set;
 
+import org.assertj.core.api.Condition;
 import org.junit.Test;
 
 import com.google.common.collect.Sets;
@@ -38,6 +40,7 @@ public class AutoDelegateGenericTests {
         Set<String> generatedMethods = TestingUtils.extractMethods(AutoDelegate_GenericsTester.class);
         Set<String> originalMethods = TestingUtils.extractNonStaticMethods(GenericsTester.class);
 
-        assertThat(Sets.difference(generatedMethods, originalMethods)).containsOnly("delegate");
+        assertThat(Sets.difference(generatedMethods, originalMethods)).haveAtLeastOne(
+                new Condition<>(string -> string.contains("delegate"), "contains the string 'delegate'"));
     }
 }

--- a/atlasdb-processors-tests/src/test/java/com/palantir/processors/AutoDelegateInterfaceTests.java
+++ b/atlasdb-processors-tests/src/test/java/com/palantir/processors/AutoDelegateInterfaceTests.java
@@ -15,11 +15,10 @@
  */
 package com.palantir.processors;
 
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -29,6 +28,8 @@ import java.lang.reflect.Modifier;
 import java.util.Set;
 
 import org.junit.Test;
+
+import com.google.common.collect.Sets;
 
 public class AutoDelegateInterfaceTests {
     @Test
@@ -65,7 +66,7 @@ public class AutoDelegateInterfaceTests {
     @Test
     public void generatedInterfaceHasInterfaceMethods() {
         Set<String> generatedMethods = TestingUtils.extractMethods(AutoDelegate_TestInterface.class);
-        Set<String> originalMethods = extractNonStaticMethods(TestInterface.class);
+        Set<String> originalMethods = TestingUtils.extractNonStaticMethods(TestInterface.class);
 
         assertThat(generatedMethods, hasItems(originalMethods.toArray(new String[0])));
     }
@@ -73,7 +74,7 @@ public class AutoDelegateInterfaceTests {
     @Test
     public void generatedInterfaceHasDelegateMethod() {
         Set<String> generatedMethods = TestingUtils.extractMethods(AutoDelegate_TestInterface.class);
-        Set<String> originalMethods = extractNonStaticMethods(TestInterface.class);
+        Set<String> originalMethods = TestingUtils.extractNonStaticMethods(TestInterface.class);
 
         generatedMethods.removeAll(originalMethods);
         assertThat(generatedMethods.size(), is(1));
@@ -86,14 +87,14 @@ public class AutoDelegateInterfaceTests {
         Set<String> originalStaticMethods = TestingUtils.extractMethodsSatisfyingPredicate(TestInterface.class,
                 method -> Modifier.isStatic(method.getModifiers()));
 
-        originalStaticMethods.forEach(staticMethod -> assertThat(generatedMethods, not(contains(staticMethod))));
+        assertThat(Sets.intersection(generatedMethods, originalStaticMethods), empty());
     }
 
     @Test
     public void childInterfaceHasParentAndChildMethods() {
         Set<String> generatedMethods = TestingUtils.extractMethods(AutoDelegate_ChildTestInterface.class);
-        Set<String> parentMethods = extractNonStaticMethods(TestInterface.class);
-        Set<String> childMethods = extractNonStaticMethods(ChildTestInterface.class);
+        Set<String> parentMethods = TestingUtils.extractNonStaticMethods(TestInterface.class);
+        Set<String> childMethods = TestingUtils.extractNonStaticMethods(ChildTestInterface.class);
 
         assertThat(generatedMethods, hasItems(parentMethods.toArray(new String[0])));
         assertThat(generatedMethods, hasItems(childMethods.toArray(new String[0])));
@@ -106,11 +107,5 @@ public class AutoDelegateInterfaceTests {
 
         instanceOfInterface.methodWithReturnType();
         verify(mockImpl, times(1)).methodWithReturnType();
-    }
-
-    private Set<String> extractNonStaticMethods(Class klass) {
-        return TestingUtils.extractMethodsSatisfyingPredicate(
-                klass,
-                method -> !Modifier.isStatic(method.getModifiers()));
     }
 }

--- a/atlasdb-processors-tests/src/test/java/com/palantir/processors/TestingUtils.java
+++ b/atlasdb-processors-tests/src/test/java/com/palantir/processors/TestingUtils.java
@@ -17,6 +17,7 @@ package com.palantir.processors;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -59,6 +60,11 @@ final class TestingUtils {
     static String constructorToString(Constructor constructor) {
         return String.format("%s", extractConstructorParameterTypes(constructor));
     }
+
+    static Set<String> extractNonStaticMethods(Class klass) {
+        return extractMethodsSatisfyingPredicate(klass, method -> !Modifier.isStatic(method.getModifiers()));
+    }
+
 
     private static String extractConstructorParameterTypes(Constructor constructor) {
         return Arrays.stream(constructor.getParameterTypes())

--- a/atlasdb-processors-tests/src/test/java/com/palantir/processors/TestingUtils.java
+++ b/atlasdb-processors-tests/src/test/java/com/palantir/processors/TestingUtils.java
@@ -19,13 +19,19 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 final class TestingUtils {
     private TestingUtils() {}
 
     static Set<String> extractMethods(Class klass) {
+        return extractMethodsSatisfyingPredicate(klass, unused -> true);
+    }
+
+    static Set<String> extractMethodsSatisfyingPredicate(Class klass, Predicate<Method> predicate) {
         return Arrays.stream(klass.getDeclaredMethods())
+                .filter(predicate)
                 .map(TestingUtils::methodToString)
                 .collect(Collectors.toSet());
     }

--- a/atlasdb-processors/src/main/java/com/palantir/processors/AutoDelegateProcessor.java
+++ b/atlasdb-processors/src/main/java/com/palantir/processors/AutoDelegateProcessor.java
@@ -53,6 +53,7 @@ import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
+import com.squareup.javapoet.TypeVariableName;
 
 @AutoService(Processor.class)
 public final class AutoDelegateProcessor extends AbstractProcessor {
@@ -204,6 +205,10 @@ public final class AutoDelegateProcessor extends AbstractProcessor {
         } else {
             typeBuilder = TypeSpec.classBuilder(newTypeName);
         }
+        typeBuilder.addTypeVariables(typeToExtend.getTypeParameterElements()
+                .stream()
+                .map(TypeVariableName::get)
+                .collect(Collectors.toList()));
 
         // Add modifiers
         TypeMirror typeMirror = typeToExtend.getType();

--- a/atlasdb-processors/src/main/java/com/palantir/processors/TypeToExtend.java
+++ b/atlasdb-processors/src/main/java/com/palantir/processors/TypeToExtend.java
@@ -28,6 +28,7 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.type.TypeMirror;
 
 import com.google.common.collect.Sets;
@@ -78,7 +79,8 @@ final class TypeToExtend {
 
     private Boolean interfaceMethodFilter(Element element) {
         return element.getKind() == ElementKind.METHOD
-                && element.getModifiers().contains(Modifier.PUBLIC);
+                && element.getModifiers().contains(Modifier.PUBLIC)
+                && !element.getModifiers().contains(Modifier.STATIC);
     }
 
     private Boolean classMethodFilter(Element element) {
@@ -136,5 +138,9 @@ final class TypeToExtend {
 
     Set<ExecutableElement> getConstructors() {
         return constructors;
+    }
+
+    List<? extends TypeParameterElement> getTypeParameterElements() {
+        return typeToExtend.getTypeParameters();
     }
 }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,25 @@ develop
     *    - Type
          - Change
 
+    *    - |fixed|
+         - The @AutoDelegate annotation now works correctly for interfaces which have static methods, and for simple cases of generics.
+           Previously, the annotation processor would generate code that wouldn't compile.
+           Note that some cases (e.g. sub-interfaces of generics that refine type parameters) are still not supported correctly.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/QQQQ>`__)
+
+========
+v0.114.0
+========
+
+03 Dec 2018
+
+.. list-table::
+    :widths: 5 40
+    :header-rows: 1
+
+    *    - Type
+         - Change
+
     *    - |userbreak|
          - As part of preparatory work to migrate to a new transactions table, this version of AtlasDB and all versions going forward expect to be using a version of TimeLock that supports the ``startIdentifiedAtlasDbTransaction`` endpoint.
            Support for previous versions of TimeLock has been dropped; please update your TimeLock server.

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -54,7 +54,7 @@ develop
          - The @AutoDelegate annotation now works correctly for interfaces which have static methods, and for simple cases of generics.
            Previously, the annotation processor would generate code that wouldn't compile.
            Note that some cases (e.g. sub-interfaces of generics that refine type parameters) are still not supported correctly.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/QQQQ>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3670>`__)
 
 ========
 v0.114.0


### PR DESCRIPTION
**Goals (and why)**:
- Add support for static methods in interfaces
- Add basic support for generic types
- These features are generally useful; the latter is needed for the coordination store in transactions2

**Implementation Description (bullets)**:
- Filter static methods out when trying to pick which methods we want to generate a copy of
- Add correct type parameter elements to the javapoet builder when generating an AutoDelegate class

**Testing (What was existing testing like?  What have you done to improve it?)**:
There were some pretty good tests, but none for these specific behaviours. I've added new ones for these.

**Concerns (what feedback would you like?)**:
- Some more complex interactions with generics, particularly around subclassing don't work correctly. For example, if I have `interface One<A, B>` and `interface Two<C> extends One<Integer, C>`, methods from `One` generated in `AutoDelegate_Two` reference `A` and `B` which clearly don't exist. Even worse, if I have `interface One<A, B>` and `interface Two<B, A> extends One<A, B>`, the parameters for the `One` methods work opposite of the way they should.

**Where should we start reviewing?**: `GenericsTester` for an overview of what's broken, then `AutoDelegateProcessor`

**Priority (whenever / two weeks / yesterday)**: this week
