### PR TITLE
Require Rescue 4.4.0

### DIFF
--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -88,7 +88,7 @@ recommendedProductDependencies {
     productDependency {
         productGroup = 'com.palantir.rescue'
         productName = 'rescue'
-        minimumVersion = '4.0.0'
+        minimumVersion = '4.4.0'
         maximumVersion = '4.x.x'
     }
 

--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -88,7 +88,7 @@ recommendedProductDependencies {
     productDependency {
         productGroup = 'com.palantir.rescue'
         productName = 'rescue'
-        minimumVersion = '3.22.0'
+        minimumVersion = '4.0.0'
         maximumVersion = '4.x.x'
     }
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -69,6 +69,9 @@ develop
            Also, ``CoordinationService.createDefault()`` now handles instrumentation of both the coordination service and store.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3894>`__)
 
+    *    - |userbreak|
+         - AtlasDB Cassandra KVS now depends on rescue 4.4.0 (was previously 3.22.0).
+
 ========
 v0.133.0
 ========


### PR DESCRIPTION
This is a requirement for rolling _transactions2 out by default. Unclear if we actually want to merge it yet if we're not quite at the "turn on by default" phase yet. As of today (April 2nd) about half of the fleet violates this constraint.