### PR TITLE
LockServiceImpl: Don't clear locks from being cleared if we haven't acquired them

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -89,6 +89,10 @@ develop
          - Reduced dependency footprint by replacing dependency on groovy-all with dependencies on groovy, groovy-groovysh, and groovy-json.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3886>`__)
 
+    *    - |fixed|
+         - Fixed a rare situation in which interrupting a thread could possibly leave dangling locks.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3805>`__)
+
 ========
 v0.127.0
 ========

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
@@ -392,14 +392,14 @@ public final class LockServiceImpl
             if (request.getVersionId() != null) {
                 versionIdMap.put(client, request.getVersionId());
             }
+            if (Thread.interrupted()) {
+                throw new InterruptedException("Interrupted while locking.");
+            }
             HeldLocksToken token = createHeldLocksToken(client, LockCollections.of(lockDescriptorMap.build()), LockCollections.of(locks),
                     request.getLockTimeout(), request.getVersionId(), request.getCreatingThreadName());
             locks.clear();
             if (log.isTraceEnabled()) {
                 logNullResponse(client, request, token);
-            }
-            if (Thread.interrupted()) {
-                throw new InterruptedException("Interrupted while locking.");
             }
             if (requestLogger.isDebugEnabled()) {
                 requestLogger.debug("Successfully acquired locks {} for requesting thread {} after {} ms",


### PR DESCRIPTION
**Goals (and why)**:
- Looks like there was a bug in `LockServiceImpl`. If the lock server was interrupted at _just the right moment_, we might leave some locks dangling (unsuccessfully acquired for a specific token, yet never explicitly released).

**Implementation Description (bullets)**:
- Fix the bug above.

**Testing (What was existing testing like?  What have you done to improve it?)**: minimal, sadly.

**Concerns (what feedback would you like?)**: Nothing in particular.

**Where should we start reviewing?**: +3/-3

**Priority (whenever / two weeks / yesterday)**: this week

Credit to Ryan Zheng for this PR (he isn't set up with external github). I've looked through and it makes sense to me as well.