### PR TITLE
[Timelock Partitioning] Part 6: Batch Pingable Leader API + Resource

### DIFF
--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPingableLeader.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPingableLeader.java
@@ -1,0 +1,59 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import java.util.Set;
+import java.util.UUID;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import com.palantir.leader.PingableLeader;
+
+@Path("/batch/leader")
+public interface BatchPingableLeader {
+
+    /**
+     * Batch counterpart to {@link PingableLeader#ping}. If this call returns, then the server is reachable.
+     * <p>
+     * For the given set of {@code clients}, the remote server returns the clients for which it thinks it is the leader
+     * for. Clients that the remote server is not the leader for will be excluded from the results.
+     *
+     * @param clients set of clients to check remote servers leadership on
+     * @return clients which the remote server believes to be the leader
+     */
+    @GET
+    @Path("ping")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    Set<Client> ping(Set<Client> clients);
+
+    /**
+     * Re-exported version of {@link PingableLeader#getUUID}. Returns the remote servers unique leadership identifier.
+     * This will be the same across all clients that the remote server it is currently aware of. It is therefore safe to
+     * coalesce ping calls to the same remote server for different clients.
+     *
+     * @return the remote servers unique leadership identifier
+     */
+    @GET
+    @Path("uuid")
+    @Produces(MediaType.APPLICATION_JSON)
+    UUID uuid();
+}

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPingableLeader.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPingableLeader.java
@@ -46,11 +46,11 @@ public interface BatchPingableLeader {
     Set<Client> ping(Set<Client> clients);
 
     /**
-     * Re-exported version of {@link PingableLeader#getUUID}. Returns the remote servers unique leadership identifier.
-     * This will be the same across all clients that the remote server it is currently aware of. It is therefore safe to
-     * coalesce ping calls to the same remote server for different clients.
+     * Re-exported version of {@link PingableLeader#getUUID}. Returns unique leadership identifier for the remote
+     * server. This can be reused across all clients because it still uniquely identifies a leader. Having a different
+     * leadership identifier per client is therefore wasteful.
      *
-     * @return the remote servers' unique leadership identifier
+     * @return the remote server's unique leadership identifier
      */
     @GET
     @Path("uuid")

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPingableLeader.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPingableLeader.java
@@ -37,7 +37,7 @@ public interface BatchPingableLeader {
      * for. Clients that the remote server is not the leader for will be excluded from the results.
      *
      * @param clients set of clients to check remote servers leadership on
-     * @return clients which the remote server believes to be the leader
+     * @return clients for which the remote server believes that it is the leader for
      */
     @GET
     @Path("ping")
@@ -50,7 +50,7 @@ public interface BatchPingableLeader {
      * This will be the same across all clients that the remote server it is currently aware of. It is therefore safe to
      * coalesce ping calls to the same remote server for different clients.
      *
-     * @return the remote servers unique leadership identifier
+     * @return the remote servers' unique leadership identifier
      */
     @GET
     @Path("uuid")

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPingableLeaderResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPingableLeaderResource.java
@@ -1,0 +1,57 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import com.palantir.common.streams.KeyedStream;
+import com.palantir.paxos.PaxosLearner;
+import com.palantir.paxos.PaxosValue;
+
+public class BatchPingableLeaderResource implements BatchPingableLeader {
+
+    private final UUID leadershipUuid;
+    private final PaxosComponents components;
+
+    public BatchPingableLeaderResource(UUID leadershipUuid, PaxosComponents components) {
+        this.leadershipUuid = leadershipUuid;
+        this.components = components;
+    }
+
+    @Override
+    public Set<Client> ping(Set<Client> clients) {
+        return KeyedStream.of(clients)
+                .map(components::learner)
+                .map(PaxosLearner::getGreatestLearnedValue)
+                .filter(Objects::nonNull)
+                .filter(this::isThisNodeTheLeaderFor)
+                .keys()
+                .collect(Collectors.toSet());
+    }
+
+    private boolean isThisNodeTheLeaderFor(PaxosValue value) {
+        return value.getLeaderUUID().equals(leadershipUuid.toString());
+    }
+
+    @Override
+    public UUID uuid() {
+        return leadershipUuid;
+    }
+}

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/BatchPingableLeaderResourceTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/BatchPingableLeaderResourceTests.java
@@ -1,0 +1,92 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.Random;
+import java.util.UUID;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.google.common.collect.ImmutableSet;
+import com.palantir.paxos.PaxosValue;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BatchPingableLeaderResourceTests {
+
+    private static final Client CLIENT_1 = Client.of("client1");
+    private static final Client CLIENT_2 = Client.of("client2");
+
+    private static final UUID LEADER_UUID = UUID.randomUUID();
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private PaxosComponents components;
+    private BatchPingableLeaderResource resource;
+
+    @Before
+    public void before() {
+        resource = new BatchPingableLeaderResource(LEADER_UUID, components);
+    }
+
+    @Test
+    public void pingReturnsTrueForLeaders() {
+        when(components.learner(CLIENT_1).getGreatestLearnedValue())
+                .thenReturn(paxosValue(LEADER_UUID));
+        when(components.learner(CLIENT_2).getGreatestLearnedValue())
+                .thenReturn(paxosValue(LEADER_UUID));
+
+        assertThat(resource.ping(ImmutableSet.of(CLIENT_1, CLIENT_2)))
+                .containsOnly(CLIENT_1, CLIENT_2);
+    }
+
+    @Test
+    public void pingFiltersOutNonLeaders() {
+        Client clientLedByAnotherServer = Client.of("client-led-by-another-server");
+
+        when(components.learner(CLIENT_1).getGreatestLearnedValue())
+                .thenReturn(paxosValue(LEADER_UUID));
+        when(components.learner(clientLedByAnotherServer).getGreatestLearnedValue())
+                .thenReturn(paxosValue(UUID.randomUUID()));
+
+        assertThat(resource.ping(ImmutableSet.of(CLIENT_1, clientLedByAnotherServer)))
+                .containsOnly(CLIENT_1);
+    }
+
+    @Test
+    public void filtersOutClientsWhereNothingHasBeenLearnt() {
+        Client clientWhereNothingHasBeenLearnt = Client.of("client-where-nothing-has-been-learnt");
+
+        when(components.learner(CLIENT_1).getGreatestLearnedValue())
+                .thenReturn(paxosValue(LEADER_UUID));
+        when(components.learner(clientWhereNothingHasBeenLearnt).getGreatestLearnedValue())
+                .thenReturn(null);
+
+        assertThat(resource.ping(ImmutableSet.of(CLIENT_1, clientWhereNothingHasBeenLearnt)))
+                .containsOnly(CLIENT_1);
+    }
+
+    private static PaxosValue paxosValue(UUID uuid) {
+        return new PaxosValue(uuid.toString(), new Random().nextLong(), null);
+    }
+}


### PR DESCRIPTION
**Goals (and why)**:
If we are to run `n` instances of paxos, then we need a way to be able to coalesce all the pings for each instance without necessarily increasing our request load by `n`.

This is in a similar vein to #4061 combined with #4065.

**Implementation Description (bullets)**:
Fairly trivial, just call through to the local knowledge (can get this through `PaxosComponents`, and then we're done!

**Concerns (what feedback would you like?)**:
* Duplicated the code from `PaxosLeaderElectionService` for ping. Wiring through a `PingableLeader` is somewhat complicated.

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:
ASAP 💃 
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
