### PR TITLE
[Timelock Partitioning] Part 16: Reuse paxos quorum checker for pingable leader get uuid

### DIFF
--- a/leader-election-impl/build.gradle
+++ b/leader-election-impl/build.gradle
@@ -12,6 +12,8 @@ dependencies {
   compile group: "commons-io", name: "commons-io"
   compile group: 'com.palantir.safe-logging', name: 'safe-logging'
 
+  implementation group: 'com.palantir.common', name: 'streams'
+
   processor group: 'org.immutables', name: 'value'
 
   testCompile(group: "org.jmock", name: "jmock", version: libVersions.jmock) {

--- a/leader-election-impl/src/main/java/com/palantir/paxos/InProgressResponseState.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/InProgressResponseState.java
@@ -1,0 +1,29 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.paxos;
+
+import java.util.Map;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface InProgressResponseState<SERVICE, T> {
+    Map<SERVICE, T> responses();
+    int successes();
+    int failures();
+    int totalRequests();
+}

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosQuorumChecker.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosQuorumChecker.java
@@ -164,8 +164,8 @@ public final class PaxosQuorumChecker {
 
     /**
      * Collects a list of responses from remote services.
-     * This method may short-circuit if a quorum can no longer be obtained (depending on the
-     * shortcircuitIfQuorumImpossible parameter) and cancels pending requests once a quorum has been obtained.
+     * This method may short-circuit depending on the {@code shouldSkipNextRequest} predicate parameter and cancels
+     * pending requests once the predicate is satisfied.
      *
      * @param remotes a list of endpoints to make the remote call on
      * @param request the request to make on each of the remote endpoints

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosResponsesWithRemote.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosResponsesWithRemote.java
@@ -1,0 +1,81 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.paxos;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import org.immutables.value.Value;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.common.streams.KeyedStream;
+
+@Value.Immutable
+public abstract class PaxosResponsesWithRemote<S, T extends PaxosResponse> {
+
+    abstract int quorum();
+    public abstract Map<S, T> responses();
+
+    public static <S, T extends PaxosResponse> PaxosResponsesWithRemote<S, T> of(int quorum, Map<S, T> responses) {
+        return ImmutablePaxosResponsesWithRemote.<S, T>builder()
+                .quorum(quorum)
+                .putAllResponses(responses)
+                .build();
+    }
+
+    public KeyedStream<S, T> stream() {
+        return KeyedStream.stream(responses());
+    }
+
+    public <U extends PaxosResponse> PaxosResponsesWithRemote<S, U> map(Function<T, U> mapper) {
+        return of(quorum(), KeyedStream.stream(responses()).map(mapper).collectToMap());
+    }
+
+    @Value.Derived
+    int successes() {
+        return (int) stream().filter(PaxosResponse::isSuccessful).entries().count();
+    }
+
+    @Value.Derived
+    public boolean hasQuorum() {
+        return successes() >= quorum();
+    }
+
+    @Value.Derived
+    public int numberOfResponses() {
+        return responses().size();
+    }
+
+    @Value.Derived
+    PaxosQuorumStatus getQuorumResult() {
+        if (hasQuorum()) {
+            return PaxosQuorumStatus.QUORUM_AGREED;
+        } else if (thereWereDisagreements()) {
+            return PaxosQuorumStatus.SOME_DISAGREED;
+        }
+        return PaxosQuorumStatus.NO_QUORUM;
+    }
+
+    @Value.Derived
+    protected boolean thereWereDisagreements() {
+        return stream().entries().anyMatch(entry -> !entry.getValue().isSuccessful());
+    }
+
+    public final PaxosResponses<T> withoutRemotes() {
+        return PaxosResponses.of(quorum(), ImmutableList.copyOf(responses().values()));
+    }
+}

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderAcceptorNetworkClient.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderAcceptorNetworkClient.java
@@ -44,7 +44,7 @@ public class SingleLeaderAcceptorNetworkClient implements PaxosAcceptorNetworkCl
                 acceptor -> acceptor.prepare(seq, proposalId),
                 quorumSize,
                 executors,
-                PaxosQuorumChecker.DEFAULT_REMOTE_REQUESTS_TIMEOUT);
+                PaxosQuorumChecker.DEFAULT_REMOTE_REQUESTS_TIMEOUT).withoutRemotes();
     }
 
     @Override
@@ -54,16 +54,16 @@ public class SingleLeaderAcceptorNetworkClient implements PaxosAcceptorNetworkCl
                 acceptor -> acceptor.accept(seq, proposal),
                 quorumSize,
                 executors,
-                PaxosQuorumChecker.DEFAULT_REMOTE_REQUESTS_TIMEOUT);
+                PaxosQuorumChecker.DEFAULT_REMOTE_REQUESTS_TIMEOUT).withoutRemotes();
     }
 
     @Override
     public PaxosResponses<PaxosLong> getLatestSequencePreparedOrAccepted() {
-        return PaxosQuorumChecker.collectQuorumResponses(
+        return PaxosQuorumChecker.<PaxosAcceptor, PaxosLong>collectQuorumResponses(
                 acceptors,
                 acceptor -> ImmutablePaxosLong.of(acceptor.getLatestSequencePreparedOrAccepted()),
                 quorumSize,
                 executors,
-                PaxosQuorumChecker.DEFAULT_REMOTE_REQUESTS_TIMEOUT);
+                PaxosQuorumChecker.DEFAULT_REMOTE_REQUESTS_TIMEOUT).withoutRemotes();
     }
 }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderLearnerNetworkClient.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderLearnerNetworkClient.java
@@ -84,7 +84,7 @@ public class SingleLeaderLearnerNetworkClient implements PaxosLearnerNetworkClie
                 learner -> mapper.apply(Optional.ofNullable(learner.getLearnedValue(seq))),
                 quorumSize,
                 executors,
-                PaxosQuorumChecker.DEFAULT_REMOTE_REQUESTS_TIMEOUT);
+                PaxosQuorumChecker.DEFAULT_REMOTE_REQUESTS_TIMEOUT).withoutRemotes();
     }
 
     @Override
@@ -94,6 +94,6 @@ public class SingleLeaderLearnerNetworkClient implements PaxosLearnerNetworkClie
                 learner -> new PaxosUpdate(ImmutableList.copyOf(learner.getLearnedValuesSince(seq))),
                 quorumSize,
                 executors,
-                PaxosQuorumChecker.DEFAULT_REMOTE_REQUESTS_TIMEOUT);
+                PaxosQuorumChecker.DEFAULT_REMOTE_REQUESTS_TIMEOUT).withoutRemotes();
     }
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStore.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStore.java
@@ -106,12 +106,12 @@ public class PaxosTimestampBoundStore implements TimestampBoundStore {
      * @throws ServiceNotAvailableException if we couldn't contact a quorum
      */
     private List<PaxosLong> getLatestSequenceNumbersFromAcceptors() {
-        PaxosResponses<PaxosLong> responses = PaxosQuorumChecker.collectQuorumResponses(
+        PaxosResponses<PaxosLong> responses = PaxosQuorumChecker.<PaxosAcceptor, PaxosLong>collectQuorumResponses(
                 acceptors,
                 acceptor -> ImmutablePaxosLong.of(acceptor.getLatestSequencePreparedOrAccepted()),
                 proposer.getQuorumSize(),
                 executor,
-                PaxosQuorumChecker.DEFAULT_REMOTE_REQUESTS_TIMEOUT);
+                PaxosQuorumChecker.DEFAULT_REMOTE_REQUESTS_TIMEOUT).withoutRemotes();
         if (!responses.hasQuorum()) {
             throw new ServiceNotAvailableException("could not get a quorum");
         }
@@ -212,7 +212,7 @@ public class PaxosTimestampBoundStore implements TimestampBoundStore {
                 learner -> getLearnedValue(seq, learner),
                 QUORUM_OF_ONE,
                 executor,
-                PaxosQuorumChecker.DEFAULT_REMOTE_REQUESTS_TIMEOUT);
+                PaxosQuorumChecker.DEFAULT_REMOTE_REQUESTS_TIMEOUT).withoutRemotes();
         return Optional.ofNullable(Iterables.getFirst(responses.get(), null))
                 .map(PaxosLong::getValue)
                 .map(value -> ImmutableSequenceAndBound.of(seq, value));


### PR DESCRIPTION
**Goals (and why)**:
Ran into the same problem with `PaxosAcceptor` and `PaxosLearner`. Have to defer creating threads to communicate to other nodes till *after* we've accumulated a batch of requests.

**Implementation Description (bullets)**:
`PaxosQuorumChecker` is close, but turns out we have different exit constraints. Instead we modify `PaxosQuorumChecker` to take in a custom exit condition, with everything else defined in terms of new exit condition.

Alternatively, I could *copy* the entire impl of the `getUuid` code from `PaxosLeaderElectionService`, but it does mean that any bugs we have fixed in `PaxosQuorumChecker` never get fixed in this similar-but-different piece of code. So it makes sense to unify it.

Trying to avoid more generics, as it's quite hairy so far. 

**Testing (What was existing testing like?  What have you done to improve it?)**:
This is a refactor, should be able to rely on existing tests for this.

**Where should we start reviewing?**:
* `PaxosResponseAccumulator`
* `PaxosLeaderElectionService`
* `PaxosQuorumChecker`

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
