### PR TITLE
do not create paxos dir on config deserialization

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -83,9 +83,10 @@ develop
            Previously, these were stored as separate entries, meaning that unnecessary values may have been written to the coordination store; this does not affect correctness, but is unperformant.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3733>`__)
 
-    *    - |changed|
-         - Timelock will now no longer create it's high level paxos directory at configuration de-serialization time. Instead it waits until creating each individual learner or acceptor log directory,
-           allowing timelock to rely more accurately on directory existence as a proxy for said timelock node being new or not.
+    *    - |changed| |improved|
+         - TimeLock will now no longer create its high level paxos directory at configuration de-serialization time.
+           Instead it waits until creating each individual learner or acceptor log directory, allowing timelock to rely more accurately on directory existence as a proxy for said timelock node being new or not.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3745>`__)
 
     *    - |improved|
          - AtlasDB now allows you to enable a new transaction retry strategy with exponential backoff via configs.

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -83,6 +83,10 @@ develop
            Previously, these were stored as separate entries, meaning that unnecessary values may have been written to the coordination store; this does not affect correctness, but is unperformant.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3733>`__)
 
+    *    - |changed|
+         - Timelock will now no longer create it's high level paxos directory at configuration de-serialization time. Instead it waits until creating each individual learner or acceptor log directory,
+           allowing timelock to rely more accurately on directory existence as a proxy for said timelock node being new or not.
+
 ========
 v0.116.1
 ========

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosInstallConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosInstallConfiguration.java
@@ -22,7 +22,6 @@ import org.immutables.value.Value;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.google.common.base.Preconditions;
 
 @JsonDeserialize(as = ImmutablePaxosInstallConfiguration.class)
 @JsonSerialize(as = ImmutablePaxosInstallConfiguration.class)

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosInstallConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosInstallConfiguration.java
@@ -62,8 +62,5 @@ public interface PaxosInstallConfiguration {
                             + "nodes, you have likely already made a mistake by this point. This is a non-trivial "
                             + "operation, please be careful and make sure that you have appropriate approvals.");
         }
-
-        Preconditions.checkArgument(dataDirectory().mkdirs() || dataDirectory().isDirectory(),
-                "Could not create paxos data directory %s", dataDirectory());
     }
 }

--- a/timelock-agent/src/test/java/com/palantir/timelock/config/PaxosInstallConfigurationTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/config/PaxosInstallConfigurationTest.java
@@ -18,6 +18,7 @@ package com.palantir.timelock.config;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -28,7 +29,7 @@ import org.junit.Test;
 public class PaxosInstallConfigurationTest {
 
     @Test
-    public void canCreateDirectoryForPaxosDirectoryIfNewService() {
+    public void doesNotCreateDirectoryForPaxosDirectoryIfNewService() {
         File mockFile = getMockFileWith(false, true);
 
         ImmutablePaxosInstallConfiguration.builder()
@@ -36,7 +37,7 @@ public class PaxosInstallConfigurationTest {
                 .isNewService(true)
                 .build();
 
-        verify(mockFile).mkdirs();
+        verify(mockFile, times(0)).mkdirs();
     }
 
     @Test
@@ -49,15 +50,6 @@ public class PaxosInstallConfigurationTest {
                 .build();
 
         verify(mockFile, atLeastOnce()).isDirectory();
-    }
-
-    @Test
-    public void throwsIfCannotCreatePaxosDirectory() {
-        File mockFile = getMockFileWith(false, false);
-
-        assertFailsToBuildConfiguration(ImmutablePaxosInstallConfiguration.builder()
-                .dataDirectory(mockFile)
-                .isNewService(true));
     }
 
     @Test


### PR DESCRIPTION
**Goals (and why)**: see internal issue 287 for timelock