### PR TITLE
Cross-Partitioning TS, Part 4: More Tests, Part 1

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/TargetedSweeper.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/TargetedSweeper.java
@@ -103,8 +103,7 @@ public class TargetedSweeper implements MultiTableSweepQueueWriter, BackgroundSw
         return new TargetedSweeper(metrics, runtime, install, followers);
     }
 
-    @VisibleForTesting
-    static TargetedSweeper createUninitializedForTest(MetricsManager metricsManager,
+    public static TargetedSweeper createUninitializedForTest(MetricsManager metricsManager,
             Supplier<TargetedSweepRuntimeConfig> runtime) {
         TargetedSweepInstallConfig install = ImmutableTargetedSweepInstallConfig.builder()
                 .conservativeThreads(0)

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepBatchAccumulatorTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepBatchAccumulatorTest.java
@@ -128,6 +128,22 @@ public class SweepBatchAccumulatorTest {
     }
 
     @Test
+    public void mergesFinePartitionsFromWritesAndDedicatedRows() {
+        accumulator.accumulateBatch(SweepBatch.of(
+                ImmutableList.of(WRITE_INFO_1),
+                DedicatedRows.of(
+                        ImmutableList.of(
+                                SweepableCellsTable.SweepableCellsRow.of(
+                                        SweepQueueUtils.minTsForFinePartition(1), PtBytes.toBytes("aaaaaaa")))),
+                SweepQueueUtils.minTsForFinePartition(2)));
+
+        SweepBatchWithPartitionInfo batchWithPartitionInfo = accumulator.toSweepBatch();
+        assertThat(batchWithPartitionInfo.finePartitions())
+                .hasSize(2)
+                .isEqualTo(ImmutableSet.of(SweepQueueUtils.tsPartitionFine(WRITE_INFO_1.timestamp()), 1L));
+    }
+
+    @Test
     public void onlyKeepsNewestVersionOfWriteInfoWhenMergingMultipleBatches() {
         accumulator.accumulateBatch(SweepBatch.of(
                 ImmutableList.of(WRITE_INFO_1),

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepBatchAccumulatorTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepBatchAccumulatorTest.java
@@ -133,7 +133,7 @@ public class SweepBatchAccumulatorTest {
                 PROGRESS_TIMESTAMP + 177));
         WriteInfo writeInfo1AtNewerVersion = WriteInfo.write(TABLE_REFERENCE_1, CELL_1,
                 PROGRESS_TIMESTAMP + 100 + SweepQueueUtils.TS_FINE_GRANULARITY);
-        long newSweepTimestamp = PROGRESS_TIMESTAMP + 288 + SweepQueueUtils.TS_FINE_GRANULARITY;
+        long newSweepTimestamp = PROGRESS_TIMESTAMP + 288 + SweepQueueUtils.minTsForFinePartition(1);
         accumulator.accumulateBatch(SweepBatch.of(
                 ImmutableList.of(writeInfo1AtNewerVersion),
                 NO_DEDICATED_ROWS,
@@ -149,7 +149,7 @@ public class SweepBatchAccumulatorTest {
         // Both must still be present here!
         assertThat(batchWithPartitionInfo.finePartitions()).isEqualTo(ImmutableSet.of(
                 SweepQueueUtils.tsPartitionFine(PROGRESS_TIMESTAMP + 177),
-                SweepQueueUtils.tsPartitionFine(PROGRESS_TIMESTAMP + 100 + SweepQueueUtils.TS_FINE_GRANULARITY)));
+                SweepQueueUtils.tsPartitionFine(PROGRESS_TIMESTAMP + 100 + SweepQueueUtils.minTsForFinePartition(1))));
     }
 
     @Test
@@ -159,8 +159,8 @@ public class SweepBatchAccumulatorTest {
                 NO_DEDICATED_ROWS,
                 PROGRESS_TIMESTAMP + 177));
         WriteInfo writeInfo1AtNewerVersion = WriteInfo.write(TABLE_REFERENCE_1, CELL_1,
-                PROGRESS_TIMESTAMP + 100 + 9 * SweepQueueUtils.TS_FINE_GRANULARITY);
-        long newSweepTimestamp = PROGRESS_TIMESTAMP + 288 + 15 * SweepQueueUtils.TS_FINE_GRANULARITY;
+                PROGRESS_TIMESTAMP + 100 + SweepQueueUtils.minTsForFinePartition(9));
+        long newSweepTimestamp = PROGRESS_TIMESTAMP + 288 + SweepQueueUtils.minTsForFinePartition(15);
         accumulator.accumulateBatch(SweepBatch.of(
                 ImmutableList.of(writeInfo1AtNewerVersion),
                 NO_DEDICATED_ROWS,
@@ -175,7 +175,7 @@ public class SweepBatchAccumulatorTest {
 
         assertThat(batchWithPartitionInfo.finePartitions()).isEqualTo(ImmutableSet.of(
                 SweepQueueUtils.tsPartitionFine(PROGRESS_TIMESTAMP + 177),
-                SweepQueueUtils.tsPartitionFine(PROGRESS_TIMESTAMP + 100 + 9 * SweepQueueUtils.TS_FINE_GRANULARITY)));
+                SweepQueueUtils.tsPartitionFine(PROGRESS_TIMESTAMP + 100 + SweepQueueUtils.minTsForFinePartition(9))));
     }
 
     @Test

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepBatchAccumulatorTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepBatchAccumulatorTest.java
@@ -122,7 +122,9 @@ public class SweepBatchAccumulatorTest {
                     ImmutableList.of(SWEEPABLE_CELLS_ROW_1, SWEEPABLE_CELLS_ROW_2)));
             assertThat(batch.lastSweptTimestamp()).isEqualTo(PROGRESS_TIMESTAMP + 288);
         });
-        assertThat(batchWithPartitionInfo.finePartitions()).isEqualTo(ImmutableSet.of());
+        assertThat(batchWithPartitionInfo.finePartitions()).isEqualTo(ImmutableSet.of(
+                SweepQueueUtils.tsPartitionFine(PROGRESS_TIMESTAMP + 177),
+                SweepQueueUtils.tsPartitionFine(PROGRESS_TIMESTAMP + 288)));
     }
 
     @Test

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepBatchAccumulatorTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepBatchAccumulatorTest.java
@@ -1,0 +1,173 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.queue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.schema.generated.SweepableCellsTable;
+
+public class SweepBatchAccumulatorTest {
+    private static final long SWEEP_TIMESTAMP = 3141592L;
+    private static final long PROGRESS_TIMESTAMP = 16180L;
+    private static final TableReference TABLE_REFERENCE_1 = TableReference.createWithEmptyNamespace("table");
+    private static final Cell CELL_1 = Cell.create(PtBytes.toBytes("row"), PtBytes.toBytes("column"));
+    private static final Cell CELL_2 = Cell.create(PtBytes.toBytes("reihe"), PtBytes.toBytes("kolumne"));
+    private static final WriteInfo WRITE_INFO_1 = WriteInfo.write(TABLE_REFERENCE_1, CELL_1, PROGRESS_TIMESTAMP + 100);
+    private static final WriteInfo WRITE_INFO_2 = WriteInfo.write(TABLE_REFERENCE_1, CELL_2, PROGRESS_TIMESTAMP + 200);
+
+    private static final DedicatedRows NO_DEDICATED_ROWS = DedicatedRows.of(ImmutableList.of());
+    private static final SweepableCellsTable.SweepableCellsRow SWEEPABLE_CELLS_ROW_1
+            = SweepableCellsTable.SweepableCellsRow.of(1, PtBytes.toBytes("metadata"));
+    private static final SweepableCellsTable.SweepableCellsRow SWEEPABLE_CELLS_ROW_2
+            = SweepableCellsTable.SweepableCellsRow.of(2, PtBytes.toBytes("more metadata"));
+    private static final DedicatedRows DEDICATED_ROWS_1 = DedicatedRows.of(ImmutableList.of(SWEEPABLE_CELLS_ROW_1));
+    private static final DedicatedRows DEDICATED_ROWS_2 = DedicatedRows.of(ImmutableList.of(SWEEPABLE_CELLS_ROW_2));
+
+    @Test
+    public void noBatchesMeansEverythingSweptUpToTheSweepTimestamp() {
+        SweepBatchAccumulator accumulator = new SweepBatchAccumulator(SWEEP_TIMESTAMP, PROGRESS_TIMESTAMP);
+        SweepBatchWithPartitionInfo batchWithPartitionInfo = accumulator.toSweepBatch();
+
+        assertThat(batchWithPartitionInfo.sweepBatch()).satisfies(batch -> {
+            assertThat(batch.writes()).isEmpty();
+            assertThat(batch.dedicatedRows()).isEqualTo(NO_DEDICATED_ROWS);
+            assertThat(batch.lastSweptTimestamp()).isEqualTo(SWEEP_TIMESTAMP - 1);
+        });
+        assertThat(batchWithPartitionInfo.finePartitions()).isEmpty();
+    }
+
+    @Test
+    public void oneBatchAccumulatesToItselfAndLogsPartition() {
+        SweepBatchAccumulator accumulator = new SweepBatchAccumulator(SWEEP_TIMESTAMP, PROGRESS_TIMESTAMP);
+        SweepBatch sweepBatch = SweepBatch.of(
+                ImmutableList.of(WRITE_INFO_1),
+                DEDICATED_ROWS_1,
+                PROGRESS_TIMESTAMP + 200);
+        accumulator.accumulateBatch(sweepBatch);
+
+        SweepBatchWithPartitionInfo batchWithPartitionInfo = accumulator.toSweepBatch();
+        assertThat(batchWithPartitionInfo.sweepBatch()).isEqualTo(sweepBatch);
+        assertThat(batchWithPartitionInfo.finePartitions())
+                .containsExactly(SweepQueueUtils.tsPartitionFine(PROGRESS_TIMESTAMP + 200));
+    }
+
+    @Test
+    public void mergesTwoBatchesWithDistinctWriteInfo() {
+        SweepBatchAccumulator accumulator = new SweepBatchAccumulator(SWEEP_TIMESTAMP, PROGRESS_TIMESTAMP);
+        accumulator.accumulateBatch(SweepBatch.of(
+                ImmutableList.of(WRITE_INFO_1),
+                NO_DEDICATED_ROWS,
+                PROGRESS_TIMESTAMP + 177));
+        accumulator.accumulateBatch(SweepBatch.of(
+                ImmutableList.of(WRITE_INFO_2),
+                NO_DEDICATED_ROWS,
+                PROGRESS_TIMESTAMP + 288));
+
+        SweepBatchWithPartitionInfo batchWithPartitionInfo = accumulator.toSweepBatch();
+        assertThat(batchWithPartitionInfo.sweepBatch()).satisfies(batch -> {
+            assertThat(batch.writes()).containsExactlyInAnyOrder(WRITE_INFO_1, WRITE_INFO_2);
+            assertThat(batch.dedicatedRows()).isEqualTo(NO_DEDICATED_ROWS);
+            assertThat(batch.lastSweptTimestamp()).isEqualTo(PROGRESS_TIMESTAMP + 288);
+        });
+        assertThat(batchWithPartitionInfo.finePartitions()).isEqualTo(ImmutableSet.of(
+                SweepQueueUtils.tsPartitionFine(PROGRESS_TIMESTAMP + 177),
+                SweepQueueUtils.tsPartitionFine(PROGRESS_TIMESTAMP + 288)));
+    }
+
+    @Test
+    public void mergesDedicatedRows() {
+        SweepBatchAccumulator accumulator = new SweepBatchAccumulator(SWEEP_TIMESTAMP, PROGRESS_TIMESTAMP);
+        accumulator.accumulateBatch(SweepBatch.of(
+                ImmutableList.of(),
+                DEDICATED_ROWS_1,
+                PROGRESS_TIMESTAMP + 177));
+        accumulator.accumulateBatch(SweepBatch.of(
+                ImmutableList.of(),
+                DEDICATED_ROWS_2,
+                PROGRESS_TIMESTAMP + 288));
+
+        SweepBatchWithPartitionInfo batchWithPartitionInfo = accumulator.toSweepBatch();
+        assertThat(batchWithPartitionInfo.sweepBatch()).satisfies(batch -> {
+            assertThat(batch.dedicatedRows()).isEqualTo(DedicatedRows.of(
+                    ImmutableList.of(SWEEPABLE_CELLS_ROW_1, SWEEPABLE_CELLS_ROW_2)));
+            assertThat(batch.lastSweptTimestamp()).isEqualTo(PROGRESS_TIMESTAMP + 288);
+        });
+        assertThat(batchWithPartitionInfo.finePartitions()).isEqualTo(ImmutableSet.of());
+    }
+
+    @Test
+    public void onlyKeepsNewestVersionOfWriteInfoWhenMergingMultipleBatches() {
+        SweepBatchAccumulator accumulator = new SweepBatchAccumulator(SWEEP_TIMESTAMP, PROGRESS_TIMESTAMP);
+        accumulator.accumulateBatch(SweepBatch.of(
+                ImmutableList.of(WRITE_INFO_1),
+                NO_DEDICATED_ROWS,
+                PROGRESS_TIMESTAMP + 177));
+        WriteInfo writeInfo1AtNewerVersion = WriteInfo.write(TABLE_REFERENCE_1, CELL_1,
+                PROGRESS_TIMESTAMP + 100 + SweepQueueUtils.TS_FINE_GRANULARITY);
+        long newSweepTimestamp = PROGRESS_TIMESTAMP + 288 + SweepQueueUtils.TS_FINE_GRANULARITY;
+        accumulator.accumulateBatch(SweepBatch.of(
+                ImmutableList.of(writeInfo1AtNewerVersion),
+                NO_DEDICATED_ROWS,
+                newSweepTimestamp));
+
+        SweepBatchWithPartitionInfo batchWithPartitionInfo = accumulator.toSweepBatch();
+        assertThat(batchWithPartitionInfo.sweepBatch()).satisfies(batch -> {
+            assertThat(batch.writes()).containsExactlyInAnyOrder(writeInfo1AtNewerVersion);
+            assertThat(batch.dedicatedRows()).isEqualTo(NO_DEDICATED_ROWS);
+            assertThat(batch.lastSweptTimestamp()).isEqualTo(newSweepTimestamp);
+        });
+
+        // Both must still be present here!
+        assertThat(batchWithPartitionInfo.finePartitions()).isEqualTo(ImmutableSet.of(
+                SweepQueueUtils.tsPartitionFine(PROGRESS_TIMESTAMP + 177),
+                SweepQueueUtils.tsPartitionFine(PROGRESS_TIMESTAMP + 100 + SweepQueueUtils.TS_FINE_GRANULARITY)));
+    }
+
+    @Test
+    public void correctlySkipsPartitionsWhenMergingMultipleBatches() {
+        SweepBatchAccumulator accumulator = new SweepBatchAccumulator(SWEEP_TIMESTAMP, PROGRESS_TIMESTAMP);
+        accumulator.accumulateBatch(SweepBatch.of(
+                ImmutableList.of(WRITE_INFO_1),
+                NO_DEDICATED_ROWS,
+                PROGRESS_TIMESTAMP + 177));
+        WriteInfo writeInfo1AtNewerVersion = WriteInfo.write(TABLE_REFERENCE_1, CELL_1,
+                PROGRESS_TIMESTAMP + 100 + 9 * SweepQueueUtils.TS_FINE_GRANULARITY);
+        long newSweepTimestamp = PROGRESS_TIMESTAMP + 288 + 15 * SweepQueueUtils.TS_FINE_GRANULARITY;
+        accumulator.accumulateBatch(SweepBatch.of(
+                ImmutableList.of(writeInfo1AtNewerVersion),
+                NO_DEDICATED_ROWS,
+                newSweepTimestamp));
+
+        SweepBatchWithPartitionInfo batchWithPartitionInfo = accumulator.toSweepBatch();
+        assertThat(batchWithPartitionInfo.sweepBatch()).satisfies(batch -> {
+            assertThat(batch.writes()).containsExactlyInAnyOrder(writeInfo1AtNewerVersion);
+            assertThat(batch.dedicatedRows()).isEqualTo(NO_DEDICATED_ROWS);
+            assertThat(batch.lastSweptTimestamp()).isEqualTo(newSweepTimestamp);
+        });
+
+        assertThat(batchWithPartitionInfo.finePartitions()).isEqualTo(ImmutableSet.of(
+                SweepQueueUtils.tsPartitionFine(PROGRESS_TIMESTAMP + 177),
+                SweepQueueUtils.tsPartitionFine(PROGRESS_TIMESTAMP + 100 + 9 * SweepQueueUtils.TS_FINE_GRANULARITY)));
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepBatchWithPartitionInfoTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepBatchWithPartitionInfoTest.java
@@ -1,0 +1,85 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.queue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableSet;
+
+public class SweepBatchWithPartitionInfoTest {
+    private final SweepBatch batch = mock(SweepBatch.class);
+
+    @Test
+    public void sweepWithinSinglePartitionLeadsToNoPartitionsToClear() {
+        when(batch.lastSweptTimestamp()).thenReturn(SweepQueueUtils.minTsForFinePartition(19) + 84L);
+        SweepBatchWithPartitionInfo batchWithPartitionInfo
+                = SweepBatchWithPartitionInfo.of(batch, ImmutableSet.of(19L));
+        assertThat(batchWithPartitionInfo.partitionsForPreviousLastSweptTs(SweepQueueUtils.minTsForFinePartition(19)))
+                .containsExactlyInAnyOrder();
+    }
+
+    @Test
+    public void currentlyActivePartitionIsNotCleared() {
+        when(batch.lastSweptTimestamp()).thenReturn(SweepQueueUtils.minTsForFinePartition(19) + 84L);
+        SweepBatchWithPartitionInfo batchWithPartitionInfo
+                = SweepBatchWithPartitionInfo.of(batch, ImmutableSet.of(15L, 16L, 17L, 18L, 19L));
+        assertThat(batchWithPartitionInfo.partitionsForPreviousLastSweptTs(SweepQueueUtils.INITIAL_TIMESTAMP))
+                .containsExactlyInAnyOrder(15L, 16L, 17L, 18L);
+    }
+
+    @Test
+    public void partitionIsClearableIfWeHaveSweptTillItsEnd() {
+        when(batch.lastSweptTimestamp()).thenReturn(SweepQueueUtils.maxTsForFinePartition(19));
+        SweepBatchWithPartitionInfo batchWithPartitionInfo
+                = SweepBatchWithPartitionInfo.of(batch, ImmutableSet.of(19L));
+        assertThat(batchWithPartitionInfo.partitionsForPreviousLastSweptTs(SweepQueueUtils.INITIAL_TIMESTAMP))
+                .containsExactlyInAnyOrder(19L);
+    }
+
+    @Test
+    public void partitionsNeedNotBeContiguous() {
+        when(batch.lastSweptTimestamp()).thenReturn(SweepQueueUtils.maxTsForFinePartition(19));
+        Set<Long> partitions = ImmutableSet.of(3L, 9L, 12L, 15L, 17L);
+        SweepBatchWithPartitionInfo batchWithPartitionInfo = SweepBatchWithPartitionInfo.of(batch, partitions);
+        assertThat(batchWithPartitionInfo.partitionsForPreviousLastSweptTs(SweepQueueUtils.INITIAL_TIMESTAMP))
+                .hasSameElementsAs(partitions);
+    }
+
+    @Test
+    public void cleansUpOldRowIfNeeded() {
+        when(batch.lastSweptTimestamp()).thenReturn(SweepQueueUtils.maxTsForFinePartition(19));
+        SweepBatchWithPartitionInfo batchWithPartitionInfo
+                = SweepBatchWithPartitionInfo.of(batch, ImmutableSet.of(19L));
+        assertThat(batchWithPartitionInfo.partitionsForPreviousLastSweptTs(SweepQueueUtils.minTsForFinePartition(8L)))
+                .containsExactlyInAnyOrder(8L, 19L);
+    }
+
+    @Test
+    public void cleansUpOldRowEvenIfItHasReachedItsEnd() { // Needed for legacy compatibility
+        when(batch.lastSweptTimestamp()).thenReturn(SweepQueueUtils.maxTsForFinePartition(19));
+        SweepBatchWithPartitionInfo batchWithPartitionInfo
+                = SweepBatchWithPartitionInfo.of(batch, ImmutableSet.of(19L));
+        assertThat(batchWithPartitionInfo.partitionsForPreviousLastSweptTs(SweepQueueUtils.maxTsForFinePartition(8L)))
+                .containsExactlyInAnyOrder(8L, 19L);
+    }
+}

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractTargetedSweepTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractTargetedSweepTest.java
@@ -37,7 +37,10 @@ import com.palantir.atlasdb.sweep.queue.ShardAndStrategy;
 import com.palantir.atlasdb.sweep.queue.SpecialTimestampsSupplier;
 import com.palantir.atlasdb.sweep.queue.TargetedSweepFollower;
 import com.palantir.atlasdb.sweep.queue.TargetedSweeper;
+import com.palantir.atlasdb.sweep.queue.config.ImmutableTargetedSweepRuntimeConfig;
 import com.palantir.atlasdb.table.description.TableMetadata;
+import com.palantir.atlasdb.util.MetricsManager;
+import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.lock.v2.TimelockService;
 
 public class AbstractTargetedSweepTest extends AbstractSweepTest {
@@ -57,7 +60,10 @@ public class AbstractTargetedSweepTest extends AbstractSweepTest {
     public void setup() {
         super.setup();
 
-        sweepQueue = TargetedSweeper.createUninitializedForTest(() -> 1);
+        MetricsManager metricsManager = MetricsManagers.createForTests();
+        sweepQueue = TargetedSweeper.createUninitializedForTest(metricsManager,
+                () -> ImmutableTargetedSweepRuntimeConfig.builder().shards(1).maximumPartitionsToBatchInSingleRead(8)
+                        .build());
         sweepQueue.initializeWithoutRunning(
                 timestampsSupplier, mock(TimelockService.class), kvs, txService, mock(TargetedSweepFollower.class));
     }


### PR DESCRIPTION
**Goals (and why)**:
- Add more tests to cross-partitioning TS; PR #4097 had a few and we manually verified things worked, but that's not sustainable especially if/when we want to push more changes to TS.

**Implementation Description (bullets)**:
- Add tests for the accumulator and 'which partitions do I need to clean' logic
- Wire up targeted sweep integration tests to read 8 at a shot.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Automated testing was somewhat lacking for #4097, this PR adds that.

**Concerns (what feedback would you like?)**: nothing major

**Where should we start reviewing?**: whenever

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
