### PR TITLE
[Timelock Partitioning] Part 14: Get rid of default value

### DIFF
--- a/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/CoalescingRequestConsumer.java
+++ b/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/CoalescingRequestConsumer.java
@@ -20,10 +20,6 @@ import java.util.Map;
 import java.util.Set;
 
 public interface CoalescingRequestConsumer<REQUEST> extends CoalescingRequestFunction<REQUEST, Void> {
-    @Override
-    default Void defaultValue() {
-        return null;
-    }
 
     @Override
     default Map<REQUEST, Void> apply(Set<REQUEST> input) {

--- a/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/CoalescingRequestFunction.java
+++ b/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/CoalescingRequestFunction.java
@@ -20,6 +20,5 @@ import java.util.Map;
 import java.util.Set;
 
 public interface CoalescingRequestFunction<REQUEST, RESPONSE> {
-    RESPONSE defaultValue();
     Map<REQUEST, RESPONSE> apply(Set<REQUEST> request);
 }

--- a/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/PostconditionFailedException.java
+++ b/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/PostconditionFailedException.java
@@ -16,23 +16,12 @@
 
 package com.palantir.atlasdb.autobatch;
 
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Supplier;
+public class PostconditionFailedException extends RuntimeException {
 
-import com.google.common.base.Preconditions;
+    public PostconditionFailedException(Class<? extends CoalescingRequestFunction> clazz) {
 
-public final class CoalescingRequestSupplier<T> implements CoalescingRequestFunction<Autobatchers.SupplierKey, T> {
+        super(clazz.getCanonicalName() + " has violated the autobatching coalescing invariant of an result entry "
+                + "existing for each request.");
 
-    private final Supplier<T> supplier;
-
-    public CoalescingRequestSupplier(Supplier<T> supplier) {
-        this.supplier = supplier;
-    }
-
-    @Override
-    public Map<Autobatchers.SupplierKey, T> apply(Set<Autobatchers.SupplierKey> request) {
-        Preconditions.checkArgument(request.size() == 1, "invalid request");
-        return Autobatchers.SupplierKey.wrap(supplier.get());
     }
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AcceptCoalescingFunction.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AcceptCoalescingFunction.java
@@ -29,15 +29,12 @@ import com.palantir.paxos.PaxosProposal;
 final class AcceptCoalescingFunction implements
         CoalescingRequestFunction<Map.Entry<Client, PaxosProposal>, BooleanPaxosResponse> {
 
+    private static final BooleanPaxosResponse FALSE_PAXOS_RESPONSE = new BooleanPaxosResponse(false);
+
     private final BatchPaxosAcceptor delegate;
 
     AcceptCoalescingFunction(BatchPaxosAcceptor delegate) {
         this.delegate = delegate;
-    }
-
-    @Override
-    public BooleanPaxosResponse defaultValue() {
-        return new BooleanPaxosResponse(false);
     }
 
     @Override
@@ -50,8 +47,9 @@ final class AcceptCoalescingFunction implements
                 .collectToMap();
 
         return KeyedStream.of(request)
-                .map(clientAndProposal -> results.get(
-                        WithSeq.of(clientAndProposal.getKey(), clientAndProposal.getValue().getValue().getRound())))
+                .map(clientAndProposal -> results.getOrDefault(
+                        WithSeq.of(clientAndProposal.getKey(), clientAndProposal.getValue().getValue().getRound()),
+                        FALSE_PAXOS_RESPONSE))
                 .collectToMap();
     }
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LearnCoalescingConsumer.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LearnCoalescingConsumer.java
@@ -36,11 +36,6 @@ final class LearnCoalescingConsumer implements CoalescingRequestFunction<Map.Ent
     }
 
     @Override
-    public PaxosResponse defaultValue() {
-        return new PaxosResponseImpl(false);
-    }
-
-    @Override
     public Map<Map.Entry<Client, PaxosValue>, PaxosResponse> apply(Set<Map.Entry<Client, PaxosValue>> request) {
         delegate.learn(ImmutableSetMultimap.copyOf(request));
         return Maps.toMap(request, $ -> SUCCESSFUL_RESPONSE);

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LearnedValuesSinceCoalescingFunction.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LearnedValuesSinceCoalescingFunction.java
@@ -43,11 +43,6 @@ final class LearnedValuesSinceCoalescingFunction
     }
 
     @Override
-    public PaxosUpdate defaultValue() {
-        return new PaxosUpdate(ImmutableList.of());
-    }
-
-    @Override
     public Map<WithSeq<Client>, PaxosUpdate> apply(Set<WithSeq<Client>> request) {
         Map<Client, Long> remoteRequest = request.stream()
                 .collect(toMap(WithSeq::value, WithSeq::seq, Math::min));

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PingCoalescingFunction.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PingCoalescingFunction.java
@@ -31,11 +31,6 @@ final class PingCoalescingFunction implements CoalescingRequestFunction<Client, 
     }
 
     @Override
-    public Boolean defaultValue() {
-        return false;
-    }
-
-    @Override
     public Map<Client, Boolean> apply(Set<Client> request) {
         Set<Client> ping = batchPingableLeader.ping(request);
         return Maps.toMap(request, ping::contains);

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosQuorumCheckingCoalescingFunctionTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosQuorumCheckingCoalescingFunctionTests.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -134,20 +133,10 @@ public class PaxosQuorumCheckingCoalescingFunctionTests {
 
     private static CoalescingRequestFunction<Long, PaxosLong> functionFor(Map.Entry<Long, Long>... mappings) {
         Map<Long, Long> function = ImmutableMap.copyOf(ImmutableList.copyOf(mappings));
-        return new CoalescingRequestFunction<Long, PaxosLong>() {
-            @Override
-            public PaxosLong defaultValue() {
-                throw new AssertionError("should never get here");
-            }
-
-            @Override
-            public Map<Long, PaxosLong> apply(Set<Long> request) {
-                return KeyedStream.stream(function)
-                        .filterKeys(request::contains)
-                        .<PaxosLong>map(ImmutablePaxosLong::of)
-                        .collectToMap();
-            }
-        };
+        return request -> KeyedStream.stream(function)
+                .filterKeys(request::contains)
+                .<PaxosLong>map(ImmutablePaxosLong::of)
+                .collectToMap();
     }
 
     private static PaxosResponses<PaxosLong> responsesFor(Long... longs) {


### PR DESCRIPTION
**Goals (and why)**:
Semantics of the `CoalescingFunction` were too confusing. Removing it to simplify code. 

Came about as part of #4112.
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
