### PR TITLE
register remoteTimelockServiceAdapter closing callback

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -669,6 +669,7 @@ public abstract class TransactionManagers {
                 .from(lockAndTimestampServices)
                 .timelock(timeLockClient)
                 .lock(LockRefreshingLockService.create(lockAndTimestampServices.lock()))
+                .close(timeLockClient::close)
                 .build();
     }
 
@@ -759,8 +760,7 @@ public abstract class TransactionManagers {
         } else if (config.timestamp().isPresent() && config.lock().isPresent()) {
             return createRawRemoteServices(metricsManager, config, userAgent);
         } else if (isUsingTimeLock(config, initialRuntimeConfig)) {
-            return createRawServicesFromTimeLock(
-                    metricsManager, config, runtimeConfigSupplier, invalidator, userAgent);
+            return createRawServicesFromTimeLock(metricsManager, config, runtimeConfigSupplier, invalidator, userAgent);
         } else {
             return createRawEmbeddedServices(metricsManager, env, lock, time, timeManagement);
         }

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
@@ -213,20 +213,11 @@ public class TransactionManagersTest {
         rawRemoteServerConfig = ImmutableServerListConfig.builder()
                 .addServers(getUriForPort(availablePort))
                 .build();
-
-        closeables = new ArrayList<>();
     }
 
     @After
     public void restoreAsyncExecution() {
         TransactionManagers.runAsync = originalAsyncMethod;
-        closeables.forEach(closeable -> {
-            try {
-                closeable.close();
-            } catch (Exception e) {
-                throw new RuntimeException("exception thrown while closing resources", e);
-            }
-        });
     }
 
     @Test
@@ -605,8 +596,7 @@ public class TransactionManagersTest {
                 () -> ts,
                 () -> ts,
                 invalidator,
-                USER_AGENT,
-                closeables);
+                USER_AGENT);
     }
 
     private void verifyUserAgentOnRawTimestampAndLockRequests() {
@@ -634,8 +624,7 @@ public class TransactionManagersTest {
                         () -> ts,
                         () -> ts,
                         invalidator,
-                        USER_AGENT,
-                        closeables);
+                        USER_AGENT);
         lockAndTimestamp.timelock().getFreshTimestamp();
         lockAndTimestamp.timelock().currentTimeMillis();
 
@@ -663,21 +652,5 @@ public class TransactionManagersTest {
                         .addAllServers(servers)
                         .build())
                 .build();
-    }
-
-    private TransactionManagers.LockAndTimestampServices createLockAndTimestampServicesForConfig(
-            AtlasDbConfig atlasDbConfig, AtlasDbRuntimeConfig atlasDbRuntimeConfig) {
-        InMemoryTimestampService ts = new InMemoryTimestampService();
-        return TransactionManagers.createLockAndTimestampServices(
-                metricsManager,
-                atlasDbConfig,
-                () -> atlasDbRuntimeConfig,
-                environment,
-                LockServiceImpl::create,
-                () -> ts,
-                () -> ts,
-                invalidator,
-                USER_AGENT,
-                closeables);
     }
 }

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
@@ -38,7 +38,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -158,8 +157,6 @@ public class TransactionManagersTest {
     private Consumer<Object> environment;
     private TimestampStoreInvalidator invalidator;
     private Consumer<Runnable> originalAsyncMethod;
-
-    private List<AutoCloseable> closeables;
 
     @ClassRule
     public static final TemporaryFolder temporaryFolder = new TemporaryFolder();

--- a/lock-api/src/main/java/com/palantir/lock/client/RemoteTimelockServiceAdapter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/RemoteTimelockServiceAdapter.java
@@ -29,7 +29,7 @@ import com.palantir.lock.v2.WaitForLocksRequest;
 import com.palantir.lock.v2.WaitForLocksResponse;
 import com.palantir.timestamp.TimestampRange;
 
-public final class RemoteTimelockServiceAdapter implements TimelockService {
+public final class RemoteTimelockServiceAdapter implements TimelockService, AutoCloseable {
     private final LockLeaseService lockLeaseService;
     private final TimelockRpcClient timelockRpcClient;
 
@@ -38,7 +38,7 @@ public final class RemoteTimelockServiceAdapter implements TimelockService {
         this.lockLeaseService = LockLeaseService.create(timelockRpcClient);
     }
 
-    public static TimelockService create(TimelockRpcClient timelockRpcClient) {
+    public static RemoteTimelockServiceAdapter create(TimelockRpcClient timelockRpcClient) {
         return new RemoteTimelockServiceAdapter(timelockRpcClient);
     }
 
@@ -91,4 +91,7 @@ public final class RemoteTimelockServiceAdapter implements TimelockService {
     public long currentTimeMillis() {
         return timelockRpcClient.currentTimeMillis();
     }
+
+    @Override
+    public void close() {}
 }


### PR DESCRIPTION
**Goals (and why)**:
`RemoteTimelockServiceAdapter` will be using disruptor to batch multiple start transaction calls, and it needs to be closed, that requires registering a closing callback. Rather than marking `TimelockService` closeable as I have tried here: #3841, this pr directly registers the `RemoteTimelockServiceAdapter::close` method, without relying on its wrappers closing it.

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
