### PR TITLE
Move some dependencies to the implementation configuration

### DIFF
--- a/atlasdb-autobatch/build.gradle
+++ b/atlasdb-autobatch/build.gradle
@@ -11,8 +11,9 @@ libsDirName = file('build/artifacts')
 dependencies {
     compile project(":atlasdb-commons")
     compile group: 'com.lmax', name: 'disruptor'
-    compile group: 'com.palantir.safe-logging', name: 'safe-logging'
     compile group: 'com.palantir.tritium', name: 'tritium-registry'
+
+    implementation group: 'com.palantir.safe-logging', name: 'safe-logging'
 
     processor project(":atlasdb-processors")
     processor group: 'org.immutables', name: 'value'

--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -11,7 +11,7 @@ configurations {
 }
 
 dependencies {
-  compile group: 'com.palantir.safe-logging', name: 'safe-logging'
+  implementation group: 'com.palantir.safe-logging', name: 'safe-logging'
 
   explicitShadow (group: 'de.jflex', name: 'jflex', version: '1.6.0') {
     exclude(group: 'org.apache.ant', module: 'ant')

--- a/atlasdb-client/build.gradle
+++ b/atlasdb-client/build.gradle
@@ -59,7 +59,6 @@ dependencies {
   compile group: 'com.fasterxml.jackson.core', name: 'jackson-core'
   compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-guava'
   compile group: 'com.palantir.tracing', name: 'tracing'
-  compile group: 'com.palantir.safe-logging', name: 'safe-logging'
   compile (group: 'com.palantir.tritium', name: 'tritium-caffeine') {
     exclude (group: 'io.dropwizard.metrics', module: 'metrics-core')
     exclude (group: 'org.hdrhistogram', module: 'HdrHistogram')
@@ -76,10 +75,12 @@ dependencies {
     exclude (group: 'io.dropwizard.metrics', module: 'metrics-core')
     exclude (group: 'org.hdrhistogram', module: 'HdrHistogram')
   }
-  compile group: 'com.squareup', name:'javapoet'
   compile group: 'org.hdrhistogram', name: 'HdrHistogram'
-  compile group: 'com.palantir.common', name: 'streams'
-  compile group: 'com.github.rholder', name: 'guava-retrying'
+
+  implementation group: 'com.github.rholder', name: 'guava-retrying'
+  implementation group: 'com.palantir.common', name: 'streams'
+  implementation group: 'com.palantir.safe-logging', name: 'safe-logging'
+  implementation group: 'com.squareup', name:'javapoet'
 
   processor group: 'org.immutables', name: 'value'
 

--- a/atlasdb-config/build.gradle
+++ b/atlasdb-config/build.gradle
@@ -14,7 +14,6 @@ dependencies {
     compile group: 'javax.validation', name: 'validation-api'
     compile group: 'com.palantir.config.crypto', name: 'encrypted-config-value-module'
     compile group: 'com.palantir.remoting2', name: 'error-handling' // needed for backwards compatibility
-    compile group: 'com.palantir.safe-logging', name: 'safe-logging'
     compile (group: 'com.palantir.tritium', name: 'tritium-lib') {
         exclude (group: 'io.dropwizard.metrics', module: 'metrics-core')
         exclude (group: 'org.hdrhistogram', module: 'HdrHistogram')
@@ -26,6 +25,8 @@ dependencies {
     compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8'
     compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk7'
     compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310'
+
+    implementation group: 'com.palantir.safe-logging', name: 'safe-logging'
 
     // This is added so that AtlasDB clients can specify the javaAgent as a JVM argument to load jars needed for HTTP/2
     // in the boot classpath

--- a/atlasdb-coordination-impl/build.gradle
+++ b/atlasdb-coordination-impl/build.gradle
@@ -10,7 +10,7 @@ repositories {
 dependencies {
   compile project(":atlasdb-client")
 
-  compile group: 'com.palantir.safe-logging', name: 'safe-logging'
+  implementation group: 'com.palantir.safe-logging', name: 'safe-logging'
 
   processor project(":atlasdb-processors")
   processor group: 'org.immutables', name: 'value'

--- a/atlasdb-impl-shared/build.gradle
+++ b/atlasdb-impl-shared/build.gradle
@@ -19,9 +19,10 @@ dependencies {
   compile project(":timestamp-client")
 
   compile 'com.palantir.patches.sourceforge:trove3:' + libVersions.trove
-  compile group: 'com.palantir.common', name: 'streams'
   compile group: 'com.palantir.conjure.java.runtime', name: 'conjure-java-jersey-server'
-  compile group: 'com.palantir.safe-logging', name: 'safe-logging'
+
+  implementation group: 'com.palantir.common', name: 'streams'
+  implementation group: 'com.palantir.safe-logging', name: 'safe-logging'
 
   processor group: 'org.immutables', name: 'value'
   processor 'com.google.auto.service:auto-service:1.0-rc2'

--- a/atlasdb-processors/build.gradle
+++ b/atlasdb-processors/build.gradle
@@ -9,6 +9,7 @@ repositories {
 
 dependencies {
     processor group: 'com.google.auto.service', name: 'auto-service', version: '1.0-rc3'
-    compile group: 'com.squareup', name: 'javapoet'
     compile group: 'com.google.guava', name: 'guava'
+
+    implementation group: 'com.squareup', name: 'javapoet'
 }

--- a/gradle/shared.gradle
+++ b/gradle/shared.gradle
@@ -35,8 +35,8 @@ libsDirName = file('build/artifacts')
 
 dependencies {
     // Dont add Java8 compile/runtime dependencies here as commons-executors needs to be compatible with Java6 clients
-    compile group: 'com.google.code.findbugs', name: 'jsr305'
-    compile group: 'com.google.code.findbugs', name: 'findbugs-annotations'
+    implementation group: 'com.google.code.findbugs', name: 'findbugs-annotations'
+    implementation group: 'com.google.code.findbugs', name: 'jsr305'
     checkstyle group: 'com.puppycrawl.tools', name: 'checkstyle', version: libVersions.checkstyle
     testCompile group: 'junit', name: 'junit'
 }

--- a/leader-election-impl/build.gradle
+++ b/leader-election-impl/build.gradle
@@ -10,7 +10,8 @@ dependencies {
   compile group: "com.github.ben-manes.caffeine", name: "caffeine"
   compile group: "com.google.protobuf", name: "protobuf-java"
   compile group: "commons-io", name: "commons-io"
-  compile group: 'com.palantir.safe-logging', name: 'safe-logging'
+
+  implementation group: 'com.palantir.safe-logging', name: 'safe-logging'
 
   processor group: 'org.immutables', name: 'value'
 

--- a/lock-api/build.gradle
+++ b/lock-api/build.gradle
@@ -17,8 +17,9 @@ dependencies {
     compile group: 'javax.ws.rs', name: 'javax.ws.rs-api'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
-    compile group: 'com.palantir.safe-logging', name: 'safe-logging'
-    compile group: 'com.palantir.safe-logging', name: 'preconditions'
+
+    implementation group: 'com.palantir.safe-logging', name: 'preconditions'
+    implementation group: 'com.palantir.safe-logging', name: 'safe-logging'
 
     processor project(":atlasdb-processors")
     processor group: 'org.immutables', name: 'value'

--- a/lock-impl/build.gradle
+++ b/lock-impl/build.gradle
@@ -10,10 +10,11 @@ dependencies {
   compile project(":atlasdb-commons")
 
   compile 'com.palantir.patches.sourceforge:trove3:' + libVersions.trove
-  compile group: 'com.palantir.safe-logging', name: 'safe-logging'
   compile group: 'joda-time', name: 'joda-time'
   compile group: 'org.yaml', name: 'snakeyaml'
   compile group: 'net.jcip', name: 'jcip-annotations'
+
+  implementation group: 'com.palantir.safe-logging', name: 'safe-logging'
 
   processor group: 'org.immutables', name: 'value'
 

--- a/timelock-impl/build.gradle
+++ b/timelock-impl/build.gradle
@@ -13,8 +13,10 @@ dependencies {
         exclude group:'io.dropwizard'
     }
 
-    compile group: 'com.palantir.safe-logging', name: 'safe-logging'
     compile group: 'org.mindrot', name: 'jbcrypt'
+
+    implementation group: 'com.palantir.common', name: 'streams'
+    implementation group: 'com.palantir.safe-logging', name: 'safe-logging'
 
     processor project(":atlasdb-processors")
     processor group: 'org.immutables', name: 'value'

--- a/timestamp-api/build.gradle
+++ b/timestamp-api/build.gradle
@@ -5,7 +5,8 @@ apply plugin: 'org.inferred.processors'
 dependencies {
     compile group: 'javax.ws.rs', name: 'javax.ws.rs-api'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations'
-    compile group: 'com.palantir.safe-logging', name: 'safe-logging'
+
+    implementation group: 'com.palantir.safe-logging', name: 'safe-logging'
 
     processor project(":atlasdb-processors")
 

--- a/timestamp-impl/build.gradle
+++ b/timestamp-impl/build.gradle
@@ -9,7 +9,7 @@ dependencies {
   compile(project(":atlasdb-commons"))
   compile(project(":atlasdb-client"))
 
-  compile group: 'com.palantir.safe-logging', name: 'safe-logging'
+  implementation group: 'com.palantir.safe-logging', name: 'safe-logging'
 
   processor 'com.google.auto.service:auto-service:1.0-rc2'
   processor project(":atlasdb-processors")


### PR DESCRIPTION
**Goals (and why)**:
Follow up to #4119. Goal is to remove some dependencies that should not be transitively exposed to consumers. 

**Implementation Description (bullets)**:
The changes in this PR are pretty conservative and the modified dependencies are almost certainly not used in any API surface. The modified dependencies are:
- `com.google.code.findbugs:findbugs-annotations`
- `com.google.code.findbugs:jsr305`
- `com.github.rholder:guava-retrying`
- `com.palantir.common:streams`
- `com.palantir.safe-logging:preconditions`
- `com.palantir.safe-logging:safe-logging`
- `org.squareup:javapoet`

**Concerns (what feedback would you like?)**:
- Are any of these dependencies exposed in a project's API?