### PR TITLE
Bump the minimum sls-cassandra dependency to 3.27.0

### DIFF
--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -95,7 +95,7 @@ recommendedProductDependencies {
     productDependency {
         productGroup = 'com.palantir.cassandra'
         productName = 'sls-cassandra'
-        minimumVersion = '3.24.0'
+        minimumVersion = '3.27.0'
         maximumVersion = '3.x.x'
     }
 }


### PR DESCRIPTION
Bumps the dependency to pull in a fix to Cassandra authorization.