### PR TITLE
[Timelock Partitioning] Part 12: Unify autobatcher exception handling + Close autobatchers

### DIFF
--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AutobatcherExecutionExceptions.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AutobatcherExecutionExceptions.java
@@ -18,6 +18,8 @@ package com.palantir.atlasdb.timelock.paxos;
 
 import java.util.concurrent.ExecutionException;
 
+import com.palantir.logsafe.Preconditions;
+
 class AutobatcherExecutionExceptions {
 
     private AutobatcherExecutionExceptions() { }
@@ -30,6 +32,7 @@ class AutobatcherExecutionExceptions {
             }
             throw new RuntimeException(cause);
         } else {
+            Preconditions.checkArgument(e instanceof InterruptedException, "expected Interrupted exception");
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AutobatcherExecutionExceptions.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AutobatcherExecutionExceptions.java
@@ -30,7 +30,7 @@ class AutobatcherExecutionExceptions {
             }
             throw new RuntimeException(cause);
         } else {
-            // handle interrupted
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         }
     }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AutobatchingPaxosLearnerNetworkClientFactory.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AutobatchingPaxosLearnerNetworkClientFactory.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.timelock.paxos;
 
 import static com.palantir.atlasdb.timelock.paxos.PaxosQuorumCheckingCoalescingFunction.wrap;
 
+import java.io.Closeable;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -36,7 +37,7 @@ import com.palantir.paxos.PaxosResponses;
 import com.palantir.paxos.PaxosUpdate;
 import com.palantir.paxos.PaxosValue;
 
-public class AutobatchingPaxosLearnerNetworkClientFactory {
+public class AutobatchingPaxosLearnerNetworkClientFactory implements Closeable {
 
     private final DisruptorAutobatcher<Map.Entry<Client, PaxosValue>, PaxosResponses<PaxosResponse>> learn;
     private final DisruptorAutobatcher<WithSeq<Client>, PaxosResponses<PaxosContainer<Optional<PaxosValue>>>> getLearnedValues;
@@ -78,6 +79,13 @@ public class AutobatchingPaxosLearnerNetworkClientFactory {
 
     public PaxosLearnerNetworkClient paxosLearnerForClient(Client client) {
         return new AutobatchingPaxosLearnerNetworkClient(client);
+    }
+
+    @Override
+    public void close() {
+        learn.close();
+        getLearnedValues.close();
+        getLearnedValuesSince.close();
     }
 
     private final class AutobatchingPaxosLearnerNetworkClient implements PaxosLearnerNetworkClient {

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AutobatchingPaxosLearnerNetworkClientFactory.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AutobatchingPaxosLearnerNetworkClientFactory.java
@@ -89,6 +89,7 @@ public class AutobatchingPaxosLearnerNetworkClientFactory implements Closeable {
     }
 
     private final class AutobatchingPaxosLearnerNetworkClient implements PaxosLearnerNetworkClient {
+
         private final Client client;
 
         private AutobatchingPaxosLearnerNetworkClient(Client client) {
@@ -100,15 +101,8 @@ public class AutobatchingPaxosLearnerNetworkClientFactory implements Closeable {
             Preconditions.checkArgument(seq == value.getRound(), "seq differs from PaxosValue.round");
             try {
                 learn.apply(Maps.immutableEntry(client, value)).get();
-            } catch (ExecutionException e) {
-                Throwable cause = e.getCause();
-                if (cause instanceof RuntimeException) {
-                    throw (RuntimeException) cause;
-                }
-                throw new RuntimeException(cause);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new RuntimeException(e);
+            } catch (ExecutionException | InterruptedException e) {
+                throw AutobatcherExecutionExceptions.handleAutobatcherExceptions(e);
             }
         }
 
@@ -118,15 +112,8 @@ public class AutobatchingPaxosLearnerNetworkClientFactory implements Closeable {
                 Function<Optional<PaxosValue>, T> mapper) {
             try {
                 return getLearnedValues.apply(WithSeq.of(seq, client)).get().map(c -> mapper.apply(c.get()));
-            } catch (ExecutionException e) {
-                Throwable cause = e.getCause();
-                if (cause instanceof RuntimeException) {
-                    throw (RuntimeException) cause;
-                }
-                throw new RuntimeException(cause);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new RuntimeException(e);
+            } catch (ExecutionException | InterruptedException e) {
+                throw AutobatcherExecutionExceptions.handleAutobatcherExceptions(e);
             }
         }
 
@@ -134,15 +121,8 @@ public class AutobatchingPaxosLearnerNetworkClientFactory implements Closeable {
         public PaxosResponses<PaxosUpdate> getLearnedValuesSince(long seq) {
             try {
                 return getLearnedValuesSince.apply(WithSeq.of(seq, client)).get();
-            } catch (ExecutionException e) {
-                Throwable cause = e.getCause();
-                if (cause instanceof RuntimeException) {
-                    throw (RuntimeException) cause;
-                }
-                throw new RuntimeException(cause);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new RuntimeException(e);
+            } catch (ExecutionException | InterruptedException e) {
+                throw AutobatcherExecutionExceptions.handleAutobatcherExceptions(e);
             }
         }
 


### PR DESCRIPTION
**Goals (and why)**:
Due to splitting out the two impls i.e. `Learner` and `Acceptor`, exception handling wasn't handled correctly, and effectively diverged as part of the review iteration. Now I'm just closing the loop.

Similarly, even though it shouldn't matter *too* much, we want the ability to close autobatchers to claim resources back.

Ticks some of the checkboxes in #4112.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
