### PR TITLE
Do not log byte arrays

### DIFF
--- a/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderLearnerNetworkClient.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderLearnerNetworkClient.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.io.BaseEncoding;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 
@@ -64,7 +65,9 @@ public class SingleLeaderLearnerNetworkClient implements PaxosLearnerNetworkClie
                     learner.learn(seq, value);
                 } catch (Throwable e) {
                     log.warn("Failed to teach learner the value {} at sequence {}",
-                            UnsafeArg.of("value", value.data),
+                            UnsafeArg.of("value", Optional.ofNullable(value.data)
+                                    .map(bytes -> BaseEncoding.base16().encode(bytes))
+                                    .orElse(null)),
                             SafeArg.of("sequence", seq),
                             e);
                 }


### PR DESCRIPTION
**Goals (and why)**:
Noticed we were logging byte arrays while testing something else