### PR TITLE
CloseableTimelockService interface (tiny refactor)

### DIFF
--- a/lock-api/src/main/java/com/palantir/lock/client/RemoteTimelockServiceAdapter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/RemoteTimelockServiceAdapter.java
@@ -18,18 +18,18 @@ package com.palantir.lock.client;
 
 import java.util.Set;
 
+import com.palantir.lock.v2.CloseableTimelockService;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
 import com.palantir.lock.v2.LockRequest;
 import com.palantir.lock.v2.LockResponse;
 import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.StartIdentifiedAtlasDbTransactionResponse;
 import com.palantir.lock.v2.TimelockRpcClient;
-import com.palantir.lock.v2.TimelockService;
 import com.palantir.lock.v2.WaitForLocksRequest;
 import com.palantir.lock.v2.WaitForLocksResponse;
 import com.palantir.timestamp.TimestampRange;
 
-public final class RemoteTimelockServiceAdapter implements TimelockService, AutoCloseable {
+public final class RemoteTimelockServiceAdapter implements CloseableTimelockService {
     private final TimelockRpcClient timelockRpcClient;
     private final LockLeaseService lockLeaseService;
     private final TransactionStarter transactionStarter;

--- a/lock-api/src/main/java/com/palantir/lock/v2/CloseableTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/v2/CloseableTimelockService.java
@@ -1,0 +1,20 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.v2;
+
+public interface CloseableTimelockService extends TimelockService, AutoCloseable {
+}


### PR DESCRIPTION
**Goals (and why)**:

Because `RemoteTimelockServiceAdapter` is a final class that inherits from two different interfaces, it's hard to interact with in our unit tests.  By adding an intermediary interface we can more easily mock the class.

**Implementation Description (bullets)**:
Adds an intermediary `CloseableTimelockService` interface which unifies the `TimelockService` and `AutoCloseable` interfaces.

**Testing (What was existing testing like?  What have you done to improve it?)**:
The test failures on this branch don't seem related to this PR.

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

Whenever.