### PR TITLE
[Timelock Partitioning] Part 21: Integration pain points

### DIFF
--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AcceptorCacheKey.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AcceptorCacheKey.java
@@ -27,14 +27,22 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 @Value.Immutable
 @JsonDeserialize(as = ImmutableAcceptorCacheKey.class)
 @JsonSerialize(as = ImmutableAcceptorCacheKey.class)
-public interface AcceptorCacheKey {
+public abstract class AcceptorCacheKey {
 
     @JsonValue
     @Value.Parameter
-    UUID value();
+    public abstract UUID value();
 
-    static AcceptorCacheKey newCacheKey() {
+    public static AcceptorCacheKey valueOf(String key) {
+        return ImmutableAcceptorCacheKey.of(UUID.fromString(key));
+    }
+
+    public static AcceptorCacheKey newCacheKey() {
         return ImmutableAcceptorCacheKey.of(UUID.randomUUID());
     }
 
+    @Override
+    public String toString() {
+        return value().toString();
+    }
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/Client.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/Client.java
@@ -20,6 +20,7 @@ import java.util.BitSet;
 
 import org.immutables.value.Value;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -69,6 +70,7 @@ public abstract class Client {
 
     }
 
+    @JsonCreator
     public static Client of(String value) {
         return ImmutableClient.of(value);
     }

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
@@ -18,6 +18,10 @@ package com.palantir.atlasdb.timelock;
 import java.util.UUID;
 import java.util.function.Consumer;
 
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.SharedMetricRegistries;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
@@ -31,6 +35,7 @@ import com.palantir.timelock.paxos.TimeLockAgent;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 
 import io.dropwizard.Application;
+import io.dropwizard.jersey.optional.EmptyOptionalException;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 
@@ -58,6 +63,7 @@ public class TimeLockServerLauncher extends Application<CombinedTimeLockServerCo
                 .registerModule(new Jdk8Module())
                 .registerModule(new JavaTimeModule());
         environment.jersey().register(ConjureJerseyFeature.INSTANCE);
+        environment.jersey().register(new EmptyOptionalTo204ExceptionMapper());
 
         MetricsManager metricsManager = MetricsManagers.of(environment.metrics(), new DefaultTaggedMetricRegistry());
         Consumer<Object> registrar = component -> environment.jersey().register(component);
@@ -69,5 +75,13 @@ public class TimeLockServerLauncher extends Application<CombinedTimeLockServerCo
                 CombinedTimeLockServerConfiguration.threadPoolSize(),
                 CombinedTimeLockServerConfiguration.blockingTimeoutMs(),
                 registrar);
+    }
+
+    @Provider
+    private final static class EmptyOptionalTo204ExceptionMapper implements ExceptionMapper<EmptyOptionalException> {
+        @Override
+        public Response toResponse(EmptyOptionalException exception) {
+            return Response.noContent().build();
+        }
     }
 }

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
@@ -78,7 +78,7 @@ public class TimeLockServerLauncher extends Application<CombinedTimeLockServerCo
     }
 
     @Provider
-    private final static class EmptyOptionalTo204ExceptionMapper implements ExceptionMapper<EmptyOptionalException> {
+    private static final class EmptyOptionalTo204ExceptionMapper implements ExceptionMapper<EmptyOptionalException> {
         @Override
         public Response toResponse(EmptyOptionalException exception) {
             return Response.noContent().build();


### PR DESCRIPTION
_**Note**: Taking a small detour to wire in the batch endpoints but for timestamp paxos (separate from leader election). Anything ironed out here will effectively solve the same issue for when the batch endpoints are integrated for leader election._

**Goals (and why)**:

A few pain points that can only really be detected when running integration tests:
  * (de)serialisation for path/query/header params
  * empty optional handling for dropwizard (unaffected by internal server)
  * (de)serialisation for string aliases in maps

**Testing (What was existing testing like?  What have you done to improve it?)**:
  * individual tests are not worth it, integration tests that are coming later are sufficient.

**Priority (whenever / two weeks / yesterday)**:
ASAP 💃 🔥 
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
