### PR TITLE
[_transactions2, Part 48] Remove NPEs in MetadataCoordinationServiceMetrics

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/metrics/MetadataCoordinationServiceMetrics.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/metrics/MetadataCoordinationServiceMetrics.java
@@ -42,9 +42,9 @@ public final class MetadataCoordinationServiceMetrics {
 
     /**
      * Registers metrics that may be useful for diagnosing the status of a {@link CoordinationService}.
-     *
-     * Only one coordination service should be registered to a single metrics manager - if multiple are registered,
-     * then it is non-deterministic as to which coordination service the metrics being reported are referring to.
+     * <p>
+     * Only one coordination service should be registered to a single metrics manager - if multiple are registered, then
+     * it is non-deterministic as to which coordination service the metrics being reported are referring to.
      *
      * @param metricsManager metrics manager to register the
      * @param metadataCoordinationService metadata coordination service that should be tracked
@@ -93,7 +93,7 @@ public final class MetadataCoordinationServiceMetrics {
     private static void registerTransactionsSchemaVersionMetrics(MetricsManager metricsManager,
             CoordinationService<InternalSchemaMetadata> metadataCoordinationService,
             TimestampService timestampService) {
-        Supplier<ValueAndBound<TimestampPartitioningMap<Integer>>> valueAndBoundSupplier =
+        Supplier<Optional<ValueAndBound<TimestampPartitioningMap<Integer>>>> valueAndBoundSupplier =
                 () -> MetadataCoordinationServiceMetrics.getTimestampToTransactionsTableSchemaVersionMap(
                         metadataCoordinationService);
         registerMetricForTransactionsSchemaVersionAtTimestamp(metricsManager,
@@ -106,7 +106,8 @@ public final class MetadataCoordinationServiceMetrics {
                 unused -> timestampService.getFreshTimestamp());
     }
 
-    private static ValueAndBound<TimestampPartitioningMap<Integer>> getTimestampToTransactionsTableSchemaVersionMap(
+    private static Optional<ValueAndBound<TimestampPartitioningMap<Integer>>>
+    getTimestampToTransactionsTableSchemaVersionMap(
             CoordinationService<InternalSchemaMetadata> metadataCoordinationService) {
         Optional<ValueAndBound<InternalSchemaMetadata>> latestValue
                 = metadataCoordinationService.getLastKnownLocalValue();
@@ -114,13 +115,12 @@ public final class MetadataCoordinationServiceMetrics {
                 .map(ValueAndBound::value)
                 .flatMap(Function.identity())
                 .map(InternalSchemaMetadata::timestampToTransactionsTableSchemaVersion)
-                .map(partitioningMap -> ValueAndBound.of(partitioningMap, latestValue.get().bound()))
-                .orElse(null);
+                .map(partitioningMap -> ValueAndBound.of(partitioningMap, latestValue.get().bound()));
     }
 
     private static void registerMetricForTransactionsSchemaVersionAtTimestamp(MetricsManager metricsManager,
             String metricName,
-            Supplier<ValueAndBound<TimestampPartitioningMap<Integer>>> timestampMapSupplier,
+            Supplier<Optional<ValueAndBound<TimestampPartitioningMap<Integer>>>> timestampMapSupplier,
             Function<ValueAndBound<TimestampPartitioningMap<Integer>>, Long> timestampQuery) {
         metricsManager.registerMetric(
                 MetadataCoordinationServiceMetrics.class,
@@ -129,10 +129,10 @@ public final class MetadataCoordinationServiceMetrics {
                         log,
                         Clock.defaultClock(),
                         metricName,
-                        () -> {
-                            ValueAndBound<TimestampPartitioningMap<Integer>> mapAndBound = timestampMapSupplier.get();
-                            return getVersionAtTimestamp(mapAndBound.value(), timestampQuery.apply(mapAndBound));
-                        }));
+                        () -> timestampMapSupplier.get()
+                                .map(mapAndBound -> getVersionAtTimestamp(
+                                        mapAndBound.value(), timestampQuery.apply(mapAndBound)))
+                                .orElse(null)));
     }
 
     private static Integer getVersionAtTimestamp(Optional<TimestampPartitioningMap<Integer>> timestampMap, long bound) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/metrics/MetadataCoordinationServiceMetrics.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/metrics/MetadataCoordinationServiceMetrics.java
@@ -107,8 +107,8 @@ public final class MetadataCoordinationServiceMetrics {
     }
 
     private static Optional<ValueAndBound<TimestampPartitioningMap<Integer>>>
-    getTimestampToTransactionsTableSchemaVersionMap(
-            CoordinationService<InternalSchemaMetadata> metadataCoordinationService) {
+            getTimestampToTransactionsTableSchemaVersionMap(
+                    CoordinationService<InternalSchemaMetadata> metadataCoordinationService) {
         Optional<ValueAndBound<InternalSchemaMetadata>> latestValue
                 = metadataCoordinationService.getLastKnownLocalValue();
         return latestValue

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -56,6 +56,10 @@ develop
            Previously, we could only increase the speed of processing future entries, as we cannot sweep entries with higher parallelism than the number of shards active when the writes were made.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3997>`__)
 
+    *    - |fixed|
+         - Coordination service metrics no longer throw ``NullPointerException`` when attempting to read the metric value before reading anything from the coordination store.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/QQQQ>`__)
+
     *    - |improved|
          - AtlasDB now throws an ``IllegalArgumentException`` when attempting to create a column range selection that is invalid (has end before start).
            Previously, exceptions were thrown from the underlying KVS, but these were implementation-dependent.

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -58,7 +58,7 @@ develop
 
     *    - |fixed|
          - Coordination service metrics no longer throw ``NullPointerException`` when attempting to read the metric value before reading anything from the coordination store.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/QQQQ>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/4031>`__)
 
     *    - |improved|
          - AtlasDB now throws an ``IllegalArgumentException`` when attempting to create a column range selection that is invalid (has end before start).


### PR DESCRIPTION
**Goals (and why)**:
- Fix NPEs that were showing up in MetadataCoordinationServiceMetrics

**Implementation Description (bullets)**:
- Actually handle the null case (which can happen if you haven't read from the store yet) nicely

**Testing (What was existing testing like?  What have you done to improve it?)**:
... not much.

**Concerns (what feedback would you like?)**:
- Is there a nicer way to do this?

**Where should we start reviewing?**: `MetadataCoordinationServiceMetrics`

**Priority (whenever / two weeks / yesterday)**: this week. Internal reference 132053 on large internal product.