### PR TITLE
Fix/circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,7 @@ jobs:
       CIRCLE_ARTIFACTS: /tmp/artifacts
     steps:
       - attach_workspace: { at: . }
+      - run: sudo apt-get update
       - run: sudo apt-get install python python-pip
       - run:
           command: |

--- a/scripts/circle-ci/run-circle-tests.sh
+++ b/scripts/circle-ci/run-circle-tests.sh
@@ -5,6 +5,7 @@ set -x
 BASE_GRADLE_ARGS="--profile --continue"
 
 function checkDocsBuild {
+    sudo apt-get update
     sudo apt-get install python-pip
     sudo -H pip install --upgrade sphinx sphinx_rtd_theme requests recommonmark
     cd docs/


### PR DESCRIPTION
**Goals (and why)**:
Circle has started failing because we fail to install a version of python that seems to have been pulled. Running `apt-get update` before install gets us to fetch the correct version

**Priority (whenever / two weeks / yesterday)**:
Asap, as all build are broken
