### PR TITLE
[_transactions2] Part 27: :fire: CONTENTIOUS - Bound Timestamp Gaps in Transactions2 to 25,000,000

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/service/TransactionService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/service/TransactionService.java
@@ -48,6 +48,18 @@ public interface TransactionService extends AutoCloseable {
     @CheckForNull
     Long get(long startTimestamp);
 
+    /**
+     * Gets the commit timestamps associated with given start timestamps.
+     * For each individual timestamp, non-null responses may be cached on the client-side. Null responses must not be
+     * cached, as they could subsequently be updated.
+     *
+     * Timestamps provided may not be present as a key in the map - if so, this means that the transaction with
+     * that start timestamp has not been committed at some point between the request being made and it returning.
+     *
+     * @param startTimestamps start timestamps of transactions being looked up
+     * @return mapping of start timestamps to commit timestamps; transactions that have not committed yet are not
+     * included in the mapping.
+     */
     Map<Long, Long> get(Iterable<Long> startTimestamps);
 
     /**

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionConstants.java
@@ -40,6 +40,7 @@ public class TransactionConstants {
     public static final long APPROX_IN_MEM_CELL_OVERHEAD_BYTES = 16;
 
     // DO NOT change without a transactions table migration!
+    public static final long V2_PARTITIONING_QUANTUM = 25_000_000;
     public static final int V2_TRANSACTION_NUM_PARTITIONS = 16;
 
     public static final int DIRECT_ENCODING_TRANSACTIONS_SCHEMA_VERSION = 1;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/encoding/TicketsEncodingStrategy.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/encoding/TicketsEncodingStrategy.java
@@ -48,7 +48,7 @@ public enum TicketsEncodingStrategy implements TimestampEncodingStrategy {
     private static final byte[] ABORTED_TRANSACTION_VALUE = PtBytes.EMPTY_BYTE_ARRAY;
 
     // DO NOT change the following without a transactions table migration!
-    public static final long PARTITIONING_QUANTUM = 25_000_000;
+    public static final long PARTITIONING_QUANTUM = TransactionConstants.V2_PARTITIONING_QUANTUM;
     public static final int ROWS_PER_QUANTUM = TransactionConstants.V2_TRANSACTION_NUM_PARTITIONS;
 
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/GapLimitingTransactionService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/GapLimitingTransactionService.java
@@ -50,7 +50,7 @@ public class GapLimitingTransactionService implements TransactionService {
      * _transactions2 table (e.g. as part of a restore).
      *
      * @param delegate underlying transaction service
-     * @return a {@link TransactionService} that routes calls to the delegates and enforces a gap equal to a quantum.
+     * @return a {@link TransactionService} that routes calls to the delegates and enforces a gap equal to a quantum
      */
     public static TransactionService createDefaultForV2(TransactionService delegate) {
         return new GapLimitingTransactionService(delegate, () -> TransactionConstants.V2_PARTITIONING_QUANTUM);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/GapLimitingTransactionService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/GapLimitingTransactionService.java
@@ -1,0 +1,95 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.service;
+
+import java.util.Map;
+import java.util.function.LongSupplier;
+
+import javax.annotation.CheckForNull;
+
+import com.google.common.collect.Maps;
+import com.google.common.math.LongMath;
+import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
+import com.palantir.atlasdb.transaction.impl.TransactionConstants;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+
+/**
+ * A {@link TransactionService} that also limits the
+ */
+public class GapLimitingTransactionService implements TransactionService {
+    private final TransactionService delegate;
+    private final LongSupplier limitSupplier;
+
+    private GapLimitingTransactionService(TransactionService delegate, LongSupplier limitSupplier) {
+        this.delegate = delegate;
+        this.limitSupplier = limitSupplier;
+    }
+
+    public TransactionService createDefaultForV2(TransactionService delegate) {
+        return new GapLimitingTransactionService(delegate, () -> TransactionConstants.V2_PARTITIONING_QUANTUM);
+    }
+
+    @CheckForNull
+    @Override
+    public Long get(long startTimestamp) {
+        return delegate.get(startTimestamp);
+    }
+
+    @Override
+    public Map<Long, Long> get(Iterable<Long> startTimestamps) {
+        return delegate.get(startTimestamps);
+    }
+
+    @Override
+    public void putUnlessExists(long startTimestamp, long commitTimestamp) throws KeyAlreadyExistsException {
+        long observedGap = LongMath.saturatedSubtract(commitTimestamp, startTimestamp);
+        long limit = limitSupplier.getAsLong();
+        if (observedGap > limit) {
+            throw new SafeIllegalStateException("Timestamp gap is too large! Expected a gap no larger than"
+                    + " {}, but observed a gap of {} (start: {}, commit: {})",
+                    SafeArg.of("gapLimit", limit),
+                    SafeArg.of("observedGap", observedGap),
+                    SafeArg.of("startTimestamp", startTimestamp),
+                    SafeArg.of("commitTimestamp", commitTimestamp));
+        }
+        delegate.putUnlessExists(startTimestamp, commitTimestamp);
+
+    }
+
+    @Override
+    public void putUnlessExistsMultiple(Map<Long, Long> startTimestampToCommitTimestamp) {
+        long limit = limitSupplier.getAsLong();
+        Map<Long, Long> legitimatePairs = Maps.filterEntries(startTimestampToCommitTimestamp,
+                entry -> LongMath.saturatedSubtract(entry.getValue(), entry.getKey()) <= limit);
+        if (legitimatePairs.size() != startTimestampToCommitTimestamp.size()) {
+            Map<Long, Long> illegitimatePairs = Maps.difference(startTimestampToCommitTimestamp, legitimatePairs)
+                    .entriesOnlyOnLeft();
+            throw new SafeIllegalStateException("Timestamp gap is too large for some pairs. Expected a gap no"
+                    + " larger than {}, but observed the following start-commit timestamp pairs where this gap was"
+                    + " exceeded: {}",
+                    SafeArg.of("gapLimit", limit),
+                    SafeArg.of("illegitimatePairs", illegitimatePairs));
+        }
+        delegate.putUnlessExistsMultiple(legitimatePairs);
+    }
+
+    @Override
+    public void close() {
+        delegate.close();
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/TransactionServices.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/TransactionServices.java
@@ -59,8 +59,10 @@ public final class TransactionServices {
     }
 
     private static TransactionService createV2TransactionService(KeyValueService keyValueService) {
-        return new PreStartHandlingTransactionService(WriteBatchingTransactionService.create(
-                        SimpleTransactionService.createV2(keyValueService)));
+        return GapLimitingTransactionService.createDefaultForV2(
+                new PreStartHandlingTransactionService(
+                        WriteBatchingTransactionService.create(
+                                SimpleTransactionService.createV2(keyValueService))));
     }
 
     /**

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/GapLimitingTransactionServiceTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/GapLimitingTransactionServiceTest.java
@@ -1,0 +1,133 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.palantir.atlasdb.transaction.impl.TransactionConstants;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+
+public class GapLimitingTransactionServiceTest {
+    private static final long ONE = 1L;
+    private static final long TWO = 2L;
+    private static final long LARGE_TIMESTAMP = TransactionConstants.V2_PARTITIONING_QUANTUM * 1000L;
+
+    private final TransactionService delegate = mock(TransactionService.class);
+    private final TransactionService gapLimitingService = GapLimitingTransactionService.createDefaultForV2(delegate);
+
+    @After
+    public void verifyMocks() {
+        verifyNoMoreInteractions(delegate);
+    }
+
+    @Test
+    public void canGetFromDelegateEvenIfGapIsExceeded() {
+        when(delegate.get(ONE)).thenReturn(LARGE_TIMESTAMP);
+        assertThat(gapLimitingService.get(1L)).isEqualTo(TransactionConstants.V2_PARTITIONING_QUANTUM * 1000L);
+        verify(delegate).get(eq(ONE));
+    }
+
+    @Test
+    public void getMultipleCallsGetMultipleOnDelegate() {
+        gapLimitingService.get(ImmutableList.of(ONE, TWO));
+        verify(delegate).get(ImmutableList.of(ONE, TWO));
+    }
+
+    @Test
+    public void defaultV2ServicePutsUnlessExistsWhereGapIsLessThanQuantum() {
+        gapLimitingService.putUnlessExists(ONE, ONE + TWO);
+        verify(delegate).putUnlessExists(ONE, ONE + TWO);
+    }
+
+    @Test
+    public void defaultV2ServicePutsUnlessExistsWhereGapEqualsQuantum() {
+        gapLimitingService.putUnlessExists(ONE, ONE + TransactionConstants.V2_PARTITIONING_QUANTUM);
+        verify(delegate).putUnlessExists(ONE, ONE + TransactionConstants.V2_PARTITIONING_QUANTUM);
+    }
+
+    @Test
+    public void defaultV2ServiceThrowsWhenAttemptingPutUnlessExistsWhereGapExceedsQuantum() {
+        assertThatThrownBy(() -> gapLimitingService.putUnlessExists(ONE, LARGE_TIMESTAMP))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Timestamp gap is too large");
+    }
+
+    @Test
+    public void defaultV2ServiceStoresLargeTimestampsWithSmallLimits() {
+        long veryLargeTimestamp = Long.MAX_VALUE - 1000;
+        gapLimitingService.putUnlessExists(veryLargeTimestamp, veryLargeTimestamp + 8);
+        verify(delegate).putUnlessExists(veryLargeTimestamp, veryLargeTimestamp + 8);
+    }
+
+    @Test
+    public void defaultV2ServiceHandlesAbortsWhereStartTimestampExceedsQuantum() {
+        gapLimitingService.putUnlessExists(LARGE_TIMESTAMP, TransactionConstants.FAILED_COMMIT_TS);
+        verify(delegate).putUnlessExists(LARGE_TIMESTAMP, TransactionConstants.FAILED_COMMIT_TS);
+    }
+
+    @Test
+    public void defaultV2ServiceDelegatesPutUnlessExistsMultipleAsOneCall() {
+        Map<Long, Long> timestampData = ImmutableMap.of(ONE, TWO, 3L, 4L);
+        gapLimitingService.putUnlessExistsMultiple(timestampData);
+        verify(delegate).putUnlessExistsMultiple(timestampData);
+    }
+
+    @Test
+    public void defaultV2ServiceThrowsOnPutUnlessExistsMultipleIfAnyPairsAreInvalid() {
+        assertThatThrownBy(() -> gapLimitingService.putUnlessExistsMultiple(
+                ImmutableMap.of(ONE, TWO, TWO, LARGE_TIMESTAMP)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Timestamp gap is too large");
+    }
+
+    @Test
+    public void closeCallsCloseOnDelegate() {
+        gapLimitingService.close();
+        verify(delegate).close();
+    }
+
+    @Test
+    public void throwsIfLimitSupplierReturnsNonPositiveValues() {
+        TransactionService transactionService = new GapLimitingTransactionService(delegate, () -> 0L);
+        assertThatThrownBy(() -> transactionService.putUnlessExists(ONE, TWO))
+                .isInstanceOf(SafeIllegalStateException.class)
+                .hasMessageContaining("limits less than 1 are unacceptable");
+
+    }
+
+    @Test
+    public void throwsIfLimitSupplierReturnsNegativeValues() {
+        TransactionService transactionService = new GapLimitingTransactionService(delegate, () -> -169L);
+        assertThatThrownBy(() -> transactionService.putUnlessExists(ONE, TWO))
+                .isInstanceOf(SafeIllegalStateException.class)
+                .hasMessageContaining("limits less than 1 are unacceptable");
+
+    }
+}

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,12 @@ develop
     *    - Type
          - Change
 
+    *    - |improved|
+         - Transactions running under _transactions2 will now fail if the gap between the commit and start timestamps exceeds 25 million.
+           This is a very large value, and we do not expect normal usage to be affected.
+           Note that this is not a break as _transactions2 does not currently have production users.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3nnn>`__)
+
     *    - |fixed|
          - ``KeyValueService`` and ``CassandraKeyValueService`` in particular now has tighter consistency guarantees in the presence of failures.
            Previously, inconsistent deletes to thoroughly swept tables could result in readers serving stale versions of cells.


### PR DESCRIPTION
**Goals (and why)**:
- Make clean-transactions-range a fast operation, by bounding commit timestamps to be 25,000,000 above start timestamps. Thus, if one needs to range scan transactions2 for _commit_ timestamps in the range `[L, U)`, it suffices to do a range query on _start_ timestamps in the range `[L-25,000,000, U)` rather than reading the history of the table up to `U`.
- Still allow moderately long running transactions to carry out the work they need to do.

**Implementation Description (bullets)**:
- Implement a `GapLimitingTransactionService` that never putUnlessExists any `(start, commit)` pairs where commit is more than 25,000,000 above start.
- As a consequence, one only needs to look in the next block of 16 rows over when doing a range scan of commit timestamps.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Added new tests for `GapLimitingTransactionService`

**Concerns (what feedback would you like?)**:
- Is this limit fair? I've timed how long it takes to burn through 25MM timestamps on some stacks (bearing in mind that they are already using startIdentifiedAtlasDbTransaction); feel free to approach me offline for details.
- There isn't really an escape strategy short of a patch if we need to force something through that consistently takes long enough that 25MM timestamps is a problem (though there won't be data corruption). Is this a concern?

**Where should we start reviewing?**: GapLimitingTransactionService.java

**Priority (whenever / two weeks / yesterday)**: this week. Kind-of blocks transactions2 rollouts.
