### PR TITLE
Fix targeted sweep batching

### DIFF
--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
@@ -140,6 +140,7 @@ public class AtlasDbEteServer extends Application<AtlasDbEteConfiguration> {
     }
 
     private TargetedSweeper initializeAndGet(TargetedSweeper sweeper, TransactionManager txManager) {
+        // Intentionally providing the immutable timestamp instead of unreadable to avoid the delay
         sweeper.initializeWithoutRunning(
                 new SpecialTimestampsSupplier(txManager::getImmutableTimestamp, txManager::getImmutableTimestamp),
                 txManager.getTimelockService(),

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/todo/TodoClient.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/todo/TodoClient.java
@@ -79,7 +79,8 @@ public class TodoClient {
         this.kvs = Suppliers.memoize(transactionManager::getKeyValueService);
         this.sweepTaskRunner = sweepTaskRunner;
         this.targetedSweeper = targetedSweeper;
-        this.sweepTimestampProvider = new SpecialTimestampsSupplier(transactionManager::getUnreadableTimestamp,
+        // Intentionally providing the immutable timestamp instead of unreadable to avoid the delay
+        this.sweepTimestampProvider = new SpecialTimestampsSupplier(transactionManager::getImmutableTimestamp,
                 transactionManager::getImmutableTimestamp);
     }
 

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/todo/TodoClient.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/todo/TodoClient.java
@@ -79,7 +79,7 @@ public class TodoClient {
         this.kvs = Suppliers.memoize(transactionManager::getKeyValueService);
         this.sweepTaskRunner = sweepTaskRunner;
         this.targetedSweeper = targetedSweeper;
-        this.sweepTimestampProvider = new SpecialTimestampsSupplier(transactionManager::getImmutableTimestamp,
+        this.sweepTimestampProvider = new SpecialTimestampsSupplier(transactionManager::getUnreadableTimestamp,
                 transactionManager::getImmutableTimestamp);
     }
 

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/todo/TodoClient.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/todo/TodoClient.java
@@ -47,7 +47,9 @@ import com.palantir.atlasdb.schema.TargetedSweepSchema;
 import com.palantir.atlasdb.sweep.ImmutableSweepBatchConfig;
 import com.palantir.atlasdb.sweep.SweepBatchConfig;
 import com.palantir.atlasdb.sweep.SweepTaskRunner;
+import com.palantir.atlasdb.sweep.Sweeper;
 import com.palantir.atlasdb.sweep.queue.ShardAndStrategy;
+import com.palantir.atlasdb.sweep.queue.SpecialTimestampsSupplier;
 import com.palantir.atlasdb.sweep.queue.TargetedSweeper;
 import com.palantir.atlasdb.table.description.Schemas;
 import com.palantir.atlasdb.table.description.ValueType;
@@ -68,6 +70,7 @@ public class TodoClient {
     private final Supplier<KeyValueService> kvs;
     private final Supplier<SweepTaskRunner> sweepTaskRunner;
     private final Supplier<TargetedSweeper> targetedSweeper;
+    private final SpecialTimestampsSupplier sweepTimestampProvider;
     private final Random random = new Random();
 
     public TodoClient(TransactionManager transactionManager, Supplier<SweepTaskRunner> sweepTaskRunner,
@@ -76,6 +79,8 @@ public class TodoClient {
         this.kvs = Suppliers.memoize(transactionManager::getKeyValueService);
         this.sweepTaskRunner = sweepTaskRunner;
         this.targetedSweeper = targetedSweeper;
+        this.sweepTimestampProvider = new SpecialTimestampsSupplier(transactionManager::getImmutableTimestamp,
+                transactionManager::getImmutableTimestamp);
     }
 
     public void addTodo(Todo todo) {
@@ -155,8 +160,13 @@ public class TodoClient {
     }
 
     public void runIterationOfTargetedSweep() {
-        targetedSweeper.get().sweepNextBatch(ShardAndStrategy.conservative(0));
-        targetedSweeper.get().sweepNextBatch(ShardAndStrategy.thorough(0));
+        runIterationOfTargetedSweepForShard(ShardAndStrategy.conservative(0));
+        runIterationOfTargetedSweepForShard(ShardAndStrategy.thorough(0));
+    }
+
+    private void runIterationOfTargetedSweepForShard(ShardAndStrategy shardStrategy) {
+        targetedSweeper.get()
+                .sweepNextBatch(shardStrategy, Sweeper.of(shardStrategy).getSweepTimestamp(sweepTimestampProvider));
     }
 
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueue.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueue.java
@@ -106,13 +106,14 @@ public final class SweepQueue implements MultiTableSweepQueueWriter {
      *
      * @param shardStrategy shard and strategy to use
      * @param sweepTs sweep timestamp, the upper limit to the start timestamp of writes to sweep
+     * @return true if we should immediately process another batch for this shard and strategy
      */
-    public void sweepNextBatch(ShardAndStrategy shardStrategy, long sweepTs) {
+    public boolean sweepNextBatch(ShardAndStrategy shardStrategy, long sweepTs) {
         metrics.updateSweepTimestamp(shardStrategy, sweepTs);
         long lastSweptTs = progress.getLastSweptTimestamp(shardStrategy);
 
         if (lastSweptTs + 1 >= sweepTs) {
-            return;
+            return false;
         }
 
         log.debug("Beginning iteration of targeted sweep for {}, and sweep timestamp {}. Last previously swept "
@@ -141,6 +142,8 @@ public final class SweepQueue implements MultiTableSweepQueueWriter {
         } else {
             metrics.registerOccurrenceOf(SweepOutcome.SUCCESS);
         }
+
+        return true;
     }
 
     /**

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/TargetedSweeper.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/TargetedSweeper.java
@@ -274,12 +274,16 @@ public class TargetedSweeper implements MultiTableSweepQueueWriter, BackgroundSw
         }
 
         private void processShard(TargetedSweeperLock lock) {
-            Stopwatch watch = Stopwatch.createStarted();
             long maxTsExclusive = Sweeper.of(lock.getShardAndStrategy()).getSweepTimestamp(timestampsSupplier);
-            boolean processNextBatch = true;
-            while (processNextBatch && runtime.get().enabled()
-                    && (watch.elapsed().compareTo(MAX_SHARD_DURATION) < 0)) {
-                processNextBatch = sweepNextBatch(lock.getShardAndStrategy(), maxTsExclusive);
+            if (runtime.get().batchShardIterations()) {
+                Stopwatch watch = Stopwatch.createStarted();
+                boolean processNextBatch = true;
+                while (processNextBatch && runtime.get().enabled()
+                        && (watch.elapsed().compareTo(MAX_SHARD_DURATION) < 0)) {
+                    processNextBatch = sweepNextBatch(lock.getShardAndStrategy(), maxTsExclusive);
+                }
+            } else {
+                sweepNextBatch(lock.getShardAndStrategy(), maxTsExclusive);
             }
         }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/TargetedSweeper.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/TargetedSweeper.java
@@ -32,7 +32,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.cleaner.Follower;
 import com.palantir.atlasdb.keyvalue.api.InsufficientConsistencyException;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/TargetedSweeper.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/TargetedSweeper.java
@@ -187,10 +187,6 @@ public class TargetedSweeper implements MultiTableSweepQueueWriter, BackgroundSw
     @VisibleForTesting
     public void sweepNextBatch(ShardAndStrategy shardStrategy) {
         assertInitialized();
-        if (!runtime.get().enabled()) {
-            metrics.registerOccurrenceOf(SweepOutcome.DISABLED);
-            return;
-        }
         long maxTsExclusive = Sweeper.of(shardStrategy).getSweepTimestamp(timestampsSupplier);
         queue.sweepNextBatch(shardStrategy, maxTsExclusive);
     }
@@ -236,6 +232,11 @@ public class TargetedSweeper implements MultiTableSweepQueueWriter, BackgroundSw
         }
 
         private void runOneIteration() {
+            if (!runtime.get().enabled()) {
+                metrics.registerOccurrenceOf(SweepOutcome.DISABLED);
+                return;
+            }
+
             Optional<TargetedSweeperLock> maybeLock = Optional.empty();
             try {
                 maybeLock = tryToAcquireLockForNextShardAndStrategy();

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperLock.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperLock.java
@@ -54,8 +54,4 @@ public final class TargetedSweeperLock {
     public void unlock() {
         timeLock.unlock(ImmutableSet.of(lockToken));
     }
-
-    public boolean refresh() {
-        return !timeLock.refreshLockLeases(ImmutableSet.of(lockToken)).isEmpty();
-    }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperLock.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperLock.java
@@ -54,4 +54,8 @@ public final class TargetedSweeperLock {
     public void unlock() {
         timeLock.unlock(ImmutableSet.of(lockToken));
     }
+
+    public boolean refresh() {
+        return !timeLock.refreshLockLeases(ImmutableSet.of(lockToken)).isEmpty();
+    }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/config/TargetedSweepRuntimeConfig.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/config/TargetedSweepRuntimeConfig.java
@@ -45,6 +45,15 @@ public abstract class TargetedSweepRuntimeConfig {
         return 8;
     }
 
+    /**
+     * If true, we batch many iterations on each shard and strategy upon obtaining the lock. This should lead to
+     * higher throughput in targeted sweep at the expense of more uneven sweeping across different shards.
+     */
+    @Value.Default
+    public boolean batchShardIterations() {
+        return false;
+    }
+
     @Value.Check
     void checkShardSize() {
         Preconditions.checkArgument(shards() >= 1 && shards() <= 256,

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
@@ -204,16 +204,6 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
     }
 
     @Test
-    public void sweepDisabledIsReportedInOutcome() {
-        sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
-        assertThat(metricsManager).hasTargetedOutcomeEqualTo(SweepOutcome.NOTHING_TO_SWEEP, 1L);
-
-        enabled = false;
-        sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
-        assertThat(metricsManager).hasTargetedOutcomeEqualTo(SweepOutcome.DISABLED, 1L);
-    }
-
-    @Test
     public void thoroughSweepDoesNotAddSentinelAndLeavesSingleValue() {
         enqueueWriteCommitted(TABLE_THOR, LOW_TS);
         assertReadAtTimestampReturnsNothing(TABLE_THOR, LOW_TS);

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractTargetedSweepTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractTargetedSweepTest.java
@@ -64,10 +64,8 @@ public class AbstractTargetedSweepTest extends AbstractSweepTest {
 
     @Override
     protected Optional<SweepResults> completeSweep(TableReference ignored, long ts) {
-        when(timestampsSupplier.getUnreadableTimestamp()).thenReturn(ts);
-        when(timestampsSupplier.getImmutableTimestamp()).thenReturn(ts);
-        sweepQueue.sweepNextBatch(ShardAndStrategy.conservative(0));
-        sweepQueue.sweepNextBatch(ShardAndStrategy.thorough(0));
+        sweepQueue.sweepNextBatch(ShardAndStrategy.conservative(0), ts);
+        sweepQueue.sweepNextBatch(ShardAndStrategy.thorough(0), ts);
         return Optional.empty();
     }
 

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractTargetedSweepTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractTargetedSweepTest.java
@@ -18,7 +18,6 @@ package com.palantir.atlasdb.sweep;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
@@ -30,6 +30,7 @@ import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.StatsTrackingKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.TracingKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.TrackingKeyValueService;
+import com.palantir.atlasdb.sweep.queue.SpecialTimestampsSupplier;
 import com.palantir.atlasdb.sweep.queue.TargetedSweeper;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
@@ -67,6 +68,7 @@ public class AtlasDbTestCase {
     protected TestTransactionManager txManager;
     protected TransactionService transactionService;
     protected TargetedSweeper sweepQueue;
+    protected SpecialTimestampsSupplier sweepTimestampSupplier;
     protected int sweepQueueShards = 128;
 
     @Before
@@ -99,6 +101,8 @@ public class AtlasDbTestCase {
 
         sweepQueue.initialize(serializableTxManager);
         txManager = new CachingTestTransactionManager(serializableTxManager);
+        sweepTimestampSupplier = new SpecialTimestampsSupplier(
+                () -> txManager.getUnreadableTimestamp(), () -> txManager.getImmutableTimestamp());
     }
 
     protected KeyValueService getBaseKeyValueService() {

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -84,6 +84,11 @@ develop
          - The default value for the length of pause between targeted sweep iterations, ``pauseMillis``, has been changed back to 500ms.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/4084>`__)
 
+    *    - |improved|
+         - Added runtime configurable behavior to targeted sweep to allow multiple consecutive iterations on the same targeted sweep shard, all while holding the relevant lock. This option
+           should improve targeted sweep throughput without adding additional load on Timelock for places where the downtime between targeted sweep iterations is a bottleneck.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/4086>`__)
+
 ========
 v0.144.0
 ========


### PR DESCRIPTION
**Goals (and why)**:
Enable targeted sweep to iterate more quickly if it is not caught up at the moment. Before this change, each iteration of sweep is accompanied by calls to lock/unlock, as well as all the attempted locks if most of the shards are covered, causing a lot of extra traffic to Timelock. Lowering the wait period between batches to speed up targeted sweep can therefore be problematic (see https://github.com/palantir/atlasdb/pull/4084).

The main goal is to enable targeted sweep to move faster when needed, but without overloading Timelock.

**Implementation Description (bullets)**:

- Each batch returns a boolean indicating whether we should immediately run another batch on the same shard/strategy.
- The sweep timestamp is fetched above the batch layer, and a single sweep timestamp is shared across multiple batches. This reduces the number of calls to Timelock.
- Once we've obtained the lock, we keep it and continue to run batches until we've caught up to the sweep timestamp or 5 minutes have elapsed.
- 5 minutes was chosen since we want to periodically confirm that we still have our lock, but also want to minimize calls to Timelock and reduce the overhead of time not spent sweeping. This also forces us to move between shards if we're in a situation where there are not enough threads to cover each shard - if we hold the lock for too long, we would instead end up with very uneven sweeping.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Most behavior stays the same. I added a few simple tests to cover the batching behavior and verify the configuration control. I did not test that we stop iterating after the time limit - would rather rely on code inspection for this since the code is easy and this is harder to test directly.

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:
`TargetedSweeper.java`

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
