### PR TITLE
[TLS] Timelock Stability: Autobatch block on becoming leader

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
@@ -146,7 +146,7 @@ public final class Leaders {
                 metricsManager, remotePaxosServerSpec.remoteLeaderUris(), trustContext, userAgent);
 
         InstrumentedExecutorService proposerExecutorService = new InstrumentedExecutorService(
-                PTExecutors.newCachedThreadPool(threadFactory("atlas-proposer-%d")),
+                PTExecutors.newCachedThreadPool(daemonThreadFactory("atlas-proposer")),
                 metricsManager.getRegistry(),
                 MetricRegistry.name(PaxosProposer.class, "executor"));
         PaxosProposer proposer = AtlasDbMetrics.instrument(metricsManager.getRegistry(), PaxosProposer.class,
@@ -162,7 +162,7 @@ public final class Leaders {
                         5000,
                         TimeUnit.MILLISECONDS,
                         new SynchronousQueue<>(),
-                        threadFactory("atlas-leaders-election-" + useCase + "-%d")),
+                        daemonThreadFactory("atlas-leaders-election-" + useCase)),
                 metricsManager.getRegistry(),
                 MetricRegistry.name(PaxosLeaderElectionService.class, useCase, "executor"));
 
@@ -195,9 +195,9 @@ public final class Leaders {
                 .build();
     }
 
-    public static ThreadFactory threadFactory(String name) {
+    private static ThreadFactory daemonThreadFactory(String name) {
         return new ThreadFactoryBuilder()
-                .setNameFormat(name)
+                .setNameFormat(name + "-%d")
                 .setDaemon(true)
                 .build();
     }

--- a/leader-election-impl/build.gradle
+++ b/leader-election-impl/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'org.inferred.processors'
 
 dependencies {
   compile project(":leader-election-api")
+  compile project(":atlasdb-autobatch")
   compile project(":atlasdb-commons")
 
   compile group: "com.github.ben-manes.caffeine", name: "caffeine"

--- a/leader-election-impl/src/main/java/com/palantir/leader/BatchingLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/BatchingLeaderElectionService.java
@@ -45,6 +45,10 @@ public class BatchingLeaderElectionService implements LeaderElectionService {
         try {
             return batcher.apply(null).get();
         } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            }
             throw new RuntimeException(e);
         }
     }

--- a/leader-election-impl/src/main/java/com/palantir/leader/BatchingLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/BatchingLeaderElectionService.java
@@ -43,7 +43,7 @@ public class BatchingLeaderElectionService implements LeaderElectionService {
             if (cause instanceof RuntimeException) {
                 throw (RuntimeException) cause;
             }
-            throw new RuntimeException(e);
+            throw new RuntimeException(cause);
         }
     }
 

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
@@ -131,6 +131,7 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
             try {
                 Thread.sleep(GAIN_LEADERSHIP_BACKOFF.toMillis());
             } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 log.warn("gain leadership backoff interrupted");
             }
         }
@@ -143,6 +144,7 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
             onGainedLeadership(leadershipToken);
             return true;
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             log.warn("attempt to gain leadership interrupted", e);
         } catch (Throwable e) {
             log.error("problem blocking on leadership", e);


### PR DESCRIPTION
**Goals (and why)**:
We really do not need to send so many block on becoming leader requests. This proved to be more efficient than using coalescing supplier
