### PR TITLE
Tag TS outcome metrics with sweep strategy

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueue.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueue.java
@@ -150,9 +150,9 @@ public final class SweepQueue implements MultiTableSweepQueueWriter {
         metrics.updateProgressForShard(shardStrategy, sweepBatch.lastSweptTimestamp());
 
         if (sweepBatch.isEmpty()) {
-            metrics.registerOccurrenceOf(SweepOutcome.NOTHING_TO_SWEEP);
+            metrics.registerOccurrenceOf(shardStrategy, SweepOutcome.NOTHING_TO_SWEEP);
         } else {
-            metrics.registerOccurrenceOf(SweepOutcome.SUCCESS);
+            metrics.registerOccurrenceOf(shardStrategy, SweepOutcome.SUCCESS);
         }
 
         return true;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/TargetedSweeper.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/TargetedSweeper.java
@@ -252,7 +252,7 @@ public class TargetedSweeper implements MultiTableSweepQueueWriter, BackgroundSw
 
         private void runOneIteration() {
             if (!runtime.get().enabled()) {
-                metrics.registerOccurrenceOf(SweepOutcome.DISABLED);
+                metrics.registerOccurrenceOf(sweepStrategy, SweepOutcome.DISABLED);
                 return;
             }
 
@@ -261,10 +261,10 @@ public class TargetedSweeper implements MultiTableSweepQueueWriter, BackgroundSw
                 maybeLock = tryToAcquireLockForNextShardAndStrategy();
                 maybeLock.ifPresent(lock -> processShard(lock.getShardAndStrategy()));
             } catch (InsufficientConsistencyException e) {
-                metrics.registerOccurrenceOf(SweepOutcome.NOT_ENOUGH_DB_NODES_ONLINE);
+                metrics.registerOccurrenceOf(sweepStrategy, SweepOutcome.NOT_ENOUGH_DB_NODES_ONLINE);
                 logException(e, maybeLock);
             } catch (Throwable th) {
-                metrics.registerOccurrenceOf(SweepOutcome.ERROR);
+                metrics.registerOccurrenceOf(sweepStrategy, SweepOutcome.ERROR);
                 logException(th, maybeLock);
             } finally {
                 try {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/metrics/SweepMetricsAssert.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/metrics/SweepMetricsAssert.java
@@ -139,7 +139,7 @@ public final class SweepMetricsAssert extends AbstractAssert<SweepMetricsAssert,
                         AtlasDbMetricNames.TAG_STRATEGY, getTagForStrategy(strategy)));
     }
 
-    private String getTagForStrategy(SweepStrategy strategy) {
+    private static String getTagForStrategy(SweepStrategy strategy) {
         return strategy == SweepStrategy.CONSERVATIVE
                 ? AtlasDbMetricNames.TAG_CONSERVATIVE
                 : AtlasDbMetricNames.TAG_THOROUGH;

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/metrics/SweepMetricsAssert.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/metrics/SweepMetricsAssert.java
@@ -27,6 +27,7 @@ import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.atlasdb.AtlasDbMetricNames;
+import com.palantir.atlasdb.protos.generated.TableMetadataPersistence.SweepStrategy;
 import com.palantir.atlasdb.sweep.BackgroundSweeperImpl;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.tritium.metrics.registry.MetricName;
@@ -106,12 +107,12 @@ public final class SweepMetricsAssert extends AbstractAssert<SweepMetricsAssert,
         objects.assertEqual(info, getGaugeForLegacyOutcome(outcome).getValue(), value);
     }
 
-    public void hasTargetedOutcomeEqualTo(SweepOutcome outcome, Long value) {
-        objects.assertEqual(info, getGaugeForTargetedOutcome(outcome).getValue(), value);
+    public void hasTargetedOutcomeEqualTo(SweepStrategy strategy, SweepOutcome outcome, Long value) {
+        objects.assertEqual(info, getGaugeForTargetedOutcome(strategy, outcome).getValue(), value);
     }
 
-    public void hasNotRegisteredTargetedOutcome(SweepOutcome outcome) {
-        objects.assertNull(info, getGaugeForTargetedOutcome(outcome));
+    public void hasNotRegisteredTargetedOutcome(SweepStrategy strategy, SweepOutcome outcome) {
+        objects.assertNull(info, getGaugeForTargetedOutcome(strategy, outcome));
     }
 
     private Gauge<Long> getGaugeConservative(String name) {
@@ -132,9 +133,16 @@ public final class SweepMetricsAssert extends AbstractAssert<SweepMetricsAssert,
                 ImmutableMap.of(AtlasDbMetricNames.TAG_OUTCOME, outcome.name()));
     }
 
-    private Gauge<Long> getGaugeForTargetedOutcome(SweepOutcome outcome) {
+    private Gauge<Long> getGaugeForTargetedOutcome(SweepStrategy strategy, SweepOutcome outcome) {
         return getGauge(TargetedSweepMetrics.class, AtlasDbMetricNames.SWEEP_OUTCOME,
-                ImmutableMap.of(AtlasDbMetricNames.TAG_OUTCOME, outcome.name()));
+                ImmutableMap.of(AtlasDbMetricNames.TAG_OUTCOME, outcome.name(),
+                        AtlasDbMetricNames.TAG_STRATEGY, getTagForStrategy(strategy)));
+    }
+
+    private String getTagForStrategy(SweepStrategy strategy) {
+        return strategy == SweepStrategy.CONSERVATIVE
+                ? AtlasDbMetricNames.TAG_CONSERVATIVE
+                : AtlasDbMetricNames.TAG_THOROUGH;
     }
 
     private <T> Gauge<Long> getGauge(Class<T> metricClass, String name, Map<String, String> tag) {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
@@ -30,6 +30,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import static com.palantir.atlasdb.protos.generated.TableMetadataPersistence.SweepStrategy.CONSERVATIVE;
+import static com.palantir.atlasdb.protos.generated.TableMetadataPersistence.SweepStrategy.THOROUGH;
 import static com.palantir.atlasdb.sweep.metrics.SweepMetricsAssert.assertThat;
 import static com.palantir.atlasdb.sweep.queue.SweepQueueUtils.BATCH_SIZE_KVS;
 import static com.palantir.atlasdb.sweep.queue.SweepQueueUtils.MAX_CELLS_GENERIC;
@@ -224,7 +226,8 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
         setTimelockTime(5_000L);
         punchTimeAtTimestamp(2_000, LOW_TS);
         assertThat(metricsManager).hasMillisSinceLastSweptConservativeEqualTo(5_000L - 2_000L);
-        assertThat(metricsManager).hasTargetedOutcomeEqualTo(SweepOutcome.SUCCESS, 1L);
+        assertThat(metricsManager).hasTargetedOutcomeEqualTo(CONSERVATIVE, SweepOutcome.SUCCESS, 1L);
+        assertThat(metricsManager).hasTargetedOutcomeEqualTo(THOROUGH, SweepOutcome.SUCCESS, 0L);
     }
 
     @Test
@@ -232,7 +235,8 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
         enqueueWriteCommitted(TABLE_CONS, getSweepTsCons());
         sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
 
-        assertThat(metricsManager).hasTargetedOutcomeEqualTo(SweepOutcome.NOTHING_TO_SWEEP, 1L);
+        assertThat(metricsManager).hasTargetedOutcomeEqualTo(CONSERVATIVE, SweepOutcome.NOTHING_TO_SWEEP, 1L);
+        assertThat(metricsManager).hasTargetedOutcomeEqualTo(THOROUGH, SweepOutcome.NOTHING_TO_SWEEP, 0L);
     }
 
     @Test

--- a/changelog/@unreleased/pr-4116.v2.yml
+++ b/changelog/@unreleased/pr-4116.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: We now tag Targeted Sweep outcome metrics with the appropriate sweep
+    strategy. Previously, the outcomes for both strategies were aggregated, resulting
+    in metrics that were difficult to interpret.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4116


### PR DESCRIPTION
**Goals (and why)**:
Initially did these without tags to reduce metrics count, but the usefulness is very limited since the numbers are conflated for the two strategies.