### PR TITLE
[_transactions2] Part 50: Clarity for DbKVS and JDBC users

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -120,6 +120,7 @@ import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager;
 import com.palantir.atlasdb.transaction.impl.SweepStrategyManager;
 import com.palantir.atlasdb.transaction.impl.SweepStrategyManagers;
 import com.palantir.atlasdb.transaction.impl.TimelockTimestampServiceAdapter;
+import com.palantir.atlasdb.transaction.impl.TransactionConstants;
 import com.palantir.atlasdb.transaction.impl.consistency.ImmutableTimestampCorroborationConsistencyCheck;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.transaction.service.TransactionServices;
@@ -505,8 +506,10 @@ public abstract class TransactionManagers {
             return Optional.of(initializeTransactionSchemaInstaller(
                     closeables, runtimeConfigSupplier, transactionSchemaManager));
         }
-        runtimeConfigSupplier.get().internalSchema().targetTransactionsSchemaVersion().ifPresent(version ->
-                log.warn("This service seems like it has been configured to use transaction schema version {},"
+        runtimeConfigSupplier.get().internalSchema().targetTransactionsSchemaVersion()
+                .filter(version -> version != TransactionConstants.DIRECT_ENCODING_TRANSACTIONS_SCHEMA_VERSION)
+                .ifPresent(version ->
+                        log.warn("This service seems like it has been configured to use transaction schema version {},"
                                 + " which isn't supported as your KVS doesn't support details on CAS failures"
                                 + " (typically Postgres or Oracle). We will remain with transactions1.",
                         SafeArg.of("configuredTransactionSchemaVersion", version)));

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -489,7 +489,7 @@ public abstract class TransactionManagers {
                 TransactionService.class,
                 TransactionServices.createTransactionService(keyValueService, transactionSchemaManager)),
                 closeables);
-        Optional<TransactionSchemaInstaller> schemaInstaller = getTransactionSchemaInstaller(
+        Optional<TransactionSchemaInstaller> schemaInstaller = getTransactionSchemaInstallerIfSupported(
                 closeables, keyValueService, runtimeConfigSupplier, transactionSchemaManager);
         return ImmutableTransactionComponents.builder()
                 .transactionService(transactionService)
@@ -497,7 +497,7 @@ public abstract class TransactionManagers {
                 .build();
     }
 
-    private Optional<TransactionSchemaInstaller> getTransactionSchemaInstaller(
+    private Optional<TransactionSchemaInstaller> getTransactionSchemaInstallerIfSupported(
             @Output List<AutoCloseable> closeables,
             KeyValueService keyValueService,
             Supplier<AtlasDbRuntimeConfig> runtimeConfigSupplier,

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -62,7 +62,7 @@ develop
          - If using DbKVS or JDBC KVS, we no longer spin up a background thread attempting to install new transaction schema versions.
            Furthermore, we now log at WARN if configuration indicates that a new schema version should be installed in these cases where it won't be respected.
            Previously, we would always read to and write from transactions1, even though the installer might actually have installed a non-1 schema version (and logged that this happened!).
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/qqqq>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/4070>`__)
 
     *    - |improved|
          - Changed the default values in ``PaxosRuntimeConfiguration`` as (`#3943 <https://github.com/palantir/atlasdb/pull/3943>`__) changed it on test configs only.

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -59,6 +59,12 @@ develop
            (`Pull Request <https://github.com/palantir/atlasdb/pull/4052>`__)
 
     *    - |improved|
+         - If using DbKVS or JDBC KVS, we no longer spin up a background thread attempting to install new transaction schema versions.
+           Furthermore, we now log at WARN if configuration indicates that a new schema version should be installed in these cases where it won't be respected.
+           Previously, we would always read to and write from transactions1, even though the installer might actually have installed a non-1 schema version (and logged that this happened!).
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/qqqq>`__)
+
+    *    - |improved|
          - Changed the default values in ``PaxosRuntimeConfiguration`` as (`#3943 <https://github.com/palantir/atlasdb/pull/3943>`__) changed it on test configs only.
            ``leader-ping-response-wait-in-ms`` was reduced to 2000 ms from 5000 ms.
            ``maximum-wait-before-proposal-in-ms`` was reduced to 300 ms from 1000 ms.


### PR DESCRIPTION
**Goals (and why)**:
There is an irregularity in the past which could have happened if users of KVSes other than memory and Cassandra attempted to install transaction schema versions V > 1. Specifically, the TransactionSchemaManager would still attempt to install V, and this could happen fine. Thus you could get a log message along the lines of `We attempted to install the transactions schema version 2, and this was successful. This version will take effect no later than timestamp 31415926535.`, which is incredibly misleading as the actual TransactionService used always only references transactions1. 

Also the old behaviour can lead to **SEVERE DATA CORRUPTION**™️ if we end up subsequently releasing a version of DbKVS that _does_ support transactions2, as in #3869, since everything has actually been written at version 1 despite whatever the coordination service says is correct.

**Implementation Description (bullets)**:
- Don't start the background thread that attempts to install new schema versions if we're using a KVS that doesn't support.
- Log at WARN if, on startup, the runtime config has a non-1 value and you're using a non-"has details of failures" KVS, saying that this is a weird configuration and is not allowed.

**Testing (What was existing testing like?  What have you done to improve it?)**:
This was pretty awkward to test. ETEs should verify that we're still able to operate normally.

**Concerns (what feedback would you like?)**: Nothing in particular.

**Where should we start reviewing?**: TransactionManagers.java

**Priority (whenever / two weeks / yesterday)**: ASAP - will be good before @h-korus's team's work on enabling transactions2 kicks off
