### PR TITLE
[no release notes] error to info

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -885,7 +885,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                 from -> RowResults.merge(from.lhSide, from.rhSide)); // prefer local writes
 
         Iterator<RowResult<byte[]>> purgeDeleted = filterEmptyColumnsFromRows(mergeIterators, tableReference);
-        return Iterators.filter(purgeDeleted, Predicates.not(RowResults.<byte[]>createIsEmptyPredicate()));
+        return Iterators.filter(purgeDeleted, Predicates.not(RowResults.createIsEmptyPredicate()));
     }
 
     private Iterator<RowResult<byte[]>> filterEmptyColumnsFromRows(
@@ -1520,7 +1520,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             final String baseMsg = "Required locks are no longer valid. ";
             String expiredLocksErrorString = getExpiredLocksErrorString(commitLocksToken, expiredLocks);
             TransactionLockTimeoutException ex = new TransactionLockTimeoutException(baseMsg + expiredLocksErrorString);
-            log.error(baseMsg + "{}", expiredLocksErrorString, ex);
+            log.info(baseMsg + "{}", expiredLocksErrorString, ex);
             transactionOutcomeMetrics.markLocksExpired();
             throw ex;
         }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -1517,10 +1517,10 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     private void throwIfImmutableTsOrCommitLocksExpired(@Nullable LockToken commitLocksToken) {
         Set<LockToken> expiredLocks = refreshCommitAndImmutableTsLocks(commitLocksToken);
         if (!expiredLocks.isEmpty()) {
-            final String baseMsg = "Required locks are no longer valid. ";
+            final String baseMsg = "Locks acquired as part of the transaction protocol are no longer valid. ";
             String expiredLocksErrorString = getExpiredLocksErrorString(commitLocksToken, expiredLocks);
             TransactionLockTimeoutException ex = new TransactionLockTimeoutException(baseMsg + expiredLocksErrorString);
-            log.info(baseMsg + "{}", expiredLocksErrorString, ex);
+            log.error(baseMsg + "{}", expiredLocksErrorString, ex);
             transactionOutcomeMetrics.markLocksExpired();
             throw ex;
         }


### PR DESCRIPTION
**Goals (and why)**:
Logging "lost locks" as ERROR is alarming when you haven't acquired any locks (as a consumer). Moving to INFO s.t. immutable ts and commit locks (locks that are part of the protocol) do not trip up any alerting etc.

@diogoholanda for SA

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
