### PR TITLE
Require Cassandra Credentials, and bump max version to 4.0

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConnectionIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConnectionIntegrationTest.java
@@ -15,30 +15,17 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
-import java.util.Optional;
-
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
-import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.containers.CassandraResource;
 
 public class CassandraConnectionIntegrationTest {
     @ClassRule
     public static final CassandraResource CASSANDRA = new CassandraResource();
 
-    private static final CassandraKeyValueServiceConfig NO_CREDS_CKVS_CONFIG = ImmutableCassandraKeyValueServiceConfig
-            .copyOf(CASSANDRA.getConfig())
-            .withCredentials(Optional.empty());
-
     @Test
     public void testAuthProvided() {
         CASSANDRA.getDefaultKvs();
-    }
-
-    @Test
-    public void testAuthMissing() {
-        CassandraKeyValueServiceImpl.createForTesting(NO_CREDS_CKVS_CONFIG).close();
     }
 }

--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -96,6 +96,6 @@ recommendedProductDependencies {
         productGroup = 'com.palantir.cassandra'
         productName = 'sls-cassandra'
         minimumVersion = '3.31.0'
-        maximumVersion = '3.x.x'
+        maximumVersion = '4.x.x'
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -142,7 +142,7 @@ public interface CassandraKeyValueServiceConfig extends KeyValueServiceConfig {
     @Deprecated
     Optional<String> keyspace();
 
-    Optional<CassandraCredentialsConfig> credentials();
+    CassandraCredentialsConfig credentials();
 
     /**
      * A boolean declaring whether or not to use ssl to communicate with cassandra.

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
@@ -116,8 +116,7 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
                     SafeArg.of("address", CassandraLogHelper.host(addr)),
                     UnsafeArg.of("keyspace", config.getKeyspaceOrThrow()),
                     SafeArg.of("usingSsl", config.usingSsl() ? " over SSL" : ""),
-                    UnsafeArg.of("usernameConfig", config.credentials().isPresent()
-                            ? " as user " + config.credentials().get().username() : ""));
+                    UnsafeArg.of("usernameConfig", " as user " + config.credentials().username()));
             return ret;
         } catch (Exception e) {
             ret.getOutputProtocol().getTransport().close();
@@ -171,14 +170,12 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
         TProtocol protocol = new TBinaryProtocol(thriftFramedTransport);
         Cassandra.Client client = new Cassandra.Client(protocol);
 
-        if (config.credentials().isPresent()) {
-            try {
-                login(client, config.credentials().get());
-            } catch (TException e) {
-                client.getOutputProtocol().getTransport().close();
-                log.error("Exception thrown attempting to authenticate with config provided credentials", e);
-                throw e;
-            }
+        try {
+            login(client, config.credentials());
+        } catch (TException e) {
+            client.getOutputProtocol().getTransport().close();
+            log.error("Exception thrown attempting to authenticate with config provided credentials", e);
+            throw e;
         }
 
         return client;

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/CassandraAtlasDbFactoryTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/CassandraAtlasDbFactoryTest.java
@@ -34,16 +34,24 @@ public class CassandraAtlasDbFactoryTest {
     private static final String KEYSPACE = "ks";
     private static final String KEYSPACE_2 = "ks2";
     private static final ImmutableSet<InetSocketAddress> SERVERS = ImmutableSet.of(new InetSocketAddress("foo", 42));
+    private static final CassandraCredentialsConfig CREDENTIALS =
+            ImmutableCassandraCredentialsConfig.builder()
+                    .username("username")
+                    .password("password")
+                    .build();
+
     private static final CassandraKeyValueServiceConfig CONFIG_WITHOUT_KEYSPACE =
             ImmutableCassandraKeyValueServiceConfig.builder()
                     .servers(SERVERS)
                     .replicationFactor(1)
+                    .credentials(CREDENTIALS)
                     .build();
     private static final CassandraKeyValueServiceConfig CONFIG_WITH_KEYSPACE =
             ImmutableCassandraKeyValueServiceConfig.builder()
                     .servers(SERVERS)
                     .keyspace(KEYSPACE)
                     .replicationFactor(1)
+                    .credentials(CREDENTIALS)
                     .build();
 
     private static final KeyValueServiceRuntimeConfig INVALID_CKVS_RUNTIME_CONFIG = () -> "test";

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfigsTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfigsTest.java
@@ -34,16 +34,23 @@ public class CassandraKeyValueServiceConfigsTest {
     private static final String KEYSPACE = "ks";
     private static final String KEYSPACE_2 = "ks2";
     private static final ImmutableSet<InetSocketAddress> SERVERS = ImmutableSet.of(new InetSocketAddress("foo", 42));
+    private static final CassandraCredentialsConfig CREDENTIALS =
+            ImmutableCassandraCredentialsConfig.builder()
+                    .username("username")
+                    .password("password")
+                    .build();
     private static final CassandraKeyValueServiceConfig CONFIG_WITHOUT_KEYSPACE =
             ImmutableCassandraKeyValueServiceConfig.builder()
                     .servers(SERVERS)
                     .replicationFactor(1)
+                    .credentials(CREDENTIALS)
                     .build();
     private static final CassandraKeyValueServiceConfig CONFIG_WITH_KEYSPACE =
             ImmutableCassandraKeyValueServiceConfig.builder()
                     .servers(SERVERS)
                     .keyspace(KEYSPACE)
                     .replicationFactor(1)
+                    .credentials(CREDENTIALS)
                     .build();
 
     @Test
@@ -52,6 +59,7 @@ public class CassandraKeyValueServiceConfigsTest {
                 .servers(SERVERS)
                 .addressTranslation(ImmutableMap.of("test", Iterables.getOnlyElement(SERVERS)))
                 .replicationFactor(1)
+                .credentials(CREDENTIALS)
                 .build();
 
         URL configUrl = CassandraKeyValueServiceConfigsTest.class.getClassLoader().getResource("testConfig.yml");

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceConfigTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceConfigTest.java
@@ -23,20 +23,27 @@ import java.nio.file.Paths;
 
 import org.junit.Test;
 
+import com.palantir.atlasdb.cassandra.CassandraCredentialsConfig;
+import com.palantir.atlasdb.cassandra.ImmutableCassandraCredentialsConfig;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
 import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
 
 public class CassandraKeyValueServiceConfigTest {
     private static final InetSocketAddress SERVER_ADDRESS = InetSocketAddress.createUnresolved("localhost", 9160);
     private static final SslConfiguration SSL_CONFIGURATION = SslConfiguration.of(Paths.get("./trustStore.jks"));
+    private static final CassandraCredentialsConfig CREDENTIALS =
+            ImmutableCassandraCredentialsConfig.builder()
+                    .username("username")
+                    .password("password")
+                    .build();
 
     private static final ImmutableCassandraKeyValueServiceConfig CASSANDRA_CONFIG =
             ImmutableCassandraKeyValueServiceConfig.builder()
                     .addServers(SERVER_ADDRESS)
                     .replicationFactor(1)
                     .keyspace("atlasdb")
+                    .credentials(CREDENTIALS)
                     .build();
-
 
     @Test
     public void usingSslIfSslParamPresentAndTrue() {

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 
 import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
+import com.palantir.atlasdb.cassandra.ImmutableCassandraCredentialsConfig;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.Blacklist;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer;
@@ -130,6 +131,10 @@ public class CassandraServiceTest {
             ImmutableSet<InetSocketAddress> serversInPool) {
         config = ImmutableCassandraKeyValueServiceConfig.builder()
                 .replicationFactor(3)
+                .credentials(ImmutableCassandraCredentialsConfig.builder()
+                                .username("username")
+                                .password("password")
+                                .build())
                 .addServers(servers.toArray(new InetSocketAddress[0]))
                 .build();
 

--- a/atlasdb-cassandra/src/test/resources/testConfig.yml
+++ b/atlasdb-cassandra/src/test/resources/testConfig.yml
@@ -4,3 +4,6 @@
   servers:
     - foo:42
   replicationFactor: 1
+  credentials:
+    username: username
+    password: password

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/ThreeNodeCassandraCluster.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/ThreeNodeCassandraCluster.java
@@ -21,7 +21,9 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.palantir.atlasdb.cassandra.CassandraCredentialsConfig;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
+import com.palantir.atlasdb.cassandra.ImmutableCassandraCredentialsConfig;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServiceImpl;
 import com.palantir.docker.compose.DockerComposeRule;
@@ -36,6 +38,11 @@ public class ThreeNodeCassandraCluster extends Container {
     public static final String FIRST_CASSANDRA_CONTAINER_NAME = "cassandra1";
     public static final String SECOND_CASSANDRA_CONTAINER_NAME = "cassandra2";
     public static final String THIRD_CASSANDRA_CONTAINER_NAME = "cassandra3";
+    private static final CassandraCredentialsConfig CREDENTIALS =
+            ImmutableCassandraCredentialsConfig.builder()
+                    .username("username")
+                    .password("password")
+                    .build();
 
     public static final CassandraKeyValueServiceConfig KVS_CONFIG = ImmutableCassandraKeyValueServiceConfig.builder()
             .addServers(new InetSocketAddress(FIRST_CASSANDRA_CONTAINER_NAME, CassandraContainer.CASSANDRA_PORT))
@@ -48,6 +55,7 @@ public class ThreeNodeCassandraCluster extends Container {
             .mutationBatchSizeBytes(10000000)
             .fetchBatchCount(1000)
             .autoRefreshNodes(false)
+            .credentials(CREDENTIALS)
             .build();
 
     @Override

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,10 @@ develop
     *    - Type
          - Change
 
+    *    - |devbreak|
+         - Cassandra clients are now required to supply credentials in the KVS config.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/4076>`__)
+
     *    - |improved|
          - The default value for the length of pause between targeted sweep iterations, ``pauseMillis``, has been reduced to 50ms.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/4067>`__)


### PR DESCRIPTION
**Goals (and why)**:

Starting in sls-cassandra 4.0, we will no longer allow anonymous users.  The easiest way to enforce this is by requiring clients to supply credentials to Atlas.

**Implementation Description (bullets)**:

Changes `CassandraCredentialsConfig` to be non-optional in the KVS config, and opens up an upgrade path to `sls-cassandra 4.0`.

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

This is a breaking change for clients that may not necessarily be discovered at test-time.  However, at this point we expect that all modern clients are already supplying credentials.

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
