### PR TITLE
[Timelock Partitioning] Part 5: Batching Paxos Acceptor

### DIFF
--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AcceptCoalescingFunction.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AcceptCoalescingFunction.java
@@ -1,0 +1,58 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.SetMultimap;
+import com.palantir.atlasdb.autobatch.CoalescingRequestFunction;
+import com.palantir.common.streams.KeyedStream;
+import com.palantir.paxos.BooleanPaxosResponse;
+import com.palantir.paxos.PaxosProposal;
+
+final class AcceptCoalescingFunction implements
+        CoalescingRequestFunction<Map.Entry<Client, PaxosProposal>, BooleanPaxosResponse> {
+
+    private final BatchPaxosAcceptor delegate;
+
+    AcceptCoalescingFunction(BatchPaxosAcceptor delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public BooleanPaxosResponse defaultValue() {
+        return new BooleanPaxosResponse(false);
+    }
+
+    @Override
+    public Map<Map.Entry<Client, PaxosProposal>, BooleanPaxosResponse> apply(
+            Set<Map.Entry<Client, PaxosProposal>> request) {
+        SetMultimap<Client, PaxosProposal> requests = ImmutableSetMultimap.copyOf(request);
+        Map<WithSeq<Client>, BooleanPaxosResponse> results = KeyedStream.stream(delegate.accept(requests))
+                .mapKeys((client, booleanResponseWithSeq) -> WithSeq.of(booleanResponseWithSeq.seq(), client))
+                .map(WithSeq::value)
+                .collectToMap();
+
+        return KeyedStream.of(request)
+                .map(clientAndProposal -> results.get(
+                        WithSeq.of(clientAndProposal.getValue().getValue().getRound(), clientAndProposal.getKey())))
+                .collectToMap();
+    }
+
+}

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AutobatcherExecutionExceptions.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AutobatcherExecutionExceptions.java
@@ -1,0 +1,37 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import java.util.concurrent.ExecutionException;
+
+class AutobatcherExecutionExceptions {
+
+    private AutobatcherExecutionExceptions() { }
+
+    static RuntimeException handleAutobatcherExceptions(Exception e) {
+        if (e instanceof ExecutionException) {
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            }
+            throw new RuntimeException(cause);
+        } else {
+            // handle interrupted
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosAcceptor.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosAcceptor.java
@@ -71,7 +71,7 @@ public interface BatchPaxosAcceptor {
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     SetMultimap<Client, WithSeq<BooleanPaxosResponse>> accept(
-            SetMultimap<Client, WithSeq<PaxosProposal>> proposalRequestsByClientAndSeq);
+            SetMultimap<Client, PaxosProposal> proposalRequestsByClientAndSeq);
 
     /**
      * Returns all latest sequences prepared or accepted for the provided {@link Client}s and the next cache key to use

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosAcceptorFactory.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosAcceptorFactory.java
@@ -89,15 +89,8 @@ public class BatchingPaxosAcceptorFactory {
         public PaxosResponses<PaxosPromise> prepare(long seq, PaxosProposalId proposalId) {
             try {
                 return prepare.apply(Maps.immutableEntry(client, WithSeq.of(seq, proposalId))).get();
-            } catch (ExecutionException e) {
-                Throwable cause = e.getCause();
-                if (cause instanceof RuntimeException) {
-                    throw (RuntimeException) cause;
-                }
-                throw new RuntimeException(cause);
-            } catch (InterruptedException e) {
-                // TODO(fdesouza): handle
-                throw new RuntimeException(e);
+            } catch (ExecutionException | InterruptedException e) {
+                throw AutobatcherExecutionExceptions.handleAutobatcherExceptions(e);
             }
         }
 
@@ -106,15 +99,8 @@ public class BatchingPaxosAcceptorFactory {
             Preconditions.checkArgument(seq == proposal.getValue().getRound(), "seq does not match round in paxos value inside proposal");
             try {
                 return accept.apply(Maps.immutableEntry(client, proposal)).get();
-            } catch (ExecutionException e) {
-                Throwable cause = e.getCause();
-                if (cause instanceof RuntimeException) {
-                    throw (RuntimeException) cause;
-                }
-                throw new RuntimeException(cause);
-            } catch (InterruptedException e) {
-                // TODO(fdesouza): handle
-                throw new RuntimeException(e);
+            } catch (ExecutionException | InterruptedException e) {
+                throw AutobatcherExecutionExceptions.handleAutobatcherExceptions(e);
             }
         }
 
@@ -122,15 +108,8 @@ public class BatchingPaxosAcceptorFactory {
         public PaxosResponses<PaxosLong> getLatestSequencePreparedOrAccepted() {
             try {
                 return latestSequence.apply(client).get();
-            } catch (ExecutionException e) {
-                Throwable cause = e.getCause();
-                if (cause instanceof RuntimeException) {
-                    throw (RuntimeException) cause;
-                }
-                throw new RuntimeException(cause);
-            } catch (InterruptedException e) {
-                // TODO(fdesouza): handle
-                throw new RuntimeException(e);
+            } catch (ExecutionException | InterruptedException e) {
+                throw AutobatcherExecutionExceptions.handleAutobatcherExceptions(e);
             }
         }
     }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosAcceptorFactory.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosAcceptorFactory.java
@@ -1,0 +1,127 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import com.google.common.collect.Maps;
+import com.palantir.atlasdb.autobatch.Autobatchers;
+import com.palantir.atlasdb.autobatch.DisruptorAutobatcher;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.paxos.BooleanPaxosResponse;
+import com.palantir.paxos.PaxosAcceptor;
+import com.palantir.paxos.PaxosPromise;
+import com.palantir.paxos.PaxosProposal;
+import com.palantir.paxos.PaxosProposalId;
+
+public class BatchingPaxosAcceptorFactory {
+
+    private final DisruptorAutobatcher<Map.Entry<Client, WithSeq<PaxosProposalId>>, PaxosPromise> prepareAutobatcher;
+    private final DisruptorAutobatcher<Map.Entry<Client, PaxosProposal>, BooleanPaxosResponse> acceptAutobatcher;
+    private final DisruptorAutobatcher<Client, Long> latestSequenceAutobatcher;
+
+    private BatchingPaxosAcceptorFactory(
+            DisruptorAutobatcher<Map.Entry<Client, WithSeq<PaxosProposalId>>, PaxosPromise> prepareAutobatcher,
+            DisruptorAutobatcher<Map.Entry<Client, PaxosProposal>, BooleanPaxosResponse> acceptAutobatcher,
+            DisruptorAutobatcher<Client, Long> latestSequenceAutobatcher) {
+        this.prepareAutobatcher = prepareAutobatcher;
+        this.acceptAutobatcher = acceptAutobatcher;
+        this.latestSequenceAutobatcher = latestSequenceAutobatcher;
+    }
+
+    public BatchingPaxosAcceptorFactory create(BatchPaxosAcceptor batchPaxosAcceptor) {
+        DisruptorAutobatcher<Map.Entry<Client, WithSeq<PaxosProposalId>>, PaxosPromise> prepareAutobatcher =
+                Autobatchers.coalescing(new PrepareCoalescingFunction(batchPaxosAcceptor))
+                        .safeLoggablePurpose("batch-paxos-acceptor-prepare")
+                        .build();
+
+        DisruptorAutobatcher<Map.Entry<Client, PaxosProposal>, BooleanPaxosResponse> acceptAutobatcher =
+                Autobatchers.coalescing(new AcceptCoalescingFunction(batchPaxosAcceptor))
+                .safeLoggablePurpose("batch-paxos-acceptor-accept")
+                .build();
+
+        DisruptorAutobatcher<Client, Long> latestSequenceAutobatcher =
+                Autobatchers.coalescing(new BatchingPaxosLatestSequenceCache(batchPaxosAcceptor))
+                .safeLoggablePurpose("batch-paxos-acceptor-latest-sequence-cache")
+                .build();
+
+        return new BatchingPaxosAcceptorFactory(prepareAutobatcher, acceptAutobatcher, latestSequenceAutobatcher);
+    }
+
+    public PaxosAcceptor paxosAcceptorForClient(Client client) {
+        return new BatchingPaxosAcceptor(client);
+    }
+
+    private final class BatchingPaxosAcceptor implements PaxosAcceptor {
+
+        private final Client client;
+
+        private BatchingPaxosAcceptor(Client client) {
+            this.client = client;
+        }
+
+        @Override
+        public PaxosPromise prepare(long seq, PaxosProposalId pid) {
+            try {
+                return prepareAutobatcher.apply(Maps.immutableEntry(client, WithSeq.of(seq, pid))).get();
+            } catch (ExecutionException e) {
+                Throwable cause = e.getCause();
+                if (cause instanceof RuntimeException) {
+                    throw (RuntimeException) cause;
+                }
+                throw new RuntimeException(cause);
+            } catch (InterruptedException e) {
+                // TODO(fdesouza): handle
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public BooleanPaxosResponse accept(long seq, PaxosProposal proposal) {
+            Preconditions.checkArgument(seq == proposal.getValue().getRound(), "seq does not match round in paxos value inside proposal");
+            try {
+                return acceptAutobatcher.apply(Maps.immutableEntry(client, proposal)).get();
+            } catch (ExecutionException e) {
+                Throwable cause = e.getCause();
+                if (cause instanceof RuntimeException) {
+                    throw (RuntimeException) cause;
+                }
+                throw new RuntimeException(cause);
+            } catch (InterruptedException e) {
+                // TODO(fdesouza): handle
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public long getLatestSequencePreparedOrAccepted() {
+            try {
+                return latestSequenceAutobatcher.apply(client).get();
+            } catch (ExecutionException e) {
+                Throwable cause = e.getCause();
+                if (cause instanceof RuntimeException) {
+                    throw (RuntimeException) cause;
+                }
+                throw new RuntimeException(cause);
+            } catch (InterruptedException e) {
+                // TODO(fdesouza): handle
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosLatestSequenceCache.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosLatestSequenceCache.java
@@ -95,7 +95,7 @@ final class BatchingPaxosLatestSequenceCache implements CoalescingRequestFunctio
     }
 
     private void processDigest(AcceptorCacheDigest digest) {
-        cacheKey = AcceptorCacheKey.of(digest.newCacheKey());
+        cacheKey = digest.newCacheKey();
         Map<Client, PaxosLong> asPaxosLong = KeyedStream.stream(digest.updates())
                 .map(PaxosLong::of)
                 .collectToMap();

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosLatestSequenceCache.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosLatestSequenceCache.java
@@ -1,0 +1,99 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.palantir.atlasdb.autobatch.CoalescingRequestFunction;
+import com.palantir.conjure.java.api.errors.RemoteException;
+
+@NotThreadSafe
+final class BatchingPaxosLatestSequenceCache implements CoalescingRequestFunction<Client, Long> {
+
+    @VisibleForTesting
+    static final String ERROR_NAME = "TimelockPartitioning:InvalidCacheKey";
+
+    private static final Logger log = LoggerFactory.getLogger(BatchingPaxosLatestSequenceCache.class);
+
+    @Nullable
+    private AcceptorCacheKey cacheKey = null;
+    private Map<Client, Long> cachedEntries = Maps.newHashMap();
+    private BatchPaxosAcceptor delegate;
+
+    BatchingPaxosLatestSequenceCache(BatchPaxosAcceptor delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Long defaultValue() {
+        return BatchPaxosAcceptor.NO_LOG_ENTRY;
+    }
+
+    @Override
+    public Map<Client, Long> apply(Set<Client> clients) {
+        try {
+            return unsafeGetLatest(clients);
+        } catch (RemoteException e) {
+            if (e.getError().errorName().equals(ERROR_NAME)) {
+                log.info("Cache key is invalid, invalidating cache");
+                cacheKey = null;
+                Set<Client> allClients = ImmutableSet.<Client>builder()
+                        .addAll(clients)
+                        .addAll(cachedEntries.keySet())
+                        .build();
+                cachedEntries.clear();
+                return unsafeGetLatest(allClients);
+            }
+
+            throw e;
+        }
+    }
+
+    private Map<Client, Long> unsafeGetLatest(Set<Client> clients) {
+        if (cacheKey == null) {
+            processDigest(delegate.latestSequencesPreparedOrAccepted(Optional.empty(), clients));
+            return Collections.unmodifiableMap(cachedEntries); // do we want a copy here? :S
+        }
+
+        Set<Client> newClients = Sets.difference(clients, cachedEntries.keySet());
+        if (newClients.isEmpty()) {
+            delegate.latestSequencesPreparedOrAcceptedCached(cacheKey).ifPresent(this::processDigest);
+            return Collections.unmodifiableMap(cachedEntries);
+        } else {
+            processDigest(delegate.latestSequencesPreparedOrAccepted(Optional.of(cacheKey), newClients));
+            return Collections.unmodifiableMap(cachedEntries);
+        }
+    }
+
+    private void processDigest(AcceptorCacheDigest digest) {
+        cacheKey = AcceptorCacheKey.of(digest.newCacheKey());
+        cachedEntries.putAll(digest.updates());
+    }
+}

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PrepareCoalescingFunction.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PrepareCoalescingFunction.java
@@ -1,0 +1,55 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.Maps;
+import com.google.common.collect.SetMultimap;
+import com.palantir.atlasdb.autobatch.CoalescingRequestFunction;
+import com.palantir.common.streams.KeyedStream;
+import com.palantir.paxos.PaxosPromise;
+import com.palantir.paxos.PaxosProposalId;
+
+final class PrepareCoalescingFunction implements
+        CoalescingRequestFunction<Map.Entry<Client, WithSeq<PaxosProposalId>>, PaxosPromise> {
+
+    private final BatchPaxosAcceptor delegate;
+
+    PrepareCoalescingFunction(BatchPaxosAcceptor delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public PaxosPromise defaultValue() {
+        throw new AssertionError("no default value");
+    }
+
+    @Override
+    public Map<Map.Entry<Client, WithSeq<PaxosProposalId>>, PaxosPromise> apply(
+            Set<Map.Entry<Client, WithSeq<PaxosProposalId>>> request) {
+        SetMultimap<Client, WithSeq<PaxosProposalId>> requests = ImmutableSetMultimap.copyOf(request);
+
+        return KeyedStream.stream(delegate.prepare(requests))
+                .mapKeys((client, paxosPromiseWithSeq) -> Maps.immutableEntry(client,
+                        WithSeq.of(paxosPromiseWithSeq.seq(), paxosPromiseWithSeq.value().getPromisedId())))
+                .map(WithSeq::value)
+                .collectToMap();
+    }
+}

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/AcceptCoalescingFunctionTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/AcceptCoalescingFunctionTests.java
@@ -1,0 +1,94 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.SetMultimap;
+import com.palantir.paxos.BooleanPaxosResponse;
+import com.palantir.paxos.PaxosProposal;
+import com.palantir.paxos.PaxosProposalId;
+import com.palantir.paxos.PaxosValue;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AcceptCoalescingFunctionTests {
+
+    private static final Client CLIENT_1 = Client.of("client-1");
+    private static final Client CLIENT_2 = Client.of("client-2");
+    private static final BooleanPaxosResponse SUCCESS = new BooleanPaxosResponse(true);
+    private static final BooleanPaxosResponse FAILURE = new BooleanPaxosResponse(false);
+
+    @Mock
+    private BatchPaxosAcceptor remote;
+
+    @Test
+    public void canProcessBatch() {
+        PaxosProposal client1seq1Proposal = proposal(1);
+        PaxosProposal client1seq2Proposal = proposal(2);
+        PaxosProposal client2seq1Proposal = proposal(1);
+
+        SetMultimap<Client, PaxosProposal> requests = ImmutableSetMultimap.<Client, PaxosProposal>builder()
+                .put(CLIENT_1, client1seq1Proposal)
+                .put(CLIENT_1, client1seq2Proposal)
+                .put(CLIENT_2, client2seq1Proposal)
+                .build();
+
+        SetMultimap<Client, WithSeq<BooleanPaxosResponse>> remoteResponse =
+                ImmutableSetMultimap.<Client, WithSeq<BooleanPaxosResponse>>builder()
+                        .put(CLIENT_1, success(client1seq1Proposal))
+                        .put(CLIENT_1, failure(client1seq2Proposal))
+                        .put(CLIENT_2, success(client2seq1Proposal))
+                        .build();
+
+
+        when(remote.accept(requests)).thenReturn(remoteResponse);
+
+        AcceptCoalescingFunction function = new AcceptCoalescingFunction(remote);
+        Map<Map.Entry<Client, PaxosProposal>, BooleanPaxosResponse> result = function.apply(requests.entries());
+
+        assertThat(result)
+                .containsEntry(entry(CLIENT_1, client1seq1Proposal), success(client1seq1Proposal).value())
+                .containsEntry(entry(CLIENT_1, client1seq2Proposal), failure(client1seq2Proposal).value())
+                .containsEntry(entry(CLIENT_2, client2seq1Proposal), success(client2seq1Proposal).value());
+    }
+
+    private static PaxosProposal proposal(long round) {
+        PaxosProposalId proposalId = new PaxosProposalId(new Random().nextLong(), UUID.randomUUID().toString());
+        PaxosValue value = new PaxosValue(UUID.randomUUID().toString(), round, null);
+        return new PaxosProposal(proposalId, value);
+    }
+
+    private static WithSeq<BooleanPaxosResponse> success(PaxosProposal proposal) {
+        return WithSeq.of(proposal.getValue().getRound(), SUCCESS);
+    }
+
+    private static WithSeq<BooleanPaxosResponse> failure(PaxosProposal proposal) {
+        return WithSeq.of(proposal.getValue().getRound(), FAILURE);
+    }
+}

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosAcceptorResourceTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosAcceptorResourceTests.java
@@ -96,8 +96,8 @@ public class BatchPaxosAcceptorResourceTests {
 
     @Test
     public void weProxyAcceptRequests() {
-        PaxosProposal proposal1 = proposal(PROPOSAL_ID_1);
-        PaxosProposal proposal2 = proposal(PROPOSAL_ID_2);
+        PaxosProposal proposal1 = proposal(PROPOSAL_ID_1, 1);
+        PaxosProposal proposal2 = proposal(PROPOSAL_ID_2, 2);
 
         when(components.acceptor(CLIENT_1).accept(1, proposal1)).thenReturn(success());
         when(components.acceptor(CLIENT_2).accept(1, proposal1)).thenReturn(success());
@@ -106,11 +106,11 @@ public class BatchPaxosAcceptorResourceTests {
         when(components.acceptor(CLIENT_1).getLatestSequencePreparedOrAccepted()).thenReturn(1L);
         when(components.acceptor(CLIENT_2).getLatestSequencePreparedOrAccepted()).thenReturn(2L);
 
-        SetMultimap<Client, WithSeq<PaxosProposal>> request = ImmutableSetMultimap
-                .<Client, WithSeq<PaxosProposal>>builder()
-                .put(CLIENT_1, WithSeq.of(1, proposal1))
-                .put(CLIENT_2, WithSeq.of(1, proposal1))
-                .put(CLIENT_2, WithSeq.of(2, proposal2))
+        SetMultimap<Client, PaxosProposal> request = ImmutableSetMultimap
+                .<Client, PaxosProposal>builder()
+                .put(CLIENT_1, proposal1)
+                .put(CLIENT_2, proposal1)
+                .put(CLIENT_2, proposal2)
                 .build();
 
         SetMultimap<Client, WithSeq<BooleanPaxosResponse>> expected = ImmutableSetMultimap
@@ -208,12 +208,12 @@ public class BatchPaxosAcceptorResourceTests {
         return new BooleanPaxosResponse(true);
     }
 
-    private static PaxosProposal proposal(PaxosProposalId proposalId) {
-        return new PaxosProposal(proposalId, paxosValue());
+    private static PaxosProposal proposal(PaxosProposalId proposalId, long seq) {
+        return new PaxosProposal(proposalId, paxosValue(seq));
     }
 
-    private static PaxosValue paxosValue() {
-        return new PaxosValue(UUID.randomUUID().toString(), new Random().nextLong(), null);
+    private static PaxosValue paxosValue(long seq) {
+        return new PaxosValue(UUID.randomUUID().toString(), seq, null);
     }
 
     private static AcceptorCacheDigest digest() {

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosLatestSequenceCacheTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosLatestSequenceCacheTests.java
@@ -1,0 +1,168 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.palantir.conjure.java.api.errors.ErrorType;
+import com.palantir.conjure.java.api.errors.RemoteException;
+import com.palantir.conjure.java.api.errors.SerializableError;
+import com.palantir.conjure.java.api.errors.ServiceException;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BatchingPaxosLatestSequenceCacheTests {
+
+    private static final Client CLIENT_1 = Client.of("client-1");
+    private static final Client CLIENT_2 = Client.of("client-2");
+    private static final Client CLIENT_3 = Client.of("client-3");
+    private static final Map<Client, Long> INITIAL_UPDATES = ImmutableMap.<Client, Long>builder()
+            .put(CLIENT_1, 5L)
+            .put(CLIENT_2, 10L)
+            .put(CLIENT_3, 15L)
+            .build();
+
+    @Mock
+    private BatchPaxosAcceptor remote;
+
+    @Test
+    public void withoutCacheKeyWeGetEverything() {
+        AcceptorCacheDigest digest = ImmutableAcceptorCacheDigest.builder()
+                .newCacheKey(UUID.randomUUID())
+                .putUpdates(CLIENT_1, 5)
+                .putUpdates(CLIENT_2, 10)
+                .build();
+
+        when(remote.latestSequencesPreparedOrAccepted(Optional.empty(), ImmutableSet.of(CLIENT_1, CLIENT_2)))
+                .thenReturn(digest);
+
+        BatchingPaxosLatestSequenceCache cache = new BatchingPaxosLatestSequenceCache(remote);
+        Map<Client, Long> result = cache.apply(ImmutableSet.of(CLIENT_1, CLIENT_2));
+
+        assertThat(result).containsOnly(
+                entry(CLIENT_1, 5L),
+                entry(CLIENT_2, 10L));
+    }
+
+    @Test
+    public void returnsSameResultIfCached() {
+        BatchingPaxosLatestSequenceCache cache = initialCache();
+        when(remote.latestSequencesPreparedOrAcceptedCached(any(AcceptorCacheKey.class)))
+                .thenReturn(Optional.empty());
+
+        assertThat(cache.apply(ImmutableSet.of(CLIENT_1)))
+                .containsEntry(CLIENT_1, INITIAL_UPDATES.get(CLIENT_1));
+
+    }
+
+    @Test
+    public void ifThereAreUpdatesWithCacheKeyWeAddToOurCache() {
+        BatchingPaxosLatestSequenceCache cache = initialCache();
+        AcceptorCacheDigest digest = digestWithUpdates(entry(CLIENT_3, 50L));
+
+        when(remote.latestSequencesPreparedOrAcceptedCached(any(AcceptorCacheKey.class)))
+                .thenReturn(Optional.of(digest));
+
+        assertThat(cache.apply(ImmutableSet.of(CLIENT_2, CLIENT_3)))
+                .containsEntry(CLIENT_2, INITIAL_UPDATES.get(CLIENT_2))
+                .containsEntry(CLIENT_3, 50L)
+                .doesNotContainEntry(CLIENT_3, INITIAL_UPDATES.get(CLIENT_3));
+    }
+
+    @Test
+    public void ifThereAreUpdatesWithCacheKeyWeAddToOurCache_unseenClient() {
+        BatchingPaxosLatestSequenceCache cache = initialCache();
+        Client client4 = Client.of("client-4");
+        AcceptorCacheDigest digest = digestWithUpdates(entry(client4, 150L));
+
+        when(remote.latestSequencesPreparedOrAccepted(any(Optional.class), eq(ImmutableSet.of(client4))))
+                .thenReturn(digest);
+
+        assertThat(cache.apply(ImmutableSet.of(CLIENT_3, client4)))
+                .containsEntry(CLIENT_3, INITIAL_UPDATES.get(CLIENT_3))
+                .containsEntry(client4, 150L);
+    }
+
+    @Test
+    public void invalidCacheKeyRequestsEverything() {
+        BatchingPaxosLatestSequenceCache cache = initialCache();
+
+        when(remote.latestSequencesPreparedOrAcceptedCached(any(AcceptorCacheKey.class)))
+                .thenThrow(invalidCacheKeyException());
+
+        Map<Client, Long> newMap = ImmutableMap.<Client, Long>builder()
+                .put(CLIENT_1, 52L)
+                .put(CLIENT_2, 17L)
+                .put(CLIENT_3, 1123L)
+                .build();
+
+        AcceptorCacheDigest newDigest = ImmutableAcceptorCacheDigest.builder()
+                .newCacheKey(UUID.randomUUID())
+                .putAllUpdates(newMap)
+                .build();
+
+        doReturn(newDigest).when(remote)
+                .latestSequencesPreparedOrAccepted(Optional.empty(), ImmutableSet.of(CLIENT_1, CLIENT_2, CLIENT_3));
+
+        assertThat(cache.apply(ImmutableSet.of(CLIENT_1)).get(CLIENT_1))
+                .as("we should get 52 which results from calling the non cached version")
+                .isEqualTo(52);
+    }
+
+    private BatchingPaxosLatestSequenceCache initialCache() {
+        AcceptorCacheDigest digest = ImmutableAcceptorCacheDigest.builder()
+                .newCacheKey(UUID.randomUUID())
+                .putAllUpdates(INITIAL_UPDATES)
+                .build();
+
+        when(remote.latestSequencesPreparedOrAccepted(Optional.empty(), ImmutableSet.of(CLIENT_1, CLIENT_2, CLIENT_3)))
+                .thenReturn(digest);
+
+        BatchingPaxosLatestSequenceCache cache = new BatchingPaxosLatestSequenceCache(remote);
+        cache.apply(ImmutableSet.of(CLIENT_1, CLIENT_2, CLIENT_3));
+        return cache;
+    }
+
+    private static RemoteException invalidCacheKeyException() {
+        ServiceException serviceException = new ServiceException(
+                ErrorType.create(ErrorType.Code.NOT_FOUND, BatchingPaxosLatestSequenceCache.ERROR_NAME));
+
+        return new RemoteException(SerializableError.forException(serviceException), 404);
+    }
+
+    private static AcceptorCacheDigest digestWithUpdates(Map.Entry<Client, Long>... entries) {
+        return ImmutableAcceptorCacheDigest.builder()
+                .newCacheKey(UUID.randomUUID())
+                .updates(ImmutableMap.copyOf(ImmutableSet.copyOf(entries)))
+                .build();
+    }
+}

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosLatestSequenceCacheTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosLatestSequenceCacheTests.java
@@ -38,6 +38,7 @@ import com.palantir.conjure.java.api.errors.ErrorType;
 import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.SerializableError;
 import com.palantir.conjure.java.api.errors.ServiceException;
+import com.palantir.paxos.ImmutablePaxosLong;
 import com.palantir.paxos.PaxosLong;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -136,7 +137,7 @@ public class BatchingPaxosLatestSequenceCacheTests {
 
         assertThat(cache.apply(ImmutableSet.of(CLIENT_1)).get(CLIENT_1))
                 .as("we should get 52 which results from calling the non cached version")
-                .isEqualTo(52);
+                .isEqualTo(ImmutablePaxosLong.of(52));
     }
 
     private BatchingPaxosLatestSequenceCache initialCache() {

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PrepareCoalescingFunctionTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PrepareCoalescingFunctionTests.java
@@ -1,0 +1,90 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+import java.util.function.Function;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.SetMultimap;
+import com.palantir.paxos.PaxosPromise;
+import com.palantir.paxos.PaxosProposalId;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PrepareCoalescingFunctionTests {
+
+    private static final Client CLIENT_1 = Client.of("client-1");
+    private static final Client CLIENT_2 = Client.of("client-2");
+
+    @Mock
+    private BatchPaxosAcceptor remote;
+
+    @Test
+    public void canReturnBatch() {
+        WithSeq<PaxosProposalId> client1seq1Id = WithSeq.of(1, proposalId());
+        WithSeq<PaxosProposalId> client1seq2Id = WithSeq.of(2, proposalId());
+        WithSeq<PaxosProposalId> client2seq1Id = WithSeq.of(1, proposalId());
+
+        SetMultimap<Client, WithSeq<PaxosProposalId>> requests =
+                ImmutableSetMultimap.<Client, WithSeq<PaxosProposalId>>builder()
+                        .put(CLIENT_1, client1seq1Id)
+                        .put(CLIENT_1, client1seq2Id)
+                        .put(CLIENT_2, client2seq1Id)
+                        .build();
+
+        SetMultimap<Client, WithSeq<PaxosPromise>> remoteResponse =
+                ImmutableSetMultimap.<Client, WithSeq<PaxosPromise>>builder()
+                .put(CLIENT_1, promiseFor(client1seq1Id))
+                .put(CLIENT_1, promiseFor(client1seq2Id))
+                .put(CLIENT_2, promiseFor(client2seq1Id))
+                .build();
+
+
+        when(remote.prepare(requests)).thenReturn(remoteResponse);
+
+        PrepareCoalescingFunction function = new PrepareCoalescingFunction(remote);
+        Map<Map.Entry<Client, WithSeq<PaxosProposalId>>, PaxosPromise> result = function.apply(requests.entries());
+
+        assertThat(result)
+                .containsEntry(entry(CLIENT_1, client1seq1Id), promiseFor(client1seq1Id).value())
+                .containsEntry(entry(CLIENT_1, client1seq2Id), promiseFor(client1seq2Id).value())
+                .containsEntry(entry(CLIENT_2, client2seq1Id), promiseFor(client2seq1Id).value());
+    }
+
+    private static PaxosProposalId proposalId() {
+        return new PaxosProposalId(new Random().nextLong(), UUID.randomUUID().toString());
+    }
+
+    private static WithSeq<PaxosPromise> promiseFor(WithSeq<PaxosProposalId> proposalIdWithSeq) {
+        return map(proposalIdWithSeq, proposalId -> PaxosPromise.accept(proposalId, null, null));
+    }
+
+    private static <T, U> WithSeq<U> map(WithSeq<T> container, Function<T, U> mapper) {
+        return WithSeq.of(container.seq(), mapper.apply(container.value()));
+    }
+}


### PR DESCRIPTION
**Goals (and why)**:
This provides autobatcher implementations for each of the `BatchPaxosAcceptor` methods. This uses the autobatcher functions defined in #4069.

**Implementation Description (bullets)**:
* Follower side caching implementation 
* implementations for `prepare` and `accept`
* Tests covering the different cases

**Testing (What was existing testing like?  What have you done to improve it?)**:
Due to #4069, it's sufficient to just test that we get the right outputs from our batch function given our inputs. Tedious but simpler than dealing all the stuff with futures and partial consumers etc.

**Where should we start reviewing?**:
Review in two parts, commit by commit. Impl in first commit, tests in second commit.

**Priority (whenever / two weeks / yesterday)**:
ASAP 💃 
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
