### PR TITLE
Fix getRowColumnRange NPEs

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -864,9 +864,10 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                         RowColumnRangeExtractor extractor = new RowColumnRangeExtractor(metricsManager);
                         extractor.extractResults(ImmutableList.of(row), results, startTs);
                         RowColumnRangeExtractor.RowColumnRangeResult decoded = extractor.getRowColumnRangeResult();
-                        //if (decoded.getResults().isEmpty()) {
-                        //    return SimpleTokenBackedResultsPage.create(startCol, ImmutableList.of(), false);
-                        //}
+                        if (decoded.getResults().isEmpty()) {
+                            return SimpleTokenBackedResultsPage.create(startCol, ImmutableList.of(),
+                                    values.size() >= batchColumnRangeSelection.getBatchHint());
+                        }
                         Map<Cell, Value> ret = decoded.getResults().get(row);
 
                         ColumnOrSuperColumn lastColumn = values.get(values.size() - 1);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -865,6 +865,17 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                         extractor.extractResults(ImmutableList.of(row), results, startTs);
                         RowColumnRangeExtractor.RowColumnRangeResult decoded = extractor.getRowColumnRangeResult();
                         if (decoded.getResults().isEmpty()) {
+                            if (values.size() == 1) {
+                                throw new RuntimeException("Found 1 result");
+                            }
+                            if (values.size() == 2) {
+                                throw new RuntimeException("Found 2 results");
+                            }
+                            if (values.size() > 2) {
+                                throw new RuntimeException("Found >2 results");
+                            }
+                            // Need to move startCol forward
+                            // What if all we read were versions of the same row?
                             return SimpleTokenBackedResultsPage.create(startCol, ImmutableList.of(),
                                     values.size() >= batchColumnRangeSelection.getBatchHint());
                         }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -21,7 +21,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -568,6 +568,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
 
                                 Map<ByteBuffer, List<ColumnOrSuperColumn>> results = wrappingQueryRunner.multiget(
                                         "getRows", client, tableRef, rowNames, pred, readConsistency);
+
                                 Map<Cell, Value> ret = Maps.newHashMapWithExpectedSize(batch.size());
                                 new ValueExtractor(metricsManager, ret)
                                         .extractResults(results, startTs, ColumnSelection.all());
@@ -863,6 +864,9 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                         RowColumnRangeExtractor extractor = new RowColumnRangeExtractor(metricsManager);
                         extractor.extractResults(ImmutableList.of(row), results, startTs);
                         RowColumnRangeExtractor.RowColumnRangeResult decoded = extractor.getRowColumnRangeResult();
+                        if (decoded.getResults().isEmpty()) {
+                            return SimpleTokenBackedResultsPage.create(startCol, ImmutableList.of(), false);
+                        }
                         Map<Cell, Value> ret = decoded.getResults().get(row);
 
                         ColumnOrSuperColumn lastColumn = values.get(values.size() - 1);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -723,7 +723,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             RowColumnRangeExtractor.RowColumnRangeResult firstPage =
                     getRowsColumnRangeForSingleHost(host, tableRef, rows, batchColumnRangeSelection, startTs);
 
-            Map<byte[], LinkedHashMap<Cell, Value>> results = firstPage.getResults();
+            Map<byte[], Map<Cell, Value>> results = firstPage.getResults();
             Map<byte[], Column> rowsToLastCompositeColumns = firstPage.getRowsToLastCompositeColumns();
             Map<byte[], byte[]> incompleteRowsToNextColumns = Maps.newHashMap();
             for (Entry<byte[], Column> e : rowsToLastCompositeColumns.entrySet()) {
@@ -865,7 +865,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                         RowColumnRangeExtractor.RowColumnRangeResult decoded = extractor.getRowColumnRangeResult();
 
                         // May be empty if all results are at ts > startTs
-                        Map<Cell, Value> ret = decoded.getResults().getOrDefault(row, Maps.newLinkedHashMap());
+                        Map<Cell, Value> ret = decoded.getResults().getOrDefault(row, Collections.emptyMap());
                         ColumnOrSuperColumn lastColumn = values.get(values.size() - 1);
                         byte[] lastCol = CassandraKeyValueServices.decomposeName(lastColumn.getColumn()).getLhSide();
                         // Same idea as the getRows case to handle seeing only newer entries of a column

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -863,15 +863,9 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                         RowColumnRangeExtractor extractor = new RowColumnRangeExtractor(metricsManager);
                         extractor.extractResults(ImmutableList.of(row), results, startTs);
                         RowColumnRangeExtractor.RowColumnRangeResult decoded = extractor.getRowColumnRangeResult();
-                        if (decoded.getResults().isEmpty()) {
-                            // All returned results were at ts > startTs
-                            // Start the next page from the last column seen to ensure forward progress
-                            byte[] lastColumn = extractor.getLastColumnForRow(row).get();
-                            return SimpleTokenBackedResultsPage.create(lastColumn, ImmutableList.of(),
-                                    values.size() >= batchColumnRangeSelection.getBatchHint());
-                        }
-                        Map<Cell, Value> ret = decoded.getResults().get(row);
 
+                        // May be empty if all results are at ts > startTs
+                        Map<Cell, Value> ret = decoded.getResults().getOrDefault(row, Maps.newLinkedHashMap());
                         ColumnOrSuperColumn lastColumn = values.get(values.size() - 1);
                         byte[] lastCol = CassandraKeyValueServices.decomposeName(lastColumn.getColumn()).getLhSide();
                         // Same idea as the getRows case to handle seeing only newer entries of a column

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -864,9 +864,9 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                         RowColumnRangeExtractor extractor = new RowColumnRangeExtractor(metricsManager);
                         extractor.extractResults(ImmutableList.of(row), results, startTs);
                         RowColumnRangeExtractor.RowColumnRangeResult decoded = extractor.getRowColumnRangeResult();
-                        if (decoded.getResults().isEmpty()) {
-                            return SimpleTokenBackedResultsPage.create(startCol, ImmutableList.of(), false);
-                        }
+                        //if (decoded.getResults().isEmpty()) {
+                        //    return SimpleTokenBackedResultsPage.create(startCol, ImmutableList.of(), false);
+                        //}
                         Map<Cell, Value> ret = decoded.getResults().get(row);
 
                         ColumnOrSuperColumn lastColumn = values.get(values.size() - 1);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -568,7 +568,6 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
 
                                 Map<ByteBuffer, List<ColumnOrSuperColumn>> results = wrappingQueryRunner.multiget(
                                         "getRows", client, tableRef, rowNames, pred, readConsistency);
-
                                 Map<Cell, Value> ret = Maps.newHashMapWithExpectedSize(batch.size());
                                 new ValueExtractor(metricsManager, ret)
                                         .extractResults(results, startTs, ColumnSelection.all());

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/RowColumnRangeExtractor.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/RowColumnRangeExtractor.java
@@ -72,11 +72,9 @@ class RowColumnRangeExtractor {
     private final Map<byte[], Column> rowsToLastCompositeColumns = Maps.newHashMap();
     private final Map<byte[], Integer> rowsToRawColumnCount = Maps.newHashMap();
     private final Set<byte[]> emptyRows = Sets.newHashSet();
-    private final MetricsManager metricsManager;
     private final Meter notLatestVisibleValueCellFilterMeter;
 
     RowColumnRangeExtractor(MetricsManager metricsManager) {
-        this.metricsManager = metricsManager;
         notLatestVisibleValueCellFilterMeter = metricsManager.registerOrGetMeter(
                 RowColumnRangeExtractor.class,
                 AtlasDbMetricNames.CellFilterMetrics.NOT_LATEST_VISIBLE_VALUE);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/RowColumnRangeExtractor.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/RowColumnRangeExtractor.java
@@ -16,6 +16,7 @@
 package com.palantir.atlasdb.keyvalue.cassandra;
 
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -51,20 +52,20 @@ class RowColumnRangeExtractor {
             this.rowsToRawColumnCount = rowsToRawColumnCount;
         }
 
-        public Map<byte[], LinkedHashMap<Cell, Value>> getResults() {
-            return results;
+        public Map<byte[], Map<Cell, Value>> getResults() {
+            return Collections.unmodifiableMap(results);
         }
 
         public Map<byte[], Column> getRowsToLastCompositeColumns() {
-            return rowsToLastCompositeColumns;
+            return Collections.unmodifiableMap(rowsToLastCompositeColumns);
         }
 
         public Set<byte[]> getEmptyRows() {
-            return emptyRows;
+            return Collections.unmodifiableSet(emptyRows);
         }
 
         public Map<byte[], Integer> getRowsToRawColumnCount() {
-            return rowsToRawColumnCount;
+            return Collections.unmodifiableMap(rowsToRawColumnCount);
         }
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/RowColumnRangeExtractor.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/RowColumnRangeExtractor.java
@@ -19,7 +19,6 @@ import java.nio.ByteBuffer;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 import org.apache.cassandra.thrift.Column;
@@ -122,11 +121,5 @@ class RowColumnRangeExtractor {
 
     public RowColumnRangeResult getRowColumnRangeResult() {
         return new RowColumnRangeResult(collector, rowsToLastCompositeColumns, emptyRows, rowsToRawColumnCount);
-    }
-
-    public Optional<byte[]> getLastColumnForRow(byte[] row) {
-        return Optional.ofNullable(rowsToLastCompositeColumns.get(row))
-                .map(CassandraKeyValueServices::decomposeName)
-                .map(Pair::getLhSide);
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/RowColumnRangeExtractor.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/RowColumnRangeExtractor.java
@@ -19,6 +19,7 @@ import java.nio.ByteBuffer;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.apache.cassandra.thrift.Column;
@@ -123,4 +124,9 @@ class RowColumnRangeExtractor {
         return new RowColumnRangeResult(collector, rowsToLastCompositeColumns, emptyRows, rowsToRawColumnCount);
     }
 
+    public Optional<byte[]> getLastColumnForRow(byte[] row) {
+        return Optional.ofNullable(rowsToLastCompositeColumns.get(row))
+                .map(CassandraKeyValueServices::decomposeName)
+                .map(Pair::getLhSide);
+    }
 }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -58,10 +58,12 @@ import com.palantir.atlasdb.cleaner.NoOpCleaner;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
 import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
 import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.RangeRequests;
+import com.palantir.atlasdb.keyvalue.api.RowColumnRangeIterator;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
@@ -256,6 +258,20 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
         byte[] rowBytes = PtBytes.toBytes("row1");
         ImmutableList<RowResult<Value>> list = ImmutableList.copyOf(keyValueService.getRange(TEST_TABLE, RangeRequest.builder().startRowInclusive(rowBytes).endRowExclusive(rowBytes).build(), 1));
         assertTrue(list.isEmpty());
+    }
+
+    @Test
+    public void testKeyValueRange_allResultsPostFiltered() {
+        putDirect("row1", "col1", "v1", 5);
+
+        byte[] rowBytes = PtBytes.toBytes("row1");
+        RowColumnRangeIterator iterator = keyValueService.getRowsColumnRange(
+                TEST_TABLE,
+                ImmutableList.of(rowBytes),
+                new ColumnRangeSelection(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY),
+                1,
+                1);
+        assertFalse(iterator.hasNext());
     }
 
     @Test

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -289,7 +289,7 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
                 new ColumnRangeSelection(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY),
                 1,
                 1);
-        assertEquals(iterator.next().getValue(), "v3");
+        assertEquals(PtBytes.toBytes("v3"), iterator.next().getValue());
         assertFalse(iterator.hasNext());
     }
 

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -263,6 +263,7 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
     @Test
     public void testKeyValueRange_allResultsPostFiltered() {
         putDirect("row1", "col1", "v1", 5);
+        putDirect("row1", "col2", "v2", 5);
 
         byte[] rowBytes = PtBytes.toBytes("row1");
         RowColumnRangeIterator iterator = keyValueService.getRowsColumnRange(

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -290,7 +290,7 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
                 new ColumnRangeSelection(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY),
                 1,
                 1);
-        assertThat(PtBytes.toBytes("v3")).isEqualTo(iterator.next().getValue());
+        assertThat(PtBytes.toBytes("v3")).isEqualTo(iterator.next().getValue().getContents());
         assertFalse(iterator.hasNext());
     }
 

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -316,6 +316,27 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
     }
 
     @Test
+    public void testRowsColumnRange_abortsCorrectlyHalfway() {
+        putDirect("row1", "col1", "v1a", 3);
+        putDirect("row1", "col1", "v1b", 4);
+        putDirect("row1", "col1", "v1c", 5);
+        putDirect("row1", "col1", "v1d", 7);
+        putDirect("row1", "col1", "v1e", 8);
+        putDirect("row1", "col2", "v2", 5);
+
+        byte[] rowBytes = PtBytes.toBytes("row1");
+        RowColumnRangeIterator iterator = keyValueService.getRowsColumnRange(
+                TEST_TABLE,
+                ImmutableList.of(rowBytes),
+                new ColumnRangeSelection(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY),
+                1,
+                6);
+        assertThat(PtBytes.toBytes("v1c")).isEqualTo(iterator.next().getValue().getContents());
+        assertThat(PtBytes.toBytes("v2")).isEqualTo(iterator.next().getValue().getContents());
+        assertThat(iterator.hasNext()).isFalse();
+    }
+
+    @Test
     public void testKeyValueRangeColumnSelection() {
         putDirect("row1", "col1", "v1", 0);
         putDirect("row1", "col2", "v2", 2);

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -275,6 +275,22 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
     }
 
     @Test
+    public void testKeyValueRange_postFilteredFirstPage() {
+        putDirect("row1", "col1", "v1", 5);
+        putDirect("row1", "col2", "v2", 5);
+        putDirect("row1", "col3", "v3", 0);
+
+        byte[] rowBytes = PtBytes.toBytes("row1");
+        RowColumnRangeIterator iterator = keyValueService.getRowsColumnRange(
+                TEST_TABLE,
+                ImmutableList.of(rowBytes),
+                new ColumnRangeSelection(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY),
+                1,
+                1);
+        assertTrue(iterator.hasNext());
+    }
+
+    @Test
     public void testKeyValueRangeColumnSelection() {
         putDirect("row1", "col1", "v1", 0);
         putDirect("row1", "col2", "v2", 2);

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -273,7 +273,7 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
                 new ColumnRangeSelection(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY),
                 1,
                 1);
-        assertFalse(iterator.hasNext());
+        assertThat(iterator.hasNext()).isFalse();
     }
 
     @Test
@@ -291,7 +291,28 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
                 1,
                 1);
         assertThat(PtBytes.toBytes("v3")).isEqualTo(iterator.next().getValue().getContents());
-        assertFalse(iterator.hasNext());
+        assertThat(iterator.hasNext()).isFalse();
+    }
+
+    @Test
+    public void testRowsColumnRange_forwardProgressAfterValidResult() {
+        putDirect("row1", "col1", "v1a", 1);
+        putDirect("row1", "col1", "v1b", 2);
+        putDirect("row1", "col1", "v1c", 3);
+        putDirect("row1", "col1", "v1d", 4);
+        putDirect("row1", "col1", "v1e", 5);
+        putDirect("row1", "col2", "v2", 5);
+
+        byte[] rowBytes = PtBytes.toBytes("row1");
+        RowColumnRangeIterator iterator = keyValueService.getRowsColumnRange(
+                TEST_TABLE,
+                ImmutableList.of(rowBytes),
+                new ColumnRangeSelection(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY),
+                1,
+                6);
+        assertThat(PtBytes.toBytes("v1e")).isEqualTo(iterator.next().getValue().getContents());
+        assertThat(PtBytes.toBytes("v2")).isEqualTo(iterator.next().getValue().getContents());
+        assertThat(iterator.hasNext()).isFalse();
     }
 
     @Test

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -278,6 +278,7 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
     @Test
     public void testKeyValueRange_postFilteredFirstPage() {
         putDirect("row1", "col1", "v1", 5);
+        putDirect("row1", "col1", "v1a", 6);
         putDirect("row1", "col2", "v2", 5);
         putDirect("row1", "col3", "v3", 0);
 
@@ -288,7 +289,8 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
                 new ColumnRangeSelection(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY),
                 1,
                 1);
-        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next().getValue(), "v3");
+        assertFalse(iterator.hasNext());
     }
 
     @Test

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -261,7 +261,7 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
     }
 
     @Test
-    public void testKeyValueRange_allResultsPostFiltered() {
+    public void testRowsColumnRange_allResultsPostFiltered() {
         putDirect("row1", "col1", "v1", 5);
         putDirect("row1", "col2", "v2", 5);
 
@@ -276,7 +276,7 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
     }
 
     @Test
-    public void testKeyValueRange_postFilteredFirstPage() {
+    public void testRowsColumnRange_postFilteredFirstPage() {
         putDirect("row1", "col1", "v1", 5);
         putDirect("row1", "col1", "v1a", 6);
         putDirect("row1", "col2", "v2", 5);

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.transaction.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -289,7 +290,7 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
                 new ColumnRangeSelection(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY),
                 1,
                 1);
-        assertEquals(PtBytes.toBytes("v3"), iterator.next().getValue());
+        assertThat(PtBytes.toBytes("v3")).isEqualTo(iterator.next().getValue());
         assertFalse(iterator.hasNext());
     }
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -83,6 +83,10 @@ develop
            Previously, these were stored as separate entries, meaning that unnecessary values may have been written to the coordination store; this does not affect correctness, but is unperformant.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3733>`__)
 
+    *    - |fixed|
+         - Fixed cases where column range scans could result in NullPointerExceptions when there were concurrent writes to the same range.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3756>`__)
+
 ========
 v0.116.1
 ========


### PR DESCRIPTION
**Goals (and why)**:
Fixes #3743 

**Implementation Description (bullets)**:
Handle the case where all results for the specified row had ts > startTs, which causes them to be filtered out and the returned results to be null. In this case, we should return an empty page and be careful to specify the correct behavior for whether or not there are potentially more results on subsequent pages. To avoid infinite paging loops, we must also extract the last column returned in the current page.

The next paging request will specify a start range using both the start column and the start timestamp, which means that we'll only return valid results or move on to the next column.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added several new test cases, all of which NPEd without the fix. Several tests cover additional edge cases where one might retrieve an entire page of results with ts > startTs, at which point it's important to continue paging, as there may be real results that are visible, or other edge cases in the paging logic.

**Concerns (what feedback would you like?)**:
Is the paging logic correct? Any more edge cases to test?

**Where should we start reviewing?**:
CKVSI

**Priority (whenever / two weeks / yesterday)**:
Soon, active support issue

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
