### PR TITLE
Avoid Iterables.partition when Lists.partition is available

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/sweep/GetEmptyLatestValues.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/sweep/GetEmptyLatestValues.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.keyvalue.api.Cell;
@@ -53,7 +53,7 @@ public class GetEmptyLatestValues {
      */
     public Set<Cell> execute() {
         Set<Cell> result = Sets.newHashSet();
-        for (List<CellWithTimestamps> batch : Iterables.partition(cellTimestamps, batchSize)) {
+        for (List<CellWithTimestamps> batch : Lists.partition(cellTimestamps, batchSize)) {
             result.addAll(getSingleBatch(batch));
         }
         return result;

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/AbstractDbWriteTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/AbstractDbWriteTable.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
 import com.palantir.atlasdb.keyvalue.api.Cell;
@@ -93,7 +92,7 @@ public abstract class AbstractDbWriteTable implements DbWriteTable {
     public void putSentinels(Iterable<Cell> cells) {
         byte[] value = new byte[0];
         long ts = Value.INVALID_VALUE_TIMESTAMP;
-        for (List<Cell> batch : Iterables.partition(Ordering.natural().immutableSortedCopy(cells), 1000)) {
+        for (List<Cell> batch : Lists.partition(Ordering.natural().immutableSortedCopy(cells), 1000)) {
             List<Object[]> args = Lists.newArrayListWithCapacity(batch.size());
             for (Cell cell : batch) {
                 args.add(new Object[] {cell.getRowName(), cell.getColumnName(), ts, value,

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleOverflowWriteTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleOverflowWriteTable.java
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Throwables;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
 import com.palantir.atlasdb.AtlasDbConstants;
@@ -157,7 +156,7 @@ public final class OracleOverflowWriteTable implements DbWriteTable {
     public void putSentinels(Iterable<Cell> cells) {
         byte[] value = new byte[0];
         long ts = Value.INVALID_VALUE_TIMESTAMP;
-        for (List<Cell> batch : Iterables.partition(Ordering.natural().immutableSortedCopy(cells), 1000)) {
+        for (List<Cell> batch : Lists.partition(Ordering.natural().immutableSortedCopy(cells), 1000)) {
             List<Object[]> args = Lists.newArrayListWithCapacity(batch.size());
             for (Cell cell : batch) {
                 args.add(new Object[] {cell.getRowName(), cell.getColumnName(), ts, value, null,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/AbortingCommitTsLoader.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/AbortingCommitTsLoader.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.cache.CacheLoader;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Streams;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
@@ -61,7 +61,7 @@ public class AbortingCommitTsLoader extends CacheLoader<Long, Long> {
         List<Long> missingKeys = ImmutableList.copyOf(nonCachedKeys);
         Map<Long, Long> result = new HashMap<>();
 
-        Streams.stream(Iterables.partition(missingKeys, AtlasDbConstants.TRANSACTION_TIMESTAMP_LOAD_BATCH_LIMIT))
+        Streams.stream(Lists.partition(missingKeys, AtlasDbConstants.TRANSACTION_TIMESTAMP_LOAD_BATCH_LIMIT))
                 .forEach(batch -> result.putAll(transactionService.get(batch)));
 
         // roll back any uncommitted transactions

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -119,6 +119,10 @@ develop
          - Cassandra client input and output transports are now properly closed.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3892>`__)
 
+    *    - |improved|
+         - Removed unnecessary memory allocations in the lock refresher, and in several other classes, by using Lists.partition(...) instead of Iterables.partition(...).
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3918>`__)
+
 ========
 v0.127.0
 ========

--- a/lock-api/src/main/java/com/palantir/lock/client/LockRefreshingLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockRefreshingLockService.java
@@ -24,8 +24,9 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.lock.HeldLocksToken;
@@ -124,13 +125,13 @@ public class LockRefreshingLockService extends SimplifyingLockService {
     }
 
     private void refreshLocks() {
-        ImmutableSet<LockRefreshToken> refreshCopy = ImmutableSet.copyOf(toRefresh);
+        ImmutableList<LockRefreshToken> refreshCopy = ImmutableList.copyOf(toRefresh);
         if (refreshCopy.isEmpty()) {
             return;
         }
         Set<LockRefreshToken> refreshedTokens = new HashSet<>();
         // We batch refreshes to avoid sending payload of excessive size
-        for (List<LockRefreshToken> tokenBatch : Iterables.partition(refreshCopy, REFRESH_BATCH_SIZE)) {
+        for (List<LockRefreshToken> tokenBatch : Lists.partition(refreshCopy, REFRESH_BATCH_SIZE)) {
             refreshedTokens.addAll(delegate.refreshLockRefreshTokens(tokenBatch));
         }
         for (LockRefreshToken token : refreshCopy) {

--- a/lock-api/src/test/java/com/palantir/lock/client/AsyncTimeLockUnlockerTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/AsyncTimeLockUnlockerTest.java
@@ -38,7 +38,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.palantir.lock.v2.LockToken;
@@ -84,7 +83,7 @@ public class AsyncTimeLockUnlockerTest {
     public void enqueueingTokensEnqueuedInGroupsAllEventuallyCaptured() {
         setupTokenCollectingTimeLock();
 
-        Iterables.partition(tokenList, 7).forEach(tokens -> unlocker.enqueue(ImmutableSet.copyOf(tokens)));
+        Lists.partition(tokenList, 7).forEach(tokens -> unlocker.enqueue(ImmutableSet.copyOf(tokens)));
 
         verifyTryUnlockAttemptedAtLeastOnce();
         assertAllTokensEventuallyUnlocked();


### PR DESCRIPTION
**Goals (and why)**:
Reduce the number of unnecessary memory allocations by Atlas

**Implementation Description (bullets)**:
Iterables.partition pre-allocates an Array of the desired batch size for every batch. This is generally a good perf optimization, but can lead to bad situations in extreme scenarios.
For instance, LockRefreshingLockService refreshes the locks in batches of 500K every 5 seconds. For a service containing just a few locks, this leads to allocation of arrays of size 500K every 5 seconds (2Mb every 5 seconds).
If the Iterable being partitioned is a List, Lists.partition is much more efficient and simply relies on the .sublist method.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Existing tests passing should be enough. This is a simple refactor.

**Concerns (what feedback would you like?)**:
I couldn't convert all usages of Iterables.partition because Atlas uses Iterables as parameters extensively. I think that the main cases were converted. Refactoring the code to be able to switch the other cases might not be worth it. I will leave this up to the dev team.

**Where should we start reviewing?**:
Anywhere

**Priority (whenever / two weeks / yesterday)**:
Not super high priority, but a nice improvement