### PR TITLE
Fix targeted sweep correctness bugs

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -332,14 +332,15 @@ public interface KeyValueService extends AutoCloseable {
     /**
      * For each cell, deletes all timestamps prior to the associated maximum timestamp. If this
      * operation fails, it's acceptable for this method to leave an inconsistent state, however
-     * implementations of this method <b>must</b> not leave a state where the timestamp listed
-     * has been inconsistently deleted and all the others have not been consistently deleted.
+     * implementations of this method <b>must</b> guarantee that, for each cell, if a value at the
+     * associated timestamp is inconsistently deleted, then all other values of that cell in the
+     * relevant range must have already been consistently deleted.
      *
      * @param tableRef the name of the table to delete the timestamps in.
      * @param rangesToDelete cells to be deleted, and the ranges of timestamps to delete for each cell
      */
     @Idempotent
-    void deleteAllTimestamps(TableReference tableRef, Map<Cell, TimestampRangeDelete> rangesToDelete)
+    void deleteAllTimestamps(TableReference tableRef, Map<Cell, TimestampRangeDelete> deletes)
             throws InsufficientConsistencyException;
 
     /**

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -337,7 +337,7 @@ public interface KeyValueService extends AutoCloseable {
      * relevant range must have already been consistently deleted.
      *
      * @param tableRef the name of the table to delete the timestamps in.
-     * @param rangesToDelete cells to be deleted, and the ranges of timestamps to delete for each cell
+     * @param deletes cells to be deleted, and the ranges of timestamps to delete for each cell
      */
     @Idempotent
     void deleteAllTimestamps(TableReference tableRef, Map<Cell, TimestampRangeDelete> deletes)

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -330,17 +330,17 @@ public interface KeyValueService extends AutoCloseable {
     void deleteRange(TableReference tableRef, RangeRequest range);
 
     /**
-     * For each cell, deletes all timestamps prior to the associated maximum timestamp. Depending on the
-     * implementation, this may result in a range tombstone in the underlying KVS.
+     * For each cell, deletes all timestamps prior to the associated maximum timestamp. If this
+     * operation fails, it's acceptable for this method to leave an inconsistent state, however
+     * implementations of this method <b>must</b> not leave a state where the timestamp listed
+     * has been inconsistently deleted and all the others have not been consistently deleted.
      *
      * @param tableRef the name of the table to delete the timestamps in.
-     * @param maxTimestampExclusiveByCell exclusive maximum timestamp to delete for each cell.
-     * @param deleteSentinels if true, this method will also delete garbage collection sentinels.
+     * @param rangesToDelete cells to be deleted, and the ranges of timestamps to delete for each cell
      */
     @Idempotent
-    void deleteAllTimestamps(TableReference tableRef,
-            Map<Cell, Long> maxTimestampExclusiveByCell,
-            boolean deleteSentinels);
+    void deleteAllTimestamps(TableReference tableRef, Map<Cell, TimestampRangeDelete> rangesToDelete)
+            throws InsufficientConsistencyException;
 
     /**
      * Truncate a table in the key-value store.

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/TimestampRangeDelete.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/TimestampRangeDelete.java
@@ -17,6 +17,7 @@
 package com.palantir.atlasdb.keyvalue.api;
 
 import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value.Lazy;
 
 @Immutable
 public interface TimestampRangeDelete {
@@ -24,10 +25,12 @@ public interface TimestampRangeDelete {
     boolean endInclusive();
     boolean deleteSentinels();
 
+    @Lazy
     default long maxTimestampToDelete() {
         return timestamp() + (endInclusive() ? 0 : -1);
     }
 
+    @Lazy
     default long minTimestampToDelete() {
         return deleteSentinels() ? Value.INVALID_VALUE_TIMESTAMP : Value.INVALID_VALUE_TIMESTAMP + 1;
     }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/TimestampRangeDelete.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/TimestampRangeDelete.java
@@ -1,0 +1,36 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.api;
+
+import org.immutables.value.Value.Immutable;
+
+@Immutable
+public interface TimestampRangeDelete {
+    long timestamp();
+    boolean endInclusive();
+    boolean deleteSentinels();
+
+    default long maxTimestampToDelete() {
+        return timestamp() + (endInclusive() ? 0 : -1);
+    }
+
+    default long minTimestampToDelete() {
+        return deleteSentinels() ? Value.INVALID_VALUE_TIMESTAMP : Value.INVALID_VALUE_TIMESTAMP + 1;
+    }
+
+    class Builder extends ImmutableTimestampRangeDelete.Builder {}
+}

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceGetRowKeysInRangeTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceGetRowKeysInRangeTest.java
@@ -36,6 +36,7 @@ import com.google.common.collect.ImmutableMap;
 import com.palantir.atlasdb.containers.CassandraResource;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.api.TimestampRangeDelete;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
 import com.palantir.atlasdb.table.description.TableMetadata;
 import com.palantir.common.random.RandomBytes;
@@ -110,7 +111,13 @@ public class CassandraKeyValueServiceGetRowKeysInRangeTest {
         List<Cell> cells = createAndWriteCells(10, 2);
         List<byte[]> sortedRows = sortedUniqueRowKeys(cells);
 
-        kvs.deleteAllTimestamps(GET_ROW_KEYS_TABLE, ImmutableMap.of(cells.get(1), Long.MAX_VALUE), true);
+        kvs.deleteAllTimestamps(GET_ROW_KEYS_TABLE,
+                ImmutableMap.of(cells.get(1),
+                        new TimestampRangeDelete.Builder()
+                                .timestamp(Long.MAX_VALUE)
+                                .endInclusive(false)
+                                .deleteSentinels(true)
+                                .build()));
         List<byte[]> result = kvs.getRowKeysInRange(GET_ROW_KEYS_TABLE, new byte[0], new byte[0], 10);
         assertListsMatch(result, sortedRows);
     }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
@@ -64,6 +64,7 @@ import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.api.TimestampRangeDelete;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.keyvalue.impl.AbstractKeyValueServiceTest;
 import com.palantir.atlasdb.keyvalue.impl.TableSplittingKeyValueService;
@@ -259,8 +260,11 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
 
         keyValueService.deleteAllTimestamps(
                 tableReference,
-                ImmutableMap.of(CELL, 1_234_567L),
-                true);
+                ImmutableMap.of(CELL, new TimestampRangeDelete.Builder()
+                        .deleteSentinels(true)
+                        .endInclusive(false)
+                        .timestamp(1_234_567L)
+                        .build()));
 
         putDummyValueAtCellAndTimestamp(tableReference, CELL, 1337L, STARTING_ATLAS_TIMESTAMP - 1);
         Map<Cell, Value> resultExpectedCoveredByRangeTombstone =
@@ -276,8 +280,11 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
 
         keyValueService.deleteAllTimestamps(
                 tableReference,
-                ImmutableMap.of(CELL, 1_234_567L),
-                true);
+                ImmutableMap.of(CELL, new TimestampRangeDelete.Builder()
+                        .deleteSentinels(true)
+                        .endInclusive(false)
+                        .timestamp(1_234_567L)
+                        .build()));
 
         // A value written outside of the range tombstone should not be covered by the range tombstone, even if
         // the Cassandra timestamp of the value is much lower than that of the range tombstone.

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/OneNodeDownDeleteTest.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/OneNodeDownDeleteTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.keyvalue.api.TimestampRangeDelete;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueService;
 
 public class OneNodeDownDeleteTest extends AbstractDegradedClusterTest {
@@ -38,6 +39,12 @@ public class OneNodeDownDeleteTest extends AbstractDegradedClusterTest {
     @Test
     public void deleteAllTimestampsThrows() {
         assertThrowsAtlasDbDependencyExceptionAndDoesNotChangeCassandraSchema(() ->
-                getTestKvs().deleteAllTimestamps(TEST_TABLE, ImmutableMap.of(CELL_1_1, TIMESTAMP), false));
+                getTestKvs().deleteAllTimestamps(
+                        TEST_TABLE,
+                        ImmutableMap.of(CELL_1_1, new TimestampRangeDelete.Builder()
+                                .timestamp(TIMESTAMP)
+                                .endInclusive(false)
+                                .deleteSentinels(false)
+                                .build())));
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -90,6 +90,7 @@ import com.palantir.atlasdb.keyvalue.api.RangeRequests;
 import com.palantir.atlasdb.keyvalue.api.RowColumnRangeIterator;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.api.TimestampRangeDelete;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServices.StartTsResultsCollector;
 import com.palantir.atlasdb.keyvalue.cassandra.cas.CheckAndSetRunner;
@@ -1572,13 +1573,14 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     }
 
     @Override
-    public void deleteAllTimestamps(TableReference tableRef, Map<Cell, Long> maxTimestampExclusiveByCell,
-            boolean deleteSentinels) {
-        new CellRangeDeleter(clientPool,
+    public void deleteAllTimestamps(
+            TableReference tableRef,
+            Map<Cell, TimestampRangeDelete> deletes) {
+        new CellRangeDeleter(
+                clientPool,
                 wrappingQueryRunner,
                 DELETE_CONSISTENCY,
-                mutationTimestampProvider::getRangeTombstoneTimestamp)
-                .deleteAllTimestamps(tableRef, maxTimestampExclusiveByCell, deleteSentinels);
+                mutationTimestampProvider::getRangeTombstoneTimestamp).deleteAllTimestamps(tableRef, deletes);
     }
 
     /**

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellRangeDeleter.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellRangeDeleter.java
@@ -19,6 +19,7 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 import java.net.InetSocketAddress;
 import java.util.Map;
 import java.util.function.LongUnaryOperator;
+import java.util.function.ToLongFunction;
 
 import org.apache.cassandra.thrift.ConsistencyLevel;
 import org.apache.cassandra.thrift.Mutation;
@@ -26,9 +27,11 @@ import org.apache.cassandra.thrift.UnavailableException;
 import org.apache.thrift.TException;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.InsufficientConsistencyException;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.api.TimestampRangeDelete;
 import com.palantir.atlasdb.keyvalue.cassandra.thrift.MutationMap;
 import com.palantir.atlasdb.keyvalue.cassandra.thrift.Mutations;
 import com.palantir.common.base.FunctionCheckedException;
@@ -50,26 +53,24 @@ class CellRangeDeleter {
         this.rangeTombstoneTimestampProvider = rangeTombstoneTimestampProvider;
     }
 
-    void deleteAllTimestamps(TableReference tableRef, Map<Cell, Long> maxTimestampExclusiveByCell,
-            boolean deleteSentinels) {
-        if (maxTimestampExclusiveByCell.isEmpty()) {
+    void deleteAllTimestamps(TableReference tableRef, Map<Cell, TimestampRangeDelete> deletes) {
+        if (deletes.isEmpty()) {
             return;
         }
 
-        Map<InetSocketAddress, Map<Cell, Long>> keysByHost = HostPartitioner.partitionMapByHost(
-                clientPool, maxTimestampExclusiveByCell.entrySet());
+        Map<InetSocketAddress, Map<Cell, TimestampRangeDelete>> keysByHost = HostPartitioner.partitionMapByHost(
+                clientPool, deletes.entrySet());
 
         // this is required by the interface of the CassandraMutationTimestampProvider, although it exists for tests
-        long maxTimestampForAllCells = maxTimestampExclusiveByCell.values().stream()
-                .mapToLong(x -> x).max().getAsLong();
+        long maxTimestampForAllCells = deletes.values().stream()
+                .mapToLong(TimestampRangeDelete::timestamp).max().getAsLong();
         long rangeTombstoneCassandraTimestamp =
                 rangeTombstoneTimestampProvider.applyAsLong(maxTimestampForAllCells);
-        for (Map.Entry<InetSocketAddress, Map<Cell, Long>> entry : keysByHost.entrySet()) {
+        for (Map.Entry<InetSocketAddress, Map<Cell, TimestampRangeDelete>> entry : keysByHost.entrySet()) {
             deleteAllTimestampsOnSingleHost(
                     tableRef,
                     entry.getKey(),
                     entry.getValue(),
-                    deleteSentinels,
                     rangeTombstoneCassandraTimestamp);
         }
     }
@@ -77,10 +78,9 @@ class CellRangeDeleter {
     private void deleteAllTimestampsOnSingleHost(
             TableReference tableRef,
             InetSocketAddress host,
-            Map<Cell, Long> maxTimestampExclusiveByCell,
-            boolean deleteSentinels,
+            Map<Cell, TimestampRangeDelete> deletes,
             long rangeTombstoneCassandraTs) {
-        if (maxTimestampExclusiveByCell.isEmpty()) {
+        if (deletes.isEmpty()) {
             return;
         }
 
@@ -89,15 +89,14 @@ class CellRangeDeleter {
 
                 @Override
                 public Void apply(CassandraClient client) throws Exception {
-                    insertRangeTombstones(client, maxTimestampExclusiveByCell, tableRef,
-                            deleteSentinels, rangeTombstoneCassandraTs);
+                    insertRangeTombstones(client, deletes, tableRef, rangeTombstoneCassandraTs);
                     return null;
                 }
 
                 @Override
                 public String toString() {
                     return "delete_timestamp_ranges_batch_mutate(" + host + ", " + tableRef.getQualifiedName() + ", "
-                            + maxTimestampExclusiveByCell.size() + " column timestamp ranges)";
+                            + deletes.size() + " column timestamp ranges)";
                 }
             });
         } catch (UnavailableException e) {
@@ -108,13 +107,27 @@ class CellRangeDeleter {
         }
     }
 
-    private void insertRangeTombstones(CassandraClient client, Map<Cell, Long> maxTimestampExclusiveByCell,
-            TableReference tableRef, boolean deleteSentinel, long rangeTombstoneCassandraTs) throws TException {
+    /**
+     * If we are deleting inclusive, we must first delete exclusive. This is because although we delete at consistency
+     * all, this doesn't mean that the write fails if there are nodes down; it means that the write partially applies
+     * if there are nodes down. This leads to a scenario where data can come back from the dead in some situations.
+     * This can only affect us if there is no covering tombstone, so we make sure that we've deleted all historical
+     * versions before deleting the latest cell (which is an Atlas level tombstone).
+     */
+    private void insertRangeTombstones(
+            CassandraClient client, Map<Cell, TimestampRangeDelete> deletes,
+            TableReference tableRef, long rangeTombstoneCassandraTs) throws TException {
+        insertTombstones(client, deletes, tableRef, rangeTombstoneCassandraTs, TimestampRangeDelete::timestamp);
+        insertTombstones(client, Maps.filterValues(deletes, TimestampRangeDelete::endInclusive),
+                tableRef, rangeTombstoneCassandraTs, delete -> delete.maxTimestampToDelete() + 1);
+    }
+
+    private void insertTombstones(CassandraClient client, Map<Cell, TimestampRangeDelete> deletes,
+            TableReference tableRef, long rangeTombstoneCassandraTs, ToLongFunction<TimestampRangeDelete> maxTimestampToDelete) throws TException {
         MutationMap mutationMap = new MutationMap();
 
-        maxTimestampExclusiveByCell.forEach((cell, maxTimestampExclusive) -> {
-            Mutation mutation = getMutation(cell, maxTimestampExclusive, deleteSentinel, rangeTombstoneCassandraTs);
-
+        deletes.forEach((cell, delete) -> {
+            Mutation mutation = getMutation(cell, delete, rangeTombstoneCassandraTs, maxTimestampToDelete);
             mutationMap.addMutationForCell(cell, tableRef, mutation);
         });
 
@@ -122,15 +135,17 @@ class CellRangeDeleter {
                 deleteConsistency);
     }
 
-    private Mutation getMutation(Cell cell, long maxTimestampExclusive,
-            boolean deleteSentinel, long rangeTombstoneCassandraTimestamp) {
-        if (deleteSentinel) {
-            return Mutations.rangeTombstoneIncludingSentinelForColumn(cell.getColumnName(), maxTimestampExclusive,
+    private Mutation getMutation(Cell cell, TimestampRangeDelete delete,
+            long rangeTombstoneCassandraTimestamp, ToLongFunction<TimestampRangeDelete> exclusiveTimestampExtractor) {
+        if (delete.deleteSentinels()) {
+            return Mutations.rangeTombstoneIncludingSentinelForColumn(
+                    cell.getColumnName(),
+                    exclusiveTimestampExtractor.applyAsLong(delete),
                     rangeTombstoneCassandraTimestamp);
         }
         return Mutations.rangeTombstoneForColumn(
                 cell.getColumnName(),
-                maxTimestampExclusive,
+                exclusiveTimestampExtractor.applyAsLong(delete),
                 rangeTombstoneCassandraTimestamp);
     }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueService.java
@@ -31,7 +31,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.Multimaps;
 import com.google.common.util.concurrent.Futures;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.AtlasDbPerformanceConstants;
@@ -153,33 +152,6 @@ public abstract class AbstractKeyValueService implements KeyValueService {
                 delete(tableRef, cellsToDelete);
             }
         }
-    }
-
-    @Override
-    public void deleteAllTimestamps(TableReference tableRef,
-            Map<Cell, Long> maxTimestampExclusiveByCell, boolean deleteSentinels) {
-        deleteAllTimestampsDefaultImpl(this, tableRef, maxTimestampExclusiveByCell, deleteSentinels);
-    }
-
-    public static void deleteAllTimestampsDefaultImpl(KeyValueService kvs, TableReference tableRef,
-            Map<Cell, Long> maxTimestampByCell, boolean deleteSentinel) {
-        if (maxTimestampByCell.isEmpty()) {
-            return;
-        }
-
-        long maxTimestampExclusive = maxTimestampByCell.values().stream().max(Long::compare).get();
-
-        Multimap<Cell, Long> timestampsByCell = kvs.getAllTimestamps(tableRef, maxTimestampByCell.keySet(),
-                maxTimestampExclusive);
-
-        Multimap<Cell, Long> timestampsByCellExcludingSentinels = Multimaps.filterEntries(timestampsByCell, entry -> {
-            long maxTimestampForCell = maxTimestampByCell.get(entry.getKey());
-
-            long timestamp = entry.getValue();
-            return timestamp < maxTimestampForCell && (deleteSentinel || timestamp != Value.INVALID_VALUE_TIMESTAMP);
-        });
-
-        kvs.delete(tableRef, timestampsByCellExcludingSentinels);
     }
 
     @Override

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DualWriteKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DualWriteKeyValueService.java
@@ -37,6 +37,7 @@ import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.RowColumnRangeIterator;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.api.TimestampRangeDelete;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.common.base.ClosableIterator;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
@@ -132,10 +133,9 @@ public class DualWriteKeyValueService implements KeyValueService {
     }
 
     @Override
-    public void deleteAllTimestamps(TableReference tableRef, Map<Cell, Long> maxTimestampExclusiveByCell,
-            boolean deleteSentinels) {
-        delegate1.deleteAllTimestamps(tableRef, maxTimestampExclusiveByCell, deleteSentinels);
-        delegate2.deleteAllTimestamps(tableRef, maxTimestampExclusiveByCell, deleteSentinels);
+    public void deleteAllTimestamps(TableReference tableRef, Map<Cell, TimestampRangeDelete> deletes) {
+        delegate1.deleteAllTimestamps(tableRef, deletes);
+        delegate2.deleteAllTimestamps(tableRef, deletes);
     }
 
     @Override

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/InMemoryKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/InMemoryKeyValueService.java
@@ -67,6 +67,7 @@ import com.palantir.atlasdb.keyvalue.api.RangeRequests;
 import com.palantir.atlasdb.keyvalue.api.RowColumnRangeIterator;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.api.TimestampRangeDelete;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.common.annotation.Output;
 import com.palantir.common.base.ClosableIterator;
@@ -477,6 +478,14 @@ public class InMemoryKeyValueService extends AbstractKeyValueService {
         for (Map.Entry<Cell, Long> e : keys.entries()) {
             table.remove(new Key(e.getKey(), e.getValue()));
         }
+    }
+
+    @Override
+    public void deleteAllTimestamps(TableReference tableRef, Map<Cell, TimestampRangeDelete> deletes) {
+        ConcurrentSkipListMap<Key, byte[]> table = getTableMap(tableRef).entries;
+        deletes.forEach((cell, delete) -> table.subMap(
+                new Key(cell, delete.minTimestampToDelete()), true,
+                new Key(cell, delete.maxTimestampToDelete()), true).clear());
     }
 
     @Override

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
@@ -43,6 +43,7 @@ import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.RowColumnRangeIterator;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.api.TimestampRangeDelete;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.logging.KvsProfilingLogger;
 import com.palantir.atlasdb.logging.KvsProfilingLogger.LoggingFunction;
@@ -180,9 +181,8 @@ public final class ProfilingKeyValueService implements KeyValueService {
     }
 
     @Override
-    public void deleteAllTimestamps(TableReference tableRef, Map<Cell, Long> maxTimestampExclusiveByCell,
-            boolean deleteSentinels) {
-        maybeLog(() -> delegate.deleteAllTimestamps(tableRef, maxTimestampExclusiveByCell, deleteSentinels),
+    public void deleteAllTimestamps(TableReference tableRef, Map<Cell, TimestampRangeDelete> deletes) {
+        maybeLog(() -> delegate.deleteAllTimestamps(tableRef, deletes),
                 logTimeAndTable("deleteAllTimestamps", tableRef));
     }
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueService.java
@@ -167,11 +167,11 @@ public final class TracingKeyValueService extends ForwardingObject implements Ke
     }
 
     @Override
-    public void deleteAllTimestamps(TableReference tableRef, Map<Cell, TimestampRangeDelete> maxTimestampByCell) {
+    public void deleteAllTimestamps(TableReference tableRef, Map<Cell, TimestampRangeDelete> deletes) {
         //noinspection unused - try-with-resources closes trace
         try (CloseableTrace trace = startLocalTrace("deleteAllTimestamps({})",
                 LoggingArgs.safeTableOrPlaceholder(tableRef))) {
-            delegate().deleteAllTimestamps(tableRef, maxTimestampByCell);
+            delegate().deleteAllTimestamps(tableRef, deletes);
         }
     }
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueService.java
@@ -41,6 +41,7 @@ import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.RowColumnRangeIterator;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.api.TimestampRangeDelete;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.logging.LoggingArgs;
 import com.palantir.atlasdb.tracing.CloseableTrace;
@@ -166,12 +167,11 @@ public final class TracingKeyValueService extends ForwardingObject implements Ke
     }
 
     @Override
-    public void deleteAllTimestamps(TableReference tableRef, Map<Cell, Long> maxTimestampExclusiveByCell,
-            boolean deleteSentinels) {
+    public void deleteAllTimestamps(TableReference tableRef, Map<Cell, TimestampRangeDelete> maxTimestampByCell) {
         //noinspection unused - try-with-resources closes trace
         try (CloseableTrace trace = startLocalTrace("deleteAllTimestamps({})",
                 LoggingArgs.safeTableOrPlaceholder(tableRef))) {
-            delegate().deleteAllTimestamps(tableRef, maxTimestampExclusiveByCell, deleteSentinels);
+            delegate().deleteAllTimestamps(tableRef, maxTimestampByCell);
         }
     }
 

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/AbstractDbWriteTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/AbstractDbWriteTable.java
@@ -28,6 +28,7 @@ import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
 import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.api.TimestampRangeDelete;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.keyvalue.dbkvs.DdlConfig;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.oracle.PrimaryKeyConstraintNames;
@@ -166,11 +167,11 @@ public abstract class AbstractDbWriteTable implements DbWriteTable {
     }
 
     @Override
-    public void deleteAllTimestamps(Map<Cell, Long> maxTimestampExclusiveByCell, boolean deleteSentinels) {
-        List<Object[]> args = Lists.newArrayListWithCapacity(maxTimestampExclusiveByCell.size());
-        long minTsToDelete = getLowerBound(deleteSentinels);
-        maxTimestampExclusiveByCell.forEach((cell, ts) ->
-                args.add(new Object[] {cell.getRowName(), cell.getColumnName(), minTsToDelete, ts}));
+    public void deleteAllTimestamps(Map<Cell, TimestampRangeDelete> deletes) {
+        List<Object[]> args = Lists.newArrayListWithCapacity(deletes.size());
+        deletes.forEach((cell, ts) ->
+                args.add(new Object[] {cell.getRowName(), cell.getColumnName(),
+                                       ts.minTimestampToDelete(), ts.maxTimestampToDelete()}));
 
         String prefixedTableName = prefixedTableNames.get(tableRef, conns);
         conns.get().updateManyUnregisteredQuery(" /* DELETE_ALL_TS (" + prefixedTableName + ") */ "
@@ -181,9 +182,5 @@ public abstract class AbstractDbWriteTable implements DbWriteTable {
                         + "  AND m.ts >= ? "
                         + "  AND m.ts < ?",
                 args);
-    }
-
-    private long getLowerBound(boolean includeSentinels) {
-        return includeSentinels ? Value.INVALID_VALUE_TIMESTAMP : Value.INVALID_VALUE_TIMESTAMP + 1;
     }
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/AbstractDbWriteTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/AbstractDbWriteTable.java
@@ -180,7 +180,7 @@ public abstract class AbstractDbWriteTable implements DbWriteTable {
                         + " WHERE m.row_name = ? "
                         + "  AND m.col_name = ? "
                         + "  AND m.ts >= ? "
-                        + "  AND m.ts < ?",
+                        + "  AND m.ts <= ?",
                 args);
     }
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
@@ -86,6 +86,7 @@ import com.palantir.atlasdb.keyvalue.api.RangeRequests;
 import com.palantir.atlasdb.keyvalue.api.RowColumnRangeIterator;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.api.TimestampRangeDelete;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.keyvalue.dbkvs.DbKeyValueServiceConfig;
 import com.palantir.atlasdb.keyvalue.dbkvs.DdlConfig;
@@ -599,10 +600,9 @@ public final class DbKvs extends AbstractKeyValueService {
     }
 
     @Override
-    public void deleteAllTimestamps(TableReference tableRef, Map<Cell, Long> maxTimestampExclusiveByCell,
-            boolean deleteSentinels) {
+    public void deleteAllTimestamps(TableReference tableRef, Map<Cell, TimestampRangeDelete> maxTimestampByCell) {
         runWriteForceAutocommit(tableRef, (Function<DbWriteTable, Void>) table -> {
-            table.deleteAllTimestamps(maxTimestampExclusiveByCell, deleteSentinels);
+            table.deleteAllTimestamps(maxTimestampByCell);
             return null;
         });
 

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
@@ -600,9 +600,9 @@ public final class DbKvs extends AbstractKeyValueService {
     }
 
     @Override
-    public void deleteAllTimestamps(TableReference tableRef, Map<Cell, TimestampRangeDelete> maxTimestampByCell) {
+    public void deleteAllTimestamps(TableReference tableRef, Map<Cell, TimestampRangeDelete> deletes) {
         runWriteForceAutocommit(tableRef, (Function<DbWriteTable, Void>) table -> {
-            table.deleteAllTimestamps(maxTimestampByCell);
+            table.deleteAllTimestamps(deletes);
             return null;
         });
 

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbWriteTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbWriteTable.java
@@ -22,6 +22,7 @@ import java.util.Map.Entry;
 
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.atlasdb.keyvalue.api.TimestampRangeDelete;
 import com.palantir.atlasdb.keyvalue.api.Value;
 
 public interface DbWriteTable {
@@ -31,5 +32,5 @@ public interface DbWriteTable {
     void update(Cell cell, long ts, byte[] oldValue, byte[] newValue);
     void delete(List<Entry<Cell, Long>> partition);
     void delete(RangeRequest range);
-    void deleteAllTimestamps(Map<Cell, Long> maxTimestampExclusiveByCell, boolean deleteSentinels);
+    void deleteAllTimestamps(Map<Cell, TimestampRangeDelete> deletes);
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableRemappingKeyValueService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableRemappingKeyValueService.java
@@ -43,6 +43,7 @@ import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.RowColumnRangeIterator;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.api.TimestampRangeDelete;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.common.base.ClosableIterator;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
@@ -115,11 +116,9 @@ public final class TableRemappingKeyValueService extends ForwardingObject implem
     }
 
     @Override
-    public void deleteAllTimestamps(TableReference tableRef, Map<Cell, Long> maxTimestampExclusiveByCell,
-            boolean deleteSentinels) {
+    public void deleteAllTimestamps(TableReference tableRef, Map<Cell, TimestampRangeDelete> deletes) {
         try {
-            delegate().deleteAllTimestamps(tableMapper.getMappedTableName(tableRef), maxTimestampExclusiveByCell,
-                    deleteSentinels);
+            delegate().deleteAllTimestamps(tableMapper.getMappedTableName(tableRef), deletes);
         } catch (TableMappingNotFoundException e) {
             throw new IllegalArgumentException(e);
         }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableSplittingKeyValueService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableSplittingKeyValueService.java
@@ -47,6 +47,7 @@ import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.RowColumnRangeIterator;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.api.TimestampRangeDelete;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.common.base.ClosableIterator;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
@@ -136,9 +137,10 @@ public final class TableSplittingKeyValueService implements KeyValueService {
     }
 
     @Override
-    public void deleteAllTimestamps(TableReference tableRef, Map<Cell, Long> maxTimestampExclusiveByCell,
-            boolean deleteSentinels) {
-        getDelegate(tableRef).deleteAllTimestamps(tableRef, maxTimestampExclusiveByCell, deleteSentinels);
+    public void deleteAllTimestamps(
+            TableReference tableRef,
+            Map<Cell, TimestampRangeDelete> deletes) {
+        getDelegate(tableRef).deleteAllTimestamps(tableRef, deletes);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueDeleter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueDeleter.java
@@ -69,10 +69,8 @@ public class SweepQueueDeleter {
                             if (sweeper.shouldAddSentinels()) {
                                 kvs.addGarbageCollectionSentinelValues(entry.getKey(),
                                         maxTimestampByCellPartition.keySet());
-                                kvs.deleteAllTimestamps(entry.getKey(), maxTimestampByCellPartition);
-                            } else {
-                                kvs.deleteAllTimestamps(entry.getKey(), maxTimestampByCellPartition);
                             }
+                            kvs.deleteAllTimestamps(entry.getKey(), maxTimestampByCellPartition);
                         });
             } catch (Exception e) {
                 if (tableWasDropped(entry.getKey())) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueDeleter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueDeleter.java
@@ -29,6 +29,7 @@ import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.api.TimestampRangeDelete;
 import com.palantir.atlasdb.logging.LoggingArgs;
 import com.palantir.atlasdb.sweep.Sweeper;
 
@@ -57,20 +58,20 @@ public class SweepQueueDeleter {
      */
     public void sweep(Collection<WriteInfo> unfilteredWrites, Sweeper sweeper) {
         Collection<WriteInfo> writes = filter.filter(unfilteredWrites);
-        Map<TableReference, Map<Cell, Long>> maxTimestampByCell = writesPerTable(writes, sweeper);
-        for (Map.Entry<TableReference, Map<Cell, Long>> entry : maxTimestampByCell.entrySet()) {
+        Map<TableReference, Map<Cell, TimestampRangeDelete>> maxTimestampByCell = writesPerTable(writes, sweeper);
+        for (Map.Entry<TableReference, Map<Cell, TimestampRangeDelete>> entry : maxTimestampByCell.entrySet()) {
             try {
                 Iterables.partition(entry.getValue().keySet(), SweepQueueUtils.BATCH_SIZE_KVS)
                         .forEach(cells -> {
-                            Map<Cell, Long> maxTimestampByCellPartition = cells.stream()
+                            Map<Cell, TimestampRangeDelete> maxTimestampByCellPartition = cells.stream()
                                     .collect(Collectors.toMap(Function.identity(), entry.getValue()::get));
                             follower.run(entry.getKey(), maxTimestampByCellPartition.keySet());
                             if (sweeper.shouldAddSentinels()) {
                                 kvs.addGarbageCollectionSentinelValues(entry.getKey(),
                                         maxTimestampByCellPartition.keySet());
-                                kvs.deleteAllTimestamps(entry.getKey(), maxTimestampByCellPartition, false);
+                                kvs.deleteAllTimestamps(entry.getKey(), maxTimestampByCellPartition);
                             } else {
-                                kvs.deleteAllTimestamps(entry.getKey(), maxTimestampByCellPartition, true);
+                                kvs.deleteAllTimestamps(entry.getKey(), maxTimestampByCellPartition);
                             }
                         });
             } catch (Exception e) {
@@ -87,9 +88,10 @@ public class SweepQueueDeleter {
         return Arrays.equals(kvs.getMetadataForTable(tableRef), AtlasDbConstants.EMPTY_TABLE_METADATA);
     }
 
-    private Map<TableReference, Map<Cell, Long>> writesPerTable(Collection<WriteInfo> writes, Sweeper sweeper) {
+    private Map<TableReference, Map<Cell, TimestampRangeDelete>> writesPerTable(
+            Collection<WriteInfo> writes, Sweeper sweeper) {
         return writes.stream().collect(Collectors.groupingBy(
                 WriteInfo::tableRef,
-                Collectors.toMap(WriteInfo::cell, write -> write.timestampToDeleteAtExclusive(sweeper))));
+                Collectors.toMap(WriteInfo::cell, write -> write.toDelete(sweeper))));
     }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/WriteInfoTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/WriteInfoTest.java
@@ -26,6 +26,7 @@ import com.palantir.atlasdb.sweep.Sweeper;
 public class WriteInfoTest {
     private static final TableReference TABLE_REF = TableReference.createFromFullyQualifiedName("test.test");
     private static final Cell CELL = Cell.create(new byte[]{1}, new byte[]{2});
+    private static final long ZERO = 0L;
     private static final long ONE = 1L;
     private static final long TWO = 2L;
     private static final int SHARDS = 128;
@@ -54,10 +55,10 @@ public class WriteInfoTest {
 
     @Test
     public void timestampToDeleteAtHigherForTombstoneAndThorough() {
-        assertThat(getWriteAt(ONE).timestampToDeleteAtExclusive(Sweeper.CONSERVATIVE)).isEqualTo(ONE);
-        assertThat(getWriteAt(ONE).timestampToDeleteAtExclusive(Sweeper.THOROUGH)).isEqualTo(ONE);
-        assertThat(getTombstoneAt(ONE).timestampToDeleteAtExclusive(Sweeper.CONSERVATIVE)).isEqualTo(ONE);
-        assertThat(getTombstoneAt(ONE).timestampToDeleteAtExclusive(Sweeper.THOROUGH)).isEqualTo(TWO);
+        assertThat(getWriteAt(ONE).toDelete(Sweeper.CONSERVATIVE).maxTimestampToDelete()).isEqualTo(ZERO);
+        assertThat(getWriteAt(ONE).toDelete(Sweeper.THOROUGH).maxTimestampToDelete()).isEqualTo(ZERO);
+        assertThat(getTombstoneAt(ONE).toDelete(Sweeper.CONSERVATIVE).maxTimestampToDelete()).isEqualTo(ZERO);
+        assertThat(getTombstoneAt(ONE).toDelete(Sweeper.THOROUGH).maxTimestampToDelete()).isEqualTo(ONE);
     }
 
     private WriteInfo getWriteAt(long timestamp) {

--- a/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueService.java
+++ b/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueService.java
@@ -701,7 +701,7 @@ public class JdbcKeyValueService implements KeyValueService {
         }
 
         long maxTimestampExclusive = deletes.values().stream()
-                .mapToLong(TimestampRangeDelete::maxTimestampToDelete).max().getAsLong();
+                .mapToLong(TimestampRangeDelete::maxTimestampToDelete).max().getAsLong() + 1;
 
         Multimap<Cell, Long> timestampsByCell = getAllTimestamps(tableRef, deletes.keySet(), maxTimestampExclusive);
 

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsDeleteBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsDeleteBenchmarks.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.atlasdb.keyvalue.api.TimestampRangeDelete;
 import com.palantir.atlasdb.performance.benchmarks.table.ConsecutiveNarrowTable;
 import com.palantir.atlasdb.performance.benchmarks.table.RegeneratingTable;
 
@@ -52,8 +53,11 @@ public class KvsDeleteBenchmarks {
 
     private Object doDeleteAllTimestamps(RegeneratingTable<Cell> table) {
         table.getKvs().deleteAllTimestamps(table.getTableRef(),
-                ImmutableMap.of(table.getTableCells(), RegeneratingTable.CELL_VERSIONS),
-                false, false);
+                ImmutableMap.of(table.getTableCells(), new TimestampRangeDelete.Builder()
+                        .timestamp(RegeneratingTable.CELL_VERSIONS)
+                        .endInclusive(false)
+                        .deleteSentinels(false)
+                        .build()));
         return table.getTableCells();
     }
 

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsDeleteBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsDeleteBenchmarks.java
@@ -53,7 +53,7 @@ public class KvsDeleteBenchmarks {
     private Object doDeleteAllTimestamps(RegeneratingTable<Cell> table) {
         table.getKvs().deleteAllTimestamps(table.getTableRef(),
                 ImmutableMap.of(table.getTableCells(), RegeneratingTable.CELL_VERSIONS),
-                false);
+                false, false);
         return table.getTableCells();
     }
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -49,7 +49,17 @@ develop
 
     *    - Type
          - Change
-    
+
+    *    - |fixed|
+         - ``KeyValueService`` and ``CassandraKeyValueService`` in particular now has tighter consistency guarantees in the presence of failures.
+           Previously, inconsistent deletes to thoroughly swept tables could result in readers serving stale versions of cells.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3807>`__)
+
+    *    - |devbreak|
+         - The contract of ``deleteAllTimestamps`` has been strengthened, and the default implementation has been removed.
+           Please contact the AtlasDB team if you think this affects your workflows.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3807>`__)
+
     *    - |improved|
          - ``CassandraKeyValueService`` now exposes a lightweight method for obtaining row keys.
            If you believe you need to use this method, you should reach out to the AtlasDB team first to assess your options.


### PR DESCRIPTION
Here, I fix two correctness bugs.

1. The abstract method is bogus. It doesn't guarantee that stuff is
deleted in the right order, and so isn't safe; when deleting cells you
HAVE to go from 0 upwards. Kill it with fire. I didn't write tests
for the fix, but it's JDBC only which isn't used in prod.
2. The Cassandra approach is unsafe. Even at delete consistency all, you
can't guarantee you deleted safely unless it _succeeds_. Turns out at
consistency all, if it didn't succeed you open yourself up to data
coming back from the dead. Which is what can happen here.