### PR TITLE
[_transactions2] Part 12: Finer-grained CAS compatibility levels for KVSes

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/CheckAndSetCompatibility.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/CheckAndSetCompatibility.java
@@ -16,6 +16,10 @@
 
 package com.palantir.atlasdb.keyvalue.api;
 
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 /**
  * Indicates whether a {@link KeyValueService} supports check and set (CAS) and put unless exists (PUE) operations, and
  * if so the granularity with which it can provide feedback.
@@ -38,5 +42,13 @@ public enum CheckAndSetCompatibility {
      *        of all pre-existing cells for any row which the implementation attempted to put into the key value
      *        service. Note that there is no guarantee that the implementation attempts to put all rows atomically.
      */
-    SUPPORTED_DETAIL_ON_FAILURE,
+    SUPPORTED_DETAIL_ON_FAILURE;
+
+    public static CheckAndSetCompatibility min(Stream<CheckAndSetCompatibility> compatibilities) {
+        Set<CheckAndSetCompatibility> presentCompatibilities = compatibilities.collect(Collectors.toSet());
+        return Stream.of(NOT_SUPPORTED, SUPPORTED_NO_DETAIL_ON_FAILURE, SUPPORTED_DETAIL_ON_FAILURE)
+                .filter(presentCompatibilities::contains)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("min requires at least 1 element, but 0 provided"));
+    }
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/CheckAndSetCompatibility.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/CheckAndSetCompatibility.java
@@ -1,0 +1,42 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.api;
+
+/**
+ * Indicates whether a {@link KeyValueService} supports check and set (CAS) and put unless exists (PUE) operations, and
+ * if so the granularity with which it can provide feedback.
+ */
+public enum CheckAndSetCompatibility {
+    NOT_SUPPORTED,
+    /**
+     * The {@link KeyValueService} supports CAS and PUE operations. However, in the event of failure, there are no
+     * guarantees that {@link CheckAndSetException#getActualValues()} or
+     * {@link KeyAlreadyExistsException#getExistingKeys()} actually return any meaningful data (other than the
+     * fact that the operation failed).
+     */
+    SUPPORTED_NO_DETAIL_ON_FAILURE,
+    /**
+     * The {@link KeyValueService} supports CAS and PUE operations. In the event of failure:
+     *
+     * - CAS: {@link CheckAndSetException#getActualValues()} on any such exception thrown must return the list
+     *        of existing values. (In practice, this should have zero or one elements.)
+     * - PUE: {@link KeyAlreadyExistsException#getExistingKeys()} on any such exception thrown must return the list
+     *        of all pre-existing cells for any row which the implementation attempted to put into the key value
+     *        service. Note that there is no guarantee that the implementation attempts to put all rows atomically.
+     */
+    SUPPORTED_DETAIL_ON_FAILURE,
+}

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -248,11 +248,21 @@ public interface KeyValueService extends AutoCloseable {
                          Map<Cell, byte[]> values) throws KeyAlreadyExistsException;
 
     /**
-     * Check whether CAS is supported. This check can go away when Rocks and JDBC KVS's are deleted.
+     * Check whether CAS is supported. This check can go away when JDBC KVS is deleted.
      *
      * @return true iff checkAndSet is supported (for all delegates/tables, if applicable)
      */
     boolean supportsCheckAndSet();
+
+    /**
+     * Get the {@link CheckAndSetCompatibility} that this {@link KeyValueService} exhibits.
+     *
+     * This method should be consistent with {@link KeyValueService#supportsCheckAndSet()} - this method should
+     * return {@link CheckAndSetCompatibility#NOT_SUPPORTED} if and only if that method returns false.
+     *
+     * @return check and set compatibility
+     */
+    CheckAndSetCompatibility getCheckAndSetCompatibility();
 
     /**
      * Performs a check-and-set into the key-value store.

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -252,7 +252,9 @@ public interface KeyValueService extends AutoCloseable {
      *
      * @return true iff checkAndSet is supported (for all delegates/tables, if applicable)
      */
-    boolean supportsCheckAndSet();
+    default boolean supportsCheckAndSet() {
+        return getCheckAndSetCompatibility() != CheckAndSetCompatibility.NOT_SUPPORTED;
+    }
 
     /**
      * Get the {@link CheckAndSetCompatibility} that this {@link KeyValueService} exhibits.

--- a/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/CheckAndSetCompatibilityTest.java
+++ b/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/CheckAndSetCompatibilityTest.java
@@ -1,0 +1,61 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.stream.Stream;
+
+import org.junit.Test;
+
+public class CheckAndSetCompatibilityTest {
+    @Test
+    public void minThrowsExceptionIfNoCompatibilitiesProvided() {
+        assertThatThrownBy(this::getMinCompatibility)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("min requires at least 1 element");
+    }
+
+    @Test
+    public void minReturnsNotSupportedIfOneKvsHasNotSupported() {
+        assertThat(getMinCompatibility(CheckAndSetCompatibility.SUPPORTED_DETAIL_ON_FAILURE,
+                        CheckAndSetCompatibility.NOT_SUPPORTED,
+                        CheckAndSetCompatibility.SUPPORTED_NO_DETAIL_ON_FAILURE))
+                .isEqualTo(CheckAndSetCompatibility.NOT_SUPPORTED);
+    }
+
+    @Test
+    public void minReturnsSupportedNoDetailIfNotSupportedAbsent() {
+        assertThat(getMinCompatibility(CheckAndSetCompatibility.SUPPORTED_DETAIL_ON_FAILURE,
+                CheckAndSetCompatibility.SUPPORTED_DETAIL_ON_FAILURE,
+                CheckAndSetCompatibility.SUPPORTED_NO_DETAIL_ON_FAILURE))
+                .isEqualTo(CheckAndSetCompatibility.SUPPORTED_NO_DETAIL_ON_FAILURE);
+    }
+
+    @Test
+    public void minReturnsSupportedWithDetailIfAllAreSupportedWithDetail() {
+        assertThat(getMinCompatibility(CheckAndSetCompatibility.SUPPORTED_DETAIL_ON_FAILURE,
+                CheckAndSetCompatibility.SUPPORTED_DETAIL_ON_FAILURE,
+                CheckAndSetCompatibility.SUPPORTED_DETAIL_ON_FAILURE))
+                .isEqualTo(CheckAndSetCompatibility.SUPPORTED_DETAIL_ON_FAILURE);
+    }
+
+    private CheckAndSetCompatibility getMinCompatibility(CheckAndSetCompatibility... compatibilities) {
+        return CheckAndSetCompatibility.min(Stream.of(compatibilities));
+    }
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -76,6 +76,7 @@ import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.CandidateCellForSweeping;
 import com.palantir.atlasdb.keyvalue.api.CandidateCellForSweepingRequest;
 import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.CheckAndSetCompatibility;
 import com.palantir.atlasdb.keyvalue.api.CheckAndSetException;
 import com.palantir.atlasdb.keyvalue.api.CheckAndSetRequest;
 import com.palantir.atlasdb.keyvalue.api.ClusterAvailabilityStatus;
@@ -156,6 +157,11 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         @Override
         public boolean supportsCheckAndSet() {
             return CassandraKeyValueServiceImpl.this.supportsCheckAndSet();
+        }
+
+        @Override
+        public CheckAndSetCompatibility getCheckAndSetCompatibility() {
+            return CassandraKeyValueServiceImpl.this.getCheckAndSetCompatibility();
         }
 
         @Override
@@ -1644,6 +1650,11 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         } catch (Exception e) {
             throw Throwables.unwrapAndThrowAtlasDbDependencyException(e);
         }
+    }
+
+    @Override
+    public CheckAndSetCompatibility getCheckAndSetCompatibility() {
+        return CheckAndSetCompatibility.SUPPORTED_DETAIL_ON_FAILURE;
     }
 
     /**

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueService.java
@@ -37,6 +37,7 @@ import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.AtlasDbPerformanceConstants;
 import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.CheckAndSetCompatibility;
 import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.RangeRequest;
@@ -84,8 +85,8 @@ public abstract class AbstractKeyValueService implements KeyValueService {
     }
 
     @Override
-    public boolean supportsCheckAndSet() {
-        return true;
+    public CheckAndSetCompatibility getCheckAndSetCompatibility() {
+        return CheckAndSetCompatibility.SUPPORTED_NO_DETAIL_ON_FAILURE;
     }
 
     @Override

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DualWriteKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DualWriteKeyValueService.java
@@ -26,6 +26,7 @@ import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.CandidateCellForSweeping;
 import com.palantir.atlasdb.keyvalue.api.CandidateCellForSweepingRequest;
 import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.CheckAndSetCompatibility;
 import com.palantir.atlasdb.keyvalue.api.CheckAndSetRequest;
 import com.palantir.atlasdb.keyvalue.api.ClusterAvailabilityStatus;
 import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
@@ -109,8 +110,8 @@ public class DualWriteKeyValueService implements KeyValueService {
     }
 
     @Override
-    public boolean supportsCheckAndSet() {
-        return delegate1.supportsCheckAndSet();
+    public CheckAndSetCompatibility getCheckAndSetCompatibility() {
+        return delegate1.getCheckAndSetCompatibility();
     }
 
     @Override

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ForwardingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ForwardingKeyValueService.java
@@ -27,6 +27,7 @@ import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.CandidateCellForSweeping;
 import com.palantir.atlasdb.keyvalue.api.CandidateCellForSweepingRequest;
 import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.CheckAndSetCompatibility;
 import com.palantir.atlasdb.keyvalue.api.CheckAndSetRequest;
 import com.palantir.atlasdb.keyvalue.api.ClusterAvailabilityStatus;
 import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
@@ -178,8 +179,8 @@ public abstract class ForwardingKeyValueService extends ForwardingObject impleme
     }
 
     @Override
-    public boolean supportsCheckAndSet() {
-        return delegate().supportsCheckAndSet();
+    public CheckAndSetCompatibility getCheckAndSetCompatibility() {
+        return delegate().getCheckAndSetCompatibility();
     }
 
     @Override
@@ -211,6 +212,7 @@ public abstract class ForwardingKeyValueService extends ForwardingObject impleme
     public void putMetadataForTable(TableReference tableRef, byte[] metadata) {
         delegate().putMetadataForTable(tableRef, metadata);
     }
+
     @Override
     public void putMetadataForTables(final Map<TableReference, byte[]> tableRefToMetadata) {
         delegate().putMetadataForTables(tableRefToMetadata);

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/InMemoryKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/InMemoryKeyValueService.java
@@ -79,7 +79,6 @@ import com.palantir.util.paging.TokenBackedBasicResultsPage;
 @ThreadSafe
 public class InMemoryKeyValueService extends AbstractKeyValueService {
 
-
     private final ConcurrentMap<TableReference, Table> tables = Maps.newConcurrentMap();
     private final ConcurrentMap<TableReference, byte[]> tableMetadata = Maps.newConcurrentMap();
     private final boolean createTablesAutomatically;

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
@@ -32,6 +32,7 @@ import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.CandidateCellForSweeping;
 import com.palantir.atlasdb.keyvalue.api.CandidateCellForSweepingRequest;
 import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.CheckAndSetCompatibility;
 import com.palantir.atlasdb.keyvalue.api.CheckAndSetRequest;
 import com.palantir.atlasdb.keyvalue.api.ClusterAvailabilityStatus;
 import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
@@ -335,8 +336,8 @@ public final class ProfilingKeyValueService implements KeyValueService {
     }
 
     @Override
-    public boolean supportsCheckAndSet() {
-        return delegate.supportsCheckAndSet();
+    public CheckAndSetCompatibility getCheckAndSetCompatibility() {
+        return delegate.getCheckAndSetCompatibility();
     }
 
     @Override

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueService.java
@@ -29,6 +29,7 @@ import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.CandidateCellForSweeping;
 import com.palantir.atlasdb.keyvalue.api.CandidateCellForSweepingRequest;
 import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.CheckAndSetCompatibility;
 import com.palantir.atlasdb.keyvalue.api.CheckAndSetException;
 import com.palantir.atlasdb.keyvalue.api.CheckAndSetRequest;
 import com.palantir.atlasdb.keyvalue.api.ClusterAvailabilityStatus;
@@ -370,8 +371,8 @@ public final class TracingKeyValueService extends ForwardingObject implements Ke
     }
 
     @Override
-    public boolean supportsCheckAndSet() {
-        return delegate().supportsCheckAndSet();
+    public CheckAndSetCompatibility getCheckAndSetCompatibility() {
+        return delegate().getCheckAndSetCompatibility();
     }
 
     @Override

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/DualWriteKeyValueServiceTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/DualWriteKeyValueServiceTest.java
@@ -1,0 +1,46 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import com.palantir.atlasdb.keyvalue.api.CheckAndSetCompatibility;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+
+public class DualWriteKeyValueServiceTest {
+    private final KeyValueService delegate1 = mock(KeyValueService.class);
+    private final KeyValueService delegate2 = mock(KeyValueService.class);
+
+    private final KeyValueService dualWriteService = new DualWriteKeyValueService(delegate1, delegate2);
+
+    @Test
+    public void checkAndSetCompatibilityIsBasedOnTheFirstDelegate() {
+        when(delegate1.getCheckAndSetCompatibility()).thenReturn(CheckAndSetCompatibility.SUPPORTED_DETAIL_ON_FAILURE);
+        when(delegate2.getCheckAndSetCompatibility()).thenReturn(CheckAndSetCompatibility.NOT_SUPPORTED);
+
+        assertThat(dualWriteService.getCheckAndSetCompatibility())
+                .isEqualTo(CheckAndSetCompatibility.SUPPORTED_DETAIL_ON_FAILURE);
+        verify(delegate1).getCheckAndSetCompatibility();
+        verifyNoMoreInteractions(delegate1, delegate2);
+    }
+}

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/keyvalue/impl/AsyncInitializeableInMemoryKvs.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/keyvalue/impl/AsyncInitializeableInMemoryKvs.java
@@ -19,6 +19,7 @@ package com.palantir.atlasdb.keyvalue.impl;
 import com.google.common.base.Preconditions;
 import com.palantir.async.initializer.AsyncInitializer;
 import com.palantir.atlasdb.keyvalue.api.AutoDelegate_KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.CheckAndSetCompatibility;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 
 public final class AsyncInitializeableInMemoryKvs extends AsyncInitializer implements AutoDelegate_KeyValueService {
@@ -61,6 +62,11 @@ public final class AsyncInitializeableInMemoryKvs extends AsyncInitializer imple
     @Override
     public boolean supportsCheckAndSet() {
         return true;
+    }
+
+    @Override
+    public CheckAndSetCompatibility getCheckAndSetCompatibility() {
+        return CheckAndSetCompatibility.SUPPORTED_NO_DETAIL_ON_FAILURE;
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableRemappingKeyValueService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableRemappingKeyValueService.java
@@ -32,6 +32,7 @@ import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.CandidateCellForSweeping;
 import com.palantir.atlasdb.keyvalue.api.CandidateCellForSweepingRequest;
 import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.CheckAndSetCompatibility;
 import com.palantir.atlasdb.keyvalue.api.CheckAndSetRequest;
 import com.palantir.atlasdb.keyvalue.api.ClusterAvailabilityStatus;
 import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
@@ -374,8 +375,8 @@ public final class TableRemappingKeyValueService extends ForwardingObject implem
     }
 
     @Override
-    public boolean supportsCheckAndSet() {
-        return delegate().supportsCheckAndSet();
+    public CheckAndSetCompatibility getCheckAndSetCompatibility() {
+        return delegate().getCheckAndSetCompatibility();
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableSplittingKeyValueService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableSplittingKeyValueService.java
@@ -35,6 +35,7 @@ import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.CandidateCellForSweeping;
 import com.palantir.atlasdb.keyvalue.api.CandidateCellForSweepingRequest;
 import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.CheckAndSetCompatibility;
 import com.palantir.atlasdb.keyvalue.api.CheckAndSetRequest;
 import com.palantir.atlasdb.keyvalue.api.ClusterAvailabilityStatus;
 import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
@@ -325,8 +326,8 @@ public final class TableSplittingKeyValueService implements KeyValueService {
     }
 
     @Override
-    public boolean supportsCheckAndSet() {
-        return getDelegates().stream().allMatch(KeyValueService::supportsCheckAndSet);
+    public CheckAndSetCompatibility getCheckAndSetCompatibility() {
+        return CheckAndSetCompatibility.min(getDelegates().stream().map(KeyValueService::getCheckAndSetCompatibility));
     }
 
     @Override

--- a/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueService.java
+++ b/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueService.java
@@ -111,6 +111,7 @@ import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.CandidateCellForSweeping;
 import com.palantir.atlasdb.keyvalue.api.CandidateCellForSweepingRequest;
 import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.CheckAndSetCompatibility;
 import com.palantir.atlasdb.keyvalue.api.CheckAndSetRequest;
 import com.palantir.atlasdb.keyvalue.api.ClusterAvailabilityStatus;
 import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
@@ -550,8 +551,8 @@ public class JdbcKeyValueService implements KeyValueService {
     }
 
     @Override
-    public boolean supportsCheckAndSet() {
-        return false;
+    public CheckAndSetCompatibility getCheckAndSetCompatibility() {
+        return CheckAndSetCompatibility.NOT_SUPPORTED;
     }
 
     @Override

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
@@ -130,6 +130,11 @@ public abstract class AbstractKeyValueServiceTest {
     }
 
     @Test
+    public void supportsCheckAndSetIsConsistentWithExpectations() {
+        assertThat(keyValueService.supportsCheckAndSet(), is(checkAndSetSupported()));
+    }
+
+    @Test
     public void testGetRowColumnSelection() {
         Cell cell1 = Cell.create(PtBytes.toBytes("row"), PtBytes.toBytes("col1"));
         Cell cell2 = Cell.create(PtBytes.toBytes("row"), PtBytes.toBytes("col2"));

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,8 +50,11 @@ develop
     *    - Type
          - Change
 
-    *    -
-         -
+    *    - |devbreak|
+         - Key value services now require their ``CheckAndSetCompatibility`` to be specified.
+           Refer to the contract of ``KeyValueService#getCheckAndSetCompatibility`` and the ``CheckAndSetCompatibility`` enum class to guide this decision.
+           Please be very careful if you are explicitly setting this to ``CheckAndSetCompatibility.SUPPORTED_DETAIL_ON_FAILURE``.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3713>`__)
 
 ========
 v0.116.1


### PR DESCRIPTION
Collaboration with @gmaretic 

**Goals (and why)**:
- Our strategy for handling batches in #3706 is significantly better with knowledge of _which_ keys failed in a given batched putUnlessExists operation. This isn't supported by all KVS (in particular DbKVS doesn't currently support it), and implementing it in DbKVS seems nontrivial and a bit hacky as it looks like we'll have to parse exception messages.
- Have a clear way of ensuring that batching is only done with services that are friendly to it.

**Implementation Description (bullets)**:
- Define 3 possible levels of CAS support: none, supports with no detail on failure besides "I failed", and supports with details on failures (i.e. "I failed because these rows are there" for PUE, "I failed and the current value is X" for CAS).
- Have existing KVSes give their level of support (Cassandra has support-with-failures, Memory and DbKVS are support-no-detail-on-failures).

**Testing (What was existing testing like?  What have you done to improve it?)**:
Mostly new code, which is tested. We added tests for the CAS Compatibility method, as well as for KVSes where the delegation is not completely straightforward.

**Concerns (what feedback would you like?)**:
- This is another devbreak 😞 but I think doing this this way is better than automatically inferring a `SUPPORTED_NO_DETAIL` from the already existing `supportsCheckAndSet()` method.

**Where should we start reviewing?**: CheckAndSetCompatibility

**Priority (whenever / two weeks / yesterday)**: tomorrow? This blocks #3706 
