### PR TITLE
[_transactions2] Coordination, Part 10: Support for ReadOnlyTransactionManagers

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/ReadOnlyTransactionSchemaManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/ReadOnlyTransactionSchemaManager.java
@@ -1,0 +1,58 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.internalschema;
+
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.coordination.CoordinationService;
+import com.palantir.atlasdb.coordination.ValueAndBound;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+
+public class ReadOnlyTransactionSchemaManager {
+    private static final Logger log = LoggerFactory.getLogger(TransactionSchemaManager.class);
+
+    private final CoordinationService<InternalSchemaMetadata> coordinationService;
+
+    public ReadOnlyTransactionSchemaManager(CoordinationService<InternalSchemaMetadata> coordinationService) {
+        this.coordinationService = coordinationService;
+    }
+
+    public Integer getTransactionsSchemaVersion(long timestamp) {
+        if (timestamp < AtlasDbConstants.STARTING_TS) {
+            throw new SafeIllegalStateException("Query attempted for timestamp {} which was never given out by the"
+                    + " timestamp service, as timestamps start at {}",
+                    SafeArg.of("queriedTimestamp", timestamp),
+                    SafeArg.of("startOfTime", AtlasDbConstants.STARTING_TS));
+        }
+        Optional<Integer> possibleVersion =
+                extractTimestampVersion(coordinationService.getValueForTimestamp(timestamp), timestamp);
+        return possibleVersion.orElse(null);
+    }
+
+    private static Optional<Integer> extractTimestampVersion(
+            Optional<ValueAndBound<InternalSchemaMetadata>> valueAndBound, long timestamp) {
+        return valueAndBound
+                .flatMap(ValueAndBound::value)
+                .map(InternalSchemaMetadata::timestampToTransactionsTableSchemaVersion)
+                .map(versionMap -> versionMap.getValueForTimestamp(timestamp));
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/SplitKeyDelegatingTransactionService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/SplitKeyDelegatingTransactionService.java
@@ -93,8 +93,9 @@ public class SplitKeyDelegatingTransactionService<T> implements TransactionServi
 
     @Override
     public void putUnlessExists(long startTimestamp, long commitTimestamp) throws KeyAlreadyExistsException {
-        getServiceForTimestamp(startTimestamp).ifPresent(
-                service -> service.putUnlessExists(startTimestamp, commitTimestamp));
+        TransactionService service = getServiceForTimestamp(startTimestamp).orElseThrow(
+                () -> new UnsupportedOperationException("putUnlessExists shouldn't be used with null services"));
+        service.putUnlessExists(startTimestamp, commitTimestamp);
     }
 
     private Optional<TransactionService> getServiceForTimestamp(long startTimestamp) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/SplitKeyDelegatingTransactionService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/SplitKeyDelegatingTransactionService.java
@@ -111,6 +111,6 @@ public class SplitKeyDelegatingTransactionService<T> implements TransactionServi
                     SafeArg.of("serviceKey", key),
                     SafeArg.of("knownServiceKeys", keyedServices.keySet()));
         }
-        return Optional.ofNullable(service);
+        return Optional.of(service);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/TransactionServices.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/TransactionServices.java
@@ -73,7 +73,7 @@ public final class TransactionServices {
                         throw new SafeIllegalStateException("Attempted to get a timestamp from a read-only"
                                 + " transaction service! This is probably a product bug. Please contact"
                                 + " support.");
-                        },
+                    },
                     false);
             ReadOnlyTransactionSchemaManager readOnlyTransactionSchemaManager
                     = new ReadOnlyTransactionSchemaManager(coordinationService);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/TransactionServices.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/TransactionServices.java
@@ -67,13 +67,13 @@ public final class TransactionServices {
     public static TransactionService createReadOnlyTransactionServiceIgnoresUncommittedTransactionsDoesNotRollBack(
             KeyValueService keyValueService) {
         if (keyValueService.supportsCheckAndSet()) {
-            CoordinationService<InternalSchemaMetadata> coordinationService
-                    = CoordinationServices.createDefault(keyValueService,
+            CoordinationService<InternalSchemaMetadata> coordinationService = CoordinationServices.createDefault(
+                    keyValueService,
                     () -> {
                         throw new SafeIllegalStateException("Attempted to get a timestamp from a read-only"
                                 + " transaction service! This is probably a product bug. Please contact"
                                 + " support.");
-                    },
+                        },
                     false);
             ReadOnlyTransactionSchemaManager readOnlyTransactionSchemaManager
                     = new ReadOnlyTransactionSchemaManager(coordinationService);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/TransactionServices.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/TransactionServices.java
@@ -31,17 +31,26 @@ public final class TransactionServices {
     public static TransactionService createTransactionService(
             KeyValueService keyValueService, CoordinationService<InternalSchemaMetadata> coordinationService) {
         if (keyValueService.supportsCheckAndSet()) {
-            return createSplitKeyTransactionService(keyValueService, coordinationService);
+            return createSplitKeyTransactionService(keyValueService, coordinationService, false);
         }
         return createV1TransactionService(keyValueService);
     }
 
+//    public static TransactionService createReadOnlyTransactionServiceIgnoresUncommittedTransactionsDoesNotRollBack(
+//            KeyValueService keyValueService,
+//            CoordinationService<InternalSchemaMetadata> coordinationService) {
+//
+//    }
+
     private static TransactionService createSplitKeyTransactionService(
-            KeyValueService keyValueService, CoordinationService<InternalSchemaMetadata> coordinationService) {
+            KeyValueService keyValueService,
+            CoordinationService<InternalSchemaMetadata> coordinationService,
+            boolean ignoreUnknown) {
         TransactionSchemaManager transactionSchemaManager = new TransactionSchemaManager(coordinationService);
         return new SplitKeyDelegatingTransactionService<>(
                 transactionSchemaManager::getTransactionsSchemaVersion,
-                ImmutableMap.of(1, createV1TransactionService(keyValueService)));
+                ImmutableMap.of(1, createV1TransactionService(keyValueService)),
+                ignoreUnknown);
     }
 
     public static TransactionService createV1TransactionService(KeyValueService keyValueService) {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/ReadOnlyTransactionServiceIntegrationTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/ReadOnlyTransactionServiceIntegrationTest.java
@@ -26,7 +26,7 @@ import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
 import com.palantir.timestamp.InMemoryTimestampService;
 
 public class ReadOnlyTransactionServiceIntegrationTest {
-    private final long COORDINATION_QUANTUM = 100_000_000L;
+    private static final long COORDINATION_QUANTUM = 100_000_000L;
 
     private final InMemoryKeyValueService keyValueService = new InMemoryKeyValueService(true);
     private final InMemoryTimestampService timestampService = new InMemoryTimestampService();

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/ReadOnlyTransactionServiceIntegrationTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/ReadOnlyTransactionServiceIntegrationTest.java
@@ -42,6 +42,7 @@ public class ReadOnlyTransactionServiceIntegrationTest {
 
         assertThat(readOnlyTransactionService.get(1L)).isEqualTo(8L);
         assertThat(readOnlyTransactionService.get(8L)).isNull();
+        assertThat(readOnlyTransactionService.get(COORDINATION_QUANTUM + 1L)).isNull();
 
         timestampService.fastForwardTimestamp(COORDINATION_QUANTUM);
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/ReadOnlyTransactionServiceIntegrationTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/ReadOnlyTransactionServiceIntegrationTest.java
@@ -1,0 +1,63 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
+import com.palantir.timestamp.InMemoryTimestampService;
+
+public class ReadOnlyTransactionServiceIntegrationTest {
+    private final long COORDINATION_QUANTUM = 100_000_000L;
+
+    private final InMemoryKeyValueService keyValueService = new InMemoryKeyValueService(true);
+    private final InMemoryTimestampService timestampService = new InMemoryTimestampService();
+    private final TransactionService writeTransactionService
+            = TransactionServices.createForTesting(keyValueService, timestampService, false);
+    private final TransactionService readOnlyTransactionService
+            = TransactionServices.createReadOnlyTransactionServiceIgnoresUncommittedTransactionsDoesNotRollBack(
+            keyValueService);
+
+    @Test
+    public void canReadAlreadyAgreedValuesEvenAfterAdditionalCoordinations() {
+        writeTransactionService.putUnlessExists(1L, 8L);
+
+        assertThat(readOnlyTransactionService.get(1L)).isEqualTo(8L);
+        assertThat(readOnlyTransactionService.get(8L)).isNull();
+
+        timestampService.fastForwardTimestamp(COORDINATION_QUANTUM);
+
+        writeTransactionService.putUnlessExists(COORDINATION_QUANTUM + 1L, COORDINATION_QUANTUM + 5L);
+        assertThat(readOnlyTransactionService.get(COORDINATION_QUANTUM + 1L)).isEqualTo(COORDINATION_QUANTUM + 5L);
+        assertThat(readOnlyTransactionService.get(Long.MAX_VALUE)).isNull();
+    }
+
+    @Test
+    public void canReadMultipleAgreedValuesEvenAfterAdditionalCoordinations() {
+        timestampService.fastForwardTimestamp(COORDINATION_QUANTUM);
+        writeTransactionService.putUnlessExists(1L, 8L);
+        writeTransactionService.putUnlessExists(COORDINATION_QUANTUM + 1L, COORDINATION_QUANTUM + 5L);
+
+        assertThat(readOnlyTransactionService.get(
+                ImmutableList.of(1L, COORDINATION_QUANTUM + 1L, 2 * COORDINATION_QUANTUM + 1L)))
+                .isEqualTo(ImmutableMap.of(1L, 8L, COORDINATION_QUANTUM + 1L, COORDINATION_QUANTUM + 5L));
+    }
+}


### PR DESCRIPTION
Paired with @gmaretic 

**Goals (and why)**:
- Support read only transaction manager based workflows. These do occur in large internal product, and the ordinary `CoordinationService` will not work because read only transaction managers may be initiated in the absence of a timestamp service.

**Implementation Description (bullets)**:
- A read only transaction schema manager (ROTSM) can read the transaction schema version for a timestamp, but unlike a normal one cannot perpetuate existing bounds or propose new values safely as it doesn't have a timestamp service, which are needed when updating a value and bound.
- Sometimes, reading a transaction schema version for a timestamp involves perpetuating the bound. In this case, an ROTSM will return null.
- This PR changes `SplitKeyDelegatingTransactionService`: if the mapping function returns null, then putUnlessExists throws an `UnsupportedOperationException`, get returns null, and getMultiple filters out values that map to null. Note that encountering a known value that is something we don't know how to read means we throw.
- The main edge case is if we need to read a value which a write transaction has written, but not done a putUnlessExists which also forces perpetuation of the current state. In this case, a read only transaction could read a value which it doesn't know whether it has committed yet or not. The convention in the past is to ignore such values - treating them as uncommitted _but not rolling them back_, which is preserved - as get() returns null and the ReadOnlyTransactionManager hasn't otherwise changed.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Existing tests should verify that the ordinary codepath is not broken. There are a few new tests for functions that can return null in a `SplitKeyDelegatingTransactionService`.

**Concerns (what feedback would you like?)**:
- Does this actually preserve the semantics correctly?
- Are there any other snags with read-only transactions / read-only transaction managers we may have missed?

**Where should we start reviewing?**: `TransactionServices`

**Priority (whenever / two weeks / yesterday)**: I'm tempted to say yesterday, but realistically this is a P1, not a P0. It's preventing large internal product from upgrading their AtlasDB dependency

@dxiao for SA