### PR TITLE
Use more up to date timestamp for correctness checks

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.function.ToLongFunction;
 import java.util.stream.Collectors;
 
 import javax.ws.rs.ClientErrorException;
@@ -47,6 +48,8 @@ import com.palantir.atlasdb.cache.TimestampCache;
 import com.palantir.atlasdb.cleaner.CleanupFollower;
 import com.palantir.atlasdb.cleaner.DefaultCleanerBuilder;
 import com.palantir.atlasdb.cleaner.Follower;
+import com.palantir.atlasdb.cleaner.GlobalClock;
+import com.palantir.atlasdb.cleaner.KeyValueServicePuncherStore;
 import com.palantir.atlasdb.cleaner.api.Cleaner;
 import com.palantir.atlasdb.compact.BackgroundCompactor;
 import com.palantir.atlasdb.compact.CompactorConfig;
@@ -121,6 +124,7 @@ import com.palantir.atlasdb.util.AtlasDbMetrics;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.common.annotation.Output;
+import com.palantir.common.time.Clock;
 import com.palantir.leader.LeaderElectionService;
 import com.palantir.leader.PingableLeader;
 import com.palantir.leader.proxy.AwaitingLeadershipProxy;
@@ -610,15 +614,19 @@ public abstract class TransactionManagers {
             AtlasDbConfig atlasDbConfig,
             AtlasDbRuntimeConfig initialRuntimeConfig,
             LockAndTimestampServices lockAndTimestampServices) {
+        // Only do the consistency check if we're using TimeLock.
+        // This avoids a bootstrapping problem with leader-block services without async initialisation,
+        // where you need a working timestamp service to check consistency, you need to check consistency
+        // before you can return a TM, you need to return a TM to listen on ports, and you need to listen on
+        // ports in order to get a working timestamp service.
         if (isUsingTimeLock(atlasDbConfig, initialRuntimeConfig)) {
-            // Only do the consistency check if we're using TimeLock.
-            // This avoids a bootstrapping problem with leader-block services without async initialisation,
-            // where you need a working timestamp service to check consistency, you need to check consistency
-            // before you can return a TM, you need to return a TM to listen on ports, and you need to listen on
-            // ports in order to get a working timestamp service.
+            ToLongFunction<TransactionManager> conservativeBoundSupplier = txnManager -> {
+                Clock clock = GlobalClock.create(txnManager.getTimelockService());
+                return KeyValueServicePuncherStore.get(txnManager.getKeyValueService(), clock.getTimeMillis());
+            };
             return ConsistencyCheckRunner.create(
                     ImmutableTimestampCorroborationConsistencyCheck.builder()
-                            .conservativeBound(TransactionManager::getUnreadableTimestamp)
+                            .conservativeBound(conservativeBoundSupplier)
                             .freshTimestampSource(unused -> lockAndTimestampServices.timelock().getFreshTimestamp())
                             .build());
         }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/consistency/TimestampCorroborationConsistencyCheck.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/consistency/TimestampCorroborationConsistencyCheck.java
@@ -30,7 +30,7 @@ import com.palantir.logsafe.SafeArg;
  * Compares a source of fresh timestamps against a conservative lower bound that should always be strictly lower than
  * a fresh timestamp, reporting inconsistency if a fresh timestamp is actually lower than this lower bound.
  *
- * In typical usage, the unreadable timestamp is used as a conservative bound, and the source of fresh
+ * In typical usage, a recent timestamp from the puncher store is used as a conservative bound, and the source of fresh
  * timestamps could be a TimeLock server or other timestamp service.
  */
 @Value.Immutable

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,10 @@ develop
     *    - Type
          - Change
 
+    *    - |improved|
+         - Improved the startup check that verifies the correctness of the timestamp source to impose tighter constraints. Now uses a recent value from the puncher store
+           rather than the unreadable timestamp.
+
     *    - |fixed|
          - ``KeyValueService`` and ``CassandraKeyValueService`` in particular now has tighter consistency guarantees in the presence of failures.
            Previously, inconsistent deletes to thoroughly swept tables could result in readers serving stale versions of cells.

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -53,6 +53,7 @@ develop
     *    - |improved|
          - Improved the startup check that verifies the correctness of the timestamp source to impose tighter constraints. Now uses a recent value from the puncher store
            rather than the unreadable timestamp.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3825>`__)
 
     *    - |fixed|
          - ``KeyValueService`` and ``CassandraKeyValueService`` in particular now has tighter consistency guarantees in the presence of failures.


### PR DESCRIPTION
**Goals (and why)**:
Tighten the constraints imposed by the `TimestampCorroborationConsistencyCheck`. It now uses a recent value from the puncher store rather than the unreadable timestamp (which is an hour old value). Previously, we couldn't catch any issues with the timestamp store if the stack had been used for less than an hour.

**Implementation Description (bullets)**:
Call through to `KeyValueServicePuncherStore#get` rather than using `TransactionManager#getUnreadableTimestamp`.

**Testing (What was existing testing like?  What have you done to improve it?)**:
No further tests added

**Concerns (what feedback would you like?)**:
Calling static methods on `KeyValueServicePuncherStore` is pretty gross here, as it's an implementation detail of the `Puncher`, but the relevant method isn't exposed on `Puncher`, nor is the `Puncher` exposed anywhere on `TransactionManager`. Furthermore, it means that different areas of the code would potentially break if we used a different `Puncher` implementation. 

However, I don't want to poke more holes through to the internals of TM to extract it, and we already call straight through in a similar manner in `TargetedSweepMetrics`.

Even worse - `KeyValueServicePuncherStore` is async initializable but also has static methods on it that only function correctly if it's been initialized. It's fine in this case since this is a callback that only occurs if the TM is initialized already (and therefore the `Puncher` is initialized as well).

Cleaning this up in a better way probably means breaking up `TransactionManager` into more reusable components rather than one giant class that does everything. 

**Where should we start reviewing?**:
`TransactionManagers`

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
