### PR TITLE
Fix precommit condition check order

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/PreCommitCondition.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/PreCommitCondition.java
@@ -25,6 +25,11 @@ package com.palantir.atlasdb.transaction.api;
  * {@link TransactionManager} API. These locks are granted before the transaction starts and cannot be refreshed
  * once they lapse, so they provide the necessary invariant. If they are valid at commit time, they were valid
  * for the entire lifetime of the transaction.
+ *
+ * Conditions are associated with a transaction, but should not interfere with the transaction locks (non-advisory)
+ * used by the transaction. The validity of those locks is controlled separately from any pre-commit conditions, and
+ * they follow different constraints - transaction locks are only acquired at commit time, for example, rather than
+ * at the beginning of a transaction.
  */
 @FunctionalInterface
 public interface PreCommitCondition {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -1453,8 +1453,10 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
 
                 // Verify that our locks and pre-commit conditions are still valid before we actually commit;
                 // this throwIfPreCommitRequirementsNotMet is required by the transaction protocol for correctness.
-                timedAndTraced("preCommitLockCheck", () -> throwIfImmutableTsOrCommitLocksExpired(commitLocksToken));
+                // We check the pre-commit conditions first since they may operate similarly to read write conflict
+                // handling - we should check lock validity last to ensure that sweep hasn't affected the checks.
                 timedAndTraced("userPreCommitCondition", () -> throwIfPreCommitConditionInvalid(commitTimestamp));
+                timedAndTraced("preCommitLockCheck", () -> throwIfImmutableTsOrCommitLocksExpired(commitLocksToken));
 
                 timedAndTraced("commitPutCommitTs",
                         () -> putCommitTimestamp(commitTimestamp, commitLocksToken, transactionService));

--- a/docs/source/transactions/life_of_a_transaction.rst
+++ b/docs/source/transactions/life_of_a_transaction.rst
@@ -92,8 +92,8 @@ The ordering of these steps is important:
    could involve transactional reads to the database, they require the same protections as the read-write conflict
    checks in the prior step. An alternative implementation of those checks could be done as a pre-commit condition, for
    example, so it is important that we handle this before the final lock check.
-9. The lock check may be run in parallel with pre-commit condition checks, though it must strictly be run before writing
-   to the transactions table, as we cannot finish our commit if we can't be certain we still have locks.
+9. The lock check must be run strictly before writing to the transactions table, as we cannot finish our commit if
+   we can't be certain we still have locks.
 
 Read-Only Variant
 ~~~~~~~~~~~~~~~~~

--- a/docs/source/transactions/life_of_a_transaction.rst
+++ b/docs/source/transactions/life_of_a_transaction.rst
@@ -55,8 +55,8 @@ Committing a write transaction is a multi-stage process:
 6. Get the commit timestamp.
 7. For serializable transactions, check that the state of the world at commit time is same as that at start time.
    Please see :ref:`Isolation Levels<isolation-levels>` for more details.
-8. Verify that locks are still valid.
-9. Verify user-specified pre-commit conditions (if applicable).
+8. Verify user-specified pre-commit conditions (if applicable).
+9. Verify that locks are still valid.
 10. Atomically putUnlessExists into the transactions table.
 
 After we have successfully written to the transactions table, the transaction is considered committed.
@@ -88,9 +88,12 @@ The ordering of these steps is important:
    in between our start and commit, and someone else deleted the value after our commit. If we pass our lock check, but
    then lose our locks and have a very long GC, Thorough Sweep might clear all evidence of the conflict, meaning that
    we miss a read-write conflict. This would be safe for conservative sweep because of the deletion sentinel.
-8. The lock check may be run in parallel with pre-commit condition checks, though it must strictly be run before writing
+8. We need to check that the pre-commit conditions, if any, still hold. Given that these checks are user defined and
+   could involve transactional reads to the database, they require the same protections as the read-write conflict
+   checks in the prior step. An alternative implementation of those checks could be done as a pre-commit condition, for
+   example, so it is important that we handle this before the final lock check.
+9. The lock check may be run in parallel with pre-commit condition checks, though it must strictly be run before writing
    to the transactions table, as we cannot finish our commit if we can't be certain we still have locks.
-9. We need to check that the pre-commit conditions still hold before we can finish committing.
 
 Read-Only Variant
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
**Goals (and why)**:
Fix the ordering of the pre-commit condition check in `SnapshotTransaction`. No one is currently affected AFAIK, but it should generally run before we check locks for the same reason that we check for read-write conflicts before checking locks. Given in-progress work that uses a pre-commit condition to do work analogous to a read-write conflict check, this will be important soon.
