### PR TITLE
Fix NPE in KeyValueServiceCoordinationStore

### DIFF
--- a/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/CoordinationService.java
+++ b/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/CoordinationService.java
@@ -56,8 +56,14 @@ public interface CoordinationService<T> {
      *
      * Evolutions of the value must be compatible in terms of backwards consistency as defined in the class docs.
      *
+     * Note that in case of check and set failure, there is no atomicity guarantee between the check and set operation
+     * and the returned value and bound; i.e., the returned value and bound may be more recent than the values found
+     * when CAS failed.
+     *
      * @param transform transformation to apply to the existing value and bound the coordination service agrees on
      * @return a {@link CheckAndSetResult} indicating whether the transform was applied and the current value
+     *
+     * @throws IllegalStateException if check and set fails, but no current value exists
      */
     CheckAndSetResult<ValueAndBound<T>> tryTransformCurrentValue(Function<ValueAndBound<T>, T> transform);
 

--- a/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/CoordinationServiceImpl.java
+++ b/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/CoordinationServiceImpl.java
@@ -25,7 +25,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Iterables;
-import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.CheckAndSetResult;
 import com.palantir.logsafe.SafeArg;
 
@@ -51,8 +50,7 @@ public class CoordinationServiceImpl<T> implements CoordinationService<T> {
 
     /**
      * In case of failure, the returned value and bound are guaranteed to be the ones that were in the KVS at the time
-     * of CAS failure only if {@link KeyValueService#getCheckAndSetCompatibility()} is
-     * {@link com.palantir.atlasdb.keyvalue.api.CheckAndSetCompatibility#SUPPORTED_DETAIL_ON_FAILURE}.
+     * of CAS failure only if the implementation of the CoordinationStore makes such guarantees.
      */
     @Override
     public CheckAndSetResult<ValueAndBound<T>> tryTransformCurrentValue(Function<ValueAndBound<T>, T> transform) {

--- a/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/CoordinationServiceImpl.java
+++ b/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/CoordinationServiceImpl.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Iterables;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.CheckAndSetResult;
 import com.palantir.logsafe.SafeArg;
 
@@ -48,6 +49,11 @@ public class CoordinationServiceImpl<T> implements CoordinationService<T> {
         return Optional.of(cachedReference);
     }
 
+    /**
+     * In case of failure, the returned value and bound are guaranteed to be the ones that were in the KVS at the time
+     * of CAS failure only if {@link KeyValueService#getCheckAndSetCompatibility()} is
+     * {@link com.palantir.atlasdb.keyvalue.api.CheckAndSetCompatibility#SUPPORTED_DETAIL_ON_FAILURE}.
+     */
     @Override
     public CheckAndSetResult<ValueAndBound<T>> tryTransformCurrentValue(Function<ValueAndBound<T>, T> transform) {
         CheckAndSetResult<ValueAndBound<T>> transformResult = store.transformAgreedValue(transform);

--- a/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/CoordinationStore.java
+++ b/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/CoordinationStore.java
@@ -50,8 +50,14 @@ public interface CoordinationStore<T> {
      * to an existing {@link ValueAndBound}. It is the responsibility of users to confirm whether their transform
      * succeeded or not.
      *
+     * Note that in case of unsuccessful proposal, there is no atomicity guarantee between the check and set operation
+     * and the returned value and bound; i.e., the returned value and bound may be more recent than the values found
+     * when CAS failed.
+     *
      * @param transform transformation of the original value passed
      * @return a {@link CheckAndSetResult} indicating if the proposal was successful and the current value
+     *
+     * @throws IllegalStateException if the proposal fails, but no current value exists
      */
     CheckAndSetResult<ValueAndBound<T>> transformAgreedValue(
             Function<ValueAndBound<T>, T> transform);

--- a/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/keyvalue/KeyValueServiceCoordinationStore.java
+++ b/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/keyvalue/KeyValueServiceCoordinationStore.java
@@ -278,9 +278,8 @@ public final class KeyValueServiceCoordinationStore<T> implements CoordinationSt
                         .stream()
                         .map(this::deserializeSequenceAndBound)
                         .collect(Collectors.toList()));
-            } else {
-                return getMostRecentValueAndBound(oldValue, newValue);
             }
+            return getFailedResultWithMostRecentValueAndBound(oldValue, newValue);
         }
     }
 
@@ -303,6 +302,7 @@ public final class KeyValueServiceCoordinationStore<T> implements CoordinationSt
         }
     }
 
+    @VisibleForTesting
     byte[] serializeSequenceAndBound(SequenceAndBound sequenceAndBound) {
         return serializeData(sequenceAndBound, COORDINATION_SEQUENCE_AND_BOUND_DESCRIPTION);
     }
@@ -322,6 +322,7 @@ public final class KeyValueServiceCoordinationStore<T> implements CoordinationSt
         }
     }
 
+    @VisibleForTesting
     Cell getCoordinationValueCell() {
         return getCellForSequence(0);
     }
@@ -335,8 +336,8 @@ public final class KeyValueServiceCoordinationStore<T> implements CoordinationSt
                 .get(cell));
     }
 
-    private CheckAndSetResult<SequenceAndBound> getMostRecentValueAndBound(Optional<SequenceAndBound> oldValue,
-            SequenceAndBound newValue) {
+    private CheckAndSetResult<SequenceAndBound> getFailedResultWithMostRecentValueAndBound(
+            Optional<SequenceAndBound> oldValue, SequenceAndBound newValue) {
         Optional<SequenceAndBound> actualValue = getCoordinationValue();
         if (!actualValue.isPresent()) {
             throw new SafeIllegalStateException("Failed to check and set coordination value from {} to {}, but "

--- a/atlasdb-coordination-impl/src/test/java/com/palantir/atlasdb/coordination/keyvalue/KeyValueServiceCoordinationStoreTest.java
+++ b/atlasdb-coordination-impl/src/test/java/com/palantir/atlasdb/coordination/keyvalue/KeyValueServiceCoordinationStoreTest.java
@@ -18,6 +18,12 @@ package com.palantir.atlasdb.coordination.keyvalue;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
@@ -26,13 +32,18 @@ import java.util.function.Function;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.coordination.CoordinationStore;
 import com.palantir.atlasdb.coordination.ImmutableSequenceAndBound;
 import com.palantir.atlasdb.coordination.SequenceAndBound;
 import com.palantir.atlasdb.coordination.ValueAndBound;
 import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.CheckAndSetException;
+import com.palantir.atlasdb.keyvalue.api.CheckAndSetRequest;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.keyvalue.impl.CheckAndSetResult;
 import com.palantir.atlasdb.keyvalue.impl.ImmutableCheckAndSetResult;
 import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
@@ -48,21 +59,14 @@ public class KeyValueServiceCoordinationStoreTest {
     private static final SequenceAndBound SEQUENCE_AND_BOUND_2 = ImmutableSequenceAndBound.of(3, 4);
     private static final Function<ValueAndBound<String>, String> VALUE_PRESERVING_FUNCTION
             = valueAndBound -> valueAndBound.value()
-                    .orElseThrow(() -> new IllegalStateException("Can only preserve a present value"));
+            .orElseThrow(() -> new IllegalStateException("Can only preserve a present value"));
 
     private final KeyValueService keyValueService = new InMemoryKeyValueService(true);
     private final AtomicLong timestampSequence = new AtomicLong();
 
     // Casting is reasonable because we initialize with false. We need the precise typing for some of the
     // tests that hit the store directly.
-    private final KeyValueServiceCoordinationStore<String> coordinationStore
-            = (KeyValueServiceCoordinationStore<String>) KeyValueServiceCoordinationStore.create(
-                    ObjectMappers.newServerObjectMapper(),
-                    keyValueService,
-                    COORDINATION_ROW,
-                    timestampSequence::incrementAndGet,
-                    String.class,
-                    false);
+    private final KeyValueServiceCoordinationStore<String> coordinationStore = coordinationStoreForKvs(keyValueService);
 
     @Test
     public void getReturnsEmptyIfNoKeyFound() {
@@ -160,15 +164,55 @@ public class KeyValueServiceCoordinationStoreTest {
         byte[] otherCoordinationKey = PtBytes.toBytes("bbbbb");
         CoordinationStore<String> otherCoordinationStore
                 = KeyValueServiceCoordinationStore.create(
-                        ObjectMappers.newServerObjectMapper(),
-                        keyValueService,
-                        otherCoordinationKey,
-                        timestampSequence::incrementAndGet,
-                        String.class,
-                        false);
+                ObjectMappers.newServerObjectMapper(),
+                keyValueService,
+                otherCoordinationKey,
+                timestampSequence::incrementAndGet,
+                String.class,
+                false);
         coordinationStore.transformAgreedValue(unused -> VALUE_1);
         otherCoordinationStore.transformAgreedValue(unused -> VALUE_2);
         assertThat(coordinationStore.getAgreedValue().get().value()).contains(VALUE_1);
         assertThat(otherCoordinationStore.getAgreedValue().get().value()).contains(VALUE_2);
+    }
+
+    @Test
+    public void whenCheckAndSetFailsWithNoDetailsReadSequenceAndBoundFromKvs() {
+        KeyValueService mockKvs = mock(KeyValueService.class);
+        KeyValueServiceCoordinationStore<String> store = coordinationStoreForKvs(mockKvs);
+        doThrow(new CheckAndSetException("No detail")).when(mockKvs).checkAndSet(any(CheckAndSetRequest.class));
+        when(mockKvs.get(eq(AtlasDbConstants.COORDINATION_TABLE), anyMap()))
+                .thenReturn(ImmutableMap.of(
+                        store.getCoordinationValueCell(),
+                        Value.create(store.serializeSequenceAndBound(SEQUENCE_AND_BOUND_1), 0L)));
+
+        CheckAndSetResult<SequenceAndBound> casResult = store
+                .checkAndSetCoordinationValue(Optional.empty(), SEQUENCE_AND_BOUND_2);
+
+        assertThat(casResult.successful()).isFalse();
+        assertThat(casResult.existingValues()).containsExactly(SEQUENCE_AND_BOUND_1);
+    }
+
+    @Test
+    public void throwsWhenCheckAndSetFailsWithNoDetailsAndNoValueInKvs() {
+        KeyValueService mockKvs = mock(KeyValueService.class);
+        KeyValueServiceCoordinationStore<String> store = coordinationStoreForKvs(mockKvs);
+        doThrow(new CheckAndSetException("No detail")).when(mockKvs).checkAndSet(any(CheckAndSetRequest.class));
+        when(mockKvs.get(eq(AtlasDbConstants.COORDINATION_TABLE), anyMap())).thenReturn(ImmutableMap.of());
+
+        assertThatThrownBy(() -> store.checkAndSetCoordinationValue(Optional.empty(), SEQUENCE_AND_BOUND_2))
+                .as("Failed but no value in KVS")
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Failed to check and set coordination value");
+    }
+
+    private KeyValueServiceCoordinationStore<String> coordinationStoreForKvs(KeyValueService kvs) {
+        return (KeyValueServiceCoordinationStore<String>) KeyValueServiceCoordinationStore.create(
+                ObjectMappers.newServerObjectMapper(),
+                kvs,
+                COORDINATION_ROW,
+                timestampSequence::incrementAndGet,
+                String.class,
+                false);
     }
 }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,10 @@ develop
     *    - Type
          - Change
 
+    *    - |fixed|
+         - Fixed an issue where the ``transformAgreedValue`` of the ``KeyValueServiceCoordinationStore`` would throw an NPE when check and set fails on KVSs that do not support detail on CAS failure (DbKvs).
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3848>`__)
+
     *    - |changed|
          - We've rolled back the change from 0.117.0 that introduces an extra delay after leader election as we are no longer pursuing leadership leases.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3836>`__)


### PR DESCRIPTION
**Goals (and why)**:
On DbKvs, if we fail to CAS, we return a KAEE without the current value present, see #3560. We were assuming that this information was present when updating the coordination value, resulting in an NPE on CAS failure.
 
**Implementation Description (bullets)**:
If we get a KAEE with no details, we instead read the coordination value from the KVS. There is no guarantee of atomicity of course, but that was not part of the contract and is now specifically cleared up in the java doc.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Just some quick unit tests.

**Concerns (what feedback would you like?)**:
Discussed with @jeremyk-91 , and it should be safe to not have atomicity in this sense.

**Priority (whenever / two weeks / yesterday)**:
ASAP, it's blocking another product
