### PR TITLE
Batch refresh locks requests on client side

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/common/base/Throwables.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/base/Throwables.java
@@ -144,7 +144,7 @@ public final class Throwables {
      */
     @SuppressWarnings("unchecked")
     public static <K extends Throwable> void rewrapAndThrowIfInstance(String newMessage, Throwable t, Class<K> clazz) throws K {
-        if ((t != null) && clazz.isAssignableFrom(t.getClass())) {
+        if (isInstance(t, clazz)) {
             K kt = (K) t;
             K wrapped = Throwables.rewrap(newMessage, kt);
             throw wrapped;

--- a/lock-api/src/main/java/com/palantir/lock/client/BatchingLockRefresher.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/BatchingLockRefresher.java
@@ -26,7 +26,7 @@ import com.palantir.common.base.Throwables;
 import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.TimelockService;
 
-public class BatchingLockRefresher {
+public final class BatchingLockRefresher {
     private final DisruptorAutobatcher<Set<LockToken>, Set<LockToken>> autobatcher;
 
     private BatchingLockRefresher(DisruptorAutobatcher<Set<LockToken>, Set<LockToken>> autobatcher) {
@@ -35,16 +35,16 @@ public class BatchingLockRefresher {
 
     public static BatchingLockRefresher create(TimelockService timelockService) {
         return new BatchingLockRefresher(DisruptorAutobatcher.create(batch -> {
-                    Set<LockToken> tokensBatch = batch.stream()
-                            .map(BatchElement::argument)
-                            .flatMap(Set::stream)
-                            .collect(Collectors.toSet());
+            Set<LockToken> tokensBatch = batch.stream()
+                    .map(BatchElement::argument)
+                    .flatMap(Set::stream)
+                    .collect(Collectors.toSet());
 
-                    Set<LockToken> refreshedTokens = timelockService.refreshLockLeases(tokensBatch);
-                    batch.forEach(element -> element.result().set(
-                            element.argument().stream()
-                                    .filter(refreshedTokens::contains)
-                                    .collect(Collectors.toSet())));
+            Set<LockToken> refreshedTokens = timelockService.refreshLockLeases(tokensBatch);
+            batch.forEach(element -> element.result().set(
+                    element.argument().stream()
+                            .filter(refreshedTokens::contains)
+                            .collect(Collectors.toSet())));
         }));
     }
 

--- a/lock-api/src/main/java/com/palantir/lock/client/BatchingLockRefresher.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/BatchingLockRefresher.java
@@ -1,0 +1,58 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.client;
+
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+import com.palantir.atlasdb.autobatch.BatchElement;
+import com.palantir.atlasdb.autobatch.DisruptorAutobatcher;
+import com.palantir.common.base.Throwables;
+import com.palantir.lock.v2.LockToken;
+import com.palantir.lock.v2.TimelockService;
+
+public class BatchingLockRefresher {
+    private final DisruptorAutobatcher<Set<LockToken>, Set<LockToken>> autobatcher;
+
+    private BatchingLockRefresher(DisruptorAutobatcher<Set<LockToken>, Set<LockToken>> autobatcher) {
+        this.autobatcher = autobatcher;
+    }
+
+    public static BatchingLockRefresher create(TimelockService timelockService) {
+        return new BatchingLockRefresher(DisruptorAutobatcher.create(batch -> {
+            Set<LockToken> tokensBatch = batch.stream()
+                    .map(BatchElement::argument)
+                    .flatMap(Set::stream)
+                    .collect(Collectors.toSet());
+
+            Set<LockToken> refreshedTokens = timelockService.refreshLockLeases(tokensBatch);
+            batch.forEach(element -> element.result().set(
+                    element.argument().stream()
+                            .filter(refreshedTokens::contains)
+                            .collect(Collectors.toSet())));
+        }));
+    }
+
+    public Set<LockToken> refreshLockLeases(Set<LockToken> lockTokens) {
+        try {
+            return autobatcher.apply(lockTokens).get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw Throwables.throwUncheckedException(e);
+        }
+    }
+}

--- a/lock-api/src/main/java/com/palantir/lock/client/TimeLockClient.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/TimeLockClient.java
@@ -49,6 +49,7 @@ public class TimeLockClient implements AutoCloseable, TimelockService {
     private final CloseableTimestampService timestampService;
     private final LockRefresher lockRefresher;
     private final TimeLockUnlocker unlocker;
+    private final BatchingLockRefresher batchingLockRefresher;
 
     public static TimeLockClient createDefault(TimelockService timelockService) {
         AsyncTimeLockUnlocker asyncUnlocker = AsyncTimeLockUnlocker.create(timelockService);
@@ -71,6 +72,7 @@ public class TimeLockClient implements AutoCloseable, TimelockService {
         this.timestampService = timestampService;
         this.lockRefresher = lockRefresher;
         this.unlocker = unlocker;
+        this.batchingLockRefresher = BatchingLockRefresher.create(delegate);
     }
 
     @Override
@@ -132,7 +134,7 @@ public class TimeLockClient implements AutoCloseable, TimelockService {
 
     @Override
     public Set<LockToken> refreshLockLeases(Set<LockToken> tokens) {
-        return executeOnTimeLock(() -> delegate.refreshLockLeases(tokens));
+        return executeOnTimeLock(() -> batchingLockRefresher.refreshLockLeases(tokens));
     }
 
     @Override

--- a/lock-api/src/test/java/com/palantir/lock/client/BatchingLockRefresherTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/BatchingLockRefresherTest.java
@@ -16,34 +16,131 @@
 
 package com.palantir.lock.client;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.stream.Collectors;
 
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.TimelockService;
+import com.palantir.util.Pair;
 
 public class BatchingLockRefresherTest {
     private static final LockToken TOKEN_1 = LockToken.of(UUID.randomUUID());
     private static final LockToken TOKEN_2 = LockToken.of(UUID.randomUUID());
-    private static final Set<LockToken> TOKENS = ImmutableSet.of(TOKEN_1, TOKEN_2);
+    private static final LockToken TOKEN_3 = LockToken.of(UUID.randomUUID());
 
+    private static final Set<LockToken> TOKENS = ImmutableSet.of(TOKEN_1, TOKEN_2);
+    private static final RuntimeException EXCEPTION = new RuntimeException("msg");
+
+    private Set<LockToken> validTokens = ImmutableSet.of();
     private final TimelockService timelockService = mock(TimelockService.class);
     private final BatchingLockRefresher lockRefresher = BatchingLockRefresher.create(timelockService);
+
 
     @Test
     public void returnsRefreshedTokens() {
         when(timelockService.refreshLockLeases(any())).thenReturn(TOKENS);
 
-        Set<LockToken> refreshedToken = lockRefresher.refreshLockLeases(TOKENS);
-        assertEquals(TOKENS, refreshedToken);
+        Set<LockToken> refreshedTokens = lockRefresher.refreshLockLeases(TOKENS);
+        assertEquals(TOKENS, refreshedTokens);
     }
 
+    @Test
+    public void onlyReturnsValidTokens() {
+        Set<LockToken> validTokens = ImmutableSet.of(TOKEN_1);
+        when(timelockService.refreshLockLeases(any())).thenReturn(validTokens);
+
+        Set<LockToken> refreshedTokens = lockRefresher.refreshLockLeases(TOKENS);
+        assertEquals(validTokens, refreshedTokens);
+    }
+
+    @Test
+    public void rethrowsException() {
+        when(timelockService.refreshLockLeases(any())).thenThrow(EXCEPTION);
+
+        assertThatThrownBy(() -> lockRefresher.refreshLockLeases(TOKENS)).isEqualTo(EXCEPTION);
+    }
+
+    @Test
+    public void usingVerify() throws Exception {
+        withValidTokens(TOKENS);
+        verifyBatchedCallsWithResults(ImmutableList.of(
+                new Pair<>(ImmutableSet.of(TOKEN_1), ImmutableSet.of(TOKEN_1)),
+                new Pair<>(ImmutableSet.of(TOKEN_1, TOKEN_2), ImmutableSet.of(TOKEN_1, TOKEN_2)),
+                new Pair<>(ImmutableSet.of(TOKEN_3), ImmutableSet.of()),
+                new Pair<>(ImmutableSet.of(TOKEN_1, TOKEN_3), ImmutableSet.of(TOKEN_1))
+        ));
+    }
+
+    private void verifyBatchedCallsWithResults(
+            List<Pair<Set<LockToken>, Set<LockToken>>> refreshRequestsWithExpectedResults) throws Exception {
+        RequestOrchestrator requestOrchestrator = new RequestOrchestrator();
+        requestOrchestrator.sendBlockingRequest();
+
+        List<Pair<Set<LockToken>, CompletableFuture<Set<LockToken>>>> result = refreshRequestsWithExpectedResults
+                .stream()
+                .map(p -> Pair.create(
+                        p.lhSide,
+                        CompletableFuture.supplyAsync(() -> lockRefresher.refreshLockLeases(p.lhSide))))
+                .collect(Collectors.toList());
+
+        requestOrchestrator.unblockRequest();
+
+        for (int i = 0; i < result.size(); i++) {
+            Set<LockToken> expectedResult = refreshRequestsWithExpectedResults.get(i).rhSide;
+            Set<LockToken> actualResult = result.get(i).rhSide.get();
+            assertEquals(expectedResult, actualResult);
+        }
+
+        verify(timelockService, times(2)).refreshLockLeases(anySet());
+    }
+
+    private class RequestOrchestrator {
+        private final CountDownLatch firstBatchReached;
+        private final CountDownLatch blockTimelockResponse;
+
+        RequestOrchestrator() {
+            this.firstBatchReached = new CountDownLatch(1);
+            this.blockTimelockResponse = new CountDownLatch(1);
+        }
+
+        void sendBlockingRequest() throws InterruptedException {
+            doAnswer(invocation -> {
+                firstBatchReached.countDown();
+                Set<LockToken> requestedTokens = invocation.getArgument(0);
+                blockTimelockResponse.await();
+                return requestedTokens.stream()
+                        .filter(validTokens::contains)
+                        .collect(Collectors.toSet());
+            }).when(timelockService).refreshLockLeases(anySet());
+
+            CompletableFuture.runAsync(() -> lockRefresher.refreshLockLeases(ImmutableSet.of()));
+            firstBatchReached.await();
+        }
+
+        void unblockRequest() {
+            blockTimelockResponse.countDown();
+        }
+    }
+
+    private void withValidTokens(Set<LockToken> validTokens) {
+        this.validTokens = validTokens;
+    }
 }

--- a/lock-api/src/test/java/com/palantir/lock/client/BatchingLockRefresherTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/BatchingLockRefresherTest.java
@@ -1,0 +1,49 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.client;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableSet;
+import com.palantir.lock.v2.LockToken;
+import com.palantir.lock.v2.TimelockService;
+
+public class BatchingLockRefresherTest {
+    private static final LockToken TOKEN_1 = LockToken.of(UUID.randomUUID());
+    private static final LockToken TOKEN_2 = LockToken.of(UUID.randomUUID());
+    private static final Set<LockToken> TOKENS = ImmutableSet.of(TOKEN_1, TOKEN_2);
+
+    private final TimelockService timelockService = mock(TimelockService.class);
+    private final BatchingLockRefresher lockRefresher = BatchingLockRefresher.create(timelockService);
+
+    @Test
+    public void returnsRefreshedTokens() {
+        when(timelockService.refreshLockLeases(any())).thenReturn(TOKENS);
+
+        Set<LockToken> refreshedToken = lockRefresher.refreshLockLeases(TOKENS);
+        assertEquals(TOKENS, refreshedToken);
+    }
+
+}


### PR DESCRIPTION
**Goals (and why)**:
As we are planning to increase the use of thorough sweep, we expect an increase in number of requests to timelock (as a result of read-only transactions checking immutable ts lock after kvs reads to guard against sweep). This pr aims to mitigate the increase in load to timelock by batching `refreshLockLeases` requests on client side.

**Implementation Description (bullets)**:
Using `DisruptorAutobatcher` to batch requests.

**Testing (What was existing testing like?  What have you done to improve it?)**:
New tests are added for `BatchingLockRefresher`

**Concerns (what feedback would you like?)**:
- This will cause mean time spent for `refreshLockLeases` calls to increase by %50 - (around 1ms).
- We are not batching periodical lock refreshes by `LockRefresher`. I thought batching these calls may end up building larger requests then we want to have - also these frequency of these calls should stay same after we move to thorough sweep.

**Where should we start reviewing?**:
`BatchingLockRefresher`

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
