### PR TITLE
add debug/trace logging to aid C* pool exhaustion debugging

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -67,6 +67,10 @@ develop
          - `AtlasDbHttpClients`, `FeignOkHttpClients` and `AtlasDbFeignTargetFactory` are refactored to get rid of deprecated methods and overused overloads.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3837>`__)
 
+    *    - |logs|
+         - Added extra debug/trace logging to log the state of the Cassandra pool / application when running into cassandra pool exhaustion errors.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3863>`__)
+
 ========
 v0.126.0
 ========


### PR DESCRIPTION
for PDS-85097
Specifically, this extra debugging is for the case of bursts of high connection usage that perform very little work / are low duration. These are more difficult to catch with other tooling, e.g. periodic jstacks would be unlikely to trigger during a connection burst, and would just show a pool that has grown to max size, but is mostly full of idle connections.

planning on putting this on an old customer branch for some debugging; if you want, develop can also have it, for future debugging needs