### PR TITLE
Add deprecated sweep tables to cassandra hidden tables.

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/HiddenTables.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/HiddenTables.java
@@ -33,6 +33,7 @@ public final class HiddenTables {
 
     public static boolean isHidden(TableReference tableReference) {
         return CASSANDRA_TABLES.contains(tableReference)
+                || AtlasDbConstants.DEPRECATED_SWEEP_TABLES_WITH_NO_METADATA.contains(tableReference)
                 || tableReference.getTablename().startsWith(AtlasDbConstants.LOCK_TABLE_PREFIX);
     }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -49,9 +49,13 @@ public final class AtlasDbConstants {
             "_schema_metadata");
 
     // Deprecated tables
+    public static final TableReference SWEEP_PROGRESS_V1 = TableReference.createFromFullyQualifiedName("sweep.progress");
     public static final TableReference SWEEP_PROGRESS_V1_5 = TableReference.createWithEmptyNamespace("_sweep_progress1_5");
     public static final TableReference SWEEP_PROGRESS_V2 = TableReference.createWithEmptyNamespace("_sweep_progress2");
     public static final String LOCK_TABLE_PREFIX = "_locks";
+
+    public static final ImmutableSet<TableReference> DEPRECATED_SWEEP_TABLES_WITH_NO_METADATA =
+            ImmutableSet.of(SWEEP_PROGRESS_V1, SWEEP_PROGRESS_V1_5, SWEEP_PROGRESS_V2);
 
     public static final String PRIMARY_KEY_CONSTRAINT_PREFIX = "pk_";
 


### PR DESCRIPTION
**Goals (and why)**:
Stop spurious logs of deprecated tables that didn't have metadata in the past.

**Implementation Description (bullets)**:
Added the deprecated tables that are no longer in use to Cassandra's `HiddenTables`. This should be safe since they aren't used in this version of atlas anyway.

Internal reference: PDS-81129
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
