### PR TITLE
[_transactions2] Coordination, Part 5: Async Initializable Coordination Store

### DIFF
--- a/atlasdb-coordination-impl/build.gradle
+++ b/atlasdb-coordination-impl/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 
   compile group: 'com.palantir.safe-logging', name: 'safe-logging'
 
+  processor project(":atlasdb-processors")
   processor group: 'org.immutables', name: 'value'
 
   testCompile group: 'org.assertj', name: 'assertj-core'

--- a/atlasdb-coordination-impl/build.gradle
+++ b/atlasdb-coordination-impl/build.gradle
@@ -19,6 +19,5 @@ dependencies {
   processor group: 'org.immutables', name: 'value'
 
   testCompile group: 'org.assertj', name: 'assertj-core'
-  testCompile group: 'org.awaitility', name: 'awaitility'
   testCompile group: 'org.mockito', name: 'mockito-core'
 }

--- a/atlasdb-coordination-impl/build.gradle
+++ b/atlasdb-coordination-impl/build.gradle
@@ -19,5 +19,6 @@ dependencies {
   processor group: 'org.immutables', name: 'value'
 
   testCompile group: 'org.assertj', name: 'assertj-core'
+  testCompile group: 'org.awaitility', name: 'awaitility'
   testCompile group: 'org.mockito', name: 'mockito-core'
 }

--- a/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/CoordinationStore.java
+++ b/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/CoordinationStore.java
@@ -20,11 +20,23 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import com.palantir.atlasdb.keyvalue.impl.CheckAndSetResult;
+import com.palantir.processors.AutoDelegate;
 
 /**
  * A {@link CoordinationStore} stores data that a {@link CoordinationService} may use.
  */
+@AutoDelegate
 public interface CoordinationStore<T> {
+    /**
+     * Coordination stores may require asynchronous initialization, if dependencies aren't initially available.
+     *
+     * @return true iff the coordination store is ready to service requests
+     */
+
+    default boolean isInitialized() {
+        return true;
+    }
+
     /**
      * Gets the value stored in this {@link CoordinationStore}. This value may not be the most recent value; however,
      * it is guaranteed that any value returned by this method will be at least as current as any value returned by

--- a/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/CoordinationStore.java
+++ b/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/CoordinationStore.java
@@ -32,7 +32,6 @@ public interface CoordinationStore<T> {
      *
      * @return true iff the coordination store is ready to service requests
      */
-
     default boolean isInitialized() {
         return true;
     }

--- a/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/keyvalue/KeyValueServiceCoordinationStore.java
+++ b/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/keyvalue/KeyValueServiceCoordinationStore.java
@@ -31,7 +31,9 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.palantir.async.initializer.AsyncInitializer;
 import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.coordination.AutoDelegate_CoordinationStore;
 import com.palantir.atlasdb.coordination.CoordinationStore;
 import com.palantir.atlasdb.coordination.SequenceAndBound;
 import com.palantir.atlasdb.coordination.ValueAndBound;
@@ -86,6 +88,7 @@ public final class KeyValueServiceCoordinationStore<T> implements CoordinationSt
     private final byte[] coordinationRow;
     private final LongSupplier sequenceNumberSupplier;
     private final Class<T> clazz;
+    private final InitializingWrapper wrapper = new InitializingWrapper();
 
     private KeyValueServiceCoordinationStore(
             ObjectMapper objectMapper,
@@ -100,17 +103,23 @@ public final class KeyValueServiceCoordinationStore<T> implements CoordinationSt
         this.clazz = clazz;
     }
 
-    public static <T> KeyValueServiceCoordinationStore<T> create(
+    public static <T> CoordinationStore<T> create(
             ObjectMapper objectMapper,
             KeyValueService kvs,
             byte[] coordinationRow,
             LongSupplier sequenceNumberSupplier,
-            Class<T> clazz) {
+            Class<T> clazz,
+            boolean initializeAsync) {
         KeyValueServiceCoordinationStore<T> coordinationStore
                 = new KeyValueServiceCoordinationStore<>(
                         objectMapper, kvs, coordinationRow, sequenceNumberSupplier, clazz);
-        kvs.createTable(AtlasDbConstants.COORDINATION_TABLE, COORDINATION_TABLE_METADATA.persistToBytes());
-        return coordinationStore;
+        coordinationStore.wrapper.initialize(initializeAsync);
+        return coordinationStore.isInitialized() ? coordinationStore : coordinationStore.wrapper;
+    }
+
+    @Override
+    public boolean isInitialized() {
+        return wrapper.isInitialized();
     }
 
     // TODO (jkong): Since apart from the coordination value all other entries are immutable, we can perform
@@ -136,6 +145,10 @@ public final class KeyValueServiceCoordinationStore<T> implements CoordinationSt
         CheckAndSetResult<SequenceAndBound> casResult = checkAndSetCoordinationValue(
                 coordinationValue, newSequenceAndBound);
         return extractRelevantValues(targetValue, newSequenceAndBound.bound(), casResult);
+    }
+
+    private void tryInitialize() {
+        kvs.createTable(AtlasDbConstants.COORDINATION_TABLE, COORDINATION_TABLE_METADATA.persistToBytes());
     }
 
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType") // Passed from other operations returning Optional
@@ -318,5 +331,22 @@ public final class KeyValueServiceCoordinationStore<T> implements CoordinationSt
                 TableMetadataPersistence.SweepStrategy.NOTHING, // we do our own cleanup
                 false,
                 TableMetadataPersistence.LogSafety.SAFE);
+    }
+
+    private class InitializingWrapper extends AsyncInitializer implements AutoDelegate_CoordinationStore<T> {
+        @Override
+        protected void tryInitialize() {
+            KeyValueServiceCoordinationStore.this.tryInitialize();
+        }
+
+        @Override
+        protected String getInitializingClassName() {
+            return KeyValueServiceCoordinationStore.class.getSimpleName();
+        }
+
+        @Override
+        public CoordinationStore<T> delegate() {
+            return KeyValueServiceCoordinationStore.this;
+        }
     }
 }

--- a/atlasdb-coordination-impl/src/test/java/com/palantir/atlasdb/coordination/keyvalue/KeyValueServiceCoordinationStoreTest.java
+++ b/atlasdb-coordination-impl/src/test/java/com/palantir/atlasdb/coordination/keyvalue/KeyValueServiceCoordinationStoreTest.java
@@ -18,16 +18,11 @@ package com.palantir.atlasdb.coordination.keyvalue;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 
-import org.awaitility.Awaitility;
-import org.awaitility.Duration;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -175,25 +170,5 @@ public class KeyValueServiceCoordinationStoreTest {
         otherCoordinationStore.transformAgreedValue(unused -> VALUE_2);
         assertThat(coordinationStore.getAgreedValue().get().value()).contains(VALUE_1);
         assertThat(otherCoordinationStore.getAgreedValue().get().value()).contains(VALUE_2);
-    }
-
-    @Test
-    public void canInitializeAsynchronously() {
-        KeyValueService kvs = mock(KeyValueService.class);
-        doThrow(new IllegalStateException("fail first"))
-                .doAnswer(invocation -> null)
-                .when(kvs)
-                .createTable(any(), any());
-
-        CoordinationStore<String> asyncStore = KeyValueServiceCoordinationStore.create(
-                ObjectMappers.newServerObjectMapper(),
-                kvs,
-                COORDINATION_ROW,
-                timestampSequence::incrementAndGet,
-                String.class,
-                true);
-        Awaitility.waitAtMost(Duration.ONE_MINUTE)
-                .pollInterval(Duration.FIVE_HUNDRED_MILLISECONDS)
-                .until(asyncStore::isInitialized);
     }
 }

--- a/atlasdb-coordination-impl/src/test/java/com/palantir/atlasdb/coordination/keyvalue/KeyValueServiceCoordinationStoreTest.java
+++ b/atlasdb-coordination-impl/src/test/java/com/palantir/atlasdb/coordination/keyvalue/KeyValueServiceCoordinationStoreTest.java
@@ -18,11 +18,16 @@ package com.palantir.atlasdb.coordination.keyvalue;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 
+import org.awaitility.Awaitility;
+import org.awaitility.Duration;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -52,12 +57,17 @@ public class KeyValueServiceCoordinationStoreTest {
 
     private final KeyValueService keyValueService = new InMemoryKeyValueService(true);
     private final AtomicLong timestampSequence = new AtomicLong();
-    private final KeyValueServiceCoordinationStore<String> coordinationStore = KeyValueServiceCoordinationStore.create(
-            ObjectMappers.newServerObjectMapper(),
-            keyValueService,
-            COORDINATION_ROW,
-            timestampSequence::incrementAndGet,
-            String.class);
+
+    // Casting is reasonable because we initialize with false. We need the precise typing for some of the
+    // tests that hit the store directly.
+    private final KeyValueServiceCoordinationStore<String> coordinationStore
+            = (KeyValueServiceCoordinationStore<String>) KeyValueServiceCoordinationStore.create(
+                    ObjectMappers.newServerObjectMapper(),
+                    keyValueService,
+                    COORDINATION_ROW,
+                    timestampSequence::incrementAndGet,
+                    String.class,
+                    false);
 
     @Test
     public void getReturnsEmptyIfNoKeyFound() {
@@ -159,10 +169,31 @@ public class KeyValueServiceCoordinationStoreTest {
                         keyValueService,
                         otherCoordinationKey,
                         timestampSequence::incrementAndGet,
-                        String.class);
+                        String.class,
+                        false);
         coordinationStore.transformAgreedValue(unused -> VALUE_1);
         otherCoordinationStore.transformAgreedValue(unused -> VALUE_2);
         assertThat(coordinationStore.getAgreedValue().get().value()).contains(VALUE_1);
         assertThat(otherCoordinationStore.getAgreedValue().get().value()).contains(VALUE_2);
+    }
+
+    @Test
+    public void canInitializeAsynchronously() {
+        KeyValueService kvs = mock(KeyValueService.class);
+        doThrow(new IllegalStateException("fail first"))
+                .doAnswer(invocation -> null)
+                .when(kvs)
+                .createTable(any(), any());
+
+        CoordinationStore<String> asyncStore = KeyValueServiceCoordinationStore.create(
+                ObjectMappers.newServerObjectMapper(),
+                kvs,
+                COORDINATION_ROW,
+                timestampSequence::incrementAndGet,
+                String.class,
+                true);
+        Awaitility.waitAtMost(Duration.ONE_MINUTE)
+                .pollInterval(Duration.FIVE_HUNDRED_MILLISECONDS)
+                .until(asyncStore::isInitialized);
     }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/internalschema/TransactionSchemaManagerIntegrationTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/internalschema/TransactionSchemaManagerIntegrationTest.java
@@ -41,7 +41,8 @@ public class TransactionSchemaManagerIntegrationTest {
                     new InMemoryKeyValueService(true),
                     PtBytes.toBytes("blablabla"),
                     timestamps::getFreshTimestamp,
-                    VersionedInternalSchemaMetadata.class));
+                    VersionedInternalSchemaMetadata.class,
+                    false));
     private final CoordinationService<InternalSchemaMetadata> actualCoordinationService
             = CoordinationServices.wrapHidingVersionSerialization(rawCoordinationService);
     private final TransactionSchemaManager manager = new TransactionSchemaManager(


### PR DESCRIPTION
**Goals (and why)**:
- Make the coordination store async initializable
- Transactions2 / Transactions Service eventually needs to follow the rules of async initialization.

**Implementation Description (bullets)**:
- Implement standard async initialization primitives for `KeyValueServiceCoordinationStore`

**Testing (What was existing testing like?  What have you done to improve it?)**:
There is one new test that handles the case where the KVS isn't ready initially, but becomes ready

**Concerns (what feedback would you like?)**: Nothing in particular

**Where should we start reviewing?**: `KeyValueServiceCoordinationStore.java`

**Priority (whenever / two weeks / yesterday)**: This week, hopefully? If not early next
