### PR TITLE
Add stream() to IterableView

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/common/collect/IterableView.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/collect/IterableView.java
@@ -88,9 +88,9 @@ public abstract class IterableView<T> extends ForwardingObject implements Iterab
          * result.
          */
         if (delegate() instanceof List) {
-            return of(Lists.transform(castAsList(), function));
+            return of(Lists.transform((List<T>) delegate(), function));
         } else if (delegate() instanceof Collection) {
-            return of(Collections2.transform(castAsCollection(), function));
+            return of(Collections2.transform((Collection<T>) delegate(), function));
         }
         return of(Iterables.transform(delegate(), function));
     }
@@ -121,7 +121,7 @@ public abstract class IterableView<T> extends ForwardingObject implements Iterab
              * Use the more efficient Lists.partition which utilizes sublists
              * without allocating new lists for the returned partitions.
              */
-            return of(Lists.partition(castAsList(), size));
+            return of(Lists.partition((List<T>) delegate(), size));
         }
 
         return of(Iterables.partition(castAsIterable(), size));
@@ -244,34 +244,6 @@ public abstract class IterableView<T> extends ForwardingObject implements Iterab
     @SuppressWarnings("unchecked")
     private Iterable<T> castAsIterable() {
         return (Iterable<T>)delegate();
-    }
-
-    /**
-     * Casts the {@link #delegate()} as a {@link Collection} of T to avoid type
-     * warnings due to type erasure. This is safe if the delegate has already
-     * been checked to be an instance of {@link Collection}, but will throw if
-     * not a {@link Collection}
-     *
-     * @throws ClassCastException if the {@link #delegate()} is not a
-     *         {@link Collection}
-     */
-    @SuppressWarnings("unchecked")
-    private Collection<T> castAsCollection() {
-        return (Collection<T>) delegate();
-    }
-
-    /**
-     * Casts the {@link #delegate()} as a {@link List} of T to avoid type
-     * warnings due to type erasure. This is safe if the delegate has already
-     * been checked to be an instance of {@link List}, but will throw if
-     * not a {@link List}
-     *
-     * @throws ClassCastException if the {@link #delegate()} is not a
-     *         {@link List}
-     */
-    @SuppressWarnings("unchecked")
-    private List<T> castAsList() {
-        return (List<T>) delegate();
     }
 
 }

--- a/atlasdb-commons/src/main/java/com/palantir/common/collect/IterableView.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/collect/IterableView.java
@@ -19,6 +19,9 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Spliterator;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import javax.annotation.Nullable;
 
@@ -210,6 +213,23 @@ public abstract class IterableView<T> extends ForwardingObject implements Iterab
     @Override
     public Iterator<T> iterator() {
         return IteratorUtils.wrap(delegate().iterator());
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Spliterator<T> spliterator() {
+        return (Spliterator<T>) delegate().spliterator();
+    }
+
+    /**
+     * @return a sequential {@code Stream} with the contents as its source.
+     */
+    @SuppressWarnings("unchecked")
+    public Stream<T> stream() {
+        if (delegate() instanceof Collection) {
+            return ((Collection<T>) delegate()).stream();
+        }
+        return StreamSupport.stream(spliterator(), false);
     }
 
     @Override

--- a/atlasdb-commons/src/test/java/com/palantir/common/collect/IterableViewTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/common/collect/IterableViewTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Spliterator;
+import java.util.stream.StreamSupport;
 
 import org.junit.Test;
 
@@ -43,64 +44,51 @@ public class IterableViewTest {
 
     @Test
     public void listSpliterator() {
-        Spliterator<String> spliterator = IterableView.of(ImmutableList.of("a", "b")).spliterator();
+        ImmutableList<String> delegate = ImmutableList.of("a", "b");
+        Spliterator<String> spliterator = IterableView.of(delegate).spliterator();
         assertThat(spliterator.estimateSize()).isEqualTo(2);
-        int characteristics = spliterator.characteristics();
-        assertThat(characteristics).isNotEqualTo(0);
-        assertThat(characteristics & Spliterator.CONCURRENT).isEqualTo(0);
-        assertThat(characteristics & Spliterator.DISTINCT).isEqualTo(0);
-        assertThat(characteristics & Spliterator.IMMUTABLE).isEqualTo(Spliterator.IMMUTABLE);
-        assertThat(characteristics & Spliterator.NONNULL).isEqualTo(Spliterator.NONNULL);
-        assertThat(characteristics & Spliterator.SIZED).isEqualTo(Spliterator.SIZED);
-        assertThat(characteristics & Spliterator.SORTED).isEqualTo(0);
-        assertThat(characteristics & Spliterator.SUBSIZED).isEqualTo(Spliterator.SUBSIZED);
+        assertThat(spliterator.characteristics()).isNotZero();
+        assertThat(spliterator.hasCharacteristics(Spliterator.SIZED)).isTrue();
+        assertThat(spliterator.hasCharacteristics(Spliterator.SUBSIZED)).isTrue();
+        assertThat(StreamSupport.stream(spliterator, false)).containsExactly("a", "b");
     }
 
     @Test
     public void listPartitionSpliterator() {
-        IterableView<List<String>> view = IterableView.of(ImmutableList.of("a", "b", "c")).partition(1);
+        ImmutableList<String> delegate = ImmutableList.of("a", "b", "c");
+        IterableView<List<String>> view = IterableView.of(delegate).partition(1);
         Spliterator<List<String>> spliterator = view.spliterator();
         assertThat(spliterator.estimateSize()).isEqualTo(3);
-        int characteristics = spliterator.characteristics();
-        assertThat(characteristics).isNotEqualTo(0);
-        assertThat(characteristics & Spliterator.CONCURRENT).isEqualTo(0);
-        assertThat(characteristics & Spliterator.DISTINCT).isEqualTo(0);
-        assertThat(characteristics & Spliterator.IMMUTABLE).isEqualTo(0);
-        assertThat(characteristics & Spliterator.NONNULL).isEqualTo(0);
-        assertThat(characteristics & Spliterator.SIZED).isEqualTo(Spliterator.SIZED);
-        assertThat(characteristics & Spliterator.SORTED).isEqualTo(0);
-        assertThat(characteristics & Spliterator.SUBSIZED).isEqualTo(Spliterator.SUBSIZED);
+        assertThat(spliterator.characteristics()).isNotZero();
+        assertThat(spliterator.hasCharacteristics(Spliterator.SIZED)).isTrue();
+        assertThat(spliterator.hasCharacteristics(Spliterator.SUBSIZED)).isTrue();
+        assertThat(StreamSupport.stream(spliterator, false)).containsExactly(
+                ImmutableList.of("a"),
+                ImmutableList.of("b"),
+                ImmutableList.of("c"));
     }
 
     @Test
     public void listTransformSpliterator() {
-        IterableView<String> view = IterableView.of(ImmutableList.of("a", "b", "c")).transform(String::toUpperCase);
+        ImmutableList<String> delegate = ImmutableList.of("a", "b", "c");
+        IterableView<String> view = IterableView.of(delegate).transform(String::toUpperCase);
         Spliterator<String> spliterator = view.spliterator();
         assertThat(spliterator.estimateSize()).isEqualTo(3);
-        int characteristics = spliterator.characteristics();
-        assertThat(characteristics).isNotEqualTo(0);
-        assertThat(characteristics & Spliterator.CONCURRENT).isEqualTo(0);
-        assertThat(characteristics & Spliterator.DISTINCT).isEqualTo(0);
-        assertThat(characteristics & Spliterator.IMMUTABLE).isEqualTo(0);
-        assertThat(characteristics & Spliterator.NONNULL).isEqualTo(0);
-        assertThat(characteristics & Spliterator.SIZED).isEqualTo(Spliterator.SIZED);
-        assertThat(characteristics & Spliterator.SORTED).isEqualTo(0);
-        assertThat(characteristics & Spliterator.SUBSIZED).isEqualTo(Spliterator.SUBSIZED);
+        assertThat(spliterator.characteristics()).isNotZero();
+        assertThat(spliterator.hasCharacteristics(Spliterator.SIZED)).isTrue();
+        assertThat(spliterator.hasCharacteristics(Spliterator.SUBSIZED)).isTrue();
+        assertThat(StreamSupport.stream(spliterator, false)).containsExactly("A", "B", "C");
     }
 
     @Test
     public void setSpliterator() {
         Spliterator<String> spliterator = IterableView.of(ImmutableSortedSet.of("a", "b")).spliterator();
         assertThat(spliterator.estimateSize()).isEqualTo(2);
-        int characteristics = spliterator.characteristics();
-        assertThat(characteristics).isNotEqualTo(0);
-        assertThat(characteristics & Spliterator.CONCURRENT).isEqualTo(0);
-        assertThat(characteristics & Spliterator.DISTINCT).isEqualTo(Spliterator.DISTINCT);
-        assertThat(characteristics & Spliterator.IMMUTABLE).isEqualTo(Spliterator.IMMUTABLE);
-        assertThat(characteristics & Spliterator.NONNULL).isEqualTo(Spliterator.NONNULL);
-        assertThat(characteristics & Spliterator.SIZED).isEqualTo(Spliterator.SIZED);
-        assertThat(characteristics & Spliterator.SORTED).isEqualTo(Spliterator.SORTED);
-        assertThat(characteristics & Spliterator.SUBSIZED).isEqualTo(Spliterator.SUBSIZED);
+        assertThat(spliterator.characteristics()).isNotZero();
+        assertThat(spliterator.hasCharacteristics(Spliterator.DISTINCT)).isTrue();
+        assertThat(spliterator.hasCharacteristics(Spliterator.SIZED)).isTrue();
+        assertThat(spliterator.hasCharacteristics(Spliterator.SUBSIZED)).isTrue();
+        assertThat(StreamSupport.stream(spliterator, false)).containsExactly("a", "b");
     }
 
     @Test
@@ -108,7 +96,10 @@ public class IterableViewTest {
         IterableView<List<String>> view = IterableView.of(Iterables.partition(ImmutableSet.of("a", "b", "c"), 1));
         Spliterator<List<String>> spliterator = view.spliterator();
         assertThat(spliterator.estimateSize()).isEqualTo(Long.MAX_VALUE);
-        int characteristics = spliterator.characteristics();
-        assertThat(characteristics).isEqualTo(0);
+        assertThat(spliterator.characteristics()).isZero();
+        assertThat(StreamSupport.stream(spliterator, false)).containsExactly(
+                ImmutableList.of("a"),
+                ImmutableList.of("b"),
+                ImmutableList.of("c"));
     }
 }

--- a/atlasdb-commons/src/test/java/com/palantir/common/collect/IterableViewTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/common/collect/IterableViewTest.java
@@ -1,0 +1,114 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.common.collect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Spliterator;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Iterables;
+
+public class IterableViewTest {
+
+    @Test
+    public void stream() {
+        assertThat(IterableView.of(ImmutableList.of("a", "b")).stream()).containsExactly("a", "b");
+        assertThat(IterableView.of(
+                Iterables.limit(Iterables.cycle(ImmutableSet.of("a", "b", "c")), 4)).stream())
+                .containsExactly("a", "b", "c", "a");
+        assertThat(IterableView.of(ImmutableList.of("a", "b")).transform(String::toUpperCase)
+                .stream())
+                .containsExactly("A", "B");
+    }
+
+    @Test
+    public void listSpliterator() {
+        Spliterator<String> spliterator = IterableView.of(ImmutableList.of("a", "b")).spliterator();
+        assertThat(spliterator.estimateSize()).isEqualTo(2);
+        int characteristics = spliterator.characteristics();
+        assertThat(characteristics).isNotEqualTo(0);
+        assertThat(characteristics & Spliterator.CONCURRENT).isEqualTo(0);
+        assertThat(characteristics & Spliterator.DISTINCT).isEqualTo(0);
+        assertThat(characteristics & Spliterator.IMMUTABLE).isEqualTo(Spliterator.IMMUTABLE);
+        assertThat(characteristics & Spliterator.NONNULL).isEqualTo(Spliterator.NONNULL);
+        assertThat(characteristics & Spliterator.SIZED).isEqualTo(Spliterator.SIZED);
+        assertThat(characteristics & Spliterator.SORTED).isEqualTo(0);
+        assertThat(characteristics & Spliterator.SUBSIZED).isEqualTo(Spliterator.SUBSIZED);
+    }
+
+    @Test
+    public void listPartitionSpliterator() {
+        IterableView<List<String>> view = IterableView.of(ImmutableList.of("a", "b", "c")).partition(1);
+        Spliterator<List<String>> spliterator = view.spliterator();
+        assertThat(spliterator.estimateSize()).isEqualTo(3);
+        int characteristics = spliterator.characteristics();
+        assertThat(characteristics).isNotEqualTo(0);
+        assertThat(characteristics & Spliterator.CONCURRENT).isEqualTo(0);
+        assertThat(characteristics & Spliterator.DISTINCT).isEqualTo(0);
+        assertThat(characteristics & Spliterator.IMMUTABLE).isEqualTo(0);
+        assertThat(characteristics & Spliterator.NONNULL).isEqualTo(0);
+        assertThat(characteristics & Spliterator.SIZED).isEqualTo(Spliterator.SIZED);
+        assertThat(characteristics & Spliterator.SORTED).isEqualTo(0);
+        assertThat(characteristics & Spliterator.SUBSIZED).isEqualTo(Spliterator.SUBSIZED);
+    }
+
+    @Test
+    public void listTransformSpliterator() {
+        IterableView<String> view = IterableView.of(ImmutableList.of("a", "b", "c")).transform(String::toUpperCase);
+        Spliterator<String> spliterator = view.spliterator();
+        assertThat(spliterator.estimateSize()).isEqualTo(3);
+        int characteristics = spliterator.characteristics();
+        assertThat(characteristics).isNotEqualTo(0);
+        assertThat(characteristics & Spliterator.CONCURRENT).isEqualTo(0);
+        assertThat(characteristics & Spliterator.DISTINCT).isEqualTo(0);
+        assertThat(characteristics & Spliterator.IMMUTABLE).isEqualTo(0);
+        assertThat(characteristics & Spliterator.NONNULL).isEqualTo(0);
+        assertThat(characteristics & Spliterator.SIZED).isEqualTo(Spliterator.SIZED);
+        assertThat(characteristics & Spliterator.SORTED).isEqualTo(0);
+        assertThat(characteristics & Spliterator.SUBSIZED).isEqualTo(Spliterator.SUBSIZED);
+    }
+
+    @Test
+    public void setSpliterator() {
+        Spliterator<String> spliterator = IterableView.of(ImmutableSortedSet.of("a", "b")).spliterator();
+        assertThat(spliterator.estimateSize()).isEqualTo(2);
+        int characteristics = spliterator.characteristics();
+        assertThat(characteristics).isNotEqualTo(0);
+        assertThat(characteristics & Spliterator.CONCURRENT).isEqualTo(0);
+        assertThat(characteristics & Spliterator.DISTINCT).isEqualTo(Spliterator.DISTINCT);
+        assertThat(characteristics & Spliterator.IMMUTABLE).isEqualTo(Spliterator.IMMUTABLE);
+        assertThat(characteristics & Spliterator.NONNULL).isEqualTo(Spliterator.NONNULL);
+        assertThat(characteristics & Spliterator.SIZED).isEqualTo(Spliterator.SIZED);
+        assertThat(characteristics & Spliterator.SORTED).isEqualTo(Spliterator.SORTED);
+        assertThat(characteristics & Spliterator.SUBSIZED).isEqualTo(Spliterator.SUBSIZED);
+    }
+
+    @Test
+    public void iterablesSpliterator() {
+        IterableView<List<String>> view = IterableView.of(Iterables.partition(ImmutableSet.of("a", "b", "c"), 1));
+        Spliterator<List<String>> spliterator = view.spliterator();
+        assertThat(spliterator.estimateSize()).isEqualTo(Long.MAX_VALUE);
+        int characteristics = spliterator.characteristics();
+        assertThat(characteristics).isEqualTo(0);
+    }
+}

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -99,6 +99,10 @@ develop
          - TimeLock Server now logs that a new client has been registered the first time a service makes a request (for each lifetime of each server).
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3676>`__)
 
+    *    - |improved|
+         - Adds com.palantir.common.collect.IterableView#stream method for simplified conversion to Java Stream API usage.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3703>`__)
+
 ========
 v0.114.0
 ========


### PR DESCRIPTION
**Goals (and why)**:

**Implementation Description (bullets)**:

Allow simple use of `IterableView` as a `Stream`, optimized if the delegate is a `Collection`.

Override `IterableView.spliterator()` to allow for potential optimizations based on delegate characteristics (e.g. if the delegate is sized).

**Testing (What was existing testing like?  What have you done to improve it?)**:

Added unit test coverage as there was no explicit coverage for `IterableView`.

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

`IterableView.stream()`

**Priority (whenever / two weeks / yesterday)**:

Whenever, nice to have for use in a downstream project to simplify & optimize stream usage.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
