### PR TITLE
[_transactions2] Part 36: Decompose Cassandra putUnlessExists() Return Buffers

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTransactionIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTransactionIntegrationTest.java
@@ -15,18 +15,35 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
 
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.TestRule;
 
 import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.Futures;
 import com.palantir.atlasdb.cassandra.CassandraMutationTimestampProviders;
 import com.palantir.atlasdb.containers.CassandraResource;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.transaction.encoding.TicketsEncodingStrategy;
 import com.palantir.atlasdb.transaction.impl.AbstractTransactionTest;
+import com.palantir.atlasdb.transaction.impl.TransactionConstants;
+import com.palantir.atlasdb.transaction.impl.TransactionTables;
+import com.palantir.atlasdb.transaction.service.SimpleTransactionService;
+import com.palantir.atlasdb.transaction.service.TransactionService;
+import com.palantir.atlasdb.transaction.service.WriteBatchingTransactionService;
 import com.palantir.exception.NotInitializedException;
 import com.palantir.flake.FlakeRetryingRule;
 import com.palantir.flake.ShouldRetry;
@@ -58,6 +75,46 @@ public class CassandraKeyValueServiceTransactionIntegrationTest extends Abstract
     @Override
     protected KeyValueService getKeyValueService() {
         return kvsSupplier.get();
+    }
+
+    @Test
+    public void f178923401274891() {
+        TransactionTables.createTables(keyValueService);
+        TransactionService s = SimpleTransactionService.createV2(keyValueService);
+        s.putUnlessExists(15, 666);
+        keyValueService.putUnlessExists(
+                TransactionConstants.TRANSACTIONS2_TABLE,
+                ImmutableMap.<Cell, byte[]>builder()
+                .put(TicketsEncodingStrategy.INSTANCE.encodeStartTimestampAsCell(31),
+                        TicketsEncodingStrategy.INSTANCE.encodeCommitTimestampAsValue(31, 999))
+                .build());
+
+    }
+
+    @Test
+    public void f1234567() {
+        TransactionTables.createTables(keyValueService);
+        TransactionTables.truncateTables(keyValueService);
+        TransactionService s = WriteBatchingTransactionService.create(
+                SimpleTransactionService.createV2(keyValueService));
+        ExecutorService es = Executors.newCachedThreadPool();
+        List<Future<?>> f = LongStream.range(0, 100)
+                .mapToObj(unused -> {
+                    return es.submit(() -> {
+                        try {
+                            s.putUnlessExists(unused, unused + 1);
+                            s.putUnlessExists(unused + 1, unused + 3);
+                            s.putUnlessExists(unused - 1, unused + 5);
+                            s.putUnlessExists(unused + 2, unused + 7);
+                            s.putUnlessExists(unused - 2, unused + 9);
+                        } catch (KeyAlreadyExistsException ex) {
+                            // bleh
+                            System.out.println(ex.getExistingKeys());
+                        }
+                    });
+                })
+                .collect(Collectors.toList());
+        f.forEach(Futures::getUnchecked);
     }
 
     private KeyValueService createAndRegisterKeyValueService() {

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTransactionIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTransactionIntegrationTest.java
@@ -15,8 +15,6 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -95,8 +93,6 @@ public class CassandraKeyValueServiceTransactionIntegrationTest extends Abstract
                 }))
                 .collect(Collectors.toList());
         futures.forEach(Futures::getUnchecked);
-
-        assertThat(exceptions).hasSize(numTransactionPutters - 1);
     }
 
     private void tryPutTimestampTrackingExceptions(

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -1664,8 +1664,8 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                     if (!casResult.isSuccess()) {
                         return Optional.of(new KeyAlreadyExistsException(
                                 String.format("The cells in table %s already exist.", tableRef.getQualifiedName()),
-                                casResult.getCurrent_values().stream().
-                                        map(column -> Cell.create(partition.getKey().toByteArray(),
+                                casResult.getCurrent_values().stream()
+                                        .map(column -> Cell.create(partition.getKey().toByteArray(),
                                                 CassandraKeyValueServices.decompose(column.bufferForName()).lhSide))
                                         .collect(Collectors.toList())));
                     }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -1664,8 +1664,9 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                     if (!casResult.isSuccess()) {
                         return Optional.of(new KeyAlreadyExistsException(
                                 String.format("The cells in table %s already exist.", tableRef.getQualifiedName()),
-                                casResult.getCurrent_values().stream().map(column ->
-                                        Cell.create(partition.getKey().toByteArray(), column.getName()))
+                                casResult.getCurrent_values().stream().
+                                        map(column -> Cell.create(partition.getKey().toByteArray(),
+                                                CassandraKeyValueServices.decompose(column.bufferForName()).lhSide))
                                         .collect(Collectors.toList())));
                     }
                 }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,12 +50,17 @@ develop
     *    - Type
          - Change
 
+    *    - |fixed|
+         - ``putUnlessExists`` in Cassandra KVS now produces correct cell names when failing with a ``KeyAlreadyExistsException``.
+           Previously, Cassandra KVS used to produce incorrect cell names (that were the concatenation of the correct cell name and an encoding of the AtlasDB timestamp).
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3qqq>`__)
+         
     *    - |improved|
          - The Cassandra KVS ``CellLoader`` now supports cross-column batching for requests which query a variety of columns for a few rows.
            Previously, we would make separate requests for each of these columns in parallel, creating additional load on Cassandra.
            Internal benchmarks reflect a 4-5x improvement in read p99s for such workflows (e.g. small numbers of rows with static columns, or rows with dynamic columns when the column key is varied and known in advance).
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3860>`__)
-         
+
     *    - |userbreak| |fixed|
          - AtlasDB Cassandra KVS now depends on sls-cassandra 3.31.0 (was 3.31.0-rc3).
            We do not want to stay on an RC version now that a full release is available.

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -53,7 +53,7 @@ develop
     *    - |fixed|
          - ``putUnlessExists`` in Cassandra KVS now produces correct cell names when failing with a ``KeyAlreadyExistsException``.
            Previously, Cassandra KVS used to produce incorrect cell names (that were the concatenation of the correct cell name and an encoding of the AtlasDB timestamp).
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/3qqq>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3882>`__)
          
     *    - |improved|
          - The Cassandra KVS ``CellLoader`` now supports cross-column batching for requests which query a variety of columns for a few rows.
@@ -77,7 +77,7 @@ develop
     *    - |fixed|
          - Oracle KVS now deletes old entries correctly if using targeted sweep.
            Previously, there were situations where it would not delete values that could safely be deleted.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/3QQQ>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3870>`__)
 
     *    - |fixed| |devbreak|
          - Callbacks specified in TransactionManagers will no longer be run synchronously when ``initializeAsync`` is set to true, even if initialization succeeds in the first, synchronous attempt.


### PR DESCRIPTION
**Goals (and why)**:
- Fix an issue where the KeyAlreadyExistsExceptions thrown by Cassandra KVS would be incorrect, as they would have columns expressed in the form `thisIsTheColumnKey || timestamp`. This was causing transactions2 to fail with `NullPointerExceptions` because it looks like it receives timestamps it never asked for, and then attempts to grab the futures for these to mark them as failed, and then explodes.

**Implementation Description (bullets)**:
- Fix PUE to extract only the column name and not the timestamp.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added a test that the cell included was the one we expected, plus a fuzz test that a large number of highly conflicting writes resolves itself quickly.

**Concerns (what feedback would you like?)**: 
- Does this actually fix the issue we saw?

**Where should we start reviewing?**: CassandraKeyValueServiceImpl

**Priority (whenever / two weeks / yesterday)**: yesterday 🔥 
