### PR TITLE
[Timelock Partitioning] Part 7: Acceptor cache

### DIFF
--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AcceptorCacheDigest.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AcceptorCacheDigest.java
@@ -17,7 +17,6 @@
 package com.palantir.atlasdb.timelock.paxos;
 
 import java.util.Map;
-import java.util.UUID;
 
 import org.immutables.value.Value;
 
@@ -28,6 +27,6 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 @JsonDeserialize(as = ImmutableAcceptorCacheDigest.class)
 @JsonSerialize(as = ImmutableAcceptorCacheDigest.class)
 public interface AcceptorCacheDigest {
-    UUID newCacheKey();
+    AcceptorCacheKey newCacheKey();
     Map<Client, Long> updates();
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AcceptorCacheImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AcceptorCacheImpl.java
@@ -127,7 +127,8 @@ public class AcceptorCacheImpl implements AcceptorCache {
                 throw new InvalidAcceptorCacheKeyException(cacheKey);
             }
 
-            Map<Client, Long> diff = clientsByLatestTimestamp.asMap().tailMap(cacheKeyTimestamp).values().stream()
+            Map<Client, Long> diff = clientsByLatestTimestamp.asMap().tailMap(cacheKeyTimestamp, false).values()
+                    .stream()
                     .flatMap(Collection::stream)
                     .collect(Collectors.toMap(WithSeq::value, WithSeq::seq));
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AcceptorCacheImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AcceptorCacheImpl.java
@@ -1,0 +1,132 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Collectors;
+
+import javax.annotation.concurrent.GuardedBy;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.collect.Maps;
+import com.google.common.collect.TreeMultimap;
+import com.palantir.common.streams.KeyedStream;
+
+public class AcceptorCacheImpl implements AcceptorCache {
+
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+    private final Cache<AcceptorCacheKey, Long> cacheKeyToTime;
+    private final Map<Client, WithSeq<Long>> clientToTimeAndSeq = Maps.newHashMap();
+    private final TreeMultimap<Long, WithSeq<Client>> clientsByLastUpdate = TreeMultimap.create(
+            Comparator.naturalOrder(),
+            Comparator.comparing(clientWithSeq -> clientWithSeq.value().value(), Comparator.naturalOrder()));
+
+    @GuardedBy("lock")
+    private long currentTimestamp = 0;
+    @GuardedBy("lock")
+    private AcceptorCacheKey latestAcceptorCacheKey = AcceptorCacheKey.newCacheKey();
+
+    public AcceptorCacheImpl() {
+        Cache<AcceptorCacheKey, Long> cacheKeyToTime = Caffeine.newBuilder()
+                .expireAfterAccess(Duration.ofMinutes(10))
+                .build();
+        cacheKeyToTime.put(latestAcceptorCacheKey, currentTimestamp);
+        this.cacheKeyToTime = cacheKeyToTime;
+    }
+
+    @Override
+    public void updateSequenceNumbers(Set<WithSeq<Client>> clientsAndSeqs) {
+        lock.writeLock().lock();
+        try {
+            long nextTimestamp = currentTimestamp + 1;
+            AcceptorCacheKey nextCacheKey = AcceptorCacheKey.newCacheKey();
+            cacheKeyToTime.put(nextCacheKey, nextTimestamp);
+
+            clientsAndSeqs.forEach(clientAndSeq -> {
+                Client client = clientAndSeq.value();
+                long incomingSequenceNumber = clientAndSeq.seq();
+                WithSeq<Long> clientLastUpdate = clientToTimeAndSeq.get(client);
+
+                if (clientLastUpdate == null) {
+                    clientToTimeAndSeq.put(client, WithSeq.of(incomingSequenceNumber, nextTimestamp));
+                    clientsByLastUpdate.put(nextTimestamp, clientAndSeq);
+                } else if (incomingSequenceNumber > clientLastUpdate.seq()) {
+                    clientToTimeAndSeq.put(client, WithSeq.of(incomingSequenceNumber, nextTimestamp));
+                    clientsByLastUpdate.put(nextTimestamp, clientAndSeq);
+                    clientsByLastUpdate.remove(clientLastUpdate.value(), WithSeq.of(clientLastUpdate.seq(), client));
+                }
+            });
+
+            currentTimestamp = nextTimestamp;
+            latestAcceptorCacheKey = nextCacheKey;
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public AcceptorCacheDigest getAllUpdates() {
+        lock.readLock().lock();
+        try {
+            Map<Client, Long> clientsToLatest = KeyedStream.stream(clientToTimeAndSeq)
+                    .map(WithSeq::seq)
+                    .collectToMap();
+            return ImmutableAcceptorCacheDigest.builder()
+                    .newCacheKey(latestAcceptorCacheKey)
+                    .updates(clientsToLatest)
+                    .build();
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public Optional<AcceptorCacheDigest> updatesSinceCacheKey(AcceptorCacheKey cacheKey)
+            throws InvalidAcceptorCacheKeyException {
+        lock.readLock().lock();
+        try {
+            if (cacheKey.equals(latestAcceptorCacheKey)) {
+                return Optional.empty();
+            }
+
+            Long cacheTime = cacheKeyToTime.getIfPresent(cacheKey);
+            if (cacheTime == null) {
+                throw new InvalidAcceptorCacheKeyException(cacheKey);
+            }
+
+            Map<Client, Long> diff = clientsByLastUpdate.asMap().tailMap(cacheTime).values().stream()
+                    .flatMap(Collection::stream)
+                    .collect(Collectors.toMap(WithSeq::value, WithSeq::seq));
+
+            return Optional.of(ImmutableAcceptorCacheDigest.builder()
+                    .newCacheKey(latestAcceptorCacheKey)
+                    .updates(diff)
+                    .build());
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+}

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AcceptorCacheKey.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AcceptorCacheKey.java
@@ -37,4 +37,8 @@ public interface AcceptorCacheKey {
         return ImmutableAcceptorCacheKey.of(uuid);
     }
 
+    static AcceptorCacheKey newCacheKey() {
+        return of(UUID.randomUUID());
+    }
+
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AcceptorCacheKey.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AcceptorCacheKey.java
@@ -33,12 +33,8 @@ public interface AcceptorCacheKey {
     @Value.Parameter
     UUID value();
 
-    static AcceptorCacheKey of(UUID uuid) {
-        return ImmutableAcceptorCacheKey.of(uuid);
-    }
-
     static AcceptorCacheKey newCacheKey() {
-        return of(UUID.randomUUID());
+        return ImmutableAcceptorCacheKey.of(UUID.randomUUID());
     }
 
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosAcceptorResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosAcceptorResource.java
@@ -108,7 +108,7 @@ public class BatchPaxosAcceptorResource implements BatchPaxosAcceptor {
 
     private static AcceptorCacheDigest emptyDigest(AcceptorCacheKey cacheKey) {
         return ImmutableAcceptorCacheDigest.builder()
-                .newCacheKey(cacheKey.value())
+                .newCacheKey(cacheKey)
                 .build();
     }
 

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/AcceptorCacheImplTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/AcceptorCacheImplTests.java
@@ -1,0 +1,135 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+public class AcceptorCacheImplTests {
+
+    @Test
+    public void unseenCacheKeyThrows() {
+        AcceptorCache cache = cache(ImmutableMap.of());
+        AcceptorCacheKey cacheKey = AcceptorCacheKey.newCacheKey();
+
+        assertThatExceptionOfType(InvalidAcceptorCacheKeyException.class)
+                .as("we've not seen this cache key before, so we throw")
+                .isThrownBy(() -> cache.updatesSinceCacheKey(cacheKey));
+    }
+
+    @Test
+    public void cacheKeyWithNoUpdatesReturnsEmpty() throws InvalidAcceptorCacheKeyException {
+        Map<Client, Long> before = ImmutableMap.<Client, Long>builder()
+                .put(Client.of("client1"), 5L)
+                .put(Client.of("client2"), 6L)
+                .put(Client.of("client3"), 7L)
+                .build();
+        AcceptorCache cache = cache(before);
+
+        AcceptorCacheDigest digest = cache.getAllUpdates();
+
+        assertThat(digest)
+                .extracting(AcceptorCacheDigest::updates)
+                .as("get all the updates")
+                .isEqualTo(before);
+
+        AcceptorCacheKey newCacheKey = digest.newCacheKey();
+        assertThat(cache.updatesSinceCacheKey(newCacheKey))
+                .as("we have not added anything after we asked for updates initially")
+                .isEmpty();
+    }
+
+    @Test
+    public void returnsLatestCacheKeyForOldCacheKeys() throws InvalidAcceptorCacheKeyException {
+        AcceptorCache cache = cache(ImmutableMap.of());
+
+        AcceptorCacheKey newCacheKey = cache.getAllUpdates().newCacheKey();
+
+        cache.updateSequenceNumbers(ImmutableSet.of(WithSeq.of(20L, Client.of("client1"))));
+        AcceptorCacheKey newCacheKeyAfterFirstUpdate = cache.getAllUpdates().newCacheKey();
+
+        cache.updateSequenceNumbers(ImmutableSet.of(WithSeq.of(25L, Client.of("client4"))));
+        AcceptorCacheKey newCacheKeyAfterSecondUpdate = cache.getAllUpdates().newCacheKey();
+
+        assertThat(cache.updatesSinceCacheKey(newCacheKey))
+                .map(AcceptorCacheDigest::newCacheKey)
+                .as("asking with first cache key after two updates should return latest cache key")
+                .contains(newCacheKeyAfterSecondUpdate);
+
+        assertThat(cache.updatesSinceCacheKey(newCacheKeyAfterFirstUpdate))
+                .map(AcceptorCacheDigest::newCacheKey)
+                .as("asking with second cache key after one update should also return latest cache key")
+                .contains(newCacheKeyAfterSecondUpdate);
+
+        assertThat(cache.updatesSinceCacheKey(newCacheKeyAfterSecondUpdate))
+                .as("no updates past this cache key as this is the latest cache key, return empty")
+                .isEmpty();
+    }
+
+    @Test
+    public void updatesAreCoalesced() throws InvalidAcceptorCacheKeyException {
+        AcceptorCache cache = cache(ImmutableMap.of());
+
+        AcceptorCacheKey cacheKey = cache.getAllUpdates().newCacheKey();
+        cache.updateSequenceNumbers(ImmutableSet.of(WithSeq.of(20L, Client.of("client1"))));
+        cache.updateSequenceNumbers(ImmutableSet.of(WithSeq.of(25L, Client.of("client4"))));
+
+        Map<Client, Long> diffAfterFirstUpdate = ImmutableMap.<Client, Long>builder()
+                .put(Client.of("client1"), 20L)
+                .put(Client.of("client4"), 25L)
+                .build();
+
+        assertThat(cache.updatesSinceCacheKey(cacheKey))
+                .map(AcceptorCacheDigest::updates)
+                .as("we should see the two updates as normal")
+                .contains(diffAfterFirstUpdate);
+
+        cache.updateSequenceNumbers(ImmutableSet.of(
+                WithSeq.of(30L, Client.of("client4")),
+                WithSeq.of(50L, Client.of("client3"))));
+
+        Map<Client, Long> diffAfterSecondUpdate = ImmutableMap.<Client, Long>builder()
+                .put(Client.of("client1"), 20L)
+                .put(Client.of("client4"), 30L)
+                .put(Client.of("client3"), 50L)
+                .build();
+
+        assertThat(cache.updatesSinceCacheKey(cacheKey))
+                .map(AcceptorCacheDigest::updates)
+                .as("we should see the final value for client4=30 as opposed to the intermediate value")
+                .contains(diffAfterSecondUpdate);
+    }
+
+    private static AcceptorCache cache(Map<Client, Long> latestSequencesForClients) {
+        AcceptorCacheImpl acceptorCache = new AcceptorCacheImpl();
+
+        Set<WithSeq<Client>> clientsAndSeq = latestSequencesForClients.entrySet().stream()
+                .map(clientAndSeq -> WithSeq.of(clientAndSeq.getValue(), clientAndSeq.getKey()))
+                .collect(Collectors.toSet());
+        acceptorCache.updateSequenceNumbers(clientsAndSeq);
+        return acceptorCache;
+    }
+}

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosAcceptorResourceTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosAcceptorResourceTests.java
@@ -130,7 +130,7 @@ public class BatchPaxosAcceptorResourceTests {
 
     @Test
     public void throwsConjureRuntime404WhenCacheKeyIsNotFound() throws InvalidAcceptorCacheKeyException {
-        AcceptorCacheKey cacheKey = AcceptorCacheKey.of(UUID.randomUUID());
+        AcceptorCacheKey cacheKey = AcceptorCacheKey.newCacheKey();
         when(cache.updatesSinceCacheKey(cacheKey))
                 .thenThrow(new InvalidAcceptorCacheKeyException(cacheKey));
 
@@ -141,7 +141,7 @@ public class BatchPaxosAcceptorResourceTests {
 
     @Test
     public void cachedEndpointDelegatesToCache() throws InvalidAcceptorCacheKeyException {
-        AcceptorCacheKey cacheKey = AcceptorCacheKey.of(UUID.randomUUID());
+        AcceptorCacheKey cacheKey = AcceptorCacheKey.newCacheKey();
         AcceptorCacheDigest digest = digest();
         when(cache.updatesSinceCacheKey(cacheKey))
                 .thenReturn(Optional.of(digest));
@@ -156,7 +156,7 @@ public class BatchPaxosAcceptorResourceTests {
         when(components.acceptor(CLIENT_2).getLatestSequencePreparedOrAccepted()).thenReturn(2L);
 
         AcceptorCacheDigest digest = ImmutableAcceptorCacheDigest.builder()
-                .newCacheKey(UUID.randomUUID())
+                .newCacheKey(AcceptorCacheKey.newCacheKey())
                 .putUpdates(CLIENT_1, 1L)
                 .putUpdates(CLIENT_2, 2L)
                 .build();
@@ -176,10 +176,10 @@ public class BatchPaxosAcceptorResourceTests {
         when(components.acceptor(CLIENT_1).getLatestSequencePreparedOrAccepted()).thenReturn(1L);
         when(components.acceptor(CLIENT_2).getLatestSequencePreparedOrAccepted()).thenReturn(2L);
 
-        AcceptorCacheKey cacheKey = AcceptorCacheKey.of(UUID.randomUUID());
+        AcceptorCacheKey cacheKey = AcceptorCacheKey.newCacheKey();
 
         AcceptorCacheDigest digest = ImmutableAcceptorCacheDigest.builder()
-                .newCacheKey(UUID.randomUUID())
+                .newCacheKey(AcceptorCacheKey.newCacheKey())
                 .putUpdates(CLIENT_2, 2L)
                 .build();
 
@@ -218,7 +218,7 @@ public class BatchPaxosAcceptorResourceTests {
 
     private static AcceptorCacheDigest digest() {
         return ImmutableAcceptorCacheDigest.builder()
-                .newCacheKey(UUID.randomUUID())
+                .newCacheKey(AcceptorCacheKey.newCacheKey())
                 .putUpdates(CLIENT_1, 50L)
                 .build();
     }


### PR DESCRIPTION
**Goals (and why)**:
An implementation of `AcceptorCache}` Behaves as described in #4061.

**Implementation Description (bullets)**:
* Each cacheKey is associated with a logical "timestamp" point in time when an update occurred.
* Use a treemap from timestamp to clients and their latest sequence numbers
* Find latest updates from cache key is to find the timestamp for a cache key and a 	`tailMap` on the treemap, combining the results.

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:
* Is the concurrency to coarse grained? I had another impl using Caffeine cache, and allowing reads/writes out of order in a way that wouldn't affect correctness, but I thought I'd just do the "simpler" thing first and see if it performed badly.
* Is there a better structure for this? that also is nice and concurrent? want an lru effectively.
* Are there any useful metrics that I should add?

**Where should we start reviewing?**:
Anywhere

**Priority (whenever / two weeks / yesterday)**:
ASAP 💃 
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
