### PR TITLE
The TransactionManager used on callbacks is instrumented

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -409,20 +409,17 @@ public abstract class TransactionManagers {
                         transactionConfigSupplier),
                 closeables);
 
-        TransactionManager instrumentedTransactionManager =
-                AtlasDbMetrics.instrument(metricsManager.getRegistry(), TransactionManager.class, transactionManager);
-
-        instrumentedTransactionManager.registerClosingCallback(lockAndTimestampServices.close());
-        instrumentedTransactionManager.registerClosingCallback(transactionService::close);
+        transactionManager.registerClosingCallback(lockAndTimestampServices.close());
+        transactionManager.registerClosingCallback(transactionService::close);
         components.schemaInstaller().ifPresent(
-                installer -> instrumentedTransactionManager.registerClosingCallback(installer::close));
-        instrumentedTransactionManager.registerClosingCallback(targetedSweep::close);
+                installer -> transactionManager.registerClosingCallback(installer::close));
+        transactionManager.registerClosingCallback(targetedSweep::close);
 
         PersistentLockManager persistentLockManager = initializeCloseable(
                 () -> new PersistentLockManager(
                         metricsManager, persistentLockService, config().getSweepPersistentLockWaitMillis()),
                 closeables);
-        instrumentedTransactionManager.registerClosingCallback(persistentLockManager::close);
+        transactionManager.registerClosingCallback(persistentLockManager::close);
 
         initializeCloseable(
                 () -> initializeSweepEndpointAndBackgroundProcess(
@@ -434,7 +431,7 @@ public abstract class TransactionManagers {
                         transactionService,
                         sweepStrategyManager,
                         follower,
-                        instrumentedTransactionManager,
+                        transactionManager,
                         persistentLockManager,
                         runBackgroundSweepProcess()),
                 closeables);
@@ -443,11 +440,11 @@ public abstract class TransactionManagers {
                         metricsManager,
                         lockAndTimestampServices,
                         keyValueService,
-                        instrumentedTransactionManager,
+                        transactionManager,
                         Suppliers.compose(AtlasDbRuntimeConfig::compact, runtimeConfigSupplier::get)),
                 closeables);
 
-        return instrumentedTransactionManager;
+        return transactionManager;
     }
 
     /**

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -383,7 +383,7 @@ public abstract class TransactionManagers {
                 () -> runtimeConfigSupplier.get().transaction());
 
         TransactionManager transactionManager = initializeCloseable(
-                () -> SerializableTransactionManager.create(
+                () -> SerializableTransactionManager.createInstrumented(
                         metricsManager,
                         keyValueService,
                         lockAndTimestampServices.timelock(),

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -196,6 +196,53 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
         }
     }
 
+    public static TransactionManager createInstrumented(
+            MetricsManager metricsManager,
+            KeyValueService keyValueService,
+            TimelockService timelockService,
+            TimestampManagementService timestampManagementService,
+            LockService lockService,
+            TransactionService transactionService,
+            Supplier<AtlasDbConstraintCheckingMode> constraintModeSupplier,
+            ConflictDetectionManager conflictDetectionManager,
+            SweepStrategyManager sweepStrategyManager,
+            Cleaner cleaner,
+            Supplier<Boolean> initializationPrerequisite,
+            boolean allowHiddenTableAccess,
+            int concurrentGetRangesThreadPoolSize,
+            int defaultGetRangesConcurrency,
+            boolean initializeAsync,
+            TimestampCache timestampCache,
+            MultiTableSweepQueueWriter sweepQueueWriter,
+            Callback<TransactionManager> callback,
+            boolean validateLocksOnReads,
+            Supplier<TransactionConfig> transactionConfig) {
+
+        return create(metricsManager,
+                keyValueService,
+                timelockService,
+                timestampManagementService,
+                lockService,
+                transactionService,
+                constraintModeSupplier,
+                conflictDetectionManager,
+                sweepStrategyManager,
+                cleaner,
+                initializationPrerequisite,
+                allowHiddenTableAccess,
+                concurrentGetRangesThreadPoolSize,
+                defaultGetRangesConcurrency,
+                initializeAsync,
+                timestampCache,
+                sweepQueueWriter,
+                callback,
+                PTExecutors.newSingleThreadScheduledExecutor(
+                        new NamedThreadFactory("AsyncInitializer-SerializableTransactionManager", true)),
+                validateLocksOnReads,
+                transactionConfig,
+                true);
+    }
+
     public static TransactionManager create(
             MetricsManager metricsManager,
             KeyValueService keyValueService,
@@ -287,53 +334,6 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 validateLocksOnReads,
                 transactionConfig,
                 false);
-    }
-
-    public static TransactionManager createInstrumented(
-            MetricsManager metricsManager,
-            KeyValueService keyValueService,
-            TimelockService timelockService,
-            TimestampManagementService timestampManagementService,
-            LockService lockService,
-            TransactionService transactionService,
-            Supplier<AtlasDbConstraintCheckingMode> constraintModeSupplier,
-            ConflictDetectionManager conflictDetectionManager,
-            SweepStrategyManager sweepStrategyManager,
-            Cleaner cleaner,
-            Supplier<Boolean> initializationPrerequisite,
-            boolean allowHiddenTableAccess,
-            int concurrentGetRangesThreadPoolSize,
-            int defaultGetRangesConcurrency,
-            boolean initializeAsync,
-            TimestampCache timestampCache,
-            MultiTableSweepQueueWriter sweepQueueWriter,
-            Callback<TransactionManager> callback,
-            boolean validateLocksOnReads,
-            Supplier<TransactionConfig> transactionConfig) {
-
-        return create(metricsManager,
-                keyValueService,
-                timelockService,
-                timestampManagementService,
-                lockService,
-                transactionService,
-                constraintModeSupplier,
-                conflictDetectionManager,
-                sweepStrategyManager,
-                cleaner,
-                initializationPrerequisite,
-                allowHiddenTableAccess,
-                concurrentGetRangesThreadPoolSize,
-                defaultGetRangesConcurrency,
-                initializeAsync,
-                timestampCache,
-                sweepQueueWriter,
-                callback,
-                PTExecutors.newSingleThreadScheduledExecutor(
-                        new NamedThreadFactory("AsyncInitializer-SerializableTransactionManager", true)),
-                validateLocksOnReads,
-                transactionConfig,
-                true);
     }
 
     public static TransactionManager create(

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -336,7 +336,7 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 false);
     }
 
-    public static TransactionManager create(
+    private static TransactionManager create(
             MetricsManager metricsManager,
             KeyValueService keyValueService,
             TimelockService timelockService,

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -72,6 +72,10 @@ develop
            These settings have empirically improved the performance of timelock when the leader node goes down without negatively affecting stability.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/4055>`__)
 
+    *    - |improved|
+         - Async initialization callbacks are run with an instrumented TransactionManager.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/4081>`__)
+
 ========
 v0.144.0
 ========


### PR DESCRIPTION
**Goals (and why)**:
Callbacks currently runs with an uninstrumented TransactionManager.
Some internal libraries do most of the work as a callback and we don't have visibility on those.