### PR TITLE
InsufficientConsistencyException shouldn't cause blacklisting

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -64,6 +64,11 @@ develop
          - Coordination service metrics no longer throw ``NullPointerException`` when attempting to read the metric value before reading anything from the coordination store.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/4031>`__)
 
+    *    - |fixed|
+         - ``InsufficientConsistencyException`` and ``NoSuchElementException`` will now not cause nodes to be blacklisted from the Cassandra client pool.
+           Previously this could happen - even though these exceptions are not reflective of the individual node in question being unable to service requests.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/4QQQ>`__)
+
     *    - |improved|
          - AtlasDB now throws an ``IllegalArgumentException`` when attempting to create a column range selection that is invalid (has end before start).
            Previously, exceptions were thrown from the underlying KVS, but these were implementation-dependent.


### PR DESCRIPTION
**Goals (and why)**:
- See #3999 

**Implementation Description (bullets)**:
- Don't blacklist if the exception is not implicating this particular node.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Added simple tests for a straight one of these, plus one which is also a connect exception (we still don't want to blacklist even in that case)

**Concerns (what feedback would you like?)**:
- Do the comments make sense?
- There is technically a weird case where `InsufficientConsistencyException` _is_ a specific node's fault (network partition)

**Where should we start reviewing?**: `CassandraRequestExceptionHandler`

**Priority (whenever / two weeks / yesterday)**: this week
