### PR TITLE
getRowsColumnRangeIterator

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
@@ -53,6 +53,12 @@ public interface Transaction {
             BatchColumnRangeSelection columnRangeSelection);
 
     @Idempotent
+    Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> getRowsColumnRangeIterator(
+            TableReference tableRef,
+            Iterable<byte[]> rows,
+            BatchColumnRangeSelection columnRangeSelection);
+
+    @Idempotent
     Iterator<Map.Entry<Cell, byte[]>> getRowsColumnRange(
             TableReference tableRef,
             Iterable<byte[]> rows,

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
@@ -53,17 +53,17 @@ public interface Transaction {
             BatchColumnRangeSelection columnRangeSelection);
 
     @Idempotent
-    Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> getRowsColumnRangeIterator(
-            TableReference tableRef,
-            Iterable<byte[]> rows,
-            BatchColumnRangeSelection columnRangeSelection);
-
-    @Idempotent
     Iterator<Map.Entry<Cell, byte[]>> getRowsColumnRange(
             TableReference tableRef,
             Iterable<byte[]> rows,
             ColumnRangeSelection columnRangeSelection,
             int batchHint);
+
+    @Idempotent
+    Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> getRowsColumnRangeIterator(
+            TableReference tableRef,
+            Iterable<byte[]> rows,
+            BatchColumnRangeSelection columnRangeSelection);
 
     @Idempotent
     Map<Cell, byte[]> get(TableReference tableRef, Set<Cell> cells);

--- a/atlasdb-client/build.gradle
+++ b/atlasdb-client/build.gradle
@@ -10,8 +10,9 @@ repositories {
 }
 
 schemas = [
-    'com.palantir.atlasdb.schema.SweepSchema',
     'com.palantir.atlasdb.schema.CompactSchema',
+    'com.palantir.atlasdb.schema.SweepSchema',
+    'com.palantir.atlasdb.schema.TargetedSweepSchema',
     'com.palantir.atlasdb.table.description.ApiTestSchema',
     'com.palantir.atlasdb.table.description.GenericTestSchema'
 ]

--- a/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/AllValueTypesTestTable.java
+++ b/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/AllValueTypesTestTable.java
@@ -1996,6 +1996,20 @@ public final class AllValueTypesTestTable implements
         });
     }
 
+    @Override
+    public Map<AllValueTypesTestRow, Iterator<AllValueTypesTestNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<AllValueTypesTestRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<AllValueTypesTestRow, Iterator<AllValueTypesTestNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            AllValueTypesTestRow row = AllValueTypesTestRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<AllValueTypesTestNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<AllValueTypesTestRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -2107,5 +2121,5 @@ public final class AllValueTypesTestTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "r4GAOsoxikdmFU+sqUQzQA==";
+    static String __CLASS_HASH = "E+l2YKDkACfDR3fqNe+o+g==";
 }

--- a/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/HashComponentsTestTable.java
+++ b/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/HashComponentsTestTable.java
@@ -589,6 +589,20 @@ public final class HashComponentsTestTable implements
         });
     }
 
+    @Override
+    public Map<HashComponentsTestRow, Iterator<HashComponentsTestNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<HashComponentsTestRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<HashComponentsTestRow, Iterator<HashComponentsTestNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            HashComponentsTestRow row = HashComponentsTestRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<HashComponentsTestNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<HashComponentsTestRowResult> getRange(RangeRequest range) {
         if (range.getColumnNames().isEmpty()) {
             range = range.getBuilder().retainColumns(allColumns).build();
@@ -749,5 +763,5 @@ public final class HashComponentsTestTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "wcMKuy9F9wZNt8f7UQPeUg==";
+    static String __CLASS_HASH = "mUSvA7C+KGeRB81zw13qGg==";
 }

--- a/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/SchemaApiTestTable.java
+++ b/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/SchemaApiTestTable.java
@@ -673,6 +673,20 @@ public final class SchemaApiTestTable implements
         });
     }
 
+    @Override
+    public Map<SchemaApiTestRow, Iterator<SchemaApiTestNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<SchemaApiTestRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<SchemaApiTestRow, Iterator<SchemaApiTestNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            SchemaApiTestRow row = SchemaApiTestRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<SchemaApiTestNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<SchemaApiTestRowResult> getRange(RangeRequest range) {
         if (range.getColumnNames().isEmpty()) {
             range = range.getBuilder().retainColumns(allColumns).build();
@@ -833,5 +847,5 @@ public final class SchemaApiTestTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "h9whmxJpFX2yqVXafsa5AQ==";
+    static String __CLASS_HASH = "G9lxb99ucQ5q+GVyaV8Exg==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/CompactMetadataTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/CompactMetadataTable.java
@@ -546,6 +546,20 @@ public final class CompactMetadataTable implements
         });
     }
 
+    @Override
+    public Map<CompactMetadataRow, Iterator<CompactMetadataNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<CompactMetadataRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<CompactMetadataRow, Iterator<CompactMetadataNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            CompactMetadataRow row = CompactMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<CompactMetadataNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<CompactMetadataRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -657,5 +671,5 @@ public final class CompactMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "vX96N598CtO5B/gkmgCmsg==";
+    static String __CLASS_HASH = "fGGhK4I5QXFQd2PwcQ3sBA==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepIdToNameTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepIdToNameTable.java
@@ -617,6 +617,22 @@ public final class SweepIdToNameTable implements
         });
     }
 
+    @Override
+    public Map<SweepIdToNameRow, Iterator<SweepIdToNameColumnValue>> getRowsColumnRangeIterator(Iterable<SweepIdToNameRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<SweepIdToNameRow, Iterator<SweepIdToNameColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            SweepIdToNameRow row = SweepIdToNameRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<SweepIdToNameColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                SweepIdToNameColumn col = SweepIdToNameColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                String val = SweepIdToNameColumnValue.hydrateValue(result.getValue());
+                return SweepIdToNameColumnValue.of(col, val);
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<SweepIdToNameRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -728,5 +744,5 @@ public final class SweepIdToNameTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "CDKO6wCjNHixix7orYR6Tw==";
+    static String __CLASS_HASH = "IK9kLlZUUg/BMhVdL0EVpA==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepNameToIdTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepNameToIdTable.java
@@ -560,6 +560,20 @@ public final class SweepNameToIdTable implements
         });
     }
 
+    @Override
+    public Map<SweepNameToIdRow, Iterator<SweepNameToIdNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<SweepNameToIdRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<SweepNameToIdRow, Iterator<SweepNameToIdNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            SweepNameToIdRow row = SweepNameToIdRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<SweepNameToIdNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<SweepNameToIdRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -671,5 +685,5 @@ public final class SweepNameToIdTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "DfAfxfVhiaGnk6aV2ilbFQ==";
+    static String __CLASS_HASH = "s9zHRD9HAzEhp13L6+ZO4g==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepPriorityTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepPriorityTable.java
@@ -1054,6 +1054,20 @@ public final class SweepPriorityTable implements
         });
     }
 
+    @Override
+    public Map<SweepPriorityRow, Iterator<SweepPriorityNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<SweepPriorityRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<SweepPriorityRow, Iterator<SweepPriorityNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            SweepPriorityRow row = SweepPriorityRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<SweepPriorityNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<SweepPriorityRowResult> getRange(RangeRequest range) {
         if (range.getColumnNames().isEmpty()) {
             range = range.getBuilder().retainColumns(allColumns).build();
@@ -1214,5 +1228,5 @@ public final class SweepPriorityTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "P4pMrqwez6sbaQ8bCukCWA==";
+    static String __CLASS_HASH = "spVvFiOcJFcq4QaH96vRWg==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepShardProgressTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepShardProgressTable.java
@@ -572,6 +572,20 @@ public final class SweepShardProgressTable implements
         });
     }
 
+    @Override
+    public Map<SweepShardProgressRow, Iterator<SweepShardProgressNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<SweepShardProgressRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<SweepShardProgressRow, Iterator<SweepShardProgressNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            SweepShardProgressRow row = SweepShardProgressRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<SweepShardProgressNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<SweepShardProgressRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -683,5 +697,5 @@ public final class SweepShardProgressTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "tTaBGffFKZLsQNSbGhRrFQ==";
+    static String __CLASS_HASH = "h70LHf5pRzCWuuJ9PCMUtQ==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepableCellsTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepableCellsTable.java
@@ -652,6 +652,22 @@ public final class SweepableCellsTable implements
         });
     }
 
+    @Override
+    public Map<SweepableCellsRow, Iterator<SweepableCellsColumnValue>> getRowsColumnRangeIterator(Iterable<SweepableCellsRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<SweepableCellsRow, Iterator<SweepableCellsColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            SweepableCellsRow row = SweepableCellsRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<SweepableCellsColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                SweepableCellsColumn col = SweepableCellsColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                com.palantir.atlasdb.keyvalue.api.StoredWriteReference val = SweepableCellsColumnValue.hydrateValue(result.getValue());
+                return SweepableCellsColumnValue.of(col, val);
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<SweepableCellsRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -763,5 +779,5 @@ public final class SweepableCellsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "C6Klz1ercH0E5BGUB3kcvg==";
+    static String __CLASS_HASH = "s80dMU7egHiRuFMttydzLw==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepableTimestampsTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepableTimestampsTable.java
@@ -649,6 +649,22 @@ public final class SweepableTimestampsTable implements
         });
     }
 
+    @Override
+    public Map<SweepableTimestampsRow, Iterator<SweepableTimestampsColumnValue>> getRowsColumnRangeIterator(Iterable<SweepableTimestampsRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<SweepableTimestampsRow, Iterator<SweepableTimestampsColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            SweepableTimestampsRow row = SweepableTimestampsRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<SweepableTimestampsColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                SweepableTimestampsColumn col = SweepableTimestampsColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                byte[] val = SweepableTimestampsColumnValue.hydrateValue(result.getValue());
+                return SweepableTimestampsColumnValue.of(col, val);
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<SweepableTimestampsRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -760,5 +776,5 @@ public final class SweepableTimestampsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "t7gPykD45L4BzA0609socA==";
+    static String __CLASS_HASH = "5iC+nT3xDVTidq0kWH0TUQ==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/TableClearsTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/TableClearsTable.java
@@ -546,6 +546,20 @@ public final class TableClearsTable implements
         });
     }
 
+    @Override
+    public Map<TableClearsRow, Iterator<TableClearsNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<TableClearsRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<TableClearsRow, Iterator<TableClearsNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            TableClearsRow row = TableClearsRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<TableClearsNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<TableClearsRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -657,5 +671,5 @@ public final class TableClearsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "RdvPMSYQMP2GE/LTiLpJ4g==";
+    static String __CLASS_HASH = "2vWHB+B39V8PwkM5hrbwlg==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/TargetedSweepTableFactory.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/TargetedSweepTableFactory.java
@@ -1,15 +1,14 @@
 package com.palantir.atlasdb.schema.generated;
 
-import java.util.List;
-
-import javax.annotation.Generated;
-
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.table.generation.Triggers;
 import com.palantir.atlasdb.transaction.api.Transaction;
+import java.lang.Override;
+import java.util.List;
+import javax.annotation.Generated;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableFactoryRenderer")
 public final class TargetedSweepTableFactory {
@@ -19,18 +18,21 @@ public final class TargetedSweepTableFactory {
 
     private final Namespace namespace;
 
-    private TargetedSweepTableFactory(List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
+    private TargetedSweepTableFactory(
+            List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
             Namespace namespace) {
         this.sharedTriggers = sharedTriggers;
         this.namespace = namespace;
     }
 
-    public static TargetedSweepTableFactory of(List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
+    public static TargetedSweepTableFactory of(
+            List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
             Namespace namespace) {
         return new TargetedSweepTableFactory(sharedTriggers, namespace);
     }
 
-    public static TargetedSweepTableFactory of(List<Function<? super Transaction, SharedTriggers>> sharedTriggers) {
+    public static TargetedSweepTableFactory of(
+            List<Function<? super Transaction, SharedTriggers>> sharedTriggers) {
         return new TargetedSweepTableFactory(sharedTriggers, defaultNamespace);
     }
 
@@ -77,32 +79,38 @@ public final class TargetedSweepTableFactory {
 
     public abstract static class NullSharedTriggers implements SharedTriggers {
         @Override
-        public void putSweepIdToName(Multimap<SweepIdToNameTable.SweepIdToNameRow, ? extends SweepIdToNameTable.SweepIdToNameColumnValue> newRows) {
+        public void putSweepIdToName(
+                Multimap<SweepIdToNameTable.SweepIdToNameRow, ? extends SweepIdToNameTable.SweepIdToNameColumnValue> newRows) {
             // do nothing
         }
 
         @Override
-        public void putSweepNameToId(Multimap<SweepNameToIdTable.SweepNameToIdRow, ? extends SweepNameToIdTable.SweepNameToIdNamedColumnValue<?>> newRows) {
+        public void putSweepNameToId(
+                Multimap<SweepNameToIdTable.SweepNameToIdRow, ? extends SweepNameToIdTable.SweepNameToIdNamedColumnValue<?>> newRows) {
             // do nothing
         }
 
         @Override
-        public void putSweepShardProgress(Multimap<SweepShardProgressTable.SweepShardProgressRow, ? extends SweepShardProgressTable.SweepShardProgressNamedColumnValue<?>> newRows) {
+        public void putSweepShardProgress(
+                Multimap<SweepShardProgressTable.SweepShardProgressRow, ? extends SweepShardProgressTable.SweepShardProgressNamedColumnValue<?>> newRows) {
             // do nothing
         }
 
         @Override
-        public void putSweepableCells(Multimap<SweepableCellsTable.SweepableCellsRow, ? extends SweepableCellsTable.SweepableCellsColumnValue> newRows) {
+        public void putSweepableCells(
+                Multimap<SweepableCellsTable.SweepableCellsRow, ? extends SweepableCellsTable.SweepableCellsColumnValue> newRows) {
             // do nothing
         }
 
         @Override
-        public void putSweepableTimestamps(Multimap<SweepableTimestampsTable.SweepableTimestampsRow, ? extends SweepableTimestampsTable.SweepableTimestampsColumnValue> newRows) {
+        public void putSweepableTimestamps(
+                Multimap<SweepableTimestampsTable.SweepableTimestampsRow, ? extends SweepableTimestampsTable.SweepableTimestampsColumnValue> newRows) {
             // do nothing
         }
 
         @Override
-        public void putTableClears(Multimap<TableClearsTable.TableClearsRow, ? extends TableClearsTable.TableClearsNamedColumnValue<?>> newRows) {
+        public void putTableClears(
+                Multimap<TableClearsTable.TableClearsRow, ? extends TableClearsTable.TableClearsNamedColumnValue<?>> newRows) {
             // do nothing
         }
     }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/api/AtlasDbImmutableTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/api/AtlasDbImmutableTable.java
@@ -21,8 +21,10 @@ import java.util.Map;
 
 import com.google.common.collect.Multimap;
 import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.transaction.api.ConstraintCheckable;
 import com.palantir.common.base.BatchingVisitable;
 
@@ -43,6 +45,14 @@ public interface AtlasDbImmutableTable<ROW, COLUMN_VALUE, ROW_RESULT> extends Co
      */
     Map<ROW, BatchingVisitable<COLUMN_VALUE>> getRowsColumnRange(Iterable<ROW> rows,
                                                                  BatchColumnRangeSelection columnRangeSelection);
+
+
+    /*
+     * This returns an iterator for each row. It should be used if you want to visit a number of the first
+     * matched columns instead of all the columns per row.
+     */
+    Map<ROW, Iterator<COLUMN_VALUE>> getRowsColumnRangeIterator(Iterable<ROW> rows,
+                                                                BatchColumnRangeSelection columnRangeSelection);
 
     /*
      * This returns an iterator that visits the result columns row by row.

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransaction.java
@@ -63,6 +63,13 @@ public abstract class ForwardingTransaction extends ForwardingObject implements 
     }
 
     @Override
+    public Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> getRowsColumnRangeIterator(TableReference tableRef,
+            Iterable<byte[]> rows,
+            BatchColumnRangeSelection columnRangeSelection) {
+        return delegate().getRowsColumnRangeIterator(tableRef, rows, columnRangeSelection);
+    }
+
+    @Override
     public Iterator<Entry<Cell, byte[]>> getRowsColumnRange(TableReference tableRef,
                                                             Iterable<byte[]> rows,
                                                             ColumnRangeSelection columnRangeSelection,

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ReadTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ReadTransaction.java
@@ -109,6 +109,13 @@ public class ReadTransaction extends ForwardingTransaction {
     }
 
     @Override
+    public Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> getRowsColumnRangeIterator(TableReference tableRef,
+            Iterable<byte[]> rows, BatchColumnRangeSelection columnRangeSelection) {
+        checkTableName(tableRef);
+        return delegate().getRowsColumnRangeIterator(tableRef, rows, columnRangeSelection);
+    }
+
+    @Override
     public Iterator<Map.Entry<Cell, byte[]>> getRowsColumnRange(TableReference tableRef, Iterable<byte[]> rows,
             ColumnRangeSelection columnRangeSelection, int batchHint) {
         checkTableName(tableRef);

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/GenericRangeScanTestTable.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/GenericRangeScanTestTable.java
@@ -602,6 +602,22 @@ public final class GenericRangeScanTestTable implements
         });
     }
 
+    @Override
+    public Map<GenericRangeScanTestRow, Iterator<GenericRangeScanTestColumnValue>> getRowsColumnRangeIterator(Iterable<GenericRangeScanTestRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<GenericRangeScanTestRow, Iterator<GenericRangeScanTestColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            GenericRangeScanTestRow row = GenericRangeScanTestRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<GenericRangeScanTestColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                GenericRangeScanTestColumn col = GenericRangeScanTestColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                String val = GenericRangeScanTestColumnValue.hydrateValue(result.getValue());
+                return GenericRangeScanTestColumnValue.of(col, val);
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<GenericRangeScanTestRowResult> getRange(RangeRequest range) {
         if (range.getColumnNames().isEmpty()) {
             range = range.getBuilder().retainColumns(allColumns).build();
@@ -766,5 +782,5 @@ public final class GenericRangeScanTestTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "MhNj3HxZmOZNNoqQgJXPtA==";
+    static String __CLASS_HASH = "nN1NQLPJtq6erK2dXro9xw==";
 }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/RangeScanTestTable.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/RangeScanTestTable.java
@@ -546,6 +546,20 @@ public final class RangeScanTestTable implements
         });
     }
 
+    @Override
+    public Map<RangeScanTestRow, Iterator<RangeScanTestNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<RangeScanTestRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<RangeScanTestRow, Iterator<RangeScanTestNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            RangeScanTestRow row = RangeScanTestRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<RangeScanTestNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<RangeScanTestRowResult> getRange(RangeRequest range) {
         if (range.getColumnNames().isEmpty()) {
             range = range.getBuilder().retainColumns(allColumns).build();
@@ -706,5 +720,5 @@ public final class RangeScanTestTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "a190vUgJKD3lViaxZJkgww==";
+    static String __CLASS_HASH = "ZKMoPN41jtJEy0pXuPnlGw==";
 }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/transaction/impl/ReadTransactionShould.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/transaction/impl/ReadTransactionShould.java
@@ -131,6 +131,12 @@ public class ReadTransactionShould {
                 BatchColumnRangeSelection.create(EMPTY_BYTES, EMPTY_BYTES, 1)),
                 IllegalStateException.class,
                 "Cannot read");
+        checkThrowsAndNoInteraction(() -> readTransaction.getRowsColumnRangeIterator(
+                DUMMY_THOROUGH_TABLE,
+                ImmutableList.of(EMPTY_BYTES),
+                BatchColumnRangeSelection.create(EMPTY_BYTES, EMPTY_BYTES, 1)),
+                IllegalStateException.class,
+                "Cannot read");
     }
 
     @Test

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/LatestSnapshotTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/LatestSnapshotTable.java
@@ -546,6 +546,20 @@ public final class LatestSnapshotTable implements
         });
     }
 
+    @Override
+    public Map<LatestSnapshotRow, Iterator<LatestSnapshotNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<LatestSnapshotRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<LatestSnapshotRow, Iterator<LatestSnapshotNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            LatestSnapshotRow row = LatestSnapshotRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<LatestSnapshotNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<LatestSnapshotRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -657,5 +671,5 @@ public final class LatestSnapshotTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "G425LkwW0GRVAmmRAB+j7w==";
+    static String __CLASS_HASH = "KXheO4Y05y+Ho61RbNUHvw==";
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/NamespacedTodoTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/NamespacedTodoTable.java
@@ -602,6 +602,22 @@ public final class NamespacedTodoTable implements
         });
     }
 
+    @Override
+    public Map<NamespacedTodoRow, Iterator<NamespacedTodoColumnValue>> getRowsColumnRangeIterator(Iterable<NamespacedTodoRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<NamespacedTodoRow, Iterator<NamespacedTodoColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            NamespacedTodoRow row = NamespacedTodoRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<NamespacedTodoColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                NamespacedTodoColumn col = NamespacedTodoColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                String val = NamespacedTodoColumnValue.hydrateValue(result.getValue());
+                return NamespacedTodoColumnValue.of(col, val);
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<NamespacedTodoRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -713,5 +729,5 @@ public final class NamespacedTodoTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "e/3fKcHrTJALXUFmSPfhiQ==";
+    static String __CLASS_HASH = "Zef0skWTrRQj7rNC9Ye+tw==";
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamHashAidxTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamHashAidxTable.java
@@ -602,6 +602,22 @@ public final class SnapshotsStreamHashAidxTable implements
         });
     }
 
+    @Override
+    public Map<SnapshotsStreamHashAidxRow, Iterator<SnapshotsStreamHashAidxColumnValue>> getRowsColumnRangeIterator(Iterable<SnapshotsStreamHashAidxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<SnapshotsStreamHashAidxRow, Iterator<SnapshotsStreamHashAidxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            SnapshotsStreamHashAidxRow row = SnapshotsStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<SnapshotsStreamHashAidxColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                SnapshotsStreamHashAidxColumn col = SnapshotsStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                Long val = SnapshotsStreamHashAidxColumnValue.hydrateValue(result.getValue());
+                return SnapshotsStreamHashAidxColumnValue.of(col, val);
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<SnapshotsStreamHashAidxRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -713,5 +729,5 @@ public final class SnapshotsStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "IwRcER9r6kzFtVSwR6OPBQ==";
+    static String __CLASS_HASH = "gHv7i6smYqWZ0xbApVSYmQ==";
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamIdxTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamIdxTable.java
@@ -602,6 +602,22 @@ public final class SnapshotsStreamIdxTable implements
         });
     }
 
+    @Override
+    public Map<SnapshotsStreamIdxRow, Iterator<SnapshotsStreamIdxColumnValue>> getRowsColumnRangeIterator(Iterable<SnapshotsStreamIdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<SnapshotsStreamIdxRow, Iterator<SnapshotsStreamIdxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            SnapshotsStreamIdxRow row = SnapshotsStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<SnapshotsStreamIdxColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                SnapshotsStreamIdxColumn col = SnapshotsStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                Long val = SnapshotsStreamIdxColumnValue.hydrateValue(result.getValue());
+                return SnapshotsStreamIdxColumnValue.of(col, val);
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<SnapshotsStreamIdxRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -713,5 +729,5 @@ public final class SnapshotsStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "1UqSkFOUzEqmTURRRYou1A==";
+    static String __CLASS_HASH = "LnbWljf6rDeRywQ1G3ptMw==";
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamMetadataTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamMetadataTable.java
@@ -570,6 +570,20 @@ public final class SnapshotsStreamMetadataTable implements
         });
     }
 
+    @Override
+    public Map<SnapshotsStreamMetadataRow, Iterator<SnapshotsStreamMetadataNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<SnapshotsStreamMetadataRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<SnapshotsStreamMetadataRow, Iterator<SnapshotsStreamMetadataNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            SnapshotsStreamMetadataRow row = SnapshotsStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<SnapshotsStreamMetadataNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<SnapshotsStreamMetadataRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -681,5 +695,5 @@ public final class SnapshotsStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "IFrSLv7Usr5bzgm/WPZoCA==";
+    static String __CLASS_HASH = "F6NqM7EjerAV0C1Yown+/Q==";
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamValueTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamValueTable.java
@@ -558,6 +558,20 @@ public final class SnapshotsStreamValueTable implements
         });
     }
 
+    @Override
+    public Map<SnapshotsStreamValueRow, Iterator<SnapshotsStreamValueNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<SnapshotsStreamValueRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<SnapshotsStreamValueRow, Iterator<SnapshotsStreamValueNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            SnapshotsStreamValueRow row = SnapshotsStreamValueRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<SnapshotsStreamValueNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<SnapshotsStreamValueRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -669,5 +683,5 @@ public final class SnapshotsStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "LtSr8KW84jJ1kASsEGryAA==";
+    static String __CLASS_HASH = "6WzLizs91Udk6a7R1JjvYw==";
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/TodoTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/TodoTable.java
@@ -546,6 +546,20 @@ public final class TodoTable implements
         });
     }
 
+    @Override
+    public Map<TodoRow, Iterator<TodoNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<TodoRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<TodoRow, Iterator<TodoNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            TodoRow row = TodoRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<TodoNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<TodoRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -657,5 +671,5 @@ public final class TodoTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "W4nZk/S4/IXkgnEvSLR5ZA==";
+    static String __CLASS_HASH = "rR2G1n7lDkzKW4J0Z4aReg==";
 }

--- a/atlasdb-ete-tests/build.gradle
+++ b/atlasdb-ete-tests/build.gradle
@@ -6,10 +6,7 @@ apply from: "../gradle/non-client-dist.gradle"
 apply plugin: 'com.palantir.sls-java-service-distribution'
 apply plugin: 'org.inferred.processors'
 
-schemas = [
-        'com.palantir.atlasdb.cas.CheckAndSetSchema',
-        'com.palantir.atlasdb.blob.BlobSchema'
-]
+schemas = ['com.palantir.atlasdb.blob.BlobSchema']
 
 dependencies {
     compile project(':lock-impl')

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/AuditedDataTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/AuditedDataTable.java
@@ -546,6 +546,20 @@ public final class AuditedDataTable implements
         });
     }
 
+    @Override
+    public Map<AuditedDataRow, Iterator<AuditedDataNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<AuditedDataRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<AuditedDataRow, Iterator<AuditedDataNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            AuditedDataRow row = AuditedDataRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<AuditedDataNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<AuditedDataRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -657,5 +671,5 @@ public final class AuditedDataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "6Nc5O+7Y+IxfjkHR4bjHiw==";
+    static String __CLASS_HASH = "EGnx5lzRwirDKf6FLStpYQ==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamHashAidxTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamHashAidxTable.java
@@ -602,6 +602,22 @@ public final class DataStreamHashAidxTable implements
         });
     }
 
+    @Override
+    public Map<DataStreamHashAidxRow, Iterator<DataStreamHashAidxColumnValue>> getRowsColumnRangeIterator(Iterable<DataStreamHashAidxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<DataStreamHashAidxRow, Iterator<DataStreamHashAidxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            DataStreamHashAidxRow row = DataStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<DataStreamHashAidxColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                DataStreamHashAidxColumn col = DataStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                Long val = DataStreamHashAidxColumnValue.hydrateValue(result.getValue());
+                return DataStreamHashAidxColumnValue.of(col, val);
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<DataStreamHashAidxRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -713,5 +729,5 @@ public final class DataStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "lvvjngrfkSQr/c1LTQJLEQ==";
+    static String __CLASS_HASH = "UJ0zX1QLrV2zFX1isVv/MQ==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamIdxTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamIdxTable.java
@@ -616,6 +616,22 @@ public final class DataStreamIdxTable implements
         });
     }
 
+    @Override
+    public Map<DataStreamIdxRow, Iterator<DataStreamIdxColumnValue>> getRowsColumnRangeIterator(Iterable<DataStreamIdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<DataStreamIdxRow, Iterator<DataStreamIdxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            DataStreamIdxRow row = DataStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<DataStreamIdxColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                DataStreamIdxColumn col = DataStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                Long val = DataStreamIdxColumnValue.hydrateValue(result.getValue());
+                return DataStreamIdxColumnValue.of(col, val);
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<DataStreamIdxRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -727,5 +743,5 @@ public final class DataStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "qvfFqIXEUvtHLzK6komRzQ==";
+    static String __CLASS_HASH = "I+ahTX+7gCXRdlNNelaHEA==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamMetadataTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamMetadataTable.java
@@ -584,6 +584,20 @@ public final class DataStreamMetadataTable implements
         });
     }
 
+    @Override
+    public Map<DataStreamMetadataRow, Iterator<DataStreamMetadataNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<DataStreamMetadataRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<DataStreamMetadataRow, Iterator<DataStreamMetadataNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            DataStreamMetadataRow row = DataStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<DataStreamMetadataNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<DataStreamMetadataRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -695,5 +709,5 @@ public final class DataStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "QSzAZuyzoZhM3sBPyaiD8w==";
+    static String __CLASS_HASH = "FVax+mY9TpfnkPSi1E1wEw==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamValueTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamValueTable.java
@@ -573,6 +573,20 @@ public final class DataStreamValueTable implements
         });
     }
 
+    @Override
+    public Map<DataStreamValueRow, Iterator<DataStreamValueNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<DataStreamValueRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<DataStreamValueRow, Iterator<DataStreamValueNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            DataStreamValueRow row = DataStreamValueRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<DataStreamValueNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<DataStreamValueRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -684,5 +698,5 @@ public final class DataStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "JtRTFoI5vtIMnD3283JE2g==";
+    static String __CLASS_HASH = "DzxAISV8iz3bHTKqbLQ9jA==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamHashAidxTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamHashAidxTable.java
@@ -602,6 +602,22 @@ public final class HotspottyDataStreamHashAidxTable implements
         });
     }
 
+    @Override
+    public Map<HotspottyDataStreamHashAidxRow, Iterator<HotspottyDataStreamHashAidxColumnValue>> getRowsColumnRangeIterator(Iterable<HotspottyDataStreamHashAidxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<HotspottyDataStreamHashAidxRow, Iterator<HotspottyDataStreamHashAidxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            HotspottyDataStreamHashAidxRow row = HotspottyDataStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<HotspottyDataStreamHashAidxColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                HotspottyDataStreamHashAidxColumn col = HotspottyDataStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                Long val = HotspottyDataStreamHashAidxColumnValue.hydrateValue(result.getValue());
+                return HotspottyDataStreamHashAidxColumnValue.of(col, val);
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<HotspottyDataStreamHashAidxRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -713,5 +729,5 @@ public final class HotspottyDataStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "VEJqEMPrTc0lfiqrnikLbQ==";
+    static String __CLASS_HASH = "CTj+ZecnwoDBbR/PSzNWZA==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamIdxTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamIdxTable.java
@@ -602,6 +602,22 @@ public final class HotspottyDataStreamIdxTable implements
         });
     }
 
+    @Override
+    public Map<HotspottyDataStreamIdxRow, Iterator<HotspottyDataStreamIdxColumnValue>> getRowsColumnRangeIterator(Iterable<HotspottyDataStreamIdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<HotspottyDataStreamIdxRow, Iterator<HotspottyDataStreamIdxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            HotspottyDataStreamIdxRow row = HotspottyDataStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<HotspottyDataStreamIdxColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                HotspottyDataStreamIdxColumn col = HotspottyDataStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                Long val = HotspottyDataStreamIdxColumnValue.hydrateValue(result.getValue());
+                return HotspottyDataStreamIdxColumnValue.of(col, val);
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<HotspottyDataStreamIdxRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -713,5 +729,5 @@ public final class HotspottyDataStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "Sc8oMFQvsi2pRHYjQPYZ3g==";
+    static String __CLASS_HASH = "AkTSV79XttyqF86psjxGvA==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamMetadataTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamMetadataTable.java
@@ -570,6 +570,20 @@ public final class HotspottyDataStreamMetadataTable implements
         });
     }
 
+    @Override
+    public Map<HotspottyDataStreamMetadataRow, Iterator<HotspottyDataStreamMetadataNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<HotspottyDataStreamMetadataRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<HotspottyDataStreamMetadataRow, Iterator<HotspottyDataStreamMetadataNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            HotspottyDataStreamMetadataRow row = HotspottyDataStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<HotspottyDataStreamMetadataNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<HotspottyDataStreamMetadataRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -681,5 +695,5 @@ public final class HotspottyDataStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "QaDIw4TvnUyZVmKnezbWCg==";
+    static String __CLASS_HASH = "MFhpeZmenoDGwE16mb7tWA==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamValueTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamValueTable.java
@@ -558,6 +558,20 @@ public final class HotspottyDataStreamValueTable implements
         });
     }
 
+    @Override
+    public Map<HotspottyDataStreamValueRow, Iterator<HotspottyDataStreamValueNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<HotspottyDataStreamValueRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<HotspottyDataStreamValueRow, Iterator<HotspottyDataStreamValueNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            HotspottyDataStreamValueRow row = HotspottyDataStreamValueRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<HotspottyDataStreamValueNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<HotspottyDataStreamValueRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -669,5 +683,5 @@ public final class HotspottyDataStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "6vh3X5Z+N1hyCKtBTfePog==";
+    static String __CLASS_HASH = "h7DRumeDwFy8zaoa4W9uNA==";
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -337,23 +337,8 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             TableReference tableRef,
             Iterable<byte[]> rows,
             BatchColumnRangeSelection columnRangeSelection) {
-        checkGetPreconditions(tableRef);
-        if (Iterables.isEmpty(rows)) {
-            return ImmutableMap.of();
-        }
-        hasReads = true;
-        Map<byte[], RowColumnRangeIterator> rawResults = keyValueService.getRowsColumnRange(tableRef, rows,
-                columnRangeSelection, getStartTimestamp());
-        Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> postFilteredResults =
-                Maps.newHashMapWithExpectedSize(rawResults.size());
-        for (Entry<byte[], RowColumnRangeIterator> e : rawResults.entrySet()) {
-            byte[] row = e.getKey();
-            RowColumnRangeIterator rawIterator = e.getValue();
-            Iterator<Map.Entry<Cell, byte[]>> postFilteredIterator =
-                    getPostFilteredColumns(tableRef, columnRangeSelection, row, rawIterator);
-            postFilteredResults.put(row, BatchingVisitableFromIterable.create(postFilteredIterator));
-        }
-        return postFilteredResults;
+        return Maps.transformEntries(getRowsColumnRangeIterator(tableRef, rows, columnRangeSelection),
+                (row, iterator) -> BatchingVisitableFromIterable.create(iterator));
     }
 
     @Override
@@ -386,6 +371,29 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         });
 
         return Iterators.concat(postFiltered);
+    }
+
+    @Override
+    public Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> getRowsColumnRangeIterator(TableReference tableRef,
+            Iterable<byte[]> rows,
+            BatchColumnRangeSelection columnRangeSelection) {
+        checkGetPreconditions(tableRef);
+        if (Iterables.isEmpty(rows)) {
+            return ImmutableMap.of();
+        }
+        hasReads = true;
+        Map<byte[], RowColumnRangeIterator> rawResults = keyValueService.getRowsColumnRange(tableRef, rows,
+                columnRangeSelection, getStartTimestamp());
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> postFilteredResults =
+                Maps.newHashMapWithExpectedSize(rawResults.size());
+        for (Entry<byte[], RowColumnRangeIterator> e : rawResults.entrySet()) {
+            byte[] row = e.getKey();
+            RowColumnRangeIterator rawIterator = e.getValue();
+            Iterator<Map.Entry<Cell, byte[]>> postFilteredIterator =
+                    getPostFilteredColumns(tableRef, columnRangeSelection, row, rawIterator);
+            postFilteredResults.put(row, postFilteredIterator);
+        }
+        return postFilteredResults;
     }
 
     private Iterator<Map.Entry<Cell, byte[]>> getPostFilteredColumns(

--- a/atlasdb-perf/build.gradle
+++ b/atlasdb-perf/build.gradle
@@ -7,6 +7,8 @@ apply plugin: 'application'
 mainClassName = 'com.palantir.atlasdb.performance.cli.AtlasDbPerfCli'
 applicationName = 'atlasdb-perf'
 
+schemas = ['com.palantir.atlasdb.performance.schema.StreamTestSchema']
+
 configurations.all {
     resolutionStrategy.eachDependency { DependencyResolveDetails details ->
         if (details.requested.group == 'com.google.code.findbugs' && details.requested.name == 'annotations') {

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/StreamTestTableFactory.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/StreamTestTableFactory.java
@@ -1,15 +1,14 @@
 package com.palantir.atlasdb.performance.schema.generated;
 
-import java.util.List;
-
-import javax.annotation.Generated;
-
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.table.generation.Triggers;
 import com.palantir.atlasdb.transaction.api.Transaction;
+import java.lang.Override;
+import java.util.List;
+import javax.annotation.Generated;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableFactoryRenderer")
 public final class StreamTestTableFactory {
@@ -19,18 +18,21 @@ public final class StreamTestTableFactory {
 
     private final Namespace namespace;
 
-    private StreamTestTableFactory(List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
+    private StreamTestTableFactory(
+            List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
             Namespace namespace) {
         this.sharedTriggers = sharedTriggers;
         this.namespace = namespace;
     }
 
-    public static StreamTestTableFactory of(List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
+    public static StreamTestTableFactory of(
+            List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
             Namespace namespace) {
         return new StreamTestTableFactory(sharedTriggers, namespace);
     }
 
-    public static StreamTestTableFactory of(List<Function<? super Transaction, SharedTriggers>> sharedTriggers) {
+    public static StreamTestTableFactory of(
+            List<Function<? super Transaction, SharedTriggers>> sharedTriggers) {
         return new StreamTestTableFactory(sharedTriggers, defaultNamespace);
     }
 
@@ -72,27 +74,32 @@ public final class StreamTestTableFactory {
 
     public abstract static class NullSharedTriggers implements SharedTriggers {
         @Override
-        public void putKeyValue(Multimap<KeyValueTable.KeyValueRow, ? extends KeyValueTable.KeyValueNamedColumnValue<?>> newRows) {
+        public void putKeyValue(
+                Multimap<KeyValueTable.KeyValueRow, ? extends KeyValueTable.KeyValueNamedColumnValue<?>> newRows) {
             // do nothing
         }
 
         @Override
-        public void putValueStreamHashAidx(Multimap<ValueStreamHashAidxTable.ValueStreamHashAidxRow, ? extends ValueStreamHashAidxTable.ValueStreamHashAidxColumnValue> newRows) {
+        public void putValueStreamHashAidx(
+                Multimap<ValueStreamHashAidxTable.ValueStreamHashAidxRow, ? extends ValueStreamHashAidxTable.ValueStreamHashAidxColumnValue> newRows) {
             // do nothing
         }
 
         @Override
-        public void putValueStreamIdx(Multimap<ValueStreamIdxTable.ValueStreamIdxRow, ? extends ValueStreamIdxTable.ValueStreamIdxColumnValue> newRows) {
+        public void putValueStreamIdx(
+                Multimap<ValueStreamIdxTable.ValueStreamIdxRow, ? extends ValueStreamIdxTable.ValueStreamIdxColumnValue> newRows) {
             // do nothing
         }
 
         @Override
-        public void putValueStreamMetadata(Multimap<ValueStreamMetadataTable.ValueStreamMetadataRow, ? extends ValueStreamMetadataTable.ValueStreamMetadataNamedColumnValue<?>> newRows) {
+        public void putValueStreamMetadata(
+                Multimap<ValueStreamMetadataTable.ValueStreamMetadataRow, ? extends ValueStreamMetadataTable.ValueStreamMetadataNamedColumnValue<?>> newRows) {
             // do nothing
         }
 
         @Override
-        public void putValueStreamValue(Multimap<ValueStreamValueTable.ValueStreamValueRow, ? extends ValueStreamValueTable.ValueStreamValueNamedColumnValue<?>> newRows) {
+        public void putValueStreamValue(
+                Multimap<ValueStreamValueTable.ValueStreamValueRow, ? extends ValueStreamValueTable.ValueStreamValueNamedColumnValue<?>> newRows) {
             // do nothing
         }
     }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueIndexCleanupTask.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueIndexCleanupTask.java
@@ -33,13 +33,14 @@ public class ValueIndexCleanupTask implements OnCleanupTask {
                 = usersIndex.getRowsColumnRange(rows, oneColumn);
         Set<ValueStreamIdxTable.ValueStreamIdxRow> rowsInDb = Sets.newHashSetWithExpectedSize(cells.size());
         for (Map.Entry<ValueStreamIdxTable.ValueStreamIdxRow, BatchingVisitable<ValueStreamIdxTable.ValueStreamIdxColumnValue>> rowVisitable
-                : existentRows.entrySet())
-        rowVisitable.getValue().batchAccept(1, columnValues -> {
-            if (!columnValues.isEmpty()) {
-                rowsInDb.add(rowVisitable.getKey());
-            }
-            return false;
-        });
+                : existentRows.entrySet()) {
+            rowVisitable.getValue().batchAccept(1, columnValues -> {
+                if (!columnValues.isEmpty()) {
+                    rowsInDb.add(rowVisitable.getKey());
+                }
+                return false;
+            });
+        }
         Set<Long> toDelete = Sets.newHashSetWithExpectedSize(rows.size() - rowsInDb.size());
         for (ValueStreamIdxTable.ValueStreamIdxRow rowToDelete : Sets.difference(rows, rowsInDb)) {
             toDelete.add(rowToDelete.getId());

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueMetadataCleanupTask.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueMetadataCleanupTask.java
@@ -11,6 +11,7 @@ import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.protos.generated.StreamPersistence.Status;
 import com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata;
+import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.Transaction;
 
 public class ValueMetadataCleanupTask implements OnCleanupTask {

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamHashAidxTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamHashAidxTable.java
@@ -602,6 +602,22 @@ public final class ValueStreamHashAidxTable implements
         });
     }
 
+    @Override
+    public Map<ValueStreamHashAidxRow, Iterator<ValueStreamHashAidxColumnValue>> getRowsColumnRangeIterator(Iterable<ValueStreamHashAidxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<ValueStreamHashAidxRow, Iterator<ValueStreamHashAidxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            ValueStreamHashAidxRow row = ValueStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<ValueStreamHashAidxColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                ValueStreamHashAidxColumn col = ValueStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                Long val = ValueStreamHashAidxColumnValue.hydrateValue(result.getValue());
+                return ValueStreamHashAidxColumnValue.of(col, val);
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<ValueStreamHashAidxRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -713,5 +729,5 @@ public final class ValueStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "S53q11+p34+R2TREhI+SWg==";
+    static String __CLASS_HASH = "SJcKLJewQAf/c3SOnwOQhA==";
 }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamIdxTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamIdxTable.java
@@ -602,6 +602,22 @@ public final class ValueStreamIdxTable implements
         });
     }
 
+    @Override
+    public Map<ValueStreamIdxRow, Iterator<ValueStreamIdxColumnValue>> getRowsColumnRangeIterator(Iterable<ValueStreamIdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<ValueStreamIdxRow, Iterator<ValueStreamIdxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            ValueStreamIdxRow row = ValueStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<ValueStreamIdxColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                ValueStreamIdxColumn col = ValueStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                Long val = ValueStreamIdxColumnValue.hydrateValue(result.getValue());
+                return ValueStreamIdxColumnValue.of(col, val);
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<ValueStreamIdxRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -713,5 +729,5 @@ public final class ValueStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "cH7jR4yF5ffaobDqwgeAnA==";
+    static String __CLASS_HASH = "HGrflX8QSRRYqWQZuZiVMQ==";
 }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamMetadataTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamMetadataTable.java
@@ -570,6 +570,20 @@ public final class ValueStreamMetadataTable implements
         });
     }
 
+    @Override
+    public Map<ValueStreamMetadataRow, Iterator<ValueStreamMetadataNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<ValueStreamMetadataRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<ValueStreamMetadataRow, Iterator<ValueStreamMetadataNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            ValueStreamMetadataRow row = ValueStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<ValueStreamMetadataNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<ValueStreamMetadataRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -681,5 +695,5 @@ public final class ValueStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "1HU/TIwFyvu660P9AsggnA==";
+    static String __CLASS_HASH = "vwVwCLJ4hP/wBF0oyyTHnw==";
 }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamStore.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamStore.java
@@ -47,7 +47,6 @@ import com.google.protobuf.ByteString;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.protos.generated.StreamPersistence.Status;
 import com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata;
-import com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata.Builder;
 import com.palantir.atlasdb.stream.AbstractPersistentStreamStore;
 import com.palantir.atlasdb.stream.BlockConsumingInputStream;
 import com.palantir.atlasdb.stream.BlockGetter;
@@ -132,7 +131,7 @@ public final class ValueStreamStore extends AbstractPersistentStreamStore {
         ValueStreamMetadataTable.ValueStreamMetadataRow row = ValueStreamMetadataTable.ValueStreamMetadataRow.of(id);
         StreamMetadata metadata = metaTable.getMetadatas(ImmutableSet.of(row)).values().iterator().next();
         Preconditions.checkState(metadata.getStatus() == Status.STORING, "This stream is being cleaned up while storing blocks: %s", id);
-        Builder builder = StreamMetadata.newBuilder(metadata);
+        StreamMetadata.Builder builder = StreamMetadata.newBuilder(metadata);
         builder.setLength(blockNumber * BLOCK_SIZE_IN_BYTES + 1);
         metaTable.putMetadata(row, builder.build());
     }
@@ -388,7 +387,6 @@ public final class ValueStreamStore extends AbstractPersistentStreamStore {
      * {@link BlockGetter}
      * {@link BlockLoader}
      * {@link BufferedInputStream}
-     * {@link Builder}
      * {@link ByteArrayIOStream}
      * {@link ByteArrayInputStream}
      * {@link ByteStreams}

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamValueTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamValueTable.java
@@ -558,6 +558,20 @@ public final class ValueStreamValueTable implements
         });
     }
 
+    @Override
+    public Map<ValueStreamValueRow, Iterator<ValueStreamValueNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<ValueStreamValueRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<ValueStreamValueRow, Iterator<ValueStreamValueNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            ValueStreamValueRow row = ValueStreamValueRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<ValueStreamValueNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<ValueStreamValueRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -669,5 +683,5 @@ public final class ValueStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "e5xKlJ7a0qaBdJay/FGvQA==";
+    static String __CLASS_HASH = "PM74YW0mIqMp265E0Cwx+w==";
 }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
@@ -38,7 +38,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Iterators;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
 import com.google.common.primitives.UnsignedBytes;

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
@@ -38,7 +38,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Iterators;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
 import com.google.common.primitives.UnsignedBytes;
@@ -70,6 +69,7 @@ import com.palantir.common.base.Throwables;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.lock.impl.LegacyTimelockService;
 
+@SuppressWarnings("CheckReturnValue")
 public abstract class AbstractSerializableTransactionTest extends AbstractTransactionTest {
 
     public AbstractSerializableTransactionTest(KvsManager kvsManager, TransactionManagerManager tmManager) {
@@ -840,11 +840,11 @@ public abstract class AbstractSerializableTransactionTest extends AbstractTransa
         Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> columnRange =
                 t1.getRowsColumnRangeIterator(TEST_TABLE, ImmutableList.of(row),
                         BatchColumnRangeSelection.create(PtBytes.toBytes("col"), PtBytes.toBytes("col0"), 1));
-        columnRange.values().forEach(Iterators::getLast);
+        assertThat(Iterables.getOnlyElement(columnRange.values()).hasNext()).isFalse();
         Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> columnRangeAgain =
                 t1.getRowsColumnRangeIterator(TEST_TABLE, ImmutableList.of(rowDifferentReference),
                         BatchColumnRangeSelection.create(PtBytes.toBytes("col"), PtBytes.toBytes("col0"), 1));
-        columnRangeAgain.values().forEach(Iterators::getLast);
+        assertThat(Iterables.getOnlyElement(columnRangeAgain.values()).hasNext()).isFalse();
         put(t1, "mutation to ensure", "conflict", "handling");
         t1.commit();
     }
@@ -880,12 +880,12 @@ public abstract class AbstractSerializableTransactionTest extends AbstractTransa
 
         Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> columnRangeResultForRow =
                 transaction.getRowsColumnRangeIterator(TEST_TABLE, ImmutableList.of(row), sameColumnRangeSelection);
-        columnRangeResultForRow.values().forEach(Iterators::getLast);
+        assertThat(Iterables.getOnlyElement(columnRangeResultForRow.values()).hasNext()).isFalse();
 
         Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> columnRangeResultForDifferentRow =
                 transaction.getRowsColumnRangeIterator(TEST_TABLE, ImmutableList.of(differentRow),
                         sameColumnRangeSelection);
-        columnRangeResultForDifferentRow.values().forEach(Iterators::getLast);
+        assertThat(Iterables.getOnlyElement(columnRangeResultForDifferentRow.values()).hasNext()).isFalse();
         put(transaction, "mutation to ensure", "conflict", "handling");
         transaction.commit();
     }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/DataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/DataTable.java
@@ -685,6 +685,20 @@ public final class DataTable implements
         });
     }
 
+    @Override
+    public Map<DataRow, Iterator<DataNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<DataRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<DataRow, Iterator<DataNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            DataRow row = DataRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<DataNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     private Multimap<DataRow, DataNamedColumnValue<?>> getAffectedCells(Multimap<DataRow, ? extends DataNamedColumnValue<?>> rows) {
         Multimap<DataRow, DataNamedColumnValue<?>> oldData = getRowsMultimap(rows.keySet());
         Multimap<DataRow, DataNamedColumnValue<?>> cellsAffected = ArrayListMultimap.create();
@@ -1377,6 +1391,22 @@ public final class DataTable implements
             });
         }
 
+        @Override
+        public Map<Index1IdxRow, Iterator<Index1IdxColumnValue>> getRowsColumnRangeIterator(Iterable<Index1IdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+            Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+            Map<Index1IdxRow, Iterator<Index1IdxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+            for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+                Index1IdxRow row = Index1IdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                Iterator<Index1IdxColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                    Index1IdxColumn col = Index1IdxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                    Long val = Index1IdxColumnValue.hydrateValue(result.getValue());
+                    return Index1IdxColumnValue.of(col, val);
+                });
+                transformed.put(row, bv);
+            }
+            return transformed;
+        }
+
         public BatchingVisitableView<Index1IdxRowResult> getRange(RangeRequest range) {
             if (range.getColumnNames().isEmpty()) {
                 range = range.getBuilder().retainColumns(allColumns).build();
@@ -2022,6 +2052,22 @@ public final class DataTable implements
             });
         }
 
+        @Override
+        public Map<Index2IdxRow, Iterator<Index2IdxColumnValue>> getRowsColumnRangeIterator(Iterable<Index2IdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+            Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+            Map<Index2IdxRow, Iterator<Index2IdxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+            for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+                Index2IdxRow row = Index2IdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                Iterator<Index2IdxColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                    Index2IdxColumn col = Index2IdxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                    Long val = Index2IdxColumnValue.hydrateValue(result.getValue());
+                    return Index2IdxColumnValue.of(col, val);
+                });
+                transformed.put(row, bv);
+            }
+            return transformed;
+        }
+
         public BatchingVisitableView<Index2IdxRowResult> getRange(RangeRequest range) {
             if (range.getColumnNames().isEmpty()) {
                 range = range.getBuilder().retainColumns(allColumns).build();
@@ -2643,6 +2689,22 @@ public final class DataTable implements
                 Index3IdxColumnValue colValue = Index3IdxColumnValue.of(col, val);
                 return Maps.immutableEntry(row, colValue);
             });
+        }
+
+        @Override
+        public Map<Index3IdxRow, Iterator<Index3IdxColumnValue>> getRowsColumnRangeIterator(Iterable<Index3IdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+            Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+            Map<Index3IdxRow, Iterator<Index3IdxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+            for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+                Index3IdxRow row = Index3IdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                Iterator<Index3IdxColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                    Index3IdxColumn col = Index3IdxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                    Long val = Index3IdxColumnValue.hydrateValue(result.getValue());
+                    return Index3IdxColumnValue.of(col, val);
+                });
+                transformed.put(row, bv);
+            }
+            return transformed;
         }
 
         public BatchingVisitableView<Index3IdxRowResult> getRange(RangeRequest range) {
@@ -3290,6 +3352,22 @@ public final class DataTable implements
             });
         }
 
+        @Override
+        public Map<Index4IdxRow, Iterator<Index4IdxColumnValue>> getRowsColumnRangeIterator(Iterable<Index4IdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+            Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+            Map<Index4IdxRow, Iterator<Index4IdxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+            for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+                Index4IdxRow row = Index4IdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                Iterator<Index4IdxColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                    Index4IdxColumn col = Index4IdxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                    Long val = Index4IdxColumnValue.hydrateValue(result.getValue());
+                    return Index4IdxColumnValue.of(col, val);
+                });
+                transformed.put(row, bv);
+            }
+            return transformed;
+        }
+
         public BatchingVisitableView<Index4IdxRowResult> getRange(RangeRequest range) {
             if (range.getColumnNames().isEmpty()) {
                 range = range.getBuilder().retainColumns(allColumns).build();
@@ -3456,5 +3534,5 @@ public final class DataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "Wmp9yvtNFIEf3vhhi/mYJg==";
+    static String __CLASS_HASH = "IVuwx7H94jntMss5V3AwCA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/TwoColumnsTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/TwoColumnsTable.java
@@ -741,6 +741,20 @@ public final class TwoColumnsTable implements
         });
     }
 
+    @Override
+    public Map<TwoColumnsRow, Iterator<TwoColumnsNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<TwoColumnsRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<TwoColumnsRow, Iterator<TwoColumnsNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            TwoColumnsRow row = TwoColumnsRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<TwoColumnsNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     private Multimap<TwoColumnsRow, TwoColumnsNamedColumnValue<?>> getAffectedCells(Multimap<TwoColumnsRow, ? extends TwoColumnsNamedColumnValue<?>> rows) {
         Multimap<TwoColumnsRow, TwoColumnsNamedColumnValue<?>> oldData = getRowsMultimap(rows.keySet());
         Multimap<TwoColumnsRow, TwoColumnsNamedColumnValue<?>> cellsAffected = ArrayListMultimap.create();
@@ -1395,6 +1409,22 @@ public final class TwoColumnsTable implements
             });
         }
 
+        @Override
+        public Map<FooToIdCondIdxRow, Iterator<FooToIdCondIdxColumnValue>> getRowsColumnRangeIterator(Iterable<FooToIdCondIdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+            Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+            Map<FooToIdCondIdxRow, Iterator<FooToIdCondIdxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+            for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+                FooToIdCondIdxRow row = FooToIdCondIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                Iterator<FooToIdCondIdxColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                    FooToIdCondIdxColumn col = FooToIdCondIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                    Long val = FooToIdCondIdxColumnValue.hydrateValue(result.getValue());
+                    return FooToIdCondIdxColumnValue.of(col, val);
+                });
+                transformed.put(row, bv);
+            }
+            return transformed;
+        }
+
         public BatchingVisitableView<FooToIdCondIdxRowResult> getAllRowsUnordered() {
             return getAllRowsUnordered(allColumns);
         }
@@ -2013,6 +2043,22 @@ public final class TwoColumnsTable implements
             });
         }
 
+        @Override
+        public Map<FooToIdIdxRow, Iterator<FooToIdIdxColumnValue>> getRowsColumnRangeIterator(Iterable<FooToIdIdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+            Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+            Map<FooToIdIdxRow, Iterator<FooToIdIdxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+            for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+                FooToIdIdxRow row = FooToIdIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                Iterator<FooToIdIdxColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                    FooToIdIdxColumn col = FooToIdIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                    Long val = FooToIdIdxColumnValue.hydrateValue(result.getValue());
+                    return FooToIdIdxColumnValue.of(col, val);
+                });
+                transformed.put(row, bv);
+            }
+            return transformed;
+        }
+
         public BatchingVisitableView<FooToIdIdxRowResult> getAllRowsUnordered() {
             return getAllRowsUnordered(allColumns);
         }
@@ -2126,5 +2172,5 @@ public final class TwoColumnsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "VuZV92tdhOJktDN2j4RtrA==";
+    static String __CLASS_HASH = "22ey1qbdFb1NsSuNpq+76A==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/KeyValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/KeyValueTable.java
@@ -546,6 +546,20 @@ public final class KeyValueTable implements
         });
     }
 
+    @Override
+    public Map<KeyValueRow, Iterator<KeyValueNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<KeyValueRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<KeyValueRow, Iterator<KeyValueNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            KeyValueRow row = KeyValueRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<KeyValueNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<KeyValueRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -657,5 +671,5 @@ public final class KeyValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "QL+z9A2s2e1NZYOyuS/1Sw==";
+    static String __CLASS_HASH = "BYGWmy0KvpGJjzSxj43itA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamHashAidxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamHashAidxTable.java
@@ -602,6 +602,22 @@ public final class StreamTestMaxMemStreamHashAidxTable implements
         });
     }
 
+    @Override
+    public Map<StreamTestMaxMemStreamHashAidxRow, Iterator<StreamTestMaxMemStreamHashAidxColumnValue>> getRowsColumnRangeIterator(Iterable<StreamTestMaxMemStreamHashAidxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<StreamTestMaxMemStreamHashAidxRow, Iterator<StreamTestMaxMemStreamHashAidxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            StreamTestMaxMemStreamHashAidxRow row = StreamTestMaxMemStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<StreamTestMaxMemStreamHashAidxColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                StreamTestMaxMemStreamHashAidxColumn col = StreamTestMaxMemStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                Long val = StreamTestMaxMemStreamHashAidxColumnValue.hydrateValue(result.getValue());
+                return StreamTestMaxMemStreamHashAidxColumnValue.of(col, val);
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<StreamTestMaxMemStreamHashAidxRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -713,5 +729,5 @@ public final class StreamTestMaxMemStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "BGKnCVLUrxJxAL0D/CF9zQ==";
+    static String __CLASS_HASH = "nbcyyrMXbuCIyL1jTu9sVg==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamIdxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamIdxTable.java
@@ -602,6 +602,22 @@ public final class StreamTestMaxMemStreamIdxTable implements
         });
     }
 
+    @Override
+    public Map<StreamTestMaxMemStreamIdxRow, Iterator<StreamTestMaxMemStreamIdxColumnValue>> getRowsColumnRangeIterator(Iterable<StreamTestMaxMemStreamIdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<StreamTestMaxMemStreamIdxRow, Iterator<StreamTestMaxMemStreamIdxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            StreamTestMaxMemStreamIdxRow row = StreamTestMaxMemStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<StreamTestMaxMemStreamIdxColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                StreamTestMaxMemStreamIdxColumn col = StreamTestMaxMemStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                Long val = StreamTestMaxMemStreamIdxColumnValue.hydrateValue(result.getValue());
+                return StreamTestMaxMemStreamIdxColumnValue.of(col, val);
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<StreamTestMaxMemStreamIdxRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -713,5 +729,5 @@ public final class StreamTestMaxMemStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "5Kw1x4oNRH59g34je0UBxg==";
+    static String __CLASS_HASH = "aGzDLu7wk6Ls77bUD0X4tA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamMetadataTable.java
@@ -570,6 +570,20 @@ public final class StreamTestMaxMemStreamMetadataTable implements
         });
     }
 
+    @Override
+    public Map<StreamTestMaxMemStreamMetadataRow, Iterator<StreamTestMaxMemStreamMetadataNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<StreamTestMaxMemStreamMetadataRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<StreamTestMaxMemStreamMetadataRow, Iterator<StreamTestMaxMemStreamMetadataNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            StreamTestMaxMemStreamMetadataRow row = StreamTestMaxMemStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<StreamTestMaxMemStreamMetadataNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<StreamTestMaxMemStreamMetadataRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -681,5 +695,5 @@ public final class StreamTestMaxMemStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "nWegvF01Lpl2jDfjGYwJCQ==";
+    static String __CLASS_HASH = "/QmjaFxtVJalkvAUB2arxw==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamValueTable.java
@@ -558,6 +558,20 @@ public final class StreamTestMaxMemStreamValueTable implements
         });
     }
 
+    @Override
+    public Map<StreamTestMaxMemStreamValueRow, Iterator<StreamTestMaxMemStreamValueNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<StreamTestMaxMemStreamValueRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<StreamTestMaxMemStreamValueRow, Iterator<StreamTestMaxMemStreamValueNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            StreamTestMaxMemStreamValueRow row = StreamTestMaxMemStreamValueRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<StreamTestMaxMemStreamValueNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<StreamTestMaxMemStreamValueRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -669,5 +683,5 @@ public final class StreamTestMaxMemStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "4uXsWYBZ/v654Q8MmVT4qQ==";
+    static String __CLASS_HASH = "5m+RZlxThp+nrLdwKr3LNw==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamHashAidxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamHashAidxTable.java
@@ -602,6 +602,22 @@ public final class StreamTestStreamHashAidxTable implements
         });
     }
 
+    @Override
+    public Map<StreamTestStreamHashAidxRow, Iterator<StreamTestStreamHashAidxColumnValue>> getRowsColumnRangeIterator(Iterable<StreamTestStreamHashAidxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<StreamTestStreamHashAidxRow, Iterator<StreamTestStreamHashAidxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            StreamTestStreamHashAidxRow row = StreamTestStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<StreamTestStreamHashAidxColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                StreamTestStreamHashAidxColumn col = StreamTestStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                Long val = StreamTestStreamHashAidxColumnValue.hydrateValue(result.getValue());
+                return StreamTestStreamHashAidxColumnValue.of(col, val);
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<StreamTestStreamHashAidxRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -713,5 +729,5 @@ public final class StreamTestStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "1izVl8c9CiqS56BSsLQGOw==";
+    static String __CLASS_HASH = "LLaxsmAl9f4epLKriPTcqA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamIdxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamIdxTable.java
@@ -602,6 +602,22 @@ public final class StreamTestStreamIdxTable implements
         });
     }
 
+    @Override
+    public Map<StreamTestStreamIdxRow, Iterator<StreamTestStreamIdxColumnValue>> getRowsColumnRangeIterator(Iterable<StreamTestStreamIdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<StreamTestStreamIdxRow, Iterator<StreamTestStreamIdxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            StreamTestStreamIdxRow row = StreamTestStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<StreamTestStreamIdxColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                StreamTestStreamIdxColumn col = StreamTestStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                Long val = StreamTestStreamIdxColumnValue.hydrateValue(result.getValue());
+                return StreamTestStreamIdxColumnValue.of(col, val);
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<StreamTestStreamIdxRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -713,5 +729,5 @@ public final class StreamTestStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "lvoXLu7X3qr+Dj2VApj7BA==";
+    static String __CLASS_HASH = "VX0leMxkkXhGYMjqZplERA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamMetadataTable.java
@@ -570,6 +570,20 @@ public final class StreamTestStreamMetadataTable implements
         });
     }
 
+    @Override
+    public Map<StreamTestStreamMetadataRow, Iterator<StreamTestStreamMetadataNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<StreamTestStreamMetadataRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<StreamTestStreamMetadataRow, Iterator<StreamTestStreamMetadataNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            StreamTestStreamMetadataRow row = StreamTestStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<StreamTestStreamMetadataNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<StreamTestStreamMetadataRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -681,5 +695,5 @@ public final class StreamTestStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "g1cGlMObiaMACzqGog6FmA==";
+    static String __CLASS_HASH = "vUhf73e3J1miSxRQllAZVw==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamValueTable.java
@@ -558,6 +558,20 @@ public final class StreamTestStreamValueTable implements
         });
     }
 
+    @Override
+    public Map<StreamTestStreamValueRow, Iterator<StreamTestStreamValueNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<StreamTestStreamValueRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<StreamTestStreamValueRow, Iterator<StreamTestStreamValueNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            StreamTestStreamValueRow row = StreamTestStreamValueRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<StreamTestStreamValueNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<StreamTestStreamValueRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -669,5 +683,5 @@ public final class StreamTestStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "l30alN6O9OyBeAKfWa2vtA==";
+    static String __CLASS_HASH = "t4siupL4rI2rgk/Ry/XT1Q==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamHashAidxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamHashAidxTable.java
@@ -602,6 +602,22 @@ public final class StreamTestWithHashStreamHashAidxTable implements
         });
     }
 
+    @Override
+    public Map<StreamTestWithHashStreamHashAidxRow, Iterator<StreamTestWithHashStreamHashAidxColumnValue>> getRowsColumnRangeIterator(Iterable<StreamTestWithHashStreamHashAidxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<StreamTestWithHashStreamHashAidxRow, Iterator<StreamTestWithHashStreamHashAidxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            StreamTestWithHashStreamHashAidxRow row = StreamTestWithHashStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<StreamTestWithHashStreamHashAidxColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                StreamTestWithHashStreamHashAidxColumn col = StreamTestWithHashStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                Long val = StreamTestWithHashStreamHashAidxColumnValue.hydrateValue(result.getValue());
+                return StreamTestWithHashStreamHashAidxColumnValue.of(col, val);
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<StreamTestWithHashStreamHashAidxRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -713,5 +729,5 @@ public final class StreamTestWithHashStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "2ASIjXLcW69Qb5PP7ReI/A==";
+    static String __CLASS_HASH = "RNJ32eZkL2rGSe39uk2XXg==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamIdxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamIdxTable.java
@@ -616,6 +616,22 @@ public final class StreamTestWithHashStreamIdxTable implements
         });
     }
 
+    @Override
+    public Map<StreamTestWithHashStreamIdxRow, Iterator<StreamTestWithHashStreamIdxColumnValue>> getRowsColumnRangeIterator(Iterable<StreamTestWithHashStreamIdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<StreamTestWithHashStreamIdxRow, Iterator<StreamTestWithHashStreamIdxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            StreamTestWithHashStreamIdxRow row = StreamTestWithHashStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<StreamTestWithHashStreamIdxColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                StreamTestWithHashStreamIdxColumn col = StreamTestWithHashStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                Long val = StreamTestWithHashStreamIdxColumnValue.hydrateValue(result.getValue());
+                return StreamTestWithHashStreamIdxColumnValue.of(col, val);
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<StreamTestWithHashStreamIdxRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -727,5 +743,5 @@ public final class StreamTestWithHashStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "07NJD5lMKnG3aVtqn8iQJg==";
+    static String __CLASS_HASH = "JfnuItwX4ywSwfP0IGb+eQ==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamMetadataTable.java
@@ -584,6 +584,20 @@ public final class StreamTestWithHashStreamMetadataTable implements
         });
     }
 
+    @Override
+    public Map<StreamTestWithHashStreamMetadataRow, Iterator<StreamTestWithHashStreamMetadataNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<StreamTestWithHashStreamMetadataRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<StreamTestWithHashStreamMetadataRow, Iterator<StreamTestWithHashStreamMetadataNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            StreamTestWithHashStreamMetadataRow row = StreamTestWithHashStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<StreamTestWithHashStreamMetadataNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<StreamTestWithHashStreamMetadataRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -695,5 +709,5 @@ public final class StreamTestWithHashStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "Zzb6mucVERw8UOL/5DyMbA==";
+    static String __CLASS_HASH = "uksCFZvSGkqIR3JxnEcOsg==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamValueTable.java
@@ -572,6 +572,20 @@ public final class StreamTestWithHashStreamValueTable implements
         });
     }
 
+    @Override
+    public Map<StreamTestWithHashStreamValueRow, Iterator<StreamTestWithHashStreamValueNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<StreamTestWithHashStreamValueRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<StreamTestWithHashStreamValueRow, Iterator<StreamTestWithHashStreamValueNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            StreamTestWithHashStreamValueRow row = StreamTestWithHashStreamValueRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<StreamTestWithHashStreamValueNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<StreamTestWithHashStreamValueRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -683,5 +697,5 @@ public final class StreamTestWithHashStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "9/7p2zY/E85gdgo+joTObw==";
+    static String __CLASS_HASH = "6+cwFXnmPwIuHlEjZQsh0w==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamHashAidxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamHashAidxTable.java
@@ -602,6 +602,22 @@ public final class TestHashComponentsStreamHashAidxTable implements
         });
     }
 
+    @Override
+    public Map<TestHashComponentsStreamHashAidxRow, Iterator<TestHashComponentsStreamHashAidxColumnValue>> getRowsColumnRangeIterator(Iterable<TestHashComponentsStreamHashAidxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<TestHashComponentsStreamHashAidxRow, Iterator<TestHashComponentsStreamHashAidxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            TestHashComponentsStreamHashAidxRow row = TestHashComponentsStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<TestHashComponentsStreamHashAidxColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                TestHashComponentsStreamHashAidxColumn col = TestHashComponentsStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                Long val = TestHashComponentsStreamHashAidxColumnValue.hydrateValue(result.getValue());
+                return TestHashComponentsStreamHashAidxColumnValue.of(col, val);
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<TestHashComponentsStreamHashAidxRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -713,5 +729,5 @@ public final class TestHashComponentsStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "i+qmiQjlxAO0X69bZqTEHw==";
+    static String __CLASS_HASH = "BRYFXhQNblQxMn0fqYlQeQ==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamIdxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamIdxTable.java
@@ -616,6 +616,22 @@ public final class TestHashComponentsStreamIdxTable implements
         });
     }
 
+    @Override
+    public Map<TestHashComponentsStreamIdxRow, Iterator<TestHashComponentsStreamIdxColumnValue>> getRowsColumnRangeIterator(Iterable<TestHashComponentsStreamIdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<TestHashComponentsStreamIdxRow, Iterator<TestHashComponentsStreamIdxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            TestHashComponentsStreamIdxRow row = TestHashComponentsStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<TestHashComponentsStreamIdxColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                TestHashComponentsStreamIdxColumn col = TestHashComponentsStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                Long val = TestHashComponentsStreamIdxColumnValue.hydrateValue(result.getValue());
+                return TestHashComponentsStreamIdxColumnValue.of(col, val);
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<TestHashComponentsStreamIdxRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -727,5 +743,5 @@ public final class TestHashComponentsStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "G9aQJCpolejByWJ/myDDgQ==";
+    static String __CLASS_HASH = "DYF/Dfsi+W/kZWKnm3fxSA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamMetadataTable.java
@@ -584,6 +584,20 @@ public final class TestHashComponentsStreamMetadataTable implements
         });
     }
 
+    @Override
+    public Map<TestHashComponentsStreamMetadataRow, Iterator<TestHashComponentsStreamMetadataNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<TestHashComponentsStreamMetadataRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<TestHashComponentsStreamMetadataRow, Iterator<TestHashComponentsStreamMetadataNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            TestHashComponentsStreamMetadataRow row = TestHashComponentsStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<TestHashComponentsStreamMetadataNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<TestHashComponentsStreamMetadataRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -695,5 +709,5 @@ public final class TestHashComponentsStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "eo/+y7JSgtyMLp1rlM2fjA==";
+    static String __CLASS_HASH = "jBhvBir87Ok9/EmherBZOg==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamValueTable.java
@@ -573,6 +573,20 @@ public final class TestHashComponentsStreamValueTable implements
         });
     }
 
+    @Override
+    public Map<TestHashComponentsStreamValueRow, Iterator<TestHashComponentsStreamValueNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<TestHashComponentsStreamValueRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<TestHashComponentsStreamValueRow, Iterator<TestHashComponentsStreamValueNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            TestHashComponentsStreamValueRow row = TestHashComponentsStreamValueRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<TestHashComponentsStreamValueNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<TestHashComponentsStreamValueRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -684,5 +698,5 @@ public final class TestHashComponentsStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "nW7JkxQROnOLFkMfqtkoHA==";
+    static String __CLASS_HASH = "94yJRCazC9VquqHhN4WA+Q==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -39,6 +39,7 @@ import static org.mockito.Mockito.when;
 import java.math.BigInteger;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -78,6 +79,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimaps;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -670,8 +672,19 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
 
         tasks.add(Pair.of("getRowsColumnRange(TableReference, Iterable<byte[]>, ColumnRangeSelection, int)",
                 (t, heldLocks) -> {
-                    t.getRowsColumnRange(TABLE_SWEPT_THOROUGH, Collections.singleton(PtBytes.toBytes("row1")),
-                            new ColumnRangeSelection(null, null), batchHint);
+                    Iterators.getLast(
+                            t.getRowsColumnRange(TABLE_SWEPT_THOROUGH, Collections.singleton(PtBytes.toBytes("row1")),
+                                    new ColumnRangeSelection(null, null), batchHint));
+                    return null;
+                }));
+
+        tasks.add(Pair.of("getRowsColumnRangeIterator",
+                (t, heldLocks) -> {
+                    Collection<Iterator<Map.Entry<Cell, byte[]>>> results =
+                            t.getRowsColumnRangeIterator(TABLE_SWEPT_THOROUGH, Collections.singleton(PtBytes.toBytes("row1")),
+                                    BatchColumnRangeSelection.create(new ColumnRangeSelection(null, null), batchHint))
+                                    .values();
+                    results.forEach(Iterators::getLast);
                     return null;
                 }));
 

--- a/changelog/@unreleased/pr-4120.v2.yml
+++ b/changelog/@unreleased/pr-4120.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Added a new method to generated table schemas, getRowsColumnRangeIterator,
+    that returns an iterator for each row rather than a BatchingVisitable.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4120

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamHashAidxTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamHashAidxTable.java
@@ -602,6 +602,22 @@ public final class UserPhotosStreamHashAidxTable implements
         });
     }
 
+    @Override
+    public Map<UserPhotosStreamHashAidxRow, Iterator<UserPhotosStreamHashAidxColumnValue>> getRowsColumnRangeIterator(Iterable<UserPhotosStreamHashAidxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<UserPhotosStreamHashAidxRow, Iterator<UserPhotosStreamHashAidxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            UserPhotosStreamHashAidxRow row = UserPhotosStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<UserPhotosStreamHashAidxColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                UserPhotosStreamHashAidxColumn col = UserPhotosStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                Long val = UserPhotosStreamHashAidxColumnValue.hydrateValue(result.getValue());
+                return UserPhotosStreamHashAidxColumnValue.of(col, val);
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<UserPhotosStreamHashAidxRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -713,5 +729,5 @@ public final class UserPhotosStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "Vm1XC0scjjk1KU1gGw0Ubg==";
+    static String __CLASS_HASH = "FXlfx+r2IE4USWa7+1GqWw==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamIdxTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamIdxTable.java
@@ -602,6 +602,22 @@ public final class UserPhotosStreamIdxTable implements
         });
     }
 
+    @Override
+    public Map<UserPhotosStreamIdxRow, Iterator<UserPhotosStreamIdxColumnValue>> getRowsColumnRangeIterator(Iterable<UserPhotosStreamIdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<UserPhotosStreamIdxRow, Iterator<UserPhotosStreamIdxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            UserPhotosStreamIdxRow row = UserPhotosStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<UserPhotosStreamIdxColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                UserPhotosStreamIdxColumn col = UserPhotosStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                Long val = UserPhotosStreamIdxColumnValue.hydrateValue(result.getValue());
+                return UserPhotosStreamIdxColumnValue.of(col, val);
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<UserPhotosStreamIdxRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -713,5 +729,5 @@ public final class UserPhotosStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "nJFsPbXaBkqqtDXgoQVkuQ==";
+    static String __CLASS_HASH = "jJRU/ZnsOP4EKkqeaNEYAQ==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamMetadataTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamMetadataTable.java
@@ -570,6 +570,20 @@ public final class UserPhotosStreamMetadataTable implements
         });
     }
 
+    @Override
+    public Map<UserPhotosStreamMetadataRow, Iterator<UserPhotosStreamMetadataNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<UserPhotosStreamMetadataRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<UserPhotosStreamMetadataRow, Iterator<UserPhotosStreamMetadataNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            UserPhotosStreamMetadataRow row = UserPhotosStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<UserPhotosStreamMetadataNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<UserPhotosStreamMetadataRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -681,5 +695,5 @@ public final class UserPhotosStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "0MdVS+7yNGBENdW0vcRR4g==";
+    static String __CLASS_HASH = "AOS3775oRbnPQYk8HYJoaA==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamValueTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamValueTable.java
@@ -558,6 +558,20 @@ public final class UserPhotosStreamValueTable implements
         });
     }
 
+    @Override
+    public Map<UserPhotosStreamValueRow, Iterator<UserPhotosStreamValueNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<UserPhotosStreamValueRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<UserPhotosStreamValueRow, Iterator<UserPhotosStreamValueNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            UserPhotosStreamValueRow row = UserPhotosStreamValueRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<UserPhotosStreamValueNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<UserPhotosStreamValueRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -669,5 +683,5 @@ public final class UserPhotosStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "ALz762RaYkJmjU1clfMg1Q==";
+    static String __CLASS_HASH = "QaMSD+Q07xDMF1dMKA3/DQ==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserProfileTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserProfileTable.java
@@ -1048,6 +1048,20 @@ public final class UserProfileTable implements
         });
     }
 
+    @Override
+    public Map<UserProfileRow, Iterator<UserProfileNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<UserProfileRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<UserProfileRow, Iterator<UserProfileNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            UserProfileRow row = UserProfileRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<UserProfileNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     private Multimap<UserProfileRow, UserProfileNamedColumnValue<?>> getAffectedCells(Multimap<UserProfileRow, ? extends UserProfileNamedColumnValue<?>> rows) {
         Multimap<UserProfileRow, UserProfileNamedColumnValue<?>> oldData = getRowsMultimap(rows.keySet());
         Multimap<UserProfileRow, UserProfileNamedColumnValue<?>> cellsAffected = ArrayListMultimap.create();
@@ -1720,6 +1734,22 @@ public final class UserProfileTable implements
             });
         }
 
+        @Override
+        public Map<CookiesIdxRow, Iterator<CookiesIdxColumnValue>> getRowsColumnRangeIterator(Iterable<CookiesIdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+            Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+            Map<CookiesIdxRow, Iterator<CookiesIdxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+            for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+                CookiesIdxRow row = CookiesIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                Iterator<CookiesIdxColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                    CookiesIdxColumn col = CookiesIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                    Long val = CookiesIdxColumnValue.hydrateValue(result.getValue());
+                    return CookiesIdxColumnValue.of(col, val);
+                });
+                transformed.put(row, bv);
+            }
+            return transformed;
+        }
+
         public BatchingVisitableView<CookiesIdxRowResult> getRange(RangeRequest range) {
             if (range.getColumnNames().isEmpty()) {
                 range = range.getBuilder().retainColumns(allColumns).build();
@@ -2375,6 +2405,22 @@ public final class UserProfileTable implements
                 CreatedIdxColumnValue colValue = CreatedIdxColumnValue.of(col, val);
                 return Maps.immutableEntry(row, colValue);
             });
+        }
+
+        @Override
+        public Map<CreatedIdxRow, Iterator<CreatedIdxColumnValue>> getRowsColumnRangeIterator(Iterable<CreatedIdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+            Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+            Map<CreatedIdxRow, Iterator<CreatedIdxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+            for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+                CreatedIdxRow row = CreatedIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                Iterator<CreatedIdxColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                    CreatedIdxColumn col = CreatedIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                    Long val = CreatedIdxColumnValue.hydrateValue(result.getValue());
+                    return CreatedIdxColumnValue.of(col, val);
+                });
+                transformed.put(row, bv);
+            }
+            return transformed;
         }
 
         public BatchingVisitableView<CreatedIdxRowResult> getRange(RangeRequest range) {
@@ -3034,6 +3080,22 @@ public final class UserProfileTable implements
             });
         }
 
+        @Override
+        public Map<UserBirthdaysIdxRow, Iterator<UserBirthdaysIdxColumnValue>> getRowsColumnRangeIterator(Iterable<UserBirthdaysIdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+            Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+            Map<UserBirthdaysIdxRow, Iterator<UserBirthdaysIdxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+            for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+                UserBirthdaysIdxRow row = UserBirthdaysIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                Iterator<UserBirthdaysIdxColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                    UserBirthdaysIdxColumn col = UserBirthdaysIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                    Long val = UserBirthdaysIdxColumnValue.hydrateValue(result.getValue());
+                    return UserBirthdaysIdxColumnValue.of(col, val);
+                });
+                transformed.put(row, bv);
+            }
+            return transformed;
+        }
+
         public BatchingVisitableView<UserBirthdaysIdxRowResult> getRange(RangeRequest range) {
             if (range.getColumnNames().isEmpty()) {
                 range = range.getBuilder().retainColumns(allColumns).build();
@@ -3200,5 +3262,5 @@ public final class UserProfileTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "90glu+qbIyo2vFb/CB2wWw==";
+    static String __CLASS_HASH = "6ERsVdIdFT9pY4XfL9rwMw==";
 }

--- a/timelock-server-benchmark-client/build.gradle
+++ b/timelock-server-benchmark-client/build.gradle
@@ -6,6 +6,8 @@ apply from: "../gradle/shared.gradle"
 apply from: "../gradle/tests.gradle"
 apply from: "../gradle/non-client-dist.gradle"
 
+schemas = ['com.palantir.atlasdb.timelock.benchmarks.schema.BenchmarksSchema']
+
 dependencies {
     compile project(":timelock-server")
     compile (project(":atlasdb-cassandra")) {

--- a/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/BenchmarksTableFactory.java
+++ b/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/BenchmarksTableFactory.java
@@ -1,15 +1,14 @@
 package com.palantir.atlasdb.timelock.benchmarks.schema.generated;
 
-import java.util.List;
-
-import javax.annotation.Generated;
-
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.table.generation.Triggers;
 import com.palantir.atlasdb.transaction.api.Transaction;
+import java.lang.Override;
+import java.util.List;
+import javax.annotation.Generated;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableFactoryRenderer")
 public final class BenchmarksTableFactory {
@@ -19,18 +18,21 @@ public final class BenchmarksTableFactory {
 
     private final Namespace namespace;
 
-    private BenchmarksTableFactory(List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
+    private BenchmarksTableFactory(
+            List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
             Namespace namespace) {
         this.sharedTriggers = sharedTriggers;
         this.namespace = namespace;
     }
 
-    public static BenchmarksTableFactory of(List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
+    public static BenchmarksTableFactory of(
+            List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
             Namespace namespace) {
         return new BenchmarksTableFactory(sharedTriggers, namespace);
     }
 
-    public static BenchmarksTableFactory of(List<Function<? super Transaction, SharedTriggers>> sharedTriggers) {
+    public static BenchmarksTableFactory of(
+            List<Function<? super Transaction, SharedTriggers>> sharedTriggers) {
         return new BenchmarksTableFactory(sharedTriggers, defaultNamespace);
     }
 
@@ -70,27 +72,32 @@ public final class BenchmarksTableFactory {
 
     public abstract static class NullSharedTriggers implements SharedTriggers {
         @Override
-        public void putBlobs(Multimap<BlobsTable.BlobsRow, ? extends BlobsTable.BlobsNamedColumnValue<?>> newRows) {
+        public void putBlobs(
+                Multimap<BlobsTable.BlobsRow, ? extends BlobsTable.BlobsNamedColumnValue<?>> newRows) {
             // do nothing
         }
 
         @Override
-        public void putBlobsSerializable(Multimap<BlobsSerializableTable.BlobsSerializableRow, ? extends BlobsSerializableTable.BlobsSerializableNamedColumnValue<?>> newRows) {
+        public void putBlobsSerializable(
+                Multimap<BlobsSerializableTable.BlobsSerializableRow, ? extends BlobsSerializableTable.BlobsSerializableNamedColumnValue<?>> newRows) {
             // do nothing
         }
 
         @Override
-        public void putKvDynamicColumns(Multimap<KvDynamicColumnsTable.KvDynamicColumnsRow, ? extends KvDynamicColumnsTable.KvDynamicColumnsColumnValue> newRows) {
+        public void putKvDynamicColumns(
+                Multimap<KvDynamicColumnsTable.KvDynamicColumnsRow, ? extends KvDynamicColumnsTable.KvDynamicColumnsColumnValue> newRows) {
             // do nothing
         }
 
         @Override
-        public void putKvRows(Multimap<KvRowsTable.KvRowsRow, ? extends KvRowsTable.KvRowsNamedColumnValue<?>> newRows) {
+        public void putKvRows(
+                Multimap<KvRowsTable.KvRowsRow, ? extends KvRowsTable.KvRowsNamedColumnValue<?>> newRows) {
             // do nothing
         }
 
         @Override
-        public void putMetadata(Multimap<MetadataTable.MetadataRow, ? extends MetadataTable.MetadataNamedColumnValue<?>> newRows) {
+        public void putMetadata(
+                Multimap<MetadataTable.MetadataRow, ? extends MetadataTable.MetadataNamedColumnValue<?>> newRows) {
             // do nothing
         }
     }

--- a/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/BlobsSerializableTable.java
+++ b/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/BlobsSerializableTable.java
@@ -546,6 +546,20 @@ public final class BlobsSerializableTable implements
         });
     }
 
+    @Override
+    public Map<BlobsSerializableRow, Iterator<BlobsSerializableNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<BlobsSerializableRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<BlobsSerializableRow, Iterator<BlobsSerializableNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            BlobsSerializableRow row = BlobsSerializableRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<BlobsSerializableNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<BlobsSerializableRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -657,5 +671,5 @@ public final class BlobsSerializableTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "SdgUSR8Y7V+fu2C7iUMTDg==";
+    static String __CLASS_HASH = "jLyPGNDSC0XzpNlnUjHbCw==";
 }

--- a/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/BlobsTable.java
+++ b/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/BlobsTable.java
@@ -546,6 +546,20 @@ public final class BlobsTable implements
         });
     }
 
+    @Override
+    public Map<BlobsRow, Iterator<BlobsNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<BlobsRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<BlobsRow, Iterator<BlobsNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            BlobsRow row = BlobsRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<BlobsNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<BlobsRowResult> getAllRowsUnordered() {
         return getAllRowsUnordered(allColumns);
     }
@@ -657,5 +671,5 @@ public final class BlobsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "Qvg9woe62nJkKkNxn/bXHg==";
+    static String __CLASS_HASH = "0BaY87Xke52zUxnOtlXXSg==";
 }

--- a/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/KvDynamicColumnsTable.java
+++ b/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/KvDynamicColumnsTable.java
@@ -630,6 +630,22 @@ public final class KvDynamicColumnsTable implements
         });
     }
 
+    @Override
+    public Map<KvDynamicColumnsRow, Iterator<KvDynamicColumnsColumnValue>> getRowsColumnRangeIterator(Iterable<KvDynamicColumnsRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<KvDynamicColumnsRow, Iterator<KvDynamicColumnsColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            KvDynamicColumnsRow row = KvDynamicColumnsRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<KvDynamicColumnsColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                KvDynamicColumnsColumn col = KvDynamicColumnsColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                byte[] val = KvDynamicColumnsColumnValue.hydrateValue(result.getValue());
+                return KvDynamicColumnsColumnValue.of(col, val);
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<KvDynamicColumnsRowResult> getRange(RangeRequest range) {
         if (range.getColumnNames().isEmpty()) {
             range = range.getBuilder().retainColumns(allColumns).build();
@@ -794,5 +810,5 @@ public final class KvDynamicColumnsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "mAC6ZGVLSNeEj4c3Qp9xyw==";
+    static String __CLASS_HASH = "A7GDU50+va5o89bxd7JuXw==";
 }

--- a/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/KvRowsTable.java
+++ b/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/KvRowsTable.java
@@ -602,6 +602,20 @@ public final class KvRowsTable implements
         });
     }
 
+    @Override
+    public Map<KvRowsRow, Iterator<KvRowsNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<KvRowsRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<KvRowsRow, Iterator<KvRowsNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            KvRowsRow row = KvRowsRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<KvRowsNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
     public BatchingVisitableView<KvRowsRowResult> getRange(RangeRequest range) {
         if (range.getColumnNames().isEmpty()) {
             range = range.getBuilder().retainColumns(allColumns).build();
@@ -762,5 +776,5 @@ public final class KvRowsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "m8yeo8CW8a+4SZzBshzfRA==";
+    static String __CLASS_HASH = "X+7b5V2BwgN8XOpNroaF/g==";
 }


### PR DESCRIPTION
**Goals (and why)**:
Adds a new method to tables `getRowsColumnRangeIterator` that is similar to `getRowsColumnRange`, except it returns an `Iterator` instead of a `BatchingVisitable`.

**Implementation Description (bullets)**:
Mostly modifications to generated tables that are checked in.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Copied existing tests using `getRowsColumnRange`. I didn't want to combine the testing in case any implementation changes in the future, and the additional tests should be cheap. The contract should be the same, so existing tests should cover the functionality.

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:
Skip all the generated files, everything else should be relevant and fairly quick.

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
