### PR TITLE
[no release notes] Remove redundant `JsonTypeInfo` from our iterators.

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/RowColumnRangeIterator.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/RowColumnRangeIterator.java
@@ -18,10 +18,6 @@ package com.palantir.atlasdb.keyvalue.api;
 import java.util.Iterator;
 import java.util.Map;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-
-@SuppressWarnings("DangerousJsonTypeInfoUsage")
-@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@class")
 public interface RowColumnRangeIterator extends Iterator<Map.Entry<Cell, Value>> {
     //
 }

--- a/atlasdb-commons/src/main/java/com/palantir/common/base/ClosableIterator.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/base/ClosableIterator.java
@@ -24,12 +24,9 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.PeekingIterator;
 
-@SuppressWarnings("DangerousJsonTypeInfoUsage")
-@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
 public interface ClosableIterator<T> extends Iterator<T>, Closeable {
     @Override
     default void close() { }


### PR DESCRIPTION
**Goals (and why)**:
These are redundant since we don't use them anywhere. Even if we somnehow happened to use these, `@class` is dangerous.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
