### PR TITLE
client side clock skew monitors

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -69,6 +69,7 @@ import com.palantir.atlasdb.factory.Leaders.LocalPaxosServices;
 import com.palantir.atlasdb.factory.startup.ConsistencyCheckRunner;
 import com.palantir.atlasdb.factory.startup.TimeLockMigrator;
 import com.palantir.atlasdb.factory.timelock.TimestampCorroboratingTimelockService;
+import com.palantir.atlasdb.factory.timelock.clock.ClockSkewMonitor;
 import com.palantir.atlasdb.factory.timestamp.FreshTimestampSupplierAdapter;
 import com.palantir.atlasdb.http.AtlasDbFeignTargetFactory;
 import com.palantir.atlasdb.http.UserAgents;
@@ -768,6 +769,8 @@ public abstract class TransactionManagers {
                 TimeLockMigrator.create(metricsManager,
                         serverListConfigSupplier, invalidator, userAgent, config.initializeAsync());
         migrator.migrate(); // This can proceed async if config.initializeAsync() was set
+
+        ClockSkewMonitor.create(metricsManager, getServerListConfigSupplierForTimeLock(config, runtimeConfigSupplier).get().servers(), Optional.empty());
         return ImmutableLockAndTimestampServices.copyOf(
                 getLockAndTimestampServices(metricsManager, serverListConfigSupplier, userAgent))
                 .withMigrator(migrator);

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/clock/ClockService.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/clock/ClockService.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,15 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.palantir.atlasdb.timelock.clock;
+package com.palantir.atlasdb.factory.timelock.clock;
 
-import java.util.UUID;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 
-public class ClockServiceImpl implements ClockService {
-    private static final UUID SYSTEM_ID = UUID.randomUUID();
-
-    @Override
-    public IdentifiedSystemTime getSystemTime() {
-        return IdentifiedSystemTime.of(System.nanoTime(), SYSTEM_ID);
-    }
+@Path("/clock")
+public interface ClockService {
+    @POST
+    @Path("system-time")
+    @Produces(MediaType.APPLICATION_JSON)
+    IdentifiedSystemTime getSystemTime();
 }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/clock/ClockServiceImpl.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/clock/ClockServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.palantir.atlasdb.timelock.clock;
+package com.palantir.atlasdb.factory.timelock.clock;
 
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import java.util.UUID;
 
-@Path("/clock")
-public interface ClockService {
-    @POST
-    @Path("system-time")
-    @Produces(MediaType.APPLICATION_JSON)
-    IdentifiedSystemTime getSystemTime();
+public class ClockServiceImpl implements ClockService {
+    private static final UUID SYSTEM_ID = UUID.randomUUID();
+
+    @Override
+    public IdentifiedSystemTime getSystemTime() {
+        return IdentifiedSystemTime.of(System.nanoTime(), SYSTEM_ID);
+    }
 }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/clock/ClockSkewComparer.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/clock/ClockSkewComparer.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.palantir.atlasdb.timelock.clock;
+package com.palantir.atlasdb.factory.timelock.clock;
 
 public class ClockSkewComparer {
     private final String server;

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/clock/ClockSkewEvent.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/clock/ClockSkewEvent.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.atlasdb.timelock.clock;
+package com.palantir.atlasdb.factory.timelock.clock;
 
 import org.immutables.value.Value;
 

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/clock/ClockSkewEvents.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/clock/ClockSkewEvents.java
@@ -45,7 +45,7 @@ public class ClockSkewEvents {
     }
 
     public void clockSkew(
-            String server, ClockSkewEvent event , long requestDuration) {
+            String server, ClockSkewEvent event, long requestDuration) {
         if (event.getClockSkew() >= WARN_SKEW_THRESHOLD_NANOS) {
             log.info("Skew of {} ns over at least {} ns was detected on the remote server {}."
                             + " (Our request took approximately {} ns.)",

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/clock/ClockSkewEvents.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/clock/ClockSkewEvents.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.palantir.atlasdb.timelock.clock;
+package com.palantir.atlasdb.factory.timelock.clock;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/clock/ClockSkewMonitor.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/clock/ClockSkewMonitor.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.palantir.atlasdb.timelock.clock;
+package com.palantir.atlasdb.factory.timelock.clock;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/clock/IdentifiedSystemTime.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/clock/IdentifiedSystemTime.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.atlasdb.timelock.clock;
+package com.palantir.atlasdb.factory.timelock.clock;
 
 import java.util.UUID;
 

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/clock/RequestTime.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/clock/RequestTime.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.palantir.atlasdb.timelock.clock;
+package com.palantir.atlasdb.factory.timelock.clock;
 
 
 import java.util.UUID;

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/clock/ReversalDetectingClockService.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/clock/ReversalDetectingClockService.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.palantir.atlasdb.timelock.clock;
+package com.palantir.atlasdb.factory.timelock.clock;
 
 import javax.annotation.concurrent.GuardedBy;
 

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/timelock/clock/ClockSkewMonitorIntegrationTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/timelock/clock/ClockSkewMonitorIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.palantir.atlasdb.timelock.clock;
+package com.palantir.atlasdb.factory.timelock.clock;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/timelock/clock/MultiNodeClockSkewMonitorIntegrationTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/timelock/clock/MultiNodeClockSkewMonitorIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.palantir.atlasdb.timelock.clock;
+package com.palantir.atlasdb.factory.timelock.clock;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/timelock/clock/ReversalDetectingClockServiceTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/timelock/clock/ReversalDetectingClockServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.palantir.atlasdb.timelock.clock;
+package com.palantir.atlasdb.factory.timelock.clock;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/timelock/clock/ReversalDetectingClockServiceTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/timelock/clock/ReversalDetectingClockServiceTest.java
@@ -61,41 +61,6 @@ public class ReversalDetectingClockServiceTest {
     }
 
     @Test
-    public void testAimd() {
-        int windowSize = 10;
-        Random rand = new Random(0);
-
-        for (double slope = 1; slope <= 6; slope += 0.2) {
-            for (double x0 = 1.0; x0 <= 3; x0 += 0.2) {
-                for (double systemLoadAvg = 0.5; systemLoadAvg <= 1; systemLoadAvg += 0.1) {
-                    Histogram histogram = new Histogram(new HdrHistogramReservoir());
-                    double qosProbability = Math.pow(systemLoadAvg / x0, slope) * Math.exp((systemLoadAvg / x0) - 1);
-                    int currentSuccessCount = 0;
-                    for (int i = 0; i < 100_000; i++) {
-                        windowSize = Math.max(windowSize, 1);
-                        histogram.update(windowSize);
-                        if (currentSuccessCount == 10) {
-                            currentSuccessCount = 0;
-                            windowSize++;
-                        }
-                        if (rand.nextDouble() > 1 - qosProbability) {
-                            currentSuccessCount = 0;
-                            windowSize = (windowSize * 9) / 10;
-                        } else {
-                            currentSuccessCount++;
-                        }
-                    }
-                    System.out.println("slope: " + slope
-                            + " x0: " + x0
-                            + " systemLoad: " + systemLoadAvg
-                            + " redirect-probability " + qosProbability
-                            + " concurrent-requests " + histogram.getSnapshot().getMean());
-                }
-            }
-        }
-    }
-
-    @Test
     public void doesNotLogIfSystemChanges() {
         when(delegate.getSystemTime())
                 .thenReturn(IdentifiedSystemTime.of(1L, new UUID(0, 0)))

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/timelock/clock/ReversalDetectingClockServiceTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/timelock/clock/ReversalDetectingClockServiceTest.java
@@ -67,26 +67,30 @@ public class ReversalDetectingClockServiceTest {
 
         for (double slope = 1; slope <= 6; slope += 0.2) {
             for (double x0 = 1.0; x0 <= 3; x0 += 0.2) {
-               for (double systemLoadAvg = 0.5; systemLoadAvg <= 1; systemLoadAvg += 0.1) {
-                   Histogram histogram = new Histogram(new HdrHistogramReservoir());
-                   double qosProbability = Math.pow(systemLoadAvg / x0, slope) * Math.exp((systemLoadAvg / x0) - 1);
-                   int currentSuccessCount = 0;
-                   for (int i = 0; i < 100_000; i++) {
-                       windowSize = Math.max(windowSize, 1);
-                       histogram.update(windowSize);
-                       if (currentSuccessCount == 10) {
-                           currentSuccessCount = 0;
-                           windowSize++;
-                       }
-                       if (rand.nextDouble() > 1 - qosProbability) {
-                           currentSuccessCount = 0;
-                           windowSize = (windowSize * 9) / 10;
-                       } else {
-                           currentSuccessCount++;
-                       }
-                   }
-                   System.out.println("slope: " + slope + " x0: " + x0 + " systemLoad: " + systemLoadAvg + "redirect-probability " + qosProbability + " concurrent-requests " + histogram.getSnapshot().getMean());
-               }
+                for (double systemLoadAvg = 0.5; systemLoadAvg <= 1; systemLoadAvg += 0.1) {
+                    Histogram histogram = new Histogram(new HdrHistogramReservoir());
+                    double qosProbability = Math.pow(systemLoadAvg / x0, slope) * Math.exp((systemLoadAvg / x0) - 1);
+                    int currentSuccessCount = 0;
+                    for (int i = 0; i < 100_000; i++) {
+                        windowSize = Math.max(windowSize, 1);
+                        histogram.update(windowSize);
+                        if (currentSuccessCount == 10) {
+                            currentSuccessCount = 0;
+                            windowSize++;
+                        }
+                        if (rand.nextDouble() > 1 - qosProbability) {
+                            currentSuccessCount = 0;
+                            windowSize = (windowSize * 9) / 10;
+                        } else {
+                            currentSuccessCount++;
+                        }
+                    }
+                    System.out.println("slope: " + slope
+                            + " x0: " + x0
+                            + " systemLoad: " + systemLoadAvg
+                            + " redirect-probability " + qosProbability
+                            + " concurrent-requests " + histogram.getSnapshot().getMean());
+                }
             }
         }
     }

--- a/timelock-agent/src/main/java/com/palantir/timelock/clock/ClockSkewMonitorCreator.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/clock/ClockSkewMonitorCreator.java
@@ -20,8 +20,8 @@ import java.util.Set;
 import java.util.function.Consumer;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.palantir.atlasdb.timelock.clock.ClockServiceImpl;
-import com.palantir.atlasdb.timelock.clock.ClockSkewMonitor;
+import com.palantir.atlasdb.factory.timelock.clock.ClockServiceImpl;
+import com.palantir.atlasdb.factory.timelock.clock.ClockSkewMonitor;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.remoting3.config.ssl.SslSocketFactories;
 import com.palantir.remoting3.config.ssl.TrustContext;

--- a/timelock-agent/src/test/java/com/palantir/timelock/clock/ClockSkewMonitorCreatorTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/clock/ClockSkewMonitorCreatorTest.java
@@ -25,7 +25,7 @@ import java.util.function.Consumer;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableSet;
-import com.palantir.atlasdb.timelock.clock.ClockServiceImpl;
+import com.palantir.atlasdb.factory.timelock.clock.ClockServiceImpl;
 import com.palantir.atlasdb.util.MetricsManagers;
 
 public class ClockSkewMonitorCreatorTest {


### PR DESCRIPTION
**Goals (and why)**:
To collect information about client-timelock clock skew.

**Implementation Description (bullets)**:
Setting up clock skew monitor while initializing TransactionManager (if remote timelock is used)

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:
I needed to move ClockSkewMonitor to atlasdb-config package, which is not ideal.

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
