### PR TITLE
[_transactions2] [WIP] Part 25: The CellLoader Reloaded

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
@@ -61,6 +61,13 @@ public interface CassandraClient {
             SlicePredicate predicate, ConsistencyLevel consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, org.apache.thrift.TException;
 
+    Map<KeyPredicate, List<ColumnOrSuperColumn>> multiget_multislice(
+            String kvsMethodName,
+            TableReference tableRef,
+            List<KeyPredicate> keyPredicates,
+            ConsistencyLevel consistency_level)
+            throws InvalidRequestException, UnavailableException, TimedOutException, org.apache.thrift.TException;
+
     List<KeySlice> get_range_slices(String kvsMethodName,
             TableReference tableRef,
             SlicePredicate predicate,

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
@@ -28,6 +28,7 @@ import org.apache.cassandra.thrift.ConsistencyLevel;
 import org.apache.cassandra.thrift.CqlPreparedResult;
 import org.apache.cassandra.thrift.CqlResult;
 import org.apache.cassandra.thrift.InvalidRequestException;
+import org.apache.cassandra.thrift.KeyPredicate;
 import org.apache.cassandra.thrift.KeyRange;
 import org.apache.cassandra.thrift.KeySlice;
 import org.apache.cassandra.thrift.KsDef;
@@ -61,7 +62,7 @@ public interface CassandraClient {
             SlicePredicate predicate, ConsistencyLevel consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, org.apache.thrift.TException;
 
-    Map<KeyPredicate, List<ColumnOrSuperColumn>> multiget_multislice(
+    Map<ByteBuffer, List<List<ColumnOrSuperColumn>>> multiget_multislice(
             String kvsMethodName,
             TableReference tableRef,
             List<KeyPredicate> keyPredicates,

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientImpl.java
@@ -87,6 +87,17 @@ public class CassandraClientImpl implements CassandraClient {
     }
 
     @Override
+    public Map<KeyPredicate, List<ColumnOrSuperColumn>> multiget_multislice(String kvsMethodName,
+            TableReference tableRef, List<KeyPredicate> keyPredicates, ConsistencyLevel consistency_level)
+            throws InvalidRequestException, UnavailableException, TimedOutException, TException {
+        ColumnParent colFam = getColumnParent(tableRef);
+        return executeHandlingExceptions(() -> client.multiget_multislice(
+                keyPredicates,
+                colFam,
+                consistency_level));
+    }
+
+    @Override
     public List<KeySlice> get_range_slices(String kvsMethodName,
             TableReference tableRef,
             SlicePredicate predicate,

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientImpl.java
@@ -36,6 +36,7 @@ import org.apache.cassandra.thrift.ConsistencyLevel;
 import org.apache.cassandra.thrift.CqlPreparedResult;
 import org.apache.cassandra.thrift.CqlResult;
 import org.apache.cassandra.thrift.InvalidRequestException;
+import org.apache.cassandra.thrift.KeyPredicate;
 import org.apache.cassandra.thrift.KeyRange;
 import org.apache.cassandra.thrift.KeySlice;
 import org.apache.cassandra.thrift.KsDef;
@@ -87,7 +88,7 @@ public class CassandraClientImpl implements CassandraClient {
     }
 
     @Override
-    public Map<KeyPredicate, List<ColumnOrSuperColumn>> multiget_multislice(String kvsMethodName,
+    public Map<ByteBuffer, List<List<ColumnOrSuperColumn>>> multiget_multislice(String kvsMethodName,
             TableReference tableRef, List<KeyPredicate> keyPredicates, ConsistencyLevel consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, TException {
         ColumnParent colFam = getColumnParent(tableRef);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/WrappingQueryRunner.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/WrappingQueryRunner.java
@@ -73,4 +73,20 @@ class WrappingQueryRunner {
                     "This get operation requires " + consistency + " Cassandra nodes to be up and available.", e);
         }
     }
+
+    Map<KeyPredicate, List<ColumnOrSuperColumn>> multiget_multislice(
+            String kvsMethodName,
+            CassandraClient client,
+            TableReference tableRef,
+            List<KeyPredicate> keyPredicates,
+            ConsistencyLevel consistency) throws TException {
+        try {
+            return queryRunner.run(client, tableRef,
+                    () -> client.multiget_multislice(kvsMethodName, tableRef, keyPredicates, consistency));
+        } catch (UnavailableException e) {
+            throw new InsufficientConsistencyException(
+                    "This get operation requires " + consistency + " Cassandra nodes to be up and available.", e);
+        }
+
+    }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/WrappingQueryRunner.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/WrappingQueryRunner.java
@@ -22,6 +22,7 @@ import java.util.Set;
 
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;
 import org.apache.cassandra.thrift.ConsistencyLevel;
+import org.apache.cassandra.thrift.KeyPredicate;
 import org.apache.cassandra.thrift.SlicePredicate;
 import org.apache.cassandra.thrift.UnavailableException;
 import org.apache.thrift.TException;
@@ -74,7 +75,7 @@ class WrappingQueryRunner {
         }
     }
 
-    Map<KeyPredicate, List<ColumnOrSuperColumn>> multiget_multislice(
+    Map<ByteBuffer, List<List<ColumnOrSuperColumn>>> multiget_multislice(
             String kvsMethodName,
             CassandraClient client,
             TableReference tableRef,

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -22,7 +22,7 @@ ext.libVersions =
     jackson: '2.9.5',
     snakeyaml: '1.12',
     cassandra_driver_core: '3.4.0',
-    palantir_cassandra_thrift: '2.2.13-1.0.0-rc1',
+    palantir_cassandra_thrift: '2.2.13-1.5.0',
     groovy: '2.4.4',
     hamcrest: '1.3',
     libthrift: '0.9.2',


### PR DESCRIPTION
**Goals (and why)**:
- Achieve faster read performance by batching reads, both in the form of `_transactions2` and in general. For instance if you read one row with 25 static columns... you're actually making 25 parallel RPCs to Cassandra while after this change you'll make just one.

**Implementation Description (bullets)**:
- Actually use the new Cassandra endpoint we're planning on introducing in `CellLoader`.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- WIP, **TODO**

**Concerns (what feedback would you like?)**:
- The commands are going to become larger, possibly because we encode the slice predicate a bunch of times. In general I think this is fine; in static columns we only need to pass the short-name, and in dynamic columns you need to relay the information anyway. Nonetheless, this could mean the size of our RPCs increases.
  - There is a mitigating factor: when benchmarking Transactions1 with the new CellLoader, its perf was largely unaffected even though all the columns being asked for were the same.
- The batch size is `50,000` right now, which seems a bit arbitrary - is this a reasonable value?
- I opted to "compile" the `Map<KeyPredicate, List<ColumnOrSuperColumn>>` into a `Map<ByteBuffer, List<ColumnOrSuperColumn>>` because the visitor framework is still used for that type in the context of `multiget`s. Is this worth a change?

**Where should we start reviewing?**: CellLoader

**Priority (whenever / two weeks / yesterday)**: this week, though this is blocked on quite a number of other issues.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
