### PR TITLE
[TimeLock Partitioning] Abdication Mechanism Part 1

### DIFF
--- a/leader-election-api/src/main/java/com/palantir/leader/LeaderElectionService.java
+++ b/leader-election-api/src/main/java/com/palantir/leader/LeaderElectionService.java
@@ -76,4 +76,12 @@ public interface LeaderElectionService {
      * @return the set of potential leaders known by this leader election service, including itself
      */
     Set<PingableLeader> getPotentialLeaders();
+
+    /**
+     * Attempts to give up leadership. Note that this does not guarantee that a different node will be elected the
+     * leader - it is possible for this node to regain leadership without any other node acquiring it in the interim.
+     *
+     * @return the state of this leader election service before it attempted to step down
+     */
+    StillLeadingStatus stepDown();
 }

--- a/leader-election-api/src/main/java/com/palantir/leader/LeaderElectionService.java
+++ b/leader-election-api/src/main/java/com/palantir/leader/LeaderElectionService.java
@@ -81,7 +81,7 @@ public interface LeaderElectionService {
      * Attempts to give up leadership. Note that this does not guarantee that a different node will be elected the
      * leader - it is possible for this node to regain leadership without any other node acquiring it in the interim.
      *
-     * @return the state of this leader election service before it attempted to step down
+     * @return true if and only if this node was able to cause itself to lose leadership
      */
-    StillLeadingStatus stepDown();
+    boolean stepDown();
 }

--- a/leader-election-api/src/main/java/com/palantir/paxos/PaxosProposer.java
+++ b/leader-election-api/src/main/java/com/palantir/paxos/PaxosProposer.java
@@ -38,6 +38,13 @@ public interface PaxosProposer {
             throws PaxosRoundFailureException;
 
     /**
+     * Reaches a consensus with peers on a value of type V using a single instance of paxos, as in
+     * {@link PaxosProposer#propose(long, byte[])}. However, this value is proposed anonymously, with a fresh
+     * proposer ID. This may be useful for relinquishing leadership in algorithms for that based on Paxos.
+     */
+    byte[] proposeAnonymously(long seq, @Nullable byte[] proposalValue) throws PaxosRoundFailureException;
+
+    /**
      * Returns the number of acceptors that need to support a successful request.
      */
     int getQuorumSize();

--- a/leader-election-impl/src/main/java/com/palantir/leader/BatchingLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/BatchingLeaderElectionService.java
@@ -71,7 +71,7 @@ public class BatchingLeaderElectionService implements LeaderElectionService {
     }
 
     @Override
-    public StillLeadingStatus stepDown() {
+    public boolean stepDown() {
         return delegate.stepDown();
     }
 

--- a/leader-election-impl/src/main/java/com/palantir/leader/BatchingLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/BatchingLeaderElectionService.java
@@ -70,6 +70,11 @@ public class BatchingLeaderElectionService implements LeaderElectionService {
         return delegate.getPotentialLeaders();
     }
 
+    @Override
+    public StillLeadingStatus stepDown() {
+        return delegate.stepDown();
+    }
+
     private void processBatch(List<BatchElement<Void, LeadershipToken>> batch) {
         try {
             LeaderElectionService.LeadershipToken leadershipToken = delegate.blockOnBecomingLeader();

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
@@ -399,7 +399,7 @@ public class PaxosLeaderElectionService implements PingableLeader, LeaderElectio
                 return;
             }
 
-            long seq = value.map(PaxosValue::getRound).orElse(PaxosAcceptor.NO_LOG_ENTRY) + 1;
+            long seq = getNextSequenceNumber(value);
 
             eventRecorder.recordProposalAttempt(seq);
             proposer.propose(seq, null);
@@ -483,7 +483,7 @@ public class PaxosLeaderElectionService implements PingableLeader, LeaderElectio
      * @returns true if new state was learned, otherwise false
      */
     public boolean updateLearnedStateFromPeers(Optional<PaxosValue> greatestLearned) {
-        final long nextToLearnSeq = greatestLearned.map(PaxosValue::getRound).orElse(PaxosAcceptor.NO_LOG_ENTRY) + 1;
+        final long nextToLearnSeq = getNextSequenceNumber(greatestLearned);
         PaxosResponses<PaxosUpdate> updates = PaxosQuorumChecker.collectQuorumResponses(
                 learners,
                 learner -> new PaxosUpdate(ImmutableList.copyOf(learner.getLearnedValuesSince(nextToLearnSeq))),
@@ -512,9 +512,7 @@ public class PaxosLeaderElectionService implements PingableLeader, LeaderElectio
         StillLeadingStatus status = leadershipState.status();
         if (status == StillLeadingStatus.LEADING) {
             try {
-                proposer.proposeAnonymously(leadershipState.greatestLearnedValue()
-                        .map(PaxosValue::getRound)
-                        .orElse(PaxosAcceptor.NO_LOG_ENTRY) + 1,
+                proposer.proposeAnonymously(getNextSequenceNumber(leadershipState.greatestLearnedValue()),
                         null);
                 return true;
             } catch (PaxosRoundFailureException e) {
@@ -526,6 +524,10 @@ public class PaxosLeaderElectionService implements PingableLeader, LeaderElectio
             }
         }
         return false;
+    }
+
+    private static long getNextSequenceNumber(Optional<PaxosValue> paxosValue) {
+        return paxosValue.map(PaxosValue::getRound).orElse(PaxosAcceptor.NO_LOG_ENTRY) + 1;
     }
 
     @Value.Immutable

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
@@ -512,11 +512,9 @@ public class PaxosLeaderElectionService implements PingableLeader, LeaderElectio
         StillLeadingStatus status = leadershipState.status();
         if (status == StillLeadingStatus.LEADING) {
             try {
-                proposer.proposeAnonymously(getNextSequenceNumber(leadershipState.greatestLearnedValue()),
-                        null);
+                proposer.proposeAnonymously(getNextSequenceNumber(leadershipState.greatestLearnedValue()), null);
                 return true;
             } catch (PaxosRoundFailureException e) {
-                System.out.println("FAILURE");
                 log.info("Couldn't relinquish leadership because a quorum could not be obtained. Last observed"
                         + " state was {}.",
                         SafeArg.of("leadershipState", leadershipState));

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosProposerImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosProposerImpl.java
@@ -104,6 +104,18 @@ public final class PaxosProposerImpl implements PaxosProposer {
 
     @Override
     public byte[] propose(final long seq, @Nullable byte[] bytes) throws PaxosRoundFailureException {
+        return propose(uuid, seq, bytes);
+    }
+
+    @Override
+    public byte[] proposeAnonymously(long seq, @Nullable byte[] proposalValue) throws PaxosRoundFailureException {
+        return propose(UUID.randomUUID().toString(), seq, proposalValue);
+    }
+
+    private byte[] propose(
+            String uuid,
+            final long seq,
+            @Nullable byte[] bytes) throws PaxosRoundFailureException {
         final PaxosProposalId proposalId = new PaxosProposalId(proposalNumber.incrementAndGet(), uuid);
         PaxosValue toPropose = new PaxosValue(uuid, seq, bytes);
 

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosProposerImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosProposerImpl.java
@@ -104,20 +104,20 @@ public final class PaxosProposerImpl implements PaxosProposer {
 
     @Override
     public byte[] propose(final long seq, @Nullable byte[] bytes) throws PaxosRoundFailureException {
-        return propose(uuid, seq, bytes);
+        return proposeWithId(uuid, seq, bytes);
     }
 
     @Override
     public byte[] proposeAnonymously(long seq, @Nullable byte[] proposalValue) throws PaxosRoundFailureException {
-        return propose(UUID.randomUUID().toString(), seq, proposalValue);
+        return proposeWithId(UUID.randomUUID().toString(), seq, proposalValue);
     }
 
-    private byte[] propose(
-            String uuid,
+    private byte[] proposeWithId(
+            String uuidToProposeWith,
             final long seq,
             @Nullable byte[] bytes) throws PaxosRoundFailureException {
-        final PaxosProposalId proposalId = new PaxosProposalId(proposalNumber.incrementAndGet(), uuid);
-        PaxosValue toPropose = new PaxosValue(uuid, seq, bytes);
+        final PaxosProposalId proposalId = new PaxosProposalId(proposalNumber.incrementAndGet(), uuidToProposeWith);
+        PaxosValue toPropose = new PaxosValue(uuidToProposeWith, seq, bytes);
 
         // paxos phase one (prepare and promise)
         final PaxosValue finalValue = phaseOne(seq, proposalId, toPropose);

--- a/leader-election-impl/src/test/java/com/palantir/leader/PaxosLeaderElectionServiceTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/PaxosLeaderElectionServiceTest.java
@@ -30,7 +30,7 @@ import com.palantir.paxos.PaxosProposer;
 
 public class PaxosLeaderElectionServiceTest {
     @Test
-    public void weAreOneOfThePotentialLeaders() throws Exception {
+    public void weAreOneOfThePotentialLeaders() {
         PingableLeader other = mock(PingableLeader.class);
         PaxosLeaderElectionService service = new PaxosLeaderElectionServiceBuilder()
                 .proposer(mock(PaxosProposer.class))
@@ -47,5 +47,4 @@ public class PaxosLeaderElectionServiceTest {
 
         assertThat(service.getPotentialLeaders()).containsExactlyInAnyOrder(other, service);
     }
-
 }

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosConsensusFastTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosConsensusFastTest.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.paxos;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
@@ -91,9 +92,7 @@ public class PaxosConsensusFastTest {
     @Test
     public void loseQuorum() {
         LeadershipToken token = state.gainLeadership(0);
-        for (int i = 1; i < NUM_POTENTIAL_LEADERS - QUORUM_SIZE + 2; i++) {
-            state.goDown(i);
-        }
+        knockOutQuorumNotIncludingZero();
         assertNotSame("leader cannot maintain leadership without quorum",
                 state.leader(0).isStillLeading(token), StillLeadingStatus.LEADING);
         state.comeUp(1);
@@ -143,9 +142,7 @@ public class PaxosConsensusFastTest {
         future.cancel(true);
         exec.shutdown();
         exec.awaitTermination(10, TimeUnit.SECONDS);
-        for (int i = 0; i < NUM_POTENTIAL_LEADERS; i++) {
-            state.comeUp(i);
-        }
+        restoreAllNodes();
     }
 
     @SuppressWarnings("EmptyCatchBlock")
@@ -188,6 +185,68 @@ public class PaxosConsensusFastTest {
         log.truncate(log.getGreatestLogEntry());
         cache.clear();
         state.gainLeadership(0);
+    }
+
+    @Test
+    public void loseLeadershipAfterSteppingDown() {
+        LeadershipToken token = state.gainLeadership(0);
+        assertThat(state.leader(0).isStillLeading(token)).isEqualTo(StillLeadingStatus.LEADING);
+        assertThat(state.leader(0).stepDown()).isTrue();
+        assertThat(state.leader(0).isStillLeading(token)).isEqualTo(StillLeadingStatus.NOT_LEADING);
+    }
+
+    @Test
+    public void otherNodeCanBecomeLeaderAfterSteppingDown() {
+        LeadershipToken token = state.gainLeadership(0);
+        assertThat(state.leader(0).isStillLeading(token)).isEqualTo(StillLeadingStatus.LEADING);
+        assertThat(state.leader(0).stepDown()).isTrue();
+
+        LeadershipToken token2 = state.gainLeadership(1);
+        assertThat(state.leader(1).isStillLeading(token2)).isEqualTo(StillLeadingStatus.LEADING);
+    }
+
+    @Test
+    public void leadershipIfRegainedImmediatelyIsOnDifferentToken() {
+        LeadershipToken token1 = state.gainLeadership(0);
+        assertThat(state.leader(0).isStillLeading(token1)).isEqualTo(StillLeadingStatus.LEADING);
+        assertThat(state.leader(0).stepDown()).isTrue();
+
+        LeadershipToken token2 = state.gainLeadership(0);
+        assertThat(state.leader(0).isStillLeading(token1)).isEqualTo(StillLeadingStatus.NOT_LEADING);
+        assertThat(state.leader(0).isStillLeading(token2)).isEqualTo(StillLeadingStatus.LEADING);
+        assertThat(state.leader(0).stepDown()).isTrue();
+    }
+
+    @Test
+    public void nonLeaderStepDownDoesNotAffectLeader() {
+        LeadershipToken token = state.gainLeadership(0);
+        assertThat(state.leader(0).isStillLeading(token)).isEqualTo(StillLeadingStatus.LEADING);
+        assertThat(state.leader(1).stepDown()).isFalse();
+        assertThat(state.leader(0).isStillLeading(token)).isEqualTo(StillLeadingStatus.LEADING);
+    }
+
+    @Test
+    public void failToStepDownIfNoQuorum() {
+        LeadershipToken token = state.gainLeadership(0);
+        assertThat(state.leader(0).isStillLeading(token)).isEqualTo(StillLeadingStatus.LEADING);
+
+        knockOutQuorumNotIncludingZero();
+        assertThat(state.leader(0).stepDown()).isFalse();
+
+        restoreAllNodes();
+        assertThat(state.leader(0).isStillLeading(token)).isEqualTo(StillLeadingStatus.LEADING);
+    }
+
+    private void knockOutQuorumNotIncludingZero() {
+        for (int i = 1; i < NUM_POTENTIAL_LEADERS - QUORUM_SIZE + 2; i++) {
+            state.goDown(i);
+        }
+    }
+
+    private void restoreAllNodes() {
+        for (int i = 0; i < NUM_POTENTIAL_LEADERS; i++) {
+            state.comeUp(i);
+        }
     }
 }
 

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosConsensusFastTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosConsensusFastTest.java
@@ -202,6 +202,7 @@ public class PaxosConsensusFastTest {
         assertThat(state.leader(0).stepDown()).isTrue();
 
         LeadershipToken token2 = state.gainLeadership(1);
+        assertThat(state.leader(0).isStillLeading(token)).isEqualTo(StillLeadingStatus.NOT_LEADING);
         assertThat(state.leader(1).isStillLeading(token2)).isEqualTo(StillLeadingStatus.LEADING);
     }
 

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
@@ -314,6 +314,15 @@ public class PaxosTimestampBoundStoreTest {
         }
 
         @Override
+        public byte[] proposeAnonymously(long seq, @Nullable byte[] proposalValue) throws PaxosRoundFailureException {
+            if (hasFailed) {
+                return delegate.proposeAnonymously(seq, proposalValue);
+            }
+            hasFailed = true;
+            throw new PaxosRoundFailureException("paxos fail");
+        }
+
+        @Override
         public int getQuorumSize() {
             return delegate.getQuorumSize();
         }


### PR DESCRIPTION
**Goals (and why)**:
- Provide a mechanism for a leader node to declare it is itself not the leader. If we're relying on randomness for timelock to balance itself, we want to have a mechanism for ensuring that we can recover (without manual action to bounce leader nodes)

**Implementation Description (bullets)**:
- Implement a `stepDown()` method in `LeaderElectionService` that makes a leading node step down, by proposing a value at a randomized UUID which isn't actually a member of the cluster.
- Only nodes that believe they are the leader can attempt to step down.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Added tests at the `LeaderElectionService` level (see `PaxosConsensusFastTests`).

**Concerns (what feedback would you like?)**:
- Is this mechanism safe?
- Should this be exposed?
- No integration tests. Plan is to do this in a Part 2; this isn't used anywhere yet.

**Where should we start reviewing?**: `LeaderElectionService`

**Priority (whenever / two weeks / yesterday)**: this week
