### PR TITLE
try all available servers before failing

### DIFF
--- a/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/FailoverFeignTarget.java
+++ b/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/FailoverFeignTarget.java
@@ -146,7 +146,7 @@ public class FailoverFeignTarget<T> implements Target<T>, Retryer {
         final long currentTime = currentTimeMillis.get();
         boolean failedDueToFastFailover = fastFailoverStartTime != 0
                 && (currentTime - fastFailoverStartTime) > fastFailoverTimeoutMillis
-                && numSwitches.get() > servers.size();
+                && numSwitches.get() > servers.size() - 1; //try all the available servers before failing
         boolean failedDueToNumSwitches = numSwitches.get() >= numServersToTryBeforeFailing;
         if (failedDueToFastFailover) {
             log.error("This connection has been instructed to fast failover for {}"

--- a/atlasdb-feign/src/test/java/com/palantir/atlasdb/http/FailoverFeignTargetTest.java
+++ b/atlasdb-feign/src/test/java/com/palantir/atlasdb/http/FailoverFeignTargetTest.java
@@ -24,7 +24,6 @@ import static org.hamcrest.Matchers.lessThan;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockingDetails;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/atlasdb-feign/src/test/java/com/palantir/atlasdb/http/FailoverFeignTargetTest.java
+++ b/atlasdb-feign/src/test/java/com/palantir/atlasdb/http/FailoverFeignTargetTest.java
@@ -217,6 +217,16 @@ public class FailoverFeignTargetTest {
         }
     }
 
+    @Test
+    public void fastFailoverShouldTryAllPossibleServersBeforeThrowing() throws Exception {
+        simulateRequest(normalTarget);
+        normalTarget.continueOrPropagate(EXCEPTION_WITH_RETRY_AFTER);
+
+        simulateRequest(normalTarget);
+        Thread.sleep(11000);
+        normalTarget.continueOrPropagate(EXCEPTION_WITH_RETRY_AFTER);
+    }
+
     private void simulateRequest(FailoverFeignTarget target) {
         // This method is called as a part of a request being invoked.
         // We need to update the mostRecentServerIndex, for the FailoverFeignTarget to track failures properly.


### PR DESCRIPTION
**Goals (and why)**:
fixing this issue: https://github.com/palantir/atlasdb/issues/3662

**Implementation Description (bullets)**:
Before failing because of timeout, check if all available servers are tried.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Passing a long supplier to feignTarget constructor, and using the supplier to control time, rather than using thread.sleep - to avoid long running tests.

**Concerns (what feedback would you like?)**:
This causes to fail slower - am I missing any edge cases that can cause more problems?

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
