### PR TITLE
Rely on default Errorprone ShutdownHook checks rather than our own one

### DIFF
--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -423,11 +423,5 @@
         </module>
 
         <!-- Stricter checks end -->
-
-        <module name="RegexpSinglelineJava">
-            <property name="id" value="DoNotUseShutdownHooks"/>
-            <property name="format" value=".*addShutdownHook\("/>
-            <property name="message" value="Shutdown hooks should not be used in AtlasDB, it is a library. Products using AtlasDB might be creating and destroying many instances of AtlasDB, therefore relying on shutdown hooks for cleaning up resources can lead to memory leaks."/>
-        </module>
     </module>
 </module>

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/Containers.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/Containers.java
@@ -44,7 +44,7 @@ import com.palantir.docker.compose.logging.LogCollector;
 import com.palantir.docker.compose.logging.LogDirectory;
 import com.palantir.docker.proxy.DockerProxyRule;
 
-@SuppressWarnings("DoNotUseShutdownHooks")
+@SuppressWarnings("ShutdownHook")
 public class Containers extends ExternalResource {
     private static final ProjectName PROJECT_NAME = ProjectName.fromString("atlasdbcontainers");
     @VisibleForTesting


### PR DESCRIPTION
**Goals (and why)**:
- Fix the build.

**Implementation Description (bullets)**:
- Replace our own "don't use shutdown hook" check with the more general one added in https://github.com/palantir/gradle-baseline/pull/473

**Testing (What was existing testing like?  What have you done to improve it?)**:
- None, errorprone checks passing would suffice

**Concerns (what feedback would you like?)**:
- Nothing in particular

**Where should we start reviewing?**: checkstyle.xml

**Priority (whenever / two weeks / yesterday)**: yesterday
