### PR TITLE
[_transactions2] Part 41: Autobatcher Profiling

### DIFF
--- a/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/BatchSizeLogger.java
+++ b/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/BatchSizeLogger.java
@@ -1,0 +1,67 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.autobatch;
+
+import java.time.Duration;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.util.concurrent.RateLimiter;
+import com.palantir.logsafe.SafeArg;
+
+@NotThreadSafe // Disruptor runs the batching function on just one thread.
+public final class BatchSizeLogger {
+    private static final Logger log = LoggerFactory.getLogger(BatchSizeLogger.class);
+
+    private static final Duration AUTOBATCHER_LOGGING_INTERVAL = Duration.ofSeconds(10);
+    private static final double AUTOBATCHER_LOGGING_PERMITS_PER_SECOND = 1. / AUTOBATCHER_LOGGING_INTERVAL.getSeconds();
+
+    private final RateLimiter rateLimiter;
+    private final String safeIdentifier;
+
+    private long total = 0;
+    private long counter = 0;
+
+    private BatchSizeLogger(RateLimiter rateLimiter, String safeIdentifier) {
+        this.rateLimiter = rateLimiter;
+        this.safeIdentifier = safeIdentifier;
+    }
+
+    public static BatchSizeLogger create(String safeLoggerIdentifier) {
+        RateLimiter profilingLimiter = RateLimiter.create(AUTOBATCHER_LOGGING_PERMITS_PER_SECOND); // every 10 seconds
+        return new BatchSizeLogger(profilingLimiter, safeLoggerIdentifier);
+    }
+
+    public void markBatchProcessed(long batchSize) {
+        total += batchSize;
+        counter++;
+        if (rateLimiter.tryAcquire()) {
+            log.info("The autobatcher with identifier {} has just processed a batch of size {}."
+                    + " Over the last {} seconds, it has processed {} batches with average size {}.",
+                    SafeArg.of("safeIdentifier", safeIdentifier),
+                    SafeArg.of("currentBatchSize", batchSize),
+                    SafeArg.of("interval", AUTOBATCHER_LOGGING_INTERVAL.getSeconds()),
+                    SafeArg.of("numBatches", counter),
+                    SafeArg.of("averageSize", (double) total / counter));
+            total = 0;
+            counter = 0;
+        }
+    }
+}

--- a/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/ProfilingAutobatchers.java
+++ b/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/ProfilingAutobatchers.java
@@ -1,0 +1,54 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.autobatch;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.slf4j.Logger;
+
+import com.google.common.util.concurrent.RateLimiter;
+import com.palantir.logsafe.SafeArg;
+
+public final class ProfilingAutobatchers {
+
+    private static final Duration AUTOBATCHER_LOGGING_INTERVAL = Duration.ofSeconds(10);
+    private static final double AUTOBATCHER_LOGGING_PERMITS_PER_SECOND = 1. / AUTOBATCHER_LOGGING_INTERVAL.getSeconds();
+
+    private ProfilingAutobatchers() {
+        // factory
+    }
+
+    public static <T, R> DisruptorAutobatcher<T, R> create(
+            Logger logger,
+            String safeIdentifier,
+            Consumer<List<BatchElement<T, R>>> batchFunction) {
+        RateLimiter profilingLimiter = RateLimiter.create(AUTOBATCHER_LOGGING_PERMITS_PER_SECOND); // every 10 seconds
+        return DisruptorAutobatcher.create(elements -> {
+            batchFunction.accept(elements);
+
+            if (profilingLimiter.tryAcquire()) {
+                logger.info("Autobatcher with ID {} just processed a batch of size {}."
+                                + " This message is rate limited to once every 10 seconds per autobatcher, so there"
+                                + " may be more batches being processed.",
+                        SafeArg.of("autobatcherIdentifier", safeIdentifier),
+                        SafeArg.of("batchSize", elements.size()));
+            }
+        });
+    }
+}

--- a/atlasdb-autobatch/src/test/java/com/palantir/atlasdb/autobatch/BatchSizeLoggerTest.java
+++ b/atlasdb-autobatch/src/test/java/com/palantir/atlasdb/autobatch/BatchSizeLoggerTest.java
@@ -1,0 +1,57 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.autobatch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+
+public class BatchSizeLoggerTest {
+    private static final String SAFE_IDENTIFIER = "identifier";
+
+    @Test
+    public void computesAverage() {
+        BatchSizeLogger batchSizeLogger = new BatchSizeLogger(() -> false, SAFE_IDENTIFIER);
+        batchSizeLogger.markBatchProcessed(5);
+        batchSizeLogger.markBatchProcessed(10);
+        assertThat(batchSizeLogger.getCurrentAverage()).isEqualTo(7.5);
+    }
+
+    @Test
+    public void resetsWhenFlushing() {
+        BatchSizeLogger batchSizeLogger = new BatchSizeLogger(() -> true, SAFE_IDENTIFIER);
+        batchSizeLogger.markBatchProcessed(5);
+        assertThat(batchSizeLogger.getCurrentAverage()).isNaN();
+    }
+
+    @Test
+    public void recoversFromReset() {
+        AtomicBoolean atomicBoolean = new AtomicBoolean(false);
+        BatchSizeLogger batchSizeLogger = new BatchSizeLogger(atomicBoolean::get, SAFE_IDENTIFIER);
+        batchSizeLogger.markBatchProcessed(8);
+        assertThat(batchSizeLogger.getCurrentAverage()).isEqualTo(8.0);
+
+        atomicBoolean.set(true);
+        batchSizeLogger.markBatchProcessed(6);
+
+        atomicBoolean.set(false);
+        batchSizeLogger.markBatchProcessed(4);
+        assertThat(batchSizeLogger.getCurrentAverage()).isEqualTo(4.0);
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/WriteBatchingTransactionService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/WriteBatchingTransactionService.java
@@ -38,6 +38,7 @@ import com.google.common.collect.Multimaps;
 import com.google.common.util.concurrent.SettableFuture;
 import com.palantir.atlasdb.autobatch.BatchElement;
 import com.palantir.atlasdb.autobatch.DisruptorAutobatcher;
+import com.palantir.atlasdb.autobatch.ProfilingAutobatchers;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
 import com.palantir.common.streams.KeyedStream;
@@ -67,7 +68,9 @@ public final class WriteBatchingTransactionService implements TransactionService
     }
 
     public static TransactionService create(EncodingTransactionService delegate) {
-        DisruptorAutobatcher<TimestampPair, Void> autobatcher = DisruptorAutobatcher.create(
+        DisruptorAutobatcher<TimestampPair, Void> autobatcher = ProfilingAutobatchers.create(
+                log,
+                WriteBatchingTransactionService.class.getSimpleName(),
                 elements -> processBatch(delegate, elements));
         return new WriteBatchingTransactionService(delegate, autobatcher);
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/WriteBatchingTransactionService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/WriteBatchingTransactionService.java
@@ -69,7 +69,6 @@ public final class WriteBatchingTransactionService implements TransactionService
 
     public static TransactionService create(EncodingTransactionService delegate) {
         DisruptorAutobatcher<TimestampPair, Void> autobatcher = ProfilingAutobatchers.create(
-                log,
                 WriteBatchingTransactionService.class.getSimpleName(),
                 elements -> processBatch(delegate, elements));
         return new WriteBatchingTransactionService(delegate, autobatcher);

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -130,6 +130,10 @@ develop
          - Removed unnecessary memory allocations in the lock refresher, and in several other classes, by using Lists.partition(...) instead of Iterables.partition(...).
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3918>`__)
 
+    *    - |improved|
+         - AtlasDB now logs diagnostic information about uses of the request batching timestamp service.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3923>`__)
+
 ========
 v0.127.0
 ========

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -131,7 +131,7 @@ develop
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3918>`__)
 
     *    - |improved|
-         - AtlasDB now logs diagnostic information about uses of the request batching timestamp service.
+         - AtlasDB now logs diagnostic information about usage of classes that utilise smart batching (e.g. when starting transactions, verifying leadership, _transactions2 put-unless-exists, etc.).
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3923>`__)
 
 ========

--- a/leader-election-impl/src/main/java/com/palantir/leader/BatchingLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/BatchingLeaderElectionService.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ExecutionException;
 import com.google.common.net.HostAndPort;
 import com.palantir.atlasdb.autobatch.BatchElement;
 import com.palantir.atlasdb.autobatch.DisruptorAutobatcher;
+import com.palantir.atlasdb.autobatch.ProfilingAutobatchers;
 
 public class BatchingLeaderElectionService implements LeaderElectionService {
     private final LeaderElectionService delegate;
@@ -31,7 +32,9 @@ public class BatchingLeaderElectionService implements LeaderElectionService {
 
     public BatchingLeaderElectionService(LeaderElectionService delegate) {
         this.delegate = delegate;
-        this.batcher = DisruptorAutobatcher.create(this::processBatch);
+        this.batcher = ProfilingAutobatchers.create(
+                BatchingLeaderElectionService.class.getSimpleName(),
+                this::processBatch);
     }
 
     @Override

--- a/lock-api/src/main/java/com/palantir/lock/client/TransactionStarter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/TransactionStarter.java
@@ -30,6 +30,7 @@ import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 import com.palantir.atlasdb.autobatch.BatchElement;
 import com.palantir.atlasdb.autobatch.DisruptorAutobatcher;
+import com.palantir.atlasdb.autobatch.ProfilingAutobatchers;
 import com.palantir.common.base.Throwables;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
 import com.palantir.lock.v2.LockToken;
@@ -58,8 +59,8 @@ final class TransactionStarter implements AutoCloseable {
     }
 
     static TransactionStarter create(LockLeaseService lockLeaseService) {
-        return new TransactionStarter(DisruptorAutobatcher.create(
-                consumer(lockLeaseService)),
+        return new TransactionStarter(ProfilingAutobatchers.create(
+                TransactionStarter.class.getSimpleName(), consumer(lockLeaseService)),
                 lockLeaseService);
     }
 

--- a/timestamp-client/src/main/java/com/palantir/timestamp/RequestBatchingTimestampService.java
+++ b/timestamp-client/src/main/java/com/palantir/timestamp/RequestBatchingTimestampService.java
@@ -29,6 +29,7 @@ import com.google.common.primitives.Ints;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.atlasdb.autobatch.BatchElement;
 import com.palantir.atlasdb.autobatch.DisruptorAutobatcher;
+import com.palantir.atlasdb.autobatch.ProfilingAutobatchers;
 import com.palantir.common.base.Throwables;
 import com.palantir.common.proxy.TimingProxy;
 import com.palantir.util.jmx.OperationTimer;
@@ -85,7 +86,9 @@ public final class RequestBatchingTimestampService implements CloseableTimestamp
 
     public static RequestBatchingTimestampService create(TimestampService untimedDelegate) {
         TimestampService delegate = TimingProxy.newProxyInstance(TimestampService.class, untimedDelegate, timer);
-        DisruptorAutobatcher<Integer, TimestampRange> autobatcher = DisruptorAutobatcher.create(consumer(delegate));
+        DisruptorAutobatcher<Integer, TimestampRange> autobatcher = ProfilingAutobatchers.create(
+                RequestBatchingTimestampService.class.getSimpleName(),
+                consumer(delegate));
         return new RequestBatchingTimestampService(delegate, autobatcher);
     }
 


### PR DESCRIPTION
**Goals (and why)**:
- Get some idea as to what batch sizes for the write batching transaction service.

**Implementation Description (bullets)**:
- Add profiling logging every 10 seconds.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Not much, I'll admit. Existing tests should catch that nothing has gone terribly wrong.

**Concerns (what feedback would you like?)**:
- I would have preferred to go for a histogram of sizes as well as the delay between submission and processing. However, workarounds already exist, and it seems annoyingly nontrivial to implement this nicely (e.g. MetricsManager is in atlasdb-api, which depends on lock-api, which depends on atlasdb-autobatch... and moving MetricsManager to atlasdb-autobatch seems wrong)
- ~Should this be extended to the other autobatchers?~ Extended it to the other autobatchers.
- The batch size logging function is not thread safe. Am I correct in implementing it to not be thread safe?

**Where should we start reviewing?**: ProfilingAutobatchers

**Priority (whenever / two weeks / yesterday)**: early next week
