### PR TITLE
use nanoTime while reaping locks

### DIFF
--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/AsyncLockService.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/AsyncLockService.java
@@ -77,7 +77,7 @@ public class AsyncLockService implements Closeable {
             } catch (Throwable t) {
                 log.warn("Error while removing expired lock requests. Trying again on next iteration.", t);
             }
-        }, 0, LeaseExpirationTimer.LEASE_TIMEOUT_MILLIS / 2, TimeUnit.MILLISECONDS);
+        }, 0, LeaseExpirationTimer.LEASE_TIMEOUT.toMillis() / 2, TimeUnit.MILLISECONDS);
     }
 
     public AsyncResult<LockToken> lock(UUID requestId, Set<LockDescriptor> lockDescriptors, TimeLimit timeout) {

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/HeldLocks.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/HeldLocks.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 import javax.annotation.concurrent.GuardedBy;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.palantir.common.time.NanoTime;
 import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.v2.LockToken;
 
@@ -36,7 +37,7 @@ public class HeldLocks {
     private boolean isUnlocked = false;
 
     public HeldLocks(LockLog lockLog, Collection<AsyncLock> acquiredLocks, UUID requestId) {
-        this(lockLog, acquiredLocks, requestId, new LeaseExpirationTimer(System::currentTimeMillis));
+        this(lockLog, acquiredLocks, requestId, new LeaseExpirationTimer(NanoTime::now));
     }
 
     @VisibleForTesting

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LeaseExpirationTimer.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LeaseExpirationTimer.java
@@ -25,16 +25,16 @@ public class LeaseExpirationTimer {
 
     public static final Duration LEASE_TIMEOUT = Duration.ofMillis(20_000);
 
-    private final AtomicReference<NanoTime> lastRefreshTime;
+    private volatile NanoTime lastRefreshTime;
     private final Supplier<NanoTime> clock;
 
     public LeaseExpirationTimer(Supplier<NanoTime> clock) {
         this.clock = clock;
-        this.lastRefreshTime = new AtomicReference<>(clock.get());
+        this.lastRefreshTime = clock.get();
     }
 
     public void refresh() {
-        lastRefreshTime.set(clock.get());
+        lastRefreshTime = clock.get();
     }
 
     public boolean isExpired() {
@@ -42,6 +42,6 @@ public class LeaseExpirationTimer {
     }
 
     private NanoTime expiry() {
-        return lastRefreshTime.get().plus(LEASE_TIMEOUT);
+        return lastRefreshTime.plus(LEASE_TIMEOUT);
     }
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LeaseExpirationTimer.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LeaseExpirationTimer.java
@@ -15,26 +15,33 @@
  */
 package com.palantir.atlasdb.timelock.lock;
 
-import com.palantir.common.time.Clock;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import com.palantir.common.time.NanoTime;
 
 public class LeaseExpirationTimer {
 
-    public static final long LEASE_TIMEOUT_MILLIS = 20_000;
+    public static final Duration LEASE_TIMEOUT = Duration.ofMillis(20_000);
 
-    private volatile long lastRefreshTimeMillis;
-    private final Clock clock;
+    private final AtomicReference<NanoTime> lastRefreshTime;
+    private final Supplier<NanoTime> clock;
 
-    public LeaseExpirationTimer(Clock clock) {
+    public LeaseExpirationTimer(Supplier<NanoTime> clock) {
         this.clock = clock;
-        this.lastRefreshTimeMillis = clock.getTimeMillis();
+        this.lastRefreshTime = new AtomicReference<>(clock.get());
     }
 
     public void refresh() {
-        lastRefreshTimeMillis = clock.getTimeMillis();
+        lastRefreshTime.set(clock.get());
     }
 
     public boolean isExpired() {
-        return clock.getTimeMillis() > lastRefreshTimeMillis + LEASE_TIMEOUT_MILLIS;
+        return expiry().isBefore(clock.get());
     }
 
+    private NanoTime expiry() {
+        return lastRefreshTime.get().plus(LEASE_TIMEOUT);
+    }
 }

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceTest.java
@@ -49,7 +49,7 @@ public class AsyncLockServiceTest {
 
     private static final String LOCK_A = "a";
     private static final String LOCK_B = "b";
-    public static final long REAPER_PERIOD_MS = LeaseExpirationTimer.LEASE_TIMEOUT_MILLIS / 2;
+    public static final long REAPER_PERIOD_MS = LeaseExpirationTimer.LEASE_TIMEOUT.toMillis() / 2;
 
     private static final TimeLimit DEADLINE = TimeLimit.of(123L);
 

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/LeaseExpirationTimerTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/LeaseExpirationTimerTest.java
@@ -16,24 +16,25 @@
 package com.palantir.atlasdb.timelock.lock;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+
+import java.util.function.Supplier;
 
 import org.junit.Before;
 import org.junit.Test;
 
-import com.palantir.common.time.Clock;
+import com.palantir.common.time.NanoTime;
 
 public class LeaseExpirationTimerTest {
 
-    private static final long START_TIME_MILLIS = 123L;
+    private static final long START_TIME_NANOS = 123L;
 
-    private final Clock clock = mock(Clock.class);
+    private long currentTimeNanos = START_TIME_NANOS;
+    private final Supplier<NanoTime> clock = () -> NanoTime.createForTests(currentTimeNanos);
     private LeaseExpirationTimer timer;
 
     @Before
     public void before() {
-        when(clock.getTimeMillis()).thenReturn(START_TIME_MILLIS);
+        currentTimeNanos = START_TIME_NANOS;
         timer = new LeaseExpirationTimer(clock);
     }
 
@@ -44,24 +45,24 @@ public class LeaseExpirationTimerTest {
 
     @Test
     public void isExpiredWhenAppropriateTimeHasElapsed() {
-        mockOffsetFromStartTime(LeaseExpirationTimer.LEASE_TIMEOUT_MILLIS + 1L);
+        mockOffsetFromStartTime(LeaseExpirationTimer.LEASE_TIMEOUT.toNanos() + 1L);
 
         assertThat(timer.isExpired()).isTrue();
     }
 
     @Test
     public void refreshResetsTimer() {
-        mockOffsetFromStartTime(LeaseExpirationTimer.LEASE_TIMEOUT_MILLIS);
+        mockOffsetFromStartTime(LeaseExpirationTimer.LEASE_TIMEOUT.toNanos());
         timer.refresh();
 
-        mockOffsetFromStartTime(LeaseExpirationTimer.LEASE_TIMEOUT_MILLIS * 2);
+        mockOffsetFromStartTime(LeaseExpirationTimer.LEASE_TIMEOUT.toNanos() * 2);
         timer.refresh();
 
         assertThat(timer.isExpired()).isFalse();
     }
 
     private void mockOffsetFromStartTime(long offset) {
-        when(clock.getTimeMillis()).thenReturn(START_TIME_MILLIS + offset);
+        currentTimeNanos = START_TIME_NANOS + offset;
     }
 
 }

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/LeaseExpirationTimerTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/LeaseExpirationTimerTest.java
@@ -17,6 +17,7 @@ package com.palantir.atlasdb.timelock.lock;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
 import java.util.function.Supplier;
 
 import org.junit.Before;
@@ -45,24 +46,28 @@ public class LeaseExpirationTimerTest {
 
     @Test
     public void isExpiredWhenAppropriateTimeHasElapsed() {
-        mockOffsetFromStartTime(LeaseExpirationTimer.LEASE_TIMEOUT.toNanos() + 1L);
+        setTime(START_TIME_NANOS + leaseDuration().toNanos() + 1L);
 
         assertThat(timer.isExpired()).isTrue();
     }
 
     @Test
     public void refreshResetsTimer() {
-        mockOffsetFromStartTime(LeaseExpirationTimer.LEASE_TIMEOUT.toNanos());
+        setTime(START_TIME_NANOS + leaseDuration().toNanos());
         timer.refresh();
 
-        mockOffsetFromStartTime(LeaseExpirationTimer.LEASE_TIMEOUT.toNanos() * 2);
+        setTime(START_TIME_NANOS + leaseDuration().toNanos() * 2);
         timer.refresh();
 
         assertThat(timer.isExpired()).isFalse();
     }
 
-    private void mockOffsetFromStartTime(long offset) {
-        currentTimeNanos = START_TIME_NANOS + offset;
+    private void setTime(long nanos) {
+        currentTimeNanos = nanos;
+    }
+
+    private Duration leaseDuration() {
+        return LeaseExpirationTimer.LEASE_TIMEOUT;
     }
 
 }


### PR DESCRIPTION
**Goals (and why)**:
We are going to be using `System.nanoTime()` as the reference time for lock-leases; and we need to use the same reference clock while reaping the locks.

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
