### PR TITLE
Timelock Auth Part 7: Use AuthManager

### DIFF
--- a/lock-api/src/main/java/com/palantir/lock/TimelockNamespace.java
+++ b/lock-api/src/main/java/com/palantir/lock/TimelockNamespace.java
@@ -18,7 +18,6 @@ package com.palantir.lock;
 
 import org.immutables.value.Value;
 
-import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
@@ -26,8 +25,12 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 @JsonDeserialize(as = ImmutableTimelockNamespace.class)
 @Value.Immutable
 public interface TimelockNamespace {
-    @JsonValue
+    @Value.Parameter
     String value();
+
+    static TimelockNamespace valueOf(String namespace) {
+        return of(namespace);
+    }
 
     static TimelockNamespace of(String namespace) {
         return ImmutableTimelockNamespace.builder()

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockRuntimeConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockRuntimeConfiguration.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Preconditions;
+import com.palantir.atlasdb.timelock.auth.config.ImmutableTimelockAuthConfiguration;
+import com.palantir.atlasdb.timelock.auth.config.TimelockAuthConfiguration;
 
 /**
  * Dynamic (live-reloaded) portions of TimeLock's configuration.
@@ -53,6 +55,14 @@ public abstract class TimeLockRuntimeConfiguration {
     @Value.Default
     public long slowLockLogTriggerMillis() {
         return 10000;
+    }
+
+    @JsonProperty("auth")
+    @Value.Default
+    public TimelockAuthConfiguration authConfiguration() {
+        return ImmutableTimelockAuthConfiguration.builder()
+                .useAuth(false)
+                .build();
     }
 
     @Value.Check

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AuthorizedTimeLockResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AuthorizedTimeLockResource.java
@@ -1,0 +1,59 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock;
+
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+import com.palantir.atlasdb.timelock.auth.AuthManager;
+import com.palantir.atlasdb.timelock.auth.api.ClientId;
+import com.palantir.atlasdb.timelock.auth.api.Password;
+import com.palantir.lock.TimelockNamespace;
+import com.palantir.logsafe.Safe;
+
+@Path("/")
+public class AuthorizedTimeLockResource {
+    private final TimeLockResource timeLockResource;
+    private final AuthManager authManager;
+
+    private AuthorizedTimeLockResource(TimeLockResource timeLockResource, AuthManager authManager) {
+        this.timeLockResource = timeLockResource;
+        this.authManager = authManager;
+    }
+
+    public static AuthorizedTimeLockResource create(TimeLockResource timeLockResource, AuthManager authManager) {
+        return new AuthorizedTimeLockResource(timeLockResource, authManager);
+    }
+
+    @Path("/{namespace: [a-zA-Z0-9_-]+}")
+    public TimeLockResource getTimeLockResource(
+            @Safe @PathParam("namespace") TimelockNamespace namespace,
+            @HeaderParam("client-id") ClientId clientId,
+            @HeaderParam("password") Password password) {
+        authManager.checkAuthorized(clientId, password, namespace);
+        return timeLockResource;
+    }
+
+    public int getNumberOfActiveClients() {
+        return timeLockResource.getNumberOfActiveClients();
+    }
+
+    public int getMaxNumberOfClients() {
+        return timeLockResource.getMaxNumberOfClients();
+    }
+}

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/auth/api/ClientId.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/auth/api/ClientId.java
@@ -27,6 +27,10 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 public interface ClientId {
     String get();
 
+    static ClientId valueOf(String value) {
+        return of(value);
+    }
+
     static ClientId of(String value) {
         return ImmutableClientId.builder()
                 .get(value)

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/auth/api/Password.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/auth/api/Password.java
@@ -22,6 +22,10 @@ import org.immutables.value.Value;
 public interface Password {
     String value();
 
+    static Password valueOf(String value) {
+        return of(value);
+    }
+
     static Password of(String value) {
         return ImmutablePassword.builder()
                 .value(value)


### PR DESCRIPTION
**Goals (and why)**:
Use AuthManager before calling TimelockResource to authorize requests.

**Implementation Description (bullets)**:
Having one more layer on top of `TimelockResource` that is responsible only for auth.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Will be adding the integration tests after implementing client side changes.

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
