### PR TITLE
[_transactions2] Part 19: Coalesce range-adjacent equivalent entries in TimestampPartitioningMaps

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/TimestampPartitioningMap.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/TimestampPartitioningMap.java
@@ -86,8 +86,11 @@ public abstract class TimestampPartitioningMap<T> {
     /**
      * Copies an existing {@link TimestampPartitioningMap}, installing a new value V for timestamps that are at least
      * a provided lower bound L. Existing mappings are unchanged, apart from the largest range [C, +∞)=O for some
-     * timestamp C and value O. This range will be split, resulting in [C, L)=O and [L, +∞)=V. This method
-     * will throw an exception if L is smaller than C.
+     * timestamp C and value O. If O and V are not equal (using {@link Objects#equals(Object, Object)}, this range will
+     * be split, resulting in [C, L)=O and [L, +∞)=V; if they are equal, the range will remain as [C, +∞)=O (but
+     * the method still returns a copy).
+     * 
+     * This method will throw an exception if L is smaller than C.
      *
      * @param lowerBoundForNewVersion lowest timestamp at which the new value should be mapped to
      * @param newValue new value to map timestamps to

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/TimestampPartitioningMap.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/TimestampPartitioningMap.java
@@ -89,7 +89,7 @@ public abstract class TimestampPartitioningMap<T> {
      * timestamp C and value O. If O and V are not equal (using {@link Objects#equals(Object, Object)}, this range will
      * be split, resulting in [C, L)=O and [L, +∞)=V; if they are equal, the range will remain as [C, +∞)=O (but
      * the method still returns a copy).
-     * 
+     *
      * This method will throw an exception if L is smaller than C.
      *
      * @param lowerBoundForNewVersion lowest timestamp at which the new value should be mapped to

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/internalschema/TimestampPartitioningMapTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/internalschema/TimestampPartitioningMapTest.java
@@ -30,6 +30,7 @@ public class TimestampPartitioningMapTest {
 
     private static final long TIMESTAMP_1 = 77L;
     private static final long TIMESTAMP_2 = 777L;
+    private static final long TIMESTAMP_3 = 7777L;
 
     @Test
     public void throwsIfInitialMapIsEmpty() {
@@ -83,6 +84,22 @@ public class TimestampPartitioningMapTest {
                 .copyInstallingNewValue(TIMESTAMP_2, 1);
         assertThat(newMap.getValueForTimestamp(TIMESTAMP_2 - 1)).isEqualTo(2);
         assertThat(newMap.getValueForTimestamp(TIMESTAMP_2)).isEqualTo(1);
+    }
+
+    @Test
+    public void coalescesRangesOnEquivalentValues() {
+        TimestampPartitioningMap newMap = DEFAULT_INITIAL_MAPPING.copyInstallingNewValue(TIMESTAMP_1, 2)
+                .copyInstallingNewValue(TIMESTAMP_2, 2)
+                .copyInstallingNewValue(TIMESTAMP_3, 2);
+        assertThat(newMap.rangeMapView().asMapOfRanges().size()).isEqualTo(2);
+    }
+
+    @Test
+    public void doesNotCoalesceRangesOnDifferentValues() {
+        TimestampPartitioningMap newMap = DEFAULT_INITIAL_MAPPING.copyInstallingNewValue(TIMESTAMP_1, 2)
+                .copyInstallingNewValue(TIMESTAMP_2, 1)
+                .copyInstallingNewValue(TIMESTAMP_3, 2);
+        assertThat(newMap.rangeMapView().asMapOfRanges().size()).isEqualTo(4);
     }
 
     @Test

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -77,7 +77,7 @@ develop
     *    - |fixed|
          - Entries with the same value in adjacent ranges in a timestamp partitioning map will now be properly coalesced, and for the purposes of coordination will not be written as new values.
            Previously, these were stored as separate entries, meaning that unnecessary values may have been written to the coordination store; this does not affect correctness, but is unperformant.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/3QQQ>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3733>`__)
 
 ========
 v0.116.1

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -74,6 +74,11 @@ develop
          - Timelock service no longer supports synchronous lock endpoints. Users who explicitly stated timelock to use synchronous resources by setting `install.asyncLock.useAsyncLockService` to `false` (default is `true`) should migrate to `AsyncLockService` before taking this upgrade.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3718>`__)
 
+    *    - |fixed|
+         - Entries with the same value in adjacent ranges in a timestamp partitioning map will now be properly coalesced, and for the purposes of coordination will not be written as new values.
+           Previously, these were stored as separate entries, meaning that unnecessary values may have been written to the coordination store; this does not affect correctness, but is unperformant.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3QQQ>`__)
+
 ========
 v0.116.1
 ========


### PR DESCRIPTION
**Goals (and why)**:
- Write as little to the coordination table as possible, avoiding unnecessary overheads.
- In particular, `[1000, inf)=2` and installing 2 at timestamp 2000 used to give us `[1000, 2000)=2, [2000, inf)=2` which is unnecessary for our purposes.

**Implementation Description (bullets)**:
- Only produce a new entry if we actually need to. 

**Testing (What was existing testing like?  What have you done to improve it?)**:
- It did cover functional characteristics (timestamps are returned correctly) but didn't cover this size-based one. I've added a test that would have failed under the old implementation.

**Concerns (what feedback would you like?)**:
- RangeMap has a `putCoalescing` but that requires mutability, would a better solution have been to create a mutable rangemap and eventually return it?

**Where should we start reviewing?**: `TimestampPartitioningMap`

**Priority (whenever / two weeks / yesterday)**: ASAP
