### PR TITLE
[_transactions2] Coordination, Part 11b: PreStartTimestampHandler

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweepableCellFilter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweepableCellFilter.java
@@ -63,7 +63,7 @@ public class SweepableCellFilter {
         for (long startTs : candidate.sortedTimestamps()) {
             Long commitTs = startToCommitTs.get(startTs);
             lastIsCommittedBeforeSweepTs = false;
-            if (startTs == Value.INVALID_VALUE_TIMESTAMP || commitTs == TransactionConstants.FAILED_COMMIT_TS) {
+            if (candidateIsNotFromACommittedTransaction(startTs, commitTs)) {
                 uncommittedTs.add(startTs);
             } else if (commitTs < sweepTs) {
                 tsToSweep.add(startTs);
@@ -85,6 +85,18 @@ public class SweepableCellFilter {
                     .build()
             );
         }
+    }
+
+    private static boolean candidateIsNotFromACommittedTransaction(long startTs, Long commitTs) {
+        return candidateIsASentinel(startTs) || candidateTransactionWasRolledBack(commitTs);
+    }
+
+    private static boolean candidateIsASentinel(long startTs) {
+        return startTs == Value.INVALID_VALUE_TIMESTAMP;
+    }
+
+    private static boolean candidateTransactionWasRolledBack(Long commitTs) {
+        return commitTs == TransactionConstants.FAILED_COMMIT_TS;
     }
 
     private static Set<Long> getAllValidTimestamps(Collection<CandidateCellForSweeping> candidates) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweepableCellFilter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweepableCellFilter.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.palantir.atlasdb.keyvalue.api.CandidateCellForSweeping;
+import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.transaction.impl.TransactionConstants;
 
 public class SweepableCellFilter {
@@ -41,7 +42,7 @@ public class SweepableCellFilter {
     // Here we need to load the commit timestamps, and it's important to do that in bulk
     // to reduce the number of round trips to the database.
     public BatchOfCellsToSweep getCellsToSweep(List<CandidateCellForSweeping> candidates) {
-        Map<Long, Long> startToCommitTs = commitTsCache.loadBatch(getAllTimestamps(candidates));
+        Map<Long, Long> startToCommitTs = commitTsCache.loadBatch(getAllValidTimestamps(candidates));
         ImmutableBatchOfCellsToSweep.Builder builder = ImmutableBatchOfCellsToSweep.builder();
         long numCellTsPairsExamined = 0;
         for (CandidateCellForSweeping candidate : candidates) {
@@ -60,9 +61,9 @@ public class SweepableCellFilter {
         boolean lastIsCommittedBeforeSweepTs = false;
 
         for (long startTs : candidate.sortedTimestamps()) {
-            long commitTs = startToCommitTs.get(startTs);
+            Long commitTs = startToCommitTs.get(startTs);
             lastIsCommittedBeforeSweepTs = false;
-            if (commitTs == TransactionConstants.FAILED_COMMIT_TS) {
+            if (startTs == Value.INVALID_VALUE_TIMESTAMP || commitTs == TransactionConstants.FAILED_COMMIT_TS) {
                 uncommittedTs.add(startTs);
             } else if (commitTs < sweepTs) {
                 tsToSweep.add(startTs);
@@ -86,10 +87,11 @@ public class SweepableCellFilter {
         }
     }
 
-    private static Set<Long> getAllTimestamps(Collection<CandidateCellForSweeping> candidates) {
+    private static Set<Long> getAllValidTimestamps(Collection<CandidateCellForSweeping> candidates) {
         return candidates.stream()
                 .map(CandidateCellForSweeping::sortedTimestamps)
                 .flatMap(Collection::stream)
+                .filter(timestamp -> timestamp != Value.INVALID_VALUE_TIMESTAMP)
                 .collect(Collectors.toSet());
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/PreStartTimestampHandler.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/PreStartTimestampHandler.java
@@ -1,0 +1,42 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.service;
+
+import java.util.function.Function;
+
+import com.palantir.atlasdb.AtlasDbConstants;
+
+/**
+ * A {@link PreStartTimestampHandler} is a {@link Function} from timestamps to specific values, that specially handles
+ * timestamps before {@link AtlasDbConstants#STARTING_TS} by returning a default fallback value.
+ *
+ * @param <T> return type of the function
+ */
+public class PreStartTimestampHandler<T> implements Function<Long, T> {
+    private final T defaultValue;
+    private final Function<Long, T> delegate;
+
+    PreStartTimestampHandler(T defaultValue, Function<Long, T> delegate) {
+        this.defaultValue = defaultValue;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public T apply(Long timestamp) {
+        return timestamp < AtlasDbConstants.STARTING_TS ? defaultValue : delegate.apply(timestamp);
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/SplitKeyDelegatingTransactionService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/SplitKeyDelegatingTransactionService.java
@@ -27,7 +27,6 @@ import javax.annotation.CheckForNull;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
-import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
@@ -37,7 +36,10 @@ import com.palantir.logsafe.exceptions.SafeIllegalStateException;
  * on which timestamps are requested. This class preserves the {@link TransactionService} guarantees regardless of
  * which underlying service is contacted.
  *
- * The timestamp service will throw an exception if the timestamp-to-service-key function returns a key which is
+ * The timestampToServiceKey function is expected to handle all possible long arguments (including negative values).
+ * The function may return null; if it does, then values written at that timestamp are considered to be uncommitted.
+ *
+ * The transaction service will also throw an exception if the timestamp-to-service-key function returns a key which is
  * not in the keyedServices map.
  *
  * Service keys are expected to be safe for logging.
@@ -56,9 +58,6 @@ public class SplitKeyDelegatingTransactionService<T> implements TransactionServi
     @CheckForNull
     @Override
     public Long get(long startTimestamp) {
-        if (startTimestamp < AtlasDbConstants.STARTING_TS) {
-            return null;
-        }
         return getServiceForTimestamp(startTimestamp).map(service -> service.get(startTimestamp)).orElse(null);
     }
 
@@ -66,9 +65,6 @@ public class SplitKeyDelegatingTransactionService<T> implements TransactionServi
     public Map<Long, Long> get(Iterable<Long> startTimestamps) {
         Multimap<T, Long> queryMap = HashMultimap.create();
         for (Long startTimestamp : startTimestamps) {
-            if (startTimestamp < AtlasDbConstants.STARTING_TS) {
-                continue;
-            }
             T mappedValue = timestampToServiceKey.apply(startTimestamp);
             if (mappedValue != null) {
                 queryMap.put(mappedValue, startTimestamp);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/SplitKeyDelegatingTransactionService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/SplitKeyDelegatingTransactionService.java
@@ -37,7 +37,8 @@ import com.palantir.logsafe.exceptions.SafeIllegalStateException;
  * which underlying service is contacted.
  *
  * The timestampToServiceKey function is expected to handle all possible long arguments (including negative values).
- * The function may return null; if it does, then values written at that timestamp are considered to be uncommitted.
+ * The function may return null; if it does, then for reads, values written at that timestamp are considered to be
+ * uncommitted. The transaction service will throw if a write is attempted at such a timestamp.
  *
  * The transaction service will also throw an exception if the timestamp-to-service-key function returns a key which is
  * not in the keyedServices map.

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/TransactionServices.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/TransactionServices.java
@@ -42,10 +42,10 @@ public final class TransactionServices {
             KeyValueService keyValueService,
             CoordinationService<InternalSchemaMetadata> coordinationService) {
         TransactionSchemaManager transactionSchemaManager = new TransactionSchemaManager(coordinationService);
+        TransactionService v1TransactionService = createV1TransactionService(keyValueService);
         return new SplitKeyDelegatingTransactionService<>(
-                transactionSchemaManager::getTransactionsSchemaVersion,
-                ImmutableMap.of(1, createV1TransactionService(keyValueService))
-        );
+                new PreStartTimestampHandler<>(1, transactionSchemaManager::getTransactionsSchemaVersion),
+                ImmutableMap.of(1, v1TransactionService));
     }
 
     public static TransactionService createV1TransactionService(KeyValueService keyValueService) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/TransactionServices.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/TransactionServices.java
@@ -42,10 +42,10 @@ public final class TransactionServices {
             KeyValueService keyValueService,
             CoordinationService<InternalSchemaMetadata> coordinationService) {
         TransactionSchemaManager transactionSchemaManager = new TransactionSchemaManager(coordinationService);
-        TransactionService v1TransactionService = createV1TransactionService(keyValueService);
+        int versionOne = 1;
         return new SplitKeyDelegatingTransactionService<>(
-                new PreStartTimestampHandler<>(1, transactionSchemaManager::getTransactionsSchemaVersion),
-                ImmutableMap.of(1, v1TransactionService));
+                new PreStartTimestampHandler<>(versionOne, transactionSchemaManager::getTransactionsSchemaVersion),
+                ImmutableMap.of(versionOne, createV1TransactionService(keyValueService)));
     }
 
     public static TransactionService createV1TransactionService(KeyValueService keyValueService) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/TransactionServices.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/TransactionServices.java
@@ -43,8 +43,10 @@ public final class TransactionServices {
             CoordinationService<InternalSchemaMetadata> coordinationService) {
         TransactionSchemaManager transactionSchemaManager = new TransactionSchemaManager(coordinationService);
         int versionOne = 1;
+        PreStartTimestampHandler<Integer> handlerMappingNonPositivesToVersionOne
+                = new PreStartTimestampHandler<>(versionOne, transactionSchemaManager::getTransactionsSchemaVersion);
         return new SplitKeyDelegatingTransactionService<>(
-                new PreStartTimestampHandler<>(versionOne, transactionSchemaManager::getTransactionsSchemaVersion),
+                handlerMappingNonPositivesToVersionOne,
                 ImmutableMap.of(versionOne, createV1TransactionService(keyValueService)));
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/SplitKeyDelegatingTransactionServiceTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/SplitKeyDelegatingTransactionServiceTest.java
@@ -73,8 +73,10 @@ public class SplitKeyDelegatingTransactionServiceTest {
     }
 
     @Test
-    public void getReturnsNullIfTimestampIsImpossible() {
-        assertThat(delegatingTransactionService.get(-1L)).isNull();
+    public void getHandlesNegativeTimestamps() {
+        when(delegate1.get(-9L)).thenReturn(37L);
+        assertThat(delegatingTransactionService.get(-9L)).isEqualTo(37L);
+        verify(delegate1).get(-9L);
     }
 
     @Test
@@ -125,12 +127,6 @@ public class SplitKeyDelegatingTransactionServiceTest {
                 .isEqualTo(ImmutableMap.of(1L, 8L, 12L, 28L, 32L, 38L, 41L, 48L));
         verifyDelegateHadMultigetCalledWith(delegate1, 1L, 41L);
         verifyDelegateHadMultigetCalledWith(delegate2, 12L, 32L);
-    }
-
-    @Test
-    public void getMultipleFiltersOutImpossibleTimestamps() {
-        delegatingTransactionService.get(ImmutableList.of(-1L, -3L, -9L, -19L, 1L));
-        verifyDelegateHadMultigetCalledWith(delegate1, 1L);
     }
 
     @Test

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/TransactionServicesTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/TransactionServicesTest.java
@@ -1,0 +1,60 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+import com.palantir.atlasdb.coordination.CoordinationService;
+import com.palantir.atlasdb.internalschema.InternalSchemaMetadata;
+import com.palantir.atlasdb.internalschema.persistence.CoordinationServices;
+import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
+import com.palantir.timestamp.InMemoryTimestampService;
+
+public class TransactionServicesTest {
+    public static final int COMMIT_TS = 555;
+    private final KeyValueService keyValueService = new InMemoryKeyValueService(true);
+    private final CoordinationService<InternalSchemaMetadata> coordinationService
+            = CoordinationServices.createDefault(keyValueService, new InMemoryTimestampService(), false);
+    private final TransactionService transactionService = TransactionServices.createTransactionService(
+            keyValueService, coordinationService);
+
+    @Test
+    public void valuesPutMayBeSubsequentlyRetrieved() {
+        transactionService.putUnlessExists(1, COMMIT_TS);
+        assertThat(transactionService.get(1)).isEqualTo(COMMIT_TS);
+    }
+
+    @Test
+    public void canPutAndGetAtNegativeTimestamps() {
+        transactionService.putUnlessExists(-1, COMMIT_TS);
+        assertThat(transactionService.get(-1)).isEqualTo(COMMIT_TS);
+    }
+
+    @Test
+    public void cannotPutNegativeValuesTwice() {
+        transactionService.putUnlessExists(-1, COMMIT_TS);
+        assertThatThrownBy(() -> transactionService.putUnlessExists(-1, COMMIT_TS + 1))
+                .isInstanceOf(KeyAlreadyExistsException.class)
+                .hasMessageContaining("already have a value for this timestamp");
+        assertThat(transactionService.get(-1)).isEqualTo(COMMIT_TS);
+    }
+}

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractGetCandidateCellsForSweepingTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractGetCandidateCellsForSweepingTest.java
@@ -26,6 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -177,6 +178,17 @@ public abstract class AbstractGetCandidateCellsForSweepingTest {
         assertThat(getAllCandidates(thoroughRequest(cell(2, 2).getRowName(), 30L, 100))
                 .stream().map(CandidateCellForSweeping::cell).collect(Collectors.toList()))
                 .containsExactly(cell(2, 1), cell(2, 2), cell(3, 1), cell(3, 2));
+    }
+
+    @Test
+    public void considersSentinelsForThorough() {
+        new TestDataBuilder()
+                .put(1, 1, -1L)
+                .put(1, 1, 5L)
+                .store();
+        CandidateCellForSweeping candidateCellForSweeping = Iterables.getOnlyElement(
+                getAllCandidates(thoroughRequest(PtBytes.EMPTY_BYTE_ARRAY, 30L, 100)));
+        assertThat(candidateCellForSweeping.sortedTimestamps()).containsExactly(-1L, 5L);
     }
 
     @Test

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -58,7 +58,7 @@ develop
     *    - |fixed|
          - AtlasDB transaction services now handle non-positive start timestamps safely and consistently with respect to past behaviour, where these are permitted.
            Previously, the transaction service would throw when the transaction service was queried with a non-positive start timestamp.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/XXXX>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3704>`__)
 
     *    - |devbreak|
          - With the introduction of _coordination, creation of ``TransactionService`` now requires a ``CoordinationService<InternalSchemaMetadata>``.

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -55,6 +55,11 @@ develop
            Services which want to adopt _transactions2 will need to go through this version, to ensure that nodes are able to reach a consensus on when to switch the transaction schema version forwards.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3686>`__)
 
+    *    - |fixed|
+         - AtlasDB transaction services now handle non-positive start timestamps safely and consistently with respect to past behaviour, where these are permitted.
+           Previously, the transaction service would throw when the transaction service was queried with a non-positive start timestamp.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/XXXX>`__)
+
     *    - |devbreak|
          - With the introduction of _coordination, creation of ``TransactionService`` now requires a ``CoordinationService<InternalSchemaMetadata>``.
            Users may create a ``CoordinationService`` via the ``CoordinationServices`` factory, if needed, or retrieve it from the relevant ``TransactionManager``.


### PR DESCRIPTION
**Goals (and why)**: See #3695. The previous PRs caused issues because they would throw an exception when attempting to call `putUnlessExists(X, Y)` on the transaction service, where `X` is non-positive. However, there are cases where this can occur in normal operation.

In particular, the change would have broken sweep for any thoroughly swept table that used to be conservatively swept and had sentinels placed, or any thoroughly swept table after a Hard Delete.

**Implementation Description (bullets)**:
- Negative timestamps are treated by the split key delegating service as normal timestamps, rather than specifically filtering them out.
- The `PreStartTimestampHandler` puts all negative timestamps on transactions 1, otherwise delegating to the regular `TransactionsSchemaManager`.

For reference, the legacy behaviour is to treat negative timestamps the same as positive timestamps, so something like

```
transactions.putUnlessExists(-5, 579);
assertThat(transactions.get(-5)).isEqualTo(579);
```

is expected to pass.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Updated old tests to reflect the new way we handle negatives, and included a broader test for the legacy behaviour in `TransactionServicesTest`.

**Concerns (what feedback would you like?)**:
- Eventually we probably want to drop support for transactions1; at that time, how should we handle this? Coordination Service doesn't like negative numbers.

**Where should we start reviewing?**: PreStartTimestampHandler

**Priority (whenever / two weeks / yesterday)**: ideally by tomorrow if that's reasonable, as this is needed to upgrade AtlasDB on the large internal product.