### PR TITLE
[PDS-87779] Throw early on finding a backwards column range

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/ColumnRangeSelection.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/ColumnRangeSelection.java
@@ -90,7 +90,8 @@ public class ColumnRangeSelection implements Serializable {
         return Joiner.on(',').join(ImmutableList.of(start, end));
     }
 
-    private static boolean isValidRange(byte[] startCol, byte[] endCol) {
-        return RangeRequests.isValidRange(false, startCol, endCol);
+    public static boolean isValidRange(byte[] startCol, byte[] endCol) {
+        return RangeRequests.isContiguousRange(false, startCol, endCol) &&
+                !RangeRequests.isExactlyEmptyRange(startCol, endCol);
     }
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/ColumnRangeSelection.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/ColumnRangeSelection.java
@@ -90,7 +90,7 @@ public class ColumnRangeSelection implements Serializable {
         return Joiner.on(',').join(ImmutableList.of(start, end));
     }
 
-    private boolean isValidRange(byte[] startCol, byte[] endCol) {
+    private static boolean isValidRange(byte[] startCol, byte[] endCol) {
         return RangeRequests.isValidRange(false, startCol, endCol);
     }
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/ColumnRangeSelection.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/ColumnRangeSelection.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.encoding.PtBytes;
 
@@ -38,6 +39,10 @@ public class ColumnRangeSelection implements Serializable {
     @JsonCreator
     public ColumnRangeSelection(@JsonProperty("startCol") byte[] startCol,
                                 @JsonProperty("endCol") byte[] endCol) {
+        Preconditions.checkArgument(isValidRange(startCol, endCol),
+                "Start and end columns (%s, %s respectively) do not form a valid range.",
+                startCol,
+                endCol);
         this.startCol = MoreObjects.firstNonNull(startCol, PtBytes.EMPTY_BYTE_ARRAY);
         this.endCol = MoreObjects.firstNonNull(endCol, PtBytes.EMPTY_BYTE_ARRAY);
     }
@@ -83,5 +88,9 @@ public class ColumnRangeSelection implements Serializable {
         String start = PtBytes.encodeBase64String(startCol);
         String end = PtBytes.encodeBase64String(endCol);
         return Joiner.on(',').join(ImmutableList.of(start, end));
+    }
+
+    private boolean isValidRange(byte[] startCol, byte[] endCol) {
+        return RangeRequests.isRangeNonemptyAndContiguous(false, startCol, endCol);
     }
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/ColumnRangeSelection.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/ColumnRangeSelection.java
@@ -39,12 +39,12 @@ public class ColumnRangeSelection implements Serializable {
     @JsonCreator
     public ColumnRangeSelection(@JsonProperty("startCol") byte[] startCol,
                                 @JsonProperty("endCol") byte[] endCol) {
-        Preconditions.checkArgument(isValidRange(startCol, endCol),
+        this.startCol = MoreObjects.firstNonNull(startCol, PtBytes.EMPTY_BYTE_ARRAY);
+        this.endCol = MoreObjects.firstNonNull(endCol, PtBytes.EMPTY_BYTE_ARRAY);
+        Preconditions.checkArgument(isValidRange(this.startCol, this.endCol),
                 "Start and end columns (%s, %s respectively) do not form a valid range.",
                 startCol,
                 endCol);
-        this.startCol = MoreObjects.firstNonNull(startCol, PtBytes.EMPTY_BYTE_ARRAY);
-        this.endCol = MoreObjects.firstNonNull(endCol, PtBytes.EMPTY_BYTE_ARRAY);
     }
 
     public byte[] getStartCol() {

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/ColumnRangeSelection.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/ColumnRangeSelection.java
@@ -91,6 +91,6 @@ public class ColumnRangeSelection implements Serializable {
     }
 
     private boolean isValidRange(byte[] startCol, byte[] endCol) {
-        return RangeRequests.isRangeNonemptyAndContiguous(false, startCol, endCol);
+        return RangeRequests.isValidRange(false, startCol, endCol);
     }
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/ColumnRangeSelection.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/ColumnRangeSelection.java
@@ -91,7 +91,7 @@ public class ColumnRangeSelection implements Serializable {
     }
 
     public static boolean isValidRange(byte[] startCol, byte[] endCol) {
-        return RangeRequests.isContiguousRange(false, startCol, endCol) &&
-                !RangeRequests.isExactlyEmptyRange(startCol, endCol);
+        return RangeRequests.isContiguousRange(false, startCol, endCol)
+                && !RangeRequests.isExactlyEmptyRange(startCol, endCol);
     }
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/RangeRequest.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/RangeRequest.java
@@ -358,14 +358,7 @@ public final class RangeRequest implements Serializable {
         }
 
         public boolean isInvalidRange() {
-            if (startInclusive.length == 0 || endExclusive.length == 0) {
-                return false;
-            }
-            if (reverse) {
-                return UnsignedBytes.lexicographicalComparator().compare(startInclusive, endExclusive) < 0;
-            } else {
-                return UnsignedBytes.lexicographicalComparator().compare(startInclusive, endExclusive) > 0;
-            }
+            return RangeRequests.isRangeNonemptyAndContiguous(false, startInclusive, endExclusive);
         }
 
         public RangeRequest build() {

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/RangeRequest.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/RangeRequest.java
@@ -358,7 +358,7 @@ public final class RangeRequest implements Serializable {
         }
 
         public boolean isInvalidRange() {
-            return !RangeRequests.isValidRange(false, startInclusive, endExclusive);
+            return !RangeRequests.isValidRange(reverse, startInclusive, endExclusive);
         }
 
         public RangeRequest build() {

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/RangeRequest.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/RangeRequest.java
@@ -358,7 +358,7 @@ public final class RangeRequest implements Serializable {
         }
 
         public boolean isInvalidRange() {
-            return RangeRequests.isRangeNonemptyAndContiguous(false, startInclusive, endExclusive);
+            return !RangeRequests.isValidRange(false, startInclusive, endExclusive);
         }
 
         public RangeRequest build() {

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/RangeRequest.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/RangeRequest.java
@@ -358,7 +358,7 @@ public final class RangeRequest implements Serializable {
         }
 
         public boolean isInvalidRange() {
-            return !RangeRequests.isValidRange(reverse, startInclusive, endExclusive);
+            return !RangeRequests.isContiguousRange(reverse, startInclusive, endExclusive);
         }
 
         public RangeRequest build() {

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/RangeRequests.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/RangeRequests.java
@@ -19,6 +19,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import com.google.common.base.Preconditions;
+import com.google.common.primitives.UnsignedBytes;
 import com.palantir.atlasdb.encoding.PtBytes;
 
 public final class RangeRequests {
@@ -199,5 +200,15 @@ public final class RangeRequests {
         } else {
             return nextLexicographicNameInternal(rowName);
         }
+    }
+
+    static boolean isRangeNonemptyAndContiguous(boolean reverse, byte[] startInclusive, byte[] endExclusive) {
+        if (startInclusive.length == 0 || endExclusive.length == 0) {
+            return false;
+        }
+        if (reverse) {
+            return UnsignedBytes.lexicographicalComparator().compare(startInclusive, endExclusive) < 0;
+        }
+        return UnsignedBytes.lexicographicalComparator().compare(startInclusive, endExclusive) > 0;
     }
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/RangeRequests.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/RangeRequests.java
@@ -202,7 +202,7 @@ public final class RangeRequests {
         }
     }
 
-    public static boolean isValidRange(boolean reverse, byte[] startInclusive, byte[] endExclusive) {
+    public static boolean isContiguousRange(boolean reverse, byte[] startInclusive, byte[] endExclusive) {
         if (startInclusive.length == 0 || endExclusive.length == 0) {
             return true;
         }
@@ -210,5 +210,12 @@ public final class RangeRequests {
             return UnsignedBytes.lexicographicalComparator().compare(startInclusive, endExclusive) >= 0;
         }
         return UnsignedBytes.lexicographicalComparator().compare(startInclusive, endExclusive) <= 0;
+    }
+
+    public static boolean isExactlyEmptyRange(byte[] startInclusive, byte[] endExclusive) {
+        if (startInclusive.length == 0 || endExclusive.length == 0) {
+            return false;
+        }
+        return UnsignedBytes.lexicographicalComparator().compare(startInclusive, endExclusive) == 0;
     }
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/RangeRequests.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/RangeRequests.java
@@ -202,13 +202,13 @@ public final class RangeRequests {
         }
     }
 
-    static boolean isRangeNonemptyAndContiguous(boolean reverse, byte[] startInclusive, byte[] endExclusive) {
+    public static boolean isValidRange(boolean reverse, byte[] startInclusive, byte[] endExclusive) {
         if (startInclusive.length == 0 || endExclusive.length == 0) {
-            return false;
+            return true;
         }
         if (reverse) {
-            return UnsignedBytes.lexicographicalComparator().compare(startInclusive, endExclusive) < 0;
+            return UnsignedBytes.lexicographicalComparator().compare(startInclusive, endExclusive) >= 0;
         }
-        return UnsignedBytes.lexicographicalComparator().compare(startInclusive, endExclusive) > 0;
+        return UnsignedBytes.lexicographicalComparator().compare(startInclusive, endExclusive) <= 0;
     }
 }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueServiceTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueServiceTest.java
@@ -45,6 +45,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
+import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.CheckAndSetRequest;
@@ -311,7 +312,7 @@ public class TracingKeyValueServiceTest {
         RowColumnRangeIterator rowColumnIterator = mock(RowColumnRangeIterator.class);
         List<byte[]> rows = ImmutableList.of(ROW_NAME);
         Map<byte[], RowColumnRangeIterator> expectedResult = ImmutableMap.of(ROW_NAME, rowColumnIterator);
-        BatchColumnRangeSelection range = BatchColumnRangeSelection.create(COL_NAME, COL_NAME, 2);
+        BatchColumnRangeSelection range = BatchColumnRangeSelection.create(COL_NAME, PtBytes.EMPTY_BYTE_ARRAY, 2);
         when(delegate.getRowsColumnRange(TABLE_REF, rows, range, TIMESTAMP)).thenReturn(expectedResult);
 
         Map<byte[], RowColumnRangeIterator> result = kvs.getRowsColumnRange(TABLE_REF, rows, range, TIMESTAMP);

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/logging/LoggingArgsTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/logging/LoggingArgsTest.java
@@ -71,7 +71,7 @@ public class LoggingArgsTest {
     private static final ColumnRangeSelection UNSAFE_COLUMN_RANGE = new ColumnRangeSelection(
             UNSAFE_COLUMN_NAME_BYTES, UNSAFE_COLUMN_NAME_BYTES);
     private static final ColumnRangeSelection MIXED_COLUMN_RANGE = new ColumnRangeSelection(
-            SAFE_COLUMN_NAME_BYTES, UNSAFE_COLUMN_NAME_BYTES);
+            SAFE_COLUMN_NAME_BYTES, PtBytes.toBytes("zzzzzzz")); // This is unsafe, and later than "saferow"
     private static final BatchColumnRangeSelection SAFE_BATCH_COLUMN_RANGE = BatchColumnRangeSelection.create(
             SAFE_COLUMN_RANGE, 1);
     private static final BatchColumnRangeSelection UNSAFE_BATCH_COLUMN_RANGE = BatchColumnRangeSelection.create(

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/logging/LoggingArgsTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/logging/LoggingArgsTest.java
@@ -52,12 +52,16 @@ public class LoggingArgsTest {
     private static final String SAFE_ROW_NAME = "saferow";
     private static final String UNSAFE_ROW_NAME = "row";
     private static final String SAFE_COLUMN_NAME = "safecolumn";
+    private static final String SAFE_COLUMN_NAME_2 = "safecolumn2";
     private static final String UNSAFE_COLUMN_NAME = "column";
+    private static final String UNSAFE_COLUMN_NAME_2 = "column2";
 
     private static final byte[] SAFE_ROW_NAME_BYTES = PtBytes.toBytes(SAFE_ROW_NAME);
     private static final byte[] UNSAFE_ROW_NAME_BYTES = PtBytes.toBytes(UNSAFE_ROW_NAME);
     private static final byte[] SAFE_COLUMN_NAME_BYTES = PtBytes.toBytes(SAFE_COLUMN_NAME);
     private static final byte[] UNSAFE_COLUMN_NAME_BYTES = PtBytes.toBytes(UNSAFE_COLUMN_NAME);
+    private static final byte[] SAFE_COLUMN_NAME_BYTES_2 = PtBytes.toBytes(SAFE_COLUMN_NAME_2);
+    private static final byte[] UNSAFE_COLUMN_NAME_BYTES_2 = PtBytes.toBytes(UNSAFE_COLUMN_NAME_2);
 
     private static final RangeRequest SAFE_RANGE_REQUEST = RangeRequest.builder()
             .retainColumns(ImmutableList.of(SAFE_ROW_NAME_BYTES)).build();
@@ -67,9 +71,9 @@ public class LoggingArgsTest {
             .retainColumns(ImmutableList.of(SAFE_ROW_NAME_BYTES, UNSAFE_ROW_NAME_BYTES)).build();
 
     private static final ColumnRangeSelection SAFE_COLUMN_RANGE = new ColumnRangeSelection(
-            SAFE_COLUMN_NAME_BYTES, SAFE_COLUMN_NAME_BYTES);
+            SAFE_COLUMN_NAME_BYTES, SAFE_COLUMN_NAME_BYTES_2);
     private static final ColumnRangeSelection UNSAFE_COLUMN_RANGE = new ColumnRangeSelection(
-            UNSAFE_COLUMN_NAME_BYTES, UNSAFE_COLUMN_NAME_BYTES);
+            UNSAFE_COLUMN_NAME_BYTES, UNSAFE_COLUMN_NAME_BYTES_2);
     private static final ColumnRangeSelection MIXED_COLUMN_RANGE = new ColumnRangeSelection(
             SAFE_COLUMN_NAME_BYTES, PtBytes.toBytes("zzzzzzz")); // This is unsafe, and later than "saferow"
     private static final BatchColumnRangeSelection SAFE_BATCH_COLUMN_RANGE = BatchColumnRangeSelection.create(

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/ColumnRangeSelectionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/ColumnRangeSelectionTest.java
@@ -1,0 +1,60 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.impl;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
+
+public class ColumnRangeSelectionTest {
+    private static final byte[] BYTES_1 = PtBytes.toBytes("aaaaaaa");
+    private static final byte[] BYTES_2 = PtBytes.toBytes("bbbbbbb");
+
+    @Test
+    public void canCreateUnboundedColumnRangeSelection() {
+        assertThatCode(() -> new ColumnRangeSelection(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> new ColumnRangeSelection(null, null)).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void canCreateWithStartBeforeEnd() {
+        assertThatCode(() -> new ColumnRangeSelection(BYTES_1, BYTES_2)).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void cannotCreateWithEndBeforeStart() {
+        assertThatThrownBy(() -> new ColumnRangeSelection(BYTES_2, BYTES_1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("do not form a valid range");
+    }
+
+    @Test
+    public void canCreateUnboundedOneEnd() {
+        assertThatCode(() -> new ColumnRangeSelection(BYTES_1, PtBytes.EMPTY_BYTE_ARRAY)).doesNotThrowAnyException();
+        assertThatCode(() -> new ColumnRangeSelection(PtBytes.EMPTY_BYTE_ARRAY, BYTES_2)).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void canCreateEmptyRange() {
+        assertThatCode(() -> new ColumnRangeSelection(BYTES_1, BYTES_1)).doesNotThrowAnyException();
+    }
+}

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/ColumnRangeSelectionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/ColumnRangeSelectionTest.java
@@ -55,6 +55,8 @@ public class ColumnRangeSelectionTest {
 
     @Test
     public void canCreateEmptyRange() {
-        assertThatCode(() -> new ColumnRangeSelection(BYTES_1, BYTES_1)).doesNotThrowAnyException();
+        assertThatThrownBy(() -> new ColumnRangeSelection(BYTES_1, BYTES_1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("do not form a valid range");
     }
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/RangeRequestsTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/RangeRequestsTest.java
@@ -44,37 +44,60 @@ public class RangeRequestsTest {
     }
 
     @Test
-    public void unboundedRangeBothEndsIsValid() {
-        assertThat(RangeRequests.isValidRange(
+    public void unboundedRangeBothEndsIsContiguous() {
+        assertThat(RangeRequests.isContiguousRange(
                 true, PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY)).isTrue();
-        assertThat(RangeRequests.isValidRange(
+        assertThat(RangeRequests.isContiguousRange(
                 false, PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY)).isTrue();
     }
 
     @Test
-    public void forwardRangeShouldStartBeforeEnd() {
-        assertThat(RangeRequests.isValidRange(false, BYTES_1, BYTES_2)).isTrue();
-        assertThat(RangeRequests.isValidRange(false, BYTES_2, BYTES_1)).isFalse();
+    public void forwardContiguousRangeShouldStartBeforeEnd() {
+        assertThat(RangeRequests.isContiguousRange(false, BYTES_1, BYTES_2)).isTrue();
+        assertThat(RangeRequests.isContiguousRange(false, BYTES_2, BYTES_1)).isFalse();
     }
 
     @Test
-    public void reverseRangeShouldEndBeforeStart() {
-        assertThat(RangeRequests.isValidRange(true, BYTES_1, BYTES_2)).isFalse();
-        assertThat(RangeRequests.isValidRange(true, BYTES_2, BYTES_1)).isTrue();
+    public void reverseContiguousRangeShouldEndBeforeStart() {
+        assertThat(RangeRequests.isContiguousRange(true, BYTES_1, BYTES_2)).isFalse();
+        assertThat(RangeRequests.isContiguousRange(true, BYTES_2, BYTES_1)).isTrue();
     }
 
     @Test
-    public void emptyRangesAreValid() {
-        assertThat(RangeRequests.isValidRange(false, BYTES_1, BYTES_1)).isTrue();
-        assertThat(RangeRequests.isValidRange(true, BYTES_1, BYTES_1)).isTrue();
+    public void emptyRangesAreContiguous() {
+        assertThat(RangeRequests.isContiguousRange(false, BYTES_1, BYTES_1)).isTrue();
+        assertThat(RangeRequests.isContiguousRange(true, BYTES_1, BYTES_1)).isTrue();
     }
 
     @Test
-    public void rangesUnboundedOnOneEndAreValid() {
-        assertThat(RangeRequests.isValidRange(false, BYTES_1, PtBytes.EMPTY_BYTE_ARRAY)).isTrue();
-        assertThat(RangeRequests.isValidRange(true, BYTES_1, PtBytes.EMPTY_BYTE_ARRAY)).isTrue();
-        assertThat(RangeRequests.isValidRange(false, PtBytes.EMPTY_BYTE_ARRAY, BYTES_1)).isTrue();
-        assertThat(RangeRequests.isValidRange(true, PtBytes.EMPTY_BYTE_ARRAY, BYTES_1)).isTrue();
+    public void rangesUnboundedOnOneEndAreContiguous() {
+        assertThat(RangeRequests.isContiguousRange(false, BYTES_1, PtBytes.EMPTY_BYTE_ARRAY)).isTrue();
+        assertThat(RangeRequests.isContiguousRange(true, BYTES_1, PtBytes.EMPTY_BYTE_ARRAY)).isTrue();
+        assertThat(RangeRequests.isContiguousRange(false, PtBytes.EMPTY_BYTE_ARRAY, BYTES_1)).isTrue();
+        assertThat(RangeRequests.isContiguousRange(true, PtBytes.EMPTY_BYTE_ARRAY, BYTES_1)).isTrue();
+    }
+
+    @Test
+    public void unboundedRangeBothEndsIsNotEmpty() {
+        assertThat(RangeRequests.isExactlyEmptyRange(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY)).isFalse();
+    }
+
+    @Test
+    public void unboundedRangeOneEndIsNotEmpty() {
+        assertThat(RangeRequests.isExactlyEmptyRange(PtBytes.EMPTY_BYTE_ARRAY, BYTES_1)).isFalse();
+        assertThat(RangeRequests.isExactlyEmptyRange(BYTES_2, PtBytes.EMPTY_BYTE_ARRAY)).isFalse();
+    }
+
+    @Test
+    public void rangeWithDifferentBoundsNotEmpty() {
+        assertThat(RangeRequests.isExactlyEmptyRange(BYTES_1, BYTES_2)).isFalse();
+        assertThat(RangeRequests.isExactlyEmptyRange(BYTES_2, BYTES_1)).isFalse();
+    }
+
+    @Test
+    public void rangeWithSameBoundIsEmpty() {
+        assertThat(RangeRequests.isExactlyEmptyRange(BYTES_1, BYTES_1)).isTrue();
+        assertThat(RangeRequests.isExactlyEmptyRange(BYTES_2, BYTES_2)).isTrue();
     }
 
     private byte[] generateRandomWithFreqLogLen() {

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/RangeRequestsTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/RangeRequestsTest.java
@@ -15,15 +15,21 @@
  */
 package com.palantir.atlasdb.keyvalue.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Arrays;
 import java.util.Random;
 
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.RangeRequests;
 
 public class RangeRequestsTest {
+
+    private static final byte[] BYTES_1 = PtBytes.toBytes("apple");
+    private static final byte[] BYTES_2 = PtBytes.toBytes("banana");
 
     private Random random = new Random();
 
@@ -37,9 +43,43 @@ public class RangeRequestsTest {
         }
     }
 
+    @Test
+    public void unboundedRangeBothEndsIsValid() {
+        assertThat(RangeRequests.isValidRange(
+                true, PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY)).isTrue();
+        assertThat(RangeRequests.isValidRange(
+                false, PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY)).isTrue();
+    }
+
+    @Test
+    public void forwardRangeShouldStartBeforeEnd() {
+        assertThat(RangeRequests.isValidRange(false, BYTES_1, BYTES_2)).isTrue();
+        assertThat(RangeRequests.isValidRange(false, BYTES_2, BYTES_1)).isFalse();
+    }
+
+    @Test
+    public void reverseRangeShouldEndBeforeStart() {
+        assertThat(RangeRequests.isValidRange(true, BYTES_1, BYTES_2)).isFalse();
+        assertThat(RangeRequests.isValidRange(true, BYTES_2, BYTES_1)).isTrue();
+    }
+
+    @Test
+    public void emptyRangesAreValid() {
+        assertThat(RangeRequests.isValidRange(false, BYTES_1, BYTES_1)).isTrue();
+        assertThat(RangeRequests.isValidRange(true, BYTES_1, BYTES_1)).isTrue();
+    }
+
+    @Test
+    public void rangesUnboundedOnOneEndAreValid() {
+        assertThat(RangeRequests.isValidRange(false, BYTES_1, PtBytes.EMPTY_BYTE_ARRAY)).isTrue();
+        assertThat(RangeRequests.isValidRange(true, BYTES_1, PtBytes.EMPTY_BYTE_ARRAY)).isTrue();
+        assertThat(RangeRequests.isValidRange(false, PtBytes.EMPTY_BYTE_ARRAY, BYTES_1)).isTrue();
+        assertThat(RangeRequests.isValidRange(true, PtBytes.EMPTY_BYTE_ARRAY, BYTES_1)).isTrue();
+    }
+
     private byte[] generateRandomWithFreqLogLen() {
         long randomLong = random.nextLong();
-        // lg(n) distrobution of len
+        // lg(n) distribution of len
         int len = Long.numberOfTrailingZeros(randomLong) + 1;
         byte[] ret = new byte[len];
         random.nextBytes(ret);

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -60,12 +60,6 @@ develop
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3992>`__)
 
     *    - |improved|
-         - The coordination store now retries when reading a value at a given sequence number that no longer exists (as opposed to throwing).
-           This is necessary for supporting cleanup of the coordination store.
-           Note that if one is performing rolling upgrades to a version that sweeps the coordination store, one MUST upgrade from at least this version.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/3990>`__)
-
-    *    - |improved|
          - The Timelock Availability Health check should not timeout if we can't reach other nodes. This should stop
            the health check firing erroneously.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3988>`__)

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -57,7 +57,7 @@ develop
     *    - |improved|
          - AtlasDB now throws an ``IllegalArgumentException`` when attempting to create a column range selection that is invalid (has end before start).
            Previously, exceptions were thrown from the underlying KVS, but these were implementation-dependent.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/3992>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3993>`__)
 
     *    - |improved|
          - The Timelock Availability Health check should not timeout if we can't reach other nodes. This should stop

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -55,6 +55,17 @@ develop
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3978>`__)
 
     *    - |improved|
+         - AtlasDB now throws an ``IllegalArgumentException`` when attempting to create a column range selection that is invalid (has end before start).
+           Previously, exceptions were thrown from the underlying KVS, but these were implementation-dependent.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3992>`__)
+
+    *    - |improved|
+         - The coordination store now retries when reading a value at a given sequence number that no longer exists (as opposed to throwing).
+           This is necessary for supporting cleanup of the coordination store.
+           Note that if one is performing rolling upgrades to a version that sweeps the coordination store, one MUST upgrade from at least this version.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3990>`__)
+
+    *    - |improved|
          - The Timelock Availability Health check should not timeout if we can't reach other nodes. This should stop
            the health check firing erroneously.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3988>`__)


### PR DESCRIPTION
**Goals (and why)**:
- See PDS-87779
- Generally, there are use cases where if you make a `ColumnRangeSelection` that is backwards (e.g. `[tom, jeremy)`) you get a cryptic error message from the underlying KVS, e.g. `InvalidRequestException: null`. We should fail more loudly and more clearly.

**Implementation Description (bullets)**:
- Add a preconditions check that the start to end forms a valid range.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Existing tests were very limited. I have added quite a few cases.

**Concerns (what feedback would you like?)**:
Nothing in particular.

**Where should we start reviewing?**: ColumnRangeSelectionTest probably

**Priority (whenever / two weeks / yesterday)**: today or tomorrow please
