### PR TITLE
refactor timelock migrator

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -788,12 +788,18 @@ public abstract class TransactionManagers {
             String userAgent) {
         Supplier<ServerListConfig> serverListConfigSupplier =
                 getServerListConfigSupplierForTimeLock(config, runtimeConfigSupplier);
-        TimeLockMigrator migrator =
-                TimeLockMigrator.create(metricsManager,
-                        serverListConfigSupplier, invalidator, userAgent, config.initializeAsync());
+
+        LockAndTimestampServices lockAndTimestampServices =
+                getLockAndTimestampServices(metricsManager, serverListConfigSupplier, userAgent);
+
+        TimeLockMigrator migrator = TimeLockMigrator.create(
+                lockAndTimestampServices.timestampManagement(),
+                invalidator,
+                config.initializeAsync());
         migrator.migrate(); // This can proceed async if config.initializeAsync() was set
+
         return ImmutableLockAndTimestampServices.copyOf(
-                getLockAndTimestampServices(metricsManager, serverListConfigSupplier, userAgent))
+                lockAndTimestampServices)
                 .withMigrator(migrator);
     }
 

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -798,8 +798,7 @@ public abstract class TransactionManagers {
                 config.initializeAsync());
         migrator.migrate(); // This can proceed async if config.initializeAsync() was set
 
-        return ImmutableLockAndTimestampServices.copyOf(
-                lockAndTimestampServices)
+        return ImmutableLockAndTimestampServices.copyOf(lockAndTimestampServices)
                 .withMigrator(migrator);
     }
 

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/startup/TimeLockMigrator.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/startup/TimeLockMigrator.java
@@ -43,24 +43,16 @@ public class TimeLockMigrator extends AsyncInitializer {
     }
 
     public static TimeLockMigrator create(
-            MetricsManager metricsManager,
-            ServerListConfig serverListConfig,
-            TimestampStoreInvalidator invalidator,
-            String userAgent) {
-        return create(metricsManager, () -> serverListConfig, invalidator,
-                userAgent, AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
+            TimestampManagementService timestampManagementService,
+            TimestampStoreInvalidator invalidator) {
+        return create(timestampManagementService, invalidator, AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
     }
 
     public static TimeLockMigrator create(
-            MetricsManager metricsManager,
-            Supplier<ServerListConfig> serverListConfigSupplier,
+            TimestampManagementService timestampManagementService,
             TimestampStoreInvalidator invalidator,
-            String userAgent,
             boolean initializeAsync) {
-        TimestampManagementService remoteTimestampManagementService =
-                createRemoteManagementService(
-                        metricsManager, serverListConfigSupplier, userAgent);
-        return new TimeLockMigrator(invalidator, remoteTimestampManagementService, initializeAsync);
+        return new TimeLockMigrator(invalidator, timestampManagementService, initializeAsync);
     }
 
     /**

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/startup/TimeLockMigratorTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/startup/TimeLockMigratorTest.java
@@ -85,10 +85,7 @@ public class TimeLockMigratorTest {
         TimeLockMigrator migrator = TimeLockMigrator.create(timestampManagementService, invalidator, true);
         migrator.migrate();
 
-        Awaitility.await()
-                .atMost(30, TimeUnit.SECONDS)
-                .pollInterval(1, TimeUnit.SECONDS)
-                .until(migrator::isInitialized);
+        waitUntilInitialized(migrator);
 
         verify(timestampManagementService, times(2)).ping();
         verify(invalidator, times(1)).backupAndInvalidate();
@@ -104,13 +101,17 @@ public class TimeLockMigratorTest {
         TimeLockMigrator migrator = TimeLockMigrator.create(timestampManagementService, invalidator, true);
         migrator.migrate();
 
-        Awaitility.await()
-                .atMost(30, TimeUnit.SECONDS)
-                .pollInterval(1, TimeUnit.SECONDS)
-                .until(migrator::isInitialized);
+        waitUntilInitialized(migrator);
 
         verify(timestampManagementService, times(2)).ping();
         verify(invalidator, times(2)).backupAndInvalidate();
         verify(timestampManagementService).fastForwardTimestamp(BACKUP_TIMESTAMP);
+    }
+
+    private static void waitUntilInitialized(TimeLockMigrator migrator) {
+        Awaitility.await()
+                .atMost(30, TimeUnit.SECONDS)
+                .pollInterval(1, TimeUnit.SECONDS)
+                .until(migrator::isInitialized);
     }
 }


### PR DESCRIPTION
**Goals (and why)**:
Currently TimelockMigrator creates its own proxy to talk to remote timelock service, which is unnecessary and makes it hard to manage proxies. This pr aims to improve that.

**Implementation Description (bullets)**:
Rather than creating its own proxy, now it gets a `TimelockManagementService`. It also makes tests easier to read.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Refactored existing tests to get rid of wiremock.

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
