### PR TITLE
Don't include timestamp in span operation

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueService.java
@@ -213,8 +213,8 @@ public final class TracingKeyValueService extends ForwardingObject implements Ke
     @Override
     public Multimap<Cell, Long> getAllTimestamps(TableReference tableRef, Set<Cell> keys, long timestamp) {
         //noinspection unused - try-with-resources closes trace
-        try (CloseableTrace trace = startLocalTrace("getAllTimestamps({}, {} keys, ts {})",
-                LoggingArgs.safeTableOrPlaceholder(tableRef), keys.size(), timestamp)) {
+        try (CloseableTrace trace = startLocalTrace("getAllTimestamps({}, {} keys)",
+                LoggingArgs.safeTableOrPlaceholder(tableRef), keys.size())) {
             return delegate().getAllTimestamps(tableRef, keys, timestamp);
         }
     }
@@ -233,8 +233,8 @@ public final class TracingKeyValueService extends ForwardingObject implements Ke
             Iterable<RangeRequest> rangeRequests,
             long timestamp) {
         //noinspection unused - try-with-resources closes trace
-        try (CloseableTrace trace = startLocalTrace("getFirstBatchForRanges({}, {} ranges, ts {})",
-                LoggingArgs.safeTableOrPlaceholder(tableRef), Iterables.size(rangeRequests), timestamp)) {
+        try (CloseableTrace trace = startLocalTrace("getFirstBatchForRanges({}, {} ranges)",
+                LoggingArgs.safeTableOrPlaceholder(tableRef), Iterables.size(rangeRequests))) {
             return delegate().getFirstBatchForRanges(tableRef, rangeRequests, timestamp);
         }
     }
@@ -295,8 +295,8 @@ public final class TracingKeyValueService extends ForwardingObject implements Ke
             ColumnSelection columnSelection,
             long timestamp) {
         //noinspection unused - try-with-resources closes trace
-        try (CloseableTrace trace = startLocalTrace("getRows({}, {} rows, ts {})",
-                LoggingArgs.safeTableOrPlaceholder(tableRef), Iterables.size(rows), timestamp)) {
+        try (CloseableTrace trace = startLocalTrace("getRows({}, {} rows)",
+                LoggingArgs.safeTableOrPlaceholder(tableRef), Iterables.size(rows))) {
             return delegate().getRows(tableRef, rows, columnSelection, timestamp);
         }
     }
@@ -307,8 +307,8 @@ public final class TracingKeyValueService extends ForwardingObject implements Ke
             BatchColumnRangeSelection columnRangeSelection,
             long timestamp) {
         //noinspection unused - try-with-resources closes trace
-        try (CloseableTrace trace = startLocalTrace("getRowsColumnRange({}, {} rows, ts {})",
-                LoggingArgs.safeTableOrPlaceholder(tableRef), Iterables.size(rows), timestamp)) {
+        try (CloseableTrace trace = startLocalTrace("getRowsColumnRange({}, {} rows)",
+                LoggingArgs.safeTableOrPlaceholder(tableRef), Iterables.size(rows))) {
             return delegate().getRowsColumnRange(tableRef, rows, columnRangeSelection, timestamp);
         }
     }
@@ -327,8 +327,8 @@ public final class TracingKeyValueService extends ForwardingObject implements Ke
     public void multiPut(Map<TableReference, ? extends Map<Cell, byte[]>> valuesByTable,
             long timestamp) {
         //noinspection unused - try-with-resources closes trace
-        try (CloseableTrace trace = startLocalTrace("multiPut({} values, ts {})",
-                valuesByTable.size(), timestamp)) {
+        try (CloseableTrace trace = startLocalTrace("multiPut({} values)",
+                valuesByTable.size())) {
             delegate().multiPut(valuesByTable, timestamp);
         }
     }
@@ -336,8 +336,8 @@ public final class TracingKeyValueService extends ForwardingObject implements Ke
     @Override
     public void put(TableReference tableRef, Map<Cell, byte[]> values, long timestamp) {
         //noinspection unused - try-with-resources closes trace
-        try (CloseableTrace trace = startLocalTrace("put({}, {} values, ts {})",
-                LoggingArgs.safeTableOrPlaceholder(tableRef), values.size(), timestamp)) {
+        try (CloseableTrace trace = startLocalTrace("put({}, {} values)",
+                LoggingArgs.safeTableOrPlaceholder(tableRef), values.size())) {
             delegate().put(tableRef, values, timestamp);
         }
     }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueServiceTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueServiceTest.java
@@ -226,7 +226,7 @@ public class TracingKeyValueServiceTest {
         Set<Cell> cells = ImmutableSet.of(CELL);
         kvs.getAllTimestamps(TABLE_REF, cells, 1L);
 
-        checkSpan("atlasdb-kvs.getAllTimestamps({table}, 1 keys, ts 1)");
+        checkSpan("atlasdb-kvs.getAllTimestamps({table}, 1 keys)");
         verify(delegate).getAllTimestamps(TABLE_REF, cells, 1L);
         verifyNoMoreInteractions(delegate);
     }
@@ -249,7 +249,7 @@ public class TracingKeyValueServiceTest {
                 TABLE_REF, RANGE_REQUESTS, TIMESTAMP);
 
         assertThat(result, equalTo(expectedResult));
-        checkSpan("atlasdb-kvs.getFirstBatchForRanges({table}, 1 ranges, ts 1)");
+        checkSpan("atlasdb-kvs.getFirstBatchForRanges({table}, 1 ranges)");
         verify(delegate).getFirstBatchForRanges(TABLE_REF, RANGE_REQUESTS, TIMESTAMP);
         verifyNoMoreInteractions(delegate);
     }
@@ -301,7 +301,7 @@ public class TracingKeyValueServiceTest {
         Map<Cell, Value> result = kvs.getRows(TABLE_REF, rows, ColumnSelection.all(), TIMESTAMP);
 
         assertThat(result, equalTo(expectedResult));
-        checkSpan("atlasdb-kvs.getRows({table}, 1 rows, ts 1)");
+        checkSpan("atlasdb-kvs.getRows({table}, 1 rows)");
         verify(delegate).getRows(TABLE_REF, rows, ColumnSelection.all(), TIMESTAMP);
         verifyNoMoreInteractions(delegate);
     }
@@ -317,7 +317,7 @@ public class TracingKeyValueServiceTest {
         Map<byte[], RowColumnRangeIterator> result = kvs.getRowsColumnRange(TABLE_REF, rows, range, TIMESTAMP);
 
         assertThat(result, equalTo(expectedResult));
-        checkSpan("atlasdb-kvs.getRowsColumnRange({table}, 1 rows, ts 1)");
+        checkSpan("atlasdb-kvs.getRowsColumnRange({table}, 1 rows)");
         verify(delegate).getRowsColumnRange(TABLE_REF, rows, range, TIMESTAMP);
         verifyNoMoreInteractions(delegate);
     }
@@ -327,7 +327,7 @@ public class TracingKeyValueServiceTest {
         Map<TableReference, Map<Cell, byte[]>> values = ImmutableMap.of(TABLE_REF, ImmutableMap.of(CELL, VALUE_BYTES));
         kvs.multiPut(values, TIMESTAMP);
 
-        checkSpan("atlasdb-kvs.multiPut(1 values, ts 1)");
+        checkSpan("atlasdb-kvs.multiPut(1 values)");
         verify(delegate).multiPut(values, TIMESTAMP);
         verifyNoMoreInteractions(delegate);
     }
@@ -337,7 +337,7 @@ public class TracingKeyValueServiceTest {
         Map<Cell, byte[]> values = ImmutableMap.of(CELL, VALUE_BYTES);
         kvs.put(TABLE_REF, values, TIMESTAMP);
 
-        checkSpan("atlasdb-kvs.put({table}, 1 values, ts 1)");
+        checkSpan("atlasdb-kvs.put({table}, 1 values)");
         verify(delegate).put(TABLE_REF, values, TIMESTAMP);
         verifyNoMoreInteractions(delegate);
     }


### PR DESCRIPTION
**Goals (and why)**:
Tracing key value service calls is great for debugging. Often when debugging you you want to aggregate all traces of a particular span to see things like p95, p99, etc. To do these aggregations, calls with similar expected performance should have the same span operation.

Currently the tracing key value services creates span names that use the timestamp. This means that reads in different transactions will have different span operations, making it impossible to do the above-mentioned aggregations.

**Implementation Description (bullets)**:
Removes the timestamp component from the tracing key value store span operations.