### PR TITLE
Add default methods to TransactionManager methods using Supplier

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
@@ -38,7 +38,7 @@ public interface TransactionManager extends AutoCloseable {
      * If an attempt is made to execute a transaction when this method returns {@code false}, a
      * {@link NotInitializedException} will be thrown.
      *
-     * This method is used for TransactionManagers that can be initialized asynchronously (i.e. those extending
+     * This method is used for TransactionManagers that can be initializeppd asynchronously (i.e. those extending
      * {@link com.palantir.async.initializer.AsyncInitializer}; other TransactionManagers can keep the default
      * implementation, and return true (they're trivially fully initialized).
      *
@@ -138,6 +138,13 @@ public interface TransactionManager extends AutoCloseable {
             Supplier<LockRequest> lockSupplier,
             LockAwareTransactionTask<T, E> task) throws E, InterruptedException, LockAcquisitionException;
 
+    default <T, E extends Exception> T runTaskWithLocksWithRetry(
+            com.google.common.base.Supplier<LockRequest> guavaSupplier,
+            LockAwareTransactionTask<T, E> task) throws E, InterruptedException, LockAcquisitionException {
+        Supplier<LockRequest> javaSupplier = guavaSupplier::get;
+        return runTaskWithLocksWithRetry(javaSupplier, task);
+    }
+
     /**
      * This method is the same as {@link #runTaskWithLocksWithRetry(Supplier, LockAwareTransactionTask)}
      * but it will also ensure that the existing lock tokens passed are still valid before committing.
@@ -154,6 +161,14 @@ public interface TransactionManager extends AutoCloseable {
             Iterable<HeldLocksToken> lockTokens,
             Supplier<LockRequest> lockSupplier,
             LockAwareTransactionTask<T, E> task) throws E, InterruptedException, LockAcquisitionException;
+
+    default <T, E extends Exception> T runTaskWithLocksWithRetry(
+            Iterable<HeldLocksToken> lockTokens,
+            com.google.common.base.Supplier<LockRequest> guavaSupplier,
+            LockAwareTransactionTask<T, E> task) throws E, InterruptedException, LockAcquisitionException {
+        Supplier<LockRequest> javaSupplier = guavaSupplier::get;
+        return runTaskWithLocksWithRetry(lockTokens, javaSupplier, task);
+    }
 
     /**
      * This method is the same as {@link #runTaskThrowOnConflict(TransactionTask)} except the created transaction
@@ -186,6 +201,12 @@ public interface TransactionManager extends AutoCloseable {
      */
     <T, C extends PreCommitCondition, E extends Exception> T runTaskWithConditionWithRetry(
             Supplier<C> conditionSupplier, ConditionAwareTransactionTask<T, C, E> task) throws E;
+
+    default <T, C extends PreCommitCondition, E extends Exception> T runTaskWithConditionWithRetry(
+            com.google.common.base.Supplier<C> guavaSupplier, ConditionAwareTransactionTask<T, C, E> task) throws E {
+        Supplier<C> javaSupplier = guavaSupplier::get;
+        return runTaskWithConditionWithRetry(javaSupplier, task);
+    }
 
     /**
      * This method is basically the same as {@link #runTaskThrowOnConflict(TransactionTask)}, but it takes


### PR DESCRIPTION
**Goals (and why)**:
Do not break users that pull in the new version of atlasdb, but are using a library compiled with a lower version of atlasdb.

**Implementation Description (bullets)**:
Have a default method that has the same signature as the legacy method, and forward the call to the new method.

**Concerns (what feedback would you like?)**:
Does this actually work? Did we miss some other place where this is necessary?

**Priority (whenever / two weeks / yesterday)**:
Now
