### PR TITLE
[_transactions2] Part 18: Exposing Configurability of Transactions2

### DIFF
--- a/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/KeyValueServiceMigratorsTest.java
+++ b/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/KeyValueServiceMigratorsTest.java
@@ -316,7 +316,7 @@ public class KeyValueServiceMigratorsTest {
         TimestampService timestampService = new InMemoryTimestampService();
 
         TransactionTables.createTables(kvs);
-        TransactionService transactionService = spy(TransactionServices.createForTesting(kvs, timestampService, false));
+        TransactionService transactionService = spy(TransactionServices.createRaw(kvs, timestampService, false));
 
         AtlasDbServices mockServices = mock(AtlasDbServices.class);
         when(mockServices.getTimestampService()).thenReturn(timestampService);

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionConstants.java
@@ -16,7 +16,10 @@
 package com.palantir.atlasdb.transaction.impl;
 
 
+import java.util.Set;
+
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
@@ -49,7 +52,11 @@ public class TransactionConstants {
     // DO NOT change without a transactions table migration!
     public static final int V2_TRANSACTION_NUM_PARTITIONS = 16;
 
-    public static final int TRANSACTIONS_TABLE_SCHEMA_VERSION = 1;
+    public static final int DIRECT_ENCODING_TRANSACTIONS_SCHEMA_VERSION = 1;
+    public static final int TICKETS_ENCODING_TRANSACTIONS_SCHEMA_VERSION = 2;
+    public static final Set<Integer> SUPPORTED_TRANSACTIONS_SCHEMA_VERSIONS = ImmutableSet.of(
+            DIRECT_ENCODING_TRANSACTIONS_SCHEMA_VERSION,
+            TICKETS_ENCODING_TRANSACTIONS_SCHEMA_VERSION);
 
     public static byte[] getValueForTimestamp(long transactionTimestamp) {
         return EncodingUtils.encodeVarLong(transactionTimestamp);

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionConstants.java
@@ -15,7 +15,6 @@
  */
 package com.palantir.atlasdb.transaction.impl;
 
-
 import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
@@ -33,7 +32,6 @@ import com.palantir.atlasdb.table.description.TableDefinition;
 import com.palantir.atlasdb.table.description.TableMetadata;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
-
 
 public class TransactionConstants {
     private TransactionConstants() {/* */}

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfig.java
@@ -23,6 +23,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.compact.CompactorConfig;
+import com.palantir.atlasdb.internalschema.ImmutableInternalSchemaConfig;
+import com.palantir.atlasdb.internalschema.InternalSchemaConfig;
 import com.palantir.atlasdb.spi.KeyValueServiceRuntimeConfig;
 import com.palantir.atlasdb.stream.StreamStorePersistenceConfiguration;
 import com.palantir.atlasdb.transaction.ImmutableTransactionConfig;
@@ -63,6 +65,11 @@ public abstract class AtlasDbRuntimeConfig {
     @Value.Default
     public TransactionConfig transaction() {
         return ImmutableTransactionConfig.builder().build();
+    }
+
+    @Value.Default
+    public InternalSchemaConfig internalSchema() {
+        return ImmutableInternalSchemaConfig.builder().build();
     }
 
     /**

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -73,6 +73,7 @@ import com.palantir.atlasdb.factory.timestamp.FreshTimestampSupplierAdapter;
 import com.palantir.atlasdb.http.AtlasDbFeignTargetFactory;
 import com.palantir.atlasdb.http.UserAgents;
 import com.palantir.atlasdb.internalschema.InternalSchemaMetadata;
+import com.palantir.atlasdb.internalschema.TransactionSchemaManager;
 import com.palantir.atlasdb.internalschema.metrics.MetadataCoordinationServiceMetrics;
 import com.palantir.atlasdb.internalschema.persistence.CoordinationServices;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
@@ -330,11 +331,12 @@ public abstract class TransactionManagers {
 
         CoordinationService<InternalSchemaMetadata> coordinationService = getSchemaMetadataCoordinationService(
                 metricsManager, lockAndTimestampServices, keyValueService);
+        TransactionSchemaManager transactionSchemaManager = new TransactionSchemaManager(coordinationService);
 
         TransactionService transactionService = initializeCloseable(() -> AtlasDbMetrics.instrument(
                 metricsManager.getRegistry(),
                 TransactionService.class,
-                TransactionServices.createTransactionService(keyValueService, coordinationService)),
+                TransactionServices.createTransactionService(keyValueService, transactionSchemaManager)),
                 closeables);
         ConflictDetectionManager conflictManager = ConflictDetectionManagers.create(keyValueService);
         SweepStrategyManager sweepStrategyManager = SweepStrategyManagers.createDefault(keyValueService);

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfigDeserializationTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfigDeserializationTest.java
@@ -57,6 +57,8 @@ public class AtlasDbRuntimeConfigDeserializationTest {
                     assertThat(overrides.blacklistTables()).containsExactlyInAnyOrder(
                             "atlas.bad_table", "atlas2.immutable_log");
                 });
+
+        assertThat(runtimeConfig.internalSchema().targetTransactionsSchemaVersion()).contains(1);
     }
 
     private void assertSslConfigDeserializedCorrectly(SslConfiguration sslConfiguration) {

--- a/atlasdb-config/src/test/resources/runtime-config-block.yml
+++ b/atlasdb-config/src/test/resources/runtime-config-block.yml
@@ -23,3 +23,6 @@ sweep:
       - "atlas2.immutable_log"
     priorityTables:
       - "atlas.mission_critical_table"
+
+internalSchema:
+  targetTransactionsSchemaVersion: 1

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/KeyValueServiceModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/KeyValueServiceModule.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.config.SweepConfig;
 import com.palantir.atlasdb.coordination.CoordinationService;
 import com.palantir.atlasdb.internalschema.InternalSchemaMetadata;
+import com.palantir.atlasdb.internalschema.TransactionSchemaManager;
 import com.palantir.atlasdb.internalschema.persistence.CoordinationServices;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.ProfilingKeyValueService;
@@ -90,7 +91,8 @@ public class KeyValueServiceModule {
     public TransactionService provideTransactionService(
             @Named("kvs") KeyValueService kvs,
             CoordinationService<InternalSchemaMetadata> coordinationService) {
-        return TransactionServices.createTransactionService(kvs, coordinationService);
+        return TransactionServices.createTransactionService(kvs,
+                new TransactionSchemaManager(coordinationService));
     }
 
     @Provides

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
@@ -131,7 +131,7 @@ public class AtlasDbEteServer extends Application<AtlasDbEteConfiguration> {
         KeyValueService kvs = transactionManager.getKeyValueService();
         LongSupplier ts = transactionManager.getTimestampService()::getFreshTimestamp;
         TransactionService txnService
-                = TransactionServices.createForTesting(kvs, transactionManager.getTimestampService(), false);
+                = TransactionServices.createRaw(kvs, transactionManager.getTimestampService(), false);
         SweepStrategyManager ssm = SweepStrategyManagers.completelyConservative(kvs); // maybe createDefault
         PersistentLockManager noLocks = new PersistentLockManager(
                 MetricsManagers.of(metricRegistry, taggedMetricRegistry),
@@ -147,7 +147,7 @@ public class AtlasDbEteServer extends Application<AtlasDbEteConfiguration> {
                 new SpecialTimestampsSupplier(txManager::getImmutableTimestamp, txManager::getImmutableTimestamp),
                 txManager.getTimelockService(),
                 txManager.getKeyValueService(),
-                TransactionServices.createForTesting(
+                TransactionServices.createRaw(
                         txManager.getKeyValueService(), txManager.getTimestampService(), false),
                 new TargetedSweepFollower(ImmutableList.of(FOLLOWER), txManager));
         sweeper.runInBackground();

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/InternalSchemaConfig.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/InternalSchemaConfig.java
@@ -36,7 +36,7 @@ import com.palantir.logsafe.SafeArg;
 public abstract class InternalSchemaConfig {
     /**
      * If specified, attempts to install the provided transactions schema version to this AtlasDB installation.
-     * This
+     * This is expected to be supported by the version of AtlasDB deployed on this service node.
      *
      * If unspecified, this AtlasDB installation should not attempt to install any new schema versions for
      * transaction persistence.

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/InternalSchemaConfig.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/InternalSchemaConfig.java
@@ -1,0 +1,54 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.internalschema;
+
+import java.util.Optional;
+
+import org.immutables.value.Value;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.palantir.atlasdb.transaction.impl.TransactionConstants;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+
+/**
+ * An {@link InternalSchemaConfig} contains information that can be used for controlling how the internal schema
+ * of an AtlasDB installation operates.
+ */
+@Value.Immutable
+@JsonSerialize(as = ImmutableInternalSchemaConfig.class)
+@JsonDeserialize(as = ImmutableInternalSchemaConfig.class)
+public abstract class InternalSchemaConfig {
+    /**
+     * If specified, attempts to install the provided transactions schema version to this AtlasDB installation.
+     * This
+     *
+     * If unspecified, this AtlasDB installation should not attempt to install any new schema versions for
+     * transaction persistence.
+     */
+    public abstract Optional<Integer> targetTransactionsSchemaVersion();
+
+    @Value.Check
+    public void check() {
+        targetTransactionsSchemaVersion().ifPresent(version ->
+                Preconditions.checkState(TransactionConstants.SUPPORTED_TRANSACTIONS_SCHEMA_VERSIONS.contains(version),
+                        "{} is not a recognised transactions schema version. Supported versions are {}",
+                        SafeArg.of("configuredVersion", version),
+                        SafeArg.of("supportedVersions", TransactionConstants.SUPPORTED_TRANSACTIONS_SCHEMA_VERSIONS)));
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/TransactionSchemaInstaller.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/TransactionSchemaInstaller.java
@@ -29,7 +29,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.logsafe.SafeArg;
 
-public class TransactionSchemaInstaller implements AutoCloseable {
+public final class TransactionSchemaInstaller implements AutoCloseable {
     private static final Logger log = LoggerFactory.getLogger(TransactionSchemaInstaller.class);
 
     @VisibleForTesting
@@ -87,7 +87,8 @@ public class TransactionSchemaInstaller implements AutoCloseable {
                                 + " but this was unsuccessful because another service changed the database. This is"
                                 + " probably benign, but note that such version changes may be delayed.",
                         SafeArg.of("version", presentVersion));
-            }});
+            }
+        });
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/TransactionSchemaInstaller.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/TransactionSchemaInstaller.java
@@ -31,7 +31,9 @@ import com.palantir.logsafe.SafeArg;
 
 public class TransactionSchemaInstaller implements AutoCloseable {
     private static final Logger log = LoggerFactory.getLogger(TransactionSchemaInstaller.class);
-    private static final Duration POLLING_INTERVAL = Duration.ofMinutes(10);
+
+    @VisibleForTesting
+    static final Duration POLLING_INTERVAL = Duration.ofMinutes(10);
 
     private final TransactionSchemaManager manager;
     private final Supplier<Optional<Integer>> versionToInstall;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/TransactionSchemaInstaller.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/TransactionSchemaInstaller.java
@@ -53,11 +53,11 @@ public final class TransactionSchemaInstaller implements AutoCloseable {
             Supplier<Optional<Integer>> versionToInstall) {
         ScheduledExecutorService scheduledExecutor = PTExecutors.newSingleThreadScheduledExecutor(
                 PTExecutors.newNamedThreadFactory(true));
-        return createAndStart(manager, versionToInstall, scheduledExecutor);
+        return createStarted(manager, versionToInstall, scheduledExecutor);
     }
 
     @VisibleForTesting
-    static TransactionSchemaInstaller createAndStart(
+    static TransactionSchemaInstaller createStarted(
             TransactionSchemaManager manager,
             Supplier<Optional<Integer>> versionToInstall,
             ScheduledExecutorService scheduledExecutor) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
@@ -168,7 +168,7 @@ public class InMemoryAtlasDbFactory implements AtlasDbFactory {
         TransactionTables.createTables(keyValueService);
 
         TransactionService transactionService
-                = TransactionServices.createForTesting(keyValueService, ts, false);
+                = TransactionServices.createRaw(keyValueService, ts, false);
         LockService lock = LockRefreshingLockService.create(LockServiceImpl.create(
                  LockServerOptions.builder().isStandaloneServer(false).build()));
         LockClient client = LockClient.of("in memory atlasdb instance");

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/TransactionServices.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/TransactionServices.java
@@ -32,17 +32,16 @@ public final class TransactionServices {
     }
 
     public static TransactionService createTransactionService(
-            KeyValueService keyValueService, CoordinationService<InternalSchemaMetadata> coordinationService) {
+            KeyValueService keyValueService, TransactionSchemaManager transactionSchemaManager) {
         if (keyValueService.getCheckAndSetCompatibility() == CheckAndSetCompatibility.SUPPORTED_DETAIL_ON_FAILURE) {
-            return createSplitKeyTransactionService(keyValueService, coordinationService);
+            return createSplitKeyTransactionService(keyValueService, transactionSchemaManager);
         }
         return createV1TransactionService(keyValueService);
     }
 
     private static TransactionService createSplitKeyTransactionService(
             KeyValueService keyValueService,
-            CoordinationService<InternalSchemaMetadata> coordinationService) {
-        TransactionSchemaManager transactionSchemaManager = new TransactionSchemaManager(coordinationService);
+            TransactionSchemaManager transactionSchemaManager) {
         return new PreStartHandlingTransactionService(
                 new SplitKeyDelegatingTransactionService<>(
                         transactionSchemaManager::getTransactionsSchemaVersion,
@@ -69,7 +68,7 @@ public final class TransactionServices {
             KeyValueService keyValueService, TimestampService timestampService, boolean initializeAsync) {
         CoordinationService<InternalSchemaMetadata> coordinationService
                 = CoordinationServices.createDefault(keyValueService, timestampService, initializeAsync);
-        return createTransactionService(keyValueService, coordinationService);
+        return createTransactionService(keyValueService, new TransactionSchemaManager(coordinationService));
     }
 
     public static TransactionService createReadOnlyTransactionServiceIgnoresUncommittedTransactionsDoesNotRollBack(

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/TransactionServices.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/TransactionServices.java
@@ -64,7 +64,7 @@ public final class TransactionServices {
      * are intermediate services like the {@link CoordinationService} this creates where metrics or other forms of
      * lifecycle management may be useful.
      */
-    public static TransactionService createForTesting(
+    public static TransactionService createRaw(
             KeyValueService keyValueService, TimestampService timestampService, boolean initializeAsync) {
         CoordinationService<InternalSchemaMetadata> coordinationService
                 = CoordinationServices.createDefault(keyValueService, timestampService, initializeAsync);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/TransactionServices.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/TransactionServices.java
@@ -23,6 +23,7 @@ import com.palantir.atlasdb.internalschema.TransactionSchemaManager;
 import com.palantir.atlasdb.internalschema.persistence.CoordinationServices;
 import com.palantir.atlasdb.keyvalue.api.CheckAndSetCompatibility;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.transaction.impl.TransactionConstants;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.timestamp.TimestampService;
 
@@ -42,12 +43,15 @@ public final class TransactionServices {
     private static TransactionService createSplitKeyTransactionService(
             KeyValueService keyValueService,
             TransactionSchemaManager transactionSchemaManager) {
+        // TODO (jkong): Is there a way to disallow DIRECT -> V2 transaction service in the map?
         return new PreStartHandlingTransactionService(
                 new SplitKeyDelegatingTransactionService<>(
                         transactionSchemaManager::getTransactionsSchemaVersion,
                         ImmutableMap.of(
-                                1, createV1TransactionService(keyValueService),
-                                2, createV2TransactionService(keyValueService))));
+                                TransactionConstants.DIRECT_ENCODING_TRANSACTIONS_SCHEMA_VERSION,
+                                createV1TransactionService(keyValueService),
+                                TransactionConstants.TICKETS_ENCODING_TRANSACTIONS_SCHEMA_VERSION,
+                                createV2TransactionService(keyValueService))));
     }
 
     public static TransactionService createV1TransactionService(KeyValueService keyValueService) {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/internalschema/InternalSchemaConfigTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/internalschema/InternalSchemaConfigTest.java
@@ -1,0 +1,48 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.internalschema;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Assume;
+import org.junit.Test;
+
+import com.palantir.atlasdb.transaction.impl.TransactionConstants;
+
+// In these tests we confirm if config is buildable, so we're interested in exceptions (or lack thereof).
+@SuppressWarnings("ResultOfMethodCallIgnored")
+public class InternalSchemaConfigTest {
+    @Test
+    public void canCreateConfigWithRecognisedSchemaVersions() {
+        for (int version : TransactionConstants.SUPPORTED_TRANSACTIONS_SCHEMA_VERSIONS) {
+            assertThatCode(() -> ImmutableInternalSchemaConfig.builder()
+                    .targetTransactionsSchemaVersion(version)
+                    .build()).doesNotThrowAnyException();
+        }
+    }
+
+    @Test
+    public void throwsIfCreatingConfigWithUnrecognizedSchemaVersions() {
+        Assume.assumeTrue(!TransactionConstants.SUPPORTED_TRANSACTIONS_SCHEMA_VERSIONS.contains(Integer.MIN_VALUE));
+        assertThatThrownBy(() -> ImmutableInternalSchemaConfig.builder()
+                .targetTransactionsSchemaVersion(Integer.MIN_VALUE)
+                .build())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("is not a recognised transactions schema version");
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/internalschema/InternalSchemaConfigTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/internalschema/InternalSchemaConfigTest.java
@@ -19,7 +19,6 @@ package com.palantir.atlasdb.internalschema;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Assume;
 import org.junit.Test;
 
 import com.palantir.atlasdb.transaction.impl.TransactionConstants;
@@ -38,7 +37,6 @@ public class InternalSchemaConfigTest {
 
     @Test
     public void throwsIfCreatingConfigWithUnrecognizedSchemaVersions() {
-        Assume.assumeTrue(!TransactionConstants.SUPPORTED_TRANSACTIONS_SCHEMA_VERSIONS.contains(Integer.MIN_VALUE));
         assertThatThrownBy(() -> ImmutableInternalSchemaConfig.builder()
                 .targetTransactionsSchemaVersion(Integer.MIN_VALUE)
                 .build())

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/internalschema/TransactionSchemaInstaller.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/internalschema/TransactionSchemaInstaller.java
@@ -1,0 +1,85 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.internalschema;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.palantir.common.concurrent.PTExecutors;
+import com.palantir.logsafe.SafeArg;
+
+public class TransactionSchemaInstaller implements AutoCloseable {
+    private static final Logger log = LoggerFactory.getLogger(TransactionSchemaInstaller.class);
+    private static final Duration POLLING_INTERVAL = Duration.ofMinutes(10);
+
+    private final TransactionSchemaManager manager;
+    private final Supplier<Optional<Integer>> versionToInstall;
+    private final ScheduledExecutorService scheduledExecutorService;
+
+    private TransactionSchemaInstaller(
+            TransactionSchemaManager manager,
+            Supplier<Optional<Integer>> versionToInstall,
+            ScheduledExecutorService scheduledExecutorService) {
+        this.manager = manager;
+        this.versionToInstall = versionToInstall;
+        this.scheduledExecutorService = scheduledExecutorService;
+    }
+
+    public static TransactionSchemaInstaller createStarted(
+            TransactionSchemaManager manager,
+            Supplier<Optional<Integer>> versionToInstall) {
+        ScheduledExecutorService scheduledExecutor = PTExecutors.newSingleThreadScheduledExecutor(
+                PTExecutors.newNamedThreadFactory(true));
+        TransactionSchemaInstaller installer = new TransactionSchemaInstaller(
+                manager, versionToInstall, scheduledExecutor);
+        scheduledExecutor.scheduleAtFixedRate(
+                installer::runOneIteration, 0, POLLING_INTERVAL.toMinutes(), TimeUnit.MINUTES);
+        return installer;
+    }
+
+    private void runOneIteration() {
+        try {
+            runOneIterationUnsafe();
+        } catch (Exception e) {
+            log.info("Encountered an error when trying to install a new transactions schema version."
+                            + " This is probably benign and we will retry, but pending version changes may be delayed.",
+                    e);
+        }
+    }
+
+    private void runOneIterationUnsafe() {
+        Optional<Integer> version = versionToInstall.get();
+        version.ifPresent(presentVersion -> {
+            if (!manager.tryInstallNewTransactionsSchemaVersion(presentVersion)) {
+                log.info("We attempted to install transactions schema version {} because we saw it in configuration, "
+                                + " but this was unsuccessful because another service changed the database. This is"
+                                + " probably benign, but note that such version changes may be delayed.",
+                        SafeArg.of("version", presentVersion));
+            }});
+    }
+
+    @Override
+    public void close() throws Exception {
+        scheduledExecutorService.shutdown();
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/internalschema/TransactionSchemaInstallerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/internalschema/TransactionSchemaInstallerTest.java
@@ -1,0 +1,93 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.internalschema;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import org.jmock.lib.concurrent.DeterministicScheduler;
+import org.junit.After;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+@SuppressWarnings("unchecked") // Generics usage in mocks
+public class TransactionSchemaInstallerTest {
+    private final DeterministicScheduler scheduler = new DeterministicScheduler();
+    private final Supplier<Optional<Integer>> versionToInstall = mock(Supplier.class);
+    private final TransactionSchemaManager manager = mock(TransactionSchemaManager.class);
+
+    // Non-final because we may need to set up mocks before hitting the factory
+    private TransactionSchemaInstaller installer;
+
+    @After
+    public void verifyNoMoreInteractions() {
+        Mockito.verifyNoMoreInteractions(versionToInstall, manager);
+    }
+
+    @Test
+    public void triesToInstallNewVersionIfPresent() {
+        when(versionToInstall.get()).thenReturn(Optional.of(1));
+        createAndStartTransactionSchemaInstaller();
+        scheduler.runUntilIdle();
+        verify(versionToInstall).get();
+        verify(manager).tryInstallNewTransactionsSchemaVersion(1);
+    }
+
+    @Test
+    public void doesNotTryToInstallAnyVersionIfAbsent() {
+        when(versionToInstall.get()).thenReturn(Optional.empty());
+        createAndStartTransactionSchemaInstaller();
+        scheduler.runUntilIdle();
+        verify(versionToInstall).get();
+    }
+
+    @Test
+    public void resilientToFailuresToGetTheVersionToInstall() {
+        when(versionToInstall.get())
+                .thenThrow(new IllegalStateException("boo"))
+                .thenReturn(Optional.of(2));
+        createAndStartTransactionSchemaInstaller();
+        scheduler.tick(15, TimeUnit.MINUTES); // TODO (jkong): Replace with expressions on the latency interval
+        scheduler.runUntilIdle();
+        verify(versionToInstall, times(2)).get();
+        verify(manager).tryInstallNewTransactionsSchemaVersion(2);
+    }
+
+    @Test
+    public void resilientToFailuresToTalkToTheCoordinationService() {
+        when(versionToInstall.get()).thenReturn(Optional.of(1));
+        when(manager.tryInstallNewTransactionsSchemaVersion(anyInt()))
+                .thenThrow(new IllegalStateException("boo"))
+                .thenReturn(true);
+        createAndStartTransactionSchemaInstaller();
+        scheduler.tick(15, TimeUnit.MINUTES); // TODO (jkong): Replace with expressions on the latency interval
+        scheduler.runUntilIdle();
+        verify(versionToInstall, times(2)).get();
+        verify(manager, times(2)).tryInstallNewTransactionsSchemaVersion(1);
+    }
+
+    private void createAndStartTransactionSchemaInstaller() {
+        installer = TransactionSchemaInstaller.createAndStart(manager, versionToInstall, scheduler);
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/ReadOnlyTransactionServiceIntegrationTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/ReadOnlyTransactionServiceIntegrationTest.java
@@ -31,7 +31,7 @@ public class ReadOnlyTransactionServiceIntegrationTest {
     private final InMemoryKeyValueService keyValueService = new InMemoryKeyValueService(true);
     private final InMemoryTimestampService timestampService = new InMemoryTimestampService();
     private final TransactionService writeTransactionService
-            = TransactionServices.createForTesting(keyValueService, timestampService, false);
+            = TransactionServices.createRaw(keyValueService, timestampService, false);
     private final TransactionService readOnlyTransactionService
             = TransactionServices.createReadOnlyTransactionServiceIgnoresUncommittedTransactionsDoesNotRollBack(
             keyValueService);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/TransactionServicesTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/TransactionServicesTest.java
@@ -56,7 +56,7 @@ public class TransactionServicesTest {
     private final CoordinationService<InternalSchemaMetadata> coordinationService
             = CoordinationServices.createDefault(keyValueService, timestampService, false);
     private final TransactionService transactionService = TransactionServices.createTransactionService(
-            keyValueService, coordinationService);
+            keyValueService, new TransactionSchemaManager(coordinationService));
 
     private long startTs;
     private long commitTs;

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractSweepTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractSweepTest.java
@@ -94,7 +94,7 @@ public abstract class AbstractSweepTest {
         kvs = kvsManager.getDefaultKvs();
         ssm = SweepStrategyManagers.createDefault(kvs);
         txManager = getManager();
-        txService = TransactionServices.createForTesting(kvs, txManager.getTimestampService(), false);
+        txService = TransactionServices.createRaw(kvs, txManager.getTimestampService(), false);
         SweepTestUtils.setupTables(kvs);
         persistentLockManager = new PersistentLockManager(
                 MetricsManagers.createForTests(),

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTestUtils.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTestUtils.java
@@ -61,7 +61,7 @@ public final class SweepTestUtils {
                 ts,
                 ts,
                 SweepStrategyManagers.createDefault(kvs),
-                TransactionServices.createForTesting(kvs, ts, false));
+                TransactionServices.createRaw(kvs, ts, false));
     }
 
     public static TransactionManager setupTxManager(KeyValueService kvs,

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTestSetup.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTestSetup.java
@@ -128,7 +128,7 @@ public abstract class TransactionTestSetup {
         timestampService = ts;
         timestampManagementService = ts;
         timelockService = new LegacyTimelockService(timestampService, lockService, lockClient);
-        transactionService = TransactionServices.createForTesting(keyValueService, timestampService, false);
+        transactionService = TransactionServices.createRaw(keyValueService, timestampService, false);
         conflictDetectionManager = ConflictDetectionManagers.createWithoutWarmingCache(keyValueService);
         sweepStrategyManager = SweepStrategyManagers.createDefault(keyValueService);
         txMgr = getManager();

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
@@ -78,7 +78,7 @@ public class AtlasDbTestCase {
         keyValueServiceWithStats = new StatsTrackingKeyValueService(kvs);
         keyValueService = spy(new TrackingKeyValueService(keyValueServiceWithStats));
         TransactionTables.createTables(kvs);
-        transactionService = TransactionServices.createForTesting(keyValueService, timestampService, false);
+        transactionService = TransactionServices.createRaw(keyValueService, timestampService, false);
         conflictDetectionManager = ConflictDetectionManagers.createWithoutWarmingCache(keyValueService);
         sweepStrategyManager = SweepStrategyManagers.createDefault(keyValueService);
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/TableTasksTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/TableTasksTest.java
@@ -71,7 +71,7 @@ public class TableTasksTest {
         InMemoryTimestampService tsService = new InMemoryTimestampService();
         LockClient lockClient = LockClient.of("sweep client");
         lockService = LockServiceImpl.create(LockServerOptions.builder().isStandaloneServer(false).build());
-        txService = TransactionServices.createForTesting(kvs, tsService, false);
+        txService = TransactionServices.createRaw(kvs, tsService, false);
         Supplier<AtlasDbConstraintCheckingMode> constraints = Suppliers.ofInstance(
                 AtlasDbConstraintCheckingMode.NO_CONSTRAINT_CHECKING);
         ConflictDetectionManager cdm = ConflictDetectionManagers.createWithoutWarmingCache(kvs);


### PR DESCRIPTION
- [x] Smoke-test on IL

**Goals (and why)**:
- Allow users to actually enable transactions2.

**Implementation Description (bullets)**:
- Allow users to configure as runtime config a target transactions schema version. We will try to read this every 10 minutes, and then install that version if it is provided. _I believe_ (but it is worth a check) that repeatedly installing the same version is not especially harmful, as the transaction schema timestamps map won't change at all.
- Set up the installer in `TransactionManagers.create()`
- Docs to follow in part 19.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Unit tests have been added for both the config object and the installer.
- We've tested that the new config deserialises, by adding it to the test yaml.
- We still want to do a smoke test on IL, and broadly speaking see if there's something we can find to sort out testing this kind of feature. It seems previous runtime configs don't really have ETEs.

**Concerns (what feedback would you like?)**:
- Is ten minutes reasonable? This isn't a common operation and I wanted to balance unnecessary coordination operations against making sure the value stays reasonably up to date.
- Should the interval be configurable? The danger of making it configurable is that someone might unknowingly put a very small delay, causing a lot of unnecessary KVS reads.
- We're making another executor per TM - has this been closed correctly, and is there a better way to do this? Ideally I'd like to use a push-based rather than pull-based model, but that looks like it'll require a nontrivial additional amount of work.

**Where should we start reviewing?**: `InternalSchemaConfig`

**Priority (whenever / two weeks / yesterday)**: this week
