### PR TITLE
[_transactions2] Part 37: Perpetuate Existing Values Less Aggressively

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -55,6 +55,11 @@ develop
            Previously, Cassandra KVS used to produce incorrect cell names (that were the concatenation of the correct cell name and an encoding of the AtlasDB timestamp).
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3882>`__)
          
+    *    - |fixed|
+         - Coordination services now only perpetuate an existing value on value-preserving transformations if the existing bound is invalid at a fresh sequence number.
+           Previously, we would perpetuate the bound regardless, meaning that when the bound is crossed in a multi-threaded environment, each thread will separately attempt to push the bound forward, possibly resulting in unnecessarily many attempts to check-and-set the value.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3QQQ>`__)
+
     *    - |improved|
          - The Cassandra KVS ``CellLoader`` now supports cross-column batching for requests which query a variety of columns for a few rows.
            Previously, we would make separate requests for each of these columns in parallel, creating additional load on Cassandra.

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -57,7 +57,9 @@ develop
          
     *    - |fixed|
          - Coordination services now only perpetuate an existing value on value-preserving transformations if the existing bound is invalid at a fresh sequence number.
-           Previously, we would perpetuate the bound regardless, meaning that when the bound is crossed in a multi-threaded environment, each thread will separately attempt to push the bound forward, possibly resulting in unnecessarily many attempts to check-and-set the value.
+           Previously, we would perpetuate the bound regardless, meaning that when the bound is crossed in a multi-threaded environment, each in-flight transaction that tries to determine its transaction schema version will independently attempt to perpetuate the bound.
+           This may lead to multiple unnecessary updates to the coordinated value in a short space of time.
+           Note that updates that do change the value will be applied regardless, and could potentially still race if applied in parallel.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3QQQ>`__)
 
     *    - |improved|


### PR DESCRIPTION
**Goals (and why)**:
- The current logic for perpetuating an existing transaction schema version caused issues for internal backup products. We observed value changes on intervals as small as 1,000 timestamps (in the sense that we read two values from the coordination store that had bounds differing by just 1,000).

**Implementation Description (bullets)**:
Define a value-preserving transformation as one that transforms a value to itself. Then:

- don't write a new value, regardless of the gap between the old bound and a fresh timestamp
- (new) *don't write a new bound if a fresh timestamp is less than the old bound* - the perpetuate call should be fine anyway, because it is looking for timestamps to get past some value that is less than the fresh timestamp we use to make the decision

Non value-preserving transformations are unaffected.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added 2 tests for the new behaviour

**Concerns (what feedback would you like?)**:
- Do these checks make sense?
- Is there still a case where a bound may be advanced by less than 5M in a value preserving transformation?
- I don't care about races on non value preserving transforms. I think this is OK but probably worth a check.

**Where should we start reviewing?**: KeyValueServiceCoordinationStore

**Priority (whenever / two weeks / yesterday)**: this week
