### PR TITLE
[_transactions2] Part 32: Metrics - Track Current Transactions Schema Version (at a fresh timestamp)

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbMetricNames.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbMetricNames.java
@@ -66,5 +66,6 @@ public final class AtlasDbMetricNames {
     public static final String TAG_CLIENT = "client";
 
     public static final String COORDINATION_LAST_VALID_BOUND = "lastValidBound";
+    public static final String COORDINATION_CURRENT_TRANSACTIONS_SCHEMA_VERSION = "currentTransactionsSchemaVersion";
     public static final String COORDINATION_EVENTUAL_TRANSACTIONS_SCHEMA_VERSION = "eventualTransactionsSchemaVersion";
 }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -455,7 +455,8 @@ public abstract class TransactionManagers {
     }
 
     private CoordinationService<InternalSchemaMetadata> getSchemaMetadataCoordinationService(
-            MetricsManager metricsManager, LockAndTimestampServices lockAndTimestampServices,
+            MetricsManager metricsManager,
+            LockAndTimestampServices lockAndTimestampServices,
             KeyValueService keyValueService) {
         @SuppressWarnings("unchecked") // Coordination service clearly has this type.
         CoordinationService<InternalSchemaMetadata> metadataCoordinationService = AtlasDbMetrics.instrument(
@@ -465,7 +466,10 @@ public abstract class TransactionManagers {
                         keyValueService,
                         lockAndTimestampServices.timestamp(),
                         config().initializeAsync()));
-        MetadataCoordinationServiceMetrics.registerMetrics(metricsManager, metadataCoordinationService);
+        MetadataCoordinationServiceMetrics.registerMetrics(
+                metricsManager,
+                metadataCoordinationService,
+                lockAndTimestampServices.timestamp());
         return metadataCoordinationService;
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/metrics/MetadataCoordinationServiceMetrics.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/metrics/MetadataCoordinationServiceMetrics.java
@@ -48,7 +48,7 @@ public final class MetadataCoordinationServiceMetrics {
      *
      * @param metricsManager metrics manager to register the
      * @param metadataCoordinationService metadata coordination service that should be tracked
-     * @param timestamp
+     * @param timestamp timestamp service that this coordination service uses for sequencing
      */
     public static void registerMetrics(
             MetricsManager metricsManager,


### PR DESCRIPTION
**Goals (and why)**:
- Provide better visibility on when transactions2 is actually installed, since it's non obvious

**Implementation Description (bullets)**:
- Add metrics for tracking the schema version at a fresh timestamp

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Added tests that we return the right answer for a given TPM and current timestamp - in particular the case where something is agreed but not ready yet.

**Concerns (what feedback would you like?)**:
- It's not ideal that we cache the entire answer, when it's probably okay to cache just the thing from the kvs and get a fresh timestamp when transforming it to the format we want.

**Where should we start reviewing?**: MetadataCoordinationServiceMetrics

**Priority (whenever / two weeks / yesterday)**: this week
