### PR TITLE
Info to debug.

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueCleaner.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueCleaner.java
@@ -54,7 +54,7 @@ public class SweepQueueCleaner {
 
     private void cleanSweepableCells(ShardAndStrategy shardStrategy, Set<Long> partitions) {
         sweepableCells.deleteNonDedicatedRows(shardStrategy, partitions);
-        log.info("Deleted persisted sweep queue information in table {} for partitions {}.",
+        log.debug("Deleted persisted sweep queue information in table {} for partitions {}.",
                 LoggingArgs.tableRef(TargetedSweepTableFactory.of().getSweepableCellsTable(null).getTableRef()),
                 SafeArg.of("partitions", partitions));
     }
@@ -70,7 +70,7 @@ public class SweepQueueCleaner {
         coarsePartitions = removeLastPartitionIfNotComplete(coarsePartitions, lastTs);
 
         sweepableTimestamps.deleteCoarsePartitions(shardStrategy, coarsePartitions);
-        log.info("Deleted persisted sweep queue information in table {} for partitions {}.",
+        log.debug("Deleted persisted sweep queue information in table {} for partitions {}.",
                 LoggingArgs.tableRef(TargetedSweepTableFactory.of().getSweepableTimestampsTable(null).getTableRef()),
                 SafeArg.of("partitions", coarsePartitions));
     }

--- a/changelog/@unreleased/pr-4156.v2.yml
+++ b/changelog/@unreleased/pr-4156.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Change Targeted Sweep logging verbosity to `DEBUG` from `INFO` to produce
+    less logs.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4156


### PR DESCRIPTION
**Goals (and why)**:
We seem to be logging *very* often, which is making internal log aggregators oom. Fortunately we can just reduce the volume by moving these to `DEBUG`.

See internal ticket: PDS-95464

**Implementation Description (bullets)**:
`INFO` to `DEBUG`

**Priority (whenever / two weeks / yesterday)**:
Let's get this out ASAP.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
