### PR TITLE
Do not delegate.

### DIFF
--- a/atlasdb-processors-tests/src/main/java/com/palantir/processors/TestInterface.java
+++ b/atlasdb-processors-tests/src/main/java/com/palantir/processors/TestInterface.java
@@ -27,6 +27,9 @@ public interface TestInterface {
     int methodWithReturnTypeAndParameters(int p1);
     int methodWithReturnTypeAndVarArgs(int... parameters);
 
+    @DoNotDelegate
+    void methodThatMustBeImplemented();
+
     void overloadedMethod();
     void overloadedMethod(int p1);
     void overloadedMethod(Integer p1, Integer p2);

--- a/atlasdb-processors-tests/src/test/java/com/palantir/processors/AutoDelegateInterfaceTests.java
+++ b/atlasdb-processors-tests/src/test/java/com/palantir/processors/AutoDelegateInterfaceTests.java
@@ -15,14 +15,13 @@
  */
 package com.palantir.processors;
 
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+
+import static com.palantir.processors.TestingUtils.extractMethodsSatisfyingPredicate;
+import static com.palantir.processors.TestingUtils.extractNonStaticMethods;
 
 import java.lang.reflect.Modifier;
 import java.util.Set;
@@ -32,19 +31,20 @@ import org.junit.Test;
 import com.google.common.collect.Sets;
 
 public class AutoDelegateInterfaceTests {
+
     @Test
     public void generatedInterfaceHasSamePackageAsOriginal() {
         Package generatedInterfacePackage = AutoDelegate_TestInterface.class.getPackage();
         Package originalInterfacePackage = TestInterface.class.getPackage();
 
-        assertThat(generatedInterfacePackage, is(originalInterfacePackage));
+        assertThat(generatedInterfacePackage).isEqualTo(originalInterfacePackage);
     }
 
     @Test
     public void generatedInterfaceIsInterface() {
         int generatedInterfaceModifiers = AutoDelegate_TestInterface.class.getModifiers();
 
-        assertThat(Modifier.isInterface(generatedInterfaceModifiers), is(true));
+        assertThat(Modifier.isInterface(generatedInterfaceModifiers)).isTrue();
     }
 
     @Test
@@ -52,7 +52,7 @@ public class AutoDelegateInterfaceTests {
         int originalModifiers = TestInterface.class.getModifiers();
         int generatedInterfaceModifiers = AutoDelegate_TestInterface.class.getModifiers();
 
-        assertThat(generatedInterfaceModifiers, is(originalModifiers));
+        assertThat(generatedInterfaceModifiers).isEqualTo(originalModifiers);
     }
 
     @Test
@@ -60,44 +60,49 @@ public class AutoDelegateInterfaceTests {
         int originalModifiers = PackagePrivateInterface.class.getModifiers();
         int generatedInterfaceModifiers = AutoDelegate_PackagePrivateInterface.class.getModifiers();
 
-        assertThat(generatedInterfaceModifiers, is(originalModifiers));
+        assertThat(generatedInterfaceModifiers).isEqualTo(originalModifiers);
     }
 
     @Test
     public void generatedInterfaceHasInterfaceMethods() {
         Set<String> generatedMethods = TestingUtils.extractMethods(AutoDelegate_TestInterface.class);
-        Set<String> originalMethods = TestingUtils.extractNonStaticMethods(TestInterface.class);
-
-        assertThat(generatedMethods, hasItems(originalMethods.toArray(new String[0])));
+        Set<String> originalMethods = extractNonStaticMethods(TestInterface.class);
+        Set<String> doNotDelegateMethods = doNotDelegateMethods(originalMethods);
+        assertThat(generatedMethods)
+                .containsAll(Sets.difference(originalMethods, doNotDelegateMethods))
+                .doesNotContainAnyElementsOf(doNotDelegateMethods);
     }
 
     @Test
     public void generatedInterfaceHasDelegateMethod() {
         Set<String> generatedMethods = TestingUtils.extractMethods(AutoDelegate_TestInterface.class);
-        Set<String> originalMethods = TestingUtils.extractNonStaticMethods(TestInterface.class);
+        Set<String> originalMethods = extractNonStaticMethods(TestInterface.class);
 
         generatedMethods.removeAll(originalMethods);
-        assertThat(generatedMethods.size(), is(1));
-        assertThat(generatedMethods.iterator().next(), containsString("delegate"));
+        assertThat(generatedMethods)
+                .hasSize(1)
+                .allMatch(s -> s.contains("delegate"));
     }
 
     @Test
     public void generatedInterfaceDoesNotHaveStaticMethods() {
         Set<String> generatedMethods = TestingUtils.extractMethods(AutoDelegate_TestInterface.class);
-        Set<String> originalStaticMethods = TestingUtils.extractMethodsSatisfyingPredicate(TestInterface.class,
+        Set<String> originalStaticMethods = extractMethodsSatisfyingPredicate(TestInterface.class,
                 method -> Modifier.isStatic(method.getModifiers()));
 
-        assertThat(Sets.intersection(generatedMethods, originalStaticMethods), empty());
+        assertThat(Sets.intersection(generatedMethods, originalStaticMethods)).isEmpty();
     }
 
     @Test
     public void childInterfaceHasParentAndChildMethods() {
         Set<String> generatedMethods = TestingUtils.extractMethods(AutoDelegate_ChildTestInterface.class);
-        Set<String> parentMethods = TestingUtils.extractNonStaticMethods(TestInterface.class);
-        Set<String> childMethods = TestingUtils.extractNonStaticMethods(ChildTestInterface.class);
+        Set<String> parentMethods = extractNonStaticMethods(TestInterface.class);
+        Set<String> childMethods = extractNonStaticMethods(ChildTestInterface.class);
 
-        assertThat(generatedMethods, hasItems(parentMethods.toArray(new String[0])));
-        assertThat(generatedMethods, hasItems(childMethods.toArray(new String[0])));
+        Set<String> doNotDelegateMethods = doNotDelegateMethods(parentMethods);
+        assertThat(generatedMethods)
+                .containsAll(Sets.difference(parentMethods, doNotDelegateMethods))
+                .containsAll(childMethods);
     }
 
     @Test
@@ -107,6 +112,10 @@ public class AutoDelegateInterfaceTests {
 
         instanceOfInterface.methodWithReturnType();
         verify(mockImpl, times(1)).methodWithReturnType();
+    }
+
+    private static Set<String> doNotDelegateMethods(Set<String> originalMethods) {
+        return Sets.filter(originalMethods, m -> m.contains("methodThatMustBeImplemented"));
     }
 
     static class AnImpl implements AutoDelegate_TestInterface {

--- a/atlasdb-processors-tests/src/test/java/com/palantir/processors/AutoDelegateInterfaceTests.java
+++ b/atlasdb-processors-tests/src/test/java/com/palantir/processors/AutoDelegateInterfaceTests.java
@@ -103,9 +103,28 @@ public class AutoDelegateInterfaceTests {
     @Test
     public void generatedInterfaceCallsMethodOnDelegate() {
         TestInterfaceImpl mockImpl = mock(TestInterfaceImpl.class);
-        AutoDelegate_TestInterface instanceOfInterface = () -> mockImpl;
+        AutoDelegate_TestInterface instanceOfInterface = new AnImpl(mockImpl);
 
         instanceOfInterface.methodWithReturnType();
         verify(mockImpl, times(1)).methodWithReturnType();
+    }
+
+    static class AnImpl implements AutoDelegate_TestInterface {
+
+        private final TestInterface delegate;
+
+        AnImpl(TestInterface delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public TestInterface delegate() {
+            return delegate;
+        }
+
+        @Override
+        public void methodThatMustBeImplemented() {
+
+        }
     }
 }

--- a/atlasdb-processors-tests/src/test/java/com/palantir/processors/TestingUtils.java
+++ b/atlasdb-processors-tests/src/test/java/com/palantir/processors/TestingUtils.java
@@ -15,7 +15,6 @@
  */
 package com.palantir.processors;
 
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
@@ -37,39 +36,22 @@ final class TestingUtils {
                 .collect(Collectors.toSet());
     }
 
-    static String methodToString(Method method) {
+    private static String methodToString(Method method) {
         return String.format("%s,%s,%s",
                 method.getReturnType(),
                 method.getName(),
                 extractMethodParameterTypes(method));
     }
 
-    static String extractMethodParameterTypes(Method method) {
+    private static String extractMethodParameterTypes(Method method) {
         return Arrays.stream(method.getParameterTypes())
                 .map(Class::getCanonicalName)
                 .collect(Collectors.toList())
                 .toString();
     }
 
-    static Set<String> extractConstructors(Class klass) {
-        return Arrays.stream(klass.getConstructors())
-                .map(TestingUtils::constructorToString)
-                .collect(Collectors.toSet());
-    }
-
-    static String constructorToString(Constructor constructor) {
-        return String.format("%s", extractConstructorParameterTypes(constructor));
-    }
-
     static Set<String> extractNonStaticMethods(Class klass) {
         return extractMethodsSatisfyingPredicate(klass, method -> !Modifier.isStatic(method.getModifiers()));
     }
 
-
-    private static String extractConstructorParameterTypes(Constructor constructor) {
-        return Arrays.stream(constructor.getParameterTypes())
-                .map(Class::getCanonicalName)
-                .collect(Collectors.toList())
-                .toString();
-    }
 }

--- a/atlasdb-processors/src/main/java/com/palantir/processors/DoNotDelegate.java
+++ b/atlasdb-processors/src/main/java/com/palantir/processors/DoNotDelegate.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.palantir.processors;
 
-public class TestInterfaceImpl implements AutoDelegate_TestInterface {
-    @Override
-    public TestInterface delegate() {
-        return null;
-    }
-
-    @Override
-    public int methodWithReturnType() {
-        return 0;
-    }
-
-    @Override
-    public void methodThatMustBeImplemented() {
-
-    }
+public @interface DoNotDelegate {
 }

--- a/atlasdb-processors/src/main/java/com/palantir/processors/TypeToExtend.java
+++ b/atlasdb-processors/src/main/java/com/palantir/processors/TypeToExtend.java
@@ -70,7 +70,8 @@ final class TypeToExtend {
     private static boolean interfaceMethodFilter(Element element) {
         return element.getKind() == ElementKind.METHOD
                 && element.getModifiers().contains(Modifier.PUBLIC)
-                && !element.getModifiers().contains(Modifier.STATIC);
+                && !element.getModifiers().contains(Modifier.STATIC)
+                && element.getAnnotation(DoNotDelegate.class) == null;
     }
 
     boolean isPublic() {


### PR DESCRIPTION
**Goals (and why)**:
Not every method should be delegated i.e. deprecated default methods that "delegate" to the non-deprecated method on the same interface. Doing so, can result in weird correctness issues since implementors of the generated `AutoDelegate_*` interfaces are not forced to implement everything (problematic).

**Implementation Description (bullets)**:
Add a `@DoNotDelegate` annotation that tells the processor to skip generating code to delegate that method.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Somewhat difficult to test since we do all this as part of our build, as opposed to a test, so compilation proves it to be okay, I suppose.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
