### PR TITLE
[Timelock Partitioning] Part 19: `AutobatchingLeaderPinger`

### DIFF
--- a/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderPinger.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderPinger.java
@@ -79,6 +79,7 @@ public class SingleLeaderPinger implements LeaderPinger {
                     TimeUnit.MILLISECONDS);
             return getAndRecordLeaderPingResult(pingFuture);
         } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
             return false;
         }
     }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AutobatchingPingableLeaderFactory.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AutobatchingPingableLeaderFactory.java
@@ -17,75 +17,168 @@
 package com.palantir.atlasdb.timelock.paxos;
 
 import java.io.Closeable;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
 import com.palantir.atlasdb.autobatch.Autobatchers;
-import com.palantir.atlasdb.autobatch.Autobatchers.SupplierKey;
 import com.palantir.atlasdb.autobatch.DisruptorAutobatcher;
-import com.palantir.leader.PingableLeader;
+import com.palantir.common.streams.KeyedStream;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.paxos.LeaderPinger;
 
 public class AutobatchingPingableLeaderFactory implements Closeable {
 
-    private final DisruptorAutobatcher<Client, Boolean> pingAutobatcher;
-    private final DisruptorAutobatcher<SupplierKey, UUID> uuidAutobatcher;
+    private static final Logger log = LoggerFactory.getLogger(AutobatchingPingableLeaderFactory.class);
 
-    public AutobatchingPingableLeaderFactory(
-            DisruptorAutobatcher<Client, Boolean> pingAutobatcher,
-            DisruptorAutobatcher<SupplierKey, UUID> uuidAutobatcher) {
-        this.pingAutobatcher = pingAutobatcher;
-        this.uuidAutobatcher = uuidAutobatcher;
+    private final Collection<? extends Closeable> closeables;
+    private final DisruptorAutobatcher<UUID, Optional<ClientAwarePingableLeader>> uuidToRemoteAutobatcher;
+    private final Map<ClientAwarePingableLeader, ExecutorService> executors;
+    private final Duration leaderPingResponseWait;
+
+    private AutobatchingPingableLeaderFactory(
+            Collection<? extends Closeable> closeables,
+            DisruptorAutobatcher<UUID, Optional<ClientAwarePingableLeader>> uuidAutobatcher,
+            Map<ClientAwarePingableLeader, ExecutorService> executors,
+            Duration leaderPingResponseWait) {
+        this.closeables = closeables;
+        this.uuidToRemoteAutobatcher = uuidAutobatcher;
+        this.executors = executors;
+        this.leaderPingResponseWait = leaderPingResponseWait;
     }
 
-    public static AutobatchingPingableLeaderFactory create(BatchPingableLeader batchPingableLeader) {
-        DisruptorAutobatcher<Client, Boolean> pingAutobatcher =
-                Autobatchers.coalescing(new PingCoalescingFunction(batchPingableLeader))
-                        .safeLoggablePurpose("batch-paxos-pingable-leader.ping")
-                        .build();
+    public static AutobatchingPingableLeaderFactory create(
+            Map<BatchPingableLeader, ExecutorService> executors,
+            Duration leaderPingResponseWait,
+            UUID localUuid) {
+        BiMap<BatchPingableLeader, ClientAwarePingableLeaderImpl> correspondence = KeyedStream.of(
+                executors.keySet())
+                .map(ClientAwarePingableLeaderImpl::create)
+                .collectTo(HashBiMap::create);
 
-        DisruptorAutobatcher<SupplierKey, UUID> uuidAutobatcher =
-                Autobatchers.coalescing(batchPingableLeader::uuid)
-                        .safeLoggablePurpose("batch-paxos-pingable-leader.uuid")
-                        .build();
+        Map<ClientAwarePingableLeader, ExecutorService> clientAwarePingableExecutors =
+                KeyedStream.stream(correspondence.inverse())
+                        .<ClientAwarePingableLeader>mapKeys(Function.identity())
+                        .map(executors::get)
+                        .collectToMap();
 
-        return new AutobatchingPingableLeaderFactory(pingAutobatcher, uuidAutobatcher);
-    }
+        DisruptorAutobatcher<UUID, Optional<ClientAwarePingableLeader>> uuidAutobatcher =
+                Autobatchers.independent(new GetSuspectedLeaderWithUuid(clientAwarePingableExecutors, localUuid, leaderPingResponseWait))
+                .safeLoggablePurpose("batch-paxos-pingable-leader.uuid")
+                .build();
 
-    public PingableLeader pingableLeaderFor(Client client) {
-        return new BatchingPingableLeader(client);
+        return new AutobatchingPingableLeaderFactory(
+                correspondence.values(),
+                uuidAutobatcher,
+                clientAwarePingableExecutors,
+                leaderPingResponseWait);
     }
 
     @Override
     public void close() {
-        pingAutobatcher.close();
-        uuidAutobatcher.close();
+        for (Closeable closeable : closeables) {
+            try {
+                closeable.close();
+            } catch (IOException e) {
+                log.error("could not close autobatcher for pingable leader");
+            }
+        }
+        uuidToRemoteAutobatcher.close();
     }
 
-    private final class BatchingPingableLeader implements PingableLeader {
+    public LeaderPinger leaderPingerFor(Client client) {
+        return new AutobatchingLeaderPinger(client);
+    }
+
+    private static final class ClientAwarePingableLeaderImpl implements ClientAwarePingableLeader, Closeable {
+
+        private final DisruptorAutobatcher<Client, Boolean> pingAutobatcher;
+        private final BatchPingableLeader remoteClient;
+
+        ClientAwarePingableLeaderImpl(
+                DisruptorAutobatcher<Client, Boolean> pingAutobatcher,
+                BatchPingableLeader remoteClient) {
+            this.pingAutobatcher = pingAutobatcher;
+            this.remoteClient = remoteClient;
+        }
+
+        static ClientAwarePingableLeaderImpl create(BatchPingableLeader remoteClient) {
+            DisruptorAutobatcher<Client, Boolean> pingAutobatcher =
+                    Autobatchers.coalescing(new PingCoalescingFunction(remoteClient))
+                            .safeLoggablePurpose("batch-pingable-leader.ping")
+                            .build();
+
+            return new ClientAwarePingableLeaderImpl(pingAutobatcher, remoteClient);
+        }
+
+        @Override
+        public boolean ping(Client client) {
+            try {
+                return pingAutobatcher.apply(client).get();
+            } catch (InterruptedException | ExecutionException e) {
+                throw AutobatcherExecutionExceptions.handleAutobatcherExceptions(e);
+            }
+        }
+
+        @Override
+        public UUID uuid() {
+            return remoteClient.uuid();
+        }
+
+        @Override
+        public void close() {
+            pingAutobatcher.close();
+        }
+    }
+
+    private final class AutobatchingLeaderPinger implements LeaderPinger {
 
         private final Client client;
 
-        private BatchingPingableLeader(Client client) {
+        private AutobatchingLeaderPinger(Client client) {
             this.client = client;
         }
 
         @Override
-        public boolean ping() {
+        public boolean pingLeaderWithUuid(UUID uuid) {
             try {
-                return pingAutobatcher.apply(client).get();
-            } catch (ExecutionException | InterruptedException e) {
-                throw AutobatcherExecutionExceptions.handleAutobatcherExceptions(e);
+                Optional<ClientAwarePingableLeader> maybePingableLeader = uuidToRemoteAutobatcher.apply(uuid).get();
+                if (!maybePingableLeader.isPresent()) {
+                    return false;
+                }
+
+                ClientAwarePingableLeader pingableLeader = maybePingableLeader.get();
+                return executors.get(pingableLeader).submit(() -> pingableLeader.ping(client))
+                        .get(leaderPingResponseWait.toMillis(), TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                log.warn("received interrupt whilst trying to ping leader",
+                        SafeArg.of("client", client));
+                Thread.currentThread().interrupt();
+                return false;
+            } catch (ExecutionException e) {
+                log.warn("received error whilst trying to ping leader", e.getCause(),
+                        SafeArg.of("client", client));
+                return false;
+            } catch (TimeoutException e) {
+                log.warn("timed out whilst trying to ping leader",
+                        SafeArg.of("client", client));
+                return false;
             }
         }
 
-        @Override
-        public String getUUID() {
-            try {
-                return uuidAutobatcher.apply(SupplierKey.INSTANCE).get().toString();
-            } catch (ExecutionException | InterruptedException e) {
-                throw AutobatcherExecutionExceptions.handleAutobatcherExceptions(e);
-            }
-        }
     }
 
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/ClientAwarePingableLeader.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/ClientAwarePingableLeader.java
@@ -1,0 +1,24 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import java.util.UUID;
+
+interface ClientAwarePingableLeader {
+    boolean ping(Client client);
+    UUID uuid();
+}

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/GetSuspectedLeaderWithUuid.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/GetSuspectedLeaderWithUuid.java
@@ -1,0 +1,150 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import static java.util.stream.Collectors.toSet;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Consumer;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.SettableFuture;
+import com.palantir.atlasdb.autobatch.BatchElement;
+import com.palantir.atlasdb.timelock.paxos.PaxosQuorumCheckingCoalescingFunction.PaxosContainer;
+import com.palantir.common.base.Throwables;
+import com.palantir.common.streams.KeyedStream;
+import com.palantir.paxos.PaxosQuorumChecker;
+import com.palantir.paxos.PaxosResponsesWithRemote;
+
+/*
+    This is not thread safe, but it is okay because it is run within an autobatcher, which is configured to not process
+    multiple batches in parallel.
+
+    In addition, since this is not a `CoalescingRequestFunction` we must ensure that no internal state is mutated
+    inside a Future. The `accept` method is ready to be called again, the moment it returns.
+ */
+@NotThreadSafe
+class GetSuspectedLeaderWithUuid implements Consumer<List<BatchElement<UUID, Optional<ClientAwarePingableLeader>>>> {
+
+    private static final Logger log = LoggerFactory.getLogger(GetSuspectedLeaderWithUuid.class);
+
+    private final Map<ClientAwarePingableLeader, ExecutorService> executors;
+    private final UUID localUuid;
+    private final Duration leaderPingResponseWait;
+
+    private final Map<UUID, ClientAwarePingableLeader> cache = Maps.newHashMap();
+
+    GetSuspectedLeaderWithUuid(
+            Map<ClientAwarePingableLeader, ExecutorService> executors,
+            UUID localUuid,
+            Duration leaderPingResponseWait) {
+        this.executors = executors;
+        this.localUuid = localUuid;
+        this.leaderPingResponseWait = leaderPingResponseWait;
+    }
+
+    @Override
+    public void accept(List<BatchElement<UUID, Optional<ClientAwarePingableLeader>>> batchElements) {
+        Multimap<UUID, SettableFuture<Optional<ClientAwarePingableLeader>>> uuidsToRequests = batchElements.stream()
+                .collect(ImmutableListMultimap.toImmutableListMultimap(BatchElement::argument, BatchElement::result));
+
+        KeyedStream.of(uuidsToRequests.keySet())
+                .filterKeys(cache::containsKey)
+                .map(cache::get)
+                .forEach((cachedUuid, pingable) -> completeRequest(uuidsToRequests, cachedUuid, Optional.of(pingable)));
+
+        Set<UUID> uncachedUuids = uuidsToRequests.keySet().stream()
+                .filter(uuid -> !cache.containsKey(uuid))
+                .collect(toSet());
+
+        if (uncachedUuids.isEmpty()) {
+            return;
+        }
+
+        PaxosResponsesWithRemote<ClientAwarePingableLeader, PaxosContainer<UUID>> results =
+                PaxosQuorumChecker.collectUntil(
+                ImmutableList.copyOf(executors.keySet()),
+                pingable -> PaxosContainer.of(pingable.uuid()),
+                executors,
+                leaderPingResponseWait,
+                state -> state.responses().values().stream().map(PaxosContainer::get).collect(toSet())
+                        .containsAll(uncachedUuids));
+
+        for (Map.Entry<ClientAwarePingableLeader, PaxosContainer<UUID>> resultEntries : results.responses().entrySet()) {
+            ClientAwarePingableLeader pingable = resultEntries.getKey();
+            UUID uuid = resultEntries.getValue().get();
+
+            ClientAwarePingableLeader oldCachedEntry = cache.putIfAbsent(uuid, pingable);
+            throwIfInvalidSetup(oldCachedEntry, pingable, uuid);
+            completeRequest(uuidsToRequests, uuid, Optional.of(pingable));
+        }
+
+        Set<UUID> missingUuids = Sets.difference(
+                uncachedUuids,
+                results.withoutRemotes().stream().map(PaxosContainer::get).collect(toSet()));
+
+        missingUuids.forEach(missingUuid -> completeRequest(uuidsToRequests, missingUuid, Optional.empty()));
+    }
+
+    private static void completeRequest(
+            Multimap<UUID, SettableFuture<Optional<ClientAwarePingableLeader>>> uuidsToRequests,
+            UUID uuid,
+            Optional<ClientAwarePingableLeader> outcome) {
+        uuidsToRequests.get(uuid).forEach(result -> result.set(outcome));
+    }
+
+    private void throwIfInvalidSetup(
+            ClientAwarePingableLeader cachedService,
+            ClientAwarePingableLeader pingedService,
+            UUID pingedServiceUuid) {
+        if (cachedService == null) {
+            return;
+        }
+
+        IllegalStateException exception = new IllegalStateException(
+                "There is a fatal problem with the leadership election configuration! "
+                        + "This is probably caused by invalid pref files setting up the cluster "
+                        + "(e.g. for lock server look at lock.prefs, leader.prefs, and lock_client.prefs)."
+                        + "If the preferences are specified with a host port pair list and localhost index "
+                        + "then make sure that the localhost index is correct (e.g. actually the localhost).");
+
+        if (cachedService != pingedService) {
+            log.error("Remote potential leaders are claiming to be each other!", exception);
+            throw Throwables.rewrap(exception);
+        }
+
+        if (pingedServiceUuid.equals(localUuid)) {
+            log.error("Remote potential leader is claiming to be you!", exception);
+            throw Throwables.rewrap(exception);
+        }
+    }
+}

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/AutobatchingPingableLeaderFactoryTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/AutobatchingPingableLeaderFactoryTests.java
@@ -1,0 +1,142 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.junit.After;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.palantir.paxos.LeaderPinger;
+
+public class AutobatchingPingableLeaderFactoryTests {
+
+    private static final Client CLIENT_1 = Client.of("client-1");
+    private static final Client CLIENT_2 = Client.of("client-2");
+    private final ExecutorService executorService = Executors.newCachedThreadPool();
+
+    @After
+    public void after() {
+        executorService.shutdown();
+    }
+
+    @Test
+    public void canPingLeaderMatchingUuidAndClient() {
+        BatchPingableLeader rpc = new FakeBatchPingableLeader(CLIENT_1);
+        AutobatchingPingableLeaderFactory factory = factoryForPingables(rpc);
+
+        LeaderPinger client1Pinger = factory.leaderPingerFor(CLIENT_1);
+        LeaderPinger client2Pinger = factory.leaderPingerFor(CLIENT_2);
+
+        assertThat(client1Pinger.pingLeaderWithUuid(rpc.uuid()))
+                .isTrue();
+
+        assertThat(client2Pinger.pingLeaderWithUuid(rpc.uuid()))
+                .isFalse();
+    }
+
+    @Test
+    public void unknownUuidReturnsFalse() {
+        BatchPingableLeader rpc = new FakeBatchPingableLeader(CLIENT_1, CLIENT_2);
+        AutobatchingPingableLeaderFactory factory = factoryForPingables(rpc);
+
+        LeaderPinger client1Pinger = factory.leaderPingerFor(CLIENT_1);
+        LeaderPinger client2Pinger = factory.leaderPingerFor(CLIENT_2);
+
+        assertThat(client1Pinger.pingLeaderWithUuid(UUID.randomUUID()))
+                .isFalse();
+
+        assertThat(client2Pinger.pingLeaderWithUuid(UUID.randomUUID()))
+                .isFalse();
+    }
+
+    @Test
+    public void twoDifferentLeaders() {
+        FakeBatchPingableLeader client1Leader = new FakeBatchPingableLeader(CLIENT_1);
+        FakeBatchPingableLeader client2Leader = new FakeBatchPingableLeader(CLIENT_2);
+
+        AutobatchingPingableLeaderFactory factory = factoryForPingables(client1Leader, client2Leader);
+        LeaderPinger client1Pinger = factory.leaderPingerFor(CLIENT_1);
+        LeaderPinger client2Pinger = factory.leaderPingerFor(CLIENT_2);
+
+        assertThat(client1Pinger.pingLeaderWithUuid(client1Leader.uuid))
+                .isTrue();
+
+        assertThat(client2Pinger.pingLeaderWithUuid(client2Leader.uuid))
+                .isTrue();
+    }
+
+    @Test
+    public void pingFailureReturnsFalse() {
+        UUID uuid = UUID.randomUUID();
+        BatchPingableLeader rpc = mock(BatchPingableLeader.class);
+        when(rpc.uuid()).thenReturn(uuid);
+        when(rpc.ping(anySet())).thenThrow(new RuntimeException("ping failure"));
+
+        AutobatchingPingableLeaderFactory factory = factoryForPingables(rpc);
+
+        assertThat(factory.leaderPingerFor(CLIENT_1).pingLeaderWithUuid(uuid))
+                .isFalse();
+        assertThat(factory.leaderPingerFor(CLIENT_2).pingLeaderWithUuid(uuid))
+                .isFalse();
+
+        // assert that the rpc call did actually take place!
+        verify(rpc).uuid();
+        verify(rpc, times(2)).ping(anySet());
+    }
+
+    private AutobatchingPingableLeaderFactory factoryForPingables(BatchPingableLeader... rpcs) {
+        return AutobatchingPingableLeaderFactory.create(
+                Maps.toMap(ImmutableSet.copyOf(rpcs), $ -> executorService),
+                Duration.ofSeconds(1),
+                UUID.randomUUID());
+    }
+
+    private static final class FakeBatchPingableLeader implements BatchPingableLeader {
+
+        private final Set<Client> clientsWhichWeAreLeaderFor;
+        private final UUID uuid = UUID.randomUUID();
+
+        private FakeBatchPingableLeader(Client... clientsWhichWeAreLeaderFor) {
+            this.clientsWhichWeAreLeaderFor = ImmutableSet.copyOf(clientsWhichWeAreLeaderFor);
+        }
+
+        @Override
+        public Set<Client> ping(Set<Client> clients) {
+            return Sets.intersection(clientsWhichWeAreLeaderFor, clients);
+        }
+
+        @Override
+        public UUID uuid() {
+            return uuid;
+        }
+    }
+}

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/GetSuspectedLeaderWithUuidTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/GetSuspectedLeaderWithUuidTests.java
@@ -1,0 +1,165 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.immutables.value.Value;
+import org.junit.After;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.SettableFuture;
+import com.palantir.atlasdb.autobatch.BatchElement;
+
+public class GetSuspectedLeaderWithUuidTests {
+
+    private static final UUID LOCAL_UUID = UUID.randomUUID();
+
+    private final ExecutorService executorService = Executors.newCachedThreadPool();
+
+    @After
+    public void after() {
+        executorService.shutdown();
+    }
+
+    @Test
+    public void completesPresentAndMissingSeparately()
+            throws InterruptedException, ExecutionException, TimeoutException {
+        ClientAwarePingableLeader remote1 = remoteWithRandomUuid();
+        ClientAwarePingableLeader remote2 = remoteWithRandomUuid();
+
+        GetSuspectedLeaderWithUuid function = functionForRemotes(remote1, remote2);
+
+        TestBatchElement element1 = TestBatchElement.of(remote1.uuid());
+        TestBatchElement element2 = TestBatchElement.random();
+
+        function.accept(ImmutableList.of(element1, element2));
+
+        assertThat(element1.get())
+                .contains(remote1);
+
+        assertThat(element2.get())
+                .as("requesting a random uuid returns empty optional")
+                .isEmpty();
+    }
+
+    @Test
+    public void coalescesSingleRequests() throws InterruptedException, ExecutionException, TimeoutException {
+        UUID uuid = UUID.randomUUID();
+        ClientAwarePingableLeader remote = remoteWithUuid(uuid);
+        GetSuspectedLeaderWithUuid function = functionForRemotes(remote);
+
+        TestBatchElement element = TestBatchElement.of(uuid);
+        TestBatchElement elementWithSameUuid = TestBatchElement.of(uuid);
+
+        assertThat(element.result())
+                .isNotEqualTo(elementWithSameUuid.result());
+
+        assertThat(element.argument())
+                .isEqualTo(elementWithSameUuid.argument());
+
+        function.accept(ImmutableList.of(element, elementWithSameUuid));
+
+        assertThat(element.get()).contains(remote);
+
+        assertThat(element.get())
+                .as("we're using the same instance for the same requests")
+                .isSameAs(elementWithSameUuid.get());
+        verify(remote, only()).uuid();
+    }
+
+    @Test
+    public void cachesPreviouslySeenUuids() throws InterruptedException, ExecutionException, TimeoutException {
+        UUID uuid = UUID.randomUUID();
+        ClientAwarePingableLeader remote = remoteWithUuid(uuid);
+        GetSuspectedLeaderWithUuid function = functionForRemotes(remote);
+
+        TestBatchElement firstRequest = TestBatchElement.of(uuid);
+        function.accept(ImmutableList.of(firstRequest));
+
+        assertThat(firstRequest.get()).contains(remote);
+        verify(remote, times(1)).uuid();
+
+        TestBatchElement secondRequest = TestBatchElement.of(uuid);
+        function.accept(ImmutableList.of(secondRequest));
+
+        assertThat(secondRequest.get()).contains(remote);
+        verifyNoMoreInteractions(remote);
+    }
+
+    private static ClientAwarePingableLeader remoteWithUuid(UUID uuid) {
+        ClientAwarePingableLeader mock = mock(ClientAwarePingableLeader.class);
+        return when(mock.uuid()).thenReturn(uuid).getMock();
+    }
+
+    private static ClientAwarePingableLeader remoteWithRandomUuid() {
+        return remoteWithUuid(UUID.randomUUID());
+    }
+
+    private GetSuspectedLeaderWithUuid functionForRemotes(ClientAwarePingableLeader... remotes) {
+        Map<ClientAwarePingableLeader, ExecutorService> executors =
+                Maps.toMap(ImmutableList.copyOf(remotes), $ -> executorService);
+
+        return new GetSuspectedLeaderWithUuid(executors, LOCAL_UUID, Duration.ofSeconds(1));
+    }
+
+    @Value.Immutable
+    interface TestBatchElement extends BatchElement<UUID, Optional<ClientAwarePingableLeader>> {
+
+        static TestBatchElement random() {
+            return of(UUID.randomUUID());
+        }
+
+        static TestBatchElement of(UUID uuid) {
+            return ImmutableTestBatchElement.of(uuid);
+        }
+
+        @Value.Parameter
+        @Override
+        UUID argument();
+
+        @Value.Lazy
+        @Override
+        default SettableFuture<Optional<ClientAwarePingableLeader>> result() {
+            return SettableFuture.create();
+        }
+
+        default Optional<ClientAwarePingableLeader> get()
+                throws InterruptedException, ExecutionException, TimeoutException {
+            return result().get(1, TimeUnit.SECONDS);
+        }
+
+    }
+}


### PR DESCRIPTION
**Goals (and why)**:
We want to be able to ping nodes about leadership and also discover their uuids in a manner than doesn't mean we spin up so many more threads. In #4139 we introduced a `LeaderPinger` interface, where you attempt to locate the node which has a given `leaderUuid`. 

We now introduce the autobatching variant. 

This should also be the final main piece when it comes to being able to wire things up. Effectively we'll have:

```java
PaxosAcceptorNetworkClient acceptor = acceptorFactory.paxosAcceptorForClient(client);
PaxosLearnerNetworkClient learner = learnerFactory.paxosLearnerForClient(client);
LeaderPinger leaderPinger = leaderPingerFactory.leaderPingerFor(client);

PaxosProposer proposer = PaxosProposerImpl.newProposer(acceptor, learner, quorumSize, leadershipUuid);

return new PaxosLeaderElectionService(
        proposer,
        components.learner(client),
        leaderPinger,
        null, // only used for health check, somehow throw here
        ImmutableList.of(), // health check doesn't make a whole lot of sense in multi leader world, throw here
        ImmutableList.of(), // we won't run with this cli in timelock, also throw here
        new PaxosLatestRoundVerifierImpl(acceptor),
        learner,
        updatePollingWait.toMillis(),
        randomWaitBeforeProposingLeadership.toMillis(),
        PaxosLeaderElectionEventRecorder.NO_OP); // replace with client scoped event recorder
```

After this, 

**Implementation Description (bullets)**:
A bit more convoluted than the autobatching variants of `PaxosAcceptor` and `PaxosLearner`. We don't want to introduce head of line blocking since all nodes will be hit (assuming uncached) to discover the uuid. So instead of using the coalescing autobatcher, we use the independent autobatcher where we can complete individual requests.

We want to batch:
* calls to `ping` or "are you the leader for this client". 
* what is your leader uuid?

Each follower will have a suspected leader, which it can garner from its knowledge. It then needs to ping that leader to see whether it is still leading.

Under the hood, each `PingableLeader` is client scoped. So when `ping` is called, and *after* we've determined which remote is the suspected leader, it will actually autobatch passing client as a parameter.

**Testing (What was existing testing like?  What have you done to improve it?)**:
* First smoke test for the autobatcher code since it's somewhat non-trivial.

**Concerns (what feedback would you like?)**:
* Likely should add a `LeaderUuidCache` that can be shared across both `SingleLeaderPinger` and `AutobatchingLeaderPinger`
* We could probably get rid of the leaderUuid api endpoint, since the node is client aware.
  So instead of asking are you the leader for this uuid, we can just ask are you the leader for this client. Locally the node can then look at its knowledge for each of its clients and then decide then and there. Although I'm not sure whether that breaks the protocol/algorithm by any change. Doesn't block for now, but would be interesting to get rid of if plausible.
* Event recording, unimplemented for now since it's just for debuggability, and isn't super blocking, but would also need to be client scoped to make things clearer.

**Where should we start reviewing?**:
* `AutobatchingPingableLeaderFactory`
* `GetSuspectedLeaderWithUuid`

**Priority (whenever / two weeks / yesterday)**:
ASAP 💃 
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
