### PR TITLE
Use soft evict limits not evict limits with the pool

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -261,8 +261,10 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Cassand
         // this test is free/just checks a boolean and does not block; borrow is still fast
         poolConfig.setTestOnBorrow(true);
 
-        poolConfig.setMinEvictableIdleTimeMillis(
+        poolConfig.setSoftMinEvictableIdleTimeMillis(
                 TimeUnit.MILLISECONDS.convert(config.idleConnectionTimeoutSeconds(), TimeUnit.SECONDS));
+        poolConfig.setMinEvictableIdleTimeMillis(Long.MAX_VALUE);
+
         // the randomness here is to prevent all of the pools for all of the hosts
         // evicting all at at once, which isn't great for C*.
         int timeBetweenEvictionsSeconds = config.timeBetweenConnectionEvictionRunsSeconds();


### PR DESCRIPTION
At the moment, we evict every connection that has been idle for 10
minutes every 10 minutes. If there is a min pool size (our default is
30) this is then immediately replaced with another SSL connection;
essentially just churning every 10 minutes.

In practice, we've seen this cause issues internally around GC; SSL
connections filling up the old gen and then finalizer issues leading to
an ultimate GC overhead exceeded OOM.

I guess my concern would be that the Thrift connections actually break
after a certain period and so we are essentially evicting anyway (but
later, taking a performance hit); in this case we will see logging
occurring in such services indicating this.

@clockfort would love your feedback here as to whether we'd need to make other changes here (e.g. changing the healthcheck functionality?).