### PR TITLE
[PDS-82684] Feign Target Edge Case Sadness

### DIFF
--- a/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/FailoverFeignTarget.java
+++ b/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/FailoverFeignTarget.java
@@ -74,7 +74,7 @@ public class FailoverFeignTarget<T> implements Target<T>, Retryer {
     }
 
     @VisibleForTesting
-    public FailoverFeignTarget(Collection<String> servers, int maxBackoffMillis, Class<T> type, LongSupplier clock) {
+    FailoverFeignTarget(Collection<String> servers, int maxBackoffMillis, Class<T> type, LongSupplier clock) {
         Preconditions.checkArgument(maxBackoffMillis > 0);
         this.servers = ImmutableList.copyOf(ImmutableSet.copyOf(servers));
         this.type = type;

--- a/atlasdb-feign/src/test/java/com/palantir/atlasdb/http/FailoverFeignTargetTest.java
+++ b/atlasdb-feign/src/test/java/com/palantir/atlasdb/http/FailoverFeignTargetTest.java
@@ -174,6 +174,14 @@ public class FailoverFeignTargetTest {
     }
 
     @Test
+    public void failsDueToFastFailoverIfAllNodesHaveBeenTalkedTo() {
+        simulateRequestOnClockedTargetAndAdvanceClock(EXCEPTION_WITH_RETRY_AFTER);
+        simulateRequestOnClockedTargetAndAdvanceClock(EXCEPTION_WITH_RETRY_AFTER);
+        assertThatThrownBy(() -> simulateRequestOnClockedTargetAndAdvanceClock(EXCEPTION_WITH_RETRY_AFTER))
+                .isEqualTo(EXCEPTION_WITH_RETRY_AFTER);
+    }
+
+    @Test
     public void retriesOnSameNodeIfBlockingTimeoutIsLastAllowedFailureBeforeSwitch() {
         for (int i = 1; i < normalTarget.failuresBeforeSwitching; i++) {
             simulateRequest(normalTarget);

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -87,6 +87,11 @@ develop
          - AtlasDB now allows you to enable a new transaction retry strategy with exponential backoff via configs.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3749>`__)
 
+    *    - |fixed|
+         - ``FailoverFeignTarget`` now retries correctly if calls to individual nodes take a long time and eventually fail with an exception.
+           Previously, we could fail out without having tried all nodes under certain circumstances, even when there existed a node that could legitimately service a request.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/QQQQ>`__)
+
 ========
 v0.116.1
 ========

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -90,7 +90,7 @@ develop
     *    - |fixed|
          - ``FailoverFeignTarget`` now retries correctly if calls to individual nodes take a long time and eventually fail with an exception.
            Previously, we could fail out without having tried all nodes under certain circumstances, even when there existed a node that could legitimately service a request.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/QQQQ>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3752>`__)
 
 ========
 v0.116.1


### PR DESCRIPTION
**Goals (and why)**:
- Internal ref. PDS-82684
- This fixes an edge case where timelock / something pointed to by an AtlasDbHttpClient can throw even when the cluster is good. Specifically, suppose you have three nodes `n1`, `n2` and `n3`, where `n3` is the leader and `n2` takes a long time to respond and eventually fails the request. Then, we will try `n1` and obtain that it is not the leader which starts a ten-second clock on fast failover exceptions. We then try `n2`, which after a long time tosses out a socket timeout exception. The ten-second clock has run out, so we fail, rather than trying `n3`.

**Implementation Description (bullets)**:
- Require additionally that we have tried all nodes at least once before failing out.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- I added two tests that would have failed under the old model.

**Concerns (what feedback would you like?)**:
- Are there concurrency issues I'm missing out? It seems the purpose of using `AtomicLong` and `AtomicReference` is for visibility, not concurrency; each request gets its own copy of the target (looking at the javadoc for `Retryer`).
- Is this bad for performance? I think it's fine, as it is no worse than what we already have today, and also once we figure out which node the leader is, we'll stay pinned to that node until there is a leader election or network failure there.
- There is a similar bug for clusters of size 15 and above, though timelock generally isn't run in a 15-node configuration so we haven't run into that.

**Where should we start reviewing?**: FailoverFeignTarget

**Priority (whenever / two weeks / yesterday)**: yesterday 🔥 
