### PR TITLE
Oracle Targeted Sweep Bounds Fix

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleOverflowWriteTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleOverflowWriteTable.java
@@ -321,7 +321,7 @@ public final class OracleOverflowWriteTable implements DbWriteTable {
                         + " WHERE m.row_name = ? "
                         + "  AND m.col_name = ? "
                         + "  AND m.ts >= ? "
-                        + "  AND m.ts < ?",
+                        + "  AND m.ts <= ?",
                 args);
     }
 
@@ -380,7 +380,7 @@ public final class OracleOverflowWriteTable implements DbWriteTable {
                 + "                  WHERE i.row_name = ? "
                 + "                    AND i.col_name = ? "
                 + "                    AND i.ts >= ? "
-                + "                    AND i.ts < ? "
+                + "                    AND i.ts <= ? "
                 + "                    AND i.overflow IS NOT NULL)",
                 args);
     }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -58,6 +58,11 @@ develop
          - `RemoteTimelockServiceAdapter` is now closeable. Users of this class should invoke `close()` before termination to avoid thread leaks.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3844>`__)
 
+    *    - |fixed|
+         - Oracle KVS now deletes old entries correctly if using targeted sweep.
+           Previously, there were situations where it would not delete values that could safely be deleted.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3QQQ>`__)
+
     *    - |fixed| |devbreak|
          - Callbacks specified in TransactionManagers will no longer be run synchronously when ``initializeAsync`` is set to true, even if initialization succeeds in the first, synchronous attempt.
            Previously, we would attempt to run the callbacks synchronously when synchronous initialization succeeds, but this prevented use cases where the callback must block until an external resource is available.


### PR DESCRIPTION
**Goals (and why)**:
- Fix bug that was causing Oracle tests to fail with edge cases, e.g. given versions -1, 999999 and 1000000 with a sweep timestamp of 1000000 and conservative sweep, we wouldn't delete anything (but we should delete 999999).

**Implementation Description (bullets)**:
- Bounds were changed from exclusive to inclusive in #3807. We fixed most of the queries to correctly respect the fact that the new bounds were inclusive, but messed up some of these in the Oracle overflow table handler.

**Testing (What was existing testing like?  What have you done to improve it?)**:
I verified this version makes the integration tests pass on Oracle.

**Concerns (what feedback would you like?)**: nothing in particular

**Where should we start reviewing?**: OracleOverflowWriteTable

**Priority (whenever / two weeks / yesterday)**: ASAP 🔥 

@mswintermeyer for SA