### PR TITLE
[_transactions2] Part 23: Tuning Tables for Cassandra

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTableCreationIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTableCreationIntegrationTest.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -25,6 +26,9 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
+import org.apache.cassandra.thrift.CfDef;
+import org.apache.cassandra.thrift.KsDef;
+import org.apache.thrift.TException;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -33,16 +37,19 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.MoreCollectors;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.containers.CassandraResource;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.keyvalue.impl.AbstractKeyValueService;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
 import com.palantir.atlasdb.table.description.TableDefinition;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
+import com.palantir.atlasdb.transaction.impl.TransactionConstants;
 
 public class CassandraKeyValueServiceTableCreationIntegrationTest {
     private static final TableReference GOOD_TABLE = TableReference.createFromFullyQualifiedName("foo.bar");
@@ -164,6 +171,29 @@ public class CassandraKeyValueServiceTableCreationIntegrationTest {
         assertThat(initialMetadata, is(existingMetadata));
 
         kvs.dropTable(caseSensitiveTable);
+    }
+
+    @Test
+    public void testCreateTransactions2TableProducesCorrectMetadata() throws TException {
+        kvs.createTable(
+                TransactionConstants.TRANSACTIONS2_TABLE,
+                TransactionConstants.TRANSACTIONS2_TABLE_METADATA.persistToBytes());
+
+        KsDef ksDef = kvs.getClientPool()
+                .run(client -> client.describe_keyspace(CASSANDRA.getConfig().getKeyspaceOrThrow()));
+        CfDef transactions2CfDef = ksDef.cf_defs.stream()
+                .filter(cfDef -> cfDef.name.equals(
+                        AbstractKeyValueService.internalTableName(TransactionConstants.TRANSACTIONS2_TABLE)))
+                .collect(MoreCollectors.onlyElement());
+        assertThat(transactions2CfDef.bloom_filter_fp_chance, equalTo(
+                CassandraConstants.DENSELY_ACCESSED_WIDE_ROWS_BLOOM_FILTER_FP_CHANCE));
+        assertThat(transactions2CfDef.min_index_interval,
+                equalTo(CassandraConstants.DENSELY_ACCESSED_WIDE_ROWS_INDEX_INTERVAL));
+        assertThat(transactions2CfDef.max_index_interval,
+                equalTo(CassandraConstants.DENSELY_ACCESSED_WIDE_ROWS_INDEX_INTERVAL));
+        assertThat(transactions2CfDef.compression_options.get(CassandraConstants.CFDEF_COMPRESSION_CHUNK_LENGTH_KEY),
+                equalTo(String.valueOf(
+                        TransactionConstants.TRANSACTIONS2_TABLE_METADATA.getExplicitCompressionBlockSizeKB())));
     }
 
     private static CassandraKeyValueService kvsWithSchemaMutationTimeout(int millis) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConstants.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConstants.java
@@ -25,6 +25,7 @@ public final class CassandraConstants {
     static final double DEFAULT_SIZE_TIERED_COMPACTION_BLOOM_FILTER_FP_CHANCE = 0.01;
     static final double NEGATIVE_LOOKUPS_BLOOM_FILTER_FP_CHANCE = 0.01;
     static final double NEGATIVE_LOOKUPS_SIZE_TIERED_BLOOM_FILTER_FP_CHANCE = 0.0001;
+    static final double DENSELY_ACCESSED_WIDE_ROWS_BLOOM_FILTER_FP_CHANCE = 0.0001;
     static final String SIMPLE_STRATEGY = "org.apache.cassandra.locator.SimpleStrategy";
     static final String NETWORK_STRATEGY = "org.apache.cassandra.locator.NetworkTopologyStrategy";
 
@@ -58,6 +59,10 @@ public final class CassandraConstants {
     public static final int DEFAULT_MUTATION_BATCH_SIZE_BYTES = 4 * 1024 * 1024;
     public static final int DEFAULT_MUTATION_BATCH_COUNT = 5000;
     public static final int DEFAULT_UNRESPONSIVE_HOST_BACKOFF_TIME_SECONDS = 30;
+
+    static final int DENSELY_ACCESSED_WIDE_ROWS_INDEX_INTERVAL = 1;
+    static final int DEFAULT_MiN_INDEX_INTERVAL = 128;
+    static final int DEFAULT_MAX_INDEX_INTERVAL = 2048;
 
     static final long CAS_TABLE_TIMESTAMP = 0L;
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConstants.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConstants.java
@@ -61,7 +61,7 @@ public final class CassandraConstants {
     public static final int DEFAULT_UNRESPONSIVE_HOST_BACKOFF_TIME_SECONDS = 30;
 
     static final int DENSELY_ACCESSED_WIDE_ROWS_INDEX_INTERVAL = 1;
-    static final int DEFAULT_MiN_INDEX_INTERVAL = 128;
+    static final int DEFAULT_MIN_INDEX_INTERVAL = 128;
     static final int DEFAULT_MAX_INDEX_INTERVAL = 2048;
 
     static final long CAS_TABLE_TIMESTAMP = 0L;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -24,7 +24,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -1478,15 +1477,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     }
 
     private boolean metadataIsDifferent(byte[] existingMetadata, byte[] requestMetadata) {
-        TableMetadata existingMetadataObject;
-        try {
-            existingMetadataObject = TableMetadata.BYTES_HYDRATOR.hydrateFromBytes(existingMetadata);
-        } catch (Exception e) {
-            // Not deserializable, so we are different.
-            return true;
-        }
-        TableMetadata requestMetadataObject = TableMetadata.BYTES_HYDRATOR.hydrateFromBytes(requestMetadata);
-        return Objects.equals(requestMetadataObject, existingMetadataObject);
+        return !Arrays.equals(existingMetadata, requestMetadata);
     }
 
     private void putMetadataAndMaybeAlterTables(

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -1477,7 +1478,15 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     }
 
     private boolean metadataIsDifferent(byte[] existingMetadata, byte[] requestMetadata) {
-        return !Arrays.equals(existingMetadata, requestMetadata);
+        TableMetadata existingMetadataObject;
+        try {
+            existingMetadataObject = TableMetadata.BYTES_HYDRATOR.hydrateFromBytes(existingMetadata);
+        } catch (Exception e) {
+            // Not deserializable, so we are different.
+            return true;
+        }
+        TableMetadata requestMetadataObject = TableMetadata.BYTES_HYDRATOR.hydrateFromBytes(requestMetadata);
+        return Objects.equals(requestMetadataObject, existingMetadataObject);
     }
 
     private void putMetadataAndMaybeAlterTables(

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTableCreator.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTableCreator.java
@@ -80,7 +80,7 @@ class CassandraTableCreator {
                 .addClusteringColumn(TIMESTAMP, DataType.bigint())
                 .addColumn(VALUE, DataType.blob())
                 .withOptions()
-                .bloomFilterFPChance(falsePositive(tableMetadata))
+                .bloomFilterFPChance(CassandraTableOptions.bloomFilterFpChance(tableMetadata))
                 .caching(SchemaBuilder.Caching.KEYS_ONLY)
                 .compactionOptions(getCompaction(appendHeavyReadLight))
                 .compactStorage()
@@ -104,7 +104,7 @@ class CassandraTableCreator {
     private int minIndexInterval(TableMetadata tableMetadata) {
         return tableMetadata.hasDenselyAccessedWideRows()
                 ? CassandraConstants.DENSELY_ACCESSED_WIDE_ROWS_INDEX_INTERVAL
-                : CassandraConstants.DEFAULT_MiN_INDEX_INTERVAL;
+                : CassandraConstants.DEFAULT_MIN_INDEX_INTERVAL;
     }
 
     private int maxIndexInterval(TableMetadata tableMetadata) {
@@ -115,20 +115,6 @@ class CassandraTableCreator {
 
     private String wrapInQuotes(String string) {
         return "\"" + string + "\"";
-    }
-
-    private double falsePositive(TableMetadata tableMetadata) {
-        if (tableMetadata.hasDenselyAccessedWideRows()) {
-            return CassandraConstants.DENSELY_ACCESSED_WIDE_ROWS_BLOOM_FILTER_FP_CHANCE;
-        }
-        if (tableMetadata.isAppendHeavyAndReadLight()) {
-            return tableMetadata.hasNegativeLookups()
-                    ? CassandraConstants.NEGATIVE_LOOKUPS_SIZE_TIERED_BLOOM_FILTER_FP_CHANCE
-                    : CassandraConstants.DEFAULT_SIZE_TIERED_COMPACTION_BLOOM_FILTER_FP_CHANCE;
-        }
-        return tableMetadata.hasNegativeLookups()
-                ? CassandraConstants.NEGATIVE_LOOKUPS_BLOOM_FILTER_FP_CHANCE
-                : CassandraConstants.DEFAULT_LEVELED_COMPACTION_BLOOM_FILTER_FP_CHANCE;
     }
 
     private CompactionOptions<?> getCompaction(boolean appendHeavyReadLight) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTableCreator.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTableCreator.java
@@ -87,8 +87,8 @@ class CassandraTableCreator {
                 .compressionOptions(getCompression(tableMetadata.getExplicitCompressionBlockSizeKB()))
                 .dcLocalReadRepairChance(0.1)
                 .gcGraceSeconds(config.gcGraceSeconds())
-                .minIndexInterval(minIndexInterval(tableMetadata))
-                .maxIndexInterval(maxIndexInterval(tableMetadata))
+                .minIndexInterval(CassandraTableOptions.minIndexInterval(tableMetadata))
+                .maxIndexInterval(CassandraTableOptions.maxIndexInterval(tableMetadata))
                 .populateIOCacheOnFlush(tableMetadata.getCachePriority() == CachePriority.HOTTEST)
                 .speculativeRetry(SchemaBuilder.noSpeculativeRetry())
                 .clusteringOrder(COLUMN, SchemaBuilder.Direction.ASC)
@@ -99,18 +99,6 @@ class CassandraTableCreator {
                 .safeQueryFormat(query + " AND id = '%s'")
                 .addArgs(SafeArg.of("cfId", getUuidForTable(tableRef)))
                 .build();
-    }
-
-    private int minIndexInterval(TableMetadata tableMetadata) {
-        return tableMetadata.hasDenselyAccessedWideRows()
-                ? CassandraConstants.DENSELY_ACCESSED_WIDE_ROWS_INDEX_INTERVAL
-                : CassandraConstants.DEFAULT_MIN_INDEX_INTERVAL;
-    }
-
-    private int maxIndexInterval(TableMetadata tableMetadata) {
-        return tableMetadata.hasDenselyAccessedWideRows()
-                ? CassandraConstants.DENSELY_ACCESSED_WIDE_ROWS_INDEX_INTERVAL
-                : CassandraConstants.DEFAULT_MAX_INDEX_INTERVAL;
     }
 
     private String wrapInQuotes(String string) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTableOptions.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTableOptions.java
@@ -1,0 +1,43 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import com.palantir.atlasdb.table.description.TableMetadata;
+
+/**
+ * Utilities for translating between AtlasDB {@link com.palantir.atlasdb.table.description.TableMetadata}-level
+ * abstractions and corresponding Cassandra table options.
+ */
+final class CassandraTableOptions {
+    private CassandraTableOptions() {
+        // Utility class
+    }
+
+    static double bloomFilterFpChance(TableMetadata tableMetadata) {
+        if (tableMetadata.hasDenselyAccessedWideRows()) {
+            return CassandraConstants.DENSELY_ACCESSED_WIDE_ROWS_BLOOM_FILTER_FP_CHANCE;
+        }
+        if (tableMetadata.isAppendHeavyAndReadLight()) {
+            return tableMetadata.hasNegativeLookups()
+                    ? CassandraConstants.NEGATIVE_LOOKUPS_SIZE_TIERED_BLOOM_FILTER_FP_CHANCE
+                    : CassandraConstants.DEFAULT_SIZE_TIERED_COMPACTION_BLOOM_FILTER_FP_CHANCE;
+        }
+        return tableMetadata.hasNegativeLookups()
+                ? CassandraConstants.NEGATIVE_LOOKUPS_BLOOM_FILTER_FP_CHANCE
+                : CassandraConstants.DEFAULT_LEVELED_COMPACTION_BLOOM_FILTER_FP_CHANCE;
+    }
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTableOptions.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTableOptions.java
@@ -40,4 +40,18 @@ final class CassandraTableOptions {
                 ? CassandraConstants.NEGATIVE_LOOKUPS_BLOOM_FILTER_FP_CHANCE
                 : CassandraConstants.DEFAULT_LEVELED_COMPACTION_BLOOM_FILTER_FP_CHANCE;
     }
+
+    static int minIndexInterval(TableMetadata tableMetadata) {
+        return tableMetadata.hasDenselyAccessedWideRows()
+                ? CassandraConstants.DENSELY_ACCESSED_WIDE_ROWS_INDEX_INTERVAL
+                : CassandraConstants.DEFAULT_MIN_INDEX_INTERVAL;
+    }
+
+    static int maxIndexInterval(TableMetadata tableMetadata) {
+        return tableMetadata.hasDenselyAccessedWideRows()
+                ? CassandraConstants.DENSELY_ACCESSED_WIDE_ROWS_INDEX_INTERVAL
+                : CassandraConstants.DEFAULT_MAX_INDEX_INTERVAL;
+    }
+
+
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTableOptions.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTableOptions.java
@@ -53,5 +53,4 @@ final class CassandraTableOptions {
                 : CassandraConstants.DEFAULT_MAX_INDEX_INTERVAL;
     }
 
-
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ColumnFamilyDefinitions.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ColumnFamilyDefinitions.java
@@ -48,7 +48,6 @@ final class ColumnFamilyDefinitions {
      *
      *  Warning to developers: you must update CKVS.isMatchingCf if you update this method
      */
-    @SuppressWarnings("CyclomaticComplexity")
     static CfDef getCfDef(String keyspace, TableReference tableRef, int gcGraceSeconds, byte[] rawMetadata) {
         CfDef cf = getStandardCfDef(keyspace, AbstractKeyValueService.internalTableName(tableRef));
 
@@ -129,8 +128,8 @@ final class ColumnFamilyDefinitions {
         cf.setDclocal_read_repair_chance(0.1);
         cf.setTriggers(ImmutableList.of());
         cf.setCells_per_row_to_cache("0");
-        cf.setMin_index_interval(128);
-        cf.setMax_index_interval(2048);
+        cf.setMin_index_interval(CassandraConstants.DEFAULT_MIN_INDEX_INTERVAL);
+        cf.setMax_index_interval(CassandraConstants.DEFAULT_MAX_INDEX_INTERVAL);
         cf.setComment("");
         cf.setColumn_metadata(ImmutableList.of());
         cf.setMin_compaction_threshold(4);
@@ -203,6 +202,18 @@ final class ColumnFamilyDefinitions {
                     clientSide.isSetPopulate_io_cache_on_flush(),
                     clusterSide.isSetPopulate_io_cache_on_flush());
             return false;
+        }
+        if (clientSide.min_index_interval != clusterSide.min_index_interval) {
+            logMismatch("min index interval",
+                    tableName,
+                    clientSide.min_index_interval,
+                    clusterSide.min_index_interval);
+        }
+        if (clientSide.max_index_interval != clusterSide.max_index_interval) {
+            logMismatch("max index interval",
+                    tableName,
+                    clientSide.max_index_interval,
+                    clusterSide.max_index_interval);
         }
 
         return true;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ColumnFamilyDefinitions.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ColumnFamilyDefinitions.java
@@ -208,12 +208,14 @@ final class ColumnFamilyDefinitions {
                     tableName,
                     clientSide.min_index_interval,
                     clusterSide.min_index_interval);
+            return false;
         }
         if (clientSide.max_index_interval != clusterSide.max_index_interval) {
             logMismatch("max index interval",
                     tableName,
                     clientSide.max_index_interval,
                     clusterSide.max_index_interval);
+            return false;
         }
 
         return true;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ColumnFamilyDefinitions.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ColumnFamilyDefinitions.java
@@ -58,7 +58,7 @@ final class ColumnFamilyDefinitions {
         Map<String, String> compressionOptions = getCompressionOptions(tableMetadata);
         cf.setCompression_options(compressionOptions);
 
-        boolean appendHeavyAndReadLight = tableMetadata.isPresent() && tableMetadata.get().isAppendHeavyAndReadLight();
+        boolean appendHeavyAndReadLight = tableMetadata.map(TableMetadata::isAppendHeavyAndReadLight).orElse(false);
         if (appendHeavyAndReadLight) {
             cf.setCompaction_strategy(CassandraConstants.SIZE_TIERED_COMPACTION_STRATEGY);
             cf.setCompaction_strategy_optionsIsSet(false);

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTableOptionsTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTableOptionsTest.java
@@ -1,0 +1,71 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import com.palantir.atlasdb.table.description.TableMetadata;
+
+public class CassandraTableOptionsTest {
+    private static final TableMetadata DENSELY_ACCESSED_WIDE_ROWS_METADATA
+            = TableMetadata.internal().denselyAccessedWideRows(true).build();
+    private static final TableMetadata DENSELY_ACCESSED_WIDE_ROWS_APPEND_HEAVY_READ_LIGHT_METADATA
+            = TableMetadata.internal().denselyAccessedWideRows(true).appendHeavyAndReadLight(true).build();
+    private static final TableMetadata APPEND_HEAVY_READ_LIGHT_METADATA
+            = TableMetadata.internal().appendHeavyAndReadLight(true).build();
+    private static final TableMetadata NEGATIVE_LOOKUPS_METADATA
+            = TableMetadata.internal().negativeLookups(true).build();
+    private static final TableMetadata APPEND_HEAVY_READ_LIGHT_NEGATIVE_LOOKUPS_METADATA
+            = TableMetadata.internal().appendHeavyAndReadLight(true).negativeLookups(true).build();
+
+    @Test
+    public void tablesWithDenselyAccessedWideRowsAlwaysHaveLowBloomFilterFpChance() {
+        assertThat(CassandraTableOptions.bloomFilterFpChance(DENSELY_ACCESSED_WIDE_ROWS_METADATA))
+                .isEqualTo(CassandraConstants.DENSELY_ACCESSED_WIDE_ROWS_BLOOM_FILTER_FP_CHANCE);
+        assertThat(CassandraTableOptions.bloomFilterFpChance(
+                DENSELY_ACCESSED_WIDE_ROWS_APPEND_HEAVY_READ_LIGHT_METADATA))
+                .isEqualTo(CassandraConstants.DENSELY_ACCESSED_WIDE_ROWS_BLOOM_FILTER_FP_CHANCE);
+    }
+
+    @Test
+    public void tablesWithAppendHeavyReadLightHaveSizeTieredBasedBloomFilterFpChance() {
+        assertThat(CassandraTableOptions.bloomFilterFpChance(APPEND_HEAVY_READ_LIGHT_METADATA))
+                .isEqualTo(CassandraConstants.DEFAULT_SIZE_TIERED_COMPACTION_BLOOM_FILTER_FP_CHANCE);
+        assertThat(CassandraTableOptions.bloomFilterFpChance(APPEND_HEAVY_READ_LIGHT_NEGATIVE_LOOKUPS_METADATA))
+                .isEqualTo(CassandraConstants.NEGATIVE_LOOKUPS_SIZE_TIERED_BLOOM_FILTER_FP_CHANCE);
+    }
+
+    @Test
+    public void tablesWithNegativeLookupsHaveDifferentBloomFilterFpChance() {
+        assertThat(CassandraTableOptions.bloomFilterFpChance(NEGATIVE_LOOKUPS_METADATA))
+                .isEqualTo(CassandraConstants.NEGATIVE_LOOKUPS_BLOOM_FILTER_FP_CHANCE);
+        assertThat(CassandraTableOptions.bloomFilterFpChance(TableMetadata.allDefault()))
+                .isEqualTo(CassandraConstants.DEFAULT_LEVELED_COMPACTION_BLOOM_FILTER_FP_CHANCE);
+    }
+
+    @Test
+    public void tablesWithDenselyAccessedWideRowsHaveReducedIndexIntervals() {
+        assertThat(CassandraTableOptions.minIndexInterval(DENSELY_ACCESSED_WIDE_ROWS_METADATA))
+                .isEqualTo(CassandraConstants.DENSELY_ACCESSED_WIDE_ROWS_INDEX_INTERVAL)
+                .isLessThan(CassandraConstants.DEFAULT_MIN_INDEX_INTERVAL);
+        assertThat(CassandraTableOptions.maxIndexInterval(DENSELY_ACCESSED_WIDE_ROWS_METADATA))
+                .isEqualTo(CassandraConstants.DENSELY_ACCESSED_WIDE_ROWS_INDEX_INTERVAL)
+                .isLessThan(CassandraConstants.DEFAULT_MAX_INDEX_INTERVAL);
+    }
+}

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/ColumnFamilyDefinitionsTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/ColumnFamilyDefinitionsTest.java
@@ -34,6 +34,7 @@ public class ColumnFamilyDefinitionsTest {
             .negativeLookups(true)
             .sweepStrategy(TableMetadataPersistence.SweepStrategy.THOROUGH)
             .appendHeavyAndReadLight(true)
+            .denselyAccessedWideRows(true)
             .build()
             .persistToBytes();
 
@@ -69,6 +70,23 @@ public class ColumnFamilyDefinitionsTest {
                 AtlasDbConstants.GENERIC_TABLE_METADATA);
 
         assertFalse("ColumnDefinitions with different gc_grace_seconds should not match",
+                ColumnFamilyDefinitions.isMatchingCf(clientSideTable, clusterSideTable));
+    }
+
+    @Test
+    public void cfDefWithDenselyAccessedWideRowsShouldDifferFromOneWithout() {
+        CfDef clientSideTable = ColumnFamilyDefinitions.getCfDef(
+                "test",
+                TableReference.fromString("cf_def"),
+                CassandraConstants.DEFAULT_GC_GRACE_SECONDS,
+                TableMetadata.builder().build().persistToBytes());
+        CfDef clusterSideTable = ColumnFamilyDefinitions.getCfDef(
+                "test",
+                TableReference.fromString("cf_def"),
+                CassandraConstants.DEFAULT_GC_GRACE_SECONDS,
+                TableMetadata.builder().denselyAccessedWideRows(true).build().persistToBytes());
+
+        assertFalse("denselyAccessedWideRows should be reflected in comparisons of ColumnFamilyDefinitions",
                 ColumnFamilyDefinitions.isMatchingCf(clientSideTable, clusterSideTable));
     }
 

--- a/atlasdb-client-protobufs/src/main/proto/TableMetadataPersistence.proto
+++ b/atlasdb-client-protobufs/src/main/proto/TableMetadataPersistence.proto
@@ -13,6 +13,7 @@ message TableMetadata {
     optional int32 explicitCompressionBlockSizeKiloBytes = 10;
     optional bool appendHeavyAndReadLight = 11;
     optional LogSafety nameLogSafety = 12 [default = UNSAFE];
+    optional bool denselyAccessedWideRows = 13;
 }
 
 message NameMetadataDescription {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/TableMetadata.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/TableMetadata.java
@@ -165,9 +165,7 @@ public abstract class TableMetadata implements Persistable {
         builder.setSweepStrategy(getSweepStrategy());
         builder.setAppendHeavyAndReadLight(isAppendHeavyAndReadLight());
         builder.setNameLogSafety(getNameLogSafety());
-        if (hasDenselyAccessedWideRows()) {
-            builder.setDenselyAccessedWideRows(hasDenselyAccessedWideRows());
-        }
+        builder.setDenselyAccessedWideRows(hasDenselyAccessedWideRows());
         return builder;
     }
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/TableMetadata.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/TableMetadata.java
@@ -83,6 +83,15 @@ public abstract class TableMetadata implements Persistable {
         return LogSafety.UNSAFE;
     }
 
+    /**
+     * @return whether the table has densely accessed wide rows. This helps identify tables which could benefit from
+     * setting database tuning parameters to values more in line with such workflows, like the _transactions2 table.
+     */
+    @Value.Default
+    public boolean hasDenselyAccessedWideRows() {
+        return false;
+    }
+
     public static TableMetadata allDefault() {
         return builder().build();
     }
@@ -156,6 +165,7 @@ public abstract class TableMetadata implements Persistable {
         builder.setSweepStrategy(getSweepStrategy());
         builder.setAppendHeavyAndReadLight(isAppendHeavyAndReadLight());
         builder.setNameLogSafety(getNameLogSafety());
+        builder.setDenselyAccessedWideRows(hasDenselyAccessedWideRows());
         return builder;
     }
 
@@ -185,6 +195,9 @@ public abstract class TableMetadata implements Persistable {
         }
         if (message.hasNameLogSafety()) {
             builder.nameLogSafety(message.getNameLogSafety());
+        }
+        if (message.hasDenselyAccessedWideRows()) {
+            builder.denselyAccessedWideRows(message.getDenselyAccessedWideRows());
         }
 
         return builder.build();

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/TableMetadata.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/TableMetadata.java
@@ -165,7 +165,9 @@ public abstract class TableMetadata implements Persistable {
         builder.setSweepStrategy(getSweepStrategy());
         builder.setAppendHeavyAndReadLight(isAppendHeavyAndReadLight());
         builder.setNameLogSafety(getNameLogSafety());
-        builder.setDenselyAccessedWideRows(hasDenselyAccessedWideRows());
+        if (hasDenselyAccessedWideRows()) {
+            builder.setDenselyAccessedWideRows(hasDenselyAccessedWideRows());
+        }
         return builder;
     }
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionConstants.java
@@ -22,8 +22,6 @@ import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
 import com.palantir.atlasdb.ptobject.EncodingUtils;
-import com.palantir.atlasdb.table.description.ColumnMetadataDescription;
-import com.palantir.atlasdb.table.description.NameMetadataDescription;
 import com.palantir.atlasdb.table.description.TableMetadata;
 import com.palantir.atlasdb.table.description.ValueType;
 
@@ -63,11 +61,18 @@ public class TransactionConstants {
             .singleNamedColumn(COMMIT_TS_COLUMN_STRING, "commit_ts", ValueType.VAR_LONG)
             .build();
 
-
+    /**
+     * Metadata for the _transactions2 table.
+     *
+     * In internal benchmarking, an explicit compression block size of 64, along with very low bloom filter
+     * false-positive chances and a low index interval were found to be very beneficial for reads.
+     */
     public static final TableMetadata TRANSACTIONS2_TABLE_METADATA = TableMetadata.internal()
             .singleSafeRowComponent("start_ts_row", ValueType.BLOB)
-            .singleDynamicColumn("start_ts_col", ValueType.BLOB, ValueType.BLOB)
+            .singleDynamicSafeColumn("start_ts_col", ValueType.BLOB, ValueType.BLOB)
             .nameLogSafety(TableMetadataPersistence.LogSafety.SAFE)
             .sweepStrategy(TableMetadataPersistence.SweepStrategy.NOTHING)
+            .explicitCompressionBlockSizeKB(64)
+            .denselyAccessedWideRows(true)
             .build();
 }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/TableMetadataTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/TableMetadataTest.java
@@ -32,6 +32,7 @@ public class TableMetadataTest {
             .explicitCompressionBlockSizeKB(32)
             .appendHeavyAndReadLight(true)
             .nameLogSafety(LogSafety.SAFE)
+            .denselyAccessedWideRows(true)
             .build();
 
     @Test


### PR DESCRIPTION
> I can't give you the heart you think you gave me;
It's time to say goodbye, to tuning tables

(with apologies)

**Goals (and why)**:
- Provide good Cassandra-level table settings to maintain read performance as we move from transactions1 to transactions2.

**Implementation Description (bullets)**:
- The core of this change is adding a boolean `denselyAccessedWideRows()` setting to table metadata. This is not exposed in schema definition.
- If this setting is specified, it currently does nothing for In-Memory and DBKVS. However, tables created in Cassandra will have the following parameters changed, based on benchmarking:
  - `bloom_filter_fp_chance` is set to 0.0001 (default: 0.1). This uses more memory, but avoids disk seeks when reading from SSTables
  - `min_index_interval` is set to 1 (default: 256), allowing for fewer disk seeks when reading from disk
  - `chunk_length_kb` in compression is set to 64 (default: 4), allowing for smaller data overall; by design, the data written by transactions2 compresses down very well

**Testing (What was existing testing like?  What have you done to improve it?)**:
Not much previous testing. I added tests for some refactors of the cf definitions, and an integration test overall that the table was created with the correct constants if we subsequently get the `CfDef` from Cassandra.

**Concerns (what feedback would you like?)**:
- Are the tests too awkward/strange to work with?
- Possibly not in scope here, but are there better ways to enforce consistency across `ColumnFamilyDefinitions` and `CassandraTableCreator`?
- More importantly, are there any changes apart from to those two classes mentioned above that need to be added?

**Where should we start reviewing?**: CassandraTableCreator

**Priority (whenever / two weeks / yesterday)**: this week
