### PR TITLE
Bump timelock-server product dependency minimum version

### DIFF
--- a/lock-api/build.gradle
+++ b/lock-api/build.gradle
@@ -42,7 +42,7 @@ recommendedProductDependencies {
     productDependency {
         productGroup = 'com.palantir.timelock'
         productName = 'timelock-server'
-        minimumVersion = '0.58.0'
+        minimumVersion = '0.59.0'
         maximumVersion = '0.x.x'
     }
 }


### PR DESCRIPTION
**Goals (and why)**:
Bump the timelock-server product dependency minimum version. This is because timelock-server 0.58.0 was a bad release and using it as the minimum version prevent projects from using automatically using dependency recommendations as integration test versions. See https://github.com/palantir/sls-packaging/pull/484 for more details.
