### PR TITLE
disable background sweep if lock immutable ts is set to true

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -439,7 +439,7 @@ public abstract class TransactionManagers {
                         follower,
                         instrumentedTransactionManager,
                         persistentLockManager,
-                        runBackgroundSweep()),
+                        runBackgroundSweepProcess()),
                 closeables);
         initializeCloseable(
                 initializeCompactBackgroundProcess(
@@ -453,7 +453,14 @@ public abstract class TransactionManagers {
         return instrumentedTransactionManager;
     }
 
-    private boolean runBackgroundSweep() {
+    /**
+     * If we decide to move a service to use thorough sweep; we need to make sure that background sweep won't cause any
+     * trouble by deleting large number of empty values at once - causing Cassandra OOMs.
+     *
+     * lockImmutableTsOnReadOnlyTransaction flag is used to decide on disabling background sweep, as this flag is used
+     * as an intermediate step for migrating to thorough sweep.
+     */
+    private boolean runBackgroundSweepProcess() {
         return !lockImmutableTsOnReadOnlyTransactions();
     }
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -116,6 +116,10 @@ develop
            enabling migrating to thorough sweep without downtime. Please contact to Atlas team before using this feature. 
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3987>`__)
 
+    *    - |new|
+         - Setting ``lockImmutableTsOnReadOnlyTransactions()`` to ``true`` disables background sweep. This aims to prevent Cassandra load caused by Conservative to Thorough sweep migration.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3992>`__)
+
 ========
 v0.133.0
 ========


### PR DESCRIPTION
**Goals (and why)**:
If we decide to move a service to use thorough sweep; we need to make sure that background sweep won't cause any trouble by deleting large number of empty values at once - causing Cassandra OOMs.

**Implementation Description (bullets)**:
Don't run background sweep process if `lockImmutableTsOnReadOnTransactions` is set to true. Sweep endpoint will still be functional.

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
