### PR TITLE
[PDS-87539] Log InvalidRequestExceptions if it wasn't the keyspace already created race condition

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -227,7 +227,16 @@ public final class CassandraVerifier {
                     "after adding the initial empty keyspace");
             return true;
         } catch (InvalidRequestException e) {
-            return keyspaceAlreadyExists(host, config);
+            boolean keyspaceAlreadyExists = keyspaceAlreadyExists(host, config);
+            if (!keyspaceAlreadyExists) {
+                log.info("Encountered an invalid request exception {} when attempting to create a keyspace"
+                        + " on a given Cassandra host {}, but the keyspace doesn't seem to exist yet. This may"
+                        + " cause issues if it recurs persistently, so logging for debugging purposes.",
+                        SafeArg.of("host", CassandraLogHelper.host(host)),
+                        UnsafeArg.of("exceptionMessage", e.toString()));
+                log.debug("Specifically, creating the keyspace failed with the following stack trace", e);
+            }
+            return keyspaceAlreadyExists;
         }
     }
 


### PR DESCRIPTION
**Goals (and why)**:
- It would have been easier to find a root cause of the first issue in PDS-87539 if we had this logging. I think we accidentally removed something along these lines in #3486.

**Implementation Description (bullets)**:
- If the keyspace doesn't exist even though our attempt to create the keyspace threw an IRE, log.

**Testing (What was existing testing like?  What have you done to improve it?)**: none

**Concerns (what feedback would you like?)**:
- Should this react even more explosively?

**Where should we start reviewing?**: CassandraVerifier

**Priority (whenever / two weeks / yesterday)**: this week
