### PR TITLE
Update dead links to http-remoting-api

### DIFF
--- a/docs/source/configuration/external_timelock_service_configs/timelock_client_config.rst
+++ b/docs/source/configuration/external_timelock_service_configs/timelock_client_config.rst
@@ -66,12 +66,12 @@ Optional parameters:
 
     *    - serversList::sslConfiguration
          - The SSL configuration of the service. This should follow the
-           `palantir/http-remoting-api <https://github.com/palantir/http-remoting-api/blob/1.4.0/ssl-config/src/main/java/com/palantir/remoting/api/config/ssl/SslConfiguration.java>`__
+           `palantir/http-remoting-api <https://github.com/palantir/conjure-java-runtime-api/blob/2.3.0/ssl-config/src/main/java/com/palantir/conjure/java/api/config/ssl/SslConfiguration.java>`__
            library. This should also be in alignment with the protocol used when configuring the servers.
 
     *    - serversList::proxyConfiguration
          - The proxy configuration of the service. This should follow the
-           `palantir/http-remoting-api <https://github.com/palantir/http-remoting-api/blob/1.4.0/service-config/src/main/java/com/palantir/remoting/api/config/service/ProxyConfiguration.java>`__
+           `palantir/http-remoting-api <https://github.com/palantir/conjure-java-runtime-api/blob/2.3.0/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java>`__
            library.
 
 Runtime Configuration
@@ -109,12 +109,12 @@ Note that if this block is present, then the ``ServerListConfiguration`` in the 
 
     *    - serversList::sslConfiguration
          - The SSL configuration of the service. This should follow the
-           `palantir/http-remoting-api <https://github.com/palantir/http-remoting-api/blob/1.4.0/ssl-config/src/main/java/com/palantir/remoting/api/config/ssl/SslConfiguration.java>`__
+           `palantir/http-remoting-api <https://github.com/palantir/conjure-java-runtime-api/blob/2.3.0/ssl-config/src/main/java/com/palantir/conjure/java/api/config/ssl/SslConfiguration.java>`__
            library. This should also be in alignment with the protocol used when configuring the servers.
 
     *    - serversList::proxyConfiguration
          - The proxy configuration of the service. This should follow the
-           `palantir/http-remoting-api <https://github.com/palantir/http-remoting-api/blob/1.4.0/service-config/src/main/java/com/palantir/remoting/api/config/service/ProxyConfiguration.java>`__
+           `palantir/http-remoting-api <https://github.com/palantir/conjure-java-runtime-api/blob/2.3.0/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java>`__
            library.
 
 

--- a/docs/source/configuration/qos_configs/qos_client_config.rst
+++ b/docs/source/configuration/qos_configs/qos_client_config.rst
@@ -38,7 +38,7 @@ Optional parameters:
            This parameter configures the maximum time a client request can be made to wait by the rate limiter.
            This should definitely be less than the server idle timeout or jetty will cause the request to timeout and potentially retry.
            The default value is 10 seconds.
-           This is of type `HumanReadableDuration <https://github.com/palantir/http-remoting-api/blob/develop/service-config/src/main/java/com/palantir/remoting/api/config/service/HumanReadableDuration.java>`__.
+           This is of type `HumanReadableDuration <https://github.com/palantir/conjure-java-runtime-api/blob/2.3.0/service-config/src/main/java/com/palantir/conjure/java/api/config/service/HumanReadableDuration.java>`__.
 
     *    - limits::readBytesPerSecond
          - The maximum number of bytes to read from Cassandra per second (specified as a long).
@@ -51,4 +51,4 @@ Optional parameters:
 
     *    - qosService
          - The config for the QoS Service.
-           This is of type `ServiceConfiguration <https://github.com/palantir/http-remoting-api/blob/develop/service-config/src/main/java/com/palantir/remoting/api/config/service/ServiceConfiguration.java>`__.
+           This is of type `ServiceConfiguration <https://github.com/palantir/conjure-java-runtime-api/blob/2.3.0/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ServiceConfiguration.java>`__.

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -3725,7 +3725,7 @@ v0.59.1
          - Change
 
     *    - |improved|
-         - Allow passing a `ProxyConfiguration <https://github.com/palantir/http-remoting-api/blob/develop/service-config/src/main/java/com/palantir/remoting/api/config/service/ProxyConfiguration.java>`__ to allow setting custom proxy on the TimeLock clients.
+         - Allow passing a `ProxyConfiguration <https://github.com/palantir/conjure-java-runtime-api/blob/2.3.0/service-config/src/main/java/com/palantir/conjure/java/api/config/service/ProxyConfiguration.java>`__ to allow setting custom proxy on the TimeLock clients.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2393>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>


### PR DESCRIPTION
**Goals (and why)**:

Keep links in documentation up to date.

**Implementation Description (bullets)**:

Update all dead links to http-remoting-api to link to the new project home: conjure-java-runtime-api.

**Testing (What was existing testing like?  What have you done to improve it?)**:

Docs-only changes

**Concerns (what feedback would you like?)**:

No concerns

**Where should we start reviewing?**:

Any of the `.rst` files changed.

**Priority (whenever / two weeks / yesterday)**:

Whenever