### PR TITLE
[PDS-94229] TimeLock - Thread Leak in Async Lock Service

### DIFF
--- a/changelog/@unreleased/pr-4162.v2.yml
+++ b/changelog/@unreleased/pr-4162.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: |
+    TimeLock no longer leaks threads when an async lock service is shut down (e.g. as part of a leader election). Previously we would not shut the lock request timeout thread down, leading to (number of clients) many threads left in limbo after each time a node loses leadership.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4162

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceImpl.java
@@ -15,7 +15,6 @@
  */
 package com.palantir.atlasdb.timelock;
 
-import java.io.IOException;
 import java.util.Set;
 import java.util.UUID;
 
@@ -179,7 +178,7 @@ public class AsyncTimelockServiceImpl implements AsyncTimelockService {
     }
 
     @Override
-    public void close() throws IOException {
+    public void close() {
         lockService.close();
     }
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/AsyncLockService.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/AsyncLockService.java
@@ -50,7 +50,7 @@ public class AsyncLockService implements Closeable {
     /**
      * Creates a new asynchronous lock service, using a standard {@link LeaderClock}.
      *
-     * Executors here are assumed to be owned by the service, and will be shut down when {@link #close()} is called.
+     * Executors here are assumed to be owned by this service, and will be shut down when {@link #close()} is called.
      *
      * @param lockLog lock logger
      * @param reaperExecutor executor for reaping locks that have not been refreshed by clients

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/AsyncLockService.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/AsyncLockService.java
@@ -47,6 +47,17 @@ public class AsyncLockService implements Closeable {
     private final ImmutableTimestampTracker immutableTsTracker;
     private final LeaderClock leaderClock;
 
+    /**
+     * Creates a new asynchronous lock service, using a standard {@link LeaderClock}.
+     *
+     * Executors here are assumed to be owned by the service, and will be shut down when {@link #close()} is called.
+     *
+     * @param lockLog lock logger
+     * @param reaperExecutor executor for reaping locks that have not been refreshed by clients
+     * @param timeoutExecutor executor for timing out lock requests that have blocked for longer than permitted
+     * @param targetedSweepRateLimitConfig configuration for special treatment of targeted sweep locks
+     * @return an asynchronous lock service
+     */
     public static AsyncLockService createDefault(
             LockLog lockLog,
             ScheduledExecutorService reaperExecutor,
@@ -170,6 +181,7 @@ public class AsyncLockService implements Closeable {
     @Override
     public void close() {
         reaperExecutor.shutdown();
+        lockAcquirer.close();
         decorator.close();
         heldLocks.failAllOutstandingRequestsWithNotCurrentLeaderException();
     }

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceTest.java
@@ -1,0 +1,50 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.lock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Supplier;
+
+import org.junit.Test;
+
+import com.palantir.atlasdb.timelock.config.ImmutableRateLimitConfig;
+import com.palantir.atlasdb.timelock.config.TargetedSweepLockControlConfig;
+import com.palantir.atlasdb.util.MetricsManagers;
+import com.palantir.common.concurrent.PTExecutors;
+
+public class AsyncLockServiceTest {
+    private static final Supplier<TargetedSweepLockControlConfig.RateLimitConfig> RATE_LIMIT_CONFIG_SUPPLIER
+            = () -> ImmutableRateLimitConfig.of(false,
+            TargetedSweepLockControlConfig.ShardAndThreadConfig.defaultConfig());
+
+    @Test
+    public void executorsShutDownAfterClose() {
+        ScheduledExecutorService reaperExecutor = PTExecutors.newSingleThreadScheduledExecutor();
+        ScheduledExecutorService timeoutExecutor = PTExecutors.newSingleThreadScheduledExecutor();
+        AsyncLockService asyncLockService = AsyncLockService.createDefault(
+                new LockLog(MetricsManagers.createForTests().getRegistry(), () -> 1L),
+                reaperExecutor,
+                timeoutExecutor,
+                RATE_LIMIT_CONFIG_SUPPLIER);
+
+        asyncLockService.close();
+        assertThat(reaperExecutor.isShutdown()).isTrue();
+        assertThat(timeoutExecutor.isShutdown()).isTrue();
+    }
+}


### PR DESCRIPTION
**Goals (and why)**:
- See PDS-94229. #4121 was the first part which addressed a thread leak in the legacy synchronous lock service, but there is another leak, this time in the async lock service.

**Implementation Description (bullets)**:
- An async lock service takes two executors, `reaperExecutor` (to reap lock grants when the client has not refreshed them for too long) and `timeoutExecutor` (to mark lock requests as failed when they block for too long). 
- The former was shut down when the `AsyncLockService` is closed, but the latter was not. This PR shuts down the timeout executor on close.

**Testing (What was existing testing like?  What have you done to improve it?)**:
This isn't tested. I've added a test.

**Concerns (what feedback would you like?)**:
- I did not switch to `Ownable<T>` and the infra used to distinguish things in `LockServiceImpl`, as this currently as far as I know is only called in one place, where the executors are created and thus need to be shut down.

**Where should we start reviewing?**: `LockAcquirer`

**Priority (whenever / two weeks / yesterday)**: tomorrow? P1 is about right for this one