### PR TITLE
[Timelock Partitioning] Part 9: Map `PaxosResponses`

### DIFF
--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosQuorumChecker.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosQuorumChecker.java
@@ -172,7 +172,9 @@ public final class PaxosQuorumChecker {
         MultiplexingCompletionService<SERVICE, RESPONSE> responseCompletionService =
                 MultiplexingCompletionService.create(executors);
 
-        PaxosResponses<RESPONSE> receivedResponses = new PaxosResponses<>(remotes.size(), quorumSize,
+        PaxosResponseAccumulator<RESPONSE> receivedResponses = PaxosResponseAccumulator.newResponse(
+                remotes.size(),
+                quorumSize,
                 shortcircuitIfQuorumImpossible);
         // kick off all the requests
         List<Future<RESPONSE>> allFutures = Lists.newArrayList();
@@ -222,7 +224,7 @@ public final class PaxosQuorumChecker {
                 encounteredErrors.forEach(throwable -> log.warn(PAXOS_MESSAGE_ERROR, throwable));
             }
         }
-        return receivedResponses;
+        return receivedResponses.collect();
     }
 
     private static boolean timedOut(Future<?> responseFuture) {

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosResponseAccumulator.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosResponseAccumulator.java
@@ -72,7 +72,7 @@ final class PaxosResponseAccumulator<T extends PaxosResponse> {
     }
 
     PaxosResponses<T> collect() {
-        return PaxosResponses.of(quorum, successes, responses);
+        return PaxosResponses.of(quorum, responses);
     }
 
 }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosResponseAccumulator.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosResponseAccumulator.java
@@ -1,0 +1,78 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.paxos;
+
+import java.util.LinkedList;
+import java.util.List;
+
+final class PaxosResponseAccumulator<T extends PaxosResponse> {
+
+    private final int totalRequests;
+    private final int quorum;
+    private final boolean shortcut;
+
+    private int successes = 0;
+    private int failures = 0;
+    private List<T> responses = new LinkedList<>();
+
+    private PaxosResponseAccumulator(int totalRequests, int quorum, boolean shortcut) {
+        this.totalRequests = totalRequests;
+        this.quorum = quorum;
+        this.shortcut = shortcut;
+    }
+
+    static <T extends PaxosResponse> PaxosResponseAccumulator<T> newResponse(
+            int totalRequests,
+            int quorumSize,
+            boolean shortcut) {
+        return new PaxosResponseAccumulator<>(totalRequests, quorumSize, shortcut);
+    }
+
+    void add(T response) {
+        if (response.isSuccessful()) {
+            successes++;
+        } else {
+            failures++;
+        }
+        responses.add(response);
+    }
+
+    boolean hasMoreRequests() {
+        return successes + failures < totalRequests;
+    }
+
+    private boolean shouldGiveUpOnAchievingQuorum() {
+        return shortcut && failures > totalRequests - quorum;
+    }
+
+    boolean hasQuorum() {
+        return successes >= quorum;
+    }
+
+    boolean shouldProcessNextRequest() {
+        return !hasQuorum() && !shouldGiveUpOnAchievingQuorum();
+    }
+
+    void markFailure() {
+        failures++;
+    }
+
+    PaxosResponses<T> collect() {
+        return PaxosResponses.of(quorum, successes, responses);
+    }
+
+}

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosResponses.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosResponses.java
@@ -16,61 +16,50 @@
 
 package com.palantir.paxos;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class PaxosResponses<T extends PaxosResponse> {
-    private final int totalRequests;
-    private final int quorum;
-    private final boolean shortcut;
-    private List<T> responses = new ArrayList<>();
-    private int successes = 0;
-    private int failures = 0;
+import org.immutables.value.Value;
 
-    PaxosResponses(int totalRequests, int quorum, boolean shortcut) {
-        this.totalRequests = totalRequests;
-        this.quorum = quorum;
-        this.shortcut = shortcut;
-    }
+@Value.Immutable
+public abstract class PaxosResponses<T extends PaxosResponse> {
+    abstract int quorum();
+    abstract int successes();
+    abstract List<T> responses();
 
-    public boolean hasMoreRequests() {
-        return successes + failures < totalRequests;
-    }
-
-    boolean shouldProcessNextRequest() {
-        return !hasQuorum() && !shouldGiveUpOnAchievingQuorum();
-    }
-
-    public void add(T response) {
-        if (response.isSuccessful()) {
-            successes++;
-        } else {
-            failures++;
-        }
-        responses.add(response);
-    }
-
-    void markFailure() {
-        failures++;
+    public static <T extends PaxosResponse> PaxosResponses<T> of(int quorum, int successes, List<T> responses) {
+        return ImmutablePaxosResponses.<T>builder()
+                .quorum(quorum)
+                .successes(successes)
+                .addAllResponses(responses)
+                .build();
     }
 
     public List<T> get() {
-        return responses;
+        return responses();
     }
 
     public Stream<T> stream() {
-        return responses.stream();
+        return responses().stream();
     }
 
+    public <U extends PaxosResponse> PaxosResponses<U> map(Function<T, U> mapper) {
+        return of(quorum(), successes(), responses().stream().map(mapper).collect(Collectors.toList()));
+    }
+
+    @Value.Derived
     public boolean hasQuorum() {
-        return successes >= quorum;
+        return successes() >= quorum();
     }
 
+    @Value.Derived
     public int numberOfResponses() {
-        return responses.size();
+        return responses().size();
     }
 
+    @Value.Derived
     PaxosQuorumStatus getQuorumResult() {
         if (hasQuorum()) {
             return PaxosQuorumStatus.QUORUM_AGREED;
@@ -80,11 +69,9 @@ public class PaxosResponses<T extends PaxosResponse> {
         return PaxosQuorumStatus.NO_QUORUM;
     }
 
-    private boolean shouldGiveUpOnAchievingQuorum() {
-        return shortcut && failures > totalRequests - quorum;
+    @Value.Derived
+    protected boolean thereWereDisagreements() {
+        return responses().stream().anyMatch(response -> !response.isSuccessful());
     }
 
-    private boolean thereWereDisagreements() {
-        return responses.stream().anyMatch(response -> !response.isSuccessful());
-    }
 }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosResponses.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosResponses.java
@@ -26,13 +26,11 @@ import org.immutables.value.Value;
 @Value.Immutable
 public abstract class PaxosResponses<T extends PaxosResponse> {
     abstract int quorum();
-    abstract int successes();
     abstract List<T> responses();
 
-    public static <T extends PaxosResponse> PaxosResponses<T> of(int quorum, int successes, List<T> responses) {
+    public static <T extends PaxosResponse> PaxosResponses<T> of(int quorum, List<T> responses) {
         return ImmutablePaxosResponses.<T>builder()
                 .quorum(quorum)
-                .successes(successes)
                 .addAllResponses(responses)
                 .build();
     }
@@ -46,7 +44,12 @@ public abstract class PaxosResponses<T extends PaxosResponse> {
     }
 
     public <U extends PaxosResponse> PaxosResponses<U> map(Function<T, U> mapper) {
-        return of(quorum(), successes(), responses().stream().map(mapper).collect(Collectors.toList()));
+        return of(quorum(), responses().stream().map(mapper).collect(Collectors.toList()));
+    }
+
+    @Value.Derived
+    int successes() {
+        return (int) responses().stream().filter(PaxosResponse::isSuccessful).count();
     }
 
     @Value.Derived


### PR DESCRIPTION
**Goals (and why)**:
In later Timelock Partitioning PRs, I need to be able to map the result of a `PaxosResponse` i.e. convert from batch to non-batch, and this is pretty convenient.

**Implementation Description (bullets)**:
* Tear apart the updating/modifiable bit, and the immutable end result.
* Add ability to map on the end result.

**Priority (whenever / two weeks / yesterday)**:
Blocking later PRs

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
