### PR TITLE
Update warning message for missing data dir

### DIFF
--- a/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosInstallConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosInstallConfiguration.java
@@ -54,12 +54,11 @@ public interface PaxosInstallConfiguration {
         }
 
         if (!isNewService() && !dataDirectory().isDirectory()) {
-            throw new IllegalArgumentException(
-                    "If this is a new timelock service, please configure paxos.is-new-service to true for the first "
-                            + "startup only of each node. \n\nOtherwise, the timelock data directory appears to no "
-                            + "longer exist. If you are trying to move the nodes on your timelock cluster or add new "
-                            + "nodes, you have likely already made a mistake by this point. This is a non-trivial "
-                            + "operation, please be careful and make sure that you have appropriate approvals.");
+            throw new IllegalArgumentException("The timelock data directory does not appear to exist. If you are "
+                    + "trying to move the nodes on your timelock cluster or add new nodes, you have likely already "
+                    + "made a mistake by this point. This is a non-trivial operation and risks service corruption, "
+                    + "so contact support for assistance. Otherwise, if this is a new timelock service, please "
+                    + "configure paxos.is-new-service to true for the first startup only of each node.");
         }
     }
 }


### PR DESCRIPTION
**Goals (and why)**:
From PDS-91818, the current log message covered the happy case first, leading someone to go ahead and create the new directories rather than realizing that they were risking corruption. Updating the message to cover the worst case first and not spread the message across multiple lines.

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
