### PR TITLE
Replace java plugin with java-library plugin

### DIFF
--- a/atlasdb-autobatch/build.gradle
+++ b/atlasdb-autobatch/build.gradle
@@ -3,9 +3,6 @@ apply plugin: 'org.inferred.processors'
 apply from: "../gradle/publish-jars.gradle"
 apply from: "../gradle/shared.gradle"
 
-apply plugin: 'java'
-apply plugin: 'eclipse'
-
 repositories {
     mavenCentral()
 }

--- a/atlasdb-client/build.gradle
+++ b/atlasdb-client/build.gradle
@@ -1,8 +1,6 @@
 apply from: "../gradle/publish-jars.gradle"
 apply from: "../gradle/shared.gradle"
 
-apply plugin: 'java'
-apply plugin: 'eclipse'
 apply plugin: 'org.inferred.processors'
 
 repositories {

--- a/atlasdb-coordination-impl/build.gradle
+++ b/atlasdb-coordination-impl/build.gradle
@@ -3,9 +3,6 @@ apply plugin: 'org.inferred.processors'
 
 apply from: "../gradle/shared.gradle"
 
-apply plugin: 'java'
-apply plugin: 'eclipse'
-
 repositories {
     mavenCentral()
 }

--- a/atlasdb-impl-shared/build.gradle
+++ b/atlasdb-impl-shared/build.gradle
@@ -3,9 +3,6 @@ apply plugin: 'org.inferred.processors'
 
 apply from: "../gradle/shared.gradle"
 
-apply plugin: 'java'
-apply plugin: 'eclipse'
-
 repositories {
     mavenCentral()
 }

--- a/commons-executors-api/build.gradle
+++ b/commons-executors-api/build.gradle
@@ -1,9 +1,6 @@
 apply from: "../gradle/publish-jars.gradle"
 apply from: "../gradle/shared.gradle"
 
-apply plugin: 'java'
-apply plugin: 'eclipse'
-
 repositories {
     mavenCentral()
 }

--- a/commons-executors/build.gradle
+++ b/commons-executors/build.gradle
@@ -1,9 +1,6 @@
 apply from: "../gradle/publish-jars.gradle"
 apply from: "../gradle/shared.gradle"
 
-apply plugin: 'java'
-apply plugin: 'eclipse'
-
 repositories {
     mavenCentral()
 }

--- a/gradle/idea.gradle
+++ b/gradle/idea.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'java'
+apply plugin: 'java-library'
 apply plugin: 'idea'
 
 assert sourceCompatibility instanceof JavaVersion;

--- a/gradle/publish-jars.gradle
+++ b/gradle/publish-jars.gradle
@@ -1,6 +1,6 @@
 import java.util.stream.Collectors;
 
-apply plugin: 'java'
+apply plugin: 'java-library'
 apply plugin: 'com.jfrog.artifactory'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven-publish'

--- a/gradle/shared.gradle
+++ b/gradle/shared.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'java'
+apply plugin: 'java-library'
 apply plugin: 'idea'
 apply plugin: 'eclipse'
 apply plugin: 'checkstyle'

--- a/leader-election-api/build.gradle
+++ b/leader-election-api/build.gradle
@@ -2,9 +2,6 @@ apply from: "../gradle/publish-jars.gradle"
 apply from: "../gradle/shared.gradle"
 apply plugin: 'org.inferred.processors'
 
-apply plugin: 'java'
-apply plugin: 'eclipse'
-
 repositories {
     mavenCentral()
 }

--- a/lock-api/build.gradle
+++ b/lock-api/build.gradle
@@ -4,9 +4,6 @@ apply plugin: 'com.palantir.sls-recommended-dependencies'
 apply from: "../gradle/publish-jars.gradle"
 apply from: "../gradle/shared.gradle"
 
-apply plugin: 'java'
-apply plugin: 'eclipse'
-
 repositories {
     mavenCentral()
 }


### PR DESCRIPTION
**Goals (and why)**:
AtlasDB leaks a lot of dependencies to the compile classpath of users. Users then incorrectly use these transitive dependencies without declaring the dependency themselves.

This PR is a first step towards cleaning that up. In follow up PRs we can move internal dependencies to the `implementation` configuration.

**Implementation Description (bullets)**:
- This PR also removes some redundant `apply plugin` statements (the removed plugins are applied by `shared.gradle`)
