### PR TITLE
Close CassandraClients constructed via CassandraClientFactory::getClientInternal

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -461,9 +461,7 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
     private void sanityCheckRingConsistency() {
         Multimap<Set<TokenRange>, InetSocketAddress> tokenRangesToHost = HashMultimap.create();
         for (InetSocketAddress host : getCachedServers()) {
-            CassandraClient client = null;
-            try {
-                client = CassandraClientFactory.getClientInternal(host, config);
+            try (CassandraClient client = CassandraClientFactory.getClientInternal(host, config)) {
                 try {
                     client.describe_keyspace(config.getKeyspaceOrThrow());
                 } catch (NotFoundException e) {
@@ -474,10 +472,6 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
                 log.warn("Failed to get ring info from host: {}",
                         SafeArg.of("host", CassandraLogHelper.host(host)),
                         e);
-            } finally {
-                if (client != null) {
-                    client.getOutputProtocol().getTransport().close();
-                }
             }
         }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -205,8 +205,7 @@ public final class CassandraVerifier {
     // swallows the expected TException subtype NotFoundException, throws connection problem related ones
     private static boolean keyspaceAlreadyExists(InetSocketAddress host, CassandraKeyValueServiceConfig config)
             throws TException {
-        try {
-            CassandraClient client = CassandraClientFactory.getClientInternal(host, config);
+        try (CassandraClient client = CassandraClientFactory.getClientInternal(host, config)) {
             client.describe_keyspace(config.getKeyspaceOrThrow());
             CassandraKeyValueServices.waitForSchemaVersions(config, client,
                     "while checking if schemas diverged on startup");
@@ -218,8 +217,7 @@ public final class CassandraVerifier {
 
     private static boolean attemptToCreateKeyspaceOnHost(InetSocketAddress host, CassandraKeyValueServiceConfig config)
             throws TException {
-        try {
-            CassandraClient client = CassandraClientFactory.getClientInternal(host, config);
+        try (CassandraClient client = CassandraClientFactory.getClientInternal(host, config)) {
             KsDef ksDef = createKsDefForFresh(client, config);
             client.system_add_keyspace(ksDef);
             log.info("Created keyspace: {}", SafeArg.of("keyspace", config.getKeyspaceOrThrow()));

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,8 +50,9 @@ develop
     *    - Type
          - Change
 
-    *    -
-         -
+    *    - |fixed|
+         - We now close Cassandra clients properly when verifying that one's Cassandra configuration makes sense.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3944>`__)
 
 ========
 v0.133.0


### PR DESCRIPTION
**Goals (and why)**:
Close CassandraClients rather than relying on Java finalizers to close them.
CassandraClients that are not closed keep references to open connections/sockets that will only be cleaned up at Finalizer time, which delays garbage collection of large objects.
The Finalizer runs in a single thread with low priority. For some reason this problem is exarcebated in java 11.
