### PR TITLE
[_transactions2] Coordination, Part 11: putUnlessExists(-1, x) shouldn't throw

### DIFF
--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/SplitKeyDelegatingTransactionServiceTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/SplitKeyDelegatingTransactionServiceTest.java
@@ -17,6 +17,7 @@
 package com.palantir.atlasdb.transaction.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -107,6 +108,12 @@ public class SplitKeyDelegatingTransactionServiceTest {
         assertThatThrownBy(() -> delegatingTransactionService.putUnlessExists(4L, 12L))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Could not find a transaction service for timestamp {}");
+    }
+
+    @Test
+    public void putUnlessExistsDoesNotThrowOnImpossibleValues() {
+        assertThatCode(() -> delegatingTransactionService.putUnlessExists(-1L, -1L))
+                .doesNotThrowAnyException();
     }
 
     @Test


### PR DESCRIPTION
**Goals (and why)**:
- Fix breaks in internal large product, specifically nomnomnom product

**Implementation Description (bullets)**:
- Don't throw on negative timestamps, though log if attempting to commit something at -1 that is not a straight rollback

**Testing (What was existing testing like?  What have you done to improve it?)**:
Not much.

**Concerns (what feedback would you like?)**:
Is straight part 10 broken in production? This was discovered on a very specific set of tests on the large internal product

**Where should we start reviewing?**: SplitKeyDelegatingTransactionService

**Priority (whenever / two weeks / yesterday)**: Ideally by EOW, to make the AtlasDB bump on large product good before Christmas.
