### PR TITLE
Ensure separate durations are wired through correctly

### DIFF
--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/PaxosLeadershipCreator.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/PaxosLeadershipCreator.java
@@ -111,8 +111,8 @@ public class PaxosLeadershipCreator {
                         PaxosTimeLockConstants.LEARNER_SUBDIRECTORY_PATH).toFile())
                 .pingRateMs(paxosRuntimeConfiguration.pingRateMs())
                 .quorumSize(PaxosRemotingUtils.getQuorumSize(PaxosRemotingUtils.getClusterAddresses(install)))
-                .leaderPingResponseWaitMs(paxosRuntimeConfiguration.pingRateMs())
-                .randomWaitBeforeProposingLeadershipMs(paxosRuntimeConfiguration.pingRateMs())
+                .leaderPingResponseWaitMs(paxosRuntimeConfiguration.leaderPingResponseWaitMs())
+                .randomWaitBeforeProposingLeadershipMs(paxosRuntimeConfiguration.maximumWaitBeforeProposalMs())
                 .build();
     }
 


### PR DESCRIPTION
**Goals (and why)**:
In #2168 we inadvertently copied `pingRate` but used it multiple times, and left `leaderPingResponseWaitMs` and `maximumWaitBeforeProposalMs` out to dry. Wiring it through correctly, so we can change it for our experiments later.

**Implementation Description (bullets)**:
Pass through the correct durations instead of using just `pingRate`.

**Concerns (what feedback would you like?)**:
None

**Priority (whenever / two weeks / yesterday)**:
asap surge 🔥 💃 
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
