### PR TITLE
client lock leases pt1

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/common/time/NanoTime.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/time/NanoTime.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,21 @@
  * limitations under the License.
  */
 
-package com.palantir.leader.lease;
+package com.palantir.common.time;
 
 import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.locks.LockSupport;
 
-import com.google.common.annotations.VisibleForTesting;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 public final class NanoTime implements Comparable<NanoTime> {
+    @JsonValue
     private final long time;
 
-    @VisibleForTesting
-    NanoTime(long time) {
+    @JsonCreator
+    public NanoTime(long time) {
         this.time = time;
     }
 

--- a/atlasdb-commons/src/main/java/com/palantir/common/time/NanoTime.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/time/NanoTime.java
@@ -28,12 +28,16 @@ public final class NanoTime implements Comparable<NanoTime> {
     private final long time;
 
     @JsonCreator
-    public NanoTime(long time) {
+    private NanoTime(long time) {
         this.time = time;
     }
 
     public static NanoTime now() {
         return new NanoTime(System.nanoTime());
+    }
+
+    public static NanoTime createForTests(long time) {
+        return new NanoTime(time);
     }
 
     /**

--- a/atlasdb-commons/src/test/java/com/palantir/common/time/NanoTimeTests.java
+++ b/atlasdb-commons/src/test/java/com/palantir/common/time/NanoTimeTests.java
@@ -27,17 +27,17 @@ public final class NanoTimeTests {
 
     @Test
     public void testIsBefore_usual() {
-        assertThat(new NanoTime(1).isBefore(new NanoTime(2))).isTrue();
+        assertThat(NanoTime.createForTests(1).isBefore(NanoTime.createForTests(2))).isTrue();
     }
 
     @Test
     public void testIsBefore_not() {
-        assertThat(new NanoTime(1).isBefore(new NanoTime(0))).isFalse();
+        assertThat(NanoTime.createForTests(1).isBefore(NanoTime.createForTests(0))).isFalse();
     }
 
     @Test
     public void testIsBefore_overflow() {
-        assertThat(new NanoTime(Long.MAX_VALUE).isBefore(new NanoTime(Long.MIN_VALUE))).isTrue();
+        assertThat(NanoTime.createForTests(Long.MAX_VALUE).isBefore(NanoTime.createForTests(Long.MIN_VALUE))).isTrue();
     }
 
     @Test

--- a/atlasdb-commons/src/test/java/com/palantir/common/time/NanoTimeTests.java
+++ b/atlasdb-commons/src/test/java/com/palantir/common/time/NanoTimeTests.java
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 
-package com.palantir.leader.lease;
+package com.palantir.common.time;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public final class NanoTimeTests {
 
@@ -35,6 +38,17 @@ public final class NanoTimeTests {
     @Test
     public void testIsBefore_overflow() {
         assertThat(new NanoTime(Long.MAX_VALUE).isBefore(new NanoTime(Long.MIN_VALUE))).isTrue();
+    }
+
+    @Test
+    public void canBeSerializedAndDeserialized() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        NanoTime nanoTime = NanoTime.now();
+        String serialized = mapper.writeValueAsString(nanoTime);
+        NanoTime deserialized = mapper.readValue(serialized, NanoTime.class);
+
+        assertEquals(nanoTime, deserialized);
     }
 }
 

--- a/leader-election-impl/src/main/java/com/palantir/leader/lease/LeasingLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/lease/LeasingLeaderElectionService.java
@@ -25,6 +25,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.net.HostAndPort;
+import com.palantir.common.time.NanoTime;
 import com.palantir.leader.LeaderElectionService;
 import com.palantir.leader.PingableLeader;
 

--- a/leader-election-impl/src/main/java/com/palantir/leader/lease/LeasingLeadershipToken.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/lease/LeasingLeadershipToken.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 import java.util.function.Supplier;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.palantir.common.time.NanoTime;
 import com.palantir.leader.LeaderElectionService.LeadershipToken;
 import com.palantir.leader.LeaderElectionService.StillLeadingStatus;
 

--- a/leader-election-impl/src/test/java/com/palantir/leader/lease/LeasingLeadershipTokenTests.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/lease/LeasingLeadershipTokenTests.java
@@ -31,6 +31,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import com.palantir.common.time.NanoTime;
 import com.palantir.leader.LeaderElectionService.LeadershipToken;
 import com.palantir.leader.LeaderElectionService.StillLeadingStatus;
 

--- a/leader-election-impl/src/test/java/com/palantir/leader/lease/LeasingLeadershipTokenTests.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/lease/LeasingLeadershipTokenTests.java
@@ -55,31 +55,31 @@ public final class LeasingLeadershipTokenTests {
 
     @Test
     public void testCaches() {
-        when(clock.get()).thenReturn(new NanoTime(0));
+        when(clock.get()).thenReturn(NanoTime.createForTests(0));
         assertThat(token.getLeadershipStatus()).isEqualTo(StillLeadingStatus.LEADING);
-        when(clock.get()).thenReturn(new NanoTime(1));
+        when(clock.get()).thenReturn(NanoTime.createForTests(1));
         assertThat(token.getLeadershipStatus()).isEqualTo(StillLeadingStatus.LEADING);
         verify(stillLeadingStatus, times(1)).get();
     }
 
     @Test
     public void testFetchesNewStateIfCacheOld() {
-        when(clock.get()).thenReturn(new NanoTime(0));
+        when(clock.get()).thenReturn(NanoTime.createForTests(0));
         assertThat(token.getLeadershipStatus()).isEqualTo(StillLeadingStatus.LEADING);
         when(stillLeadingStatus.get()).thenReturn(StillLeadingStatus.NOT_LEADING);
-        when(clock.get()).thenReturn(new NanoTime(11));
+        when(clock.get()).thenReturn(NanoTime.createForTests(11));
         assertThat(token.getLeadershipStatus()).isEqualTo(StillLeadingStatus.NOT_LEADING);
     }
 
     @Test
     public void testSelectsTimeBeforeFetchingNewState() {
-        when(clock.get()).thenReturn(new NanoTime(0));
+        when(clock.get()).thenReturn(NanoTime.createForTests(0));
         when(stillLeadingStatus.get()).thenAnswer(inv -> {
-            when(clock.get()).thenReturn(new NanoTime(5));
+            when(clock.get()).thenReturn(NanoTime.createForTests(5));
             return StillLeadingStatus.LEADING;
         });
         token.getLeadershipStatus();
-        when(clock.get()).thenReturn(new NanoTime(12));
+        when(clock.get()).thenReturn(NanoTime.createForTests(12));
         doReturn(StillLeadingStatus.NOT_LEADING).when(stillLeadingStatus).get();
         assertThat(token.getLeadershipStatus()).isEqualTo(StillLeadingStatus.NOT_LEADING);
     }

--- a/lock-api/src/main/java/com/palantir/lock/client/LeasedLockToken.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LeasedLockToken.java
@@ -1,0 +1,96 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.client;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import com.google.common.base.Preconditions;
+import com.palantir.lock.v2.IdentifiedTime;
+import com.palantir.lock.v2.Lease;
+import com.palantir.lock.v2.LockToken;
+
+public final class LeasedLockToken implements LockToken {
+    private final LockToken serverToken;
+    private final LockToken clientToken;
+
+    private Lease lease;
+    private boolean inValidated = false;
+
+    static LeasedLockToken of(LockToken serverToken, Lease lease) {
+        return new LeasedLockToken(serverToken,
+                LockToken.of(UUID.randomUUID()),
+                lease);
+    }
+
+    private LeasedLockToken(LockToken serverToken, LockToken clientToken, Lease lease) {
+        this.serverToken = serverToken;
+        this.clientToken = clientToken;
+        this.lease = lease;
+    }
+
+    LockToken serverToken() {
+        return serverToken;
+    }
+
+    synchronized Lease getLease() {
+        return lease;
+    }
+
+    synchronized void updateLease(Lease newLease) {
+        Preconditions.checkArgument(newLease.leaseOwnerId().equals(lease.leaseOwnerId()),
+                "Lock leases can only be refreshed by lease owners");
+
+        if (this.lease.expiry().isBefore(newLease.expiry())) {
+            this.lease = newLease;
+        }
+    }
+
+    synchronized boolean isValid(IdentifiedTime identifiedCurrentTime) {
+        return !inValidated && lease.isValid(identifiedCurrentTime);
+    }
+
+    synchronized void inValidate() {
+        inValidated = true;
+    }
+
+    @Override
+    public UUID getRequestId() {
+        return clientToken.getRequestId();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(serverToken);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        LeasedLockToken otherToken = (LeasedLockToken) other;
+
+        return serverToken.equals(otherToken.serverToken)
+                && clientToken.equals(otherToken.clientToken)
+                && lease.equals(otherToken.lease)
+                && inValidated == otherToken.inValidated;
+    }
+}

--- a/lock-api/src/main/java/com/palantir/lock/client/TimelockRpcClient.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/TimelockRpcClient.java
@@ -43,6 +43,14 @@ import com.palantir.lock.v2.WaitForLocksResponse;
 import com.palantir.logsafe.Safe;
 import com.palantir.timestamp.TimestampRange;
 
+/**
+ * Interface describing timelock endpoints to be used by feign client factories to create raw clients.
+ *
+ * If you are adding a new endpoint that is a modified version of an existing one, please use the existing naming scheme
+ * in which you add a new version number, rather than describing the additional functionality (i.e. refresh-locks-v2
+ * rather than leasable-refresh-locks)
+ */
+
 @Path("/timelock")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)

--- a/lock-api/src/main/java/com/palantir/lock/client/TimelockRpcClient.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/TimelockRpcClient.java
@@ -1,0 +1,141 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.client;
+
+import java.util.Set;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import com.palantir.lock.v2.IdentifiedTime;
+import com.palantir.lock.v2.IdentifiedTimeLockRequest;
+import com.palantir.lock.v2.LeasableLockResponse;
+import com.palantir.lock.v2.LeasableRefreshLockResponse;
+import com.palantir.lock.v2.LeasableStartIdentifiedAtlasDbTransactionResponse;
+import com.palantir.lock.v2.LockImmutableTimestampResponse;
+import com.palantir.lock.v2.LockRequest;
+import com.palantir.lock.v2.LockResponse;
+import com.palantir.lock.v2.LockToken;
+import com.palantir.lock.v2.StartAtlasDbTransactionResponse;
+import com.palantir.lock.v2.StartIdentifiedAtlasDbTransactionRequest;
+import com.palantir.lock.v2.StartIdentifiedAtlasDbTransactionResponse;
+import com.palantir.lock.v2.WaitForLocksRequest;
+import com.palantir.lock.v2.WaitForLocksResponse;
+import com.palantir.logsafe.Safe;
+import com.palantir.timestamp.TimestampRange;
+
+@Path("/timelock")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public interface TimelockRpcClient {
+
+    @POST
+    @Path("fresh-timestamp")
+    long getFreshTimestamp();
+
+    @POST
+    @Path("fresh-timestamps")
+    TimestampRange getFreshTimestamps(@Safe @QueryParam("number") int numTimestampsRequested);
+
+    @POST
+    @Path("lock-immutable-timestamp")
+        // TODO (jkong): Can this be deprecated? Are there users outside of Atlas transactions?
+    LockImmutableTimestampResponse lockImmutableTimestamp(IdentifiedTimeLockRequest request);
+
+    /**
+     * @deprecated Please use {@link TimelockRpcClient#startAtlasDbTransactionV3(
+     * StartIdentifiedAtlasDbTransactionRequest)} instead; ignore the partition information if it is not useful for you.
+     */
+    @POST
+    @Path("start-atlasdb-transaction")
+    @Deprecated
+    StartAtlasDbTransactionResponse startAtlasDbTransaction(IdentifiedTimeLockRequest request);
+
+    /**
+     * @deprecated Please use {@link TimelockRpcClient#startAtlasDbTransactionV3(
+     * StartIdentifiedAtlasDbTransactionRequest)} instead
+     */
+    @POST
+    @Path("start-identified-atlasdb-transaction")
+    @Deprecated
+    StartIdentifiedAtlasDbTransactionResponse startIdentifiedAtlasDbTransaction(
+            StartIdentifiedAtlasDbTransactionRequest request);
+
+    @POST
+    @Path("immutable-timestamp")
+    long getImmutableTimestamp();
+
+    /**
+     * @deprecated Please use {@link TimelockRpcClient#lockV2(LockRequest) instead}
+     */
+    @POST
+    @Path("lock")
+    @Deprecated
+    LockResponse lock(LockRequest request);
+
+    @POST
+    @Path("await-locks")
+    WaitForLocksResponse waitForLocks(WaitForLocksRequest request);
+
+    /**
+     * @deprecated Please use {@link TimelockRpcClient#refreshLockLeasesV2(Set)} instead}
+     */
+    @POST
+    @Path("refresh-locks")
+    @Deprecated
+    Set<LockToken> refreshLockLeases(Set<LockToken> tokens);
+
+    @POST
+    @Path("refresh-locks-v2")
+    LeasableRefreshLockResponse refreshLockLeasesV2(Set<LockToken> tokens);
+
+    @POST
+    @Path("lock-v2")
+    LeasableLockResponse lockV2(LockRequest request);
+
+    @POST
+    @Path("start-atlasdb-transaction-v3")
+    LeasableStartIdentifiedAtlasDbTransactionResponse startAtlasDbTransactionV3(
+            StartIdentifiedAtlasDbTransactionRequest request);
+
+    /**
+     * Releases locks associated with the set of {@link LockToken}s provided.
+     * The set of tokens returned are the tokens for which the associated locks were unlocked in this call.
+     * It is possible that a token that was provided is NOT in the returned set (e.g. if it expired).
+     * However, in this case it is guaranteed that that token is no longer valid.
+     *
+     * @param tokens Tokens for which associated locks should be unlocked.
+     * @return Tokens for which associated locks were unlocked
+     */
+    @POST
+    @Path("unlock")
+    Set<LockToken> unlock(Set<LockToken> tokens);
+
+    @GET
+    @Path("leader-time")
+    IdentifiedTime getLeaderTime();
+
+    @POST
+    @Path("current-time-millis")
+    long currentTimeMillis();
+
+}

--- a/lock-api/src/main/java/com/palantir/lock/client/TimelockRpcClient.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/TimelockRpcClient.java
@@ -80,7 +80,7 @@ public interface TimelockRpcClient {
 
     /**
      * @deprecated Please use {@link TimelockRpcClient#startAtlasDbTransactionV3(
-     * StartIdentifiedAtlasDbTransactionRequest)} instead
+     * StartIdentifiedAtlasDbTransactionRequest)} instead.
      */
     @POST
     @Path("start-identified-atlasdb-transaction")
@@ -93,7 +93,7 @@ public interface TimelockRpcClient {
     long getImmutableTimestamp();
 
     /**
-     * @deprecated Please use {@link TimelockRpcClient#lockV2(LockRequest) instead}
+     * @deprecated Please use {@link TimelockRpcClient#lockV2(LockRequest) instead}.
      */
     @POST
     @Path("lock")
@@ -105,7 +105,7 @@ public interface TimelockRpcClient {
     WaitForLocksResponse waitForLocks(WaitForLocksRequest request);
 
     /**
-     * @deprecated Please use {@link TimelockRpcClient#refreshLockLeasesV2(Set)} instead}
+     * @deprecated Please use {@link TimelockRpcClient#refreshLockLeasesV2(Set)} instead}.
      */
     @POST
     @Path("refresh-locks")

--- a/lock-api/src/main/java/com/palantir/lock/v2/IdentifiedTime.java
+++ b/lock-api/src/main/java/com/palantir/lock/v2/IdentifiedTime.java
@@ -1,0 +1,40 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.v2;
+
+import java.util.UUID;
+
+import org.immutables.value.Value;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.palantir.common.time.NanoTime;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableIdentifiedTime.class)
+@JsonDeserialize(as = ImmutableIdentifiedTime.class)
+public interface IdentifiedTime {
+    @Value.Parameter
+    UUID clockId();
+
+    @Value.Parameter
+    NanoTime currentTimeNanos();
+
+    static IdentifiedTime of(UUID id, NanoTime time) {
+        return ImmutableIdentifiedTime.of(id, time);
+    }
+}

--- a/lock-api/src/main/java/com/palantir/lock/v2/LeasableLockResponse.java
+++ b/lock-api/src/main/java/com/palantir/lock/v2/LeasableLockResponse.java
@@ -1,0 +1,45 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.v2;
+
+import java.util.Optional;
+
+import org.immutables.value.Value;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableLeasableLockResponse.class)
+@JsonDeserialize(as = ImmutableLeasableLockResponse.class)
+public abstract class LeasableLockResponse {
+    @Value.Parameter
+    public abstract Optional<LockToken> getTokenOrEmpty();
+
+    @Value.Parameter
+    public abstract Lease getLease();
+
+    @JsonIgnore
+    public LockResponse getLockResponse() {
+        return ImmutableLockResponse.of(getTokenOrEmpty());
+    }
+
+    public static LeasableLockResponse of(LockResponse lockResponse, Lease lease) {
+        return ImmutableLeasableLockResponse.of(lockResponse.getTokenOrEmpty(), lease);
+    }
+}

--- a/lock-api/src/main/java/com/palantir/lock/v2/LeasableRefreshLockResponse.java
+++ b/lock-api/src/main/java/com/palantir/lock/v2/LeasableRefreshLockResponse.java
@@ -1,0 +1,39 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.v2;
+
+import java.util.Set;
+
+import org.immutables.value.Value;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableLeasableRefreshLockResponse.class)
+@JsonDeserialize(as = ImmutableLeasableRefreshLockResponse.class)
+public interface LeasableRefreshLockResponse {
+    @Value.Parameter
+    Set<LockToken> refreshedTokens();
+
+    @Value.Parameter
+    Lease getLease();
+
+    static LeasableRefreshLockResponse of(Set<LockToken> tokens, Lease lease) {
+        return ImmutableLeasableRefreshLockResponse.of(tokens, lease);
+    }
+}

--- a/lock-api/src/main/java/com/palantir/lock/v2/LeasableStartIdentifiedAtlasDbTransactionResponse.java
+++ b/lock-api/src/main/java/com/palantir/lock/v2/LeasableStartIdentifiedAtlasDbTransactionResponse.java
@@ -1,0 +1,53 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.v2;
+
+import org.immutables.value.Value;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableLeasableStartIdentifiedAtlasDbTransactionResponse.class)
+@JsonDeserialize(as = ImmutableLeasableStartIdentifiedAtlasDbTransactionResponse.class)
+public abstract class LeasableStartIdentifiedAtlasDbTransactionResponse {
+    @Value.Parameter
+    public abstract LockImmutableTimestampResponse immutableTimestamp();
+
+    @Value.Parameter
+    public abstract TimestampAndPartition startTimestampAndPartition();
+
+    @Value.Parameter
+    public abstract Lease getLease();
+
+    @JsonIgnore
+    public StartIdentifiedAtlasDbTransactionResponse getStartTransactionResponse() {
+        return ImmutableStartIdentifiedAtlasDbTransactionResponse.of(
+                immutableTimestamp(),
+                startTimestampAndPartition());
+    }
+
+    public static LeasableStartIdentifiedAtlasDbTransactionResponse of(
+            StartIdentifiedAtlasDbTransactionResponse response,
+            Lease lease) {
+        return ImmutableLeasableStartIdentifiedAtlasDbTransactionResponse.of(
+                response.immutableTimestamp(),
+                response.startTimestampAndPartition(),
+                lease);
+    }
+}

--- a/lock-api/src/main/java/com/palantir/lock/v2/Lease.java
+++ b/lock-api/src/main/java/com/palantir/lock/v2/Lease.java
@@ -1,0 +1,60 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.v2;
+
+import java.time.Duration;
+import java.util.UUID;
+
+import org.immutables.value.Value;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.palantir.common.time.NanoTime;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableLease.class)
+@JsonDeserialize(as = ImmutableLease.class)
+public abstract class Lease {
+    @Value.Parameter
+    public abstract UUID leaseOwnerId();
+
+    @Value.Parameter
+    public abstract NanoTime startTime();
+
+    @Value.Parameter
+    public abstract Duration validity();
+
+    public boolean isValid(IdentifiedTime identifiedTime) {
+        return leaseOwnerId().equals(identifiedTime.clockId())
+                && identifiedTime.currentTimeNanos().isBefore(expiry());
+    }
+
+    public NanoTime expiry() {
+        return startTime().plus(validity());
+    }
+
+    public static Lease of(IdentifiedTime identifiedTime, Duration validity) {
+        return ImmutableLease.of(
+                identifiedTime.clockId(),
+                identifiedTime.currentTimeNanos(),
+                validity);
+    }
+
+    public static Lease of(UUID leaseOwnerId, NanoTime startTime, Duration period) {
+        return ImmutableLease.of(leaseOwnerId, startTime, period);
+    }
+}

--- a/lock-api/src/test/java/com/palantir/lock/client/LeasedLockTokenTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/LeasedLockTokenTest.java
@@ -55,5 +55,4 @@ public class LeasedLockTokenTest {
     private IdentifiedTime getIdentifiedTime() {
         return IdentifiedTime.of(LEADER_ID, NanoTime.now());
     }
-
 }

--- a/lock-api/src/test/java/com/palantir/lock/client/LeasedLockTokenTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/LeasedLockTokenTest.java
@@ -1,0 +1,59 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.UUID;
+
+import org.junit.Test;
+
+import com.palantir.common.time.NanoTime;
+import com.palantir.lock.v2.IdentifiedTime;
+import com.palantir.lock.v2.Lease;
+import com.palantir.lock.v2.LockToken;
+
+public class LeasedLockTokenTest {
+    private static final LockToken LOCK_TOKEN = LockToken.of(UUID.randomUUID());
+    private static final UUID LEADER_ID = UUID.randomUUID();
+
+    @Test
+    public void shouldCreateValidTokensUntilExpiry() {
+        LeasedLockToken token = LeasedLockToken.of(LOCK_TOKEN, Lease.of(getIdentifiedTime(), Duration.ofSeconds(1)));
+        assertThat(token.isValid(getIdentifiedTime())).isTrue();
+    }
+
+    @Test
+    public void shouldBeInvalidAfterExpiry() throws Exception {
+        LeasedLockToken token = LeasedLockToken.of(LOCK_TOKEN, Lease.of(getIdentifiedTime(), Duration.ofMillis(10)));
+        Thread.sleep(15);
+        assertThat(token.isValid(getIdentifiedTime())).isFalse();
+    }
+
+    @Test
+    public void shouldBeInvalidAfterInvalidation() {
+        LeasedLockToken token = LeasedLockToken.of(LOCK_TOKEN, Lease.of(getIdentifiedTime(), Duration.ofSeconds(1)));
+        token.inValidate();
+        assertThat(token.isValid(getIdentifiedTime())).isFalse();
+    }
+
+    private IdentifiedTime getIdentifiedTime() {
+        return IdentifiedTime.of(LEADER_ID, NanoTime.now());
+    }
+
+}

--- a/lock-api/src/test/java/com/palantir/lock/client/LeasedLockTokenTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/LeasedLockTokenTest.java
@@ -48,7 +48,7 @@ public class LeasedLockTokenTest {
     @Test
     public void shouldBeInvalidAfterInvalidation() {
         LeasedLockToken token = LeasedLockToken.of(LOCK_TOKEN, Lease.of(getIdentifiedTime(), Duration.ofSeconds(1)));
-        token.inValidate();
+        token.invalidate();
         assertThat(token.isValid(getIdentifiedTime())).isFalse();
     }
 


### PR DESCRIPTION
**Goals (and why)**:
Separating #3723 into smaller ones.
This pr introduces the interfaces used by lock-lease mechanism.

**Implementation Description (bullets)**:
Separating timelock client and service interfaces - so that we can add-remove functionality on server side without worrying about client side.

Also introducing leasable responses, where an additional `Lease` object is stored in addition to original response. So that clients can know how long they can trust to a lock.

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
