### PR TITLE
Cross-Partitioning TS, Part 1: KeyValueService#deleteRows()

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -27,6 +27,7 @@ import com.palantir.common.annotation.NonIdempotent;
 import com.palantir.common.base.ClosableIterator;
 import com.palantir.common.exception.AtlasDbDependencyException;
 import com.palantir.processors.AutoDelegate;
+import com.palantir.processors.DoNotDelegate;
 import com.palantir.util.paging.BasicResultsPage;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
 
@@ -347,6 +348,7 @@ public interface KeyValueService extends AutoCloseable {
      * @param rows rows to delete
      */
     @Idempotent
+    @DoNotDelegate
     default void deleteRows(TableReference tableRef, Iterable<byte[]> rows) {
         rows.forEach(row -> deleteRange(tableRef, RangeRequests.ofSingleRow(row)));
     }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -330,6 +330,24 @@ public interface KeyValueService extends AutoCloseable {
     void deleteRange(TableReference tableRef, RangeRequest range);
 
     /**
+     * Deletes multiple rows from the key-value store.
+     *
+     * Does not guarantee atomicity in any way (deletes may be partial within *any* of the rows provided, and
+     * there is no guarantee of any correlation or lack thereof between success of the deletes for each of the rows
+     * provided).
+     *
+     * Some systems may require more nodes to be up to ensure that a delete is successful. If this
+     * is the case then this method may throw if the delete can't be completed on all nodes.
+     *
+     * @param tableRef the name of the table to delete values from.
+     * @param rows rows to delete
+     */
+    @Idempotent
+    default void deleteRows(TableReference tableRef, Iterable<byte[]> rows) {
+        rows.forEach(row -> deleteRange(tableRef, RangeRequests.ofSingleRow(row)));
+    }
+
+    /**
      * For each cell, deletes all timestamps prior to the associated maximum timestamp. If this
      * operation fails, it's acceptable for this method to leave an inconsistent state, however
      * implementations of this method <b>must</b> guarantee that, for each cell, if a value at the

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -340,6 +340,9 @@ public interface KeyValueService extends AutoCloseable {
      * this method may throw if the delete can't be completed on all nodes. Please be aware that if it does throw,
      * some deletes may have been applied on some nodes.
      *
+     * This method MAY require linearly many calls to the database in the number of rows, so should be used with
+     * caution.
+     *
      * @param tableRef the name of the table to delete values from.
      * @param rows rows to delete
      */

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -330,14 +330,15 @@ public interface KeyValueService extends AutoCloseable {
     void deleteRange(TableReference tableRef, RangeRequest range);
 
     /**
-     * Deletes multiple rows from the key-value store.
+     * Deletes multiple complete rows from the key-value store.
      *
      * Does not guarantee atomicity in any way (deletes may be partial within *any* of the rows provided, and
      * there is no guarantee of any correlation or lack thereof between success of the deletes for each of the rows
      * provided).
      *
-     * Some systems may require more nodes to be up to ensure that a delete is successful. If this
-     * is the case then this method may throw if the delete can't be completed on all nodes.
+     * Some systems may require more nodes to be up to ensure that a delete is successful. If this is the case then
+     * this method may throw if the delete can't be completed on all nodes. Please be aware that if it does throw,
+     * some deletes may have been applied on some nodes.
      *
      * @param tableRef the name of the table to delete values from.
      * @param rows rows to delete

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -27,7 +27,6 @@ import com.palantir.common.annotation.NonIdempotent;
 import com.palantir.common.base.ClosableIterator;
 import com.palantir.common.exception.AtlasDbDependencyException;
 import com.palantir.processors.AutoDelegate;
-import com.palantir.processors.DoNotDelegate;
 import com.palantir.util.paging.BasicResultsPage;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
 
@@ -348,10 +347,7 @@ public interface KeyValueService extends AutoCloseable {
      * @param rows rows to delete
      */
     @Idempotent
-    @DoNotDelegate
-    default void deleteRows(TableReference tableRef, Iterable<byte[]> rows) {
-        rows.forEach(row -> deleteRange(tableRef, RangeRequests.ofSingleRow(row)));
-    }
+    void deleteRows(TableReference tableRef, Iterable<byte[]> rows);
 
     /**
      * For each cell, deletes all timestamps prior to the associated maximum timestamp. If this

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/RangeRequests.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/RangeRequests.java
@@ -218,4 +218,11 @@ public final class RangeRequests {
         }
         return UnsignedBytes.lexicographicalComparator().compare(startInclusive, endExclusive) == 0;
     }
+
+    public static RangeRequest ofSingleRow(@Nonnull byte[] row) {
+        return RangeRequest.builder()
+                .startRowInclusive(row)
+                .endRowExclusive(RangeRequests.nextLexicographicName(row))
+                .build();
+    }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -1593,7 +1593,6 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         try {
             clientPool.runWithRetry(client -> {
                 client.batch_mutate("deleteRows", mutationMap, DELETE_CONSISTENCY);
-                System.out.println("batch mutate" + mutationMap);
                 return null;
             });
         } catch (UnavailableException e) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -30,6 +30,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import javax.annotation.Nullable;
 
@@ -38,6 +39,7 @@ import org.apache.cassandra.thrift.CfDef;
 import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;
 import org.apache.cassandra.thrift.ConsistencyLevel;
+import org.apache.cassandra.thrift.Deletion;
 import org.apache.cassandra.thrift.KsDef;
 import org.apache.cassandra.thrift.Mutation;
 import org.apache.cassandra.thrift.SlicePredicate;
@@ -123,6 +125,7 @@ import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.common.base.Throwables;
 import com.palantir.common.exception.AtlasDbDependencyException;
 import com.palantir.common.exception.PalantirRuntimeException;
+import com.palantir.common.streams.KeyedStream;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.util.paging.AbstractPagingIterable;
 import com.palantir.util.paging.SimpleTokenBackedResultsPage;
@@ -1572,6 +1575,35 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             return false;
         }
         return Arrays.equals(endExclusive, RangeRequests.nextLexicographicName(startInclusive));
+    }
+
+    @Override
+    public void deleteRows(TableReference tableRef, Iterable<byte[]> rows) {
+        long timestamp = mutationTimestampProvider.getRemoveTimestamp();
+        Map<ByteBuffer, Map<String, List<Mutation>>> mutationMap
+                = KeyedStream.of(StreamSupport.stream(rows.spliterator(), false))
+                .mapKeys(ByteBuffer::wrap)
+                .map(row -> new Deletion().setTimestamp(timestamp).setPredicate(new SlicePredicate()))
+                .map(deletion -> new Mutation().setDeletion(deletion))
+                .map(mutation -> keyMutationMapByColumnFamily(tableRef, mutation))
+                .collectToMap();
+
+        try {
+            clientPool.runWithRetry(client -> {
+                client.batch_mutate("deleteRanges", mutationMap, DELETE_CONSISTENCY);
+                return null;
+            });
+        } catch (UnavailableException e) {
+            throw new InsufficientConsistencyException(
+                    "Deleting requires all Cassandra nodes to be up and available.", e);
+        } catch (TException e) {
+            throw Throwables.unwrapAndThrowAtlasDbDependencyException(e);
+        }
+    }
+
+    private Map<String, List<Mutation>> keyMutationMapByColumnFamily(TableReference tableRef,
+            Mutation mutation) {
+        return ImmutableMap.of(CassandraKeyValueServiceImpl.internalTableName(tableRef), ImmutableList.of(mutation));
     }
 
     @Override

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueService.java
@@ -40,6 +40,7 @@ import com.palantir.atlasdb.keyvalue.api.CheckAndSetCompatibility;
 import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.atlasdb.keyvalue.api.RangeRequests;
 import com.palantir.atlasdb.keyvalue.api.RowColumnRangeIterator;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
@@ -152,6 +153,11 @@ public abstract class AbstractKeyValueService implements KeyValueService {
                 delete(tableRef, cellsToDelete);
             }
         }
+    }
+
+    @Override
+    public void deleteRows(TableReference tableRef, Iterable<byte[]> rows) {
+        rows.forEach(row -> deleteRange(tableRef, RangeRequests.ofSingleRow(row)));
     }
 
     @Override

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DualWriteKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DualWriteKeyValueService.java
@@ -133,6 +133,12 @@ public class DualWriteKeyValueService implements KeyValueService {
     }
 
     @Override
+    public void deleteRows(TableReference tableRef, Iterable<byte[]> rows) {
+        delegate1.deleteRows(tableRef, rows);
+        delegate2.deleteRows(tableRef, rows);
+    }
+
+    @Override
     public void deleteAllTimestamps(TableReference tableRef, Map<Cell, TimestampRangeDelete> deletes) {
         delegate1.deleteAllTimestamps(tableRef, deletes);
         delegate2.deleteAllTimestamps(tableRef, deletes);

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueService.java
@@ -167,6 +167,15 @@ public final class TracingKeyValueService extends ForwardingObject implements Ke
     }
 
     @Override
+    public void deleteRows(TableReference tableRef, Iterable<byte[]> rows) {
+        //noinspection unused - try-with-resources closes trace
+        try (CloseableTrace trace = startLocalTrace("deleteRows({})",
+                LoggingArgs.safeTableOrPlaceholder(tableRef))) {
+            delegate().deleteRows(tableRef, rows);
+        }
+    }
+
+    @Override
     public void deleteAllTimestamps(TableReference tableRef, Map<Cell, TimestampRangeDelete> deletes) {
         //noinspection unused - try-with-resources closes trace
         try (CloseableTrace trace = startLocalTrace("deleteAllTimestamps({})",

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableRemappingKeyValueService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableRemappingKeyValueService.java
@@ -117,6 +117,15 @@ public final class TableRemappingKeyValueService extends ForwardingObject implem
     }
 
     @Override
+    public void deleteRows(TableReference tableRef, Iterable<byte[]> rows) {
+        try {
+            delegate().deleteRows(tableMapper.getMappedTableName(tableRef), rows);
+        } catch (TableMappingNotFoundException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    @Override
     public void deleteAllTimestamps(TableReference tableRef, Map<Cell, TimestampRangeDelete> deletes) {
         try {
             delegate().deleteAllTimestamps(tableMapper.getMappedTableName(tableRef), deletes);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableSplittingKeyValueService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableSplittingKeyValueService.java
@@ -137,6 +137,11 @@ public final class TableSplittingKeyValueService implements KeyValueService {
     }
 
     @Override
+    public void deleteRows(TableReference tableRef, Iterable<byte[]> rows) {
+        getDelegate(tableRef).deleteRows(tableRef, rows);
+    }
+
+    @Override
     public void deleteAllTimestamps(
             TableReference tableRef,
             Map<Cell, TimestampRangeDelete> deletes) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/config/TargetedSweepRuntimeConfig.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/config/TargetedSweepRuntimeConfig.java
@@ -54,15 +54,6 @@ public abstract class TargetedSweepRuntimeConfig {
         return false;
     }
 
-    /**
-     * If true, we may read information from multiple partitions before performing deletes. This may reduce RPC
-     * overhead, as deletes can be batched together.
-     */
-    @Value.Default
-    public boolean batchAcrossFinePartitions() {
-        return false;
-    }
-
     @Value.Check
     void checkShardSize() {
         Preconditions.checkArgument(shards() >= 1 && shards() <= 256,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/config/TargetedSweepRuntimeConfig.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/config/TargetedSweepRuntimeConfig.java
@@ -54,6 +54,15 @@ public abstract class TargetedSweepRuntimeConfig {
         return false;
     }
 
+    /**
+     * If true, we may read information from multiple partitions before performing deletes. This may reduce RPC
+     * overhead, as deletes can be batched together.
+     */
+    @Value.Default
+    public boolean batchAcrossFinePartitions() {
+        return false;
+    }
+
     @Value.Check
     void checkShardSize() {
         Preconditions.checkArgument(shards() >= 1 && shards() <= 256,

--- a/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueService.java
+++ b/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueService.java
@@ -695,6 +695,11 @@ public class JdbcKeyValueService implements KeyValueService {
     }
 
     @Override
+    public void deleteRows(TableReference tableRef, Iterable<byte[]> rows) {
+        rows.forEach(row -> deleteRange(tableRef, RangeRequests.ofSingleRow(row)));
+    }
+
+    @Override
     public void deleteAllTimestamps(TableReference tableRef, Map<Cell, TimestampRangeDelete> deletes) {
         if (deletes.isEmpty()) {
             return;

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
@@ -1086,6 +1086,42 @@ public abstract class AbstractKeyValueServiceTest {
     }
 
     @Test
+    public void deleteRowsWithNothing() {
+        setupTestRowsZeroOneAndTwoAndDeleteSpecific(ImmutableList.of());
+        checkThatTableIsNowOnly(row(0), row(1), row(2));
+    }
+
+    @Test
+    public void deleteRowsDeletesOneRow() {
+        setupTestRowsZeroOneAndTwoAndDeleteSpecific(ImmutableList.of(row(0)));
+        checkThatTableIsNowOnly(row(1), row(2));
+    }
+
+    @Test
+    public void deleteRowsDeletesMultipleRows() {
+        setupTestRowsZeroOneAndTwoAndDeleteSpecific(ImmutableList.of(row(0), row(2), row(1)));
+        checkThatTableIsNowOnly();
+    }
+
+    @Test
+    public void deleteRowsDeletesMultipleNoncontiguousRows() {
+        setupTestRowsZeroOneAndTwoAndDeleteSpecific(ImmutableList.of(row(0), row(2)));
+        checkThatTableIsNowOnly(row(1));
+    }
+
+    @Test
+    public void deleteRowsIgnoresRowsThatDoNotExist() {
+        setupTestRowsZeroOneAndTwoAndDeleteSpecific(ImmutableList.of(row(5), row(7)));
+        checkThatTableIsNowOnly(row(0), row(1), row(2));
+    }
+
+    @Test
+    public void deleteRowsResilientToDuplicates() {
+        setupTestRowsZeroOneAndTwoAndDeleteSpecific(ImmutableList.of(row(0), row(0), row(0), row(0)));
+        checkThatTableIsNowOnly(row(1), row(2));
+    }
+
+    @Test
     public void deleteTimestampRangesIgnoresEmptyMap() {
         keyValueService.deleteAllTimestamps(TEST_TABLE, ImmutableMap.of());
     }
@@ -1299,7 +1335,7 @@ public abstract class AbstractKeyValueServiceTest {
 
     private void setupTestRowsZeroOneAndTwoAndDeleteSpecific(List<byte[]> rows) {
         putTestDataForRowsZeroOneAndTwo();
-        
+
         keyValueService.deleteRows(TEST_TABLE, rows);
     }
 

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
@@ -1297,6 +1297,12 @@ public abstract class AbstractKeyValueServiceTest {
         keyValueService.deleteRange(TEST_TABLE, range);
     }
 
+    private void setupTestRowsZeroOneAndTwoAndDeleteSpecific(List<byte[]> rows) {
+        putTestDataForRowsZeroOneAndTwo();
+        
+        keyValueService.deleteRows(TEST_TABLE, rows);
+    }
+
     private void checkThatTableIsNowOnly(byte[]... rows) {
         List<byte[]> keys = Lists.newArrayList();
         keyValueService.getRange(TEST_TABLE, RangeRequest.all(), AtlasDbConstants.MAX_TS)

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -89,6 +89,11 @@ develop
            should improve targeted sweep throughput without adding additional load on Timelock for places where the downtime between targeted sweep iterations is a bottleneck.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/4086>`__)
 
+    *    - |devbreak|
+         - ``KeyValueService`` implementations now have a new endpoint ``deleteRows()`` that allows row-level deletes to be performed.
+           Users who extend ``KeyValueService`` will need to implement this method.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/4086>`__)
+
 ========
 v0.144.0
 ========

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -91,7 +91,7 @@ develop
 
     *    - |devbreak|
          - ``KeyValueService`` implementations now have a new endpoint ``deleteRows()`` that allows row-level deletes to be performed.
-           Users who extend ``KeyValueService`` will need to implement this method.
+           Users who extend ``KeyValueService`` will need to implement this method, but can refer to ``AbstractKeyValueService`` for a functional implementation (as this method can be written in terms of ``deleteRange()``).
            (`Pull Request <https://github.com/palantir/atlasdb/pull/4086>`__)
 
 ========


### PR DESCRIPTION
**Goals (and why)**:
- Provide a mechanism to delete entire specified rows from a key-value-service in a single call. The current APIs don't support this: `delete(TableReference, Multimap)` requires column names to be provided explicitly, and `delete(TableReference, RangeRequest)` requires the deletion to take place over a contiguous range. 
- This is needed for efficient batch cleanup of multiple rows from the targeted sweep queues, since the operation we want to do is "for a given shard and strategy, delete the rows corresponding to some partitions"; by the time we're in this operation we may not have all of the columns to hand (e.g. if we're clearing out only half of a batch), and the queues have hashed row components so they are non-contiguous.

**Implementation Description (bullets)**:
- Added a new `deleteRows()` method to the `KeyValueService`. This has a default implementation that creates single-row range requests and pushes them through sequentially to `deleteRange`.
- Implemented `deleteRows()` in `CassandraKeyValueService` to use `batch_mutate` so that only one RPC is needed regardless of the number of rows involved.
- Extended other implementations of `KeyValueService` to implement `deleteRows()` accordingly.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Added several tests to the Abstract KVS integration test that exercise the new functionality.

**Concerns (what feedback would you like?)**:
- Is the abstract implementation workable? I'm pretty sure it does give correct results. My fear is more that users aren't expecting this to take one RPC per row. It's been documented.
- Do we need a better implementation for DbKVS? This is only planned to be used in TS so as far as I'm aware it's not urgently needed at this time.

**Where should we start reviewing?**: The API docs and test probably give a good feel of what the method is supposed to do.

**Priority (whenever / two weeks / yesterday)**: this week