### PR TITLE
Resilient health check

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -51,6 +51,11 @@ develop
          - Change
 
     *    - |improved|
+         - The Timelock Availability Health check should not timeout if we can't reach other nodes. This should stop
+           the health check firing erroneously.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3988>`__)
+
+    *    - |improved|
          - Changed the default values in ``PaxosConfiguration``.
            ``leader-ping-response-wait-in-ms`` was reduced to 2000 ms from 5000 ms.
            ``maximum-wait-before-proposal-in-ms`` was reduced to 300 ms from 1000 ms.

--- a/timelock-agent/src/test/java/com/palantir/timelock/paxos/LeaderPingHealthCheckTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/paxos/LeaderPingHealthCheckTest.java
@@ -15,7 +15,7 @@
  */
 package com.palantir.timelock.paxos;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -31,25 +31,25 @@ public class LeaderPingHealthCheckTest {
     @Test
     public void shouldBeUnhealthyIfAllNodesPingedSuccessfully() {
         ImmutableSet<PingableLeader> leaders = getPingableLeaders(true, true, true);
-        assertEquals(TimeLockStatus.MULTIPLE_LEADERS, new LeaderPingHealthCheck(leaders).getStatus());
+        assertThat(new LeaderPingHealthCheck(leaders).getStatus()).isEqualTo(TimeLockStatus.MULTIPLE_LEADERS);
     }
 
     @Test
     public void shouldBeUnhealthyIfMultipleNodesPingedSuccessfully() {
         ImmutableSet<PingableLeader> leaders = getPingableLeaders(true, true, false);
-        assertEquals(TimeLockStatus.MULTIPLE_LEADERS, new LeaderPingHealthCheck(leaders).getStatus());
+        assertThat(new LeaderPingHealthCheck(leaders).getStatus()).isEqualTo(TimeLockStatus.MULTIPLE_LEADERS);
     }
 
     @Test
     public void shouldBeHealthyIfExactlyOneNodePingedSuccessfully() {
         ImmutableSet<PingableLeader> leaders = getPingableLeaders(true, false, false);
-        assertEquals(TimeLockStatus.ONE_LEADER, new LeaderPingHealthCheck(leaders).getStatus());
+        assertThat(new LeaderPingHealthCheck(leaders).getStatus()).isEqualTo(TimeLockStatus.ONE_LEADER);
     }
 
     @Test
     public void shouldBeUnhealthyIfNoNodesPingedSuccessfully() {
         ImmutableSet<PingableLeader> leaders = getPingableLeaders(false, false, false);
-        assertEquals(TimeLockStatus.NO_LEADER, new LeaderPingHealthCheck(leaders).getStatus());
+        assertThat(new LeaderPingHealthCheck(leaders).getStatus()).isEqualTo(TimeLockStatus.NO_LEADER);
     }
 
     @Test
@@ -58,7 +58,7 @@ public class LeaderPingHealthCheckTest {
         PingableLeader leader2 = getMockOfPingableLeaderWherePingReturns(false);
         PingableLeader leader3 = getMockOfPingableLeaderWherePingThrows();
         ImmutableSet<PingableLeader> leaders = ImmutableSet.of(leader1, leader2, leader3);
-        assertEquals(TimeLockStatus.ONE_LEADER, new LeaderPingHealthCheck(leaders).getStatus());
+        assertThat(new LeaderPingHealthCheck(leaders).getStatus()).isEqualTo(TimeLockStatus.ONE_LEADER);
     }
 
     @Test
@@ -67,7 +67,7 @@ public class LeaderPingHealthCheckTest {
         PingableLeader leader2 = getMockOfPingableLeaderWherePingReturns(false);
         PingableLeader leader3 = getMockOfPingableLeaderWherePingThrows();
         ImmutableSet<PingableLeader> leaders = ImmutableSet.of(leader1, leader2, leader3);
-        assertEquals(TimeLockStatus.NO_LEADER, new LeaderPingHealthCheck(leaders).getStatus());
+        assertThat(new LeaderPingHealthCheck(leaders).getStatus()).isEqualTo(TimeLockStatus.NO_LEADER);
     }
 
     @Test
@@ -76,7 +76,7 @@ public class LeaderPingHealthCheckTest {
         PingableLeader leader2 = getMockOfPingableLeaderWherePingThrows();
         PingableLeader leader3 = getMockOfPingableLeaderWherePingThrows();
         ImmutableSet<PingableLeader> leaders = ImmutableSet.of(leader1, leader2, leader3);
-        assertEquals(TimeLockStatus.NO_QUORUM, new LeaderPingHealthCheck(leaders).getStatus());
+        assertThat(new LeaderPingHealthCheck(leaders).getStatus()).isEqualTo(TimeLockStatus.NO_QUORUM);
     }
 
     @Test
@@ -85,7 +85,7 @@ public class LeaderPingHealthCheckTest {
         PingableLeader leader2 = getMockOfPingableLeaderWherePingThrows();
         PingableLeader leader3 = getMockOfPingableLeaderWherePingThrows();
         ImmutableSet<PingableLeader> leaders = ImmutableSet.of(leader1, leader2, leader3);
-        assertEquals(TimeLockStatus.NO_QUORUM, new LeaderPingHealthCheck(leaders).getStatus());
+        assertThat(new LeaderPingHealthCheck(leaders).getStatus()).isEqualTo(TimeLockStatus.NO_QUORUM);
     }
 
     private static ImmutableSet<PingableLeader> getPingableLeaders(

--- a/timelock-agent/src/test/java/com/palantir/timelock/paxos/LeaderPingHealthCheckTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/paxos/LeaderPingHealthCheckTest.java
@@ -29,31 +29,31 @@ import com.palantir.timelock.TimeLockStatus;
 public class LeaderPingHealthCheckTest {
 
     @Test
-    public void shouldBeUnhealthyIfAllNodesPingedSuccessfully() throws Exception {
+    public void shouldBeUnhealthyIfAllNodesPingedSuccessfully() {
         ImmutableSet<PingableLeader> leaders = getPingableLeaders(true, true, true);
         assertEquals(TimeLockStatus.MULTIPLE_LEADERS, new LeaderPingHealthCheck(leaders).getStatus());
     }
 
     @Test
-    public void shouldBeUnhealthyIfMultipleNodesPingedSuccessfully() throws Exception {
+    public void shouldBeUnhealthyIfMultipleNodesPingedSuccessfully() {
         ImmutableSet<PingableLeader> leaders = getPingableLeaders(true, true, false);
         assertEquals(TimeLockStatus.MULTIPLE_LEADERS, new LeaderPingHealthCheck(leaders).getStatus());
     }
 
     @Test
-    public void shouldBeHealthyIfExactlyOneNodePingedSuccessfully() throws Exception {
+    public void shouldBeHealthyIfExactlyOneNodePingedSuccessfully() {
         ImmutableSet<PingableLeader> leaders = getPingableLeaders(true, false, false);
         assertEquals(TimeLockStatus.ONE_LEADER, new LeaderPingHealthCheck(leaders).getStatus());
     }
 
     @Test
-    public void shouldBeUnhealthyIfNoNodesPingedSuccessfully() throws Exception {
+    public void shouldBeUnhealthyIfNoNodesPingedSuccessfully() {
         ImmutableSet<PingableLeader> leaders = getPingableLeaders(false, false, false);
         assertEquals(TimeLockStatus.NO_LEADER, new LeaderPingHealthCheck(leaders).getStatus());
     }
 
     @Test
-    public void shouldBeHealthyIfQuorumNodesUpAndOnePingedSuccessfully() throws Exception {
+    public void shouldBeHealthyIfQuorumNodesUpAndOnePingedSuccessfully() {
         PingableLeader leader1 = getMockOfPingableLeaderWherePingReturns(true);
         PingableLeader leader2 = getMockOfPingableLeaderWherePingReturns(false);
         PingableLeader leader3 = getMockOfPingableLeaderWherePingThrows();
@@ -62,7 +62,7 @@ public class LeaderPingHealthCheckTest {
     }
 
     @Test
-    public void shouldBeUnhealthyIfQuorumNodesAreUpAndNoNodePingedSuccessfully() throws Exception {
+    public void shouldBeUnhealthyIfQuorumNodesAreUpAndNoNodePingedSuccessfully() {
         PingableLeader leader1 = getMockOfPingableLeaderWherePingReturns(false);
         PingableLeader leader2 = getMockOfPingableLeaderWherePingReturns(false);
         PingableLeader leader3 = getMockOfPingableLeaderWherePingThrows();
@@ -71,7 +71,7 @@ public class LeaderPingHealthCheckTest {
     }
 
     @Test
-    public void shouldBeUnhealthyIfQuorumNodesAreNotUpAndOnePingedSuccessfully() throws Exception {
+    public void shouldBeUnhealthyIfQuorumNodesAreNotUpAndOnePingedSuccessfully() {
         PingableLeader leader1 = getMockOfPingableLeaderWherePingReturns(true);
         PingableLeader leader2 = getMockOfPingableLeaderWherePingThrows();
         PingableLeader leader3 = getMockOfPingableLeaderWherePingThrows();
@@ -80,7 +80,7 @@ public class LeaderPingHealthCheckTest {
     }
 
     @Test
-    public void shouldBeUnhealthyIfQuorumNodesAreNotUpAndNoNodePingedSuccessfully() throws Exception {
+    public void shouldBeUnhealthyIfQuorumNodesAreNotUpAndNoNodePingedSuccessfully() {
         PingableLeader leader1 = getMockOfPingableLeaderWherePingReturns(false);
         PingableLeader leader2 = getMockOfPingableLeaderWherePingThrows();
         PingableLeader leader3 = getMockOfPingableLeaderWherePingThrows();
@@ -88,7 +88,7 @@ public class LeaderPingHealthCheckTest {
         assertEquals(TimeLockStatus.NO_QUORUM, new LeaderPingHealthCheck(leaders).getStatus());
     }
 
-    private ImmutableSet<PingableLeader> getPingableLeaders(
+    private static ImmutableSet<PingableLeader> getPingableLeaders(
             boolean pingResultForLeader1,
             boolean pingResultForLeader2,
             boolean pingResultForLeader3) {
@@ -98,13 +98,13 @@ public class LeaderPingHealthCheckTest {
         return ImmutableSet.of(leader1, leader2, leader3);
     }
 
-    private PingableLeader getMockOfPingableLeaderWherePingReturns(boolean pingResult) {
+    private static PingableLeader getMockOfPingableLeaderWherePingReturns(boolean pingResult) {
         PingableLeader mockLeader = mock(PingableLeader.class);
         when(mockLeader.ping()).thenReturn(pingResult);
         return mockLeader;
     }
 
-    private PingableLeader getMockOfPingableLeaderWherePingThrows() {
+    private static PingableLeader getMockOfPingableLeaderWherePingThrows() {
         PingableLeader mockLeader = mock(PingableLeader.class);
         when(mockLeader.ping()).thenThrow(mock(AtlasDbRemoteException.class));
         return mockLeader;


### PR DESCRIPTION
**Goals (and why)**:
If for some reason a timelock node is unresponsive for longer than 20s (which is the deployment infrastructures timeout for health checks. We would fail the health check despite being able to find a leader.

**Implementation Description (bullets)**:
We fire off the requests in parallel, and have a strict (and arbitrary) deadline of 7 seconds.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Relied on previous tests. If we really wanted to be fancy, we could do some stuff with deterministic scheduler, but unclear whether it's worth it/feels like we're just testing whether `PaxosQuorumChecker` works or not.

**Concerns (what feedback would you like?)**:
Have I bastardised `PaxosQuorumChecker` lol, how do we feel about the fixed thread pool for the health check?

**Where should we start reviewing?**:
Everywhere

**Priority (whenever / two weeks / yesterday)**:
ASAP

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
