### PR TITLE
move timelock dep to lock-api

### DIFF
--- a/atlasdb-config/build.gradle
+++ b/atlasdb-config/build.gradle
@@ -1,6 +1,5 @@
 apply from: "../gradle/publish-jars.gradle"
 apply plugin: 'org.inferred.processors'
-apply plugin: 'com.palantir.sls-recommended-dependencies'
 
 apply from: "../gradle/shared.gradle"
 
@@ -46,13 +45,4 @@ dependencies {
     testCompile group: 'org.awaitility', name: 'awaitility'
     // Needed for Jersey Response-based tests
     testCompile group: 'org.glassfish.jersey.core', name: 'jersey-common'
-}
-
-recommendedProductDependencies {
-    productDependency {
-        productGroup = 'com.palantir.timelock'
-        productName = 'timelock-server'
-        minimumVersion = '0.51.0'
-        maximumVersion = '0.x.x'
-    }
 }

--- a/lock-api/build.gradle
+++ b/lock-api/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'org.inferred.processors'
+apply plugin: 'com.palantir.sls-recommended-dependencies'
 
 apply from: "../gradle/publish-jars.gradle"
 apply from: "../gradle/shared.gradle"
@@ -34,4 +35,13 @@ dependencies {
       exclude group: 'org.hamcrest'
     }
     testCompile group: 'org.mockito', name: 'mockito-core'
+}
+
+recommendedProductDependencies {
+    productDependency {
+        productGroup = 'com.palantir.timelock'
+        productName = 'timelock-server'
+        minimumVersion = '0.51.0'
+        maximumVersion = '0.x.x'
+    }
 }


### PR DESCRIPTION
atlasdb-config has a dep on lock-api so this isn't a break. It just makes sure people who are only dep'ing on lock-api and not atlasdb-config can detect constraints.