### PR TITLE
Remove leaderConfig from CassandraKVSImpl since it's unused.

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraBackgroundSweeperIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraBackgroundSweeperIntegrationTest.java
@@ -36,7 +36,6 @@ public class CassandraBackgroundSweeperIntegrationTest extends AbstractBackgroun
         return CassandraKeyValueServiceImpl.create(
                 MetricsManagers.createForTests(),
                 CASSANDRA.getConfig(),
-                CassandraResource.LEADER_CONFIG,
                 CassandraTestTools.getMutationProviderWithStartingTimestamp(1_000_000));
     }
 }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConnectionIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConnectionIntegrationTest.java
@@ -39,8 +39,6 @@ public class CassandraConnectionIntegrationTest {
 
     @Test
     public void testAuthMissing() {
-        CassandraKeyValueServiceImpl.createForTesting(
-                NO_CREDS_CKVS_CONFIG,
-                CassandraResource.LEADER_CONFIG).close();
+        CassandraKeyValueServiceImpl.createForTesting(NO_CREDS_CKVS_CONFIG).close();
     }
 }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
@@ -91,7 +91,6 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
     public static final CassandraResource CASSANDRA = new CassandraResource(() -> CassandraKeyValueServiceImpl.create(
             MetricsManagers.createForTests(),
             getConfigWithGcGraceSeconds(FOUR_DAYS_IN_SECONDS),
-            CassandraResource.LEADER_CONFIG,
             CassandraTestTools.getMutationProviderWithStartingTimestamp(STARTING_ATLAS_TIMESTAMP),
             logger));
 
@@ -149,7 +148,7 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
         kvs3.close();
     }
 
-    private void assertThatGcGraceSecondsIs(CassandraKeyValueService kvs, int gcGraceSeconds) throws TException {
+    private static void assertThatGcGraceSecondsIs(CassandraKeyValueService kvs, int gcGraceSeconds) throws TException {
         List<CfDef> knownCfs = kvs.getClientPool().runWithRetry(client ->
                 client.describe_keyspace(CASSANDRA.getConfig().getKeyspaceOrThrow()).getCf_defs());
         CfDef clusterSideCf = Iterables.getOnlyElement(knownCfs.stream()
@@ -191,7 +190,7 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
                 .withGcGraceSeconds(gcGraceSeconds);
     }
 
-    private String getInternalTestTableName() {
+    private static String getInternalTestTableName() {
         return NEVER_SEEN.getQualifiedName().replaceFirst("\\.", "__");
     }
 
@@ -358,12 +357,11 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
         verify(logger, never()).error(anyString(), any(Object.class));
     }
 
-    private CassandraKeyValueService createKvs(CassandraKeyValueServiceConfig config, Logger testLogger) {
+    private static CassandraKeyValueService createKvs(CassandraKeyValueServiceConfig config, Logger testLogger) {
         // Mutation provider is needed, because deletes/sentinels are to be written after writes
         return CassandraKeyValueServiceImpl.create(
                 metricsManager,
                 config,
-                CassandraResource.LEADER_CONFIG,
                 CassandraTestTools.getMutationProviderWithStartingTimestamp(STARTING_ATLAS_TIMESTAMP),
                 testLogger);
     }
@@ -392,7 +390,7 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
         });
     }
 
-    private String convertBytesToHexString(byte[] bytes) {
+    private static String convertBytesToHexString(byte[] bytes) {
         return "0x" + BaseEncoding.base16().lowerCase().encode(bytes);
     }
 

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceSweepTaskRunnerIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceSweepTaskRunnerIntegrationTest.java
@@ -52,7 +52,6 @@ public class CassandraKeyValueServiceSweepTaskRunnerIntegrationTest extends Abst
         return CassandraKeyValueServiceImpl.create(
                 MetricsManagers.createForTests(),
                 CASSANDRA.getConfig(),
-                CassandraResource.LEADER_CONFIG,
                 CassandraTestTools.getMutationProviderWithStartingTimestamp(1_000_000));
     }
 
@@ -63,7 +62,7 @@ public class CassandraKeyValueServiceSweepTaskRunnerIntegrationTest extends Abst
         }
     }
 
-    private String makeLongRandomString() {
+    private static String makeLongRandomString() {
         return RandomStringUtils.random(1_000_000);
     }
 }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTableCreationIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTableCreationIntegrationTest.java
@@ -200,8 +200,6 @@ public class CassandraKeyValueServiceTableCreationIntegrationTest {
         ImmutableCassandraKeyValueServiceConfig config = ImmutableCassandraKeyValueServiceConfig
                 .copyOf(CASSANDRA.getConfig())
                 .withSchemaMutationTimeoutMillis(millis);
-        return CassandraKeyValueServiceImpl.createForTesting(
-                config,
-                CassandraResource.LEADER_CONFIG);
+        return CassandraKeyValueServiceImpl.createForTesting(config);
     }
 }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTransactionIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTransactionIntegrationTest.java
@@ -64,7 +64,6 @@ public class CassandraKeyValueServiceTransactionIntegrationTest extends Abstract
         KeyValueService kvs = CassandraKeyValueServiceImpl.create(
                 metricsManager,
                 CASSANDRA.getConfig(),
-                CassandraResource.LEADER_CONFIG,
                 CassandraMutationTimestampProviders.singleLongSupplierBacked(
                         () -> {
                             if (timestampService == null) {

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/CassandraSchemaLockTest.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/CassandraSchemaLockTest.java
@@ -27,7 +27,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
@@ -74,7 +73,7 @@ public class CassandraSchemaLockTest {
             for (int i = 0; i < THREAD_COUNT; i++) {
                 async(() -> {
                     CassandraKeyValueService keyValueService =
-                            CassandraKeyValueServiceImpl.createForTesting(config, Optional.empty());
+                            CassandraKeyValueServiceImpl.createForTesting(config);
                     barrier.await();
                     keyValueService.createTable(table1, AtlasDbConstants.GENERIC_TABLE_METADATA);
                     return null;
@@ -85,7 +84,7 @@ public class CassandraSchemaLockTest {
             assertTrue(executorService.awaitTermination(4, TimeUnit.MINUTES));
         }
 
-        CassandraKeyValueService kvs = CassandraKeyValueServiceImpl.createForTesting(config, Optional.empty());
+        CassandraKeyValueService kvs = CassandraKeyValueServiceImpl.createForTesting(config);
         assertThat(kvs.getAllTableNames(), hasItem(table1));
 
         assertThat(new File(CONTAINERS.getLogDirectory()),

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/NodesDownTestSetup.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/NodesDownTestSetup.java
@@ -55,8 +55,7 @@ public abstract class NodesDownTestSetup {
     }
 
     private static CassandraKeyValueService createKvs(Class<?> testClass) {
-        return CassandraKeyValueServiceImpl
-                .createForTesting(getConfig(testClass), ThreeNodeCassandraCluster.LEADER_CONFIG);
+        return CassandraKeyValueServiceImpl.createForTesting(getConfig(testClass));
     }
 
     static CassandraKeyValueServiceConfig getConfig(Class<?> testClass) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraAtlasDbFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraAtlasDbFactory.java
@@ -54,7 +54,7 @@ public class CassandraAtlasDbFactory implements AtlasDbFactory {
             MetricsManager metricsManager,
             KeyValueServiceConfig config,
             Supplier<Optional<KeyValueServiceRuntimeConfig>> runtimeConfig,
-            Optional<LeaderConfig> leaderConfig,
+            Optional<LeaderConfig> unused,
             Optional<String> namespace,
             LongSupplier freshTimestampSource,
             boolean initializeAsync) {
@@ -66,7 +66,6 @@ public class CassandraAtlasDbFactory implements AtlasDbFactory {
                 metricsManager,
                 preprocessedConfig,
                 cassandraRuntimeConfig,
-                leaderConfig,
                 CassandraMutationTimestampProviders.singleLongSupplierBacked(freshTimestampSource),
                 initializeAsync);
     }

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraContainer.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraContainer.java
@@ -87,9 +87,7 @@ public class CassandraContainer extends Container {
 
     @Override
     public SuccessOrFailure isReady(DockerComposeRule rule) {
-        return SuccessOrFailure.onResultOf(() -> CassandraKeyValueServiceImpl.createForTesting(
-                config,
-                LEADER_CONFIG)
+        return SuccessOrFailure.onResultOf(() -> CassandraKeyValueServiceImpl.createForTesting(config)
                 .isInitialized());
     }
 

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraResource.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraResource.java
@@ -24,7 +24,6 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
-import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueService;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServiceImpl;
@@ -34,8 +33,6 @@ import com.palantir.atlasdb.keyvalue.impl.TransactionManagerManager;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
 
 public class CassandraResource extends ExternalResource implements KvsManager, TransactionManagerManager {
-    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    public static final Optional<LeaderConfig> LEADER_CONFIG = CassandraContainer.LEADER_CONFIG;
     private final CassandraContainer containerInstance = new CassandraContainer();
     private final Supplier<KeyValueService> supplier;
     private Containers containers;
@@ -43,7 +40,7 @@ public class CassandraResource extends ExternalResource implements KvsManager, T
 
     public CassandraResource() {
         this.supplier = () -> CassandraKeyValueServiceImpl.createForTesting(
-                containerInstance.getConfig(), CassandraContainer.LEADER_CONFIG);
+                containerInstance.getConfig());
     }
 
     public CassandraResource(Supplier<KeyValueService> supplier) {

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/ThreeNodeCassandraCluster.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/ThreeNodeCassandraCluster.java
@@ -17,16 +17,12 @@ package com.palantir.atlasdb.containers;
 
 import java.net.InetSocketAddress;
 import java.util.Map;
-import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
-import com.palantir.atlasdb.config.ImmutableLeaderConfig;
-import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServiceImpl;
 import com.palantir.docker.compose.DockerComposeRule;
 import com.palantir.docker.compose.connection.waiting.SuccessOrFailure;
@@ -54,13 +50,6 @@ public class ThreeNodeCassandraCluster extends Container {
             .autoRefreshNodes(false)
             .build();
 
-    public static final Optional<LeaderConfig> LEADER_CONFIG = Optional.of(ImmutableLeaderConfig
-            .builder()
-            .quorumSize(1)
-            .localServer("localhost")
-            .leaders(ImmutableSet.of("localhost"))
-            .build());
-
     @Override
     public String getDockerComposeFile() {
         return "/docker-compose-cassandra-three-node.yml";
@@ -86,9 +75,7 @@ public class ThreeNodeCassandraCluster extends Container {
     }
 
     private static boolean canCreateCassandraKeyValueService() {
-        return CassandraKeyValueServiceImpl.createForTesting(
-                KVS_CONFIG,
-                LEADER_CONFIG)
+        return CassandraKeyValueServiceImpl.createForTesting(KVS_CONFIG)
                 .isInitialized();
     }
 }

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/ThreeNodeCassandraResource.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/ThreeNodeCassandraResource.java
@@ -37,8 +37,8 @@ public class ThreeNodeCassandraResource extends ExternalResource implements KvsM
     private TestResourceManager testResourceManager;
 
     public ThreeNodeCassandraResource() {
-        this.supplier = () -> CassandraKeyValueServiceImpl.createForTesting(
-                ThreeNodeCassandraCluster.KVS_CONFIG, Optional.empty());
+        this.supplier = () ->
+                CassandraKeyValueServiceImpl.createForTesting(ThreeNodeCassandraCluster.KVS_CONFIG);
     }
 
     public Statement apply(Statement base, Description description) {

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/UninitializedCassandraResource.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/UninitializedCassandraResource.java
@@ -72,7 +72,6 @@ public class UninitializedCassandraResource extends ExternalResource {
                 MetricsManagers.createForTests(),
                 containerInstance.getConfig(),
                 CassandraKeyValueServiceRuntimeConfig::getDefault,
-                CassandraContainer.LEADER_CONFIG,
                 CassandraMutationTimestampProviders.legacyModeForTestsOnly(),
                 true);
     }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/backend/CassandraKeyValueServiceInstrumentation.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/backend/CassandraKeyValueServiceInstrumentation.java
@@ -16,13 +16,10 @@
 package com.palantir.atlasdb.performance.backend;
 
 import java.net.InetSocketAddress;
-import java.util.Optional;
 
-import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraCredentialsConfig;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
-import com.palantir.atlasdb.config.ImmutableLeaderConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServiceImpl;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 
@@ -54,12 +51,7 @@ public class CassandraKeyValueServiceInstrumentation extends KeyValueServiceInst
     @Override
     public boolean canConnect(InetSocketAddress addr) {
         return CassandraKeyValueServiceImpl.createForTesting(
-                (CassandraKeyValueServiceConfig) getKeyValueServiceConfig(addr),
-                Optional.of(ImmutableLeaderConfig.builder()
-                        .quorumSize(1)
-                        .localServer(addr.getHostString())
-                        .leaders(ImmutableSet.of(addr.getHostString()))
-                        .build()))
+                (CassandraKeyValueServiceConfig) getKeyValueServiceConfig(addr))
                 .isInitialized();
     }
 


### PR DESCRIPTION
Stop wiring in leader config for CassandraKVSImpl since it's unused, reducing cruft when we see it!

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
