### PR TITLE
Bump min version of timelock

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -51,6 +51,10 @@ develop
          - Change
 
     *    - |fixed|
+         - lock-api now declares a minimum dependency on timelock-server 0.59.0.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3894>`__)
+
+    *    - |fixed|
          - ``putUnlessExists`` in Cassandra KVS now produces correct cell names when failing with a ``KeyAlreadyExistsException``.
            Previously, Cassandra KVS used to produce incorrect cell names (that were the concatenation of the correct cell name and an encoding of the AtlasDB timestamp).
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3882>`__)

--- a/lock-api/build.gradle
+++ b/lock-api/build.gradle
@@ -42,7 +42,7 @@ recommendedProductDependencies {
     productDependency {
         productGroup = 'com.palantir.timelock'
         productName = 'timelock-server'
-        minimumVersion = '0.58.0'
+        minimumVersion = '0.59.0'
         maximumVersion = '0.x.x'
     }
 }


### PR DESCRIPTION
0.58.0's docker image is busted and I'd like to just in my testing say "use the min version specified by atlasdb"