### PR TITLE
ClockSkewMonitor now correctly handles services being restarted

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,10 @@ develop
     *    - Type
          - Change
 
+    *    - |improved|
+         - We now correctly handle host restart in the clock skew monitor.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3716>`__)
+
     *    - |devbreak|
          - Key value services now require their ``CheckAndSetCompatibility`` to be specified.
            Refer to the contract of ``KeyValueService#getCheckAndSetCompatibility`` and the ``CheckAndSetCompatibility`` enum class to guide this decision.

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/clock/ClockService.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/clock/ClockService.java
@@ -23,7 +23,7 @@ import javax.ws.rs.core.MediaType;
 @Path("/clock")
 public interface ClockService {
     @POST
-    @Path("system-time-nanos")
+    @Path("system-time")
     @Produces(MediaType.APPLICATION_JSON)
-    long getSystemTimeInNanos();
+    IdentifiedSystemTime getSystemTime();
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/clock/ClockServiceImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/clock/ClockServiceImpl.java
@@ -15,9 +15,13 @@
  */
 package com.palantir.atlasdb.timelock.clock;
 
+import java.util.UUID;
+
 public class ClockServiceImpl implements ClockService {
+    private static final UUID SYSTEM_ID = UUID.randomUUID();
+
     @Override
-    public long getSystemTimeInNanos() {
-        return System.nanoTime();
+    public IdentifiedSystemTime getSystemTime() {
+        return IdentifiedSystemTime.of(System.nanoTime(), SYSTEM_ID);
     }
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/clock/ClockSkewMonitor.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/clock/ClockSkewMonitor.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
@@ -30,6 +31,7 @@ import com.palantir.atlasdb.http.AtlasDbHttpClients;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.common.concurrent.NamedThreadFactory;
 import com.palantir.common.concurrent.PTExecutors;
+import com.palantir.common.streams.KeyedStream;
 import com.palantir.remoting3.config.ssl.TrustContext;
 
 /**
@@ -86,35 +88,34 @@ public final class ClockSkewMonitor {
     }
 
     private Map<String, RequestTime> getRemoteRequestTimes() {
-        Map<String, RequestTime> newRequestTimes = Maps.newHashMap();
-
-        clocksByServer.forEach((host, clockService) -> {
-            try {
-                RequestTime requestTime = getNewRequestTime(clockService);
-                newRequestTimes.put(host, requestTime);
-            } catch (Throwable t) {
-                events.exception(t);
-            }
-        });
-        return newRequestTimes;
+        return KeyedStream.stream(clocksByServer)
+                .flatMap(value -> {
+                    try {
+                        return Stream.of(getNewRequestTime(value));
+                    } catch (Throwable t) {
+                        events.exception(t);
+                        return Stream.empty();
+                    }
+                }).collectToMap();
     }
 
     private RequestTime getNewRequestTime(ReversalDetectingClockService remoteClockService) {
-        long localTimeAtStart = localClockService.getSystemTimeInNanos();
-        long remoteSystemTime = remoteClockService.getSystemTimeInNanos();
-        long localTimeAtEnd = localClockService.getSystemTimeInNanos();
+        long localTimeAtStart = localClockService.getSystemTime().getTimeNanos();
+        IdentifiedSystemTime remoteSystemTime = remoteClockService.getSystemTime();
+        long localTimeAtEnd = localClockService.getSystemTime().getTimeNanos();
 
         return RequestTime.builder()
                 .localTimeAtStart(localTimeAtStart)
                 .localTimeAtEnd(localTimeAtEnd)
-                .remoteSystemTime(remoteSystemTime)
+                .remoteSystemTime(remoteSystemTime.getTimeNanos())
+                .remoteSystemId(remoteSystemTime.getSystemId())
                 .build();
     }
 
     private void checkAndUpdatePreviousRequestTimes(Map<String, RequestTime> newRequests) {
         newRequests.forEach((remoteHost, newRequest) -> {
             RequestTime previousRequest = previousRequestsByServer.get(remoteHost);
-            if (previousRequest != null) {
+            if (previousRequest != null && previousRequest.isFromSameSystem(newRequest)) {
                 new ClockSkewComparer(remoteHost, events, previousRequest, newRequest).compare();
             }
             previousRequestsByServer.put(remoteHost, newRequest);

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/clock/IdentifiedSystemTime.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/clock/IdentifiedSystemTime.java
@@ -1,0 +1,43 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.clock;
+
+import java.util.UUID;
+
+import org.immutables.value.Value;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableIdentifiedSystemTime.class)
+@JsonDeserialize(as = ImmutableIdentifiedSystemTime.class)
+public interface IdentifiedSystemTime {
+    @Value.Parameter
+    long getTimeNanos();
+
+    /**
+     * Returns a unique identifier per JVM launch, which enables detecting JVM restarts,
+     * where the clock offset may change.
+     */
+    @Value.Parameter
+    UUID getSystemId();
+
+    static IdentifiedSystemTime of(long time, UUID systemId) {
+        return ImmutableIdentifiedSystemTime.of(time, systemId);
+    }
+}

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/clock/RequestTime.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/clock/RequestTime.java
@@ -16,6 +16,8 @@
 package com.palantir.atlasdb.timelock.clock;
 
 
+import java.util.UUID;
+
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -26,6 +28,12 @@ public interface RequestTime {
     long localTimeAtEnd();
 
     long remoteSystemTime();
+
+    UUID remoteSystemId();
+
+    default boolean isFromSameSystem(RequestTime other) {
+        return remoteSystemId().equals(other.remoteSystemId());
+    }
 
     default RequestTime progressLocalClock(long delta) {
         return builder().from(this)

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/clock/ReversalDetectingClockServiceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/clock/ReversalDetectingClockServiceTest.java
@@ -21,6 +21,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.UUID;
+
 import org.junit.After;
 import org.junit.Test;
 
@@ -38,42 +40,55 @@ public class ReversalDetectingClockServiceTest {
         verifyNoMoreInteractions(events);
     }
 
+    private static IdentifiedSystemTime st(long time) {
+        return IdentifiedSystemTime.of(time, new UUID(0, 0));
+    }
+
     @Test
     public void doesNotLogIfClockDoesNotGoBackwards() {
-        when(delegate.getSystemTimeInNanos())
-                .thenReturn(1L)
-                .thenReturn(2L)
-                .thenReturn(3L);
+        when(delegate.getSystemTime())
+                .thenReturn(st(1L))
+                .thenReturn(st(2L))
+                .thenReturn(st(3L));
 
-        clock.getSystemTimeInNanos();
-        clock.getSystemTimeInNanos();
-        clock.getSystemTimeInNanos();
+        clock.getSystemTime();
+        clock.getSystemTime();
+        clock.getSystemTime();
+    }
+
+    @Test
+    public void doesNotLogIfSystemChanges() {
+        when(delegate.getSystemTime())
+                .thenReturn(IdentifiedSystemTime.of(1L, new UUID(0, 0)))
+                .thenReturn(IdentifiedSystemTime.of(-1L, new UUID(1, 1)));
+        clock.getSystemTime();
+        clock.getSystemTime();
     }
 
     @Test
     public void logsIfClockGoesBackwards() {
-        when(delegate.getSystemTimeInNanos())
-                .thenReturn(5L)
-                .thenReturn(2L);
+        when(delegate.getSystemTime())
+                .thenReturn(st(5L))
+                .thenReturn(st(2L));
 
-        clock.getSystemTimeInNanos();
-        clock.getSystemTimeInNanos();
+        clock.getSystemTime();
+        clock.getSystemTime();
 
         verify(events).clockWentBackwards(SERVER_NAME, 3L);
     }
 
     @Test
     public void returnsDelegateValueRegardlessOfWhetherClockGoesBackwards() {
-        when(delegate.getSystemTimeInNanos())
-                .thenReturn(1L)
-                .thenReturn(2L)
-                .thenReturn(1L)
-                .thenReturn(3L);
+        when(delegate.getSystemTime())
+                .thenReturn(st(1L))
+                .thenReturn(st(2L))
+                .thenReturn(st(1L))
+                .thenReturn(st(3L));
 
-        assertThat(clock.getSystemTimeInNanos()).isEqualTo(1);
-        assertThat(clock.getSystemTimeInNanos()).isEqualTo(2);
-        assertThat(clock.getSystemTimeInNanos()).isEqualTo(1);
-        assertThat(clock.getSystemTimeInNanos()).isEqualTo(3);
+        assertThat(clock.getSystemTime()).isEqualTo(st(1));
+        assertThat(clock.getSystemTime()).isEqualTo(st(2));
+        assertThat(clock.getSystemTime()).isEqualTo(st(1));
+        assertThat(clock.getSystemTime()).isEqualTo(st(3));
 
         verify(events).clockWentBackwards(SERVER_NAME, 1L);
     }

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/clock/ClockSkewMonitorIntegrationTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/clock/ClockSkewMonitorIntegrationTest.java
@@ -129,12 +129,10 @@ public class ClockSkewMonitorIntegrationTest {
 
     @Test
     public void logsIfLocalTimeGoesBackwards() {
-        when(mockedLocalClockService.getSystemTime())
-                .thenReturn(remote(-1L));
+        when(mockedLocalClockService.getSystemTime()).thenReturn(local(-1L));
         tickOneIteration();
 
-        verify(mockedEvents, times(1))
-                .clockWentBackwards("local", 2);
+        verify(mockedEvents, times(1)).clockWentBackwards("local", 2);
     }
 
     @Test

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/clock/ClockSkewMonitorIntegrationTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/clock/ClockSkewMonitorIntegrationTest.java
@@ -19,10 +19,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.jmock.lib.concurrent.DeterministicScheduler;
@@ -31,6 +33,10 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class ClockSkewMonitorIntegrationTest {
+    private static final UUID LOCAL_ID = new UUID(0, 0);
+    private static final UUID REMOTE_ID = new UUID(1, 1);
+    private static final UUID DIFFERENT_REMOTE_ID = new UUID(2, 2);
+
     private final String server = "test";
     private final ClockService mockedLocalClockService = mock(ClockService.class);
     private final ClockService mockedRemoteClockService = mock(ClockService.class);
@@ -56,6 +62,7 @@ public class ClockSkewMonitorIntegrationTest {
                 .localTimeAtStart(0)
                 .localTimeAtEnd(1)
                 .remoteSystemTime(0)
+                .remoteSystemId(REMOTE_ID)
                 .build();
 
         mockLocalAndRemoteClockSuppliers(originalRequest);
@@ -122,8 +129,8 @@ public class ClockSkewMonitorIntegrationTest {
 
     @Test
     public void logsIfLocalTimeGoesBackwards() {
-        when(mockedLocalClockService.getSystemTimeInNanos())
-                .thenReturn(-1L);
+        when(mockedLocalClockService.getSystemTime())
+                .thenReturn(remote(-1L));
         tickOneIteration();
 
         verify(mockedEvents, times(1))
@@ -132,12 +139,20 @@ public class ClockSkewMonitorIntegrationTest {
 
     @Test
     public void logsIfRemoteTimeGoesBackwards() {
-        when(mockedRemoteClockService.getSystemTimeInNanos())
-                .thenReturn(-1L);
+        when(mockedRemoteClockService.getSystemTime())
+                .thenReturn(remote(-1L));
         tickOneIteration();
 
         verify(mockedEvents, times(1))
                 .clockWentBackwards(server, 1);
+    }
+
+    @Test
+    public void doesNotLogIfRemoteChanges() {
+        when(mockedRemoteClockService.getSystemTime())
+                .thenReturn(differentRemote(-1L));
+        tickOneIteration();
+        verifyZeroInteractions(mockedEvents);
     }
 
     private void tickOneIteration() {
@@ -145,13 +160,25 @@ public class ClockSkewMonitorIntegrationTest {
     }
 
     private void mockLocalAndRemoteClockSuppliers(RequestTime request) {
-        when(mockedLocalClockService.getSystemTimeInNanos()).thenReturn(request.localTimeAtStart(),
-                request.localTimeAtEnd());
-        when(mockedRemoteClockService.getSystemTimeInNanos()).thenReturn(request.remoteSystemTime());
+        when(mockedLocalClockService.getSystemTime()).thenReturn(local(request.localTimeAtStart()),
+                local(request.localTimeAtEnd()));
+        when(mockedRemoteClockService.getSystemTime()).thenReturn(remote(request.remoteSystemTime()));
     }
 
     @After
     public void tearDown() {
         verifyNoMoreInteractions(mockedEvents);
+    }
+
+    private static IdentifiedSystemTime local(long time) {
+        return IdentifiedSystemTime.of(time, LOCAL_ID);
+    }
+
+    private static IdentifiedSystemTime remote(long time) {
+        return IdentifiedSystemTime.of(time, REMOTE_ID);
+    }
+
+    private static IdentifiedSystemTime differentRemote(long time) {
+        return IdentifiedSystemTime.of(time, DIFFERENT_REMOTE_ID);
     }
 }


### PR DESCRIPTION
We generate an id on system startup and handle it changing properly;
note will error when rolling out via rolling restart, but this is
transient and ok.