### PR TITLE
Fix batching logic for TS

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepBatch.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepBatch.java
@@ -29,15 +29,22 @@ public interface SweepBatch {
     List<WriteInfo> writes();
     DedicatedRows dedicatedRows();
     long lastSweptTimestamp();
+    boolean hasNext();
 
     default boolean isEmpty() {
         return writes().isEmpty();
     }
 
     static SweepBatch of(Collection<WriteInfo> writes, DedicatedRows dedicatedRows, long timestamp) {
+        return of(writes, dedicatedRows, timestamp, true);
+    }
+
+    static SweepBatch of(Collection<WriteInfo> writes, DedicatedRows dedicatedRows, long timestamp, boolean next) {
         return ImmutableSweepBatch.builder()
                 .writes(writes)
                 .dedicatedRows(dedicatedRows)
-                .lastSweptTimestamp(timestamp).build();
+                .lastSweptTimestamp(timestamp)
+                .hasNext(next)
+                .build();
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueue.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueue.java
@@ -155,7 +155,7 @@ public final class SweepQueue implements MultiTableSweepQueueWriter {
             metrics.registerOccurrenceOf(SweepOutcome.SUCCESS);
         }
 
-        return true;
+        return lastSweptTs != sweepBatch.lastSweptTimestamp() && sweepBatch.hasNext();
     }
 
     /**

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueReader.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueReader.java
@@ -45,15 +45,8 @@ class SweepQueueReader {
             SweepBatch batch = sweepableCells.getBatchForPartition(
                     shardStrategy, nextFinePartition.get(), previousProgress, sweepTs);
             accumulator.accumulateBatch(batch);
-            if (noProgressMadeThisIteration(accumulator, previousProgress)) {
-                return accumulator.toSweepBatch();
-            }
             previousProgress = accumulator.getProgressTimestamp();
         }
         return accumulator.toSweepBatch();
-    }
-
-    private static boolean noProgressMadeThisIteration(SweepBatchAccumulator accumulator, long previousProgress) {
-        return accumulator.getProgressTimestamp() == previousProgress;
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableCells.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableCells.java
@@ -165,7 +165,7 @@ public class SweepableCells extends SweepQueueTable {
         Collection<WriteInfo> writes = getWritesToSweep(writesByStartTs, tsToSweep.timestampsDescending());
         DedicatedRows filteredDedicatedRows = getDedicatedRowsToClear(writeBatch.dedicatedRows, tsToSweep);
         long lastSweptTs = getLastSweptTs(tsToSweep, peekingResultIterator, partitionFine, sweepTs);
-        return SweepBatch.of(writes, filteredDedicatedRows, lastSweptTs);
+        return SweepBatch.of(writes, filteredDedicatedRows, lastSweptTs, tsToSweep.processedAll());
     }
 
     private DedicatedRows getDedicatedRowsToClear(List<SweepableCellsRow> rows, TimestampsToSweep tsToSweep) {
@@ -262,6 +262,7 @@ public class SweepableCells extends SweepQueueTable {
                 committedTimestamps.add(startTs);
             } else {
                 processedAll = false;
+                lastSweptTs = startTs - 1;
                 break;
             }
         }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
@@ -766,14 +766,14 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
         enqueueWriteCommitted(TABLE_CONS, 970);
 
         sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
-        assertThat(progress.getLastSweptTimestamp(ShardAndStrategy.conservative(CONS_SHARD))).isEqualTo(920L);
+        assertThat(progress.getLastSweptTimestamp(ShardAndStrategy.conservative(CONS_SHARD))).isEqualTo(950 - 1);
         ArgumentCaptor<Map> argument = ArgumentCaptor.forClass(Map.class);
         verify(spiedKvs, times(1)).deleteAllTimestamps(eq(TABLE_CONS), argument.capture());
         assertThat(argument.getValue()).containsValue(
                 new TimestampRangeDelete.Builder().timestamp(920L).endInclusive(false).deleteSentinels(false).build());
 
         sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
-        assertThat(progress.getLastSweptTimestamp(ShardAndStrategy.conservative(CONS_SHARD))).isEqualTo(920L);
+        assertThat(progress.getLastSweptTimestamp(ShardAndStrategy.conservative(CONS_SHARD))).isEqualTo(950 - 1);
         verify(spiedKvs, times(1)).deleteAllTimestamps(any(TableReference.class), anyMap());
 
         immutableTs = 1001L;
@@ -795,7 +795,7 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
         enqueueWriteUncommitted(TABLE_CONS, 1110);
 
         sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
-        assertThat(progress.getLastSweptTimestamp(ShardAndStrategy.conservative(CONS_SHARD))).isEqualTo(920L);
+        assertThat(progress.getLastSweptTimestamp(ShardAndStrategy.conservative(CONS_SHARD))).isEqualTo(950 - 1);
         verify(spiedKvs, never()).deleteAllTimestamps(any(TableReference.class), anyMap());
 
         ArgumentCaptor<Multimap> multimap = ArgumentCaptor.forClass(Multimap.class);
@@ -804,7 +804,7 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
         assertThat(multimap.getValue().values()).containsExactly(900L, 920L);
 
         sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
-        assertThat(progress.getLastSweptTimestamp(ShardAndStrategy.conservative(CONS_SHARD))).isEqualTo(920L);
+        assertThat(progress.getLastSweptTimestamp(ShardAndStrategy.conservative(CONS_SHARD))).isEqualTo(950 - 1);
         verify(spiedKvs, never()).deleteAllTimestamps(any(TableReference.class), anyMap());
         verify(spiedKvs, times(1)).delete(any(TableReference.class), any(Multimap.class));
         assertReadAtTimestampReturnsValue(TABLE_CONS, 1500L, 1110L);
@@ -836,27 +836,23 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
 
         // first iteration reads all before giving up
         sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
-        assertThat(metricsManager).hasEntriesReadConservativeEqualTo(
-                4 + writesInDedicated + (readBatchSize > 1 ? 1 : 0));
+        assertThat(metricsManager).hasEntriesReadConservativeEqualTo(4 + writesInDedicated);
 
         // we read one entry and give up
         sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
-        assertThat(metricsManager).hasEntriesReadConservativeEqualTo(
-                4 + writesInDedicated + 1 + (readBatchSize > 1 ? 1 : 0));
+        assertThat(metricsManager).hasEntriesReadConservativeEqualTo(4 + writesInDedicated + 1);
 
         immutableTs = 170;
 
         // we read one good entry and then a reference to bad entries and give up
         sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
-        assertThat(metricsManager).hasEntriesReadConservativeEqualTo(
-                4 + writesInDedicated + 3 + (readBatchSize > 1 ? 2 : 0));
+        assertThat(metricsManager).hasEntriesReadConservativeEqualTo(4 + writesInDedicated + 3);
 
         immutableTs = 250;
 
         // we now read all to the end
         sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
-        assertThat(metricsManager).hasEntriesReadConservativeEqualTo(
-                4 + writesInDedicated + 3 + writesInDedicated + 2 + (readBatchSize > 1 ? 2 : 0));
+        assertThat(metricsManager).hasEntriesReadConservativeEqualTo(4 + writesInDedicated + 3 + writesInDedicated + 2);
     }
 
     @Test
@@ -1059,6 +1055,45 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
         sweepQueue.processShard(ShardAndStrategy.conservative(CONS_SHARD));
 
         assertReadAtTimestampReturnsSentinel(TABLE_CONS, maxTsForFinePartition(0) + 1);
+    }
+
+    @Test
+    public void sweepNextBatchReturnsFalseWhenEncounteringEntryCommittedAfterSweepTs() {
+        ShardAndStrategy shardStrategy = ShardAndStrategy.conservative(CONS_SHARD);
+        long sweepTimestamp = getSweepTsCons();
+        enqueueWriteCommitted(TABLE_CONS, sweepTimestamp - 10);
+        enqueueWriteCommitedAt(TABLE_CONS, sweepTimestamp - 5, sweepTimestamp + 5);
+
+        assertThat(sweepNextBatch(shardStrategy)).isFalse();
+        assertThat(metricsManager).hasEntriesReadConservativeEqualTo(2L);
+        assertThat(metricsManager).hasTombstonesPutConservativeEqualTo(1L);
+        assertThat(progress.getLastSweptTimestamp(shardStrategy)).isEqualTo(sweepTimestamp - 6);
+
+        assertThat(sweepNextBatch(shardStrategy)).isFalse();
+        assertThat(metricsManager).hasEntriesReadConservativeEqualTo(3L);
+        assertThat(metricsManager).hasTombstonesPutConservativeEqualTo(1L);
+        assertThat(progress.getLastSweptTimestamp(shardStrategy)).isEqualTo(sweepTimestamp - 6);
+    }
+
+    @Test
+    public void sweepNextBatchReturnsTrueWhenThereCouldBeMoreEntries() {
+        ShardAndStrategy shardStrategy = ShardAndStrategy.conservative(CONS_SHARD);
+        long sweepTimestamp = getSweepTsCons();
+        for (int i = 0; i < readBatchSize; i++) {
+            enqueueWriteCommitted(TABLE_CONS, SweepQueueUtils.maxTsForFinePartition(i) - 5);
+        }
+        enqueueWriteCommitedAt(TABLE_CONS, sweepTimestamp - 5, sweepTimestamp + 5);
+
+        assertThat(sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD))).isTrue();
+        assertThat(metricsManager).hasEntriesReadConservativeEqualTo(readBatchSize);
+        assertThat(metricsManager).hasTombstonesPutConservativeEqualTo(1L);
+        assertThat(progress.getLastSweptTimestamp(shardStrategy))
+                .isEqualTo(SweepQueueUtils.maxTsForFinePartition(readBatchSize - 1));
+
+        assertThat(sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD))).isFalse();
+        assertThat(metricsManager).hasEntriesReadConservativeEqualTo(readBatchSize + 1);
+        assertThat(metricsManager).hasTombstonesPutConservativeEqualTo(1L);
+        assertThat(progress.getLastSweptTimestamp(shardStrategy)).isEqualTo(sweepTimestamp - 6);
     }
 
     private void writeValuesAroundSweepTimestampAndSweepAndCheck(long sweepTimestamp, int sweepIterations) {


### PR DESCRIPTION
**Goals (and why)**:
When encountering an entry with commit TS after sweep TS, we would thing there is more to sweep, and aggressively re-read it. Along the way made it so that the last swept timestamp is set to just before the entry that cannot be processed, and used this information to inform the multi-batching.
