### PR TITLE
Relax concurrency model for MetricsManager.

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/util/MetricsManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/util/MetricsManager.java
@@ -15,10 +15,10 @@
  */
 package com.palantir.atlasdb.util;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Predicate;
@@ -57,8 +57,8 @@ public class MetricsManager {
             Predicate<TableReference> isSafeToLog) {
         this.metricRegistry = metricRegistry;
         this.taggedMetricRegistry = taggedMetricRegistry;
-        this.registeredMetrics = new HashSet<>();
-        this.registeredTaggedMetrics = new HashSet<>();
+        this.registeredMetrics = ConcurrentHashMap.newKeySet();
+        this.registeredTaggedMetrics = ConcurrentHashMap.newKeySet();
         this.isSafeToLog = isSafeToLog;
         this.lock = new ReentrantReadWriteLock();
     }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/util/MetricsManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/util/MetricsManager.java
@@ -19,6 +19,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -48,6 +50,7 @@ public class MetricsManager {
     private final Set<String> registeredMetrics;
     private final Set<MetricName> registeredTaggedMetrics;
     private final Predicate<TableReference> isSafeToLog;
+    private final ReadWriteLock lock;
 
     public MetricsManager(MetricRegistry metricRegistry,
             TaggedMetricRegistry taggedMetricRegistry,
@@ -57,6 +60,7 @@ public class MetricsManager {
         this.registeredMetrics = new HashSet<>();
         this.registeredTaggedMetrics = new HashSet<>();
         this.isSafeToLog = isSafeToLog;
+        this.lock = new ReentrantReadWriteLock();
     }
 
     public MetricRegistry getRegistry() {
@@ -67,38 +71,8 @@ public class MetricsManager {
         return taggedMetricRegistry;
     }
 
-    public void registerMetric(Class clazz, String metricPrefix, String metricName, Gauge gauge) {
-        registerMetric(clazz, metricPrefix, metricName, (Metric) gauge);
-    }
-
-    public void registerMetric(Class clazz, String metricPrefix, String metricName, Metric metric) {
-        registerMetricWithFqn(MetricRegistry.name(clazz, metricPrefix, metricName), metric);
-    }
-
     public void registerMetric(Class clazz, String metricName, Gauge gauge) {
-        registerMetric(clazz, metricName, (Metric) gauge);
-    }
-
-    public void registerMetric(Class clazz, String metricName, Metric metric) {
-        registerMetricWithFqn(MetricRegistry.name(clazz, metricName), metric);
-    }
-
-    /**
-     * Add a new gauge metric of the given name.
-     *
-     * If the metric already exists, this will REPLACE it with a new metric.
-     * Consider using {@link MetricsManager#registerOrGet} instead.
-     */
-    public synchronized void registerMetric(Class clazz, String metricName, Gauge gauge, Map<String, String> tag) {
-        MetricName metricToAdd = getTaggedMetricName(clazz, metricName, tag);
-        if (taggedMetricRegistry.getMetrics().containsKey(metricToAdd)) {
-            log.warn("Replacing the metric [ {} ]. This will happen if you are trying to re-register metrics "
-                            + "or have two tagged metrics with the same name across the application.",
-                    SafeArg.of("metricName", metricName));
-            taggedMetricRegistry.remove(metricToAdd);
-        }
-        taggedMetricRegistry.gauge(metricToAdd, gauge);
-        registeredTaggedMetrics.add(metricToAdd);
+        registerMetricWithFqn(MetricRegistry.name(clazz, metricName), gauge);
     }
 
     /**
@@ -106,12 +80,12 @@ public class MetricsManager {
      *
      * @throws IllegalStateException if a non-gauge metric with the same name already exists.
      */
-    public synchronized Gauge registerOrGet(Class clazz, String metricName, Gauge gauge, Map<String, String> tag) {
+    public Gauge registerOrGet(Class clazz, String metricName, Gauge gauge, Map<String, String> tag) {
         MetricName metricToAdd = getTaggedMetricName(clazz, metricName, tag);
 
         try {
             Gauge registeredGauge = taggedMetricRegistry.gauge(metricToAdd, gauge);
-            registeredTaggedMetrics.add(metricToAdd);
+            registerTaggedMetricName(metricToAdd);
             return registeredGauge;
         } catch (IllegalArgumentException ex) {
             log.error("Tried to add a gauge to a metric name {} that has non-gauge metrics associated with it."
@@ -138,10 +112,10 @@ public class MetricsManager {
         return ImmutableMap.of("tableName", tableName);
     }
 
-    private synchronized void registerMetricWithFqn(String fullyQualifiedMetricName, Metric metric) {
+    private void registerMetricWithFqn(String fullyQualifiedMetricName, Metric metric) {
         try {
             metricRegistry.register(fullyQualifiedMetricName, metric);
-            registeredMetrics.add(fullyQualifiedMetricName);
+            registerMetricName(fullyQualifiedMetricName);
         } catch (Exception e) {
             // Primarily to handle integration tests that instantiate this class multiple times in a row
             log.warn("Unable to register metric {}."
@@ -160,9 +134,9 @@ public class MetricsManager {
         return registerOrGetHistogram(MetricRegistry.name(clazz, metricName));
     }
 
-    private synchronized Histogram registerOrGetHistogram(String fullyQualifiedHistogramName) {
+    private Histogram registerOrGetHistogram(String fullyQualifiedHistogramName) {
         Histogram histogram = metricRegistry.histogram(fullyQualifiedHistogramName);
-        registeredMetrics.add(fullyQualifiedHistogramName);
+        registerMetricName(fullyQualifiedHistogramName);
         return histogram;
     }
 
@@ -170,9 +144,9 @@ public class MetricsManager {
         return registerOrGetTimer(MetricRegistry.name(clazz, metricName));
     }
 
-    private synchronized Timer registerOrGetTimer(String fullyQualifiedHistogramName) {
+    private Timer registerOrGetTimer(String fullyQualifiedHistogramName) {
         Timer timer = metricRegistry.timer(fullyQualifiedHistogramName);
-        registeredMetrics.add(fullyQualifiedHistogramName);
+        registerMetricName(fullyQualifiedHistogramName);
         return timer;
     }
 
@@ -184,40 +158,69 @@ public class MetricsManager {
         return registerOrGetMeter(MetricRegistry.name(clazz, metricPrefix, meterName));
     }
 
-    private synchronized Meter registerOrGetMeter(String fullyQualifiedMeterName) {
+    private Meter registerOrGetMeter(String fullyQualifiedMeterName) {
         Meter meter = metricRegistry.meter(fullyQualifiedMeterName);
-        registeredMetrics.add(fullyQualifiedMeterName);
+        registerMetricName(fullyQualifiedMeterName);
         return meter;
     }
 
-    public synchronized Meter registerOrGetTaggedMeter(Class clazz, String metricName, Map<String, String> tags) {
+    public Meter registerOrGetTaggedMeter(Class clazz, String metricName, Map<String, String> tags) {
         MetricName name = getTaggedMetricName(clazz, metricName, tags);
         Meter meter = taggedMetricRegistry.meter(name);
-        registeredTaggedMetrics.add(name);
+        registerTaggedMetricName(name);
         return meter;
     }
 
-    public synchronized Histogram registerOrGetTaggedHistogram(Class clazz, String metricName,
-                                                                Map<String, String> tags) {
+    public Histogram registerOrGetTaggedHistogram(
+            Class clazz, String metricName,
+            Map<String, String> tags) {
         MetricName name = getTaggedMetricName(clazz, metricName, tags);
         Histogram histogram = taggedMetricRegistry.histogram(name);
-        registeredTaggedMetrics.add(name);
+        registerTaggedMetricName(name);
         return histogram;
     }
 
-    public synchronized void deregisterMetrics() {
-        registeredMetrics.forEach(metricRegistry::remove);
-        registeredMetrics.clear();
-
-        registeredTaggedMetrics.forEach(taggedMetricRegistry::remove);
-        registeredTaggedMetrics.clear();
+    private void registerMetricName(String fullyQualifiedMeterName) {
+        lock.readLock().lock();
+        try {
+            registeredMetrics.add(fullyQualifiedMeterName);
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
-    public synchronized void deregisterTaggedMetrics(Predicate<MetricName> predicate) {
-        List<MetricName> metricsToRemove = taggedMetricRegistry.getMetrics().keySet().stream()
-                .filter(predicate)
-                .collect(Collectors.toList());
+    private void registerTaggedMetricName(MetricName name) {
+        lock.readLock().lock();
+        try {
+            registeredTaggedMetrics.add(name);
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
 
-        metricsToRemove.forEach(taggedMetricRegistry::remove);
+    public void deregisterMetrics() {
+        lock.writeLock().lock();
+        try {
+            registeredMetrics.forEach(metricRegistry::remove);
+            registeredMetrics.clear();
+
+            registeredTaggedMetrics.forEach(taggedMetricRegistry::remove);
+            registeredTaggedMetrics.clear();
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    public void deregisterTaggedMetrics(Predicate<MetricName> predicate) {
+        lock.writeLock().lock();
+        try {
+            List<MetricName> metricsToRemove = taggedMetricRegistry.getMetrics().keySet().stream()
+                    .filter(predicate)
+                    .collect(Collectors.toList());
+
+            metricsToRemove.forEach(taggedMetricRegistry::remove);
+        } finally {
+            lock.writeLock().unlock();
+        }
     }
 }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/util/MetricsManagerTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/util/MetricsManagerTest.java
@@ -27,11 +27,9 @@ import org.junit.Test;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
-import com.google.common.collect.ImmutableMap;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
-import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 
 public class MetricsManagerTest {
@@ -61,54 +59,11 @@ public class MetricsManagerTest {
     }
 
     @Test
-    public void registersMetricsByPrefixAndName() {
-        metricsManager.registerMetric(LIST_CLASS, ERROR_PREFIX, OUT_OF_BOUNDS, GAUGE);
-
-        assertThat(registry.getNames()).containsExactly(MetricRegistry.name(LIST_CLASS, ERROR_OUT_OF_BOUNDS));
-    }
-
-    @Test
     public void registersMeters() {
         metricsManager.registerOrGetMeter(LIST_CLASS, RUNTIME, METER_NAME);
 
         assertThat(registry.getMeters().keySet()).containsExactly(
                 MetricRegistry.name(LIST_CLASS, RUNTIME, METER_NAME));
-    }
-
-    @Test
-    public void registersSingleTaggedGauge() {
-        ImmutableMap<String, String> oneTag = ImmutableMap.of("tag1", "value");
-        metricsManager.registerMetric(LIST_CLASS, METER_NAME, GAUGE, oneTag);
-
-        assertThat(taggedMetricRegistry.getMetrics().keySet())
-                .contains(MetricName.builder()
-                        .safeName(MetricRegistry.name(LIST_CLASS, METER_NAME))
-                        .safeTags(oneTag)
-                        .build());
-    }
-
-    @Test
-    public void registersMultipleTaggedGauge() {
-        ImmutableMap<String, String> oneTag = ImmutableMap.of("tag1", "value", "tag2", "value2");
-        metricsManager.registerMetric(LIST_CLASS, METER_NAME, GAUGE, oneTag);
-
-        assertThat(taggedMetricRegistry.getMetrics().keySet())
-                .contains(MetricName.builder()
-                        .safeName(MetricRegistry.name(LIST_CLASS, METER_NAME))
-                        .safeTags(oneTag)
-                        .build());
-    }
-
-    @Test
-    public void registersSameGaugeMultipleTimesWithDifferentTags() {
-        ImmutableMap<String, String> gauge1Tags = ImmutableMap.of("tag1", "value");
-        ImmutableMap<String, String> gauge2Tags = ImmutableMap.of("tag2", "value2");
-        metricsManager.registerMetric(LIST_CLASS, METER_NAME, GAUGE, gauge1Tags);
-        metricsManager.registerMetric(LIST_CLASS, METER_NAME, GAUGE, gauge2Tags);
-
-        assertThat(taggedMetricRegistry.getMetrics().keySet())
-                .contains(MetricName.builder().safeName(MetricRegistry.name(LIST_CLASS, METER_NAME)).safeTags(gauge1Tags).build(),
-                        MetricName.builder().safeName(MetricRegistry.name(LIST_CLASS, METER_NAME)).safeTags(gauge2Tags).build());
     }
 
     @Test
@@ -144,7 +99,7 @@ public class MetricsManagerTest {
         assertThat(tag.get("tableName")).isEqualTo("unsafeTable");
     }
 
-    private TableReference table(String tableName) {
+    private static TableReference table(String tableName) {
         return TableReference.create(Namespace.create("foo"), tableName);
     }
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -91,7 +91,7 @@ develop
 
     *    - |improved|
          - Relaxed concurrency model of ``MetricsManager`` allowing for more concurrency.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/4097>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/4098>`__)
 
 ========
 v0.144.0

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -89,6 +89,10 @@ develop
            should improve targeted sweep throughput without adding additional load on Timelock for places where the downtime between targeted sweep iterations is a bottleneck.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/4086>`__)
 
+    *    - |improved|
+         - Relaxed concurrency model of ``MetricsManager`` allowing for more concurrency.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/4097>`__)
+
 ========
 v0.144.0
 ========


### PR DESCRIPTION
**Goals (and why)**:
Can get into situations where a lot of threads are blocked on trying to do something with metrics, and `synchronized` doesn't help here. Unclear whether or not this will fix the underlying issue, but this is a relatively trivial PR.

**Implementation Description (bullets)**:
* Delete unused code
* Only need exclusive access when deregistering, so this becomes write lock, everything else becomes write lock.

**Testing (What was existing testing like?  What have you done to improve it?)**:
None

**Where should we start reviewing?**:
`MetricsManager`

**Priority (whenever / two weeks / yesterday)**:
Relatively soon.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
