### PR TITLE
[Timelock Partitioning] Part 20: Proper usage of get learned values

### DIFF
--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AcceptCoalescingFunction.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AcceptCoalescingFunction.java
@@ -42,7 +42,7 @@ final class AcceptCoalescingFunction implements
             Set<Map.Entry<Client, PaxosProposal>> request) {
         SetMultimap<Client, PaxosProposal> requests = ImmutableSetMultimap.copyOf(request);
         Map<WithSeq<Client>, BooleanPaxosResponse> results = KeyedStream.stream(delegate.accept(requests))
-                .mapKeys((client, booleanResponseWithSeq) -> WithSeq.of(client, booleanResponseWithSeq.seq()))
+                .mapKeys((client, booleanResponseWithSeq) -> booleanResponseWithSeq.withNewValue(client))
                 .map(WithSeq::value)
                 .collectToMap();
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosAcceptorResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosAcceptorResource.java
@@ -60,7 +60,7 @@ public class BatchPaxosAcceptorResource implements BatchPaxosAcceptor {
                 .map((client, paxosProposalIdWithSeq) -> {
                     PaxosPromise promise = paxosComponents.acceptor(client)
                             .prepare(paxosProposalIdWithSeq.seq(), paxosProposalIdWithSeq.value());
-                    return WithSeq.of(promise, paxosProposalIdWithSeq.seq());
+                    return paxosProposalIdWithSeq.withNewValue(promise);
                 })
                 .collectToSetMultimap();
         primeCache(promiseWithSeqRequestsByClient.keySet());
@@ -116,7 +116,7 @@ public class BatchPaxosAcceptorResource implements BatchPaxosAcceptor {
         Set<WithSeq<Client>> latestSequences = KeyedStream.of(clients)
                 .map(paxosComponents::acceptor)
                 .map(PaxosAcceptor::getLatestSequencePreparedOrAccepted)
-                .map((client, latestSeq) -> WithSeq.of(client, latestSeq))
+                .map(WithSeq::of)
                 .values()
                 .collect(toSet());
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosLearner.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosLearner.java
@@ -50,10 +50,12 @@ public interface BatchPaxosLearner {
      * ({@link WithSeq}), it returns the learnt value. Values where nothing has been learnt are excluded. If for a given
      * {@link Client} nothing has been learnt, the {@link Client} is also excluded.
      * <p>
+     * In addition to the above, if a {@link PaxosValue} <em>is</em> returned, it is guaranteed to be non-null.
+     * <p>
      * @param clientAndSeqs each {@link Client} with a given paxos instance ({@link WithSeq}) to retrieve the learnt
      * values for
      * @return for each {@link Client} the different {@link PaxosValue}s learnt for different
-     * {@link PaxosValue#getRound}s
+     * {@link PaxosValue#getRound}s. Any {@link PaxosValue}s are guaranteed to be non-null
      */
     @POST
     @Path("learned-values")

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosLearnerResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosLearnerResource.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.timelock.paxos;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import com.google.common.collect.SetMultimap;
@@ -44,6 +45,7 @@ public class BatchPaxosLearnerResource implements BatchPaxosLearner {
                 .mapKeys(WithSeq::value)
                 .map(WithSeq::seq)
                 .map((client, seq) -> paxosComponents.learner(client).getLearnedValue(seq))
+                .filter(Objects::nonNull)
                 .collectToSetMultimap();
     }
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LearnedValuesCoalescingFunction.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LearnedValuesCoalescingFunction.java
@@ -44,7 +44,7 @@ final class LearnedValuesCoalescingFunction implements
 
         Map<WithSeq<Client>, PaxosContainer<Optional<PaxosValue>>> resultMap = KeyedStream.stream(learnedValues)
                 .mapKeys((client, paxosValue) -> WithSeq.of(client, paxosValue.getRound()))
-                .map(Optional::ofNullable)
+                .map(Optional::of)
                 .map(PaxosContainer::of)
                 .collectToMap();
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PrepareCoalescingFunction.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PrepareCoalescingFunction.java
@@ -43,8 +43,8 @@ final class PrepareCoalescingFunction implements
 
         SetMultimap<Client, WithSeq<PaxosPromise>> prepareResult = delegate.prepare(requests);
         Map<Map.Entry<Client, WithSeq<PaxosProposalId>>, PaxosPromise> responsesMap = KeyedStream.stream(prepareResult)
-                .mapKeys((client, paxosPromiseWithSeq) -> Maps.immutableEntry(client,
-                        WithSeq.of(paxosPromiseWithSeq.value().getPromisedId(), paxosPromiseWithSeq.seq())))
+                .mapKeys((client, paxosPromiseWithSeq) ->
+                        Maps.immutableEntry(client, paxosPromiseWithSeq.map(PaxosPromise::getPromisedId)))
                 .map(WithSeq::value)
                 .collectToMap();
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/WithSeq.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/WithSeq.java
@@ -16,6 +16,9 @@
 
 package com.palantir.atlasdb.timelock.paxos;
 
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -31,6 +34,18 @@ public interface WithSeq<T> {
 
     @Value.Parameter
     T value();
+
+    default <U> WithSeq<U> map(BiFunction<T, Long, U> mapper) {
+        return WithSeq.of(mapper.apply(value(), seq()), seq());
+    }
+
+    default <U> WithSeq<U> map(Function<T, U> mapper) {
+        return WithSeq.of(mapper.apply(value()), seq());
+    }
+
+    default <U> WithSeq<U> withNewValue(U newValue) {
+        return WithSeq.of(newValue, seq());
+    }
 
     static <T> WithSeq<T> of(T value, long seq) {
         return ImmutableWithSeq.of(seq, value);

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/AcceptorCacheImplTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/AcceptorCacheImplTests.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.palantir.common.streams.KeyedStream;
 
 public class AcceptorCacheImplTests {
 
@@ -156,8 +157,9 @@ public class AcceptorCacheImplTests {
     private static AcceptorCache cache(Map<Client, Long> latestSequencesForClients) {
         AcceptorCacheImpl acceptorCache = new AcceptorCacheImpl();
 
-        Set<WithSeq<Client>> clientsAndSeq = latestSequencesForClients.entrySet().stream()
-                .map(clientAndSeq -> WithSeq.of(clientAndSeq.getKey(), clientAndSeq.getValue()))
+        Set<WithSeq<Client>> clientsAndSeq = KeyedStream.stream(latestSequencesForClients)
+                .map(WithSeq::of)
+                .values()
                 .collect(Collectors.toSet());
         acceptorCache.updateSequenceNumbers(clientsAndSeq);
         return acceptorCache;

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosLearnerResourceTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosLearnerResourceTests.java
@@ -76,6 +76,7 @@ public class BatchPaxosLearnerResourceTests {
         PaxosValue paxosValue1 = paxosValue(1);
         PaxosValue paxosValue2 = paxosValue(2);
         when(paxosComponents.learner(CLIENT_1).getLearnedValue(1)).thenReturn(paxosValue1);
+        when(paxosComponents.learner(CLIENT_1).getLearnedValue(2)).thenReturn(null);
         when(paxosComponents.learner(CLIENT_2).getLearnedValue(1)).thenReturn(paxosValue1);
         when(paxosComponents.learner(CLIENT_2).getLearnedValue(2)).thenReturn(paxosValue2);
 
@@ -86,6 +87,7 @@ public class BatchPaxosLearnerResourceTests {
 
         Set<WithSeq<Client>> request = ImmutableSet.of(
                 WithSeq.of(CLIENT_1, 1),
+                WithSeq.of(CLIENT_1, 2),
                 WithSeq.of(CLIENT_2, 1),
                 WithSeq.of(CLIENT_2, 2));
 

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PrepareCoalescingFunctionTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PrepareCoalescingFunctionTests.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.when;
 import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
-import java.util.function.Function;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -81,10 +80,7 @@ public class PrepareCoalescingFunctionTests {
     }
 
     private static WithSeq<PaxosPromise> promiseFor(WithSeq<PaxosProposalId> proposalIdWithSeq) {
-        return map(proposalIdWithSeq, proposalId -> PaxosPromise.accept(proposalId, null, null));
+        return proposalIdWithSeq.map(proposalId -> PaxosPromise.accept(proposalId, null, null));
     }
 
-    private static <T, U> WithSeq<U> map(WithSeq<T> container, Function<T, U> mapper) {
-        return WithSeq.of(mapper.apply(container.value()), container.seq());
-    }
 }


### PR DESCRIPTION
**Goals (and why)**:
Whilst wiring up the impl for trying to batch timestamp paxos, I ended up having passing tests for `PaxosTimestampBoundStoreTests` for both the new and old clients. However I was receiving `NullPointerException`.

Some of the tests *expected* an `NPE`, which somewhat masked the issue. This should fix it.

The problem lies in that when we haven't learned any values instead of `PaxosLearner` returning `Optional<PaxosValue>` it returns null. This also means we have no idea what sequence number the "no learned values" corresponds to.

**Implementation Description (bullets)**:
Change the type (this is fine, none of this is released) to have a `WithSeq<Optional<PaxosValue>>` which correctly encodes the type that we want to use.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added extra test cases.

**Priority (whenever / two weeks / yesterday)**:
ASAP 💃 

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
