### PR TITLE
Change ts pause millis back to 500ms.

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/config/TargetedSweepRuntimeConfig.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/config/TargetedSweepRuntimeConfig.java
@@ -53,7 +53,7 @@ public abstract class TargetedSweepRuntimeConfig {
 
     @Value.Default
     public long pauseMillis() {
-        return 50L;
+        return 500L;
     }
 
     public static TargetedSweepRuntimeConfig defaultTargetedSweepRuntimeConfig() {

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -80,6 +80,10 @@ develop
          - Async initialization callbacks are run with an instrumented TransactionManager.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/4081>`__)
 
+    *    - |fixed|
+         - The default value for the length of pause between targeted sweep iterations, ``pauseMillis``, has been changed back to 500ms.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/4084>`__)
+
 ========
 v0.144.0
 ========


### PR DESCRIPTION
**Goals (and why)**:
Revert #4067. See https://github.com/palantir/atlasdb/pull/4067#issuecomment-500870622

**Implementation Description (bullets)**:
Need a better approach to this. Maybe holding the lock for longer/smarter backoffs etc.

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:
ASAP
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
