### PR TITLE
[no changelog] Remove deprecated commons-lang 2.6

### DIFF
--- a/atlasdb-client/build.gradle
+++ b/atlasdb-client/build.gradle
@@ -52,7 +52,6 @@ dependencies {
   compile (group: 'com.googlecode.json-simple', name: 'json-simple') {
     exclude group: 'junit'
   }
-  compile group: "commons-lang", name: "commons-lang", version: libVersions.commons_lang
   compile group: "org.xerial.snappy", name: "snappy-java", version: libVersions.snappy
   compile group: "com.github.ben-manes.caffeine", name: "caffeine"
   compile group: "com.googlecode.protobuf-java-format", name: "protobuf-java-format", version: "1.2"

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ValidatingQueryRewritingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ValidatingQueryRewritingKeyValueService.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/TypeAndName.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/TypeAndName.java
@@ -15,7 +15,7 @@
  */
 package com.palantir.atlasdb.table.description.render;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence.ValueByteOrder;
 import com.palantir.atlasdb.table.description.ValueType;

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -10,7 +10,6 @@ ext.libVersions =
     mockito: '1.10.17',
     dropwizard:   '0.8.2',
     commons_codec: '1.10',
-    commons_lang: '2.6',
     commons_lang3: '3.1',
     commons_io: '2.1',
     commons_dbutils: '1.3',

--- a/leader-election-impl/build.gradle
+++ b/leader-election-impl/build.gradle
@@ -8,7 +8,6 @@ dependencies {
 
   compile group: "com.github.ben-manes.caffeine", name: "caffeine"
   compile group: "com.google.protobuf", name: "protobuf-java"
-  compile group: "commons-lang", name: "commons-lang", version: libVersions.commons_lang
   compile group: "commons-io", name: "commons-io"
   compile group: 'com.palantir.safe-logging', name: 'safe-logging'
 


### PR DESCRIPTION
**Goals (and why)**:

commons-lang 2.6 is deprecated and should not be used. Functionality is replaced by commons-lang3.
