### PR TITLE
[_transactions2] Part 47: Clean the Coordination Store, Part 1 - Retry Hanging Reads

### DIFF
--- a/atlasdb-coordination-impl/src/test/java/com/palantir/atlasdb/coordination/keyvalue/KeyValueServiceCoordinationStoreTest.java
+++ b/atlasdb-coordination-impl/src/test/java/com/palantir/atlasdb/coordination/keyvalue/KeyValueServiceCoordinationStoreTest.java
@@ -23,6 +23,8 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
@@ -31,6 +33,8 @@ import java.util.function.Function;
 
 import org.junit.Test;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
@@ -60,6 +64,7 @@ public class KeyValueServiceCoordinationStoreTest {
     private static final Function<ValueAndBound<String>, String> VALUE_PRESERVING_FUNCTION
             = valueAndBound -> valueAndBound.value()
             .orElseThrow(() -> new IllegalStateException("Can only preserve a present value"));
+    private static final ObjectMapper OBJECT_MAPPER = ObjectMappers.newServerObjectMapper();
 
     private final KeyValueService keyValueService = new InMemoryKeyValueService(true);
     private final AtomicLong timestampSequence = new AtomicLong();
@@ -222,6 +227,66 @@ public class KeyValueServiceCoordinationStoreTest {
                 .as("Failed but no value in KVS")
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Failed to check and set coordination value");
+    }
+
+    @Test
+    public void retriesOnKeyValueServiceWhenValuesDeletedInGets() throws JsonProcessingException {
+        KeyValueService mockKvs = mock(KeyValueService.class);
+        KeyValueServiceCoordinationStore<String> store = coordinationStoreForKvs(mockKvs);
+        setupOnceFailingMockKvs(mockKvs, store);
+
+        assertThat(store.getAgreedValue()).isPresent()
+                .contains(ValueAndBound.of(VALUE_2, SEQUENCE_AND_BOUND_2.bound()));
+
+        verifyReadsOnOnceFailingMockKvs(mockKvs, store);
+    }
+
+    @Test
+    public void retriesOnKeyValueServiceWhenValuesDeletedInTransforms() throws JsonProcessingException {
+        KeyValueService mockKvs = mock(KeyValueService.class);
+        KeyValueServiceCoordinationStore<String> store = coordinationStoreForKvs(mockKvs);
+        setupOnceFailingMockKvs(mockKvs, store);
+
+        CheckAndSetResult<ValueAndBound<String>> casResult = store.transformAgreedValue(value ->
+                value.value().orElseThrow(() -> new RuntimeException("unexpected absent value")) + ".");
+        assertThat(casResult.successful()).isTrue();
+        assertThat(Iterables.getOnlyElement(casResult.existingValues()).value()).contains(VALUE_2 + ".");
+
+        verifyReadsOnOnceFailingMockKvs(mockKvs, store);
+    }
+
+    private void setupOnceFailingMockKvs(KeyValueService mockKvs, KeyValueServiceCoordinationStore<String> store)
+            throws JsonProcessingException {
+        when(mockKvs.get(
+                eq(AtlasDbConstants.COORDINATION_TABLE),
+                eq(ImmutableMap.of(store.getCoordinationValueCell(), Long.MAX_VALUE))))
+                .thenReturn(ImmutableMap.of(
+                        store.getCoordinationValueCell(),
+                        Value.create(store.serializeSequenceAndBound(SEQUENCE_AND_BOUND_1), 0L)))
+                .thenReturn(ImmutableMap.of(
+                        store.getCoordinationValueCell(),
+                        Value.create(store.serializeSequenceAndBound(SEQUENCE_AND_BOUND_2), 0L)));
+        when(mockKvs.get(eq(AtlasDbConstants.COORDINATION_TABLE), eq(ImmutableMap.of(
+                store.getCellForSequence(SEQUENCE_AND_BOUND_1.sequence()), Long.MAX_VALUE))))
+                .thenReturn(ImmutableMap.of());
+        when(mockKvs.get(eq(AtlasDbConstants.COORDINATION_TABLE), eq(ImmutableMap.of(
+                store.getCellForSequence(SEQUENCE_AND_BOUND_2.sequence()), Long.MAX_VALUE))))
+                .thenReturn(ImmutableMap.of(
+                        store.getCellForSequence(SEQUENCE_AND_BOUND_2.sequence()),
+                        Value.create(OBJECT_MAPPER.writeValueAsBytes(VALUE_2), 0L)));
+    }
+
+    private void verifyReadsOnOnceFailingMockKvs(KeyValueService mockKvs,
+            KeyValueServiceCoordinationStore<String> store) {
+        verify(mockKvs, times(2)).get(
+                eq(AtlasDbConstants.COORDINATION_TABLE),
+                eq(ImmutableMap.of(store.getCoordinationValueCell(), Long.MAX_VALUE)));
+        verify(mockKvs).get(
+                eq(AtlasDbConstants.COORDINATION_TABLE),
+                eq(ImmutableMap.of(store.getCellForSequence(SEQUENCE_AND_BOUND_1.sequence()), Long.MAX_VALUE)));
+        verify(mockKvs).get(
+                eq(AtlasDbConstants.COORDINATION_TABLE),
+                eq(ImmutableMap.of(store.getCellForSequence(SEQUENCE_AND_BOUND_2.sequence()), Long.MAX_VALUE)));
     }
 
     private KeyValueServiceCoordinationStore<String> coordinationStoreForKvs(KeyValueService kvs) {

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -55,6 +55,12 @@ develop
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3978>`__)
 
     *    - |improved|
+         - The coordination store now retries when reading a value at a given sequence number that no longer exists (as opposed to throwing).
+           This is necessary for supporting cleanup of the coordination store.
+           Note that if one is performing rolling upgrades to a version that sweeps the coordination store, one MUST upgrade from at least this version.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3990>`__)
+
+    *    - |improved|
          - Changed the default values in ``PaxosConfiguration``.
            ``leader-ping-response-wait-in-ms`` was reduced to 2000 ms from 5000 ms.
            ``maximum-wait-before-proposal-in-ms`` was reduced to 300 ms from 1000 ms.


### PR DESCRIPTION
**Goals (and why)**:
- Eventually support deleting of old entries from the coordination store, which may be relevant if we expect to agree things that may frequently change (e.g. transaction schema version in blue green deployment!)
- The semantics used to be that if we read a value at a given sequence number that doesn't exist, we assume that the world hasn't been initialized yet. If we do sweeps, then that is not a valid assumption.

**Implementation Description (bullets)**:
- Retry reads of values that were deleted (including re-reading the coordination cell).
- Refactor some of the shared paths between get and transform to a `CoordinationStateStore`

**Testing (What was existing testing like?  What have you done to improve it?)**: 
- Added new tests for the retrying paths. Other than that, for refactors I'm banking on the existing tests

**Concerns (what feedback would you like?)**:
- Is there a much simpler solution than having a schema version gateway?

**Where should we start reviewing?**: Tests are probably a good place to start

**Priority (whenever / two weeks / yesterday)**: this week