### PR TITLE
Fix annotation processing in IntelliJ

### DIFF
--- a/atlasdb-dagger/build.gradle
+++ b/atlasdb-dagger/build.gradle
@@ -8,12 +8,7 @@ dependencies {
   compile project(':atlasdb-service')
   compile group: 'com.google.dagger', name: 'dagger'
 
-  processor(group: 'com.google.dagger', name: 'dagger-compiler') {
-      // We need to explicitly exclude these so that intellij does not label them as provided
-      if(gradle.startParameter.taskNames.contains('idea')) {
-          exclude group: 'com.google.dagger', module: 'dagger'
-      }
-  }
+  processor group: 'com.google.dagger', name: 'dagger-compiler'
   processor group: 'org.immutables', name: 'value'
 
   shadow project(':atlasdb-service')

--- a/atlasdb-perf/build.gradle
+++ b/atlasdb-perf/build.gradle
@@ -34,12 +34,7 @@ dependencies {
 
   compile group: 'org.openjdk.jmh', name: 'jmh-core', version: '1.13'
   processor group: 'org.immutables', name: 'value'
-  processor(group: 'org.openjdk.jmh', name: 'jmh-generator-annprocess', version: '1.13') {
-      // We need to explicitly exclude these so that intellij does not label them as provided
-      if(gradle.startParameter.taskNames.contains('idea')) {
-          exclude group: 'org.openjdk.jmh', module: 'jmh-core'
-      }
-  }
+  processor group: 'org.openjdk.jmh', name: 'jmh-generator-annprocess', version: '1.13'
 }
 
 distZip {

--- a/atlasdb-processors/build.gradle
+++ b/atlasdb-processors/build.gradle
@@ -2,6 +2,7 @@ apply from: "../gradle/publish-jars.gradle"
 apply from: "../gradle/shared.gradle"
 
 apply plugin: 'org.inferred.processors'
+apply plugin: 'java-library'
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,14 @@ allprojects {
     apply plugin: 'nebula.dependency-recommender'
     apply plugin: 'org.inferred.processors'  // installs the "processor" configuration needed for baseline-error-prone
 
+    // temporary until this is merged/fixed inside gradle-processors
+    configurations.allProcessors {
+        canBeConsumed = false
+        attributes {
+            attribute Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API)
+        }
+    }
+
     dependencyRecommendations {
         strategy OverrideTransitives
         propertiesFile file: project.rootProject.file('versions.props')

--- a/versions.props
+++ b/versions.props
@@ -7,6 +7,7 @@ com.github.rholder:guava-retrying = 2.0.0
 com.github.stefanbirkner:system-rules = 1.19.0
 com.github.tomakehurst:wiremock = 1.57
 com.google.auto:auto-common = 0.10
+com.google.auto.service:auto-service = 1.0-rc3
 com.google.code.findbugs:findbugs-annotations = 3.0.1
 com.google.code.findbugs:jsr305 = 3.0.2
 com.google.dagger:dagger = 2.19


### PR DESCRIPTION
We upgraded to gradle-processors 2.2.0 as part of #3974, which means that annotation processors are no longer sourced from the classpath, but are explicitly referenced in the `javac` processor path. This is a good direction, however it breaks us because we have an annotation processor (`atlasdb-processors`) and we expect to be able to build against it in IntelliJ. As it stands, we would need to build a *jar* of atlasdb processors via gradle.

This should improve it a bit, as it only requires the classes, but if I'm not mistaken, it still points to the classes that are generated by *gradle* as opposed to IntelliJ. It's probably okay for now seeing as we never really change the processors and that we end up doing `compileTestJava` (well at least I do) quite often. But it would be nice to get it working as it was before via processor path.

Until this is merged, you'll have to run `./gradlew jar` or whatever actually generates jars.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
