### PR TITLE
[PDS-94229] Thread Leak in LockServiceImpl

### DIFF
--- a/changelog/@unreleased/pr-4121.v2.yml
+++ b/changelog/@unreleased/pr-4121.v2.yml
@@ -1,7 +1,6 @@
 type: fix
 fix:
-  description: |2
-
+  description: |
     TimeLock now interrupts lock reaper threads in the legacy lock service when losing leadership. Previously, it did not, meaning that if a node repeatedly gained and lost leadership, lock reaper threads would still execute their polling for expired tokens or grants, possibly manifesting in performance issues if this continues in the absence of bounces.
   links:
   - https://github.com/palantir/atlasdb/pull/4121

--- a/changelog/@unreleased/pr-4121.v2.yml
+++ b/changelog/@unreleased/pr-4121.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: |2
+
+    TimeLock now interrupts lock reaper threads in the legacy lock service when losing leadership. Previously, it did not, meaning that if a node repeatedly gained and lost leadership, lock reaper threads would still execute their polling for expired tokens or grants, possibly manifesting in performance issues if this continues in the absence of bounces.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4121


### PR DESCRIPTION
**Goals (and why)**:
- See PDS-94229. Basically there's a problem in the legacy lock service: if the executor provided is `notOwned` (which happens in timelock) we do not interrupt the lock grant and token reapers. This is incorrect, because they can make calls that could block indefinitely. The reason we haven't seen this on other stacks is that other stacks generally don't have many elections outside of rolling bounces, which annihilate all JVM threads anyway.

**Implementation Description (bullets)**:
- Factor out some of the creation and processing logic to a small inner class `LockReapRunner`.
- Have `LockReapRunner` do the closing logic properly.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Bleh. Not much in the way of automated tests. I did write a manual test and verified it worked properly, and it's possible that we want something similar but automated, though we probably want it to be faster than the version I wrote.

```java
@Test
public void jkong() throws InterruptedException {
    List<Integer> threadCounts = Lists.newArrayList();
    for (int iteration = 0; iteration < 300; iteration++) {
        threadCounts.add(ManagementFactory.getThreadMXBean().getThreadCount());
        System.err.println("[" + iteration + "] Thread counts: " + threadCounts);
        CLUSTER.currentLeader().pingableLeader().boom();
        waitForClusterToStabilize();
        CLUSTER.remoteLock(BLOCKING_LOCK_REQUEST);
    }
}
```

| Iteration number | Old #threads | New #threads |
|------------------|--------------|--------------|
| 100              | 417          | 324          |
| 200              | 510          | 313          |
| 300              | 606          | 318          |

**Concerns (what feedback would you like?)**:
- Does this fix the thread leak?
- Did this actually break anything else?

**Where should we start reviewing?**: LockServiceImpl

**Priority (whenever / two weeks / yesterday)**: yesterday 🔥 