### PR TITLE
Fix typos in overview docs page

### DIFF
--- a/docs/source/overview/benefits.rst
+++ b/docs/source/overview/benefits.rst
@@ -5,7 +5,7 @@ Benefits
 Deadlock Free
 =============
 
-AtlasDB support Snapshot Isolation (SI) as well as full Serializable
+AtlasDB supports Snapshot Isolation (SI) as well as full Serializable Snapshot Isolation
 (SSI). SI is naturally deadlock free however a transaction may need to
 be retried due to a write/write (w/w) conflict.
 


### PR DESCRIPTION
Docs

One character change: Support -> Supports

Fix missing words in "Full Serializable Snapshot Isolation"

I realize these docs might be auto generated. If so please let me know if I can help fix them upstream!
