### PR TITLE
Deprecate AtlasSchema

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/AtlasSchema.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/AtlasSchema.java
@@ -18,6 +18,10 @@ package com.palantir.atlasdb.schema;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.table.description.Schema;
 
+/**
+ * @deprecated Schema classes do not need to extend this class.
+ */
+@Deprecated
 public interface AtlasSchema {
     Namespace getNamespace();
     Schema getLatestSchema();

--- a/changelog/@unreleased/pr-4118.v2.yml
+++ b/changelog/@unreleased/pr-4118.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '`AtlasSchema` has been marked as deprecated.'
+  links:
+  - https://github.com/palantir/atlasdb/pull/4118


### PR DESCRIPTION
**Goals (and why)**:
Schema classes do not need to extend `AtlasSchema`. It's essentially unused (it would be trivial to remove it in the few places it is used). We should mark it as deprecated to discourage continued usage of it.

**Concerns (what feedback would you like?)**:
- Is this class actually useful?
- I originally planned to stop using it internally to follow best practices, but this is technically a dev break since the static instances were public. I'm happy to remove these uses if we feel the minor dev break is worth it.
