### PR TITLE
Use a simple Caffeine cache around MetricName construction.

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/util/MetricNameCache.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/util/MetricNameCache.java
@@ -1,0 +1,71 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.util;
+
+import java.util.Map;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.immutables.value.Value;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.palantir.tritium.metrics.registry.MetricName;
+
+/** Cache to avoid excessive string concatenation in MetricRegistry.name(clazz, metricName). */
+final class MetricNameCache {
+
+    private final LoadingCache<Key, MetricName> cache;
+
+    MetricNameCache() {
+        this.cache = Caffeine.newBuilder()
+                .build(new CacheLoader<Key, MetricName>() {
+                    @Nullable
+                    @Override
+                    public MetricName load(@Nonnull Key key) {
+                        return MetricName.builder()
+                                .safeName(MetricRegistry.name(key.getClazz(), key.getMetricName()))
+                                .safeTags(key.getTags())
+                                .build();
+                    }
+                });
+    }
+
+    MetricName get(Class<?> clazz, String metricName, Map<String, String> tags) {
+        return cache.get(ImmutableKey.of(clazz, metricName, tags));
+    }
+
+    void invalidate() {
+        cache.invalidateAll();
+    }
+
+    @Value.Immutable
+    interface Key {
+
+        @Value.Parameter
+        Class<?> getClazz();
+
+        @Value.Parameter
+        String getMetricName();
+
+        @Value.Parameter
+        Map<String, String> getTags();
+    }
+}

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/util/MetricsManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/util/MetricsManager.java
@@ -52,6 +52,7 @@ public class MetricsManager {
     private final Set<MetricName> registeredTaggedMetrics;
     private final Predicate<TableReference> isSafeToLog;
     private final ReadWriteLock lock;
+    private final MetricNameCache metricNameCache;
 
     public MetricsManager(MetricRegistry metricRegistry,
             TaggedMetricRegistry taggedMetricRegistry,
@@ -62,6 +63,7 @@ public class MetricsManager {
         this.registeredTaggedMetrics = ConcurrentHashMap.newKeySet();
         this.isSafeToLog = isSafeToLog;
         this.lock = new ReentrantReadWriteLock();
+        this.metricNameCache = new MetricNameCache();
     }
 
     public MetricRegistry getRegistry() {
@@ -97,11 +99,8 @@ public class MetricsManager {
         }
     }
 
-    private static MetricName getTaggedMetricName(Class clazz, String metricName, Map<String, String> tags) {
-        return MetricName.builder()
-                .safeName(MetricRegistry.name(clazz, metricName))
-                .safeTags(tags)
-                .build();
+    private MetricName getTaggedMetricName(Class clazz, String metricName, Map<String, String> tags) {
+        return metricNameCache.get(clazz, metricName, tags);
     }
 
     public Map<String, String> getTableNameTagFor(@Nullable TableReference tableRef) {
@@ -217,6 +216,8 @@ public class MetricsManager {
 
             registeredTaggedMetrics.forEach(taggedMetricRegistry::remove);
             registeredTaggedMetrics.clear();
+
+            metricNameCache.invalidate();
         } finally {
             lock.writeLock().unlock();
         }
@@ -230,6 +231,9 @@ public class MetricsManager {
                     .collect(Collectors.toList());
 
             metricsToRemove.forEach(taggedMetricRegistry::remove);
+
+            // Don't be clever, invalidate everything. This should be relatively uncommon.
+            metricNameCache.invalidate();
         } finally {
             lock.writeLock().unlock();
         }

--- a/changelog/@unreleased/pr-4157.v2.yml
+++ b/changelog/@unreleased/pr-4157.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Use a simple Caffeine cache around MetricName construction
+  links:
+  - https://github.com/palantir/atlasdb/pull/4157


### PR DESCRIPTION
**Goals (and why)**:

We look up the same metrics a lot, and string concatenation is
relatively expensive. MetricName values are already stored in a
map in the TaggedMetricRegistry, so there's little risk of causing
excessive heap pressure due to this cache.

**Implementation Description (bullets)**:

Uses an unbounded Caffeine cache which roughly mirrors the TaggedMetricRegistry.