### PR TITLE
fix javadoc for WRITE_WRITE handler

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/ConflictHandler.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/ConflictHandler.java
@@ -23,7 +23,7 @@ public enum ConflictHandler {
     IGNORE_ALL(false, false, false, false),
 
     /**
-     * If two transactions concurrently write to the same cell the one that commits later will
+     * If two transactions concurrently write to the same row the one that commits later will
      * throw a {@link TransactionConflictException} and should have details about how this happened.
      */
     RETRY_ON_WRITE_WRITE(false, true, true, false),


### PR DESCRIPTION
**Goals (and why)**:
Currently, the description for WRITE_WRITE conflict handling makes it sound like the same behaviour as WRITE_WRITE_CELL. `s/cell/row` gives a more accurate description.
