### PR TITLE
Better error message when writing too many cells

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueTable.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueTable.java
@@ -55,6 +55,8 @@ public abstract class SweepQueueTable {
         Map<Cell, byte[]> cellsToWrite = new HashMap<>();
         Map<PartitionInfo, List<WriteInfo>> partitionedWrites = partitioner.filterAndPartition(allWrites);
 
+        SweepQueueUtils.validateNumberOfCellsWritten(partitionedWrites.values());
+
         partitionedWrites.forEach((partitionInfo, writes) -> {
             referencesToDedicatedCells.putAll(populateReferences(partitionInfo, writes));
             cellsToWrite.putAll(populateCells(partitionInfo, writes));


### PR DESCRIPTION
**Goals (and why)**:
`java.lang.IllegalArgumentException: Dedicated row number must non-negative and strictly less than 64, but it is 64.` is not very informative when the real problem is that you're writing more than 6.4 million cells corresponding to the same shard in a single transaction.
