### PR TITLE
asynchronously synchronize for great gains!

### DIFF
--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/PaxosTimestampCreator.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/PaxosTimestampCreator.java
@@ -52,7 +52,9 @@ public class PaxosTimestampCreator implements TimestampCreator {
     private final Optional<TrustContext> optionalSecurity;
     private final Supplier<PaxosRuntimeConfiguration> paxosRuntime;
 
-    public PaxosTimestampCreator(MetricRegistry metricRegistry, PaxosResource paxosResource,
+    public PaxosTimestampCreator(
+            MetricRegistry metricRegistry,
+            PaxosResource paxosResource,
             Set<String> remoteServers,
             Optional<TrustContext> optionalSecurity,
             Supplier<PaxosRuntimeConfiguration> paxosRuntime) {
@@ -98,7 +100,7 @@ public class PaxosTimestampCreator implements TimestampCreator {
                         executor),
                 client);
 
-        PaxosSynchronizer.synchronizeLearner(ourLearner, learners);
+        executor.submit(() -> PaxosSynchronizer.synchronizeLearner(ourLearner, learners));
 
         return () -> createManagedPaxosTimestampService(proposer, client, acceptors, learners);
     }


### PR DESCRIPTION
**Goals (and why)**:
When fetching timestamps (for example) on a new namespace, we create a `ManagedTimestampService`, in doing so we call `PaxosSynchronizer` to try and get as much information as possible. However we wait up to 5 seconds (by default) to get all responses back from all clients (should be lower after #3811 - around 1.3 seconds).

If we've had a leader election, then all the namespaces are effectively "fresh". So all clients will hit the new leader and then synchronise for all their namespaces.

According to @jeremyk-91 this isn't *required* for correctness and has no guarantees, so it should be okay to do this asynchronously.

In a simple quick-to-iterate test:
```java
    @Test
    public void yesLeaderElectionsAreUnstable() {
        for (TestableTimelockServer server : CLUSTER.servers()) {
            server.kill();
            CLUSTER.getFreshTimestamp();
            server.start();
        }
    }
```

The first `getFreshTimestamp` call (includes 503s) after killing the leader went from around dropped from 5s (or whatever time we're improving on via #3811) to around 300ms

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
