### PR TITLE
[Timelock Partitioning] Part 22: Fix up `BatcingPaxosLatestSequenceCache`.

### DIFF
--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosAcceptor.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosAcceptor.java
@@ -28,6 +28,7 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 
 import com.google.common.collect.SetMultimap;
+import com.palantir.conjure.java.api.errors.ErrorType;
 import com.palantir.paxos.BooleanPaxosResponse;
 import com.palantir.paxos.PaxosAcceptor;
 import com.palantir.paxos.PaxosPromise;
@@ -37,6 +38,8 @@ import com.palantir.paxos.PaxosProposalId;
 @Path("/batch/acceptor")
 public interface BatchPaxosAcceptor {
 
+    ErrorType CACHE_KEY_NOT_FOUND =
+            ErrorType.create(ErrorType.Code.NOT_FOUND, "TimelockBatchPaxosAcceptor:CacheKeyNotFound");
     long NO_LOG_ENTRY = PaxosAcceptor.NO_LOG_ENTRY;
 
     /**

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosAcceptorResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosAcceptorResource.java
@@ -24,10 +24,8 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.SetMultimap;
 import com.palantir.common.streams.KeyedStream;
-import com.palantir.conjure.java.api.errors.ErrorType;
 import com.palantir.conjure.java.api.errors.ServiceException;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.paxos.BooleanPaxosResponse;
@@ -39,10 +37,6 @@ import com.palantir.paxos.PaxosProposalId;
 public class BatchPaxosAcceptorResource implements BatchPaxosAcceptor {
 
     private static final Logger log = LoggerFactory.getLogger(BatchPaxosAcceptorResource.class);
-
-    @VisibleForTesting
-    static final ErrorType CACHE_KEY_NOT_FOUND =
-            ErrorType.create(ErrorType.Code.NOT_FOUND, "TimelockBatchPaxosAcceptor:CacheKeyNotFound");
 
     private final AcceptorCache acceptorCache;
     private final PaxosComponents paxosComponents;

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosLatestSequenceCache.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosLatestSequenceCache.java
@@ -63,7 +63,7 @@ final class BatchingPaxosLatestSequenceCache implements CoalescingRequestFunctio
                 return handleCacheMiss(clients);
             }
 
-            log.error("received remote exception that is not a cache key miss", e);
+            log.warn("received remote exception that is not a cache key miss", e);
             throw e;
         } catch (RuntimeException e) {
             // TODO(fdesouza): Remove this once we've moved to CJR properly and the above works.
@@ -72,7 +72,7 @@ final class BatchingPaxosLatestSequenceCache implements CoalescingRequestFunctio
                 return handleCacheMiss(clients);
             }
 
-            log.error("received unexpected runtime exception", e);
+            log.warn("received unexpected runtime exception", e);
             throw e;
         }
     }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosLatestSequenceCache.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosLatestSequenceCache.java
@@ -26,7 +26,6 @@ import javax.annotation.concurrent.NotThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -41,9 +40,6 @@ import com.palantir.paxos.PaxosLong;
  */
 @NotThreadSafe
 final class BatchingPaxosLatestSequenceCache implements CoalescingRequestFunction<Client, PaxosLong> {
-
-    @VisibleForTesting
-    static final String ERROR_NAME = "TimelockPartitioning:InvalidCacheKey";
 
     private static final Logger log = LoggerFactory.getLogger(BatchingPaxosLatestSequenceCache.class);
     private static final PaxosLong DEFAULT_VALUE = PaxosLong.of(BatchPaxosAcceptor.NO_LOG_ENTRY);
@@ -62,19 +58,33 @@ final class BatchingPaxosLatestSequenceCache implements CoalescingRequestFunctio
         try {
             return unsafeGetLatest(clients);
         } catch (RemoteException e) {
-            if (e.getError().errorName().equals(ERROR_NAME)) {
+            if (e.getError().errorName().equals(BatchPaxosAcceptor.CACHE_KEY_NOT_FOUND.name())) {
                 log.info("Cache key is invalid, invalidating cache");
-                cacheKey = null;
-                Set<Client> allClients = ImmutableSet.<Client>builder()
-                        .addAll(clients)
-                        .addAll(cachedEntries.keySet())
-                        .build();
-                cachedEntries.clear();
-                return unsafeGetLatest(allClients);
+                return handleCacheMiss(clients);
             }
 
+            log.error("received remote exception that is not a cache key miss", e);
+            throw e;
+        } catch (RuntimeException e) {
+            // TODO(fdesouza): Remove this once we've moved to CJR properly and the above works.
+            if (e.getMessage().contains(BatchPaxosAcceptor.CACHE_KEY_NOT_FOUND.name())) {
+                log.info("Cache key is invalid, invalidating cache - using deprecated detection method");
+                return handleCacheMiss(clients);
+            }
+
+            log.error("received unexpected runtime exception", e);
             throw e;
         }
+    }
+
+    private Map<Client, PaxosLong> handleCacheMiss(Set<Client> requestedClients) {
+        cacheKey = null;
+        Set<Client> allClients = ImmutableSet.<Client>builder()
+                .addAll(requestedClients)
+                .addAll(cachedEntries.keySet())
+                .build();
+        cachedEntries.clear();
+        return unsafeGetLatest(allClients);
     }
 
     private Map<Client, PaxosLong> unsafeGetLatest(Set<Client> clients) {

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosLatestSequenceCacheTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosLatestSequenceCacheTests.java
@@ -34,7 +34,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.common.streams.KeyedStream;
-import com.palantir.conjure.java.api.errors.ErrorType;
 import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.SerializableError;
 import com.palantir.conjure.java.api.errors.ServiceException;
@@ -158,9 +157,7 @@ public class BatchingPaxosLatestSequenceCacheTests {
     }
 
     private static RemoteException invalidCacheKeyException() {
-        ServiceException serviceException = new ServiceException(
-                ErrorType.create(ErrorType.Code.NOT_FOUND, BatchingPaxosLatestSequenceCache.ERROR_NAME));
-
+        ServiceException serviceException = new ServiceException(BatchPaxosAcceptor.CACHE_KEY_NOT_FOUND);
         return new RemoteException(SerializableError.forException(serviceException), 404);
     }
 


### PR DESCRIPTION
_**Note**: Taking a small detour to wire in the batch endpoints but for timestamp paxos (separate from leader election). Anything ironed out here will effectively solve the same issue for when the batch endpoints are integrated for leader election._

**Goals (and why)**:
During integration, the error for cache miss was not the same between the server and client meaning we were never handling it.

In addition to that, our custom feign has its own custom error decoding which is incompatible with conjure-java-runtime errors. This means our error handling for cache miss never gets invoked. Obviously we don't want to block on conjure-java-runtime. 

**Implementation Description (bullets)**:
I evaluated the following options:
  * (picked) search for the error name in the `RuntimeException` that gets thrown 
    from being unable to deserialise the conjure-java-runtime error.
  * go to cjr (infeasible)
  * use retrofit instead
    * very self contained and doable, but we are subject to limits which the 
      conjure-java-runtime workstream will eventually resolve, and doesn't seem 
      useful to duplicate this work

I went with the ugly hack which is unfortunate but works in testing. I've also added it to #4112 of things to do at a later date, perhaps a separate issue?

I also pulled out the error into `BatchPaxosAcceptor` which is where it should live really.

At a later date when the RPC layer changes have merged, it might make more sense to have the rpc layer do this, and then throw an application exception such as `AcceptorCacheKeyMiss`, which means we don't need to worry about the remoting layer in a mainly non-remoting aware class.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Covered by integration tests. Also seems pointless to test the error is same unless we're not sharing the same constant.

**Priority (whenever / two weeks / yesterday)**:
ASAP 🔥 💃 🚒 
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
