### PR TITLE
Close Cassandra client input and output transports

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
+import java.io.Closeable;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
@@ -47,7 +48,7 @@ import com.palantir.processors.AutoDelegate;
 
 @SuppressWarnings({"all"}) // thrift variable names.
 @AutoDelegate
-public interface CassandraClient {
+public interface CassandraClient extends Closeable {
     /**
      * Checks if the client has a valid connection to Cassandra cluster. Can be used by a client pool
      * to eliminate clients in bad state.
@@ -159,4 +160,6 @@ public interface CassandraClient {
     void truncate(String cfname)
             throws InvalidRequestException, UnavailableException, TimedOutException, TException;
 
+    @Override
+    void close();
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
@@ -203,10 +203,12 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
 
     @Override
     public void destroyObject(PooledObject<CassandraClient> client) {
-        client.getObject().getOutputProtocol().getTransport().close();
-        log.debug("Closed transport for client {} of host {}",
-                UnsafeArg.of("client", client),
-                SafeArg.of("cassandraClient", CassandraLogHelper.host(addr)));
+        try (CassandraClient cassandraClient = client.getObject()) {
+            cassandraClient.close();
+            log.debug("Closed transport for client {} of host {}",
+                    UnsafeArg.of("client", client),
+                    SafeArg.of("cassandraClient", CassandraLogHelper.host(addr)));
+        }
     }
 
     static class ClientCreationFailedException extends AtlasDbDependencyException {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
@@ -203,12 +203,10 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
 
     @Override
     public void destroyObject(PooledObject<CassandraClient> client) {
-        try (CassandraClient cassandraClient = client.getObject()) {
-            cassandraClient.close();
-            log.debug("Closed transport for client {} of host {}",
-                    UnsafeArg.of("client", client),
-                    SafeArg.of("cassandraClient", CassandraLogHelper.host(addr)));
-        }
+        client.getObject().close();
+        log.debug("Closed transport for client {} of host {}",
+                UnsafeArg.of("client", client),
+                SafeArg.of("cassandraClient", CassandraLogHelper.host(addr)));
     }
 
     static class ClientCreationFailedException extends AtlasDbDependencyException {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientImpl.java
@@ -50,6 +50,7 @@ import org.apache.cassandra.thrift.UnavailableException;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.protocol.TProtocolException;
+import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 
 import com.google.common.collect.ImmutableSet;
@@ -275,6 +276,17 @@ public class CassandraClientImpl implements CassandraClient {
         ByteBuffer queryBytes = ByteBuffer.wrap(cqlQuery.toString().getBytes(StandardCharsets.UTF_8));
 
         return executeHandlingExceptions(() -> client.execute_cql3_query(queryBytes, compression, consistency));
+    }
+
+    @Override
+    public void close() {
+        TProtocol inputProtocol = getInputProtocol();
+        TProtocol outputProtocol = getOutputProtocol();
+        try (TTransport inputTransport = inputProtocol.getTransport();
+                TTransport outputTransport = outputProtocol.getTransport()) {
+            inputProtocol.reset();
+            outputProtocol.reset();
+        }
     }
 
     private ColumnParent getColumnParent(TableReference tableRef) {

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -104,6 +104,10 @@ develop
          - Fixed a rare situation in which interrupting a thread could possibly leave dangling locks.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3805>`__)
 
+    *    - |fixed|
+         - Cassandra client input and output transports are now properly closed.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3892>`__)
+
 ========
 v0.127.0
 ========


### PR DESCRIPTION
**Goals (and why)**:

When removing a Cassandra client from the pool, close both the input and
output transports to ensure any underlying sockets are also closed.

**Implementation Description (bullets)**:
`CassandraClient` interface now extends `Closeable` and implementations handle closing their input and output transports, and the Cassandra pool now just closes evicted clients.

**Testing (What was existing testing like?  What have you done to improve it?)**:
none, noticed unclosed sockets & clients while looking through a test heap dump

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
