### PR TITLE
Backport Docker Coordinate Correction

### DIFF
--- a/atlasdb-ete-tests/Dockerfile
+++ b/atlasdb-ete-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM frolvlad/alpine-oraclejdk8:slim
+FROM abrtech/alpine-oraclejdk8
 
 RUN apk update && apk add libstdc++ bash wget
 

--- a/timelock-server/Dockerfile
+++ b/timelock-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM frolvlad/alpine-oraclejdk8:slim
+FROM abrtech/alpine-oraclejdk8
 MAINTAINER AtlasDB Team
 
 # Bash is useful for monitoring; curl is used by our healthchecks.


### PR DESCRIPTION
**Goals (and why)**: Allow 0.39.x to be published, which won't work if it's red.

**Implementation Description (bullets)**: Change coordinates to the same image we use on develop in our Dockerfiles.

**Testing (What was existing testing like?  What have you done to improve it?)**: the build is red, it should be green after this.

**Concerns (what feedback would you like?)**: nil

**Where should we start reviewing?**: +2/-2

**Priority (whenever / two weeks / yesterday)**: yesterday 🔥 
