### PR TITLE
[_transactions2] Part 30: MatrixIndexOutOfBounds (Live Reloading CellLoader Limits)

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraCellLoadingConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraCellLoadingConfig.java
@@ -1,0 +1,71 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.cassandra;
+
+import org.immutables.value.Value;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.base.Preconditions;
+import com.palantir.atlasdb.keyvalue.cassandra.CassandraConstants;
+
+/**
+ * Specifies limits on query sizes for how cells should be loaded from an underlying Cassandra key-value service.
+ *
+ * Specifying large limits may allow for greater overall throughput across nodes as there are overall fewer RPCs,
+ * but may increase the latency of individual queries owing to implementation reasons.
+ *
+ * Limits provided should be positive; also, the cross column load batch limit should not exceed the single query
+ * load batch limit.
+ */
+@JsonSerialize(as = ImmutableCassandraCellLoadingConfig.class)
+@JsonDeserialize(as = ImmutableCassandraCellLoadingConfig.class)
+@Value.Immutable
+public abstract class CassandraCellLoadingConfig {
+    /**
+     * Implementations of Cassandra KVS may combine requests for different columns in a single call to the database.
+     * These "merged" calls will have size no larger than this value.
+     */
+    @Value.Default
+    public int crossColumnLoadBatchLimit() {
+        return CassandraConstants.DEFAULT_CROSS_COLUMN_LOAD_BATCH_LIMIT;
+    }
+
+    /**
+     * Implementations should not make requests for more than this many cells in a single call to the database.
+     */
+    @Value.Default
+    public int singleQueryLoadBatchLimit() {
+        return CassandraConstants.DEFAULT_SINGLE_QUERY_LOAD_BATCH_LIMIT;
+    }
+
+    @Value.Check
+    public void check() {
+        Preconditions.checkState(
+                crossColumnLoadBatchLimit() > 0,
+                "crossColumnLoadBatchLimit should be positive, but found %s",
+                crossColumnLoadBatchLimit());
+        Preconditions.checkState(
+                singleQueryLoadBatchLimit() > 0,
+                "singleQueryLoadBatchLimit should be positive, but found %s",
+                singleQueryLoadBatchLimit());
+        Preconditions.checkState(crossColumnLoadBatchLimit() <= singleQueryLoadBatchLimit(),
+                "Cross column load batch limit %s shouldn't exceed single query load batch limit %s",
+                crossColumnLoadBatchLimit(),
+                singleQueryLoadBatchLimit());
+    }
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraCellLoadingConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraCellLoadingConfig.java
@@ -24,7 +24,7 @@ import com.google.common.base.Preconditions;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraConstants;
 
 /**
- * Specifies limits on query sizes for how cells should be loaded from an underlying Cassandra key-value service.
+ * Specifies limits on query sizes when loading cells from an underlying Cassandra key-value service.
  *
  * Specifying large limits may allow for greater overall throughput across nodes as there are overall fewer RPCs,
  * but may increase the latency of individual queries owing to implementation reasons.
@@ -39,6 +39,8 @@ public abstract class CassandraCellLoadingConfig {
     /**
      * Implementations of Cassandra KVS may combine requests for different columns in a single call to the database.
      * These "merged" calls will have size no larger than this value.
+     *
+     * To disable cross-column batching, this value may be set to 1.
      */
     @Value.Default
     public int crossColumnLoadBatchLimit() {
@@ -67,5 +69,9 @@ public abstract class CassandraCellLoadingConfig {
                 "Cross column load batch limit %s shouldn't exceed single query load batch limit %s",
                 crossColumnLoadBatchLimit(),
                 singleQueryLoadBatchLimit());
+    }
+
+    static CassandraCellLoadingConfig defaultConfig() {
+        return ImmutableCassandraCellLoadingConfig.builder().build();
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraCellLoadingConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraCellLoadingConfig.java
@@ -74,4 +74,11 @@ public abstract class CassandraCellLoadingConfig {
     static CassandraCellLoadingConfig defaultConfig() {
         return ImmutableCassandraCellLoadingConfig.builder().build();
     }
+
+    static CassandraCellLoadingConfig of(int crossColumnLoadBatchLimit, int singleQueryLoadBatchLimit) {
+        return ImmutableCassandraCellLoadingConfig.builder()
+                .crossColumnLoadBatchLimit(crossColumnLoadBatchLimit)
+                .singleQueryLoadBatchLimit(singleQueryLoadBatchLimit)
+                .build();
+    }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceRuntimeConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceRuntimeConfig.java
@@ -67,9 +67,20 @@ public abstract class CassandraKeyValueServiceRuntimeConfig implements KeyValueS
         return CassandraConstants.DEFAULT_MUTATION_BATCH_SIZE_BYTES;
     }
 
+    /**
+     * The maximum number of rows to query for in a single call to the database when loading entire rows.
+     */
     @Value.Default
     public int fetchBatchCount() {
         return CassandraConstants.DEFAULT_FETCH_BATCH_COUNT;
+    }
+
+    /**
+     * Limits on query sizes when loading cells from an underlying Cassandra key-value service.
+     */
+    @Value.Default
+    public CassandraCellLoadingConfig cellLoadingConfig() {
+        return CassandraCellLoadingConfig.defaultConfig();
     }
 
     /**

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConstants.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConstants.java
@@ -61,6 +61,7 @@ public final class CassandraConstants {
     public static final int DEFAULT_UNRESPONSIVE_HOST_BACKOFF_TIME_SECONDS = 30;
 
     public static final int DEFAULT_CROSS_COLUMN_LOAD_BATCH_LIMIT = 200;
+    // TODO (jkong): Review this limit, it seems like we are making very big requests to Cassandra even at this value
     public static final int DEFAULT_SINGLE_QUERY_LOAD_BATCH_LIMIT = 50_000;
 
     static final int DENSELY_ACCESSED_WIDE_ROWS_INDEX_INTERVAL = 1;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConstants.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConstants.java
@@ -60,6 +60,9 @@ public final class CassandraConstants {
     public static final int DEFAULT_MUTATION_BATCH_COUNT = 5000;
     public static final int DEFAULT_UNRESPONSIVE_HOST_BACKOFF_TIME_SECONDS = 30;
 
+    public static final int DEFAULT_CROSS_COLUMN_LOAD_BATCH_LIMIT = 200;
+    public static final int DEFAULT_SINGLE_QUERY_LOAD_BATCH_LIMIT = 50_000;
+
     static final int DENSELY_ACCESSED_WIDE_ROWS_INDEX_INTERVAL = 1;
     static final int DEFAULT_MIN_INDEX_INTERVAL = 128;
     static final int DEFAULT_MAX_INDEX_INTERVAL = 2048;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
@@ -228,7 +229,9 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                 config,
                 CassandraClientPoolImpl.StartupChecks.RUN,
                 new Blacklist(config));
-        return createOrShutdownClientPool(metricsManager, config, clientPool,
+        return createOrShutdownClientPool(metricsManager, config,
+                CassandraKeyValueServiceRuntimeConfig::getDefault,
+                clientPool,
                 CassandraMutationTimestampProviders.legacyModeForTestsOnly(),
                 LoggerFactory.getLogger(CassandraKeyValueService.class),
                 AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
@@ -253,6 +256,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             CassandraClientPool clientPool) {
         return createOrShutdownClientPool(metricsManager,
                 config,
+                CassandraKeyValueServiceRuntimeConfig::getDefault,
                 clientPool,
                 mutationTimestampProvider,
                 LoggerFactory.getLogger(CassandraKeyValueService.class),
@@ -290,28 +294,41 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     private static CassandraKeyValueService create(
             MetricsManager metricsManager,
             CassandraKeyValueServiceConfig config,
-            java.util.function.Supplier<CassandraKeyValueServiceRuntimeConfig> runtimeConfig,
+            Supplier<CassandraKeyValueServiceRuntimeConfig> runtimeConfigSupplier,
             CassandraMutationTimestampProvider mutationTimestampProvider,
             Logger log,
             boolean initializeAsync) {
         CassandraClientPool clientPool = CassandraClientPoolImpl.create(metricsManager,
                 config,
-                runtimeConfig,
+                runtimeConfigSupplier,
                 initializeAsync);
-        return createOrShutdownClientPool(metricsManager, config, clientPool, mutationTimestampProvider,
-                log, initializeAsync);
+        return createOrShutdownClientPool(
+                metricsManager,
+                config,
+                runtimeConfigSupplier,
+                clientPool,
+                mutationTimestampProvider,
+                log,
+                initializeAsync);
     }
 
     private static CassandraKeyValueService createOrShutdownClientPool(
             MetricsManager metricsManager,
             CassandraKeyValueServiceConfig config,
+            Supplier<CassandraKeyValueServiceRuntimeConfig> runtimeConfigSupplier,
             CassandraClientPool clientPool,
             CassandraMutationTimestampProvider mutationTimestampProvider,
             Logger log,
             boolean initializeAsync) {
         try {
-            return createAndInitialize(metricsManager, config, clientPool,
-                    mutationTimestampProvider, log, initializeAsync);
+            return createAndInitialize(
+                    metricsManager,
+                    config,
+                    runtimeConfigSupplier,
+                    clientPool,
+                    mutationTimestampProvider,
+                    log,
+                    initializeAsync);
         } catch (Exception e) {
             log.warn("Error occurred in creating Cassandra KVS. Now attempting to shut down client pool...", e);
             try {
@@ -328,6 +345,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     private static CassandraKeyValueService createAndInitialize(
             MetricsManager metricsManager,
             CassandraKeyValueServiceConfig config,
+            Supplier<CassandraKeyValueServiceRuntimeConfig> runtimeConfigSupplier,
             CassandraClientPool clientPool,
             CassandraMutationTimestampProvider mutationTimestampProvider,
             Logger log,
@@ -336,14 +354,18 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                 log,
                 metricsManager,
                 config,
+                runtimeConfigSupplier,
                 clientPool,
                 mutationTimestampProvider);
         keyValueService.wrapper.initialize(initializeAsync);
         return keyValueService.wrapper.isInitialized() ? keyValueService : keyValueService.wrapper;
     }
 
-    private CassandraKeyValueServiceImpl(Logger log,
-            MetricsManager metricsManager, CassandraKeyValueServiceConfig config,
+    private CassandraKeyValueServiceImpl(
+            Logger log,
+            MetricsManager metricsManager,
+            CassandraKeyValueServiceConfig config,
+            Supplier<CassandraKeyValueServiceRuntimeConfig> runtimeConfigSupplier,
             CassandraClientPool clientPool,
             CassandraMutationTimestampProvider mutationTimestampProvider) {
         super(createInstrumentedFixedThreadPool(config, metricsManager.getRegistry()));
@@ -356,7 +378,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         this.wrappingQueryRunner = new WrappingQueryRunner(queryRunner);
         this.cassandraTables = new CassandraTables(clientPool, config);
         this.taskRunner = new TaskRunner(executor);
-        this.cellLoader = new CellLoader(clientPool, wrappingQueryRunner, taskRunner);
+        this.cellLoader = CellLoader.create(clientPool, wrappingQueryRunner, taskRunner, runtimeConfigSupplier);
         this.rangeLoader = new RangeLoader(clientPool, queryRunner, metricsManager, readConsistency);
         this.cellValuePutter = new CellValuePutter(
                 config,

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoader.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoader.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.function.Supplier;
 
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;
 import org.apache.cassandra.thrift.ColumnParent;
@@ -37,6 +38,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.primitives.UnsignedBytes;
+import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceRuntimeConfig;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.cassandra.thrift.SlicePredicates;
@@ -52,11 +54,26 @@ class CellLoader {
     private final CassandraClientPool clientPool;
     private final WrappingQueryRunner queryRunner;
     private final TaskRunner taskRunner;
+    private final CellLoadingBatcher batcher;
 
-    CellLoader(CassandraClientPool clientPool, WrappingQueryRunner queryRunner, TaskRunner taskRunner) {
+    private CellLoader(
+            CassandraClientPool clientPool,
+            WrappingQueryRunner queryRunner,
+            TaskRunner taskRunner,
+            CellLoadingBatcher batcher) {
         this.clientPool = clientPool;
         this.queryRunner = queryRunner;
         this.taskRunner = taskRunner;
+        this.batcher = batcher;
+    }
+
+    static CellLoader create(
+            CassandraClientPool clientPool,
+            WrappingQueryRunner queryRunner,
+            TaskRunner taskRunner,
+            Supplier<CassandraKeyValueServiceRuntimeConfig> configSupplier) {
+        CellLoadingBatcher batcher = new CellLoadingBatcher(() -> configSupplier.get().cellLoadingConfig());
+        return new CellLoader(clientPool, queryRunner, taskRunner, batcher);
     }
 
     Multimap<Cell, Long> getAllTimestamps(TableReference tableRef, Set<Cell> cells, long ts,
@@ -123,11 +140,9 @@ class CellLoader {
             final CassandraKeyValueServices.ThreadSafeResultVisitor visitor,
             final ConsistencyLevel consistency) {
         final ColumnParent colFam = new ColumnParent(CassandraKeyValueServiceImpl.internalTableName(tableRef));
-        CellLoadingBatcher batcher = CellLoadingBatcher.create(
-                (numRows) -> logRebatchingWarnMessage(host, tableRef, numRows));
-
         List<Callable<Void>> tasks = Lists.newArrayList();
-        for (final List<Cell> partition : batcher.partitionIntoBatches(cells)) {
+        for (final List<Cell> partition : batcher.partitionIntoBatches(
+                cells, (numRows) -> logRebatchingWarnMessage(host, tableRef, numRows))) {
             Callable<Void> multiGetCallable = () -> clientPool.runWithRetryOnHost(
                     host,
                     new FunctionCheckedException<CassandraClient, Void, Exception>() {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoader.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoader.java
@@ -48,7 +48,7 @@ import com.palantir.atlasdb.util.AnnotationType;
 import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.logsafe.SafeArg;
 
-class CellLoader {
+final class CellLoader {
     private static final Logger log = LoggerFactory.getLogger(CellLoader.class);
 
     private final CassandraClientPool clientPool;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoadingBatcher.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoadingBatcher.java
@@ -20,91 +20,71 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.IntConsumer;
-import java.util.function.IntSupplier;
+import java.util.function.Supplier;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.MultimapBuilder;
 import com.google.common.collect.Multimaps;
 import com.google.common.primitives.UnsignedBytes;
-import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.cassandra.CassandraCellLoadingConfig;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 
 /**
  * Divides a list of {@link com.palantir.atlasdb.keyvalue.api.Cell}s into batches for querying.
  *
  * The batcher partitions cells by columns.
- * If for a given column the number of cells provided is at least the value returned by the
- * crossColumnLoadBatchLimitSupplier, then the cells for that column will exclusively occupy one or more
- * batches, with no batch having size greater than the value returned by the singleQueryLoadBatchLimitSupplier.
+ * If for a given column the number of cells provided is at least
+ * {@link CassandraCellLoadingConfig#crossColumnLoadBatchLimit()}, then the cells for that column will exclusively
+ * occupy one or more batches, with no batch having size greater than that limit..
  * Otherwise, the cells provided may be combined with cells for other columns in batches of size up to the value
- * returned by the crossColumnLoadBatchLimitSupplier. There is no guarantee that all cells for this column will
- * be in the same batch in this case.
+ * from {@link CassandraCellLoadingConfig#singleQueryLoadBatchLimit()}. There is no guarantee that all cells for this
+ * column will be in the same batch in this case.
  *
- * Live reloading: Batching will take place following some values of crossColumnLoadBatchLimit or
- * singleQueryLoadBatchLimit that were available during the execution of a partition operation. There is no guarantee
- * that changes during a partition operation may or may not be applied. Furthermore, there is no guarantee that both
- * limits are read atomically in any way.
+ * Live reloading: Batching will take place following some {@link CassandraCellLoadingConfig} available from
+ * the supplier during the execution of a partition operation. There is no guarantee as to whether new values
+ * available during a partition operation will or will not be applied.
  */
 final class CellLoadingBatcher {
-    private static final int DEFAULT_CROSS_COLUMN_LOAD_BATCH_LIMIT = 200;
+    private final Supplier<CassandraCellLoadingConfig> loadingConfigSupplier;
 
-    private final IntSupplier crossColumnLoadBatchLimitSupplier;
-    private final IntSupplier singleQueryLoadBatchLimitSupplier;
+    CellLoadingBatcher(Supplier<CassandraCellLoadingConfig> loadingConfigSupplier) {
+        this.loadingConfigSupplier = loadingConfigSupplier;
+    }
 
-    private final IntConsumer rebatchingManyRowsWarningCallback;
-
-    @VisibleForTesting
-    CellLoadingBatcher(
-            IntSupplier crossColumnLoadBatchLimitSupplier,
-            IntSupplier singleQueryLoadBatchLimitSupplier,
+    List<List<Cell>> partitionIntoBatches(Collection<Cell> cellsToPartition,
             IntConsumer rebatchingManyRowsWarningCallback) {
-        this.crossColumnLoadBatchLimitSupplier = crossColumnLoadBatchLimitSupplier;
-        this.singleQueryLoadBatchLimitSupplier = singleQueryLoadBatchLimitSupplier;
-        this.rebatchingManyRowsWarningCallback = rebatchingManyRowsWarningCallback;
-    }
-
-    static CellLoadingBatcher create(IntConsumer rebatchingManyRowsWarningCallback) {
-        // TODO (jkong): Maybe not the best default for the transaction timestamp batching.
-        return new CellLoadingBatcher(
-                () -> DEFAULT_CROSS_COLUMN_LOAD_BATCH_LIMIT,
-                () -> AtlasDbConstants.TRANSACTION_TIMESTAMP_LOAD_BATCH_LIMIT,
-                rebatchingManyRowsWarningCallback);
-    }
-
-    List<List<Cell>> partitionIntoBatches(Collection<Cell> cellsToPartition) {
-        int multigetMultisliceBatchLimit = crossColumnLoadBatchLimitSupplier.getAsInt();
-        int singleQueryLoadBatchLimit = singleQueryLoadBatchLimitSupplier.getAsInt();
+        CassandraCellLoadingConfig config = loadingConfigSupplier.get();
 
         ListMultimap<byte[], Cell> cellsByColumn = indexCellsByColumnName(cellsToPartition);
 
         List<List<Cell>> batches = Lists.newArrayList();
         List<Cell> cellsForCrossColumnBatching = Lists.newArrayList();
         for (Map.Entry<byte[], List<Cell>> cellColumnPair : Multimaps.asMap(cellsByColumn).entrySet()) {
-            if (shouldExplicitlyAllocateBatchToColumn(multigetMultisliceBatchLimit, cellColumnPair.getValue())) {
-                batches.addAll(
-                        partitionBySingleQueryLoadBatchLimit(cellColumnPair.getValue(), singleQueryLoadBatchLimit));
+            if (shouldExplicitlyAllocateBatchToColumn(config, cellColumnPair.getValue())) {
+                batches.addAll(partitionBySingleQueryLoadBatchLimit(
+                        cellColumnPair.getValue(), config, rebatchingManyRowsWarningCallback));
             } else {
                 cellsForCrossColumnBatching.addAll(cellColumnPair.getValue());
             }
         }
-        batches.addAll(Lists.partition(cellsForCrossColumnBatching, multigetMultisliceBatchLimit));
+        batches.addAll(Lists.partition(cellsForCrossColumnBatching, config.crossColumnLoadBatchLimit()));
 
         return batches;
     }
 
-    private List<List<Cell>> partitionBySingleQueryLoadBatchLimit(List<Cell> cells, int singleQueryLoadBatchLimit) {
-        if (cells.size() > singleQueryLoadBatchLimit) {
+    private List<List<Cell>> partitionBySingleQueryLoadBatchLimit(
+            List<Cell> cells, CassandraCellLoadingConfig config, IntConsumer rebatchingManyRowsWarningCallback) {
+        if (cells.size() > config.singleQueryLoadBatchLimit()) {
             rebatchingManyRowsWarningCallback.accept(cells.size());
-            return Lists.partition(cells, singleQueryLoadBatchLimit);
+            return Lists.partition(cells, config.singleQueryLoadBatchLimit());
         }
         return ImmutableList.of(cells);
     }
 
-    private static boolean shouldExplicitlyAllocateBatchToColumn(int multigetMultisliceBatchLimit, List<Cell> cells) {
-        return cells.size() > multigetMultisliceBatchLimit;
+    private static boolean shouldExplicitlyAllocateBatchToColumn(CassandraCellLoadingConfig config, List<Cell> cells) {
+        return cells.size() > config.crossColumnLoadBatchLimit();
     }
 
     private static ListMultimap<byte[], Cell> indexCellsByColumnName(Collection<Cell> cells) {

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/CassandraCellLoadingConfigTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/CassandraCellLoadingConfigTest.java
@@ -1,0 +1,68 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.cassandra;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+@SuppressWarnings("ResultOfMethodCallIgnored") // We are concerned that there are no exceptions
+public class CassandraCellLoadingConfigTest {
+    @Test
+    public void canCreateConfigWithDefaultValues() {
+        assertThatCode(() -> ImmutableCassandraCellLoadingConfig.builder().build())
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void canCreateConfigWithCrossColumnBatchingDisabled() {
+        assertThatCode(() -> CassandraCellLoadingConfig.of(1, 100)).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void cannotCreateConfigWithNonPositiveCrossColumnLoadBatchLimit() {
+        assertThatThrownBy(() -> CassandraCellLoadingConfig.of(-31, 4159))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("crossColumnLoadBatchLimit should be positive");
+        assertThatThrownBy(() -> CassandraCellLoadingConfig.of(0, 4242))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("crossColumnLoadBatchLimit should be positive");
+    }
+
+    @Test
+    public void cannotCreateConfigWithNonPositiveSingleQueryLoadBatchLimit() {
+        assertThatThrownBy(() -> CassandraCellLoadingConfig.of(5, -24))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("singleQueryLoadBatchLimit should be positive");
+        assertThatThrownBy(() -> CassandraCellLoadingConfig.of(-512, -333))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("should be positive"); // could be either one
+    }
+
+    @Test
+    public void cannotCreateConfigWhereCrossColumnBatchLimitExceedsSingleQueryLimit() {
+        assertThatThrownBy(() -> CassandraCellLoadingConfig.of(100, 99))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("shouldn't exceed single query load batch limit");
+    }
+
+    @Test
+    public void canCreateConfigWhereCrossColumnBatchLimitEqualsSingleQueryLimit() {
+        assertThatCode(() -> CassandraCellLoadingConfig.of(777, 777)).doesNotThrowAnyException();
+    }
+}

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/CassandraCellLoadingConfigTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/CassandraCellLoadingConfigTest.java
@@ -49,7 +49,20 @@ public class CassandraCellLoadingConfigTest {
         assertThatThrownBy(() -> CassandraCellLoadingConfig.of(5, -24))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("singleQueryLoadBatchLimit should be positive");
+        assertThatThrownBy(() -> CassandraCellLoadingConfig.of(8, 0))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("singleQueryLoadBatchLimit should be positive");
         assertThatThrownBy(() -> CassandraCellLoadingConfig.of(-512, -333))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("should be positive"); // could be either one
+    }
+
+    @Test
+    public void cannotCreateConfigWithBothLimitsNonPositive() {
+        assertThatThrownBy(() -> CassandraCellLoadingConfig.of(-512, -333))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("should be positive"); // could be either one
+        assertThatThrownBy(() -> CassandraCellLoadingConfig.of(0, 0))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("should be positive"); // could be either one
     }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfigsTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfigsTest.java
@@ -88,6 +88,10 @@ public class CassandraKeyValueServiceConfigsTest {
         CassandraKeyValueServiceRuntimeConfig expectedConfig = ImmutableCassandraKeyValueServiceRuntimeConfig.builder()
                 .numberOfRetriesOnSameHost(4)
                 .numberOfRetriesOnAllHosts(8)
+                .cellLoadingConfig(ImmutableCassandraCellLoadingConfig.builder()
+                        .crossColumnLoadBatchLimit(42)
+                        .singleQueryLoadBatchLimit(424242)
+                        .build())
                 .conservativeRequestExceptionHandler(true)
                 .build();
 

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoadingBatcherTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoadingBatcherTest.java
@@ -144,9 +144,10 @@ public class CellLoadingBatcherTest {
         verify(rebatchingCallback, never()).consume(any(), any(), anyInt());
     }
 
-    private void updateConfig(AtomicReference<CassandraCellLoadingConfig> config, int i, int singleQueryLimit) {
+    private void updateConfig(
+            AtomicReference<CassandraCellLoadingConfig> config, int crossColumnLimit, int singleQueryLimit) {
         config.set(ImmutableCassandraCellLoadingConfig.builder()
-                .crossColumnLoadBatchLimit(i)
+                .crossColumnLoadBatchLimit(crossColumnLimit)
                 .singleQueryLoadBatchLimit(singleQueryLimit)
                 .build());
     }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoadingBatcherTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoadingBatcherTest.java
@@ -173,6 +173,10 @@ public class CellLoadingBatcherTest {
                 .hasSameElementsAs(randomCells);
     }
 
+    private List<List<Cell>> partitionUsingMockCallback(List<Cell> cells) {
+        return batcher.partitionIntoBatches(cells, ADDRESS, TABLE_REFERENCE);
+    }
+
     private static boolean batchIsSingleColumnOrSatisfiesCrossColumnLimit(List<Cell> batch) {
         return batchIsSingleColumn(batch) || batch.size() <= CROSS_COLUMN_LIMIT;
     }
@@ -182,10 +186,6 @@ public class CellLoadingBatcherTest {
                 .map(Cell::getColumnName)
                 .collect(Collectors.toCollection(
                         () -> new TreeSet<>(UnsignedBytes.lexicographicalComparator()))).size() == 1;
-    }
-
-    private List<List<Cell>> partitionUsingMockCallback(List<Cell> cells) {
-        return batcher.partitionIntoBatches(cells, ADDRESS, TABLE_REFERENCE);
     }
 
     private static void assertBatchContentsMatch(List<List<Cell>> actual, List<Cell>... expected) {

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoadingBatcherTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoadingBatcherTest.java
@@ -123,12 +123,7 @@ public class CellLoadingBatcherTest {
     public void respondsToChangesInCrossColumnLimitBatchParameter() {
         AtomicReference<CassandraCellLoadingConfig> config = new AtomicReference<>(LOADING_CONFIG);
         CellLoadingBatcher reloadingBatcher = new CellLoadingBatcher(config::get, rebatchingCallback);
-
-        reloadingBatcher.partitionIntoBatches(columnRange(0, 0, CROSS_COLUMN_LIMIT), ADDRESS, TABLE_REFERENCE);
-        config.set(ImmutableCassandraCellLoadingConfig.builder()
-                .crossColumnLoadBatchLimit(2 * CROSS_COLUMN_LIMIT)
-                .singleQueryLoadBatchLimit(SINGLE_QUERY_LIMIT)
-                .build());
+        updateConfig(config, 2 * CROSS_COLUMN_LIMIT, SINGLE_QUERY_LIMIT);
 
         List<List<Cell>> largerBatches = reloadingBatcher.partitionIntoBatches(
                 columnRange(0, 0, 2 * CROSS_COLUMN_LIMIT), ADDRESS, TABLE_REFERENCE);
@@ -136,16 +131,18 @@ public class CellLoadingBatcherTest {
         verify(rebatchingCallback, never()).consume(any(), any(), anyInt());
     }
 
+    private void updateConfig(AtomicReference<CassandraCellLoadingConfig> config, int i, int singleQueryLimit) {
+        config.set(ImmutableCassandraCellLoadingConfig.builder()
+                .crossColumnLoadBatchLimit(i)
+                .singleQueryLoadBatchLimit(singleQueryLimit)
+                .build());
+    }
+
     @Test
     public void respondsToChangesInSingleQueryLimitBatchParameter() {
         AtomicReference<CassandraCellLoadingConfig> config = new AtomicReference<>(LOADING_CONFIG);
         CellLoadingBatcher reloadingBatcher = new CellLoadingBatcher(config::get, rebatchingCallback);
-
-        reloadingBatcher.partitionIntoBatches(rowRange(SINGLE_QUERY_LIMIT, 0), ADDRESS, TABLE_REFERENCE);
-        config.set(ImmutableCassandraCellLoadingConfig.builder()
-                .crossColumnLoadBatchLimit(CROSS_COLUMN_LIMIT)
-                .singleQueryLoadBatchLimit(2 * SINGLE_QUERY_LIMIT)
-                .build());
+        updateConfig(config, CROSS_COLUMN_LIMIT, 2 * SINGLE_QUERY_LIMIT);
 
         List<List<Cell>> largerBatches = reloadingBatcher.partitionIntoBatches(
                 rowRange(2 * SINGLE_QUERY_LIMIT, 0), ADDRESS, TABLE_REFERENCE);

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoadingBatcherTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoadingBatcherTest.java
@@ -62,6 +62,19 @@ public class CellLoadingBatcherTest {
     private CellLoadingBatcher batcher = new CellLoadingBatcher(() -> LOADING_CONFIG, rebatchingCallback);
 
     @Test
+    public void handlesEmptyBatch() {
+        List<List<Cell>> batches = partitionUsingMockCallback(ImmutableList.of());
+        assertThat(batches).isEmpty();
+    }
+
+    @Test
+    public void queriesOneCellInOneBatch() {
+        List<Cell> oneCell = ImmutableList.of(cell(0, 0));
+        List<List<Cell>> batches = partitionUsingMockCallback(oneCell);
+        assertBatchContentsMatch(batches, oneCell);
+    }
+
+    @Test
     public void splitsCellsByColumnKey() {
         List<Cell> cells = new ArrayList<>();
         cells.addAll(rowRange(CROSS_COLUMN_LIMIT, 0));

--- a/atlasdb-cassandra/src/test/resources/testRuntimeConfig.yml
+++ b/atlasdb-cassandra/src/test/resources/testRuntimeConfig.yml
@@ -2,3 +2,6 @@
   numberOfRetriesOnSameHost: 4
   numberOfRetriesOnAllHosts: 8
   conservativeRequestExceptionHandler: true
+  cellLoadingConfig:
+    crossColumnLoadBatchLimit: 42
+    singleQueryLoadBatchLimit: 424242

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -49,7 +49,13 @@ develop
 
     *    - Type
          - Change
-         
+
+    *    - |improved|
+         - The Cassandra KVS ``CellLoader`` now supports cross-column batching for requests which query a variety of columns for a few rows.
+           Previously, we would make separate requests for each of these columns in parallel, creating additional load on Cassandra.
+           Internal benchmarks reflect a 4-5x improvement in read p99s for such workflows (e.g. small numbers of rows with static columns, or rows with dynamic columns when the column key is varied and known in advance).
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3860>`__)
+
     *    - |improved|
          - Concurrent calls to `TimelockService.startIdentifiedAtlasDbTransaction()` now coalesced into a single Timelock rpc to reduce load on Timelock.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3844>`__)


### PR DESCRIPTION
**This PR has dependencies on #3857, so please review that first!**

**Goals (and why)**:
- Allow runtime configuration of the numbers the cell loader takes into account: cross-column batch limits, and load batch limits. In benchmarking 200 looked like a reasonable number, but I can't guarantee this is right for all stacks.
- Have an escape hatch for disabling cross-column batching, if necessary

**Implementation Description (bullets)**:
- Implement `CassandraCellLoadingConfig` which allows specifying what these numbers are
- Enforce some simple invariants on the config
- Wire the config through to the `CellLoader`.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added a deserialisation test and tests for config invariants. Also updated the existing CellLoadingBatcher test to accommodate batches.

**Concerns (what feedback would you like?)**:
- Should I have rolled this change into the `CassandraKeyValueServiceReloadableConfig`

**Where should we start reviewing?**: CassandraCellLoadingConfig.java

**Priority (whenever / two weeks / yesterday)**: this week
