### PR TITLE
[TLS] TimeLock Slow Logger

### DIFF
--- a/changelog/@unreleased/pr-4105.v1.yml
+++ b/changelog/@unreleased/pr-4105.v1.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: AtlasDB clients using TimeLock now output logs indicating
+    the slowest operation they encountered in the last 10 seconds, if said
+    operation took at least 1 second.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4105
+

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -103,6 +103,11 @@ develop
          - Relaxed concurrency model of ``MetricsManager`` allowing for more concurrency.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/4098>`__)
 
+    *    - |improved|
+         - Clients now log at most once every 10 seconds when a timelock-level request is slow.
+           Please see the JavaDocs of ``ProfilingTimelockService`` for more information.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/4QQQ>`__)
+
 ========
 v0.144.0
 ========

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -104,7 +104,7 @@ develop
            (`Pull Request <https://github.com/palantir/atlasdb/pull/4098>`__)
 
     *    - |improved|
-         - Clients now log at most once every 10 seconds when a timelock-level request is slow.
+         - Clients now log at most once every 10 seconds when a ``TimelockService`` level request is slow.
            Please see the JavaDocs of ``ProfilingTimelockService`` for more information.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/4QQQ>`__)
 

--- a/lock-api/src/main/java/com/palantir/lock/client/ProfilingTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/ProfilingTimelockService.java
@@ -1,0 +1,188 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.client;
+
+import java.io.Closeable;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import org.immutables.value.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Stopwatch;
+import com.google.common.util.concurrent.RateLimiter;
+import com.palantir.lock.v2.LockImmutableTimestampResponse;
+import com.palantir.lock.v2.LockRequest;
+import com.palantir.lock.v2.LockResponse;
+import com.palantir.lock.v2.LockToken;
+import com.palantir.lock.v2.StartIdentifiedAtlasDbTransactionResponse;
+import com.palantir.lock.v2.TimelockService;
+import com.palantir.lock.v2.WaitForLocksRequest;
+import com.palantir.lock.v2.WaitForLocksResponse;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.timestamp.TimestampRange;
+
+/**
+ * Logs operations on an underlying {@link TimelockService} that take a long time (defined as longer than
+ * {@link ProfilingTimelockService#SLOW_THRESHOLD}). This logger is configured not to record more than one
+ * operation every {@link ProfilingTimelockService#LOGGING_TIME_WINDOW}. It will log what the longest operation that
+ * completed in the past {@link ProfilingTimelockService#LOGGING_TIME_WINDOW} window was, and how long it took. If no
+ * operation took longer than {@link ProfilingTimelockService#SLOW_THRESHOLD} it will not log.
+ *
+ * The {@link ProfilingTimelockService} does not cover specific operations which are at risk for taking long
+ * times owing to contention - in particular, this includes {@link #lock(LockRequest)} and
+ * {@link #waitForLocks(WaitForLocksRequest)}.
+ *
+ * Profiling is done explicitly at this level (and not at {@link com.palantir.lock.v2.TimelockRpcClient} level)
+ * to reflect the impact of timelock operations and cluster state changes (e.g. leader elections, rolling bounces) on
+ * clients.
+ */
+public class ProfilingTimelockService implements AutoCloseable, TimelockService {
+    private static final Logger log = LoggerFactory.getLogger(ProfilingTimelockService.class);
+
+    private static final Duration SLOW_THRESHOLD = Duration.ofSeconds(1);
+    private static final Duration LOGGING_TIME_WINDOW = Duration.ofSeconds(10);
+
+    private final TimelockService delegate;
+    private final Supplier<Stopwatch> stopwatchSupplier;
+
+    private final AtomicReference<Optional<ActionNameAndDuration>> slowestOperation
+            = new AtomicReference<>(Optional.empty());
+    private final RateLimiter rateLimiter;
+
+    private ProfilingTimelockService(
+            TimelockService delegate,
+            Supplier<Stopwatch> stopwatchSupplier,
+            RateLimiter rateLimiter) {
+        this.delegate = delegate;
+        this.stopwatchSupplier = stopwatchSupplier;
+        this.rateLimiter = rateLimiter;
+    }
+
+    public static ProfilingTimelockService create(TimelockService delegate) {
+        return new ProfilingTimelockService(
+                delegate, Stopwatch::createStarted, RateLimiter.create(1. / LOGGING_TIME_WINDOW.getSeconds()));
+    }
+
+    @Override
+    public long getFreshTimestamp() {
+        return runTaskTimed("getFreshTimestamp", delegate::getFreshTimestamp);
+    }
+
+    @Override
+    public TimestampRange getFreshTimestamps(int numTimestampsRequested) {
+        return runTaskTimed("getFreshTimestamps", () -> delegate.getFreshTimestamps(numTimestampsRequested));
+    }
+
+    @Override
+    public LockImmutableTimestampResponse lockImmutableTimestamp() {
+        // N.B. Immutable timestamp lock is not exclusive, so it should be fast.
+        return runTaskTimed("lockImmutableTimestamp", delegate::lockImmutableTimestamp);
+    }
+
+    @Override
+    public StartIdentifiedAtlasDbTransactionResponse startIdentifiedAtlasDbTransaction() {
+        return runTaskTimed("startIdentifiedAtlasDbTransaction", delegate::startIdentifiedAtlasDbTransaction);
+    }
+
+    @Override
+    public long getImmutableTimestamp() {
+        return runTaskTimed("getImmutableTimestamp", delegate::getImmutableTimestamp);
+    }
+
+    @Override
+    public LockResponse lock(LockRequest request) {
+        // Don't profile this, as it may be skewed by user contention on locks.
+        return delegate.lock(request);
+    }
+
+    @Override
+    public WaitForLocksResponse waitForLocks(WaitForLocksRequest request) {
+        // Don't profile this, as it may be skewed by user contention on locks.
+        return delegate.waitForLocks(request);
+    }
+
+    @Override
+    public Set<LockToken> refreshLockLeases(Set<LockToken> tokens) {
+        return runTaskTimed("refreshLockLeases", () -> delegate.refreshLockLeases(tokens));
+    }
+
+    @Override
+    public Set<LockToken> unlock(Set<LockToken> tokens) {
+        return runTaskTimed("unlock", () -> delegate.unlock(tokens));
+    }
+
+    @Override
+    public long currentTimeMillis() {
+        return runTaskTimed("currentTimeMillis", delegate::currentTimeMillis);
+    }
+
+    private <T> T runTaskTimed(String actionName, Supplier<T> action) {
+        Stopwatch stopwatch = stopwatchSupplier.get();
+        T result = action.get();
+        submitActionTimeAndMaybeLog(actionName, stopwatch);
+        return result;
+    }
+
+    private void submitActionTimeAndMaybeLog(String actionName, Stopwatch stopwatch) {
+        stopwatch.stop();
+        if (stopwatchDescribesSlowOperation(stopwatch)) {
+            slowestOperation.accumulateAndGet(
+                    Optional.of(ImmutableActionNameAndDuration.of(actionName, stopwatch.elapsed())),
+                    (current, update) -> !update.isPresent()
+                            || update.get().duration().compareTo(stopwatch.elapsed()) < 0
+                            ? current
+                            : update);
+        }
+
+        if (rateLimiter.tryAcquire()) {
+            Optional<ActionNameAndDuration> actionNameAndDuration = slowestOperation.getAndSet(Optional.empty());
+            if (actionNameAndDuration.isPresent()) {
+                ActionNameAndDuration presentActionNameAndDuration = actionNameAndDuration.get();
+                log.info("Call to TimeLockService#{} took {}. This was the slowest operation that completed"
+                                + " in the last {}.",
+                        SafeArg.of("actionName", presentActionNameAndDuration.actionName()),
+                        SafeArg.of("duration", presentActionNameAndDuration.duration()),
+                        SafeArg.of("timeWindow", LOGGING_TIME_WINDOW));
+            }
+
+        }
+    }
+
+    private boolean stopwatchDescribesSlowOperation(Stopwatch stopwatch) {
+        return stopwatch.elapsed().compareTo(SLOW_THRESHOLD) >= 0;
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (delegate instanceof AutoCloseable) {
+            ((AutoCloseable) delegate).close();
+        }
+    }
+
+    @Value.Immutable
+    interface ActionNameAndDuration {
+        @Value.Parameter
+        String actionName();
+        @Value.Parameter
+        Duration duration();
+    }
+}

--- a/lock-api/src/main/java/com/palantir/lock/client/ProfilingTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/ProfilingTimelockService.java
@@ -191,13 +191,12 @@ public class ProfilingTimelockService implements AutoCloseable, TimelockService 
                 ActionProfile presentActionProfile = actionProfile.get();
                 logger.info("Call to TimeLockService#{} took {}. This was the slowest operation that completed"
                                 + " in the last {}. The operation completed with outcome {} - if it failed, the error"
-                                + " was {}. We include a stack trace of the call: {}",
+                                + " was {}.",
                         SafeArg.of("actionName", presentActionProfile.actionName()),
                         SafeArg.of("duration", presentActionProfile.duration()),
                         SafeArg.of("timeWindow", LOGGING_TIME_WINDOW),
                         SafeArg.of("outcome", presentActionProfile.failure().isPresent() ? "fail" : "success"),
-                        UnsafeArg.of("failure", presentActionProfile.failure()),
-                        SafeArg.of("stacktrace", new RuntimeException().getStackTrace()));
+                        UnsafeArg.of("failure", presentActionProfile.failure()));
             }
         }
     }

--- a/lock-api/src/main/java/com/palantir/lock/client/ProfilingTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/ProfilingTimelockService.java
@@ -175,10 +175,10 @@ public class ProfilingTimelockService implements AutoCloseable, TimelockService 
         if (stopwatchDescribesSlowOperation(stopwatch)) {
             slowestOperation.accumulateAndGet(
                     Optional.of(ImmutableActionProfile.of(actionName, stopwatch.elapsed(), failure)),
-                    (current, update) -> !update.isPresent()
-                            || update.get().duration().compareTo(stopwatch.elapsed()) < 0
-                            ? current
-                            : update);
+                    (existing, update) -> !existing.isPresent()
+                            || existing.get().duration().compareTo(stopwatch.elapsed()) < 0
+                            ? update
+                            : existing);
         }
     }
 

--- a/lock-api/src/main/java/com/palantir/lock/client/ProfilingTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/ProfilingTimelockService.java
@@ -188,12 +188,13 @@ public class ProfilingTimelockService implements AutoCloseable, TimelockService 
                 ActionProfile presentActionProfile = actionProfile.get();
                 logger.info("Call to TimeLockService#{} took {}. This was the slowest operation that completed"
                                 + " in the last {}. The operation completed with outcome {} - if it failed, the error"
-                                + " was {}.",
+                                + " was {}. We include a stack trace of the call: {}",
                         SafeArg.of("actionName", presentActionProfile.actionName()),
                         SafeArg.of("duration", presentActionProfile.duration()),
                         SafeArg.of("timeWindow", LOGGING_TIME_WINDOW),
                         SafeArg.of("outcome", presentActionProfile.failure().isPresent() ? "fail" : "success"),
-                        UnsafeArg.of("failure", presentActionProfile.failure()));
+                        UnsafeArg.of("failure", presentActionProfile.failure()),
+                        SafeArg.of("stacktrace", new RuntimeException().getStackTrace()));
             }
         }
     }

--- a/lock-api/src/main/java/com/palantir/lock/client/ProfilingTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/ProfilingTimelockService.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
 import com.google.common.util.concurrent.RateLimiter;
+import com.palantir.common.base.Throwables;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
 import com.palantir.lock.v2.LockRequest;
 import com.palantir.lock.v2.LockResponse;
@@ -204,9 +205,13 @@ public class ProfilingTimelockService implements AutoCloseable, TimelockService 
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         if (delegate instanceof AutoCloseable) {
-            ((AutoCloseable) delegate).close();
+            try {
+                ((AutoCloseable) delegate).close();
+            } catch (Exception e) {
+                throw Throwables.rewrapAndThrowUncheckedException("Error closing delegate timelock service", e);
+            }
         }
     }
 

--- a/lock-api/src/main/java/com/palantir/lock/client/ProfilingTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/ProfilingTimelockService.java
@@ -175,10 +175,12 @@ public class ProfilingTimelockService implements AutoCloseable, TimelockService 
         if (stopwatchDescribesSlowOperation(stopwatch)) {
             slowestOperation.accumulateAndGet(
                     Optional.of(ImmutableActionProfile.of(actionName, stopwatch.elapsed(), failure)),
-                    (existing, update) -> !existing.isPresent()
-                            || existing.get().duration().compareTo(stopwatch.elapsed()) < 0
-                            ? update
-                            : existing);
+                    (existing, update) -> {
+                        if (!existing.isPresent()) {
+                            return update;
+                        }
+                        return existing.get().duration().compareTo(stopwatch.elapsed()) < 0 ? update : existing;
+                    });
         }
     }
 
@@ -200,7 +202,7 @@ public class ProfilingTimelockService implements AutoCloseable, TimelockService 
         }
     }
 
-    private boolean stopwatchDescribesSlowOperation(Stopwatch stopwatch) {
+    private static boolean stopwatchDescribesSlowOperation(Stopwatch stopwatch) {
         return stopwatch.elapsed().compareTo(SLOW_THRESHOLD) >= 0;
     }
 

--- a/lock-api/src/test/java/com/palantir/lock/client/ProfilingTimelockServiceTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/ProfilingTimelockServiceTest.java
@@ -195,14 +195,15 @@ public class ProfilingTimelockServiceTest {
         // XXX Maybe there's a better way? The approaches I tried didn't work because of conflict with other methods
         ArgumentCaptor<Arg<String>> messageCaptor = ArgumentCaptor.forClass(Arg.class);
         ArgumentCaptor<Arg<Duration>> durationCaptor = ArgumentCaptor.forClass(Arg.class);
-        verify(logger).info(any(String.class), messageCaptor.capture(), durationCaptor.capture(), any(), any(), any());
+        verify(logger).info(
+                any(String.class), messageCaptor.capture(), durationCaptor.capture(), any(), any(), any(), any());
 
         assertThat(messageCaptor.getValue().getValue()).isEqualTo(operation);
         assertThat(durationCaptor.getValue().getValue()).isEqualTo(duration);
     }
 
     private void verifyLoggerInvokedSpecificNumberOfTimes(int times) {
-        verify(logger, times(times)).info(any(String.class), any(), any(), any(), any(), any());
+        verify(logger, times(times)).info(any(String.class), any(), any(), any(), any(), any(), any());
     }
 
     private void makeOperationsTakeSpecifiedDuration(Duration duration) {

--- a/lock-api/src/test/java/com/palantir/lock/client/ProfilingTimelockServiceTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/ProfilingTimelockServiceTest.java
@@ -132,7 +132,7 @@ public class ProfilingTimelockServiceTest {
     @Test
     public void logsSlowestOperationIfMultipleOperationsExceedTheSlowThresholdIfFirst() {
         accumulateLogsWithCall(TWO_CENTURIES, profilingTimelockService::getFreshTimestamp);
-        flushLogsWithCall(TWO_CENTURIES, profilingTimelockService::startIdentifiedAtlasDbTransaction);
+        flushLogsWithCall(LONG_DURATION, profilingTimelockService::startIdentifiedAtlasDbTransaction);
 
         verifyLoggerInvokedOnceWithSpecificProfile("getFreshTimestamp", TWO_CENTURIES);
     }
@@ -189,7 +189,7 @@ public class ProfilingTimelockServiceTest {
         ArgumentCaptor<Arg<String>> messageCaptor = ArgumentCaptor.forClass(Arg.class);
         ArgumentCaptor<Arg<Duration>> durationCaptor = ArgumentCaptor.forClass(Arg.class);
         verify(logger).info(
-                any(String.class), messageCaptor.capture(), durationCaptor.capture(), any(), any(), any(), any());
+                any(String.class), messageCaptor.capture(), durationCaptor.capture(), any(), any(), any());
 
         assertThat(messageCaptor.getValue().getValue()).isEqualTo(operation);
         assertThat(durationCaptor.getValue().getValue()).isEqualTo(duration);
@@ -200,13 +200,13 @@ public class ProfilingTimelockServiceTest {
     private void verifyLoggerInvokedOnceWithException(Exception exception) {
         ArgumentCaptor<Arg<Optional<Exception>>> exceptionCaptor = ArgumentCaptor.forClass(Arg.class);
         verify(logger).info(
-                any(String.class), any(), any(), any(), any(), exceptionCaptor.capture(), any());
+                any(String.class), any(), any(), any(), any(), exceptionCaptor.capture());
         assertThat(exceptionCaptor.getValue().getValue()).contains(exception);
     }
 
     @SuppressWarnings("Slf4jConstantLogMessage") // only for tests
     private void verifyLoggerInvokedSpecificNumberOfTimes(int times) {
-        verify(logger, times(times)).info(any(String.class), any(), any(), any(), any(), any(), any());
+        verify(logger, times(times)).info(any(String.class), any(), any(), any(), any(), any());
     }
 
     private void makeOperationsTakeSpecifiedDuration(Duration duration) {

--- a/lock-api/src/test/java/com/palantir/lock/client/ProfilingTimelockServiceTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/ProfilingTimelockServiceTest.java
@@ -1,0 +1,203 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.slf4j.Logger;
+
+import com.google.common.base.Stopwatch;
+import com.google.common.base.Ticker;
+import com.google.common.collect.ImmutableSet;
+import com.palantir.lock.StringLockDescriptor;
+import com.palantir.lock.v2.LockRequest;
+import com.palantir.lock.v2.TimelockService;
+import com.palantir.lock.v2.WaitForLocksRequest;
+import com.palantir.logsafe.Arg;
+
+public class ProfilingTimelockServiceTest {
+    private static final Duration SHORT_DURATION = ProfilingTimelockService.SLOW_THRESHOLD.dividedBy(5);
+    private static final Duration LONG_DURATION = ProfilingTimelockService.SLOW_THRESHOLD.multipliedBy(5);
+    private static final Duration TWO_CENTURIES = Duration.ofDays(365 * 100 * 2 + 50 - 2); // most of the time
+
+    private final Logger logger = mock(Logger.class);
+    private final TimelockService delegate = mock(TimelockService.class);
+
+    private long clock = 0;
+    private long operationTiming = 0;
+    private final Ticker ticker = new Ticker() {
+        @Override
+        public long read() {
+            clock += operationTiming;
+            return clock;
+        }
+    };
+
+    private final AtomicBoolean allowLogging = new AtomicBoolean();
+    private final BooleanSupplier loggingPermissionSupplier = () -> allowLogging.getAndSet(false);
+
+    private final ProfilingTimelockService profilingTimelockService = new ProfilingTimelockService(
+            logger, delegate, () -> Stopwatch.createStarted(ticker), loggingPermissionSupplier);
+
+    @Test
+    public void doesNotLogIfOperationsAreFast() {
+        makeOperationsTakeSpecifiedDuration(SHORT_DURATION);
+        allowLogging();
+        profilingTimelockService.getFreshTimestamp();
+        profilingTimelockService.startIdentifiedAtlasDbTransaction();
+
+        verify(delegate).getFreshTimestamp();
+        verify(delegate).startIdentifiedAtlasDbTransaction();
+        verifyLoggerNeverInvoked();
+    }
+
+    @Test
+    public void logsIfOperationsAreSlowAndLoggingAllowed() {
+        makeOperationsTakeSpecifiedDuration(LONG_DURATION);
+        allowLogging();
+        profilingTimelockService.getFreshTimestamp();
+
+        verify(delegate).getFreshTimestamp();
+        verifyLoggerInvokedWithSpecificProfile("getFreshTimestamp", LONG_DURATION);
+    }
+
+    @Test
+    public void doesNotLogIfLoggingNotAllowedEvenIfOperationsAreSlow() {
+        makeOperationsTakeSpecifiedDuration(LONG_DURATION);
+        profilingTimelockService.getFreshTimestamp();
+
+        verify(delegate).getFreshTimestamp();
+        verifyLoggerNeverInvoked();
+    }
+
+    @Test
+    public void returnsResultReturnedByDelegate() {
+        when(profilingTimelockService.getFreshTimestamp()).thenReturn(42L);
+        assertThat(profilingTimelockService.getFreshTimestamp()).isEqualTo(42L);
+    }
+
+    @Test
+    public void logsIfFailedOperationsAreSlow() {
+        RuntimeException exception = new RuntimeException("kaboom");
+        when(profilingTimelockService.getFreshTimestamp()).thenThrow(exception);
+
+        makeOperationsTakeSpecifiedDuration(LONG_DURATION);
+        allowLogging();
+        assertThatThrownBy(profilingTimelockService::getFreshTimestamp).isEqualTo(exception);
+
+        verify(delegate).getFreshTimestamp();
+        verifyLoggerInvokedWithSpecificProfile("getFreshTimestamp", LONG_DURATION);
+    }
+
+    @Test
+    public void doesNotLogIfLockIsSlow() {
+        makeOperationsTakeSpecifiedDuration(LONG_DURATION);
+        allowLogging();
+        profilingTimelockService.lock(LockRequest.of(ImmutableSet.of(StringLockDescriptor.of("exclusive")), 1234));
+
+        verifyLoggerNeverInvoked();
+    }
+
+    @Test
+    public void doesNotLogIfWaitForLocksIsSlow() {
+        makeOperationsTakeSpecifiedDuration(LONG_DURATION);
+        allowLogging();
+        profilingTimelockService.waitForLocks(WaitForLocksRequest.of(
+                ImmutableSet.of(StringLockDescriptor.of("readwrite")), 123));
+
+        verifyLoggerNeverInvoked();
+    }
+
+    @Test
+    public void logsSlowestOperationIfMultipleOperationsExceedTheSlowThreshold() {
+        makeOperationsTakeSpecifiedDuration(LONG_DURATION);
+        profilingTimelockService.getFreshTimestamp();
+
+        makeOperationsTakeSpecifiedDuration(TWO_CENTURIES);
+        allowLogging();
+        profilingTimelockService.startIdentifiedAtlasDbTransaction();
+
+        verifyLoggerInvokedWithSpecificProfile("startIdentifiedAtlasDbTransaction", TWO_CENTURIES);
+    }
+
+    @Test
+    public void logsOnlyOnceEvenIfManyRequestsAreSlow() {
+        makeOperationsTakeSpecifiedDuration(LONG_DURATION);
+        for (int i = 0; i < 100; i++) {
+            profilingTimelockService.lockImmutableTimestamp();
+        }
+
+        makeOperationsTakeSpecifiedDuration(SHORT_DURATION);
+        allowLogging();
+        profilingTimelockService.startIdentifiedAtlasDbTransaction();
+
+        verifyLoggerInvokedWithSpecificProfile("lockImmutableTimestamp", LONG_DURATION);
+        verifyNoMoreInteractions(logger);
+    }
+
+    @Test
+    public void logsMultipleTimesIfAllowedToMultipleTimes() {
+        makeOperationsTakeSpecifiedDuration(LONG_DURATION);
+        for (int i = 0; i < 100; i++) {
+            allowLogging();
+            profilingTimelockService.lockImmutableTimestamp();
+            profilingTimelockService.lockImmutableTimestamp();
+            profilingTimelockService.lockImmutableTimestamp();
+        }
+        verifyLoggerInvokedSpecificNumberOfTimes(100);
+    }
+
+    private void verifyLoggerNeverInvoked() {
+        verifyNoMoreInteractions(logger);
+    }
+
+    @SuppressWarnings("unchecked") // Captors of generics
+    private void verifyLoggerInvokedWithSpecificProfile(String operation, Duration duration) {
+        // XXX Maybe there's a better way? The approaches I tried didn't work because of conflict with other methods
+        ArgumentCaptor<Arg<String>> messageCaptor = ArgumentCaptor.forClass(Arg.class);
+        ArgumentCaptor<Arg<Duration>> durationCaptor = ArgumentCaptor.forClass(Arg.class);
+        verify(logger).info(any(String.class), messageCaptor.capture(), durationCaptor.capture(), any(), any(), any());
+
+        assertThat(messageCaptor.getValue().getValue()).isEqualTo(operation);
+        assertThat(durationCaptor.getValue().getValue()).isEqualTo(duration);
+    }
+
+    private void verifyLoggerInvokedSpecificNumberOfTimes(int times) {
+        verify(logger, times(times)).info(any(String.class), any(), any(), any(), any(), any());
+    }
+
+    private void makeOperationsTakeSpecifiedDuration(Duration duration) {
+        operationTiming = duration.toNanos();
+    }
+
+    private void allowLogging() {
+        allowLogging.set(true);
+    }
+}

--- a/lock-api/src/test/java/com/palantir/lock/client/ProfilingTimelockServiceTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/ProfilingTimelockServiceTest.java
@@ -202,8 +202,8 @@ public class ProfilingTimelockServiceTest {
         verifyNoMoreInteractions(logger);
     }
 
-    @SuppressWarnings("unchecked") // Captors of generics
-    @SuppressWarnings("Slf4jConstantLogMessage") // only for tests
+    @SuppressWarnings({ "unchecked", // Captors of generics
+                        "Slf4jConstantLogMessage" }) // Logger verify
     private void verifyLoggerInvokedWithSpecificProfile(String operation, Duration duration) {
         // XXX Maybe there's a better way? The approaches I tried didn't work because of conflict with other methods
         ArgumentCaptor<Arg<String>> messageCaptor = ArgumentCaptor.forClass(Arg.class);

--- a/lock-api/src/test/java/com/palantir/lock/client/ProfilingTimelockServiceTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/ProfilingTimelockServiceTest.java
@@ -203,6 +203,7 @@ public class ProfilingTimelockServiceTest {
     }
 
     @SuppressWarnings("unchecked") // Captors of generics
+    @SuppressWarnings("Slf4jConstantLogMessage") // only for tests
     private void verifyLoggerInvokedWithSpecificProfile(String operation, Duration duration) {
         // XXX Maybe there's a better way? The approaches I tried didn't work because of conflict with other methods
         ArgumentCaptor<Arg<String>> messageCaptor = ArgumentCaptor.forClass(Arg.class);
@@ -214,6 +215,7 @@ public class ProfilingTimelockServiceTest {
         assertThat(durationCaptor.getValue().getValue()).isEqualTo(duration);
     }
 
+    @SuppressWarnings("Slf4jConstantLogMessage") // only for tests
     private void verifyLoggerInvokedSpecificNumberOfTimes(int times) {
         verify(logger, times(times)).info(any(String.class), any(), any(), any(), any(), any(), any());
     }

--- a/lock-api/src/test/java/com/palantir/lock/client/ProfilingTimelockServiceTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/ProfilingTimelockServiceTest.java
@@ -137,18 +137,6 @@ public class ProfilingTimelockServiceTest {
 
     @Test
     public void logsSlowestOperationIfMultipleOperationsExceedTheSlowThresholdIfFirst() {
-        makeOperationsTakeSpecifiedDuration(LONG_DURATION);
-        profilingTimelockService.getFreshTimestamp();
-
-        makeOperationsTakeSpecifiedDuration(TWO_CENTURIES);
-        allowLogging();
-        profilingTimelockService.startIdentifiedAtlasDbTransaction();
-
-        verifyLoggerInvokedWithSpecificProfile("startIdentifiedAtlasDbTransaction", TWO_CENTURIES);
-    }
-
-    @Test
-    public void logsSlowestOperationIfMultipleOperationsExceedTheSlowThresholdIfNotFirst() {
         makeOperationsTakeSpecifiedDuration(TWO_CENTURIES);
         profilingTimelockService.getFreshTimestamp();
 
@@ -157,6 +145,18 @@ public class ProfilingTimelockServiceTest {
         profilingTimelockService.startIdentifiedAtlasDbTransaction();
 
         verifyLoggerInvokedWithSpecificProfile("getFreshTimestamp", TWO_CENTURIES);
+    }
+
+    @Test
+    public void logsSlowestOperationIfMultipleOperationsExceedTheSlowThresholdIfNotFirst() {
+        makeOperationsTakeSpecifiedDuration(LONG_DURATION);
+        profilingTimelockService.getFreshTimestamp();
+
+        makeOperationsTakeSpecifiedDuration(TWO_CENTURIES);
+        allowLogging();
+        profilingTimelockService.startIdentifiedAtlasDbTransaction();
+
+        verifyLoggerInvokedWithSpecificProfile("startIdentifiedAtlasDbTransaction", TWO_CENTURIES);
     }
 
     @Test

--- a/lock-api/src/test/java/com/palantir/lock/client/ProfilingTimelockServiceTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/ProfilingTimelockServiceTest.java
@@ -136,7 +136,7 @@ public class ProfilingTimelockServiceTest {
     }
 
     @Test
-    public void logsSlowestOperationIfMultipleOperationsExceedTheSlowThreshold() {
+    public void logsSlowestOperationIfMultipleOperationsExceedTheSlowThresholdIfFirst() {
         makeOperationsTakeSpecifiedDuration(LONG_DURATION);
         profilingTimelockService.getFreshTimestamp();
 
@@ -145,6 +145,18 @@ public class ProfilingTimelockServiceTest {
         profilingTimelockService.startIdentifiedAtlasDbTransaction();
 
         verifyLoggerInvokedWithSpecificProfile("startIdentifiedAtlasDbTransaction", TWO_CENTURIES);
+    }
+
+    @Test
+    public void logsSlowestOperationIfMultipleOperationsExceedTheSlowThresholdIfNotFirst() {
+        makeOperationsTakeSpecifiedDuration(TWO_CENTURIES);
+        profilingTimelockService.getFreshTimestamp();
+
+        makeOperationsTakeSpecifiedDuration(LONG_DURATION);
+        allowLogging();
+        profilingTimelockService.startIdentifiedAtlasDbTransaction();
+
+        verifyLoggerInvokedWithSpecificProfile("getFreshTimestamp", TWO_CENTURIES);
     }
 
     @Test

--- a/lock-api/src/test/java/com/palantir/lock/client/ProfilingTimelockServiceTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/ProfilingTimelockServiceTest.java
@@ -130,7 +130,7 @@ public class ProfilingTimelockServiceTest {
         makeOperationsTakeSpecifiedDuration(LONG_DURATION);
         allowLogging();
         profilingTimelockService.waitForLocks(WaitForLocksRequest.of(
-                ImmutableSet.of(StringLockDescriptor.of("readwrite")), 123));
+                ImmutableSet.of(StringLockDescriptor.of("combination")), 123));
 
         verifyLoggerNeverInvoked();
     }
@@ -145,6 +145,18 @@ public class ProfilingTimelockServiceTest {
         profilingTimelockService.startIdentifiedAtlasDbTransaction();
 
         verifyLoggerInvokedWithSpecificProfile("startIdentifiedAtlasDbTransaction", TWO_CENTURIES);
+    }
+
+    @Test
+    public void logsTheSlowestNonBannedOperationAboveThreshold() {
+        makeOperationsTakeSpecifiedDuration(LONG_DURATION);
+        profilingTimelockService.getFreshTimestamp();
+
+        makeOperationsTakeSpecifiedDuration(TWO_CENTURIES);
+        allowLogging();
+        profilingTimelockService.lock(LockRequest.of(ImmutableSet.of(StringLockDescriptor.of("mortice")), 2366));
+
+        verifyLoggerInvokedWithSpecificProfile("getFreshTimestamp", LONG_DURATION);
     }
 
     @Test


### PR DESCRIPTION
**Goals (and why)**:
- Have clearer signalling on the client side when `TimelockService` operations are slow. This is partially available using the metrics on internal logging systems, but this allows for better visibility (e.g. errors, stacktraces).

**Implementation Description (bullets)**:
- Implement `ProfilingTimelockService` - see javadocs for detail on what it does.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- This is additional code, and tests have been added for what was added. The logic around picking the rate-limiter's limit isn't really covered by the tests, unfortunately.

**Concerns (what feedback would you like?)**:
- Are stack trace elements safe for logging?
- I chose to keep track of the longest operation satisfying the criteria; is this reasonable? Should I have kept more? My worry is taking up too much memory or logging very large operations. 
- I did think as a compromise logging the _number_ of slow operations and the _details_ of the slowest, but didn't as I didn't see a use for it immediately; would that be useful?
- A design decision here was that a calling thread would flush the logs; this concerned me a little as it is on a semi-hot path, though given you can only do that if you successfully acquired the rate limiter permit I think it's fine. 
- This also means that if you had a single slow operation complete immediately after a flush and no further operations, you wouldn't see anything. This seems very much like an edge case to me.

**Where should we start reviewing?**: ProfilingTimelockService

**Priority (whenever / two weeks / yesterday)**: two weeks?
