### PR TITLE
[_transactions2] Part 29: The CellLoader Revolutions

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoader.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoader.java
@@ -17,6 +17,7 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -26,18 +27,16 @@ import java.util.concurrent.Callable;
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;
 import org.apache.cassandra.thrift.ColumnParent;
 import org.apache.cassandra.thrift.ConsistencyLevel;
+import org.apache.cassandra.thrift.KeyPredicate;
 import org.apache.cassandra.thrift.SlicePredicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.Multimaps;
-import com.google.common.collect.Ordering;
-import com.google.common.collect.TreeMultimap;
 import com.google.common.primitives.UnsignedBytes;
-import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.cassandra.thrift.SlicePredicates;
@@ -124,70 +123,79 @@ class CellLoader {
             final CassandraKeyValueServices.ThreadSafeResultVisitor visitor,
             final ConsistencyLevel consistency) {
         final ColumnParent colFam = new ColumnParent(CassandraKeyValueServiceImpl.internalTableName(tableRef));
-        Multimap<byte[], Cell> cellsByCol =
-                TreeMultimap.create(UnsignedBytes.lexicographicalComparator(), Ordering.natural());
-        for (Cell cell : cells) {
-            cellsByCol.put(cell.getColumnName(), cell);
-        }
+        CellLoadingBatcher batcher = CellLoadingBatcher.create(
+                (numRows) -> logRebatchingWarnMessage(host, tableRef, numRows));
+
         List<Callable<Void>> tasks = Lists.newArrayList();
-        int fetchBatchCount = AtlasDbConstants.TRANSACTION_TIMESTAMP_LOAD_BATCH_LIMIT;
-        for (Map.Entry<byte[], Collection<Cell>> entry : Multimaps.asMap(cellsByCol).entrySet()) {
-            final byte[] col = entry.getKey();
-            Collection<Cell> columnCells = entry.getValue();
-            if (columnCells.size() > fetchBatchCount) {
-                log.warn("Re-batching in getLoadWithTsTasksForSingleHost a call to {} for table {} that attempted to"
-                                + " multiget {} rows; this may indicate overly-large batching on a higher level."
-                                + " Note that batches are executed in parallel, which may cause load on both"
-                                + " your Atlas client as well as on Cassandra if the number of rows is exceptionally"
-                                + " high.\n{}",
-                        SafeArg.of("host", CassandraLogHelper.host(host)),
-                        LoggingArgs.tableRef(tableRef),
-                        SafeArg.of("rows", columnCells.size()),
-                        SafeArg.of("stacktrace", CassandraKeyValueServices.getFilteredStackTrace("com.palantir")));
-            }
-            for (final List<Cell> partition : Lists.partition(ImmutableList.copyOf(columnCells), fetchBatchCount)) {
-                Callable<Void> multiGetCallable = () -> clientPool.runWithRetryOnHost(
-                        host,
-                        new FunctionCheckedException<CassandraClient, Void, Exception>() {
-                            @Override
-                            public Void apply(CassandraClient client) throws Exception {
-                                SlicePredicates.Range range = SlicePredicates.Range.singleColumn(col, startTs);
-                                SlicePredicates.Limit limit =
-                                        loadAllTs ? SlicePredicates.Limit.NO_LIMIT : SlicePredicates.Limit.ONE;
-                                SlicePredicate predicate = SlicePredicates.create(range, limit);
+        for (final List<Cell> partition : batcher.partitionIntoBatches(cells)) {
+            Callable<Void> multiGetCallable = () -> clientPool.runWithRetryOnHost(
+                    host,
+                    new FunctionCheckedException<CassandraClient, Void, Exception>() {
+                        @Override
+                        public Void apply(CassandraClient client) throws Exception {
+                            Map<byte[], SlicePredicate> canonicalPredicates
+                                    = Maps.newTreeMap(UnsignedBytes.lexicographicalComparator());
+                            List<KeyPredicate> query = new ArrayList<>(partition.size());
 
-                                List<ByteBuffer> rowNames = Lists.newArrayListWithCapacity(partition.size());
-                                for (Cell c : partition) {
-                                    rowNames.add(ByteBuffer.wrap(c.getRowName()));
-                                }
+                            for (Cell cell : partition) {
+                                SlicePredicate predicate = canonicalPredicates.computeIfAbsent(
+                                        cell.getColumnName(),
+                                        columnKey -> {
+                                            SlicePredicates.Range range = SlicePredicates.Range.singleColumn(
+                                                    columnKey, startTs);
+                                            SlicePredicates.Limit limit = loadAllTs
+                                                    ? SlicePredicates.Limit.NO_LIMIT
+                                                    : SlicePredicates.Limit.ONE;
+                                            return SlicePredicates.create(range, limit);
+                                        });
 
-                                if (log.isTraceEnabled()) {
-                                    log.trace("Requesting {} cells from {} {}starting at timestamp {} on {}",
-                                            SafeArg.of("cells", partition.size()),
-                                            LoggingArgs.tableRef(tableRef),
-                                            SafeArg.of("timestampClause", loadAllTs ? "for all timestamps " : ""),
-                                            SafeArg.of("startTs", startTs),
-                                            SafeArg.of("host", CassandraLogHelper.host(host)));
-                                }
-
-                                Map<ByteBuffer, List<ColumnOrSuperColumn>> results = queryRunner.multiget(
-                                        kvsMethodName, client, tableRef, rowNames, predicate, consistency);
-                                visitor.visit(results);
-                                return null;
+                                KeyPredicate keyPredicate = new KeyPredicate()
+                                        .setKey(cell.getRowName())
+                                        .setPredicate(predicate);
+                                query.add(keyPredicate);
                             }
 
-                            @Override
-                            public String toString() {
-                                return "multiget_slice(" + host + ", " + colFam + ", "
-                                        + partition.size() + " cells" + ")";
+                            if (log.isTraceEnabled()) {
+                                log.trace("Requesting {} cells from {} {}starting at timestamp {} on {}",
+                                        SafeArg.of("cells", partition.size()),
+                                        LoggingArgs.tableRef(tableRef),
+                                        SafeArg.of("timestampClause", loadAllTs ? "for all timestamps " : ""),
+                                        SafeArg.of("startTs", startTs),
+                                        SafeArg.of("host", CassandraLogHelper.host(host)));
                             }
 
-                        });
-                tasks.add(AnnotatedCallable.wrapWithThreadName(AnnotationType.PREPEND,
-                        "Atlas loadWithTs " + partition.size() + " cells from " + tableRef + " on " + host,
-                        multiGetCallable));
-            }
+                            Map<ByteBuffer, List<List<ColumnOrSuperColumn>>> results = queryRunner.multiget_multislice(
+                                    kvsMethodName, client, tableRef, query, consistency);
+
+                            Map<ByteBuffer, List<ColumnOrSuperColumn>> aggregatedResults = Maps.transformValues(results,
+                                    lists -> Lists.newArrayList(Iterables.concat(lists)));
+                            visitor.visit(aggregatedResults);
+                            return null;
+                        }
+
+                        @Override
+                        public String toString() {
+                            return "multiget_slice(" + host + ", " + colFam + ", "
+                                    + partition.size() + " cells" + ")";
+                        }
+
+                    });
+            tasks.add(AnnotatedCallable.wrapWithThreadName(AnnotationType.PREPEND,
+                    "Atlas loadWithTs " + partition.size() + " cells from " + tableRef + " on " + host,
+                    multiGetCallable));
         }
         return tasks;
+    }
+
+    private void logRebatchingWarnMessage(InetSocketAddress host, TableReference tableRef, int numRows) {
+        log.warn("Re-batching in getLoadWithTsTasksForSingleHost a call to {} for table {} that attempted to"
+                        + " multiget {} rows; this may indicate overly-large batching on a higher level."
+                        + " Note that batches are executed in parallel, which may cause load on both"
+                        + " your Atlas client as well as on Cassandra if the number of rows is exceptionally"
+                        + " high.\n{}",
+                SafeArg.of("host", CassandraLogHelper.host(host)),
+                LoggingArgs.tableRef(tableRef),
+                SafeArg.of("rows", numRows),
+                SafeArg.of("stacktrace", CassandraKeyValueServices.getFilteredStackTrace("com.palantir")));
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoadingBatcher.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoadingBatcher.java
@@ -1,0 +1,105 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.function.IntConsumer;
+import java.util.function.IntSupplier;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.MultimapBuilder;
+import com.google.common.collect.Multimaps;
+import com.google.common.primitives.UnsignedBytes;
+import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+
+/**
+ * Divides a list of {@link com.palantir.atlasdb.keyvalue.api.Cell}s into batches for querying.
+ */
+class CellLoadingBatcher {
+    private static final int DEFAULT_CROSS_COLUMN_LOAD_BATCH_LIMIT = 200;
+
+    private final IntSupplier crossColumnLoadBatchLimitSupplier;
+    private final IntSupplier singleQueryLoadBatchLimitSupplier;
+
+    private final IntConsumer rebatchingManyRowsWarningCallback;
+
+    private CellLoadingBatcher(
+            IntSupplier crossColumnLoadBatchLimitSupplier,
+            IntSupplier singleQueryLoadBatchLimitSupplier,
+            IntConsumer rebatchingManyRowsWarningCallback) {
+        this.crossColumnLoadBatchLimitSupplier = crossColumnLoadBatchLimitSupplier;
+        this.singleQueryLoadBatchLimitSupplier = singleQueryLoadBatchLimitSupplier;
+        this.rebatchingManyRowsWarningCallback = rebatchingManyRowsWarningCallback;
+    }
+
+    public static CellLoadingBatcher create(IntConsumer rebatchingManyRowsWarningCallback) {
+        // TODO (jkong): Maybe not the best default for the transaction timestamp batching.
+        return new CellLoadingBatcher(
+                () -> DEFAULT_CROSS_COLUMN_LOAD_BATCH_LIMIT,
+                () -> AtlasDbConstants.TRANSACTION_TIMESTAMP_LOAD_BATCH_LIMIT,
+                rebatchingManyRowsWarningCallback);
+    }
+
+    List<List<Cell>> partitionIntoBatches(Collection<Cell> cellsToPartition) {
+        int multigetMultisliceBatchLimit = crossColumnLoadBatchLimitSupplier.getAsInt();
+        int singleQueryLoadBatchLimit = singleQueryLoadBatchLimitSupplier.getAsInt();
+
+        ListMultimap<byte[], Cell> cellsByColumn = indexCellsByColumnName(cellsToPartition);
+
+        List<List<Cell>> batches = Lists.newArrayList();
+        List<Cell> cellsForCrossColumnBatching = Lists.newArrayList();
+        for (Map.Entry<byte[], List<Cell>> cellColumnPair : Multimaps.asMap(cellsByColumn).entrySet()) {
+            if (shouldExplicitlyAllocateBatchToColumn(multigetMultisliceBatchLimit, cellColumnPair.getValue())) {
+                batches.addAll(
+                        partitionBySingleQueryLoadBatchLimit(cellColumnPair.getValue(), singleQueryLoadBatchLimit));
+            } else {
+                cellsForCrossColumnBatching.addAll(cellColumnPair.getValue());
+            }
+        }
+        batches.addAll(Lists.partition(cellsForCrossColumnBatching, multigetMultisliceBatchLimit));
+
+        return batches;
+    }
+
+    private List<List<Cell>> partitionBySingleQueryLoadBatchLimit(List<Cell> cells, int singleQueryLoadBatchLimit) {
+        if (cells.size() > singleQueryLoadBatchLimit) {
+            rebatchingManyRowsWarningCallback.accept(cells.size());
+            return Lists.partition(cells, singleQueryLoadBatchLimit);
+        }
+        return ImmutableList.of(cells);
+    }
+
+    private static boolean shouldExplicitlyAllocateBatchToColumn(int multigetMultisliceBatchLimit, List<Cell> cells) {
+        return cells.size() > multigetMultisliceBatchLimit;
+    }
+
+    private static ListMultimap<byte[], Cell> indexCellsByColumnName(Collection<Cell> cells) {
+        // Cannot use Multimaps.index(), because byte[] equality is tricky.
+        ListMultimap<byte[], Cell> cellsByColumn = MultimapBuilder.treeKeys(UnsignedBytes.lexicographicalComparator())
+                .arrayListValues()
+                .build();
+        for (Cell cell : cells) {
+            cellsByColumn.put(cell.getColumnName(), cell);
+        }
+        return cellsByColumn;
+    }
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoadingBatcher.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoadingBatcher.java
@@ -34,7 +34,7 @@ import com.palantir.atlasdb.keyvalue.api.Cell;
 /**
  * Divides a list of {@link com.palantir.atlasdb.keyvalue.api.Cell}s into batches for querying.
  */
-class CellLoadingBatcher {
+final class CellLoadingBatcher {
     private static final int DEFAULT_CROSS_COLUMN_LOAD_BATCH_LIMIT = 200;
 
     private final IntSupplier crossColumnLoadBatchLimitSupplier;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoadingBatcher.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoadingBatcher.java
@@ -33,6 +33,14 @@ import com.palantir.atlasdb.keyvalue.api.Cell;
 
 /**
  * Divides a list of {@link com.palantir.atlasdb.keyvalue.api.Cell}s into batches for querying.
+ *
+ * The batcher partitions cells by columns.
+ * If for a given column the number of cells provided is at least the value returned by the
+ * crossColumnLoadBatchLimitSupplier, then the cells for that column will exclusively occupy one or more
+ * batches, with no batch exceeding the value returned by the singleQueryLoadBatchLimitSupplier.
+ * Otherwise, the cells provided may be combined with cells for other columns in batches of size up to the value
+ * returned by the crossColumnLoadBatchLimitSupplier. There is no guarantee that all cells for this column will
+ * be in the same batch.
  */
 final class CellLoadingBatcher {
     private static final int DEFAULT_CROSS_COLUMN_LOAD_BATCH_LIMIT = 200;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoadingBatcher.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoadingBatcher.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.function.IntConsumer;
 import java.util.function.IntSupplier;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
@@ -50,7 +51,8 @@ final class CellLoadingBatcher {
 
     private final IntConsumer rebatchingManyRowsWarningCallback;
 
-    private CellLoadingBatcher(
+    @VisibleForTesting
+    CellLoadingBatcher(
             IntSupplier crossColumnLoadBatchLimitSupplier,
             IntSupplier singleQueryLoadBatchLimitSupplier,
             IntConsumer rebatchingManyRowsWarningCallback) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/WrappingQueryRunner.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/WrappingQueryRunner.java
@@ -22,6 +22,7 @@ import java.util.Set;
 
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;
 import org.apache.cassandra.thrift.ConsistencyLevel;
+import org.apache.cassandra.thrift.KeyPredicate;
 import org.apache.cassandra.thrift.SlicePredicate;
 import org.apache.cassandra.thrift.UnavailableException;
 import org.apache.thrift.TException;
@@ -68,6 +69,21 @@ class WrappingQueryRunner {
         try {
             return queryRunner.run(client, tableRef,
                     () -> client.multiget_slice(kvsMethodName, tableRef, rowNames, pred, consistency));
+        } catch (UnavailableException e) {
+            throw new InsufficientConsistencyException(
+                    "This get operation requires " + consistency + " Cassandra nodes to be up and available.", e);
+        }
+    }
+
+    Map<ByteBuffer, List<List<ColumnOrSuperColumn>>> multiget_multislice(
+            String kvsMethodName,
+            CassandraClient client,
+            TableReference tableRef,
+            List<KeyPredicate> request,
+            ConsistencyLevel consistency) throws TException {
+        try {
+            return queryRunner.run(client, tableRef,
+                    () -> client.multiget_multislice(kvsMethodName, tableRef, request, consistency));
         } catch (UnavailableException e) {
             throw new InsufficientConsistencyException(
                     "This get operation requires " + consistency + " Cassandra nodes to be up and available.", e);

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoadingBatcherTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoadingBatcherTest.java
@@ -103,7 +103,7 @@ public class CellLoadingBatcherTest {
         verify(rebatchingCallback).accept(2 * SINGLE_QUERY_LIMIT);
     }
 
-    private void assertBatchContentsMatch(List<List<Cell>> actual, List<Cell>... expected) {
+    private static void assertBatchContentsMatch(List<List<Cell>> actual, List<Cell>... expected) {
         List<List<Cell>> sortedExpected = Arrays.stream(expected)
                 .map(CellLoadingBatcherTest::sortedCopyOf)
                 .collect(Collectors.toList());
@@ -112,7 +112,7 @@ public class CellLoadingBatcherTest {
                 .containsExactlyInAnyOrderElementsOf(sortedExpected);
     }
 
-    private void assertBatchContainsAllCells(List<List<Cell>> actual, List<Cell> expected) {
+    private static void assertBatchContainsAllCells(List<List<Cell>> actual, List<Cell> expected) {
         assertThat(actual.stream().flatMap(Collection::stream)).hasSameElementsAs(expected);
     }
 

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoadingBatcherTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoadingBatcherTest.java
@@ -1,0 +1,142 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.IntConsumer;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+
+@SuppressWarnings("unchecked") // AssertJ assertions
+public class CellLoadingBatcherTest {
+    private static final int CROSS_COLUMN_LIMIT = 3;
+    private static final int SINGLE_QUERY_LIMIT = 10;
+
+    private IntConsumer rebatchingCallback = mock(IntConsumer.class);
+    private CellLoadingBatcher batcher = new CellLoadingBatcher(
+            () -> CROSS_COLUMN_LIMIT, () -> SINGLE_QUERY_LIMIT, rebatchingCallback);
+
+    @Test
+    public void splitsCellsByColumnKey() {
+        List<Cell> cells = new ArrayList<>();
+        cells.addAll(rowRange(CROSS_COLUMN_LIMIT, 0));
+        cells.addAll(rowRange(CROSS_COLUMN_LIMIT, 1));
+
+        List<List<Cell>> batches = batcher.partitionIntoBatches(cells);
+        assertBatchContentsMatch(batches, rowRange(CROSS_COLUMN_LIMIT, 0), rowRange(CROSS_COLUMN_LIMIT, 1));
+    }
+
+    @Test
+    public void doesNotSplitCellsForSingleColumnsIfUnderSingleQueryLimit() {
+        List<List<Cell>> batches = batcher.partitionIntoBatches(rowRange(SINGLE_QUERY_LIMIT, 0));
+        assertBatchContentsMatch(batches, rowRange(SINGLE_QUERY_LIMIT, 0));
+    }
+
+    @Test
+    public void rebatchesLargeColumnsAndInvokesCallback() {
+        List<List<Cell>> batches = batcher.partitionIntoBatches(rowRange(2 * SINGLE_QUERY_LIMIT, 0));
+        assertBatchContentsMatch(batches,
+                rowRange(0, SINGLE_QUERY_LIMIT, 0),
+                rowRange(SINGLE_QUERY_LIMIT, 2 * SINGLE_QUERY_LIMIT, 0));
+        verify(rebatchingCallback).accept(2 * SINGLE_QUERY_LIMIT);
+    }
+
+    @Test
+    public void combinesSmallNumberOfRowsForDifferentColumns() {
+        List<Cell> smallColumnBatch = ImmutableList.of(cell(1, 1), cell(1, 2), cell(2, 1));
+        List<List<Cell>> batches = batcher.partitionIntoBatches(smallColumnBatch);
+        assertBatchContentsMatch(batches, smallColumnBatch);
+        verify(rebatchingCallback, never()).accept(anyInt());
+    }
+
+    @Test
+    public void preservesCellsAcrossColumnsAndRebatchesThemToCrossColumnLimit() {
+        List<Cell> manyColumns = columnRange(0, 0, 100);
+        List<List<Cell>> batches = batcher.partitionIntoBatches(manyColumns);
+
+        assertBatchContainsAllCells(batches, manyColumns);
+        batches.forEach(batch -> assertThat(batch.size()).isLessThanOrEqualTo(CROSS_COLUMN_LIMIT));
+    }
+
+    @Test
+    public void simultaneouslyHandlesLargeColumnsAndSmallColumns() {
+        List<Cell> cells = new ArrayList<>();
+        cells.addAll(rowRange(SINGLE_QUERY_LIMIT, 0));
+        cells.addAll(rowRange(2 * SINGLE_QUERY_LIMIT, 1));
+        cells.addAll(columnRange(0, 2, 2 + CROSS_COLUMN_LIMIT));
+
+        List<List<Cell>> batches = batcher.partitionIntoBatches(cells);
+        assertBatchContentsMatch(batches,
+                rowRange(SINGLE_QUERY_LIMIT, 0),
+                rowRange(0, SINGLE_QUERY_LIMIT, 1),
+                rowRange(SINGLE_QUERY_LIMIT, 2 * SINGLE_QUERY_LIMIT, 1),
+                columnRange(0, 2, 2 + CROSS_COLUMN_LIMIT));
+        verify(rebatchingCallback).accept(2 * SINGLE_QUERY_LIMIT);
+    }
+
+    private void assertBatchContentsMatch(List<List<Cell>> actual, List<Cell>... expected) {
+        List<List<Cell>> sortedExpected = Arrays.stream(expected)
+                .map(CellLoadingBatcherTest::sortedCopyOf)
+                .collect(Collectors.toList());
+        assertThat(actual)
+                .extracting(CellLoadingBatcherTest::sortedCopyOf)
+                .containsExactlyInAnyOrderElementsOf(sortedExpected);
+    }
+
+    private void assertBatchContainsAllCells(List<List<Cell>> actual, List<Cell> expected) {
+        assertThat(actual.stream().flatMap(Collection::stream)).hasSameElementsAs(expected);
+    }
+
+    private static List<Cell> sortedCopyOf(List<Cell> original) {
+        return original.stream().sorted().collect(Collectors.toList());
+    }
+
+    private static Cell cell(long row, long column) {
+        return Cell.create(PtBytes.toBytes(row), PtBytes.toBytes(column));
+    }
+
+    private static List<Cell> rowRange(long numRows, long column) {
+        return rowRange(0, numRows, column);
+    }
+
+    private static List<Cell> rowRange(long firstRow, long lastRowExclusive, long column) {
+        return LongStream.range(firstRow, lastRowExclusive)
+                .mapToObj(row -> cell(row, column))
+                .collect(Collectors.toList());
+    }
+
+    private static List<Cell> columnRange(long row, long firstColumn, long lastColumnExclusive) {
+        return LongStream.range(firstColumn, lastColumnExclusive)
+                .mapToObj(col -> cell(row, col))
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
**This PR has a dependency on #3849 - please review that first.**

**Goals (and why)**:
- Implement a new cell-loader that is able to use the new Cassandra multiget-multislice endpoint
- Clean up batching of queries, and leverage batching when we have columns that don't have too many associated rows (because RPC overhead becomes unnecessary in these cases)

**Implementation Description (bullets)**:
- Extract the part of CellLoader that divides up cells by their columns to a separate class `CellLoadingBatcher`
- Implement the CL2+ algorithm, that merges requests for columns with only a few rows.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Overall behaviour of the CellLoader - in particular, whether we accidentally miss any cells, should already be covered by existing Cassandra integration tests. I've added tests for the new batching logic.

**Concerns (what feedback would you like?)**:
- Are the default thresholds sensible? Part 30 is planned to be exposing these in runtime config, but I don't imagine that most deployments want to override this.
- Was anything lost in the refactor?

**Where should we start reviewing?**: Probably CellLoadingBatcherTest is a decent place to start.

**Priority (whenever / two weeks / yesterday)**: This week
