### PR TITLE
[no release notes] Fix broken reverse migration docs for DbKvs in TimeLock

### DIFF
--- a/docs/source/services/timelock_service/manual-migration.rst
+++ b/docs/source/services/timelock_service/manual-migration.rst
@@ -93,7 +93,7 @@ The steps for invalidating the old AtlasDB timestamp will vary, depending on you
 
      .. code:: sql
 
-        ALTER TABLE atlasdb_timestamp RENAME last_allocated TO LEGACY_last_allocated;
+        ALTER TABLE timestamp RENAME last_allocated TO LEGACY_last_allocated;
 
 - If using Cassandra, one method of invalidating the table is to overwrite the timestamp bound record with an invalid
   byte array. We recommend using a bogus one-byte array for this; the zero byte array is a deletion sentinel, and

--- a/docs/source/services/timelock_service/reverse-migration.rst
+++ b/docs/source/services/timelock_service/reverse-migration.rst
@@ -115,11 +115,23 @@ This will vary depending on your choice of key-value service:
       0x7473 |  0x7473 |      -1 | 0x00000000075bcd15
 
 - If you are using DBKVS and have followed the steps outlined in :ref:`Manual TimeLock Migration<manual-timelock-migration>`,
-  it suffices to rename the column back:
+  you will first want to rename the column back to its original name.
 
   .. code:: sql
 
-     ALTER TABLE atlasdb_timestamp RENAME LEGACY_last_allocated TO last_allocated;
+     ALTER TABLE timestamp RENAME LEGACY_last_allocated TO last_allocated;
+
+  After that, you will want to set the value stored in that table in the database to be ``TS``.
+
+  .. code:: sql
+
+     multipass_db=# UPDATE _timestamp SET last_allocated = 314159265;
+     UPDATE 1
+     multipass_db=# SELECT * FROM _timestamp;
+      last_allocated
+     ----------------
+           314159265
+     (1 row)
 
 Step 6: Start your AtlasDB Clients
 ----------------------------------

--- a/docs/source/services/timelock_service/reverse-migration.rst
+++ b/docs/source/services/timelock_service/reverse-migration.rst
@@ -125,9 +125,9 @@ This will vary depending on your choice of key-value service:
 
   .. code:: sql
 
-     multipass_db=# UPDATE _timestamp SET last_allocated = 314159265;
+     a_db=# UPDATE _timestamp SET last_allocated = 314159265;
      UPDATE 1
-     multipass_db=# SELECT * FROM _timestamp;
+     a_db=# SELECT * FROM _timestamp;
       last_allocated
      ----------------
            314159265


### PR DESCRIPTION
**Goals (and why)**:
- Avoid people following clearly incomplete docs that would have resulted in Severe Data Corruption™.

**Implementation Description (bullets)**:
- Add the update step, together with examples.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- The commands here are a copy paste of what was run on a real cluster in psql, so I'm confident they're right. Besides that there isn't really testing here other than that the docs build works.

**Concerns (what feedback would you like?)**: Nothing in particular.

**Where should we start reviewing?**: reverse-migration.rst

**Priority (whenever / two weeks / yesterday)**: This week
