### PR TITLE
Fix bug in PaxosQuorumChecker

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
@@ -33,7 +33,6 @@ import org.immutables.value.Value;
 
 import com.codahale.metrics.InstrumentedExecutorService;
 import com.codahale.metrics.MetricRegistry;
-import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
@@ -182,7 +181,6 @@ public final class Leaders {
                 .randomWaitBeforeProposingLeadershipMs(config.randomWaitBeforeProposingLeadershipMs())
                 .leaderPingResponseWaitMs(config.leaderPingResponseWaitMs())
                 .eventRecorder(leadershipEventRecorder)
-                .onlyLogOnQuorumFailure(Suppliers.compose(LeaderRuntimeConfig::onlyLogOnQuorumFailure, runtime::get))
                 .build();
 
         LeaderElectionService leaderElectionService = AtlasDbMetrics.instrument(metricsManager.getRegistry(),

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -49,6 +49,10 @@ develop
 
     *    - Type
          - Change
+
+    *    - |fixed|
+         - Fixed a bug in ``PaxosQuorumChecker`` causing a new timelock leader to block for 5 seconds before being able to serve requests if another node was unreachable.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3811>`__)
     
     *    - |improved|
          - ``CassandraKeyValueService`` now exposes a lightweight method for obtaining row keys.

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
@@ -515,7 +515,7 @@ public class PaxosLeaderElectionService implements PingableLeader, LeaderElectio
 
         // learn the state accumulated from peers
         boolean learned = false;
-        for (PaxosUpdate update : updates.getResponses()) {
+        for (PaxosUpdate update : updates.get()) {
             ImmutableCollection<PaxosValue> values = update.getValues();
             for (PaxosValue value : values) {
                 if (knowledge.getLearnedValue(value.getRound()) == null) {

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionServiceBuilder.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionServiceBuilder.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.net.HostAndPort;
@@ -39,7 +38,6 @@ public class PaxosLeaderElectionServiceBuilder {
     private long randomWaitBeforeProposingLeadershipMs;
     private long leaderPingResponseWaitMs;
     private PaxosLeaderElectionEventRecorder eventRecorder = PaxosLeaderElectionEventRecorder.NO_OP;
-    private Supplier<Boolean> onlyLogOnQuorumFailure = () -> true;
 
     public PaxosLeaderElectionServiceBuilder proposer(PaxosProposer proposer) {
         this.proposer = proposer;
@@ -104,11 +102,6 @@ public class PaxosLeaderElectionServiceBuilder {
         return this;
     }
 
-    public PaxosLeaderElectionServiceBuilder onlyLogOnQuorumFailure(Supplier<Boolean> onlyLogOnQuorumFailure) {
-        this.onlyLogOnQuorumFailure = onlyLogOnQuorumFailure;
-        return this;
-    }
-
     public PaxosLeaderElectionService build() {
         return new PaxosLeaderElectionService(
                 proposer,
@@ -120,7 +113,6 @@ public class PaxosLeaderElectionServiceBuilder {
                 pingRateMs,
                 randomWaitBeforeProposingLeadershipMs,
                 leaderPingResponseWaitMs,
-                eventRecorder,
-                onlyLogOnQuorumFailure);
+                eventRecorder);
     }
 }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosProposerImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosProposerImpl.java
@@ -17,6 +17,7 @@ package com.palantir.paxos;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.OptionalLong;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
@@ -163,7 +164,7 @@ public final class PaxosProposerImpl implements PaxosProposer {
             long maxProposal = receivedPromises.getResponses().stream()
                     .mapToLong(promise -> promise.promisedId.number)
                     .max()
-                    .getAsLong();
+                    .orElseGet(proposalNumber::get);
             proposalNumber.getAndUpdate(currentNumber -> maxProposal > currentNumber ? maxProposal : currentNumber);
             throw new PaxosRoundFailureException("failed to acquire quorum in paxos phase one");
         }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosProposerImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosProposerImpl.java
@@ -17,7 +17,6 @@ package com.palantir.paxos;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.OptionalLong;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
@@ -161,7 +160,7 @@ public final class PaxosProposerImpl implements PaxosProposer {
 
         if (!receivedPromises.hasQuorum()) {
             // update proposal number on failure
-            long maxProposal = receivedPromises.getResponses().stream()
+            long maxProposal = receivedPromises.stream()
                     .mapToLong(promise -> promise.promisedId.number)
                     .max()
                     .orElseGet(proposalNumber::get);
@@ -169,7 +168,7 @@ public final class PaxosProposerImpl implements PaxosProposer {
             throw new PaxosRoundFailureException("failed to acquire quorum in paxos phase one");
         }
 
-        PaxosPromise greatestPromise = Collections.max(receivedPromises.getResponses());
+        PaxosPromise greatestPromise = Collections.max(receivedPromises.get());
         if (greatestPromise.lastAcceptedValue != null) {
             return greatestPromise.lastAcceptedValue;
         }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosProposerImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosProposerImpl.java
@@ -26,7 +26,6 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.palantir.logsafe.SafeArg;
@@ -82,7 +81,7 @@ public final class PaxosProposerImpl implements PaxosProposer {
     final PaxosLearner localLearner;
     final int quorumSize;
     final String uuid;
-    final AtomicLong proposalNum;
+    final AtomicLong proposalNumber;
 
     private final ExecutorService executor;
 
@@ -100,13 +99,13 @@ public final class PaxosProposerImpl implements PaxosProposer {
         this.allLearners = ImmutableList.copyOf(learners);
         this.quorumSize = quorumSize;
         this.uuid = uuid;
-        this.proposalNum = new AtomicLong();
+        this.proposalNumber = new AtomicLong();
         this.executor = executor;
     }
 
     @Override
     public byte[] propose(final long seq, @Nullable byte[] bytes) throws PaxosRoundFailureException {
-        final PaxosProposalId proposalId = new PaxosProposalId(proposalNum.incrementAndGet(), uuid);
+        final PaxosProposalId proposalId = new PaxosProposalId(proposalNumber.incrementAndGet(), uuid);
         PaxosValue toPropose = new PaxosValue(uuid, seq, bytes);
 
         // paxos phase one (prepare and promise)
@@ -152,36 +151,24 @@ public final class PaxosProposerImpl implements PaxosProposer {
      */
     private PaxosValue phaseOne(final long seq, final PaxosProposalId proposalId, PaxosValue proposalValue)
             throws PaxosRoundFailureException {
-        List<PaxosPromise> receivedPromises = PaxosQuorumChecker.collectQuorumResponses(
+        PaxosResponses<PaxosPromise> receivedPromises = PaxosQuorumChecker.collectQuorumResponses(
                 allAcceptors,
-                new Function<PaxosAcceptor, PaxosPromise>() {
-                    @Override
-                    @Nullable
-                    public PaxosPromise apply(@Nullable PaxosAcceptor acceptor) {
-                        return acceptor.prepare(seq, proposalId);
-                    }
-                },
+                acceptor -> acceptor.prepare(seq, proposalId),
                 quorumSize,
                 executor,
-                PaxosQuorumChecker.DEFAULT_REMOTE_REQUESTS_TIMEOUT_IN_SECONDS);
+                PaxosQuorumChecker.DEFAULT_REMOTE_REQUESTS_TIMEOUT);
 
-        if (!PaxosQuorumChecker.hasQuorum(receivedPromises, quorumSize)) {
+        if (!receivedPromises.hasQuorum()) {
             // update proposal number on failure
-            for (PaxosPromise promise : receivedPromises) {
-                while (true) {
-                    long curNum = proposalNum.get();
-                    if (promise.promisedId.number <= curNum) {
-                        break;
-                    }
-                    if (proposalNum.compareAndSet(curNum, promise.promisedId.number)) {
-                        break;
-                    }
-                }
-            }
+            long maxProposal = receivedPromises.getResponses().stream()
+                    .mapToLong(promise -> promise.promisedId.number)
+                    .max()
+                    .getAsLong();
+            proposalNumber.getAndUpdate(currentNumber -> maxProposal > currentNumber ? maxProposal : currentNumber);
             throw new PaxosRoundFailureException("failed to acquire quorum in paxos phase one");
         }
 
-        PaxosPromise greatestPromise = Collections.max(receivedPromises);
+        PaxosPromise greatestPromise = Collections.max(receivedPromises.getResponses());
         if (greatestPromise.lastAcceptedValue != null) {
             return greatestPromise.lastAcceptedValue;
         }
@@ -200,19 +187,13 @@ public final class PaxosProposerImpl implements PaxosProposer {
     private void phaseTwo(final long seq, PaxosProposalId proposalId, PaxosValue proposalValue)
             throws PaxosRoundFailureException {
         final PaxosProposal proposal = new PaxosProposal(proposalId, proposalValue);
-        List<PaxosResponse> responses = PaxosQuorumChecker.collectQuorumResponses(
+        PaxosResponses<PaxosResponse> responses = PaxosQuorumChecker.collectQuorumResponses(
                 allAcceptors,
-                new Function<PaxosAcceptor, PaxosResponse>() {
-                    @Override
-                    @Nullable
-                    public PaxosResponse apply(@Nullable PaxosAcceptor acceptor) {
-                        return acceptor.accept(seq, proposal);
-                    }
-                },
+                acceptor -> acceptor.accept(seq, proposal),
                 quorumSize,
                 executor,
-                PaxosQuorumChecker.DEFAULT_REMOTE_REQUESTS_TIMEOUT_IN_SECONDS);
-        if (!PaxosQuorumChecker.hasQuorum(responses, quorumSize)) {
+                PaxosQuorumChecker.DEFAULT_REMOTE_REQUESTS_TIMEOUT);
+        if (!responses.hasQuorum()) {
             throw new PaxosRoundFailureException("failed to acquire quorum in paxos phase two");
         }
     }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosQuorumChecker.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosQuorumChecker.java
@@ -179,7 +179,7 @@ public final class PaxosQuorumChecker {
                 shortcircuitIfQuorumImpossible);
         try {
             long deadline = System.nanoTime() + remoteRequestTimeout.toNanos();
-            while (receivedResponses.shouldProcessNextRequest()) {
+            while (receivedResponses.hasMoreRequests() && receivedResponses.shouldProcessNextRequest()) {
                 try {
                     Future<RESPONSE> responseFuture = responseCompletionService.poll(
                             deadline - System.nanoTime(),
@@ -203,7 +203,7 @@ public final class PaxosQuorumChecker {
                 Thread.currentThread().interrupt();
             }
 
-            if (receivedResponses.hasQuorum()) {
+            if (!receivedResponses.hasQuorum()) {
                 encounteredErrors.forEach(throwable -> log.warn(PAXOS_MESSAGE_ERROR, throwable));
             }
         }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosQuorumChecker.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosQuorumChecker.java
@@ -178,7 +178,7 @@ public final class PaxosQuorumChecker {
         PaxosResponses<RESPONSE> receivedResponses = new PaxosResponses<>(remotes.size(), quorumSize,
                 shortcircuitIfQuorumImpossible);
         try {
-            long deadline = System.nanoTime() + remoteRequestTimeout.getNano();
+            long deadline = System.nanoTime() + remoteRequestTimeout.toNanos();
             while (receivedResponses.shouldProcessNextRequest()) {
                 try {
                     Future<RESPONSE> responseFuture = responseCompletionService.poll(

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosQuorumChecker.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosQuorumChecker.java
@@ -15,7 +15,7 @@
  */
 package com.palantir.paxos;
 
-import java.util.ArrayList;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -33,9 +33,7 @@ import org.slf4j.LoggerFactory;
 import com.codahale.metrics.Meter;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.palantir.common.concurrent.MultiplexingCompletionService;
@@ -46,7 +44,7 @@ import com.palantir.logsafe.SafeArg;
 @SuppressWarnings("MethodTypeParameterName")
 public final class PaxosQuorumChecker {
 
-    public static final int DEFAULT_REMOTE_REQUESTS_TIMEOUT_IN_SECONDS = 5;
+    public static final Duration DEFAULT_REMOTE_REQUESTS_TIMEOUT = Duration.ofSeconds(5);
     private static final Logger log = LoggerFactory.getLogger(PaxosQuorumChecker.class);
     private static final String PAXOS_MESSAGE_ERROR =
             "We encountered an error while trying to request an acknowledgement from another paxos node."
@@ -75,41 +73,30 @@ public final class PaxosQuorumChecker {
      * @param request the request to make on each of the remote endpoints
      * @param quorumSize number of acknowledge requests required to reach quorum
      * @param executorService runs the requests
+     * @param remoteRequestTimeout timeout for the call
      * @return a list responses
      */
-    public static <SERVICE, RESPONSE extends PaxosResponse> List<RESPONSE> collectQuorumResponses(
+    public static <SERVICE, RESPONSE extends PaxosResponse> PaxosResponses<RESPONSE> collectQuorumResponses(
             ImmutableList<SERVICE> remotes,
             final Function<SERVICE, RESPONSE> request,
             int quorumSize,
             ExecutorService executorService,
-            long remoteRequestTimeoutInSec) {
-        return collectQuorumResponses(remotes, request, quorumSize, executorService, remoteRequestTimeoutInSec, false);
-    }
-
-    public static <SERVICE, RESPONSE extends PaxosResponse> List<RESPONSE> collectQuorumResponses(
-            ImmutableList<SERVICE> remotes,
-            final Function<SERVICE, RESPONSE> request,
-            int quorumSize,
-            ExecutorService executorService,
-            long remoteRequestTimeoutInSec,
-            boolean onlyLogOnQuorumFailure) {
+            Duration remoteRequestTimeout) {
         return collectResponses(
                 remotes,
                 request,
                 quorumSize,
                 mapToSingleExecutorService(remotes, executorService),
-                remoteRequestTimeoutInSec,
-                onlyLogOnQuorumFailure,
+                remoteRequestTimeout,
                 true);
     }
 
-    public static <SERVICE, RESPONSE extends PaxosResponse> List<RESPONSE> collectQuorumResponses(
+    public static <SERVICE, RESPONSE extends PaxosResponse> PaxosResponses<RESPONSE> collectQuorumResponses(
             ImmutableList<SERVICE> remotes,
             final Function<SERVICE, RESPONSE> request,
             int quorumSize,
             Map<SERVICE, ExecutorService> executors,
-            long remoteRequestTimeoutInSec,
-            boolean onlyLogOnQuorumFailure) {
+            Duration remoteRequestTimeout) {
         Preconditions.checkState(executors.keySet().equals(Sets.newHashSet(remotes)),
                 "Each remote should have an executor.");
         return collectResponses(
@@ -117,8 +104,7 @@ public final class PaxosQuorumChecker {
                 request,
                 quorumSize,
                 executors,
-                remoteRequestTimeoutInSec,
-                onlyLogOnQuorumFailure,
+                remoteRequestTimeout,
                 true);
     }
 
@@ -131,18 +117,17 @@ public final class PaxosQuorumChecker {
      * @param executorService runs the requests
      * @return a list of responses
      */
-    public static <SERVICE, RESPONSE extends PaxosResponse> List<RESPONSE> collectAsManyResponsesAsPossible(
+    public static <SERVICE, RESPONSE extends PaxosResponse> PaxosResponses<RESPONSE> collectAsManyResponsesAsPossible(
             ImmutableList<SERVICE> remotes,
             final Function<SERVICE, RESPONSE> request,
             ExecutorService executorService,
-            long remoteRequestTimeoutInSec) {
+            Duration remoteRequestTimeout) {
         return collectResponses(
                 remotes,
                 request,
                 remotes.size(),
                 mapToSingleExecutorService(remotes, executorService),
-                remoteRequestTimeoutInSec,
-                false,
+                remoteRequestTimeout,
                 false);
     }
 
@@ -163,13 +148,12 @@ public final class PaxosQuorumChecker {
      * @param executors run the requests
      * @return a list of responses
      */
-    private static <SERVICE, RESPONSE extends PaxosResponse> List<RESPONSE> collectResponses(
+    private static <SERVICE, RESPONSE extends PaxosResponse> PaxosResponses<RESPONSE> collectResponses(
             ImmutableList<SERVICE> remotes,
             final Function<SERVICE, RESPONSE> request,
             int quorumSize,
             Map<SERVICE, ExecutorService> executors,
-            long remoteRequestTimeoutInSec,
-            boolean onlyLogOnQuorumFailure,
+            Duration remoteRequestTimeout,
             boolean shortcircuitIfQuorumImpossible) {
         MultiplexingCompletionService<SERVICE, RESPONSE> responseCompletionService =
                 MultiplexingCompletionService.create(executors);
@@ -189,90 +173,50 @@ public final class PaxosQuorumChecker {
             }
         }
 
-        List<Throwable> toLog = Lists.newArrayList();
+        List<Throwable> encounteredErrors = Lists.newArrayList();
         boolean interrupted = false;
-        List<RESPONSE> receivedResponses = new ArrayList<RESPONSE>();
-        int acksRecieved = 0;
-        int nacksRecieved = 0;
-
+        PaxosResponses<RESPONSE> receivedResponses = new PaxosResponses<>(remotes.size(), quorumSize,
+                shortcircuitIfQuorumImpossible);
         try {
-            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(remoteRequestTimeoutInSec);
-            // handle responses
-            while (acksRecieved < quorumSize) {
+            long deadline = System.nanoTime() + remoteRequestTimeout.getNano();
+            while (receivedResponses.shouldProcessNextRequest()) {
                 try {
-                    // check if quorum is impossible (nack quorum failure)
-                    if (shortcircuitIfQuorumImpossible && nacksRecieved > remotes.size() - quorumSize) {
-                        break;
-                    }
-
                     Future<RESPONSE> responseFuture = responseCompletionService.poll(
                             deadline - System.nanoTime(),
                             TimeUnit.NANOSECONDS);
-                    // check if out of responses (no quorum failure)
-                    if (responseFuture == null) {
-                        return receivedResponses;
+                    if (timedOut(responseFuture)) {
+                        break;
                     }
-
-                    // reject invalid or repeat promises
-                    RESPONSE response = responseFuture.get();
-                    if (response.isSuccessful()) {
-                        acksRecieved++;
-                    } else {
-                        nacksRecieved++;
-                    }
-
-                    // record response
-                    receivedResponses.add(response);
-                } catch (InterruptedException e) {
-                    log.warn("paxos request interrupted", e);
-                    interrupted = true;
-                    break;
+                    receivedResponses.add(responseFuture.get());
                 } catch (ExecutionException e) {
-                    nacksRecieved++;
-                    if (onlyLogOnQuorumFailure) {
-                        toLog.add(e.getCause());
-                    } else {
-                        log.warn(PAXOS_MESSAGE_ERROR, e.getCause());
-                    }
+                    receivedResponses.markFailure();
+                    encounteredErrors.add(e.getCause());
                 }
             }
-
-            // poll for extra completed futures
-            Future<RESPONSE> future;
-            while ((future = responseCompletionService.poll()) != null) {
-                try {
-                    receivedResponses.add(future.get());
-                } catch (InterruptedException e) {
-                    log.warn("paxos request interrupted", e);
-                    interrupted = true;
-                    break;
-                } catch (ExecutionException e) {
-                    log.warn(PAXOS_MESSAGE_ERROR, e.getCause());
-                }
-            }
-
+        } catch (InterruptedException e) {
+            log.warn("paxos request interrupted", e);
+            interrupted = true;
         } finally {
-            // cancel pending futures
             cancelOutstandingRequestsAfterTimeout(allFutures);
 
-            // reset interrupted flag
             if (interrupted) {
                 Thread.currentThread().interrupt();
             }
 
-            if (onlyLogOnQuorumFailure && acksRecieved < quorumSize) {
-                for (Throwable throwable : toLog) {
-                    log.warn(PAXOS_MESSAGE_ERROR, throwable);
-                }
+            if (receivedResponses.hasQuorum()) {
+                encounteredErrors.forEach(throwable -> log.warn(PAXOS_MESSAGE_ERROR, throwable));
             }
         }
-
         return receivedResponses;
+    }
+
+    private static boolean timedOut(Future<?> responseFuture) {
+        return responseFuture == null;
     }
 
     private static <RESPONSE extends PaxosResponse> void cancelOutstandingRequestsAfterTimeout(
             List<Future<RESPONSE>> responseFutures) {
-        boolean areAllRequestsComplete = Iterables.all(responseFutures, Future::isDone);
+        boolean areAllRequestsComplete = responseFutures.stream().allMatch(Future::isDone);
         if (areAllRequestsComplete) {
             return;
         }
@@ -296,24 +240,6 @@ public final class PaxosQuorumChecker {
                     SafeArg.of("rateCancelled", cancelOutstandingRequestSuccess.getOneMinuteRate()),
                     SafeArg.of("rateNoOpCancellation", cancelOutstandingRequestNoOp.getOneMinuteRate()));
         }
-    }
-
-    public static boolean hasQuorum(List<? extends PaxosResponse> responses, int quorumSize) {
-        return Collections2.filter(responses, PaxosResponses.isSuccessfulPredicate()).size() >= quorumSize;
-    }
-
-    public static PaxosQuorumStatus getQuorumResult(List<PaxosResponse> responses, int quorumSize) {
-        if (hasQuorum(responses, quorumSize)) {
-            return PaxosQuorumStatus.QUORUM_AGREED;
-        } else if (hasAnyDisagreements(responses)) {
-            return PaxosQuorumStatus.SOME_DISAGREED;
-        }
-
-        return PaxosQuorumStatus.NO_QUORUM;
-    }
-
-    private static boolean hasAnyDisagreements(List<PaxosResponse> responses) {
-        return responses.stream().anyMatch(response -> !response.isSuccessful());
     }
 
     private static boolean shouldLogDiagnosticInformation() {

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosResponses.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosResponses.java
@@ -34,8 +34,12 @@ public class PaxosResponses<T extends PaxosResponse> {
         this.shortcut = shortcut;
     }
 
-    public boolean shouldProcessNextRequest() {
-        return !hasQuorum() && !shouldGiveUpOnAchievingQuorum() && !noMoreRequests();
+    public boolean hasMoreRequests() {
+        return successes + failures < totalRequests;
+    }
+
+    boolean shouldProcessNextRequest() {
+        return !hasQuorum() && !shouldGiveUpOnAchievingQuorum();
     }
 
     public void add(T response) {
@@ -47,7 +51,7 @@ public class PaxosResponses<T extends PaxosResponse> {
         responses.add(response);
     }
 
-    public void markFailure() {
+    void markFailure() {
         failures++;
     }
 
@@ -63,7 +67,7 @@ public class PaxosResponses<T extends PaxosResponse> {
         return successes >= quorum;
     }
 
-    public PaxosQuorumStatus getQuorumResult() {
+    PaxosQuorumStatus getQuorumResult() {
         if (hasQuorum()) {
             return PaxosQuorumStatus.QUORUM_AGREED;
         } else if (thereWereDisagreements()) {
@@ -74,10 +78,6 @@ public class PaxosResponses<T extends PaxosResponse> {
 
     private boolean shouldGiveUpOnAchievingQuorum() {
         return shortcut && failures > totalRequests - quorum;
-    }
-
-    private boolean noMoreRequests() {
-        return successes + failures == totalRequests;
     }
 
     private boolean thereWereDisagreements() {

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosResponses.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosResponses.java
@@ -64,7 +64,6 @@ public class PaxosResponses<T extends PaxosResponse> {
         } else if (thereWereDisagreements()) {
             return PaxosQuorumStatus.SOME_DISAGREED;
         }
-
         return PaxosQuorumStatus.NO_QUORUM;
     }
 

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosResponses.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosResponses.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,26 +13,70 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.palantir.paxos;
 
-import com.google.common.base.Predicate;
-import com.palantir.paxos.persistence.generated.remoting.PaxosAcceptorPersistence;
+import java.util.ArrayList;
+import java.util.List;
 
-public final class PaxosResponses {
-    private PaxosResponses() {}
+public class PaxosResponses<T extends PaxosResponse> {
+    private final int totalRequests;
+    private final int quorum;
+    private final boolean shortcut;
+    private List<T> responses = new ArrayList<>();
+    private int successes = 0;
+    private int failures = 0;
 
-    public static Predicate<PaxosResponse> isSuccessfulPredicate() {
-        return response -> response != null && response.isSuccessful();
+    PaxosResponses(int totalRequests, int quorum, boolean shortcut) {
+        this.totalRequests = totalRequests;
+        this.quorum = quorum;
+        this.shortcut = shortcut;
     }
 
-    public static PaxosAcceptorPersistence.PaxosResponse toProto(PaxosResponse result) {
-        return PaxosAcceptorPersistence.PaxosResponse.newBuilder()
-                .setAck(result.isSuccessful())
-                .build();
+    public boolean shouldProcessNextRequest() {
+        return !hasQuorum() && !shouldGiveUpOnAchievingQuorum() && !noMoreRequests();
     }
 
-    public static PaxosResponse fromProto(PaxosAcceptorPersistence.PaxosResponse proto) {
-        boolean ack = proto.getAck();
-        return new PaxosResponseImpl(ack);
+    public void add(T response) {
+        if (response.isSuccessful()) {
+            successes++;
+        } else {
+            failures++;
+        }
+        responses.add(response);
+    }
+
+    public void markFailure() {
+        failures++;
+    }
+
+    public List<T> getResponses() {
+        return responses;
+    }
+
+    public boolean hasQuorum() {
+        return successes >= quorum;
+    }
+
+    public PaxosQuorumStatus getQuorumResult() {
+        if (hasQuorum()) {
+            return PaxosQuorumStatus.QUORUM_AGREED;
+        } else if (thereWereDisagreements()) {
+            return PaxosQuorumStatus.SOME_DISAGREED;
+        }
+
+        return PaxosQuorumStatus.NO_QUORUM;
+    }
+
+    private boolean shouldGiveUpOnAchievingQuorum() {
+        return shortcut && failures > totalRequests - quorum;
+    }
+
+    private boolean noMoreRequests() {
+        return successes + failures == totalRequests;
+    }
+
+    private boolean thereWereDisagreements() {
+        return responses.stream().anyMatch(response -> !response.isSuccessful());
     }
 }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosResponses.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosResponses.java
@@ -18,6 +18,7 @@ package com.palantir.paxos;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
 public class PaxosResponses<T extends PaxosResponse> {
     private final int totalRequests;
@@ -50,8 +51,12 @@ public class PaxosResponses<T extends PaxosResponse> {
         failures++;
     }
 
-    public List<T> getResponses() {
+    public List<T> get() {
         return responses;
+    }
+
+    public Stream<T> stream() {
+        return responses.stream();
     }
 
     public boolean hasQuorum() {

--- a/leader-election-impl/src/test/java/com/palantir/leader/PaxosLeaderElectionServiceTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/PaxosLeaderElectionServiceTest.java
@@ -43,7 +43,6 @@ public class PaxosLeaderElectionServiceTest {
                 .randomWaitBeforeProposingLeadershipMs(0L)
                 .leaderPingResponseWaitMs(0L)
                 .eventRecorder(mock(PaxosLeadershipEventRecorder.class))
-                .onlyLogOnQuorumFailure(() -> true)
                 .build();
 
         assertThat(service.getPotentialLeaders()).containsExactlyInAnyOrder(other, service);

--- a/leader-election-impl/src/test/java/com/palantir/leader/PaxosLeaderEventsTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/PaxosLeaderEventsTest.java
@@ -45,7 +45,6 @@ public class PaxosLeaderEventsTest {
             .randomWaitBeforeProposingLeadershipMs(0L)
             .leaderPingResponseWaitMs(0L)
             .eventRecorder(recorder)
-            .onlyLogOnQuorumFailure(() -> true)
             .build();
 
     @Test

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosConsensusTestUtils.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosConsensusTestUtils.java
@@ -91,7 +91,6 @@ public final class PaxosConsensusTestUtils {
                     .pingRateMs(0L)
                     .randomWaitBeforeProposingLeadershipMs(0L)
                     .leaderPingResponseWaitMs(0L)
-                    .onlyLogOnQuorumFailure(() -> true)
                     .build();
             leaders.add(SimulatingFailingServerProxy.newProxyInstance(
                     LeaderElectionService.class,

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosLatestRoundVerifierTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosLatestRoundVerifierTest.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.function.Supplier;
 
 import org.junit.Test;
 
@@ -46,7 +45,6 @@ public class PaxosLatestRoundVerifierTest {
             acceptor2,
             acceptor3);
 
-    private final Supplier<Boolean> onlyLogOnQuorumFailure = () -> false;
     private final Map<PaxosAcceptor, ExecutorService> executorServiceMap = ImmutableMap.of(
             acceptor1, Executors.newSingleThreadExecutor(),
             acceptor2, Executors.newSingleThreadExecutor(),
@@ -54,7 +52,7 @@ public class PaxosLatestRoundVerifierTest {
     );
 
     private final PaxosLatestRoundVerifierImpl verifier = new PaxosLatestRoundVerifierImpl(acceptors, 2,
-            executorServiceMap, onlyLogOnQuorumFailure);
+            executorServiceMap);
 
     @Test
     public void hasQuorumIfAllNodesAgree() {

--- a/leader-election-impl/src/test/java/com/palantir/paxos/persistence/ProtobufTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/persistence/ProtobufTest.java
@@ -25,7 +25,6 @@ import com.palantir.paxos.PaxosProposal;
 import com.palantir.paxos.PaxosProposalId;
 import com.palantir.paxos.PaxosResponse;
 import com.palantir.paxos.PaxosResponseImpl;
-import com.palantir.paxos.PaxosResponses;
 import com.palantir.paxos.PaxosValue;
 import com.palantir.paxos.persistence.generated.PaxosPersistence;
 import com.palantir.paxos.persistence.generated.remoting.PaxosAcceptorPersistence;
@@ -125,13 +124,24 @@ public class ProtobufTest {
         PaxosResponse actual;
 
         expected = new PaxosResponseImpl(true);
-        persisted = PaxosResponses.toProto(expected);
-        actual = PaxosResponses.fromProto(persisted);
+        persisted = toProto(expected);
+        actual = fromProto(persisted);
         assertEquals(expected, actual);
 
         expected = new PaxosResponseImpl(false);
-        persisted = PaxosResponses.toProto(expected);
-        actual = PaxosResponses.fromProto(persisted);
+        persisted = toProto(expected);
+        actual = fromProto(persisted);
         assertEquals(expected, actual);
+    }
+
+    private static PaxosAcceptorPersistence.PaxosResponse toProto(PaxosResponse result) {
+        return PaxosAcceptorPersistence.PaxosResponse.newBuilder()
+                .setAck(result.isSuccessful())
+                .build();
+    }
+
+    private static PaxosResponse fromProto(PaxosAcceptorPersistence.PaxosResponse proto) {
+        boolean ack = proto.getAck();
+        return new PaxosResponseImpl(ack);
     }
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosSynchronizer.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosSynchronizer.java
@@ -67,7 +67,7 @@ public final class PaxosSynchronizer {
                 learner -> ImmutablePaxosValueResponse.of(learner.getGreatestLearnedValue()),
                 executor,
                 PaxosQuorumChecker.DEFAULT_REMOTE_REQUESTS_TIMEOUT);
-        return responses.getResponses().stream()
+        return responses.stream()
                 .filter(response -> response.paxosValue() != null)
                 .map(PaxosValueResponse::paxosValue)
                 .max(Comparator.comparingLong(PaxosValue::getRound));

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosSynchronizer.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosSynchronizer.java
@@ -33,6 +33,7 @@ import com.palantir.paxos.PaxosLearner;
 import com.palantir.paxos.PaxosQuorumChecker;
 import com.palantir.paxos.PaxosResponse;
 import com.palantir.paxos.PaxosValue;
+import com.palantir.paxos.PaxosResponses;
 
 public final class PaxosSynchronizer {
     private static final Logger log = LoggerFactory.getLogger(PaxosSynchronizer.class);
@@ -61,12 +62,12 @@ public final class PaxosSynchronizer {
 
     private static Optional<PaxosValue> getMostRecentLearnedValue(List<PaxosLearner> paxosLearners) {
         ExecutorService executor = PTExecutors.newCachedThreadPool();
-        List<PaxosValueResponse> responses = PaxosQuorumChecker.collectAsManyResponsesAsPossible(
+        PaxosResponses<PaxosValueResponse> responses = PaxosQuorumChecker.collectAsManyResponsesAsPossible(
                 ImmutableList.copyOf(paxosLearners),
                 learner -> ImmutablePaxosValueResponse.of(learner.getGreatestLearnedValue()),
                 executor,
-                PaxosQuorumChecker.DEFAULT_REMOTE_REQUESTS_TIMEOUT_IN_SECONDS);
-        return responses.stream()
+                PaxosQuorumChecker.DEFAULT_REMOTE_REQUESTS_TIMEOUT);
+        return responses.getResponses().stream()
                 .filter(response -> response.paxosValue() != null)
                 .map(PaxosValueResponse::paxosValue)
                 .max(Comparator.comparingLong(PaxosValue::getRound));

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStore.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStore.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Ordering;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.common.concurrent.PTExecutors;
@@ -115,7 +116,7 @@ public class PaxosTimestampBoundStore implements TimestampBoundStore {
         if (!responses.hasQuorum()) {
             throw new ServiceNotAvailableException("could not get a quorum");
         }
-        return responses.getResponses();
+        return responses.get();
     }
 
     /**
@@ -213,10 +214,9 @@ public class PaxosTimestampBoundStore implements TimestampBoundStore {
                 QUORUM_OF_ONE,
                 executor,
                 PaxosQuorumChecker.DEFAULT_REMOTE_REQUESTS_TIMEOUT);
-        if (!responses.hasQuorum()) {
-            return Optional.empty();
-        }
-        return Optional.of(ImmutableSequenceAndBound.of(seq, responses.getResponses().get(0).getValue()));
+        return Optional.ofNullable(Iterables.getFirst(responses.get(), null))
+                .map(PaxosLong::getValue)
+                .map(value -> ImmutableSequenceAndBound.of(seq, value));
     }
 
     /**


### PR DESCRIPTION
**Goals (and why)**:
When calling ``collectAsManyResponsesAsPossible`` with a node down, exceptions were not treated correctly and would result in blocking until timeout (which is set to 5 seconds in all usages).

**Implementation Description (bullets)**:
Refactored to understand the code better, and made a change to check if we actually did get all of the responses in the loop condition.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Did not add any tests. Are there particularly concerning bits?

**Concerns (what feedback would you like?)**:
It's mostly a refactor, other than the bug fix. Did we introduce a change by accident?

**Where should we start reviewing?**:
PaxosResponses?

**Priority (whenever / two weeks / yesterday)**:
asap