### PR TITLE
(KVS migration) Fast forward source KVS timestamps as well

### DIFF
--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/KeyValueServiceMigrators.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/KeyValueServiceMigrators.java
@@ -51,6 +51,9 @@ public final class KeyValueServiceMigrators {
         long migrationCommitTimestamp = toServices.getTimestampService().getFreshTimestamp();
         toServices.getTransactionService().putUnlessExists(migrationStartTimestamp, migrationCommitTimestamp);
 
+        TimestampManagementService fromTimestampManagementService = getTimestampManagementService(fromServices);
+        fromTimestampManagementService.fastForwardTimestamp(migrationCommitTimestamp + 1);
+
         return new KeyValueServiceMigrator(
                 CHECKPOINT_NAMESPACE,
                 fromServices.getTransactionManager(),

--- a/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/KeyValueServiceMigratorsTest.java
+++ b/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/KeyValueServiceMigratorsTest.java
@@ -96,13 +96,23 @@ public class KeyValueServiceMigratorsTest {
             .build();
 
     @Test
-    public void setupMigratorFastForwardsTimestamp() {
+    public void setupMigratorFastForwardsDestinationTimestamp() {
         KeyValueServiceMigrators.getTimestampManagementService(fromServices).fastForwardTimestamp(FUTURE_TIMESTAMP);
         assertThat(toServices.getTimestampService().getFreshTimestamp()).isLessThan(FUTURE_TIMESTAMP);
 
         KeyValueServiceMigrators.setupMigrator(migratorSpec);
 
         assertThat(toServices.getTimestampService().getFreshTimestamp()).isGreaterThanOrEqualTo(FUTURE_TIMESTAMP);
+    }
+
+    @Test
+    public void setupMigratorFastForwardsSourceTimestamp() {
+        KeyValueServiceMigrators.getTimestampManagementService(toServices).fastForwardTimestamp(FUTURE_TIMESTAMP);
+        assertThat(fromServices.getTimestampService().getFreshTimestamp()).isLessThan(FUTURE_TIMESTAMP);
+
+        KeyValueServiceMigrators.setupMigrator(migratorSpec);
+
+        assertThat(fromServices.getTimestampService().getFreshTimestamp()).isGreaterThanOrEqualTo(FUTURE_TIMESTAMP);
     }
 
     @Test

--- a/docs/source/cluster_management/kvs-migration.rst
+++ b/docs/source/cluster_management/kvs-migration.rst
@@ -43,6 +43,12 @@ Then, we immediately insert an entry into the transactions table of the target K
     If you are using TimeLock, the TimeLock server must be running in order to do the migration.
     Otherwise, you must use the ``--offline`` flag, which will remove the leader block from your configuration for the purposes of migration.
 
+.. warning::
+
+    After attempting a migration, the source KVS is likely going to be behind in timestamps than the target KVS.
+    In the specific use case where the destination KVS is a ``TableSplittingKvs`` that refers atomic tables back to the source KVS, this means that for some timestamp service implementations on the source KVS it could be possible to be issued timestamps that are already committed.
+    Therefore, if the migration needs to be abandoned in favour of again using the source KVS, the source timestamp service must first be fast forwarded to a timestamp higher than the fresh timestamp of the target timestamp service.
+
 Setup
 -----
 


### PR DESCRIPTION
**Goals (and why)**:
Avoid specific issue if we tablesplitting kvs for atomic tables, attempt a migration, and then decide to instead keep using the old KVS. If we are not on timelock, we can end up reusing timestamps that are already precommitted in the _transactions table.

**Concerns (what feedback would you like?)**:
Maybe this is splitting hairs, but it's simple enough to fix
