### PR TITLE
[PDS-88514 / _transactions2 part 43] Smart Batching of Coordination Service Perpetuates

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/TransactionSchemaManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/TransactionSchemaManager.java
@@ -16,6 +16,7 @@
 
 package com.palantir.atlasdb.internalschema;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -37,11 +38,11 @@ public class TransactionSchemaManager {
     private static final Logger log = LoggerFactory.getLogger(TransactionSchemaManager.class);
 
     private final CoordinationService<InternalSchemaMetadata> coordinationService;
-    private final CoalescingSupplier<CheckAndSetResult<ValueAndBound<InternalSchemaMetadata>>> boundPerpetuator;
+    private final CoalescingSupplier<List<ValueAndBound<InternalSchemaMetadata>>> boundPerpetuator;
 
     public TransactionSchemaManager(CoordinationService<InternalSchemaMetadata> coordinationService) {
         this.coordinationService = coordinationService;
-        this.boundPerpetuator = new CoalescingSupplier<>(this::tryPerpetuateExistingState);
+        this.boundPerpetuator = new CoalescingSupplier<>(() -> tryPerpetuateExistingState().existingValues());
     }
 
     /**
@@ -63,8 +64,8 @@ public class TransactionSchemaManager {
         Optional<Integer> possibleVersion =
                 extractTimestampVersion(coordinationService.getValueForTimestamp(timestamp), timestamp);
         while (!possibleVersion.isPresent()) {
-            CheckAndSetResult<ValueAndBound<InternalSchemaMetadata>> casResult = boundPerpetuator.get();
-            possibleVersion = extractTimestampVersion(casResult.existingValues()
+            List<ValueAndBound<InternalSchemaMetadata>> existingValues = boundPerpetuator.get();
+            possibleVersion = extractTimestampVersion(existingValues
                             .stream()
                             .filter(valueAndBound -> valueAndBound.bound() >= timestamp)
                             .findAny(),

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,11 @@ develop
     *    - Type
          - Change
 
+    *    - |improved|
+         - Coordination service now only initiates one request to perpetuate the bound forward at a time.
+           This should avoid unnecessarily many CAS operations taking place when we need to do this.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3qqq>`__)
+
     *    - |fixed|
          - We now close Cassandra clients properly when verifying that one's Cassandra configuration makes sense.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3944>`__)


### PR DESCRIPTION
**Goals (and why)**:
- See PDS-88514
- Don't cause too much load when perpetuating the bound

**Implementation Description (bullets)**:
- Use a `CoalescingSupplier` to perpetuate the bound forwards, rather than have each thread that wants to push the bound forwards do it by itself.

**Testing (What was existing testing like?  What have you done to improve it?)**: none.

**Concerns (what feedback would you like?)**:
- Is this safe? I think so, as the effect is similar to your thread sleeping until the requests gets executed, and then all threads that are participating in a batch executing their reads before any of them tries an update, and then all the updates being applied at one shot.
- I had the CoalescingSupplier return the list of existing values rather than the CheckAndSetResult, in case someone thinks that looking at the `successful()` part of the result is a good idea. Does this make sense?

**Where should we start reviewing?**: TransactionSchemaManager.java

**Priority (whenever / two weeks / yesterday)**: While this should be yesterday, because the semantics are tricky it may need some careful thought. 🔥💧?