### PR TITLE
remove db username from hikari pool name

### DIFF
--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
@@ -114,10 +114,9 @@ public abstract class ConnectionConfig {
     @Value.Derived
     public String getConnectionPoolName() {
         return String.format(
-                "%s-%s-%s",
+                "%s-%s",
                 getConnectionPoolIdentifier(),
-                getConnId(),
-                getDbLogin());
+                getConnId());
     }
 
     /**

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -145,6 +145,10 @@ develop
          - ``AtlasDbHttpClients.createProxyWithFailover()`` now requires ``UserAgent`` parameter.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3996>`__)
 
+    *    - |fixed|
+         - Removed the DB username from the Hikari connection pool name.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3949>`__)
+
 ========
 v0.133.0
 ========


### PR DESCRIPTION
The Hikari connection pool name gets used as the name for metrics, so it
should not include the DB username credentials.

**Goals (and why)**: When trying to create default metrics dashboards for internal products, I noticed that all of the hikari pool metrics contain the DB username as part of the metric name. The DB username is something that is usually going to be customized on each install, so this would make it impossible to have a set of standard metrics dashboards for various internal products (each dashboard would need to be customized to query a different metric name depending on the configured DB username).

There is still plenty of room to control the name of metrics by setting the pool identifier and the connection id (which don't reveal any actual DB credentials). These config values are usually set by products (and not changed on individual installs).

**Implementation Description (bullets)**: Removed the username from the connection pool name

**Testing (What was existing testing like?  What have you done to improve it?)**: N/A

**Concerns (what feedback would you like?)**: N/A

**Where should we start reviewing?**: N/A

**Priority (whenever / two weeks / yesterday)**: normal
