### PR TITLE
Add backoff when leadership check hits NO_QUORUM to develop

### DIFF
--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionServiceBuilder.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionServiceBuilder.java
@@ -117,8 +117,11 @@ public class PaxosLeaderElectionServiceBuilder {
     }
 
     public PaxosLeaderElectionService build() {
-        Preconditions.checkState(randomWaitBeforeProposingLeadershipMs >= 0, "randomWaitBeforeProposingLeadershipMs should be positive; was " + randomWaitBeforeProposingLeadershipMs);
-        Preconditions.checkState(noQuorumMaxDelayMs >= 0, "noQuorumMaxDelayMs should be positive; was " + noQuorumMaxDelayMs);
+        Preconditions.checkState(randomWaitBeforeProposingLeadershipMs >= 0,
+                "randomWaitBeforeProposingLeadershipMs should be positive; was "
+                        + randomWaitBeforeProposingLeadershipMs);
+        Preconditions.checkState(noQuorumMaxDelayMs >= 0,
+                "noQuorumMaxDelayMs should be positive; was " + noQuorumMaxDelayMs);
         return new PaxosLeaderElectionService(
                 proposer,
                 knowledge,


### PR DESCRIPTION
**Goals (and why)**:
Port #3796 to develop
 
**Concerns (what feedback would you like?)**:
Does this still make sense? Did I mess something up in fixing conflicts?