### PR TITLE
[_transactions2] Part 24: Modulus Generator Fairness Across Instances

### DIFF
--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/transaction/client/DistributingModulusGenerator.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/transaction/client/DistributingModulusGenerator.java
@@ -52,16 +52,6 @@ public class DistributingModulusGenerator {
         return chosenResidue.residue();
     }
 
-    private ReferenceCountedResidue getRandomLeastReferencedReferenceCountingResidue() {
-        SortedSet<ReferenceCountedResidue> leastReferencedResidues = getAllLeastReferencedResidues();
-        int elementIndex = ThreadLocalRandom.current().nextInt(leastReferencedResidues.size());
-        return leastReferencedResidues.stream()
-                .skip(elementIndex)
-                .findFirst()
-                .orElseThrow(() ->
-                        new IllegalStateException("Attempted to select a random element from an empty collection!"));
-    }
-
     public synchronized void unmarkResidue(int residue) {
         // There are usually only 16 elements, so this O(n) algo probably will do, but we can pair this with a HashMap
         // and/or make ReferenceCountedResidue modifiable if we decide to use higher moduli in the future.
@@ -77,6 +67,16 @@ public class DistributingModulusGenerator {
             }
         }
         throw new IllegalStateException("Residue " + residue + " was not found when unmarking!");
+    }
+
+    private ReferenceCountedResidue getRandomLeastReferencedReferenceCountingResidue() {
+        SortedSet<ReferenceCountedResidue> leastReferencedResidues = getAllLeastReferencedResidues();
+        int elementIndex = ThreadLocalRandom.current().nextInt(leastReferencedResidues.size());
+        return leastReferencedResidues.stream()
+                .skip(elementIndex)
+                .findFirst()
+                .orElseThrow(() ->
+                        new IllegalStateException("Attempted to select a random element from an empty collection!"));
     }
 
     private SortedSet<ReferenceCountedResidue> getAllLeastReferencedResidues() {

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/transaction/client/DistributingModulusGenerator.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/transaction/client/DistributingModulusGenerator.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.timelock.transaction.client;
 
 import java.util.Comparator;
 import java.util.SortedSet;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -30,7 +31,9 @@ import com.google.common.collect.Sets;
  * Distributes residues of a given modulus in a balanced fashion (though we don't automatically rebalance between
  * residues).
  *
- * Unmarking residues may not be performant if the number of residues used is large.
+ * The implementation of this class takes time linear in the number of residues for getAndMarkResidue and unmarkResidue.
+ * A logarithmic implementation with balanced trees is possible, but we haven't implemented it as in our usage the
+ * number of residues is very small.
  */
 public class DistributingModulusGenerator {
     private final SortedSet<ReferenceCountedResidue> referenceCounts;
@@ -43,10 +46,20 @@ public class DistributingModulusGenerator {
     }
 
     public synchronized int getAndMarkResidue() {
-        ReferenceCountedResidue leastReferenced = referenceCounts.first();
-        referenceCounts.remove(leastReferenced);
-        referenceCounts.add(leastReferenced.mark());
-        return leastReferenced.residue();
+        ReferenceCountedResidue chosenResidue = getRandomLeastReferencedReferenceCountingResidue();
+        referenceCounts.remove(chosenResidue);
+        referenceCounts.add(chosenResidue.mark());
+        return chosenResidue.residue();
+    }
+
+    private ReferenceCountedResidue getRandomLeastReferencedReferenceCountingResidue() {
+        SortedSet<ReferenceCountedResidue> leastReferencedResidues = getAllLeastReferencedResidues();
+        int elementIndex = ThreadLocalRandom.current().nextInt(leastReferencedResidues.size());
+        return leastReferencedResidues.stream()
+                .skip(elementIndex)
+                .findFirst()
+                .orElseThrow(() ->
+                        new IllegalStateException("Attempted to select a random element from an empty collection!"));
     }
 
     public synchronized void unmarkResidue(int residue) {
@@ -64,6 +77,14 @@ public class DistributingModulusGenerator {
             }
         }
         throw new IllegalStateException("Residue " + residue + " was not found when unmarking!");
+    }
+
+    private SortedSet<ReferenceCountedResidue> getAllLeastReferencedResidues() {
+        return referenceCounts.headSet(upperBoundOnEquallyReferencedResidues(referenceCounts.first()));
+    }
+
+    private static ReferenceCountedResidue upperBoundOnEquallyReferencedResidues(ReferenceCountedResidue residue) {
+        return ImmutableReferenceCountedResidue.of(residue.references() + 1, Integer.MIN_VALUE);
     }
 
     @Value.Immutable


### PR DESCRIPTION
**Goals (and why)**:
- Spread transaction start timestamps more evenly between high-order bits of `_transactions2` rows. Currently, every time you have a leader election we start giving out residues from zero again. Thus, rows corresponding to values with `0` or `1` (and maybe `2`) modulo `16` will be disproportionately large, and other rows will be mostly unused (with some exceptions around service bounces). This could limit horizontal scalability of `_transactions2` read performance.
- Fixes #3762 

**Implementation Description (bullets)**:
- Change `getAndMarkResidue()` to return a _random_ residue with the lowest reference count (as opposed to the residue attached to the lexicographically smallest `(referenceCount, residue)`). This works by finding everything with the lowest reference count and then picking a random element from that.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Previous tests for `DistributingModulusGenerator` (DMG) checked that we balance clients correctly; these still pass. There is a new hotspotting test for multiple DMGs being created, which happens every time you have a leader election.

**Concerns (what feedback would you like?)**:
- This makes `getAndMarkResidue()` linear time instead of logarithmic. It's possible to preserve logarithmic time with a straightforward-if-nontrivial-to-implement algorithm, but I think since N = 16 I wouldn't bother. In any case, is the performance of this something I need to worry about?

**Where should we start reviewing?**: DistributingModulusGenerator

**Priority (whenever / two weeks / yesterday)**: this week

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
