### PR TITLE
Local `PingableLeader.ping` is not called every time a request occurs

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
@@ -96,8 +96,11 @@ public final class Leaders {
         return localPaxosServices;
     }
 
-    public static LocalPaxosServices createInstrumentedLocalServices(MetricsManager metricsManager,
-            LeaderConfig config, Supplier<LeaderRuntimeConfig> runtime, String userAgent) {
+    public static LocalPaxosServices createInstrumentedLocalServices(
+            MetricsManager metricsManager,
+            LeaderConfig config,
+            Supplier<LeaderRuntimeConfig> runtime,
+            String userAgent) {
         Set<String> remoteLeaderUris = Sets.newHashSet(config.leaders());
         remoteLeaderUris.remove(config.localServer());
 
@@ -192,6 +195,7 @@ public final class Leaders {
                 .leaderElectionService(new BatchingLeaderElectionService(leaderElectionService))
                 .pingableLeader(pingableLeader)
                 .leadershipObserver(leadershipObserver)
+                .isCurrentSuspectedLeader(paxosLeaderElectionService::ping)
                 .build();
     }
 
@@ -244,6 +248,7 @@ public final class Leaders {
         LeaderElectionService leaderElectionService();
         PingableLeader pingableLeader();
         LeadershipObserver leadershipObserver();
+        Supplier<Boolean> isCurrentSuspectedLeader();
     }
 
     @Value.Immutable


### PR DESCRIPTION
**Goals (and why)**:
To have clearer metrics regarding leader election, we should only measure calls that occur as part of leader election i.e. the pinging of the leader. Since `PingableLeader.ping` also tells us whether or not the node is the leader, it makes sense to use it for the `isCurrentSuspectedLeader` tag, but it does mean metrics are very confusing.

**Implementation Description (bullets)**:
Call through the non-instrumented version.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
