### PR TITLE
[_transactions2] Part 8: Split Key Delegating Transactions Service

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/service/TransactionService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/service/TransactionService.java
@@ -25,7 +25,7 @@ import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
  * Transaction service is used by the atlas protocol to determine is a given transaction has been
  * committed or aborted.
  *
- * A given startTimestamp will only ever have one non-null value.  This means that anything
+ * A given startTimestamp will only ever have one non-null value.  This means that non-null values
  * returned from this service can be aggressively cached.  Caching negative look ups should not be
  * done for performance reasons.  If a null value is returned, that startTimestamp will likely be
  * rolled back and set to TransactionConstants.FAILED_COMMIT_TS (-1).

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/SplitKeyDelegatingTransactionService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/SplitKeyDelegatingTransactionService.java
@@ -1,0 +1,100 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import javax.annotation.CheckForNull;
+
+import com.google.common.collect.Sets;
+import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+
+/**
+ * A {@link SplitKeyDelegatingTransactionService} delegates between multiple {@link TransactionService}s, depending
+ * on which timestamps are requested. We guarantee that for get on a given startTimestamp, if we return a non-null value
+ * we guarantee to always return that value on subsequent get calls.
+ *
+ * The timestamp service will throw an exception if the timestamp-to-service-key function returns a key which is
+ * not in the keyedServices map.
+ *
+ * Service keys are expected to be safe for logging.
+ */
+public class SplitKeyDelegatingTransactionService<T> implements TransactionService {
+    private final Function<Long, T> timestampToServiceKey;
+    private final Map<T, TransactionService> keyedServices;
+
+    public SplitKeyDelegatingTransactionService(
+            Function<Long, T> timestampToServiceKey,
+            Map<T, TransactionService> keyedServices) {
+        this.timestampToServiceKey = timestampToServiceKey;
+        this.keyedServices = keyedServices;
+    }
+
+    @CheckForNull
+    @Override
+    public Long get(long startTimestamp) {
+        return getServiceForTimestamp(startTimestamp).get(startTimestamp);
+    }
+
+    @Override
+    public Map<Long, Long> get(Iterable<Long> startTimestamps) {
+        // TODO (jkong): If this is too slow, don't use streams.
+        Map<T, List<Long>> queryMap = StreamSupport.stream(startTimestamps.spliterator(), false)
+                .collect(Collectors.groupingBy(timestampToServiceKey));
+
+        Set<T> extraKeys = Sets.difference(queryMap.keySet(), keyedServices.keySet());
+        if (!extraKeys.isEmpty()) {
+            throw new SafeIllegalStateException("A batch of timestamps {} produced some transaction service keys which"
+                    + " are unknown: {}. Known transaction service keys were {}.",
+                    SafeArg.of("timestamps", startTimestamps),
+                    SafeArg.of("extraKeys", extraKeys),
+                    SafeArg.of("knownServiceKeys", keyedServices.keySet()));
+        }
+
+        return queryMap.entrySet()
+                .stream()
+                .map(entry -> keyedServices.get(entry.getKey()).get(entry.getValue()))
+                .flatMap(longLongMap -> longLongMap.entrySet().stream())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @Override
+    public void putUnlessExists(long startTimestamp, long commitTimestamp) throws KeyAlreadyExistsException {
+        getServiceForTimestamp(startTimestamp).putUnlessExists(startTimestamp, commitTimestamp);
+    }
+
+    private TransactionService getServiceForTimestamp(long startTimestamp) {
+        T key = timestampToServiceKey.apply(startTimestamp);
+        TransactionService service = keyedServices.get(key);
+
+        if (service == null) {
+            throw new SafeIllegalStateException("Could not find a transaction service for timestamp {}, which"
+                    + " produced a key of {}. Known transaction service keys were {}.",
+                    SafeArg.of("timestamp", startTimestamp),
+                    SafeArg.of("serviceKey", key),
+                    SafeArg.of("knownServiceKeys", keyedServices.keySet()));
+        }
+        return service;
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/SplitKeyDelegatingTransactionServiceTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/SplitKeyDelegatingTransactionServiceTest.java
@@ -36,7 +36,7 @@ import com.google.common.collect.ImmutableMap;
 public class SplitKeyDelegatingTransactionServiceTest {
     private static final Function<Long, Long> EXTRACT_LAST_DIGIT = num -> num % 10;
 
-    private final TransactionService delegate1 = mock(TransactionService.class); // using 0 for modulo reasons
+    private final TransactionService delegate1 = mock(TransactionService.class);
     private final TransactionService delegate2 = mock(TransactionService.class);
     private final TransactionService delegate3 = mock(TransactionService.class);
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/SplitKeyDelegatingTransactionServiceTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/SplitKeyDelegatingTransactionServiceTest.java
@@ -126,6 +126,6 @@ public class SplitKeyDelegatingTransactionServiceTest {
                 .hasMessageContaining("A batch of timestamps {} produced some transaction service keys which are"
                         + " unknown");
 
-        // no requests made is implicit, since delegate1 is a mock
+        Mockito.verifyNoMoreInteractions(delegate1);
     }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/SplitKeyDelegatingTransactionServiceTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/SplitKeyDelegatingTransactionServiceTest.java
@@ -1,0 +1,131 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import org.junit.After;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+public class SplitKeyDelegatingTransactionServiceTest {
+    private static final Function<Long, Long> EXTRACT_LAST_DIGIT = num -> num % 10;
+
+    private final TransactionService delegate1 = mock(TransactionService.class); // using 0 for modulo reasons
+    private final TransactionService delegate2 = mock(TransactionService.class);
+    private final TransactionService delegate3 = mock(TransactionService.class);
+
+    private final Map<Long, TransactionService> transactionServiceMap = ImmutableMap.of(
+            1L, delegate1, 2L, delegate2, 3L, delegate3);
+    private final TransactionService delegatingTransactionService
+            = new SplitKeyDelegatingTransactionService<>(EXTRACT_LAST_DIGIT, transactionServiceMap);
+
+    @After
+    public void verifyNoMoreInteractions() {
+        Mockito.verifyNoMoreInteractions(delegate1, delegate2, delegate3);
+    }
+
+    @Test
+    public void canCallGetOnDelegate() {
+        when(delegate1.get(1L)).thenReturn(2L);
+        assertThat(delegatingTransactionService.get(1L)).isEqualTo(2L);
+        verify(delegate1).get(1L);
+    }
+
+    @Test
+    public void delegatesGetBasedOnFunction() {
+        when(delegate1.get(1L)).thenReturn(2L);
+        when(delegate2.get(2L)).thenReturn(4L);
+        assertThat(delegatingTransactionService.get(1L)).isEqualTo(2L);
+        assertThat(delegatingTransactionService.get(2L)).isEqualTo(4L);
+        verify(delegate1).get(1L);
+        verify(delegate2).get(2L);
+    }
+
+    @Test
+    public void getThrowsIfFunctionReturnsUnmappedValue() {
+        assertThatThrownBy(() -> delegatingTransactionService.get(7L))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Could not find a transaction service for timestamp {}");
+    }
+
+    @Test
+    public void rethrowsExceptionsFromMappingFunction() {
+        RuntimeException ex = new IllegalStateException("bad");
+        TransactionService unusableService = new SplitKeyDelegatingTransactionService<>(
+                num -> {
+                    throw ex;
+                },
+                transactionServiceMap);
+
+        assertThatThrownBy(() -> unusableService.get(5L)).isEqualTo(ex);
+    }
+
+    @Test
+    public void putUnlessExistsDelegateDecidedByStartTimestamp() {
+        delegatingTransactionService.putUnlessExists(3L, 12L);
+        verify(delegate3).putUnlessExists(3L, 12L);
+    }
+
+    @Test
+    public void putUnlessExistsThrowsIfFunctionReturnsUnmappedValue() {
+        assertThatThrownBy(() -> delegatingTransactionService.putUnlessExists(4L, 12L))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Could not find a transaction service for timestamp {}");
+    }
+
+    @Test
+    public void getMultipleDelegatesRequestsToGetMultipleOnDelegates() {
+        when(delegate1.get(eq(ImmutableList.of(1L)))).thenReturn(ImmutableMap.of(1L, 2L));
+        assertThat(delegatingTransactionService.get(ImmutableList.of(1L)))
+                .isEqualTo(ImmutableMap.of(1L, 2L));
+        verify(delegate1).get(eq(ImmutableList.of(1L)));
+    }
+
+    @Test
+    public void getMultiplePartitionsRequestsAndMergesMaps() {
+        when(delegate1.get(eq(ImmutableList.of(1L, 41L)))).thenReturn(ImmutableMap.of(1L, 8L, 41L, 48L));
+        when(delegate2.get(eq(ImmutableList.of(12L, 32L)))).thenReturn(ImmutableMap.of(12L, 28L, 32L, 38L));
+
+        assertThat(delegatingTransactionService.get(ImmutableList.of(1L, 12L, 32L, 41L)))
+                .isEqualTo(ImmutableMap.of(1L, 8L, 12L, 28L, 32L, 38L, 41L, 48L));
+        verify(delegate1).get(eq(ImmutableList.of(1L, 41L)));
+        verify(delegate2).get(eq(ImmutableList.of(12L, 32L)));
+    }
+
+    @Test
+    public void getMultipleThrowsAndDoesNotMakeRequestsIfAnyTimestampsCannotBeMapped() {
+        when(delegate1.get(eq(ImmutableList.of(1L, 41L)))).thenReturn(ImmutableMap.of(1L, 8L, 41L, 48L));
+        assertThatThrownBy(() -> delegatingTransactionService.get(ImmutableList.of(1L, 7L, 41L)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("A batch of timestamps {} produced some transaction service keys which are"
+                        + " unknown");
+
+        // no requests made is implicit, since delegate1 is a mock
+    }
+}


### PR DESCRIPTION
Goals (and why):

Have a transaction service that knows how to deal with multiple (or unknown!) transaction schema versions
Implementation Description (bullets):

Implement SplitKeyDelegatingTransactionService<T> that has a function from timestamp to some key, and a mapping of key to transaction services.
Testing (What was existing testing like? What have you done to improve it?):
New code is tested.

Concerns (what feedback would you like?):

Would it be easier to just have a single Function<Long, TransactionService> to map timestamps to services?
Where should we start reviewing?: There's one class and its tests - pick one.

Priority (whenever / two weeks / yesterday): next week?