### PR TITLE
[no release notes] Fix the wrapper getDelegates()

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -84,6 +84,7 @@ import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
 import com.palantir.atlasdb.keyvalue.api.ImmutableCandidateCellForSweepingRequest;
 import com.palantir.atlasdb.keyvalue.api.InsufficientConsistencyException;
 import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.RangeRequests;
 import com.palantir.atlasdb.keyvalue.api.RowColumnRangeIterator;
@@ -147,6 +148,11 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         public CassandraKeyValueServiceImpl delegate() {
             checkInitialized();
             return CassandraKeyValueServiceImpl.this;
+        }
+
+        @Override
+        public Collection<? extends KeyValueService> getDelegates() {
+            return ImmutableList.of(delegate());
         }
 
         @Override


### PR DESCRIPTION
**Goals (and why)**:
Noticed that AutoDelegate for KVS does not implement the `getDelegates` method as we would want since it calls it on the delegate, thus skipping a level. In particular, this means that if we async initialize a Cassandra KVS, and get back a wrapper, we have no way of accessing the underlying CKVSImpl to access its methods.

**Implementation Description (bullets)**:
Just return the delegate instead, making sure it is initialized first.

**Where should we start reviewing?**:
Tiny

**Priority (whenever / two weeks / yesterday)**:
This is technically a bug, but not one anyone has ever hit, so not high.
