### PR TITLE
More resilient resilient health check test

### DIFF
--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosResponses.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosResponses.java
@@ -67,6 +67,10 @@ public class PaxosResponses<T extends PaxosResponse> {
         return successes >= quorum;
     }
 
+    public int numberOfResponses() {
+        return responses.size();
+    }
+
     PaxosQuorumStatus getQuorumResult() {
         if (hasQuorum()) {
             return PaxosQuorumStatus.QUORUM_AGREED;


### PR DESCRIPTION
**Goals (and why)**:
Turns out the impl for #3988 isn't sufficiently resilient for tests => flaky results in production. This should fix that. 

**Implementation Description (bullets)**:
Use `PaxosQuorumChecker.collectAsManyResponsesAsPossible`, and manually count number of responses compared to our quorum size. It's all a hack tbh.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Tests should remain the same, ran them 5000 times lol

**Priority (whenever / two weeks / yesterday)**:
ASAP 🔥 


<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
