### PR TITLE
Reduce TS default pause

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/config/TargetedSweepRuntimeConfig.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/config/TargetedSweepRuntimeConfig.java
@@ -53,7 +53,7 @@ public abstract class TargetedSweepRuntimeConfig {
 
     @Value.Default
     public long pauseMillis() {
-        return 500L;
+        return 5L;
     }
 
     public static TargetedSweepRuntimeConfig defaultTargetedSweepRuntimeConfig() {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/config/TargetedSweepRuntimeConfig.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/config/TargetedSweepRuntimeConfig.java
@@ -53,7 +53,7 @@ public abstract class TargetedSweepRuntimeConfig {
 
     @Value.Default
     public long pauseMillis() {
-        return 5L;
+        return 50L;
     }
 
     public static TargetedSweepRuntimeConfig defaultTargetedSweepRuntimeConfig() {

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,10 @@ develop
     *    - Type
          - Change
 
+    *    - |improved|
+         - The default value for the length of pause between targeted sweep iterations, ``pauseMillis``, has been reduced to 5ms.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/4067>`__)
+
     *    - |fixed|
          - Fixed a bug causing connection leaks to timelock.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/4052>`__)

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -51,7 +51,7 @@ develop
          - Change
 
     *    - |improved|
-         - The default value for the length of pause between targeted sweep iterations, ``pauseMillis``, has been reduced to 5ms.
+         - The default value for the length of pause between targeted sweep iterations, ``pauseMillis``, has been reduced to 50ms.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/4067>`__)
 
     *    - |fixed|


### PR DESCRIPTION
**Goals (and why)**:
To deal with very sparse rows in sweepable cells
