### PR TITLE
[_transactions2] Coordination, Part 7.1: Expose the Transaction Service

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.transaction.api;
 import com.google.common.base.Supplier;
 import com.palantir.atlasdb.cleaner.api.Cleaner;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.exception.NotInitializedException;
 import com.palantir.lock.HeldLocksToken;
 import com.palantir.lock.LockRequest;
@@ -265,6 +266,16 @@ public interface TransactionManager extends AutoCloseable {
      * @return the timestamp management service for this transaction manager
      */
     TimestampManagementService getTimestampManagementService();
+
+    /**
+     * The transaction service is used by libraries providing additional functionality around AtlasDB.
+     * End-user clients probably should not require it.
+     * Abuse of the transaction service, especially involving putting new records in, may result in severe and
+     * irrecoverable data corruption.
+     *
+     * @return the transaction service for this transaction manager
+     */
+    TransactionService getTransactionService();
 
     /**
      * Returns the cleaner used by this transaction manager.

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ReadOnlyTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ReadOnlyTransactionManager.java
@@ -181,6 +181,11 @@ public final class ReadOnlyTransactionManager extends AbstractLockAwareTransacti
     }
 
     @Override
+    public TransactionService getTransactionService() {
+        return transactionService;
+    }
+
+    @Override
     public Cleaner getCleaner() {
         return null;
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -421,6 +421,11 @@ import com.palantir.timestamp.TimestampService;
     }
 
     @Override
+    public TransactionService getTransactionService() {
+        return transactionService;
+    }
+
+    @Override
     public KeyValueServiceStatus getKeyValueServiceStatus() {
         ClusterAvailabilityStatus clusterAvailabilityStatus = keyValueService.getClusterAvailabilityStatus();
         switch (clusterAvailabilityStatus) {

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -59,12 +59,12 @@ develop
          - With the introduction of _coordination, creation of ``TransactionService`` now requires a ``CoordinationService<InternalSchemaMetadata>``.
            Users may create a ``CoordinationService`` via the ``CoordinationServices`` factory, if needed, or retrieve it from the relevant ``TransactionManager``.
            Generally speaking, ``TransactionService`` should not be directly used by standard AtlasDB consumers; abusing it can result in **SEVERE DATA CORRUPTION**.
-           (`Pull Request 1 <https://github.com/palantir/atlasdb/pull/3686>`__ and `Pull Request 2 <https://github.com/palantir/atlasdb/pull/3xyz>`__)
+           (`Pull Request 1 <https://github.com/palantir/atlasdb/pull/3686>`__ and `Pull Request 2 <https://github.com/palantir/atlasdb/pull/3689>`__)
 
     *    - |devbreak|
          - Transaction Managers now expose a ``getTransactionService()`` method.
            Users with custom subclasses of ``TransactionManager`` will need to implement this.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/3xyz>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3689>`__)
 
     *    - |fixed| |userbreak|
          - Cassandra KVS `getMetadataForTables` method now returns a map where table reference keys have capitalisation matching the table names in Cassandra.

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -57,9 +57,14 @@ develop
 
     *    - |devbreak|
          - With the introduction of _coordination, creation of ``TransactionService`` now requires a ``CoordinationService<InternalSchemaMetadata>``.
-           Users may create a ``CoordinationService`` via the ``CoordinationServices`` factory, if needed.
+           Users may create a ``CoordinationService`` via the ``CoordinationServices`` factory, if needed, or retrieve it from the relevant ``TransactionManager``.
            Generally speaking, ``TransactionService`` should not be directly used by standard AtlasDB consumers; abusing it can result in **SEVERE DATA CORRUPTION**.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/3686>`__)
+           (`Pull Request 1 <https://github.com/palantir/atlasdb/pull/3686>`__ and `Pull Request 2 <https://github.com/palantir/atlasdb/pull/3xyz>`__)
+
+    *    - |devbreak|
+         - Transaction Managers now expose a ``getTransactionService()`` method.
+           Users with custom subclasses of ``TransactionManager`` will need to implement this.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3xyz>`__)
 
     *    - |fixed| |userbreak|
          - Cassandra KVS `getMetadataForTables` method now returns a map where table reference keys have capitalisation matching the table names in Cassandra.


### PR DESCRIPTION
**Goals (and why)**: Expose the transaction service for libraries using AtlasDB that need it.

**Implementation Description (bullets)**:
- Add a new endpoint, and wire it up for classes that need it. Main logic here was seeing which classes implemented `getTimestampService()` or related getters, and adding an implementation where relevant.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Not much; the change is pretty straightforward.

**Concerns (what feedback would you like?)**:
- Is the transactions service code thread safe? I think so as the only real state we store in memory is the cached value-and-bound, and that is an AtomicReference with a suitable accumulation algorithm, so I'm inclined to say it is thread-safe.

**Where should we start reviewing?**: TransactionManager

**Priority (whenever / two weeks / yesterday)**: this week
