### PR TITLE
Revert postgres 9.5.2+ requirement

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresVersionCheck.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresVersionCheck.java
@@ -17,7 +17,6 @@ package com.palantir.atlasdb.keyvalue.dbkvs.impl.postgres;
 
 import org.slf4j.Logger;
 
-import com.palantir.util.AssertUtils;
 import com.palantir.util.VersionStrings;
 
 public final class PostgresVersionCheck {
@@ -26,11 +25,11 @@ public final class PostgresVersionCheck {
     private PostgresVersionCheck() {}
 
     public static void checkDatabaseVersion(String version, Logger log) {
-        boolean checkPasses = version.matches("^[\\.0-9]+$")
-                && VersionStrings.compareVersions(version, MIN_POSTGRES_VERSION) >= 0;
-        AssertUtils.assertAndLog(log, checkPasses, "Your key value service currently uses version %s of postgres."
-                + " The minimum supported version is %s."
-                + " If you absolutely need to use an older version of postgres,"
-                + " please contact Palantir support for assistance.", version, MIN_POSTGRES_VERSION);
+        if (!version.matches("^[\\.0-9]+$") || VersionStrings.compareVersions(version, MIN_POSTGRES_VERSION) < 0) {
+            log.error("Your key value service currently uses version {} of postgres."
+                    + " The minimum supported version is {}."
+                    + " If you absolutely need to use an older version of postgres,"
+                    + " please contact Palantir support for assistance.", version, MIN_POSTGRES_VERSION);
+        }
     }
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresVersionCheck.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresVersionCheck.java
@@ -20,7 +20,7 @@ import org.slf4j.Logger;
 import com.palantir.util.VersionStrings;
 
 public final class PostgresVersionCheck {
-    static final String MIN_POSTGRES_VERSION = "9.5.2";
+    private static final String MIN_POSTGRES_VERSION = "9.2";
 
     private PostgresVersionCheck() {}
 
@@ -30,6 +30,12 @@ public final class PostgresVersionCheck {
                     + " The minimum supported version is {}."
                     + " If you absolutely need to use an older version of postgres,"
                     + " please contact Palantir support for assistance.", version, MIN_POSTGRES_VERSION);
+        } else if (VersionStrings.compareVersions(version, "9.5") >= 0
+                && VersionStrings.compareVersions(version, "9.5.2") < 0) {
+            throw new DbkvsVersionException(
+                    "You are running Postgres " + version + ". Versions 9.5.0 and 9.5.1 contain a known bug "
+                            + "that causes incorrect results to be returned for certain queries. "
+                            + "Please update your Postgres distribution.");
         }
     }
 }

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresVersionCheckTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresVersionCheckTest.java
@@ -16,9 +16,7 @@
 package com.palantir.atlasdb.keyvalue.dbkvs.impl.postgres;
 
 import static org.mockito.ArgumentMatchers.contains;
-import static org.mockito.ArgumentMatchers.eq;
 
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -34,18 +32,9 @@ public class PostgresVersionCheckTest {
     @SuppressWarnings(value = "Slf4jConstantLogMessage")
     public void shouldLogErrorOn_9_2_24() {
         Logger log = Mockito.mock(Logger.class);
-        String expectedMessage = "The minimum supported version is " + PostgresVersionCheck.MIN_POSTGRES_VERSION;
-        try {
-            PostgresVersionCheck.checkDatabaseVersion("9.2.24", log);
-            Assert.fail("Expected an AssertionError");
-        } catch (AssertionError error) {
-            Assert.assertTrue("Error did not contain expected message. Actual error: " + error,
-                    error.getMessage().contains(expectedMessage));
-        }
-        Mockito.verify(log).error(
-                eq("Assertion {} with exception "),
-                contains(expectedMessage),
-                Mockito.any(Exception.class));
+        PostgresVersionCheck.checkDatabaseVersion("9.2.24", log);
+        Mockito.verify(log).error(contains("The minimum supported version is {}"), Mockito.anyObject(),
+                Mockito.eq(PostgresVersionCheck.MIN_POSTGRES_VERSION));
         Mockito.verifyNoMoreInteractions(log);
     }
 

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresVersionCheckTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresVersionCheckTest.java
@@ -30,25 +30,43 @@ public class PostgresVersionCheckTest {
 
     @Test
     @SuppressWarnings(value = "Slf4jConstantLogMessage")
-    public void shouldLogErrorOn_9_2_24() {
+    public void shouldLogErrorOn_9_1_24() {
         Logger log = Mockito.mock(Logger.class);
-        PostgresVersionCheck.checkDatabaseVersion("9.2.24", log);
+        PostgresVersionCheck.checkDatabaseVersion("9.1.24", log);
         Mockito.verify(log).error(contains("The minimum supported version is {}"), Mockito.anyObject(),
-                Mockito.eq(PostgresVersionCheck.MIN_POSTGRES_VERSION));
+                Mockito.eq("9.2"));
         Mockito.verifyNoMoreInteractions(log);
+    }
+
+    @Test
+    public void shouldBeFineOn_9_2() {
+        Logger log = Mockito.mock(Logger.class);
+        PostgresVersionCheck.checkDatabaseVersion("9.2", log);
+        Mockito.verifyNoMoreInteractions(log);
+    }
+
+    @Test
+    public void shouldFailOn_9_5() {
+        thrown.expectMessage("Versions 9.5.0 and 9.5.1 contain a known bug");
+        PostgresVersionCheck.checkDatabaseVersion("9.5", Mockito.mock(Logger.class));
+    }
+
+    @Test
+    public void shouldFailOn_9_5_0() {
+        thrown.expectMessage("Versions 9.5.0 and 9.5.1 contain a known bug");
+        PostgresVersionCheck.checkDatabaseVersion("9.5.0", Mockito.mock(Logger.class));
+    }
+
+    @Test
+    public void shouldFailOn_9_5_1() {
+        thrown.expectMessage("Versions 9.5.0 and 9.5.1 contain a known bug");
+        PostgresVersionCheck.checkDatabaseVersion("9.5.1", Mockito.mock(Logger.class));
     }
 
     @Test
     public void shouldBeFineOn_9_5_2() {
         Logger log = Mockito.mock(Logger.class);
         PostgresVersionCheck.checkDatabaseVersion("9.5.2", log);
-        Mockito.verifyNoMoreInteractions(log);
-    }
-
-    @Test
-    public void shouldBeFineOn_9_6_12() {
-        Logger log = Mockito.mock(Logger.class);
-        PostgresVersionCheck.checkDatabaseVersion("9.6.12", log);
         Mockito.verifyNoMoreInteractions(log);
     }
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -67,6 +67,10 @@ develop
          - `AtlasDbHttpClients`, `FeignOkHttpClients` and `AtlasDbFeignTargetFactory` are refactored to get rid of deprecated methods and overused overloads.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3837>`__)
 
+    *    - |changed|
+         - Postgres 9.5.2+ requirement temporarily rescinded.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3862>`__)
+
 ========
 v0.126.0
 ========


### PR DESCRIPTION
We stink and can't bump this requirement, this month. Found too many stragglers that need to be moved.

next month 😢
