### PR TITLE
Cross-Partitioning TS, Part 5: Parameterized Integration Tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
     resource_class: xlarge
     environment:
       GRADLE_OPTS: -Dorg.gradle.console=plain -Dorg.gradle.internal.launcher.welcomeMessageEnabled=false
-      _JAVA_OPTIONS: "-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -verbose:gc -XX:+PrintGC -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:-TraceClassUnloading -Xloggc:build-%t-%p.gc.log"
+      _JAVA_OPTIONS: "-Xmx8g -XX:+HeapDumpOnOutOfMemoryError -verbose:gc -XX:+PrintGC -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:-TraceClassUnloading -Xloggc:build-%t-%p.gc.log"
       CIRCLE_TEST_REPORTS: /home/circleci/junit
       CIRCLE_ARTIFACTS: /home/circleci/artifacts
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueUtils.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueUtils.java
@@ -71,6 +71,10 @@ public final class SweepQueueUtils {
         return minTsForFinePartition(finePartition) + TS_FINE_GRANULARITY - 1;
     }
 
+    public static long minTsForCoarsePartition(long coarsePartition) {
+        return coarsePartition * TS_COARSE_GRANULARITY;
+    }
+
     public static boolean firstSweep(long previousTs) {
         return previousTs == INITIAL_TIMESTAMP;
     }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/AbstractSweepQueueTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/AbstractSweepQueueTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Objects;
 
 import org.assertj.core.api.Assertions;
+import org.junit.After;
 import org.junit.Before;
 
 import com.google.common.collect.ImmutableList;
@@ -84,6 +85,12 @@ public abstract class AbstractSweepQueueTest {
         spiedKvs.createTable(TABLE_NOTH, metadataBytes(SweepStrategy.NOTHING));
         partitioner = new WriteInfoPartitioner(spiedKvs, () -> numShards);
         txnService = TransactionServices.createV1TransactionService(spiedKvs);
+    }
+
+    @After
+    public void tearDown() {
+        // This is required because of JUnit memory issues
+        spiedKvs = null;
     }
 
     static byte[] metadataBytes(SweepStrategy sweepStrategy) {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
@@ -53,6 +53,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.eclipse.jetty.util.ConcurrentHashSet;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -119,7 +120,7 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
     private boolean enabled = true;
     private boolean batchShardIterations = false;
 
-    public  TargetedSweeperTest(int readBatchSize) {
+    public TargetedSweeperTest(int readBatchSize) {
         this.readBatchSize = readBatchSize;
     }
 
@@ -142,6 +143,16 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
         sweepableTimestamps = new SweepableTimestamps(spiedKvs, partitioner);
         sweepableCells = new SweepableCells(spiedKvs, partitioner, null, txnService);
         puncherStore = KeyValueServicePuncherStore.create(spiedKvs, false);
+    }
+
+    @After
+    public void tearDown() {
+        // This is required because of JUnit memory issues
+        sweepQueue = null;
+        progress = null;
+        sweepableTimestamps = null;
+        sweepableCells = null;
+        puncherStore = null;
     }
 
     @Test

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
@@ -313,7 +313,7 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
 
     @Test
     public void conservativeSweepDeletesAllButLatestWithSingleDeleteAllTimestamps() {
-        long lastWriteTs = TS_FINE_GRANULARITY - 1;
+        long lastWriteTs = 5000;
         for (long i = 1; i <= lastWriteTs; i++) {
             enqueueWriteCommitted(TABLE_CONS, i);
         }
@@ -325,7 +325,7 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
 
     @Test
     public void thoroughSweepDeletesAllButLatestWithSingleDeleteAllTimestampsIncludingSentinels() {
-        long lastWriteTs = TS_FINE_GRANULARITY - 1;
+        long lastWriteTs = 5000;
         for (long i = 1; i <= lastWriteTs; i++) {
             enqueueWriteCommitted(TABLE_THOR, i);
         }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
@@ -94,7 +94,6 @@ import com.palantir.lock.v2.LockResponse;
 import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.TimelockService;
 
-// TODO (jkong): Assert stricter properties on the types of ranged deletes that are created.
 @RunWith(Parameterized.class)
 public class TargetedSweeperTest extends AbstractSweepQueueTest {
     @Parameterized.Parameters(name = "readBatchSize = {0}")
@@ -331,7 +330,6 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
             enqueueWriteCommitted(TABLE_CONS, LOW_TS + SweepQueueUtils.minTsForFinePartition(partition));
             enqueueWriteCommitted(TABLE_CONS, LOW_TS + SweepQueueUtils.minTsForFinePartition(partition) + 1);
         }
-        enqueueWriteCommitted(TABLE_CONS, TS_FINE_GRANULARITY);
 
         sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
         assertReadAtTimestampReturnsSentinel(
@@ -847,7 +845,7 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
         // we now read all to the end
         sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
         assertThat(metricsManager).hasEntriesReadConservativeEqualTo(
-                4 + writesInDedicated + 3 + writesInDedicated + 2 + + (readBatchSize > 1 ? 2 : 0));
+                4 + writesInDedicated + 3 + writesInDedicated + 2 + (readBatchSize > 1 ? 2 : 0));
     }
 
     @Test


### PR DESCRIPTION
**Goals (and why)**:
- Extend the known-good and known-rigorous `TargetedSweeperTest` to the multinode case. @gmaretic and I already ran these tests manually with batch sizes of 8 and confirmed that they work, but it's good to automate these.

**Implementation Description (bullets)**:
- Re-write setup and assertions in the relevant tests to work parametrically in the batch size
- Fix one bug: don't keep requesting batches if you aren't making progress.

**Testing (What was existing testing like?  What have you done to improve it?)**:
This is a test-only PR.

**Concerns (what feedback would you like?)**:
- The tests aren't fully parameterizable, in particular things get funky because some of them assume that a small constant number of fine partitions is less than a coarse partition. I tested with 1, 8 and 99 and these seem to pass; I tried 199 which causes a few failures, and 12345 which caused a few more.

**Where should we start reviewing?**: TargetedSweeperTest

**Priority (whenever / two weeks / yesterday)**: this week
