### PR TITLE
TS batch size metrics

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/util/MetricsManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/util/MetricsManager.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
@@ -176,6 +177,16 @@ public class MetricsManager {
             Map<String, String> tags) {
         MetricName name = getTaggedMetricName(clazz, metricName, tags);
         Histogram histogram = taggedMetricRegistry.histogram(name);
+        registerTaggedMetricName(name);
+        return histogram;
+    }
+
+    public Histogram registerOrGetTaggedHistogram(
+            Class clazz, String metricName,
+            Map<String, String> tags,
+            Supplier<Histogram> supplier) {
+        MetricName name = getTaggedMetricName(clazz, metricName, tags);
+        Histogram histogram = taggedMetricRegistry.histogram(name, supplier);
         registerTaggedMetricName(name);
         return histogram;
     }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbMetricNames.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbMetricNames.java
@@ -58,7 +58,6 @@ public final class AtlasDbMetricNames {
     public static final String SWEEP_TS = "sweepTimestamp";
     public static final String LAST_SWEPT_TS = "lastSweptTimestamp";
     public static final String LAG_MILLIS = "millisSinceLastSweptTs";
-    public static final String BATCH_SIZE = "batchSizeHistogram";
     public static final String BATCH_SIZE_MEAN = "batchSizeMean";
 
     public static final String SWEEP_OUTCOME = "outcome";

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbMetricNames.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbMetricNames.java
@@ -58,6 +58,8 @@ public final class AtlasDbMetricNames {
     public static final String SWEEP_TS = "sweepTimestamp";
     public static final String LAST_SWEPT_TS = "lastSweptTimestamp";
     public static final String LAG_MILLIS = "millisSinceLastSweptTs";
+    public static final String BATCH_SIZE = "batchSizeHistogram";
+    public static final String BATCH_SIZE_MEAN = "batchSizeMean";
 
     public static final String SWEEP_OUTCOME = "outcome";
     public static final String TAG_OUTCOME = "status";

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/SlidingWindowMeanGauge.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/SlidingWindowMeanGauge.java
@@ -1,0 +1,47 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.util;
+
+import java.util.concurrent.TimeUnit;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.SlidingTimeWindowArrayReservoir;
+import com.codahale.metrics.Snapshot;
+import com.google.common.annotations.VisibleForTesting;
+
+public class SlidingWindowMeanGauge implements Gauge<Double> {
+    private final Histogram histogram;
+
+    public SlidingWindowMeanGauge() {
+        histogram = new Histogram(new SlidingTimeWindowArrayReservoir(1, TimeUnit.HOURS));
+    }
+
+    @Override
+    public Double getValue() {
+        return getSnapshot().getMean();
+    }
+
+    public void update(long entry) {
+        histogram.update(entry);
+    }
+
+    @VisibleForTesting
+    public Snapshot getSnapshot() {
+        return histogram.getSnapshot();
+    }
+}

--- a/atlasdb-commons/src/main/java/com/palantir/util/AggregatingVersionedSupplier.java
+++ b/atlasdb-commons/src/main/java/com/palantir/util/AggregatingVersionedSupplier.java
@@ -50,10 +50,10 @@ public class AggregatingVersionedSupplier<T> implements Supplier<VersionedType<T
     }
 
     public static <C extends Comparable<C>> AggregatingVersionedSupplier<C> min(long expirationMillis) {
-        return new AggregatingVersionedSupplier<>(AggregatingVersionedSupplier::minimum, expirationMillis);
+        return new AggregatingVersionedSupplier<>(AggregatingVersionedSupplier::min, expirationMillis);
     }
 
-    private static <C extends Comparable<C>> C minimum(Collection<C> currentValues) {
+    private static <C extends Comparable<C>> C min(Collection<C> currentValues) {
         return currentValues.stream().min(Comparator.naturalOrder()).orElse(null);
     }
 

--- a/atlasdb-commons/src/main/java/com/palantir/util/AggregatingVersionedSupplier.java
+++ b/atlasdb-commons/src/main/java/com/palantir/util/AggregatingVersionedSupplier.java
@@ -16,6 +16,7 @@
 package com.palantir.util;
 
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
@@ -46,6 +47,14 @@ public class AggregatingVersionedSupplier<T> implements Supplier<VersionedType<T
         this.aggregator = aggregator;
         this.memoizedValue = Suppliers
                 .memoizeWithExpiration(this::recalculate, expirationMillis, TimeUnit.MILLISECONDS);
+    }
+
+    public static <C extends Comparable<C>> AggregatingVersionedSupplier<C> min(long expirationMillis) {
+        return new AggregatingVersionedSupplier<>(AggregatingVersionedSupplier::minimum, expirationMillis);
+    }
+
+    private static <C extends Comparable<C>> C minimum(Collection<C> currentValues) {
+        return currentValues.stream().min(Comparator.naturalOrder()).orElse(null);
     }
 
     /**

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepBatch.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepBatch.java
@@ -29,15 +29,22 @@ public interface SweepBatch {
     List<WriteInfo> writes();
     DedicatedRows dedicatedRows();
     long lastSweptTimestamp();
+    boolean hasNext();
 
     default boolean isEmpty() {
         return writes().isEmpty();
     }
 
     static SweepBatch of(Collection<WriteInfo> writes, DedicatedRows dedicatedRows, long timestamp) {
+        return of(writes, dedicatedRows, timestamp, true);
+    }
+
+    static SweepBatch of(Collection<WriteInfo> writes, DedicatedRows dedicatedRows, long timestamp, boolean next) {
         return ImmutableSweepBatch.builder()
                 .writes(writes)
                 .dedicatedRows(dedicatedRows)
-                .lastSweptTimestamp(timestamp).build();
+                .lastSweptTimestamp(timestamp)
+                .hasNext(next)
+                .build();
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepBatch.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepBatch.java
@@ -31,20 +31,32 @@ public interface SweepBatch {
     long lastSweptTimestamp();
     boolean hasNext();
 
+    @Value.Default
+    default long entriesRead() {
+        return writes().size();
+    }
+
     default boolean isEmpty() {
         return writes().isEmpty();
     }
 
     static SweepBatch of(Collection<WriteInfo> writes, DedicatedRows dedicatedRows, long timestamp) {
-        return of(writes, dedicatedRows, timestamp, true);
+        return ImmutableSweepBatch.builder()
+                .writes(writes)
+                .dedicatedRows(dedicatedRows)
+                .lastSweptTimestamp(timestamp)
+                .hasNext(true)
+                .build();
     }
 
-    static SweepBatch of(Collection<WriteInfo> writes, DedicatedRows dedicatedRows, long timestamp, boolean next) {
+    static SweepBatch of(Collection<WriteInfo> writes, DedicatedRows dedicatedRows, long timestamp, boolean next,
+            long entriesRead) {
         return ImmutableSweepBatch.builder()
                 .writes(writes)
                 .dedicatedRows(dedicatedRows)
                 .lastSweptTimestamp(timestamp)
                 .hasNext(next)
+                .entriesRead(entriesRead)
                 .build();
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepBatchAccumulator.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepBatchAccumulator.java
@@ -33,6 +33,7 @@ class SweepBatchAccumulator {
     private final long sweepTimestamp;
 
     private long progressTimestamp;
+    private long entriesRead = 0;
     private boolean anyBatchesPresent = false;
     private boolean nextBatchAvailable = true;
 
@@ -57,6 +58,7 @@ class SweepBatchAccumulator {
         progressTimestamp = Math.max(progressTimestamp, sweepBatch.lastSweptTimestamp());
         anyBatchesPresent = true;
         nextBatchAvailable = sweepBatch.hasNext();
+        entriesRead += sweepBatch.entriesRead();
     }
 
     long getProgressTimestamp() {
@@ -68,7 +70,8 @@ class SweepBatchAccumulator {
                 getLatestWritesByCellReference(),
                 DedicatedRows.of(accumulatedDedicatedRows),
                 getLastSweptTimestamp(),
-                nextBatchAvailable);
+                nextBatchAvailable,
+                entriesRead);
         return SweepBatchWithPartitionInfo.of(sweepBatch, finePartitions);
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueue.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueue.java
@@ -155,7 +155,7 @@ public final class SweepQueue implements MultiTableSweepQueueWriter {
             metrics.registerOccurrenceOf(shardStrategy, SweepOutcome.SUCCESS);
         }
 
-        return true;
+        return lastSweptTs != sweepBatch.lastSweptTimestamp() && sweepBatch.hasNext();
     }
 
     /**

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueue.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueue.java
@@ -131,6 +131,7 @@ public final class SweepQueue implements MultiTableSweepQueueWriter {
 
         SweepBatchWithPartitionInfo batchWithInfo = reader.getNextBatchToSweep(shardStrategy, lastSweptTs, sweepTs);
         SweepBatch sweepBatch = batchWithInfo.sweepBatch();
+        metrics.registerEntriesReadInBatch(shardStrategy, sweepBatch.entriesRead());
 
         deleter.sweep(sweepBatch.writes(), Sweeper.of(shardStrategy));
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueReader.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueReader.java
@@ -45,15 +45,8 @@ class SweepQueueReader {
             SweepBatch batch = sweepableCells.getBatchForPartition(
                     shardStrategy, nextFinePartition.get(), previousProgress, sweepTs);
             accumulator.accumulateBatch(batch);
-            if (noProgressMadeThisIteration(accumulator, previousProgress)) {
-                return accumulator.toSweepBatch();
-            }
             previousProgress = accumulator.getProgressTimestamp();
         }
         return accumulator.toSweepBatch();
-    }
-
-    private static boolean noProgressMadeThisIteration(SweepBatchAccumulator accumulator, long previousProgress) {
-        return accumulator.getProgressTimestamp() == previousProgress;
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableCells.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableCells.java
@@ -165,7 +165,7 @@ public class SweepableCells extends SweepQueueTable {
         Collection<WriteInfo> writes = getWritesToSweep(writesByStartTs, tsToSweep.timestampsDescending());
         DedicatedRows filteredDedicatedRows = getDedicatedRowsToClear(writeBatch.dedicatedRows, tsToSweep);
         long lastSweptTs = getLastSweptTs(tsToSweep, peekingResultIterator, partitionFine, sweepTs);
-        return SweepBatch.of(writes, filteredDedicatedRows, lastSweptTs);
+        return SweepBatch.of(writes, filteredDedicatedRows, lastSweptTs, tsToSweep.processedAll());
     }
 
     private DedicatedRows getDedicatedRowsToClear(List<SweepableCellsRow> rows, TimestampsToSweep tsToSweep) {
@@ -262,6 +262,7 @@ public class SweepableCells extends SweepQueueTable {
                 committedTimestamps.add(startTs);
             } else {
                 processedAll = false;
+                lastSweptTs = startTs - 1;
                 break;
             }
         }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableCells.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableCells.java
@@ -158,14 +158,15 @@ public class SweepableCells extends SweepQueueTable {
         PeekingIterator<Map.Entry<Cell, Value>> peekingResultIterator = Iterators.peekingIterator(resultIterator);
         WriteBatch writeBatch = getBatchOfWrites(row, peekingResultIterator, sweepTs);
         Multimap<Long, WriteInfo> writesByStartTs = writeBatch.writesByStartTs;
-        maybeMetrics.ifPresent(metrics -> metrics.updateEntriesRead(shardStrategy, writesByStartTs.size()));
-        log.debug("Read {} entries from the sweep queue.", SafeArg.of("number", writesByStartTs.size()));
+        int entriesRead = writesByStartTs.size();
+        maybeMetrics.ifPresent(metrics -> metrics.updateEntriesRead(shardStrategy, entriesRead));
+        log.debug("Read {} entries from the sweep queue.", SafeArg.of("number", entriesRead));
         TimestampsToSweep tsToSweep = getTimestampsToSweepDescendingAndCleanupAborted(
                 shardStrategy, minTsExclusive, sweepTs, writesByStartTs);
         Collection<WriteInfo> writes = getWritesToSweep(writesByStartTs, tsToSweep.timestampsDescending());
         DedicatedRows filteredDedicatedRows = getDedicatedRowsToClear(writeBatch.dedicatedRows, tsToSweep);
         long lastSweptTs = getLastSweptTs(tsToSweep, peekingResultIterator, partitionFine, sweepTs);
-        return SweepBatch.of(writes, filteredDedicatedRows, lastSweptTs, tsToSweep.processedAll());
+        return SweepBatch.of(writes, filteredDedicatedRows, lastSweptTs, tsToSweep.processedAll(), entriesRead);
     }
 
     private DedicatedRows getDedicatedRowsToClear(List<SweepableCellsRow> rows, TimestampsToSweep tsToSweep) {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/metrics/SweepMetricsAssert.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/metrics/SweepMetricsAssert.java
@@ -15,7 +15,6 @@
  */
 package com.palantir.atlasdb.sweep.metrics;
 
-import java.util.Arrays;
 import java.util.Map;
 
 import javax.annotation.CheckReturnValue;
@@ -25,14 +24,12 @@ import org.assertj.core.api.WritableAssertionInfo;
 import org.assertj.core.data.Offset;
 import org.assertj.core.internal.Doubles;
 import org.assertj.core.internal.LongArrays;
-import org.assertj.core.internal.ObjectArrays;
 import org.assertj.core.internal.Objects;
 
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import com.palantir.atlasdb.AtlasDbMetricNames;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence.SweepStrategy;
 import com.palantir.atlasdb.sweep.BackgroundSweeperImpl;

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/metrics/SweepMetricsAssert.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/metrics/SweepMetricsAssert.java
@@ -110,11 +110,11 @@ public final class SweepMetricsAssert extends AbstractAssert<SweepMetricsAssert,
         objects.assertEqual(info, getGaugeThorough(AtlasDbMetricNames.LAG_MILLIS).getValue(), value);
     }
 
-    public void hasEntriesReadInBatchConservativeEqualTo(long... outcomes) {
+    public void containsEntriesReadInBatchConservative(long... outcomes) {
         arrays.assertContainsExactlyInAnyOrder(info, getBatchSizeSnapshotConservative().getValues(), outcomes);
     }
 
-    public void hasEntriesReadInBatchThoroughEqualTo(long... outcomes) {
+    public void containsEntriesReadInBatchThorough(long... outcomes) {
         arrays.assertContainsExactlyInAnyOrder(info, getBatchSizeSnapshotThorough().getValues(), outcomes);
     }
 
@@ -163,21 +163,23 @@ public final class SweepMetricsAssert extends AbstractAssert<SweepMetricsAssert,
     }
 
     private Double getEntriesReadInBatchMeanConservative() {
-        return (Double) getGaugeConservative(AtlasDbMetricNames.BATCH_SIZE_MEAN).getValue();
+        Gauge<Double> gauge = getGaugeConservative(AtlasDbMetricNames.BATCH_SIZE_MEAN);
+        return gauge.getValue();
     }
 
     private Double getEntriesReadInBatchMeanThorough() {
-        return (Double) getGaugeThorough(AtlasDbMetricNames.BATCH_SIZE_MEAN).getValue();
+        Gauge<Double> gauge = getGaugeThorough(AtlasDbMetricNames.BATCH_SIZE_MEAN);
+        return gauge.getValue();
     }
 
     private Snapshot getBatchSizeSnapshotConservative() {
-        Gauge<Double> asGauge = getGaugeConservative(AtlasDbMetricNames.BATCH_SIZE_MEAN);
-        return ((SlidingWindowMeanGauge) asGauge).getSnapshot();
+        Gauge<Double> gauge = getGaugeConservative(AtlasDbMetricNames.BATCH_SIZE_MEAN);
+        return ((SlidingWindowMeanGauge) gauge).getSnapshot();
     }
 
     private Snapshot getBatchSizeSnapshotThorough() {
-        Gauge<Double> asGauge = getGaugeThorough(AtlasDbMetricNames.BATCH_SIZE_MEAN);
-        return ((SlidingWindowMeanGauge) asGauge).getSnapshot();
+        Gauge<Double> gauge = getGaugeThorough(AtlasDbMetricNames.BATCH_SIZE_MEAN);
+        return ((SlidingWindowMeanGauge) gauge).getSnapshot();
     }
 
     private static String getTagForStrategy(SweepStrategy strategy) {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/metrics/TargetedSweepMetricsTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/metrics/TargetedSweepMetricsTest.java
@@ -70,7 +70,7 @@ public class TargetedSweepMetricsTest {
         assertThat(metricsManager).hasSweepTimestampConservativeEqualTo(null);
         assertThat(metricsManager).hasLastSweptTimestampConservativeEqualTo(null);
         assertThat(metricsManager).hasMillisSinceLastSweptConservativeEqualTo(null);
-        assertThat(metricsManager).hasEntriesReadInBatchConservativeEqualTo();
+        assertThat(metricsManager).containsEntriesReadInBatchConservative();
         assertThat(metricsManager).hasEntriesReadInBatchMeanConservativeEqualTo(0.0);
     }
 
@@ -91,7 +91,7 @@ public class TargetedSweepMetricsTest {
         assertThat(metricsManager).hasAbortedWritesDeletedConservativeEquals(2);
         assertThat(metricsManager).hasSweepTimestampConservativeEqualTo(7L);
         assertThat(metricsManager).hasLastSweptTimestampConservativeEqualTo(4L);
-        assertThat(metricsManager).hasEntriesReadInBatchConservativeEqualTo(100L);
+        assertThat(metricsManager).containsEntriesReadInBatchConservative(100L);
         assertThat(metricsManager).hasEntriesReadInBatchMeanConservativeEqualTo(100.0);
 
         puncherStore.put(3, 2);
@@ -117,7 +117,7 @@ public class TargetedSweepMetricsTest {
         assertThat(metricsManager).hasAbortedWritesDeletedThoroughEqualTo(3);
         assertThat(metricsManager).hasSweepTimestampThoroughEqualTo(9);
         assertThat(metricsManager).hasLastSweptTimestampThoroughEqualTo(6);
-        assertThat(metricsManager).hasEntriesReadInBatchThoroughEqualTo(50L);
+        assertThat(metricsManager).containsEntriesReadInBatchThorough(50L);
         assertThat(metricsManager).hasEntriesReadInBatchMeanThoroughEqualTo(50.0);
 
         puncherStore.put(5, 1);
@@ -220,7 +220,7 @@ public class TargetedSweepMetricsTest {
         assertThat(metricsManager).hasTombstonesPutConservativeEqualTo(1);
         assertThat(metricsManager).hasAbortedWritesDeletedConservativeEquals(2);
         assertThat(metricsManager).hasSweepTimestampConservativeEqualTo(7L);
-        assertThat(metricsManager).hasEntriesReadInBatchConservativeEqualTo(20L);
+        assertThat(metricsManager).containsEntriesReadInBatchConservative(20L);
 
         secondMetrics.updateEnqueuedWrites(CONS_ZERO, 5);
         secondMetrics.updateEntriesRead(CONS_ZERO, 5);
@@ -234,7 +234,7 @@ public class TargetedSweepMetricsTest {
         assertThat(metricsManager).hasTombstonesPutConservativeEqualTo(1 + 5);
         assertThat(metricsManager).hasAbortedWritesDeletedConservativeEquals(2 + 5);
         assertThat(metricsManager).hasSweepTimestampConservativeEqualTo(5L);
-        assertThat(metricsManager).hasEntriesReadInBatchConservativeEqualTo(20L, 15L);
+        assertThat(metricsManager).containsEntriesReadInBatchConservative(20L, 15L);
     }
 
     @Test
@@ -434,7 +434,7 @@ public class TargetedSweepMetricsTest {
         metrics.registerEntriesReadInBatch(CONS_ZERO, 10);
         metrics.registerEntriesReadInBatch(CONS_ONE, 15);
 
-        assertThat(metricsManager).hasEntriesReadInBatchConservativeEqualTo(5L, 10L, 15L);
+        assertThat(metricsManager).containsEntriesReadInBatchConservative(5L, 10L, 15L);
         assertThat(metricsManager).hasEntriesReadInBatchMeanConservativeEqualTo(10.0);
     }
 
@@ -445,8 +445,8 @@ public class TargetedSweepMetricsTest {
         metrics.registerEntriesReadInBatch(THOR_ZERO, 15);
         metrics.registerEntriesReadInBatch(THOR_ZERO, 25);
 
-        assertThat(metricsManager).hasEntriesReadInBatchConservativeEqualTo(5L, 10L);
-        assertThat(metricsManager).hasEntriesReadInBatchThoroughEqualTo(15L, 25L);
+        assertThat(metricsManager).containsEntriesReadInBatchConservative(5L, 10L);
+        assertThat(metricsManager).containsEntriesReadInBatchThorough(15L, 25L);
         assertThat(metricsManager).hasEntriesReadInBatchMeanConservativeEqualTo(7.5);
         assertThat(metricsManager).hasEntriesReadInBatchMeanThoroughEqualTo(20.0);
     }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
@@ -341,7 +341,7 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
 
     @Test
     public void sweepsOnlyThePrescribedNumberOfBatchesAtATime() {
-        for (int partition = 0; partition < readBatchSize + 1; partition++) {
+        for (int partition = 0; partition <= readBatchSize; partition++) {
             enqueueWriteCommitted(TABLE_CONS, LOW_TS + SweepQueueUtils.minTsForFinePartition(partition));
             enqueueWriteCommitted(TABLE_CONS, LOW_TS + SweepQueueUtils.minTsForFinePartition(partition) + 1);
         }
@@ -353,6 +353,11 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
                 TABLE_CONS, LOW_TS + SweepQueueUtils.minTsForFinePartition(readBatchSize - 1) + 1);
         assertTestValueEnqueuedAtGivenTimestampStillPresent(
                 TABLE_CONS, LOW_TS + SweepQueueUtils.minTsForFinePartition(readBatchSize));
+
+        assertThat(metricsManager).hasEntriesReadInBatchConservativeEqualTo(readBatchSize * 2);
+        assertThat(metricsManager).hasEntriesReadInBatchThoroughEqualTo();
+        assertThat(metricsManager).hasEntriesReadInBatchMeanConservativeEqualTo(readBatchSize * 2);
+        assertThat(metricsManager).hasEntriesReadInBatchMeanThoroughEqualTo(0.0);
     }
 
     @Test
@@ -468,6 +473,8 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
         assertThat(metricsManager).hasEntriesReadConservativeEqualTo(2 * readBatchSize + 2);
         assertThat(metricsManager).hasLastSweptTimestampConservativeEqualTo(
                 maxTsForFinePartition(permittedPartitions.get(2 * readBatchSize)));
+        assertThat(metricsManager).hasEntriesReadInBatchConservativeEqualTo(readBatchSize, readBatchSize, 2L);
+        assertThat(metricsManager).hasEntriesReadInBatchMeanConservativeEqualTo((2 * readBatchSize + 2) / 3.0);
 
         setTimelockTime(5000L);
         assertThat(metricsManager).hasMillisSinceLastSweptConservativeEqualTo(5000L - finalValueWallClockTime);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
@@ -354,8 +354,8 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
         assertTestValueEnqueuedAtGivenTimestampStillPresent(
                 TABLE_CONS, LOW_TS + SweepQueueUtils.minTsForFinePartition(readBatchSize));
 
-        assertThat(metricsManager).hasEntriesReadInBatchConservativeEqualTo(readBatchSize * 2);
-        assertThat(metricsManager).hasEntriesReadInBatchThoroughEqualTo();
+        assertThat(metricsManager).containsEntriesReadInBatchConservative(readBatchSize * 2);
+        assertThat(metricsManager).containsEntriesReadInBatchThorough();
         assertThat(metricsManager).hasEntriesReadInBatchMeanConservativeEqualTo(readBatchSize * 2);
         assertThat(metricsManager).hasEntriesReadInBatchMeanThoroughEqualTo(0.0);
     }
@@ -473,7 +473,7 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
         assertThat(metricsManager).hasEntriesReadConservativeEqualTo(2 * readBatchSize + 2);
         assertThat(metricsManager).hasLastSweptTimestampConservativeEqualTo(
                 maxTsForFinePartition(permittedPartitions.get(2 * readBatchSize)));
-        assertThat(metricsManager).hasEntriesReadInBatchConservativeEqualTo(readBatchSize, readBatchSize, 2L);
+        assertThat(metricsManager).containsEntriesReadInBatchConservative(readBatchSize, readBatchSize, 2L);
         assertThat(metricsManager).hasEntriesReadInBatchMeanConservativeEqualTo((2 * readBatchSize + 2) / 3.0);
 
         setTimelockTime(5000L);

--- a/changelog/@unreleased/pr-4128.v2.yml
+++ b/changelog/@unreleased/pr-4128.v2.yml
@@ -1,7 +1,6 @@
 type: improvement
 improvement:
-  description: Targeted sweep metrics now expose a histogram `batchSizeHistogram`
-    of the number of entries read in each iteration of targeted sweep, as well as
-    a gauge `batchSizeMean` that samples the mean of that histogram.
+  description: |
+    Targeted sweep metrics now expose a gauge `batchSizeMean` with the mean of the number of entries read in iterations of targeted sweep durinng a sliding time window of one hour.
   links:
   - https://github.com/palantir/atlasdb/pull/4128

--- a/changelog/@unreleased/pr-4128.v2.yml
+++ b/changelog/@unreleased/pr-4128.v2.yml
@@ -1,6 +1,5 @@
 type: improvement
 improvement:
-  description: |
-    Targeted sweep metrics now expose a gauge `batchSizeMean` with the mean of the number of entries read in iterations of targeted sweep durinng a sliding time window of one hour.
+  description: Targeted sweep metrics now expose a gauge `batchSizeMean` with the mean of the number of entries read in iterations of targeted sweep during a sliding time window of one hour.
   links:
   - https://github.com/palantir/atlasdb/pull/4128


### PR DESCRIPTION
**Goals (and why)**:
Metrics for entries read in iterations of targeted sweep

**Implementation Description (bullets)**:
Added some bookkeeping for number of entries before any filtering is performed to be consistent.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added some unit tests and a couple to TargetedSweeperTest

**Concerns (what feedback would you like?)**:
We are registering a histogram somewhat unnecessarily, this also results in locking twice per metrics collection cycle. Should be fine, but pointing out.

