### PR TITLE
Update old ADR status

### DIFF
--- a/docs/source/miscellaneous/doc/adr/0002-prevent-tables-from-being-creating-simultaneously-in-cassandra-via-a-locks-table.md
+++ b/docs/source/miscellaneous/doc/adr/0002-prevent-tables-from-being-creating-simultaneously-in-cassandra-via-a-locks-table.md
@@ -6,6 +6,8 @@ Date: 18/05/2016
 
 Accepted
 
+Superseded by [PR #3620: Use CQL to create tables](https://github.com/palantir/atlasdb/pull/3620).
+
 ## Context
 
 Cassandra [has an issue](https://issues.apache.org/jira/browse/CASSANDRA-10699) which can cause data loss in the situation:

--- a/docs/source/miscellaneous/doc/adr/0004-create-schema-lock-table-via-a-one-off-cli-command.md
+++ b/docs/source/miscellaneous/doc/adr/0004-create-schema-lock-table-via-a-one-off-cli-command.md
@@ -4,7 +4,9 @@ Date: 18/05/2016
 
 ## Status
 
-Superceded by [6. Create schema lock table using configuration](0006-create-schema-lock-table-using-configuration.md)
+Accepted
+
+Superseded by [6. Create schema lock table using configuration](0006-create-schema-lock-table-using-configuration.md)
 
 ## Context
 

--- a/docs/source/miscellaneous/doc/adr/0006-create-schema-lock-table-using-configuration.md
+++ b/docs/source/miscellaneous/doc/adr/0006-create-schema-lock-table-using-configuration.md
@@ -6,7 +6,9 @@ Date: 18/07/2016
 
 Accepted
 
-Supercedes [4. Create schema lock table via a one off CLI command](0004-create-schema-lock-table-via-a-one-off-cli-command.md)
+Supersedes [4. Create schema lock table via a one off CLI command](0004-create-schema-lock-table-via-a-one-off-cli-command.md)
+
+Superseded by [PR #3620: Use CQL to create tables](https://github.com/palantir/atlasdb/pull/3620).
 
 ## Context
 

--- a/docs/source/miscellaneous/doc/adr/0008-add-heartbeat-for-schema-lock-holders.md
+++ b/docs/source/miscellaneous/doc/adr/0008-add-heartbeat-for-schema-lock-holders.md
@@ -6,6 +6,8 @@ Date: 27/09/2016
 
 Accepted
 
+Superseded by [PR #3620: Use CQL to create tables](https://github.com/palantir/atlasdb/pull/3620).
+
 ## Context
 
 As of version 0.16.0, anyone trying to acquire the a schema mutation lock that is already held by someone else

--- a/docs/source/miscellaneous/doc/adr/0011-retry-long-running-locks-via-blockingtimeoutexception.md
+++ b/docs/source/miscellaneous/doc/adr/0011-retry-long-running-locks-via-blockingtimeoutexception.md
@@ -6,6 +6,10 @@ Date: 08/05/2017
 
 Accepted
 
+Note that this decision applies only to locks that were taken out via the legacy (V1) lock service. We have since
+implemented an asynchronous lock service which is used for all transactional locks; blocking timeouts are not relevant
+there.
+
 ## Context
 
 Our implementation of AtlasDB clients and the TimeLock server were interacting in ways that were causing the TimeLock

--- a/docs/source/miscellaneous/doc/adr/0012-batch-timestamp-requests-on-the-client-side.md
+++ b/docs/source/miscellaneous/doc/adr/0012-batch-timestamp-requests-on-the-client-side.md
@@ -6,6 +6,9 @@ Date: 26/09/2017
 
 Accepted
 
+The third decision point has been superseded. The ability to disable request batching has been removed, as we
+have not seen cases in practice where enabling it has caused issues (even in spite of the latency cost there).
+
 ## Context
 
 A TimeLock cluster can serve multiple services. Under these circumstances, each TimeLock client node can separately

--- a/docs/source/miscellaneous/doc/adr/0015-batch-asynchronous-post-transaction-unlock-calls.md
+++ b/docs/source/miscellaneous/doc/adr/0015-batch-asynchronous-post-transaction-unlock-calls.md
@@ -4,7 +4,9 @@ Date: 28/06/2018
 
 ## Status
 
-Functionally, this decision remains accepted. 
+Accepted
+
+Functionally, this decision remains accepted.
 The implementation has been superseded; we now use Disruptor Autobatchers.
 
 ## Context

--- a/docs/source/miscellaneous/doc/adr/0015-batch-asynchronous-post-transaction-unlock-calls.md
+++ b/docs/source/miscellaneous/doc/adr/0015-batch-asynchronous-post-transaction-unlock-calls.md
@@ -4,7 +4,8 @@ Date: 28/06/2018
 
 ## Status
 
-Accepted
+Functionally, this decision remains accepted. 
+The implementation has been superseded; we now use Disruptor Autobatchers.
 
 ## Context
 


### PR DESCRIPTION
**Goals (and why)**:
- Ensure ADR readers aren't confused by things that were true at the time but have since changed.

**Implementation Description (bullets)**:
- Update the status of several older ADRs. Most of these pertain to the schema mutation lock or to DisruptorAutobatchers.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Docs change. Docs build passing should do

**Concerns (what feedback would you like?)**:
- Are there any other documents which should have such notes attached?

**Where should we start reviewing?**: no particular order

**Priority (whenever / two weeks / yesterday)**: whenever
