### PR TITLE
add user agent parameter to proxy creator

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
@@ -96,6 +96,7 @@ public final class AtlasDbHttpClients {
             Optional<TrustContext> trustContext,
             Optional<ProxySelector> proxySelector,
             Collection<String> endpointUris,
+            String userAgent,
             Class<T> type) {
         return AtlasDbMetrics.instrument(
                 metricRegistry,
@@ -108,7 +109,7 @@ public final class AtlasDbHttpClients {
                         DEFAULT_READ_TIMEOUT_MILLIS,
                         FailoverFeignTarget.DEFAULT_MAX_BACKOFF.toMillis(),
                         type,
-                        UserAgents.DEFAULT_USER_AGENT,
+                        userAgent,
                         false),
                 MetricRegistry.name(type));
     }

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/AtlasDbHttpClientsTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/AtlasDbHttpClientsTest.java
@@ -140,7 +140,7 @@ public class AtlasDbHttpClientsTest {
 
         TestResource client = AtlasDbHttpClients.createProxyWithFailover(new MetricRegistry(),
                 NO_SSL,
-                Optional.empty(), bothUris, TestResource.class);
+                Optional.empty(), bothUris, UserAgents.DEFAULT_USER_AGENT, TestResource.class);
         int response = client.getTestNumber();
 
         assertThat(response, equalTo(TEST_NUMBER));
@@ -164,8 +164,12 @@ public class AtlasDbHttpClientsTest {
         Optional<ProxySelector> directProxySelector = Optional.of(
                 ServiceCreator.createProxySelector(ProxyConfiguration.DIRECT));
         TestResource clientWithDirectCall = AtlasDbHttpClients.createProxyWithFailover(
-                new MetricRegistry(), NO_SSL,
-                directProxySelector, ImmutableSet.of(getUriForPort(availablePort)), TestResource.class);
+                new MetricRegistry(),
+                NO_SSL,
+                directProxySelector,
+                ImmutableSet.of(getUriForPort(availablePort)),
+                UserAgents.DEFAULT_USER_AGENT,
+                TestResource.class);
         clientWithDirectCall.getTestNumber();
         String defaultUserAgent = UserAgents.fromStrings(UserAgents.DEFAULT_VALUE, UserAgents.DEFAULT_VALUE);
 
@@ -180,7 +184,10 @@ public class AtlasDbHttpClientsTest {
         TestResource clientWithHttpProxy = AtlasDbHttpClients.createProxyWithFailover(
                 new MetricRegistry(),
                 NO_SSL,
-                httpProxySelector, ImmutableSet.of(getUriForPort(availablePort)), TestResource.class);
+                httpProxySelector,
+                ImmutableSet.of(getUriForPort(availablePort)),
+                UserAgents.DEFAULT_USER_AGENT,
+                TestResource.class);
         clientWithHttpProxy.getTestNumber();
         String defaultUserAgent = UserAgents.fromStrings(UserAgents.DEFAULT_VALUE, UserAgents.DEFAULT_VALUE);
 

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/EteSetup.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/EteSetup.java
@@ -33,6 +33,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.palantir.atlasdb.http.AtlasDbHttpClients;
+import com.palantir.atlasdb.http.UserAgents;
 import com.palantir.atlasdb.todo.TodoResource;
 import com.palantir.conjure.java.config.ssl.TrustContext;
 import com.palantir.docker.compose.DockerComposeRule;
@@ -182,7 +183,13 @@ public abstract class EteSetup {
                 .map(nodeName -> String.format("http://%s:%s", nodeName, port))
                 .collect(Collectors.toList());
 
-        return AtlasDbHttpClients.createProxyWithFailover(new MetricRegistry(), NO_SSL, Optional.empty(), uris, clazz);
+        return AtlasDbHttpClients.createProxyWithFailover(
+                new MetricRegistry(),
+                NO_SSL,
+                Optional.empty(),
+                uris,
+                UserAgents.DEFAULT_USER_AGENT,
+                clazz);
     }
 
     private static <T> T createClientFor(Class<T> clazz, String host, short port) {

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -116,6 +116,9 @@ develop
          - Setting ``lockImmutableTsOnReadOnlyTransactions()`` to ``true`` disables background sweep. This aims to prevent Cassandra load caused by Conservative to Thorough sweep migration.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3992>`__)
 
+    *    - |devbreak|
+         - ``AtlasDbHttpClients.createProxyWithFailover()`` now requires ``UserAgent`` parameter.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3???>`__)
 ========
 v0.133.0
 ========

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -118,7 +118,8 @@ develop
 
     *    - |devbreak|
          - ``AtlasDbHttpClients.createProxyWithFailover()`` now requires ``UserAgent`` parameter.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/3???>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3996>`__)
+
 ========
 v0.133.0
 ========

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/util/TestProxies.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/util/TestProxies.java
@@ -25,6 +25,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.palantir.atlasdb.http.AtlasDbHttpClients;
+import com.palantir.atlasdb.http.UserAgents;
 import com.palantir.atlasdb.timelock.MultiNodePaxosTimeLockServerIntegrationTest;
 import com.palantir.atlasdb.timelock.TestableTimelockServer;
 import com.palantir.atlasdb.timelock.TimeLockServerHolder;
@@ -78,6 +79,7 @@ public class TestProxies {
                 Optional.of(TRUST_CONTEXT),
                 Optional.empty(),
                 uris,
+                UserAgents.DEFAULT_USER_AGENT,
                 serviceInterface));
     }
 


### PR DESCRIPTION
**Goals (and why)**:
In recent refactors, we removed number of redundant methods from ``AtlasDbHttpClients``. Our internal backup services was using one of them - and now there isn't a way to specify userAgent for `createProxyWithFailover`. Given that we are reducing number of methods, I think it would make more sense to keep more capable ones, rather than restricted.

**Implementation Description (bullets)**:
Add userAgent parameter to `createProxyWithFailover` method, and fix internal usage of the method.

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
