### PR TITLE
SLS-Cassandra to 3.31.0 (not RC)

### DIFF
--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -95,7 +95,7 @@ recommendedProductDependencies {
     productDependency {
         productGroup = 'com.palantir.cassandra'
         productName = 'sls-cassandra'
-        minimumVersion = '3.31.0-rc3'
+        minimumVersion = '3.31.0'
         maximumVersion = '3.x.x'
     }
 }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,11 @@ develop
     *    - Type
          - Change
          
+    *    - |userbreak| |fixed|
+         - AtlasDB Cassandra KVS now depends on sls-cassandra 3.31.0 (was 3.31.0-rc3).
+           This version of Cassandra KVS supports a ``multiget_multislice`` operation which retrieves different columns across different rows in a single query; the main goal was to avoid us staying on an RC version.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3872>`__)
+
     *    - |improved|
          - Concurrent calls to `TimelockService.startIdentifiedAtlasDbTransaction()` now coalesced into a single Timelock rpc to reduce load on Timelock.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3844>`__)
@@ -97,7 +102,7 @@ v0.127.0
     *    - |userbreak|
          - AtlasDB Cassandra KVS now depends on sls-cassandra 3.31.0-rc3 (was 3.27.0).
            This version of Cassandra KVS supports a ``multiget_multislice`` operation which retrieves different columns across different rows in a single query.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/3qqq>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3849>`__)
 
     *    - |logs|
          - Added extra debug/trace logging to log the state of the Cassandra pool / application when running into cassandra pool exhaustion errors.

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -52,7 +52,7 @@ develop
          
     *    - |userbreak| |fixed|
          - AtlasDB Cassandra KVS now depends on sls-cassandra 3.31.0 (was 3.31.0-rc3).
-           This version of Cassandra KVS supports a ``multiget_multislice`` operation which retrieves different columns across different rows in a single query; the main goal was to avoid us staying on an RC version.
+           We do not want to stay on an RC version now that a full release is available.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3872>`__)
 
     *    - |improved|


### PR DESCRIPTION
**Goals (and why)**:
- Avoid depending on an RC for sls-cassandra

**Implementation Description (bullets)**:
- Bump the version up to the next non-rc version.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Nothing in particular.

**Concerns (what feedback would you like?)**:
Nothing in particular.

**Where should we start reviewing?**: atlasdb-cassandra/build.gradle

**Priority (whenever / two weeks / yesterday)**: this week

@jkozlowski for SA