### PR TITLE
a place for remote timelock specific perf optimisations

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -129,8 +129,8 @@ import com.palantir.lock.LockRequest;
 import com.palantir.lock.LockServerOptions;
 import com.palantir.lock.LockService;
 import com.palantir.lock.SimpleTimeDuration;
-import com.palantir.lock.client.LeasingTimelockClient;
 import com.palantir.lock.client.LockRefreshingLockService;
+import com.palantir.lock.client.RemoteTimelockServiceAdapter;
 import com.palantir.lock.client.TimeLockClient;
 import com.palantir.lock.impl.LegacyTimelockService;
 import com.palantir.lock.impl.LockServiceImpl;
@@ -810,7 +810,7 @@ public abstract class TransactionManagers {
         ServiceCreator creator = ServiceCreator.withPayloadLimiter(metricsManager, userAgent, timelockServerListConfig);
         LockService lockService = creator.createService(LockService.class);
         TimelockRpcClient timelockClient = creator.createService(TimelockRpcClient.class);
-        TimelockService timelockService = LeasingTimelockClient.create(timelockClient);
+        TimelockService timelockService = RemoteTimelockServiceAdapter.create(timelockClient);
         TimestampManagementService timestampManagementService = creator.createService(TimestampManagementService.class);
 
         return ImmutableLockAndTimestampServices.builder()

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/AsyncLockClient.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/AsyncLockClient.java
@@ -22,7 +22,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.lock.StringLockDescriptor;
-import com.palantir.lock.client.LeasingTimelockClient;
+import com.palantir.lock.client.RemoteTimelockServiceAdapter;
 import com.palantir.lock.v2.LockRequest;
 import com.palantir.lock.v2.LockResponse;
 import com.palantir.lock.v2.LockToken;
@@ -33,7 +33,7 @@ public final class AsyncLockClient implements JepsenLockClient<LockToken> {
     private final TimelockService timelockService;
 
     private AsyncLockClient(TimelockRpcClient timelockService) {
-        this.timelockService = LeasingTimelockClient.create(timelockService);
+        this.timelockService = RemoteTimelockServiceAdapter.create(timelockService);
     }
 
     public static AsyncLockClient create(MetricRegistry metricRegistry, List<String> hosts) {

--- a/lock-api/src/main/java/com/palantir/lock/client/LockLeaseService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockLeaseService.java
@@ -36,39 +36,24 @@ import com.palantir.lock.v2.StartAtlasDbTransactionResponseV3;
 import com.palantir.lock.v2.StartIdentifiedAtlasDbTransactionRequest;
 import com.palantir.lock.v2.StartIdentifiedAtlasDbTransactionResponse;
 import com.palantir.lock.v2.TimelockRpcClient;
-import com.palantir.lock.v2.TimelockService;
-import com.palantir.lock.v2.WaitForLocksRequest;
-import com.palantir.lock.v2.WaitForLocksResponse;
 import com.palantir.logsafe.Preconditions;
-import com.palantir.timestamp.TimestampRange;
 
-public final class LeasingTimelockClient implements TimelockService {
+final class LockLeaseService {
     private final TimelockRpcClient delegate;
     private final UUID clientId;
     private final CoalescingSupplier<LeaderTime> time;
 
     @VisibleForTesting
-    LeasingTimelockClient(TimelockRpcClient timelockRpcClient, UUID clientId) {
+    LockLeaseService(TimelockRpcClient timelockRpcClient, UUID clientId) {
         this.delegate = timelockRpcClient;
         this.clientId = clientId;
         this.time = new CoalescingSupplier<>(timelockRpcClient::getLeaderTime);
     }
 
-    public static LeasingTimelockClient create(TimelockRpcClient timelockRpcClient) {
-        return new LeasingTimelockClient(timelockRpcClient, UUID.randomUUID());
+    public static LockLeaseService create(TimelockRpcClient timelockRpcClient) {
+        return new LockLeaseService(timelockRpcClient, UUID.randomUUID());
     }
 
-    @Override
-    public long getFreshTimestamp() {
-        return delegate.getFreshTimestamp();
-    }
-
-    @Override
-    public TimestampRange getFreshTimestamps(int numTimestampsRequested) {
-        return delegate.getFreshTimestamps(numTimestampsRequested);
-    }
-
-    @Override
     public LockImmutableTimestampResponse lockImmutableTimestamp() {
         StartAtlasDbTransactionResponseV3 response =
                 delegate.startAtlasDbTransaction(StartIdentifiedAtlasDbTransactionRequest.createForRequestor(clientId));
@@ -78,7 +63,6 @@ public final class LeasingTimelockClient implements TimelockService {
                 LeasedLockToken.of(response.immutableTimestamp().getLock(), response.getLease()));
     }
 
-    @Override
     public StartIdentifiedAtlasDbTransactionResponse startIdentifiedAtlasDbTransaction() {
         StartAtlasDbTransactionResponseV3 response =
                 delegate.startAtlasDbTransaction(StartIdentifiedAtlasDbTransactionRequest.createForRequestor(clientId));
@@ -92,12 +76,6 @@ public final class LeasingTimelockClient implements TimelockService {
                 response.startTimestampAndPartition());
     }
 
-    @Override
-    public long getImmutableTimestamp() {
-        return delegate.getImmutableTimestamp();
-    }
-
-    @Override
     public LockResponse lock(LockRequest request) {
         LockResponseV2 leasableResponse = delegate.lock(IdentifiedLockRequest.from(request));
 
@@ -107,12 +85,6 @@ public final class LeasingTimelockClient implements TimelockService {
                 unsuccessful -> LockResponse.timedOut()));
     }
 
-    @Override
-    public WaitForLocksResponse waitForLocks(WaitForLocksRequest request) {
-        return delegate.waitForLocks(request);
-    }
-
-    @Override
     public Set<LockToken> refreshLockLeases(Set<LockToken> uncastedTokens) {
         LeaderTime leaderTime = time.get();
         Set<LeasedLockToken> allTokens = leasedTokens(uncastedTokens);
@@ -127,7 +99,6 @@ public final class LeasingTimelockClient implements TimelockService {
         return Sets.union(refreshedTokens, validByLease);
     }
 
-    @Override
     public Set<LockToken> unlock(Set<LockToken> tokens) {
         Set<LeasedLockToken> leasedLockTokens = leasedTokens(tokens);
         leasedLockTokens.forEach(LeasedLockToken::invalidate);
@@ -136,11 +107,6 @@ public final class LeasingTimelockClient implements TimelockService {
         return leasedLockTokens.stream()
                 .filter(leasedLockToken -> unlocked.contains(leasedLockToken.serverToken()))
                 .collect(Collectors.toSet());
-    }
-
-    @Override
-    public long currentTimeMillis() {
-        return delegate.currentTimeMillis();
     }
 
     private Set<LeasedLockToken> refreshTokens(Set<LeasedLockToken> leasedTokens) {

--- a/lock-api/src/main/java/com/palantir/lock/client/RemoteTimelockServiceAdapter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/RemoteTimelockServiceAdapter.java
@@ -1,0 +1,94 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.client;
+
+import java.util.Set;
+
+import com.palantir.lock.v2.LockImmutableTimestampResponse;
+import com.palantir.lock.v2.LockRequest;
+import com.palantir.lock.v2.LockResponse;
+import com.palantir.lock.v2.LockToken;
+import com.palantir.lock.v2.StartIdentifiedAtlasDbTransactionResponse;
+import com.palantir.lock.v2.TimelockRpcClient;
+import com.palantir.lock.v2.TimelockService;
+import com.palantir.lock.v2.WaitForLocksRequest;
+import com.palantir.lock.v2.WaitForLocksResponse;
+import com.palantir.timestamp.TimestampRange;
+
+public class RemoteTimelockServiceAdapter implements TimelockService {
+    private final LockLeaseService lockLeaseService;
+    private final TimelockRpcClient timelockRpcClient;
+
+    private RemoteTimelockServiceAdapter(TimelockRpcClient timelockRpcClient) {
+        this.timelockRpcClient = timelockRpcClient;
+        this.lockLeaseService = LockLeaseService.create(timelockRpcClient);
+    }
+
+    public static TimelockService create(TimelockRpcClient timelockRpcClient) {
+        return new RemoteTimelockServiceAdapter(timelockRpcClient);
+    }
+
+    @Override
+    public long getFreshTimestamp() {
+        return timelockRpcClient.getFreshTimestamp();
+    }
+
+    @Override
+    public TimestampRange getFreshTimestamps(int numTimestampsRequested) {
+        return timelockRpcClient.getFreshTimestamps(numTimestampsRequested);
+    }
+
+    @Override
+    public LockImmutableTimestampResponse lockImmutableTimestamp() {
+        return lockLeaseService.lockImmutableTimestamp();
+    }
+
+    @Override
+    public StartIdentifiedAtlasDbTransactionResponse startIdentifiedAtlasDbTransaction() {
+        return lockLeaseService.startIdentifiedAtlasDbTransaction();
+    }
+
+    @Override
+    public long getImmutableTimestamp() {
+        return timelockRpcClient.getImmutableTimestamp();
+    }
+
+    @Override
+    public LockResponse lock(LockRequest request) {
+        return lockLeaseService.lock(request);
+    }
+
+    @Override
+    public WaitForLocksResponse waitForLocks(WaitForLocksRequest request) {
+        return timelockRpcClient.waitForLocks(request);
+    }
+
+    @Override
+    public Set<LockToken> refreshLockLeases(Set<LockToken> tokens) {
+        return lockLeaseService.refreshLockLeases(tokens);
+    }
+
+    @Override
+    public Set<LockToken> unlock(Set<LockToken> tokens) {
+        return lockLeaseService.unlock(tokens);
+    }
+
+    @Override
+    public long currentTimeMillis() {
+        return timelockRpcClient.currentTimeMillis();
+    }
+}

--- a/lock-api/src/main/java/com/palantir/lock/client/RemoteTimelockServiceAdapter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/RemoteTimelockServiceAdapter.java
@@ -29,7 +29,7 @@ import com.palantir.lock.v2.WaitForLocksRequest;
 import com.palantir.lock.v2.WaitForLocksResponse;
 import com.palantir.timestamp.TimestampRange;
 
-public class RemoteTimelockServiceAdapter implements TimelockService {
+public final class RemoteTimelockServiceAdapter implements TimelockService {
     private final LockLeaseService lockLeaseService;
     private final TimelockRpcClient timelockRpcClient;
 

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
@@ -62,7 +62,7 @@ import com.palantir.lock.LockRefreshToken;
 import com.palantir.lock.LockService;
 import com.palantir.lock.SimpleTimeDuration;
 import com.palantir.lock.StringLockDescriptor;
-import com.palantir.lock.client.LeasingTimelockClient;
+import com.palantir.lock.client.RemoteTimelockServiceAdapter;
 import com.palantir.lock.v2.LockRequest;
 import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.TimelockRpcClient;
@@ -481,7 +481,7 @@ public class PaxosTimeLockServerIntegrationTest {
     }
 
     private static TimelockService getTimelockService(String client) {
-        return LeasingTimelockClient.create(getProxyForService(client, TimelockRpcClient.class));
+        return RemoteTimelockServiceAdapter.create(getProxyForService(client, TimelockRpcClient.class));
     }
 
     private static LockService getLockService(String client) {

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
@@ -38,7 +38,7 @@ import com.palantir.atlasdb.timelock.util.TestProxies;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.lock.LockRefreshToken;
 import com.palantir.lock.LockService;
-import com.palantir.lock.client.LeasingTimelockClient;
+import com.palantir.lock.client.RemoteTimelockServiceAdapter;
 import com.palantir.lock.v2.LockRequest;
 import com.palantir.lock.v2.LockResponse;
 import com.palantir.lock.v2.LockToken;
@@ -219,7 +219,7 @@ public class TestableTimelockCluster {
     }
 
     public TimelockService timelockServiceForClient(String name) {
-        return LeasingTimelockClient.create(proxies.failoverForClient(name, TimelockRpcClient.class));
+        return RemoteTimelockServiceAdapter.create(proxies.failoverForClient(name, TimelockRpcClient.class));
     }
 
     public <T> CompletableFuture<T> runWithRpcClientAsync(Function<TimelockRpcClient, T> function) {

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
@@ -24,7 +24,7 @@ import com.palantir.atlasdb.timelock.util.TestProxies;
 import com.palantir.leader.PingableLeader;
 import com.palantir.lock.LockRefreshToken;
 import com.palantir.lock.LockService;
-import com.palantir.lock.client.LeasingTimelockClient;
+import com.palantir.lock.client.RemoteTimelockServiceAdapter;
 import com.palantir.lock.v2.LockRequest;
 import com.palantir.lock.v2.LockResponse;
 import com.palantir.lock.v2.TimelockRpcClient;
@@ -94,7 +94,7 @@ public class TestableTimelockServer {
     }
 
     public TimelockService timelockServiceForClient(String client) {
-        return LeasingTimelockClient.create(
+        return RemoteTimelockServiceAdapter.create(
                 proxies.singleNodeForClient(client, serverHolder, TimelockRpcClient.class));
     }
 


### PR DESCRIPTION
**Goals (and why)**:
This pr lays the groundwork for shared start transaction calls. Rather than having each layer implement `TimelockService` and decorate one another, I think it would be better to have one adapter that turns `TimelockRpcClient` into `TimelockService` (and encapsulates the knowledge of how to do so).

**Implementation Description (bullets)**:
Creating a `RemoteTimelockServiceAdapter` that implements `TimelockService` and encapsulates multiple perf optimisation related adapters (currently only lockLeaseService, soon will also have a start transaction coalescing service, and maybe more in future.)

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:
`RemoteTimelockServiceAdapter`

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
