### PR TITLE
[Timelock Partitionining] Part 10: Paxos network client

### DIFF
--- a/leader-election-api/build.gradle
+++ b/leader-election-api/build.gradle
@@ -1,5 +1,6 @@
 apply from: "../gradle/publish-jars.gradle"
 apply from: "../gradle/shared.gradle"
+apply plugin: 'org.inferred.processors'
 
 apply plugin: 'java'
 apply plugin: 'eclipse'
@@ -16,4 +17,6 @@ dependencies {
   compile group: 'javax.ws.rs', name: 'javax.ws.rs-api'
   compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations'
   compile group: 'net.jcip', name: 'jcip-annotations'
+
+  processor group: 'org.immutables', name: 'value'
 }

--- a/leader-election-api/src/main/java/com/palantir/paxos/PaxosLong.java
+++ b/leader-election-api/src/main/java/com/palantir/paxos/PaxosLong.java
@@ -1,0 +1,32 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.paxos;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface PaxosLong extends PaxosResponse {
+
+    @Override
+    default boolean isSuccessful() {
+        return true;
+    }
+
+    @Value.Parameter
+    long getValue();
+
+}

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosAcceptorNetworkClient.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosAcceptorNetworkClient.java
@@ -1,0 +1,53 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.paxos;
+
+/**
+ * {@link PaxosAcceptorNetworkClient}s encapsulates the consensus portion of the request, and this should be used over
+ * {@link PaxosAcceptor}. This allows us to specifically tailor our approach for single leader vs multi leader
+ * configurations.
+ */
+public interface PaxosAcceptorNetworkClient {
+
+    /**
+     * The acceptor prepares for a given proposal by either promising not to accept future proposals
+     * or rejecting the proposal.
+     *
+     * @param seq the number identifying this instance of paxos
+     * @param proposalId the proposal to prepare for
+     * @return a paxos promise not to accept lower numbered proposals
+     */
+    PaxosResponses<PaxosPromise> prepare(long seq, PaxosProposalId proposalId);
+
+    /**
+     * The acceptor decides whether to accept or reject a given proposal.
+     *
+     * @param seq the number identifying this instance of paxos
+     * @param proposal the proposal in question
+     * @return a paxos message indicating if the proposal was accepted or rejected
+     */
+    PaxosResponses<BooleanPaxosResponse> accept(long seq, PaxosProposal proposal);
+
+    /**
+     * Gets the sequence number of the acceptor's most recent known round.
+     *
+     * @return the sequence number of the most recent round or {@value PaxosAcceptor#NO_LOG_ENTRY} if this
+     *         acceptor has not prepared or accepted any rounds
+     */
+    PaxosResponses<PaxosLong> getLatestSequencePreparedOrAccepted();
+
+}

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosAcceptorNetworkClient.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosAcceptorNetworkClient.java
@@ -17,36 +17,36 @@
 package com.palantir.paxos;
 
 /**
- * {@link PaxosAcceptorNetworkClient}s encapsulates the consensus portion of the request, and this should be used over
- * {@link PaxosAcceptor}. This allows us to specifically tailor our approach for single leader vs multi leader
- * configurations.
+ * {@link PaxosAcceptorNetworkClient} encapsulates the consensus portion of the request and involves communicating with
+ * multiple {@link PaxosAcceptor}s. This should be used over {@link PaxosQuorumChecker} and {@link PaxosAcceptor} where
+ * possible. This allows us to specifically tailor our approach for single leader vs multi leader configurations.
  */
 public interface PaxosAcceptorNetworkClient {
 
     /**
-     * The acceptor prepares for a given proposal by either promising not to accept future proposals
+     * The acceptors prepare for a given proposal by either promising not to accept future proposals
      * or rejecting the proposal.
      *
      * @param seq the number identifying this instance of paxos
      * @param proposalId the proposal to prepare for
-     * @return a paxos promise not to accept lower numbered proposals
+     * @return promises from the cluster not to accept lower numbered proposals
      */
     PaxosResponses<PaxosPromise> prepare(long seq, PaxosProposalId proposalId);
 
     /**
-     * The acceptor decides whether to accept or reject a given proposal.
+     * The acceptors decide whether to accept or reject a given proposal.
      *
      * @param seq the number identifying this instance of paxos
      * @param proposal the proposal in question
-     * @return a paxos message indicating if the proposal was accepted or rejected
+     * @return paxos messages indicating whether the cluster accepted or rejected the proposal
      */
     PaxosResponses<BooleanPaxosResponse> accept(long seq, PaxosProposal proposal);
 
     /**
-     * Gets the sequence number of the acceptor's most recent known round.
+     * The acceptors return the sequence number of their most recent known round.
      *
-     * @return the sequence number of the most recent round or {@value PaxosAcceptor#NO_LOG_ENTRY} if this
-     *         acceptor has not prepared or accepted any rounds
+     * @return sequence numbers of each acceptor's most recent round. {@value PaxosAcceptor#NO_LOG_ENTRY} will be
+     *         included if an acceptor has not prepared or accepted any rounds.
      */
     PaxosResponses<PaxosLong> getLatestSequencePreparedOrAccepted();
 

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosLearnerImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosLearnerImpl.java
@@ -94,7 +94,7 @@ public final class PaxosLearnerImpl implements PaxosLearner {
             greatestSeq = greatestLearnedValue.seq;
         }
 
-        Collection<PaxosValue> values = new ArrayList<PaxosValue>();
+        Collection<PaxosValue> values = new ArrayList<>();
         for (long i = seq; i <= greatestSeq; i++) {
             PaxosValue value;
             value = getLearnedValue(i);

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosLearnerNetworkClient.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosLearnerNetworkClient.java
@@ -1,0 +1,56 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.paxos;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * {@link PaxosLearnerNetworkClient}s encapsulates the consensus portion of the request, and this should be used over
+ * {@link PaxosLearner}. This allows us to specifically tailor our approach for single leader vs multi leader
+ * configurations.
+ */
+public interface PaxosLearnerNetworkClient {
+
+    /**
+     * Learn given value for the seq-th round. This should communicate with all learner nodes in the cluster.
+     *
+     * @param seq round in question
+     * @param value value learned for that round
+     * @see PaxosLearner#learn
+     */
+    void learn(long seq, PaxosValue value);
+
+    /**
+     * Calls {@code mapper} with the learned value or {@code Optional.empty()} if the value at {@code seq} has not been
+     * learned. This should communicate with all learner nodes in the cluster and should collect at least
+     * {@code quorumResponses}.
+     *
+     * @see PaxosLearner#getLearnedValue
+     */
+    <T extends PaxosResponse> PaxosResponses<T> getLearnedValue(long seq, Function<Optional<PaxosValue>, T> mapper);
+
+    /**
+     * Returns some collection of learned values since the seq-th round (inclusive). This will communicate with all
+     * learner nodes in the cluster and will wait for consensus.
+     *
+     * @param seq lower round cutoff for returned values
+     * @return some set of learned values for rounds since the seq-th round
+     * @see PaxosLearner#getLearnedValuesSince
+     */
+    PaxosResponses<PaxosUpdate> getLearnedValuesSince(long seq);
+}

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosLearnerNetworkClient.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosLearnerNetworkClient.java
@@ -20,14 +20,17 @@ import java.util.Optional;
 import java.util.function.Function;
 
 /**
- * {@link PaxosLearnerNetworkClient}s encapsulates the consensus portion of the request, and this should be used over
- * {@link PaxosLearner}. This allows us to specifically tailor our approach for single leader vs multi leader
- * configurations.
+ * {@link PaxosLearnerNetworkClient} encapsulates the consensus portion of the request and involves communicating with
+ * multiple {@link PaxosLearner}s. This should be used over {@link PaxosQuorumChecker} and {@link PaxosAcceptor} where
+ * possible. This allows us to specifically tailor our approach for single leader vs multi leader configurations.
  */
 public interface PaxosLearnerNetworkClient {
 
     /**
-     * Learn given value for the seq-th round. This should communicate with all learner nodes in the cluster.
+     * Teaches the given value for the seq-th round to all (read {@code quorumSize}) learner nodes including the local
+     * node.
+     *
+     * This will attempt to communicate with all learner nodes in the cluster.
      *
      * @param seq round in question
      * @param value value learned for that round
@@ -36,8 +39,10 @@ public interface PaxosLearnerNetworkClient {
     void learn(long seq, PaxosValue value);
 
     /**
+     * Retrieves the learned value for the given seq from the cluster.
+     * <p>
      * Calls {@code mapper} with the learned value or {@code Optional.empty()} if the value at {@code seq} has not been
-     * learned. This should communicate with all learner nodes in the cluster and should collect at least
+     * learned. This will attempt to communicate with all learner nodes in the cluster and should collect at least
      * {@code quorumResponses}.
      *
      * @see PaxosLearner#getLearnedValue
@@ -45,8 +50,9 @@ public interface PaxosLearnerNetworkClient {
     <T extends PaxosResponse> PaxosResponses<T> getLearnedValue(long seq, Function<Optional<PaxosValue>, T> mapper);
 
     /**
-     * Returns some collection of learned values since the seq-th round (inclusive). This will communicate with all
-     * learner nodes in the cluster and will wait for consensus.
+     * Returns some collection of learned values since the seq-th round (inclusive) from the cluster.
+     * This will attempt to communicate with all learner nodes in the cluster and will wait for consensus and should
+     * collect at least {@code quorumResponses}.
      *
      * @param seq lower round cutoff for returned values
      * @return some set of learned values for rounds since the seq-th round

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderAcceptorNetworkClient.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderAcceptorNetworkClient.java
@@ -16,6 +16,7 @@
 
 package com.palantir.paxos;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
@@ -28,10 +29,10 @@ public class SingleLeaderAcceptorNetworkClient implements PaxosAcceptorNetworkCl
     private final Map<PaxosAcceptor, ExecutorService> executors;
 
     public SingleLeaderAcceptorNetworkClient(
-            ImmutableList<PaxosAcceptor> acceptors,
+            List<PaxosAcceptor> acceptors,
             int quorumSize,
             Map<PaxosAcceptor, ExecutorService> executors) {
-        this.acceptors = acceptors;
+        this.acceptors = ImmutableList.copyOf(acceptors);
         this.quorumSize = quorumSize;
         this.executors = executors;
     }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderAcceptorNetworkClient.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderAcceptorNetworkClient.java
@@ -1,0 +1,68 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.paxos;
+
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+
+import com.google.common.collect.ImmutableList;
+
+public class SingleLeaderAcceptorNetworkClient implements PaxosAcceptorNetworkClient {
+
+    private final ImmutableList<PaxosAcceptor> acceptors;
+    private final int quorumSize;
+    private final Map<PaxosAcceptor, ExecutorService> executors;
+
+    public SingleLeaderAcceptorNetworkClient(
+            ImmutableList<PaxosAcceptor> acceptors,
+            int quorumSize,
+            Map<PaxosAcceptor, ExecutorService> executors) {
+        this.acceptors = acceptors;
+        this.quorumSize = quorumSize;
+        this.executors = executors;
+    }
+
+    @Override
+    public PaxosResponses<PaxosPromise> prepare(long seq, PaxosProposalId proposalId) {
+        return PaxosQuorumChecker.collectQuorumResponses(
+                acceptors,
+                acceptor -> acceptor.prepare(seq, proposalId),
+                quorumSize,
+                executors,
+                PaxosQuorumChecker.DEFAULT_REMOTE_REQUESTS_TIMEOUT);
+    }
+
+    @Override
+    public PaxosResponses<BooleanPaxosResponse> accept(long seq, PaxosProposal proposal) {
+        return PaxosQuorumChecker.collectQuorumResponses(
+                acceptors,
+                acceptor -> acceptor.accept(seq, proposal),
+                quorumSize,
+                executors,
+                PaxosQuorumChecker.DEFAULT_REMOTE_REQUESTS_TIMEOUT);
+    }
+
+    @Override
+    public PaxosResponses<PaxosLong> getLatestSequencePreparedOrAccepted() {
+        return PaxosQuorumChecker.collectQuorumResponses(
+                acceptors,
+                acceptor -> ImmutablePaxosLong.of(acceptor.getLatestSequencePreparedOrAccepted()),
+                quorumSize,
+                executors,
+                PaxosQuorumChecker.DEFAULT_REMOTE_REQUESTS_TIMEOUT);
+    }
+}

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderLearnerNetworkClient.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderLearnerNetworkClient.java
@@ -1,0 +1,99 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.paxos;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Function;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
+
+public class SingleLeaderLearnerNetworkClient implements PaxosLearnerNetworkClient {
+
+    private static final Logger log = LoggerFactory.getLogger(SingleLeaderLearnerNetworkClient.class);
+
+    private final PaxosLearner localLearner;
+    private final ImmutableList<PaxosLearner> remoteLearners;
+    private final ImmutableList<PaxosLearner> allLearners;
+    private final int quorumSize;
+    private final Map<PaxosLearner, ExecutorService> executors;
+
+    public SingleLeaderLearnerNetworkClient(
+            PaxosLearner localLearner,
+            List<PaxosLearner> remoteLearners,
+            int quorumSize,
+            Map<PaxosLearner, ExecutorService> executors) {
+        this.localLearner = localLearner;
+        this.remoteLearners = ImmutableList.copyOf(remoteLearners);
+        this.quorumSize = quorumSize;
+        this.executors = executors;
+        this.allLearners = ImmutableList.<PaxosLearner>builder()
+                .add(localLearner)
+                .addAll(remoteLearners)
+                .build();
+    }
+
+
+    @Override
+    public void learn(long seq, PaxosValue value) {
+        // broadcast learned value
+        for (final PaxosLearner learner : remoteLearners) {
+            executors.get(learner).execute(() -> {
+                try {
+                    learner.learn(seq, value);
+                } catch (Throwable e) {
+                    log.warn("Failed to teach learner the value {} at sequence {}",
+                            UnsafeArg.of("value", value.data),
+                            SafeArg.of("sequence", seq),
+                            e);
+                }
+            });
+        }
+
+        // force local learner to update
+        localLearner.learn(seq, value);
+    }
+
+    @Override
+    public <T extends PaxosResponse> PaxosResponses<T> getLearnedValue(
+            long seq,
+            Function<Optional<PaxosValue>, T> mapper) {
+        return PaxosQuorumChecker.collectQuorumResponses(
+                allLearners,
+                learner -> mapper.apply(Optional.ofNullable(learner.getLearnedValue(seq))),
+                quorumSize,
+                executors,
+                PaxosQuorumChecker.DEFAULT_REMOTE_REQUESTS_TIMEOUT);
+    }
+
+    @Override
+    public PaxosResponses<PaxosUpdate> getLearnedValuesSince(long seq) {
+        return PaxosQuorumChecker.collectQuorumResponses(
+                allLearners,
+                learner -> new PaxosUpdate(ImmutableList.copyOf(learner.getLearnedValuesSince(seq))),
+                quorumSize,
+                executors,
+                PaxosQuorumChecker.DEFAULT_REMOTE_REQUESTS_TIMEOUT);
+    }
+}


### PR DESCRIPTION
**Goals (and why)**:
In the current world we have this thread "profile":
![current situation](https://user-images.githubusercontent.com/4521225/60594139-2bfd7280-9d9c-11e9-9f01-c578004347db.png)

If we were to have a leader per client, we have to be careful to not batch at the wrong level and end up with something like this:
![thread explosion](https://user-images.githubusercontent.com/4521225/60594183-46cfe700-9d9c-11e9-855f-42c7b74707c7.png)

`PaxosQuorumChecker` spins up 2-3 threads [(there is an optimisation we could do to bring it to 2 however)](https://github.com/palantir/atlasdb/issues/4083). We have to batch the request *before* we go to the `PaxosQuorumChecker` as they'd just be batched later on anyway. 

The ideal situation batches the requests made at the client level and *then* invokes the `PaxosQuorumChecker` on a batch on the batch apis. Like below:
![Ideal situation](https://user-images.githubusercontent.com/4521225/60596763-91a02d80-9da1-11e9-960c-88971aa236d6.png)


The end result in terms of the number of requests made to other timelock nodes is the same. The resource we're trying to control and look after here is the number of clients.

This means we should introduce a layer on top of the `PaxosQuorumChecker` that can deal with this. This is is just a refactor.

**Implementation Description (bullets)**:
* Introduce `Paxos*NetworkClient` (name is finicky, can change to whatever we want). Similar to how we have `TimelockService` and `TimelockRpcClient` etc. except we can't reasonably change `PaxosAcceptor` and `PaxosLearner`.

**Testing (What was existing testing like?  What have you done to improve it?)**:
* Rely on existing tests, this is just a refactor.

**Concerns (what feedback would you like?)**:
* I have bumped quorum size for one of the methods back to normal instead of `QUORUM_OF_ONE`, as it's:
  * weird to have it be `QUORUM_OF_ONE` underneath the hood
  * adding a `quorum` argument complicates batching, despite it in practice being the same for all invocations i.e. we'd have to:
    * group by quorum size and invoke `PaxosQuorumChecker` for each quorum size
    * or have `PaxosQuorumChecker` be some sort of async thing, but again far too complicated.

* I've left timestamp paxos alone, although it would benefit especially with the all the batching on the acceptor, I want to change *just* leadership for now.

**Where should we start reviewing?**:
* `PaxosAcceptorNetworkClient`
* `PaxosLearnerNetworkClient`

**Priority (whenever / two weeks / yesterday)**:
ASAP, blocking other PRs.
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
