### PR TITLE
[Timelock Partitioning] Part 15: Swap arguments of `WithSeq.of`

### DIFF
--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AcceptCoalescingFunction.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AcceptCoalescingFunction.java
@@ -45,13 +45,13 @@ final class AcceptCoalescingFunction implements
             Set<Map.Entry<Client, PaxosProposal>> request) {
         SetMultimap<Client, PaxosProposal> requests = ImmutableSetMultimap.copyOf(request);
         Map<WithSeq<Client>, BooleanPaxosResponse> results = KeyedStream.stream(delegate.accept(requests))
-                .mapKeys((client, booleanResponseWithSeq) -> WithSeq.of(booleanResponseWithSeq.seq(), client))
+                .mapKeys((client, booleanResponseWithSeq) -> WithSeq.of(client, booleanResponseWithSeq.seq()))
                 .map(WithSeq::value)
                 .collectToMap();
 
         return KeyedStream.of(request)
                 .map(clientAndProposal -> results.get(
-                        WithSeq.of(clientAndProposal.getValue().getValue().getRound(), clientAndProposal.getKey())))
+                        WithSeq.of(clientAndProposal.getKey(), clientAndProposal.getValue().getValue().getRound())))
                 .collectToMap();
     }
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AcceptorCacheImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AcceptorCacheImpl.java
@@ -70,15 +70,15 @@ public class AcceptorCacheImpl implements AcceptorCache {
                 WithSeq<Long> clientLatestWithTs = clientToTimeAndSeq.get(client);
 
                 if (clientLatestWithTs == null) {
-                    clientToTimeAndSeq.put(client, WithSeq.of(incomingSequenceNumber, nextTimestamp));
+                    clientToTimeAndSeq.put(client, WithSeq.of(nextTimestamp, incomingSequenceNumber));
                     clientsByLatestTimestamp.put(nextTimestamp, clientAndSeq);
                     updated.set(true);
                 } else if (incomingSequenceNumber > clientLatestWithTs.seq()) {
-                    clientToTimeAndSeq.put(client, WithSeq.of(incomingSequenceNumber, nextTimestamp));
+                    clientToTimeAndSeq.put(client, WithSeq.of(nextTimestamp, incomingSequenceNumber));
                     clientsByLatestTimestamp.put(nextTimestamp, clientAndSeq);
                     clientsByLatestTimestamp.remove(
                             clientLatestWithTs.value(),
-                            WithSeq.of(clientLatestWithTs.seq(), client));
+                            WithSeq.of(client, clientLatestWithTs.seq()));
                     updated.set(true);
                 }
             });

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AutobatchingPaxosAcceptorNetworkClientFactory.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AutobatchingPaxosAcceptorNetworkClientFactory.java
@@ -96,7 +96,7 @@ public class AutobatchingPaxosAcceptorNetworkClientFactory implements Closeable 
         @Override
         public PaxosResponses<PaxosPromise> prepare(long seq, PaxosProposalId proposalId) {
             try {
-                return prepare.apply(Maps.immutableEntry(client, WithSeq.of(seq, proposalId))).get();
+                return prepare.apply(Maps.immutableEntry(client, WithSeq.of(proposalId, seq))).get();
             } catch (ExecutionException | InterruptedException e) {
                 throw AutobatcherExecutionExceptions.handleAutobatcherExceptions(e);
             }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AutobatchingPaxosLearnerNetworkClientFactory.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AutobatchingPaxosLearnerNetworkClientFactory.java
@@ -111,7 +111,7 @@ public class AutobatchingPaxosLearnerNetworkClientFactory implements Closeable {
                 long seq,
                 Function<Optional<PaxosValue>, T> mapper) {
             try {
-                return getLearnedValues.apply(WithSeq.of(seq, client)).get().map(c -> mapper.apply(c.get()));
+                return getLearnedValues.apply(WithSeq.of(client, seq)).get().map(c -> mapper.apply(c.get()));
             } catch (ExecutionException | InterruptedException e) {
                 throw AutobatcherExecutionExceptions.handleAutobatcherExceptions(e);
             }
@@ -120,7 +120,7 @@ public class AutobatchingPaxosLearnerNetworkClientFactory implements Closeable {
         @Override
         public PaxosResponses<PaxosUpdate> getLearnedValuesSince(long seq) {
             try {
-                return getLearnedValuesSince.apply(WithSeq.of(seq, client)).get();
+                return getLearnedValuesSince.apply(WithSeq.of(client, seq)).get();
             } catch (ExecutionException | InterruptedException e) {
                 throw AutobatcherExecutionExceptions.handleAutobatcherExceptions(e);
             }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosAcceptorResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosAcceptorResource.java
@@ -60,7 +60,7 @@ public class BatchPaxosAcceptorResource implements BatchPaxosAcceptor {
                 .map((client, paxosProposalIdWithSeq) -> {
                     PaxosPromise promise = paxosComponents.acceptor(client)
                             .prepare(paxosProposalIdWithSeq.seq(), paxosProposalIdWithSeq.value());
-                    return WithSeq.of(paxosProposalIdWithSeq.seq(), promise);
+                    return WithSeq.of(promise, paxosProposalIdWithSeq.seq());
                 })
                 .collectToSetMultimap();
         primeCache(promiseWithSeqRequestsByClient.keySet());
@@ -75,7 +75,7 @@ public class BatchPaxosAcceptorResource implements BatchPaxosAcceptor {
                     long seq = paxosProposal.getValue().getRound();
                     BooleanPaxosResponse ack = paxosComponents.acceptor(client)
                             .accept(seq, paxosProposal);
-                    return WithSeq.of(seq, ack);
+                    return WithSeq.of(ack, seq);
                 })
                 .collectToSetMultimap();
         primeCache(proposalRequestsByClient.keySet());
@@ -116,7 +116,7 @@ public class BatchPaxosAcceptorResource implements BatchPaxosAcceptor {
         Set<WithSeq<Client>> latestSequences = KeyedStream.of(clients)
                 .map(paxosComponents::acceptor)
                 .map(PaxosAcceptor::getLatestSequencePreparedOrAccepted)
-                .map((client, latestSeq) -> WithSeq.of(latestSeq, client))
+                .map((client, latestSeq) -> WithSeq.of(client, latestSeq))
                 .values()
                 .collect(toSet());
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LearnedValuesCoalescingFunction.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LearnedValuesCoalescingFunction.java
@@ -44,7 +44,7 @@ final class LearnedValuesCoalescingFunction implements
     public Map<WithSeq<Client>, PaxosContainer<Optional<PaxosValue>>> apply(Set<WithSeq<Client>> request) {
         SetMultimap<Client, PaxosValue> learnedValues = delegate.getLearnedValues(request);
         return KeyedStream.stream(learnedValues)
-                .mapKeys((client, paxosValue) -> WithSeq.of(paxosValue.getRound(), client))
+                .mapKeys((client, paxosValue) -> WithSeq.of(client, paxosValue.getRound()))
                 .map(Optional::ofNullable)
                 .map(PaxosContainer::of)
                 .collectToMap();

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PrepareCoalescingFunction.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PrepareCoalescingFunction.java
@@ -48,7 +48,7 @@ final class PrepareCoalescingFunction implements
 
         return KeyedStream.stream(delegate.prepare(requests))
                 .mapKeys((client, paxosPromiseWithSeq) -> Maps.immutableEntry(client,
-                        WithSeq.of(paxosPromiseWithSeq.seq(), paxosPromiseWithSeq.value().getPromisedId())))
+                        WithSeq.of(paxosPromiseWithSeq.value().getPromisedId(), paxosPromiseWithSeq.seq())))
                 .map(WithSeq::value)
                 .collectToMap();
     }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/WithSeq.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/WithSeq.java
@@ -32,7 +32,7 @@ public interface WithSeq<T> {
     @Value.Parameter
     T value();
 
-    static <T> WithSeq<T> of(long seq, T value) {
+    static <T> WithSeq<T> of(T value, long seq) {
         return ImmutableWithSeq.of(seq, value);
     }
 

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/AcceptCoalescingFunctionTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/AcceptCoalescingFunctionTests.java
@@ -85,10 +85,10 @@ public class AcceptCoalescingFunctionTests {
     }
 
     private static WithSeq<BooleanPaxosResponse> success(PaxosProposal proposal) {
-        return WithSeq.of(proposal.getValue().getRound(), SUCCESS);
+        return WithSeq.of(SUCCESS, proposal.getValue().getRound());
     }
 
     private static WithSeq<BooleanPaxosResponse> failure(PaxosProposal proposal) {
-        return WithSeq.of(proposal.getValue().getRound(), FAILURE);
+        return WithSeq.of(FAILURE, proposal.getValue().getRound());
     }
 }

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/AcceptorCacheImplTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/AcceptorCacheImplTests.java
@@ -74,14 +74,14 @@ public class AcceptorCacheImplTests {
         AcceptorCacheDigest digest = cache.getAllUpdates();
 
         cache.updateSequenceNumbers(ImmutableSet.of(
-                WithSeq.of(10L, Client.of("client1")),
-                WithSeq.of(3L, Client.of("client2"))));
+                WithSeq.of(Client.of("client1"), 10L),
+                WithSeq.of(Client.of("client2"), 3L)));
 
         AcceptorCacheDigest secondDigest = cache.updatesSinceCacheKey(digest.newCacheKey()).get();
         assertThat(secondDigest.updates())
                 .containsOnly(entry(Client.of("client1"), 10L));
 
-        cache.updateSequenceNumbers(ImmutableSet.of(WithSeq.of(5L, Client.of("client3"))));
+        cache.updateSequenceNumbers(ImmutableSet.of(WithSeq.of(Client.of("client3"), 5L)));
 
         assertThat(cache.updatesSinceCacheKey(secondDigest.newCacheKey()))
                 .as("there are no actionable changes, cache is the same")
@@ -98,10 +98,10 @@ public class AcceptorCacheImplTests {
 
         AcceptorCacheKey initialCacheKey = cache.getAllUpdates().newCacheKey();
 
-        cache.updateSequenceNumbers(ImmutableSet.of(WithSeq.of(20L, Client.of("client1"))));
+        cache.updateSequenceNumbers(ImmutableSet.of(WithSeq.of(Client.of("client1"), 20L)));
         AcceptorCacheKey cacheKeyAfterFirstUpdate = cache.getAllUpdates().newCacheKey();
 
-        cache.updateSequenceNumbers(ImmutableSet.of(WithSeq.of(25L, Client.of("client4"))));
+        cache.updateSequenceNumbers(ImmutableSet.of(WithSeq.of(Client.of("client4"), 25L)));
         AcceptorCacheKey cacheKeyAfterSecondUpdate = cache.getAllUpdates().newCacheKey();
 
         assertThat(cache.updatesSinceCacheKey(initialCacheKey))
@@ -124,8 +124,8 @@ public class AcceptorCacheImplTests {
         AcceptorCache cache = cache(ImmutableMap.of());
 
         AcceptorCacheKey cacheKey = cache.getAllUpdates().newCacheKey();
-        cache.updateSequenceNumbers(ImmutableSet.of(WithSeq.of(20L, Client.of("client1"))));
-        cache.updateSequenceNumbers(ImmutableSet.of(WithSeq.of(25L, Client.of("client4"))));
+        cache.updateSequenceNumbers(ImmutableSet.of(WithSeq.of(Client.of("client1"), 20L)));
+        cache.updateSequenceNumbers(ImmutableSet.of(WithSeq.of(Client.of("client4"), 25L)));
 
         Map<Client, Long> diffAfterFirstUpdate = ImmutableMap.<Client, Long>builder()
                 .put(Client.of("client1"), 20L)
@@ -138,8 +138,8 @@ public class AcceptorCacheImplTests {
                 .contains(diffAfterFirstUpdate);
 
         cache.updateSequenceNumbers(ImmutableSet.of(
-                WithSeq.of(30L, Client.of("client4")),
-                WithSeq.of(50L, Client.of("client3"))));
+                WithSeq.of(Client.of("client4"), 30L),
+                WithSeq.of(Client.of("client3"), 50L)));
 
         Map<Client, Long> diffAfterSecondUpdate = ImmutableMap.<Client, Long>builder()
                 .put(Client.of("client1"), 20L)
@@ -157,7 +157,7 @@ public class AcceptorCacheImplTests {
         AcceptorCacheImpl acceptorCache = new AcceptorCacheImpl();
 
         Set<WithSeq<Client>> clientsAndSeq = latestSequencesForClients.entrySet().stream()
-                .map(clientAndSeq -> WithSeq.of(clientAndSeq.getValue(), clientAndSeq.getKey()))
+                .map(clientAndSeq -> WithSeq.of(clientAndSeq.getKey(), clientAndSeq.getValue()))
                 .collect(Collectors.toSet());
         acceptorCache.updateSequenceNumbers(clientsAndSeq);
         return acceptorCache;

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosAcceptorResourceTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosAcceptorResourceTests.java
@@ -76,22 +76,22 @@ public class BatchPaxosAcceptorResourceTests {
 
         SetMultimap<Client, WithSeq<PaxosProposalId>> request = ImmutableSetMultimap
                 .<Client, WithSeq<PaxosProposalId>>builder()
-                .put(CLIENT_1, WithSeq.of(1, PROPOSAL_ID_1))
-                .putAll(CLIENT_2, WithSeq.of(1, PROPOSAL_ID_1), WithSeq.of(2, PROPOSAL_ID_2))
+                .put(CLIENT_1, WithSeq.of(PROPOSAL_ID_1, 1))
+                .putAll(CLIENT_2, WithSeq.of(PROPOSAL_ID_1, 1), WithSeq.of(PROPOSAL_ID_2, 2))
                 .build();
 
         SetMultimap<Client, WithSeq<PaxosPromise>> expected = ImmutableSetMultimap
                 .<Client, WithSeq<PaxosPromise>>builder()
-                .put(CLIENT_1, WithSeq.of(1, promise(PROPOSAL_ID_1)))
-                .putAll(CLIENT_2, WithSeq.of(1, promise(PROPOSAL_ID_1)), WithSeq.of(2, promise(PROPOSAL_ID_2)))
+                .put(CLIENT_1, WithSeq.of(promise(PROPOSAL_ID_1), 1))
+                .putAll(CLIENT_2, WithSeq.of(promise(PROPOSAL_ID_1), 1), WithSeq.of(promise(PROPOSAL_ID_2), 2))
                 .build();
 
         assertThat(resource.prepare(request))
                 .isEqualTo(expected);
 
         verify(cache).updateSequenceNumbers(ImmutableSet.of(
-                WithSeq.of(1, CLIENT_1),
-                WithSeq.of(2, CLIENT_2)));
+                WithSeq.of(CLIENT_1, 1),
+                WithSeq.of(CLIENT_2, 2)));
     }
 
     @Test
@@ -115,17 +115,17 @@ public class BatchPaxosAcceptorResourceTests {
 
         SetMultimap<Client, WithSeq<BooleanPaxosResponse>> expected = ImmutableSetMultimap
                 .<Client, WithSeq<BooleanPaxosResponse>>builder()
-                .put(CLIENT_1, WithSeq.of(1, success()))
-                .put(CLIENT_2, WithSeq.of(1, success()))
-                .put(CLIENT_2, WithSeq.of(2, success()))
+                .put(CLIENT_1, WithSeq.of(success(), 1))
+                .put(CLIENT_2, WithSeq.of(success(), 1))
+                .put(CLIENT_2, WithSeq.of(success(), 2))
                 .build();
 
         assertThat(resource.accept(request))
                 .isEqualTo(expected);
 
         verify(cache).updateSequenceNumbers(ImmutableSet.of(
-                WithSeq.of(1, CLIENT_1),
-                WithSeq.of(2, CLIENT_2)));
+                WithSeq.of(CLIENT_1, 1),
+                WithSeq.of(CLIENT_2, 2)));
     }
 
     @Test
@@ -167,8 +167,8 @@ public class BatchPaxosAcceptorResourceTests {
                 .isEqualTo(digest);
 
         verify(cache).updateSequenceNumbers(ImmutableSet.of(
-                WithSeq.of(1, CLIENT_1),
-                WithSeq.of(2, CLIENT_2)));
+                WithSeq.of(CLIENT_1, 1),
+                WithSeq.of(CLIENT_2, 2)));
     }
 
     @Test
@@ -192,8 +192,8 @@ public class BatchPaxosAcceptorResourceTests {
                 .isEqualTo(digest);
 
         verify(cache).updateSequenceNumbers(ImmutableSet.of(
-                WithSeq.of(1, CLIENT_1),
-                WithSeq.of(2, CLIENT_2)));
+                WithSeq.of(CLIENT_1, 1),
+                WithSeq.of(CLIENT_2, 2)));
     }
 
     private static PaxosProposalId proposalId() {

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosLearnerResourceTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosLearnerResourceTests.java
@@ -85,9 +85,9 @@ public class BatchPaxosLearnerResourceTests {
                 .build();
 
         Set<WithSeq<Client>> request = ImmutableSet.of(
-                WithSeq.of(1, CLIENT_1),
-                WithSeq.of(1, CLIENT_2),
-                WithSeq.of(2, CLIENT_2));
+                WithSeq.of(CLIENT_1, 1),
+                WithSeq.of(CLIENT_2, 1),
+                WithSeq.of(CLIENT_2, 2));
 
         assertThat(resource.getLearnedValues(request)).isEqualTo(expected);
     }

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LearnedValuesCoalescingFunctionTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LearnedValuesCoalescingFunctionTests.java
@@ -47,9 +47,9 @@ public class LearnedValuesCoalescingFunctionTests {
     @Test
     public void canProcessBatch() {
         Set<WithSeq<Client>> remoteRequest = ImmutableSet.of(
-                WithSeq.of(10, CLIENT_1),
-                WithSeq.of(12, CLIENT_1),
-                WithSeq.of(10, CLIENT_2));
+                WithSeq.of(CLIENT_1, 10),
+                WithSeq.of(CLIENT_1, 12),
+                WithSeq.of(CLIENT_2, 10));
 
         PaxosValue paxosValue1 = paxosValue(10);
         PaxosValue paxosValue2 = paxosValue(12);
@@ -66,9 +66,9 @@ public class LearnedValuesCoalescingFunctionTests {
         Map<WithSeq<Client>, PaxosContainer<Optional<PaxosValue>>> results = function.apply(remoteRequest);
 
         assertThat(results)
-                .containsEntry(WithSeq.of(10, CLIENT_1), asResult(paxosValue1))
-                .containsEntry(WithSeq.of(12, CLIENT_1), asResult(paxosValue2))
-                .containsEntry(WithSeq.of(10, CLIENT_2), asResult(paxosValue1));
+                .containsEntry(WithSeq.of(CLIENT_1, 10), asResult(paxosValue1))
+                .containsEntry(WithSeq.of(CLIENT_1, 12), asResult(paxosValue2))
+                .containsEntry(WithSeq.of(CLIENT_2, 10), asResult(paxosValue1));
     }
 
     private static PaxosValue paxosValue(long round) {

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LearnedValuesSinceCoalescingFunctionTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LearnedValuesSinceCoalescingFunctionTests.java
@@ -56,12 +56,12 @@ public class LearnedValuesSinceCoalescingFunctionTests {
         PaxosValue paxosValue4 = paxosValue(25);
 
         Set<WithSeq<Client>> request = ImmutableSet.of(
-                WithSeq.of(10, CLIENT_1),
-                WithSeq.of(12, CLIENT_1),
-                WithSeq.of(14, CLIENT_1),
-                WithSeq.of(15, CLIENT_2),
-                WithSeq.of(23, CLIENT_2),
-                WithSeq.of(1, CLIENT_3));
+                WithSeq.of(CLIENT_1, 10),
+                WithSeq.of(CLIENT_1, 12),
+                WithSeq.of(CLIENT_1, 14),
+                WithSeq.of(CLIENT_2, 15),
+                WithSeq.of(CLIENT_2, 23),
+                WithSeq.of(CLIENT_3, 1));
 
         // we pick the lowest sequence number from the set per client
         Map<Client, Long> minimumRequest = ImmutableMap.<Client, Long>builder()
@@ -86,11 +86,11 @@ public class LearnedValuesSinceCoalescingFunctionTests {
 
         SetMultimap<WithSeq<Client>, PaxosValue> expectedResult =
                 ImmutableSetMultimap.<WithSeq<Client>, PaxosValue>builder()
-                        .putAll(WithSeq.of(10, CLIENT_1), paxosValue1, paxosValue2, paxosValue4)
-                        .putAll(WithSeq.of(12, CLIENT_1), paxosValue2, paxosValue4)
-                        .putAll(WithSeq.of(14, CLIENT_1), paxosValue4)
-                        .putAll(WithSeq.of(15, CLIENT_2), paxosValue3, paxosValue4)
-                        .putAll(WithSeq.of(23, CLIENT_2), paxosValue4)
+                        .putAll(WithSeq.of(CLIENT_1, 10), paxosValue1, paxosValue2, paxosValue4)
+                        .putAll(WithSeq.of(CLIENT_1, 12), paxosValue2, paxosValue4)
+                        .putAll(WithSeq.of(CLIENT_1, 14), paxosValue4)
+                        .putAll(WithSeq.of(CLIENT_2, 15), paxosValue3, paxosValue4)
+                        .putAll(WithSeq.of(CLIENT_2, 23), paxosValue4)
                         .build();
 
         assertThat(asMultimap).isEqualTo(expectedResult);
@@ -98,7 +98,7 @@ public class LearnedValuesSinceCoalescingFunctionTests {
         assertThat(asMultimap.keySet())
                 .as("despite requesting learnt values for client-3, we still learn nothing, if remote server hasn't "
                         + "learnt anything for that client")
-                .doesNotContain(WithSeq.of(1, CLIENT_3));
+                .doesNotContain(WithSeq.of(CLIENT_3, 1));
     }
 
     private static PaxosValue paxosValue(long round) {

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PrepareCoalescingFunctionTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PrepareCoalescingFunctionTests.java
@@ -46,9 +46,9 @@ public class PrepareCoalescingFunctionTests {
 
     @Test
     public void canReturnBatch() {
-        WithSeq<PaxosProposalId> client1seq1Id = WithSeq.of(1, proposalId());
-        WithSeq<PaxosProposalId> client1seq2Id = WithSeq.of(2, proposalId());
-        WithSeq<PaxosProposalId> client2seq1Id = WithSeq.of(1, proposalId());
+        WithSeq<PaxosProposalId> client1seq1Id = WithSeq.of(proposalId(), 1);
+        WithSeq<PaxosProposalId> client1seq2Id = WithSeq.of(proposalId(), 2);
+        WithSeq<PaxosProposalId> client2seq1Id = WithSeq.of(proposalId(), 1);
 
         SetMultimap<Client, WithSeq<PaxosProposalId>> requests =
                 ImmutableSetMultimap.<Client, WithSeq<PaxosProposalId>>builder()
@@ -85,6 +85,6 @@ public class PrepareCoalescingFunctionTests {
     }
 
     private static <T, U> WithSeq<U> map(WithSeq<T> container, Function<T, U> mapper) {
-        return WithSeq.of(container.seq(), mapper.apply(container.value()));
+        return WithSeq.of(mapper.apply(container.value()), container.seq());
     }
 }


### PR DESCRIPTION
**Goals (and why)**:
As part of #4112 just swap the arguments of `WithSeq`, makes code a bit more readable especially in tests.

**Concerns (what feedback would you like?)**:
None, purely a refactor.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
