### PR TITLE
[Timelock Partitioning] Part 11: Paxos quorum checker coalescing function

### DIFF
--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosQuorumChecker.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosQuorumChecker.java
@@ -25,13 +25,13 @@ import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.Meter;
-import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -78,7 +78,7 @@ public final class PaxosQuorumChecker {
      */
     public static <SERVICE, RESPONSE extends PaxosResponse> PaxosResponses<RESPONSE> collectQuorumResponses(
             ImmutableList<SERVICE> remotes,
-            final Function<SERVICE, RESPONSE> request,
+            Function<SERVICE, RESPONSE> request,
             int quorumSize,
             ExecutorService executorService,
             Duration remoteRequestTimeout) {
@@ -93,7 +93,7 @@ public final class PaxosQuorumChecker {
 
     public static <SERVICE, RESPONSE extends PaxosResponse> PaxosResponses<RESPONSE> collectQuorumResponses(
             ImmutableList<SERVICE> remotes,
-            final Function<SERVICE, RESPONSE> request,
+            Function<SERVICE, RESPONSE> request,
             int quorumSize,
             Map<SERVICE, ExecutorService> executors,
             Duration remoteRequestTimeout) {
@@ -110,7 +110,7 @@ public final class PaxosQuorumChecker {
 
     public static <SERVICE, RESPONSE extends PaxosResponse> PaxosResponses<RESPONSE> collectQuorumResponses(
             Map<SERVICE, ExecutorService> remotesToExecutors,
-            final Function<SERVICE, RESPONSE> request,
+            Function<SERVICE, RESPONSE> request,
             int quorumSize,
             Duration remoteRequestTimeout) {
         return collectResponses(
@@ -133,7 +133,7 @@ public final class PaxosQuorumChecker {
      */
     public static <SERVICE, RESPONSE extends PaxosResponse> PaxosResponses<RESPONSE> collectAsManyResponsesAsPossible(
             ImmutableList<SERVICE> remotes,
-            final Function<SERVICE, RESPONSE> request,
+            Function<SERVICE, RESPONSE> request,
             ExecutorService executorService,
             Duration remoteRequestTimeout) {
         return collectResponses(
@@ -164,7 +164,7 @@ public final class PaxosQuorumChecker {
      */
     private static <SERVICE, RESPONSE extends PaxosResponse> PaxosResponses<RESPONSE> collectResponses(
             ImmutableList<SERVICE> remotes,
-            final Function<SERVICE, RESPONSE> request,
+            Function<SERVICE, RESPONSE> request,
             int quorumSize,
             Map<SERVICE, ExecutorService> executors,
             Duration remoteRequestTimeout,
@@ -178,7 +178,7 @@ public final class PaxosQuorumChecker {
                 shortcircuitIfQuorumImpossible);
         // kick off all the requests
         List<Future<RESPONSE>> allFutures = Lists.newArrayList();
-        for (final SERVICE remote : remotes) {
+        for (SERVICE remote : remotes) {
             try {
                 allFutures.add(responseCompletionService.submit(remote, () -> request.apply(remote)));
             } catch (RejectedExecutionException e) {

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosQuorumCheckingCoalescingFunction.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosQuorumCheckingCoalescingFunction.java
@@ -1,0 +1,95 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toList;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.atlasdb.autobatch.CoalescingRequestFunction;
+import com.palantir.paxos.PaxosQuorumChecker;
+import com.palantir.paxos.PaxosResponse;
+import com.palantir.paxos.PaxosResponses;
+
+public class PaxosQuorumCheckingCoalescingFunction<REQUEST, RESPONSE extends PaxosResponse> implements
+        CoalescingRequestFunction<REQUEST, PaxosResponses<RESPONSE>> {
+
+    private final List<CoalescingRequestFunction<REQUEST, RESPONSE>> delegates;
+    private final Map<CoalescingRequestFunction<REQUEST, RESPONSE>, ExecutorService> executors;
+    private final int quorumSize;
+
+    public PaxosQuorumCheckingCoalescingFunction(
+            List<CoalescingRequestFunction<REQUEST, RESPONSE>> delegates,
+            Map<CoalescingRequestFunction<REQUEST, RESPONSE>, ExecutorService> executors,
+            int quorumSize) {
+        this.delegates = delegates;
+        this.executors = executors;
+        this.quorumSize = quorumSize;
+    }
+
+    @Override
+    public PaxosResponses<RESPONSE> defaultValue() {
+        return PaxosResponses.of(quorumSize, ImmutableList.of());
+    }
+
+    @Override
+    public Map<REQUEST, PaxosResponses<RESPONSE>> apply(Set<REQUEST> request) {
+        PaxosResponses<PaxosContainer<Map<REQUEST, RESPONSE>>> responses = PaxosQuorumChecker.collectQuorumResponses(
+                ImmutableList.copyOf(delegates),
+                delegate -> new PaxosContainer<>(delegate.apply(request)),
+                quorumSize,
+                executors,
+                PaxosQuorumChecker.DEFAULT_REMOTE_REQUESTS_TIMEOUT);
+
+        return responses.stream()
+                .map(PaxosContainer::get)
+                .map(Map::entrySet)
+                .flatMap(Collection::stream)
+                .collect(groupingBy(
+                        Map.Entry::getKey,
+                        mapping(Map.Entry::getValue, collectingAndThen(
+                                toList(),
+                                responseForSingleRequest -> PaxosResponses.of(quorumSize, responseForSingleRequest)))));
+    }
+
+    private class PaxosContainer<T> implements PaxosResponse {
+
+        private final T response;
+
+        PaxosContainer(T response) {
+            this.response = response;
+        }
+
+        @Override
+        public boolean isSuccessful() {
+            return true;
+        }
+
+        public T get() {
+            return response;
+        }
+    }
+
+}

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosQuorumCheckingCoalescingFunctionTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosQuorumCheckingCoalescingFunctionTests.java
@@ -1,0 +1,156 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import static java.util.stream.Collectors.toList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import com.palantir.atlasdb.autobatch.CoalescingRequestFunction;
+import com.palantir.common.streams.KeyedStream;
+import com.palantir.paxos.ImmutablePaxosLong;
+import com.palantir.paxos.ImmutablePaxosResponses;
+import com.palantir.paxos.PaxosLong;
+import com.palantir.paxos.PaxosResponses;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PaxosQuorumCheckingCoalescingFunctionTests {
+
+    private static final int QUORUM_SIZE = 3;
+    private final ExecutorService executorService = Executors.newCachedThreadPool();
+
+    @After
+    public void after() {
+        executorService.shutdown();
+    }
+
+    @Test
+    public void successfullyCombinesAndDeconstructs() {
+        CoalescingRequestFunction<Long, PaxosLong> node1 = functionFor(
+                Maps.immutableEntry(1L, 2L),
+                Maps.immutableEntry(2L, 23L),
+                Maps.immutableEntry(5L, 65L));
+
+        CoalescingRequestFunction<Long, PaxosLong> node2 = functionFor(
+                Maps.immutableEntry(1L, 6L),
+                Maps.immutableEntry(2L, 23L),
+                Maps.immutableEntry(5L, 32L));
+
+        CoalescingRequestFunction<Long, PaxosLong> node3 = functionFor(
+                Maps.immutableEntry(1L, 3L),
+                Maps.immutableEntry(2L, 65L),
+                Maps.immutableEntry(5L, 32L));
+
+        PaxosQuorumCheckingCoalescingFunction<Long, PaxosLong> paxosQuorumChecker =
+                paxosQuorumCheckerFor(node1, node2, node3);
+
+        Map<Long, PaxosResponses<PaxosLong>> expected = ImmutableMap.<Long, PaxosResponses<PaxosLong>>builder()
+                .put(1L, sorted(responsesFor(2L, 6L, 3L)))
+                .put(2L, sorted(responsesFor(23L, 23L, 65L)))
+                .put(5L, sorted(responsesFor( 65L, 32L, 32L)))
+                .build();
+
+        Map<Long, PaxosResponses<PaxosLong>> results = paxosQuorumChecker.apply(ImmutableSet.of(1L, 2L, 5L));
+        assertThat(results.entrySet())
+                .allSatisfy(entry -> assertThat(expected).contains(sorted(entry)));
+    }
+
+    @Test
+    public void individualRequestsCanHaveQuorumFailures() {
+        CoalescingRequestFunction<Long, PaxosLong> node1 = functionFor(
+                Maps.immutableEntry(1L, 2L),
+                Maps.immutableEntry(2L, 23L));
+
+        CoalescingRequestFunction<Long, PaxosLong> node2 = functionFor(
+                Maps.immutableEntry(2L, 23L),
+                Maps.immutableEntry(5L, 32L));
+
+        CoalescingRequestFunction<Long, PaxosLong> node3 = functionFor(
+                Maps.immutableEntry(2L, 65L));
+
+        PaxosQuorumCheckingCoalescingFunction<Long, PaxosLong> paxosQuorumChecker =
+                paxosQuorumCheckerFor(node1, node2, node3);
+
+        Map<Long, PaxosResponses<PaxosLong>> expected = ImmutableMap.<Long, PaxosResponses<PaxosLong>>builder()
+                .put(1L, sorted(responsesFor(2L)))
+                .put(2L, sorted(responsesFor(23L, 23L, 65L)))
+                .put(5L, sorted(responsesFor( 32L)))
+                .build();
+
+        Map<Long, PaxosResponses<PaxosLong>> results = paxosQuorumChecker.apply(ImmutableSet.of(1L, 2L, 5L));
+        assertThat(results.entrySet())
+                .allSatisfy(entry -> assertThat(expected).contains(sorted(entry)));
+    }
+
+    private PaxosQuorumCheckingCoalescingFunction<Long, PaxosLong> paxosQuorumCheckerFor(
+            CoalescingRequestFunction<Long, PaxosLong>... nodes) {
+        Map<CoalescingRequestFunction<Long, PaxosLong>, ExecutorService> executors =
+                Maps.asMap(ImmutableSet.copyOf(nodes), $ -> executorService);
+        return new PaxosQuorumCheckingCoalescingFunction<>(ImmutableList.copyOf(nodes), executors, QUORUM_SIZE);
+    }
+
+    private static Map.Entry<Long, PaxosResponses<PaxosLong>> sorted(Map.Entry<Long, PaxosResponses<PaxosLong>> entry) {
+        return Maps.immutableEntry(entry.getKey(), sorted(entry.getValue()));
+    }
+
+    private static PaxosResponses<PaxosLong> sorted(PaxosResponses<PaxosLong> responses) {
+        List<PaxosLong> sorted = responses.stream()
+                .sorted(Comparator.comparing(PaxosLong::getValue))
+                .collect(toList());
+
+        return ImmutablePaxosResponses.of(QUORUM_SIZE, sorted);
+    }
+
+    private static CoalescingRequestFunction<Long, PaxosLong> functionFor(Map.Entry<Long, Long>... mappings) {
+        Map<Long, Long> function = ImmutableMap.copyOf(ImmutableList.copyOf(mappings));
+        return new CoalescingRequestFunction<Long, PaxosLong>() {
+            @Override
+            public PaxosLong defaultValue() {
+                throw new AssertionError("should never get here");
+            }
+
+            @Override
+            public Map<Long, PaxosLong> apply(Set<Long> request) {
+                return KeyedStream.stream(function)
+                        .filterKeys(request::contains)
+                        .<PaxosLong>map(ImmutablePaxosLong::of)
+                        .collectToMap();
+            }
+        };
+    }
+
+    private static PaxosResponses<PaxosLong> responsesFor(Long... longs) {
+        return PaxosResponses.of(QUORUM_SIZE, Arrays.stream(longs).map(ImmutablePaxosLong::of).collect(toList()));
+    }
+}

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosQuorumCheckingCoalescingFunctionTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosQuorumCheckingCoalescingFunctionTests.java
@@ -78,7 +78,7 @@ public class PaxosQuorumCheckingCoalescingFunctionTests {
         Map<Long, PaxosResponses<PaxosLong>> expected = ImmutableMap.<Long, PaxosResponses<PaxosLong>>builder()
                 .put(1L, sorted(responsesFor(2L, 6L, 3L)))
                 .put(2L, sorted(responsesFor(23L, 23L, 65L)))
-                .put(5L, sorted(responsesFor( 65L, 32L, 32L)))
+                .put(5L, sorted(responsesFor(65L, 32L, 32L)))
                 .build();
 
         Map<Long, PaxosResponses<PaxosLong>> results = paxosQuorumChecker.apply(ImmutableSet.of(1L, 2L, 5L));
@@ -105,7 +105,7 @@ public class PaxosQuorumCheckingCoalescingFunctionTests {
         Map<Long, PaxosResponses<PaxosLong>> expected = ImmutableMap.<Long, PaxosResponses<PaxosLong>>builder()
                 .put(1L, sorted(responsesFor(2L)))
                 .put(2L, sorted(responsesFor(23L, 23L, 65L)))
-                .put(5L, sorted(responsesFor( 32L)))
+                .put(5L, sorted(responsesFor(32L)))
                 .build();
 
         Map<Long, PaxosResponses<PaxosLong>> results = paxosQuorumChecker.apply(ImmutableSet.of(1L, 2L, 5L));


### PR DESCRIPTION
**Goals (and why)**:
All of the coalescing functions in #4072 and #4075 need to be wrapped in this so we can achieve the ideal threading model for multi leader timelock:
![Ideal situation](https://user-images.githubusercontent.com/4521225/60605231-0af34c80-9db1-11e9-82a9-18f221a5c75b.png)

**Implementation Description (bullets)**:
We batch all the requests and then via `PaxosQuorumChecker` we send them to the batch endpoints on timelock.

**Testing (What was existing testing like?  What have you done to improve it?)**:
* Probably missing a few edge cases, feel free to suggest more

**Priority (whenever / two weeks / yesterday)**:
ASAP, actually blocking now.
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
