### PR TITLE
Always specify LEADING with USE_NL

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleQueryFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleQueryFactory.java
@@ -51,7 +51,7 @@ public class OracleQueryFactory extends AbstractDbQueryFactory {
                                        boolean includeValue) {
         String query = " /* GET_LATEST_ONE_ROW_INNER (" + tableName + ") */ "
                 + " SELECT"
-                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m "
+                + "   /*+ USE_NL(t m) LEADING(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m "
                 + PrimaryKeyConstraintNames.get(tableName) + ") */ "
                 + "   m.row_name, m.col_name, max(m.ts) as ts "
                 + " FROM " + tableName + " m "
@@ -79,7 +79,7 @@ public class OracleQueryFactory extends AbstractDbQueryFactory {
                                         boolean includeValue) {
         String query = " /* GET_LATEST_ROWS_SINGLE_BOUND_INNER (" + tableName + ") */ "
                 + " SELECT"
-                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m "
+                + "   /*+ USE_NL(t m) LEADING(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m "
                 + PrimaryKeyConstraintNames.get(tableName) + ") */ "
                 + "   m.row_name, m.col_name, max(m.ts) as ts "
                 + " FROM " + tableName + " m, TABLE(CAST(? AS " + structArrayPrefix() + "CELL_TS_TABLE)) t "
@@ -106,7 +106,7 @@ public class OracleQueryFactory extends AbstractDbQueryFactory {
                                         boolean includeValue) {
         String query = " /* GET_LATEST_ROWS_MANY_BOUNDS_INNER (" + tableName + ") */ "
                 + " SELECT"
-                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m "
+                + "   /*+ USE_NL(t m) LEADING(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m "
                 + PrimaryKeyConstraintNames.get(tableName) + ") */ "
                 + "   m.row_name, m.col_name, max(m.ts) as ts "
                 + " FROM " + tableName + " m, TABLE(CAST(? AS " + structArrayPrefix() + "CELL_TS_TABLE)) t "
@@ -159,7 +159,7 @@ public class OracleQueryFactory extends AbstractDbQueryFactory {
                                      boolean includeValue) {
         String query = " /* GET_ALL_ROWS_SINGLE_BOUND (" + tableName + ") */ "
                 + " SELECT"
-                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m "
+                + "   /*+ USE_NL(t m) LEADING(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m "
                 + PrimaryKeyConstraintNames.get(tableName) + ") */ "
                 + "   m.row_name, m.col_name, m.ts" + getValueSubselect("m", includeValue)
                 + " FROM " + tableName + " m, TABLE(CAST(? AS " + structArrayPrefix() + "CELL_TS_TABLE)) t "
@@ -184,7 +184,7 @@ public class OracleQueryFactory extends AbstractDbQueryFactory {
                                      boolean includeValue) {
         String query = " /* GET_ALL_ROWS_MANY_BOUNDS (" + tableName + ") */ "
                 + " SELECT"
-                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m "
+                + "   /*+ USE_NL(t m) LEADING(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m "
                 + PrimaryKeyConstraintNames.get(tableName) + ") */ "
                 + "   m.row_name, m.col_name, m.ts" + getValueSubselect("m", includeValue)
                 + " FROM " + tableName + " m, TABLE(CAST(? AS " + structArrayPrefix() + "CELL_TS_TABLE)) t "
@@ -222,7 +222,7 @@ public class OracleQueryFactory extends AbstractDbQueryFactory {
     public FullQuery getLatestCellsQuery(Iterable<Cell> cells, long ts, boolean includeValue) {
         String query = " /* GET_LATEST_CELLS_SINGLE_BOUND_INNER (" + tableName + ") */ "
                 + " SELECT"
-                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m "
+                + "   /*+ USE_NL(t m) LEADING(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m "
                 + PrimaryKeyConstraintNames.get(tableName) + ") */ "
                 + "   m.row_name, m.col_name, max(m.ts) as ts "
                 + " FROM " + tableName + " m, TABLE(CAST(? AS " + structArrayPrefix() + "CELL_TS_TABLE)) t "
@@ -238,7 +238,7 @@ public class OracleQueryFactory extends AbstractDbQueryFactory {
     public FullQuery getLatestCellsQuery(Collection<Map.Entry<Cell, Long>> cells, boolean includeValue) {
         String query = " /* GET_LATEST_CELLS_MANY_BOUNDS_INNER (" + tableName + ") */ "
                 + " SELECT"
-                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m "
+                + "   /*+ USE_NL(t m) LEADING(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m "
                 + PrimaryKeyConstraintNames.get(tableName) + ") */ "
                 + "   m.row_name, m.col_name, max(m.ts) as ts "
                 + " FROM " + tableName + " m, TABLE(CAST(? AS " + structArrayPrefix() + "CELL_TS_TABLE)) t "
@@ -267,7 +267,7 @@ public class OracleQueryFactory extends AbstractDbQueryFactory {
     public FullQuery getAllCellsQuery(Iterable<Cell> cells, long ts, boolean includeValue) {
         String query = " /* GET_ALL_CELLS_SINGLE_BOUND (" + tableName + ") */ "
                 + " SELECT"
-                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m "
+                + "   /*+ USE_NL(t m) LEADING(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m "
                 + PrimaryKeyConstraintNames.get(tableName) + ") */ "
                 + "   m.row_name, m.col_name, m.ts" + getValueSubselect("m", includeValue)
                 + " FROM " + tableName + " m, TABLE(CAST(? AS " + structArrayPrefix() + "CELL_TS_TABLE)) t "
@@ -281,7 +281,7 @@ public class OracleQueryFactory extends AbstractDbQueryFactory {
     public FullQuery getAllCellsQuery(Collection<Map.Entry<Cell, Long>> cells, boolean includeValue) {
         String query = " /* GET_ALL_CELLS_MANY_BOUNDS (" + tableName + ") */ "
                 + " SELECT"
-                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m "
+                + "   /*+ USE_NL(t m) LEADING(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m "
                 + PrimaryKeyConstraintNames.get(tableName) + ") */ "
                 + "   m.row_name, m.col_name, m.ts" + getValueSubselect("m", includeValue)
                 + " FROM " + tableName + " m, TABLE(CAST(? AS " + structArrayPrefix() + "CELL_TS_TABLE)) t "

--- a/changelog/@unreleased/pr-4146.v2.yml
+++ b/changelog/@unreleased/pr-4146.v2.yml
@@ -1,23 +1,7 @@
 type: improvement
 improvement:
-  description: |-
-    Always specify LEADING with USE_NL
-
-    **Goals (and why)**:
-    Fix bad performance in joins.  It is a best practice to always specify a join order when forcing nested loops, since almost always one join order is better than the other.
-
-
-    **Implementation Description (bullets)**:
-    Added LEADING to all queries in OracleQueryFactory that specify USE_NL
-
-    **Testing (What was existing testing like?  What have you done to improve it?)**:
-    Does not affect correctness.  Will test performance in production.  One of those situations.
-
-    **Concerns (what feedback would you like?)**:
-
-    **Where should we start reviewing?**:
-    Immediately.
-    **Priority (whenever / two weeks / yesterday)**:
-    Now.
+  description: Fix bad performance in joins.  It is a best practice to always specify
+    a join order when forcing nested loops, since almost always one join order is
+    better than the other.
   links:
   - https://github.com/palantir/atlasdb/pull/4146

--- a/changelog/@unreleased/pr-4146.v2.yml
+++ b/changelog/@unreleased/pr-4146.v2.yml
@@ -1,0 +1,23 @@
+type: improvement
+improvement:
+  description: |-
+    Always specify LEADING with USE_NL
+
+    **Goals (and why)**:
+    Fix bad performance in joins.  It is a best practice to always specify a join order when forcing nested loops, since almost always one join order is better than the other.
+
+
+    **Implementation Description (bullets)**:
+    Added LEADING to all queries in OracleQueryFactory that specify USE_NL
+
+    **Testing (What was existing testing like?  What have you done to improve it?)**:
+    Does not affect correctness.  Will test performance in production.  One of those situations.
+
+    **Concerns (what feedback would you like?)**:
+
+    **Where should we start reviewing?**:
+    Immediately.
+    **Priority (whenever / two weeks / yesterday)**:
+    Now.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4146


### PR DESCRIPTION
**Goals (and why)**:
Fix bad performance in joins.  It is a best practice to always specify a join order when forcing nested loops, since almost always one join order is better than the other.


**Implementation Description (bullets)**:
Added LEADING to all queries in OracleQueryFactory that specify USE_NL

**Testing (What was existing testing like?  What have you done to improve it?)**:
Does not affect correctness.  Will test performance in production.  One of those situations.

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:
Immediately.
**Priority (whenever / two weeks / yesterday)**:
Now.
