### PR TITLE
[Timestamp Partitioning] Part 23: Have a separate RPC client layer from logical layer

### DIFF
--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AcceptorCacheImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AcceptorCacheImpl.java
@@ -27,6 +27,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nonnull;
 import javax.annotation.concurrent.GuardedBy;
 
 import com.github.benmanes.caffeine.cache.Cache;
@@ -114,7 +115,7 @@ public class AcceptorCacheImpl implements AcceptorCache {
     }
 
     @Override
-    public Optional<AcceptorCacheDigest> updatesSinceCacheKey(AcceptorCacheKey cacheKey)
+    public Optional<AcceptorCacheDigest> updatesSinceCacheKey(@Nonnull AcceptorCacheKey cacheKey)
             throws InvalidAcceptorCacheKeyException {
         lock.readLock().lock();
         try {

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosAcceptor.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosAcceptor.java
@@ -45,7 +45,7 @@ public interface BatchPaxosAcceptor {
 
     /**
      * Batch counterpart to {@link PaxosAcceptor#accept}. For a given {@link Client} on paxos instance {@code seq}, the
-     * acceptor decides whether to accept or reject a given proposal ({@link PaxosProposal}.
+     * acceptor decides whether to accept or reject a given proposal ({@link PaxosProposal}).
      * <p>
      * @param proposalRequestsByClientAndSeq for each {@link Client}, the set of paxos instances tied to a particular
      * {@link PaxosProposal} to respond to; {@link PaxosProposal} the proposal in question for the above {@link Client}
@@ -65,10 +65,11 @@ public interface BatchPaxosAcceptor {
      * acceptor has received multiple proposals at multiple sequence numbers for the same client past {@code cacheKey},
      * it will return the sequence number for the latest proposal.
      * <p>
-     * If a provided {@code cacheKey} has expired/invalid, a {@code 404 Not Found} is thrown and this request
+     * If a provided {@code cacheKey} has expired/is invalid, a {@code 404 Not Found} is thrown and this request
      * should be retried without a {@code cacheKey} and also with a full set of clients to ensure a correct response.
      * <p>
-     * If an acceptor has received multiple proposals at multiple sequence numbers for a given client, only the la
+     * If an acceptor has received multiple proposals at multiple sequence numbers for a given client, only the latest
+     * sequence number is returned for that client.
      *
      * @param clients clients to force getting latest sequences for
      * @return digest containing next cacheKey and updates since provided {@code cacheKey}

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosLearnerRpcClient.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosLearnerRpcClient.java
@@ -19,11 +19,22 @@ package com.palantir.atlasdb.timelock.paxos;
 import java.util.Map;
 import java.util.Set;
 
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
 import com.google.common.collect.SetMultimap;
 import com.palantir.paxos.PaxosLearner;
 import com.palantir.paxos.PaxosValue;
 
-public interface BatchPaxosLearner {
+@Path("/" + PaxosTimeLockConstants.INTERNAL_NAMESPACE
+        + "/{useCase}"
+        + "/" + PaxosTimeLockConstants.BATCH_INTERNAL_NAMESPACE
+        + "/learner")
+public interface BatchPaxosLearnerRpcClient {
 
     /**
      * Batch counterpart to {@link PaxosLearner#learn}. For a given {@link Client} on paxos instance {@code seq},
@@ -32,7 +43,11 @@ public interface BatchPaxosLearner {
      * @param paxosValuesByClient for each {@link Client} and the different {@link PaxosValue}s that are being taught;
      * {@link PaxosValue} is the value being taught for the sequence number in {@link PaxosValue#getRound}.
      */
-    void learn(SetMultimap<Client, PaxosValue> paxosValuesByClient);
+    @POST
+    @Path("learn")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    void learn(@PathParam("useCase") PaxosUseCase paxosUseCase, SetMultimap<Client, PaxosValue> paxosValuesByClient);
 
     /**
      * Batch counterpart to {@link PaxosLearner#getLearnedValue}. For a given {@link Client} on paxos instance
@@ -46,7 +61,13 @@ public interface BatchPaxosLearner {
      * @return for each {@link Client} the different {@link PaxosValue}s learnt for different
      * {@link PaxosValue#getRound}s. Any {@link PaxosValue}s are guaranteed to be non-null
      */
-    SetMultimap<Client, PaxosValue> getLearnedValues(Set<WithSeq<Client>> clientAndSeqs);
+    @POST
+    @Path("learned-values")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    SetMultimap<Client, PaxosValue> getLearnedValues(
+            @PathParam("useCase") PaxosUseCase paxosUseCase,
+            Set<WithSeq<Client>> clientAndSeqs);
 
     /**
      * Batch counterpart to {@link PaxosLearner#getLearnedValuesSince}. For a given {@link Client}, returns all learnt
@@ -56,6 +77,12 @@ public interface BatchPaxosLearner {
      * learnt paxos values since that paxos round.
      * @return for each {@link Client}, all learnt {@link PaxosValue}'s past the given lower bound for the round
      */
-    SetMultimap<Client, PaxosValue> getLearnedValuesSince(Map<Client, Long> seqLowerBoundsByClient);
+    @POST
+    @Path("learned-values-since")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    SetMultimap<Client, PaxosValue> getLearnedValuesSince(
+            @PathParam("useCase") PaxosUseCase paxosUseCase,
+            Map<Client, Long> seqLowerBoundsByClient);
 
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimeLockConstants.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimeLockConstants.java
@@ -23,6 +23,7 @@ public final class PaxosTimeLockConstants {
     public static final String LEADER_ELECTION_NAMESPACE = "leader";
 
     public static final String INTERNAL_NAMESPACE = ".internal";
+    public static final String BATCH_INTERNAL_NAMESPACE = ".batch";
     public static final String LEADER_PAXOS_NAMESPACE = "leaderPaxos";
     public static final String CLIENT_PAXOS_NAMESPACE = "clientPaxos";
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosUseCase.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosUseCase.java
@@ -1,0 +1,50 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+
+public enum PaxosUseCase {
+    LEADER(PaxosTimeLockConstants.LEADER_PAXOS_NAMESPACE),
+    TIMESTAMP(PaxosTimeLockConstants.CLIENT_PAXOS_NAMESPACE);
+
+    PaxosUseCase(String useCasePath) {
+        this.useCasePath = useCasePath;
+    }
+
+    private final String useCasePath;
+
+    /*
+        Although this has no compile time usages, this is used for serialisation/deserialisation via Jersey
+        {@link QueryParam}.
+     */
+    public static PaxosUseCase fromString(String string) {
+        switch(string) {
+            case PaxosTimeLockConstants.LEADER_PAXOS_NAMESPACE:
+                return LEADER;
+            case PaxosTimeLockConstants.CLIENT_PAXOS_NAMESPACE:
+                return TIMESTAMP;
+            default:
+                throw new SafeIllegalArgumentException("unrecognized used case");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return useCasePath;
+    }
+}

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosUseCase.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosUseCase.java
@@ -39,7 +39,7 @@ public enum PaxosUseCase {
             case PaxosTimeLockConstants.CLIENT_PAXOS_NAMESPACE:
                 return TIMESTAMP;
             default:
-                throw new SafeIllegalArgumentException("unrecognized used case");
+                throw new SafeIllegalArgumentException("unrecognized use case");
         }
     }
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/UseCaseAwareBatchPaxosAcceptorAdapter.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/UseCaseAwareBatchPaxosAcceptorAdapter.java
@@ -1,0 +1,69 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.SetMultimap;
+import com.palantir.paxos.BooleanPaxosResponse;
+import com.palantir.paxos.PaxosPromise;
+import com.palantir.paxos.PaxosProposal;
+import com.palantir.paxos.PaxosProposalId;
+
+public class UseCaseAwareBatchPaxosAcceptorAdapter implements BatchPaxosAcceptor {
+
+    private final PaxosUseCase useCase;
+    private final BatchPaxosAcceptorRpcClient rpcClient;
+
+    private UseCaseAwareBatchPaxosAcceptorAdapter(PaxosUseCase useCase, BatchPaxosAcceptorRpcClient rpcClient) {
+        this.useCase = useCase;
+        this.rpcClient = rpcClient;
+    }
+
+    @Override
+    public SetMultimap<Client, WithSeq<PaxosPromise>> prepare(
+            SetMultimap<Client, WithSeq<PaxosProposalId>> promiseWithSeqRequestsByClient) {
+        return rpcClient.prepare(useCase, promiseWithSeqRequestsByClient);
+    }
+
+    @Override
+    public SetMultimap<Client, WithSeq<BooleanPaxosResponse>> accept(
+            SetMultimap<Client, PaxosProposal> proposalRequestsByClientAndSeq) {
+        return rpcClient.accept(useCase, proposalRequestsByClientAndSeq);
+    }
+
+    @Override
+    public AcceptorCacheDigest latestSequencesPreparedOrAccepted(
+            Optional<AcceptorCacheKey> cacheKey,
+            Set<Client> clients) {
+        return rpcClient.latestSequencesPreparedOrAccepted(useCase, cacheKey.orElse(null), clients);
+    }
+
+    @Override
+    public Optional<AcceptorCacheDigest> latestSequencesPreparedOrAcceptedCached(AcceptorCacheKey cacheKey) {
+        return rpcClient.latestSequencesPreparedOrAcceptedCached(useCase, cacheKey);
+    }
+
+    public static List<BatchPaxosAcceptor> wrap(PaxosUseCase useCase, List<BatchPaxosAcceptorRpcClient> remotes) {
+        return remotes.stream()
+                .map(rpcClient -> new UseCaseAwareBatchPaxosAcceptorAdapter(useCase, rpcClient))
+                .collect(Collectors.toList());
+    }
+}

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/UseCaseAwareBatchPaxosLearnerAdapter.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/UseCaseAwareBatchPaxosLearnerAdapter.java
@@ -1,0 +1,54 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.SetMultimap;
+import com.palantir.paxos.PaxosValue;
+
+public class UseCaseAwareBatchPaxosLearnerAdapter implements BatchPaxosLearner {
+
+    private final PaxosUseCase useCase;
+    private final BatchPaxosLearnerRpcClient rpcClient;
+
+    private UseCaseAwareBatchPaxosLearnerAdapter(PaxosUseCase useCase, BatchPaxosLearnerRpcClient rpcClient) {
+        this.useCase = useCase;
+        this.rpcClient = rpcClient;
+    }
+
+    public void learn(SetMultimap<Client, PaxosValue> paxosValuesByClient) {
+        rpcClient.learn(useCase, paxosValuesByClient);
+    }
+
+    public SetMultimap<Client, PaxosValue> getLearnedValues(Set<WithSeq<Client>> clientAndSeqs) {
+        return rpcClient.getLearnedValues(useCase, clientAndSeqs);
+    }
+
+    public SetMultimap<Client, PaxosValue> getLearnedValuesSince(Map<Client, Long> seqLowerBoundsByClient) {
+        return rpcClient.getLearnedValuesSince(useCase, seqLowerBoundsByClient);
+    }
+
+    public static List<BatchPaxosLearner> wrap(PaxosUseCase useCase, List<BatchPaxosLearnerRpcClient> remotes) {
+        return remotes.stream()
+                .map(rpcClient -> new UseCaseAwareBatchPaxosLearnerAdapter(useCase, rpcClient))
+                .collect(Collectors.toList());
+    }
+}

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/UseCaseAwareBatchPaxosResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/UseCaseAwareBatchPaxosResource.java
@@ -1,0 +1,72 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import java.util.EnumMap;
+
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+import org.immutables.value.Value;
+
+import com.google.common.collect.ImmutableMap;
+
+@Path("/" + PaxosTimeLockConstants.INTERNAL_NAMESPACE)
+public class UseCaseAwareBatchPaxosResource {
+
+    private final EnumMap<PaxosUseCase, BatchPaxosResources> resourcesByUseCase;
+
+    UseCaseAwareBatchPaxosResource(
+            BatchPaxosAcceptorResource clientPaxosAcceptor,
+            BatchPaxosLearnerResource clientPaxosLearner) {
+        this(new EnumMap<>(ImmutableMap.<PaxosUseCase, BatchPaxosResources>of(
+                PaxosUseCase.TIMESTAMP,
+                ImmutableBatchPaxosResources.of(clientPaxosAcceptor, clientPaxosLearner))));
+    }
+
+    UseCaseAwareBatchPaxosResource(EnumMap<PaxosUseCase, BatchPaxosResources> resourcesByUseCase) {
+        this.resourcesByUseCase = resourcesByUseCase;
+    }
+
+    @Path("{useCase}/" + PaxosTimeLockConstants.BATCH_INTERNAL_NAMESPACE + "/acceptor")
+    public BatchPaxosAcceptorResource acceptor(@PathParam("useCase") PaxosUseCase useCase) {
+        return getResourcesForUseCase(useCase).batchAcceptor();
+    }
+
+    @Path("{useCase}/" + PaxosTimeLockConstants.BATCH_INTERNAL_NAMESPACE + "/learner")
+    public BatchPaxosLearnerResource learner(@PathParam("useCase") PaxosUseCase useCase) {
+        return getResourcesForUseCase(useCase).batchLearner();
+    }
+
+    private BatchPaxosResources getResourcesForUseCase(PaxosUseCase useCase) {
+        BatchPaxosResources resourcesForUseCase = resourcesByUseCase.get(useCase);
+        if (resourcesForUseCase == null) {
+            throw new NotFoundException();
+        }
+        return resourcesForUseCase;
+    }
+
+    @Value.Immutable
+    interface BatchPaxosResources {
+        @Value.Parameter
+        BatchPaxosAcceptorResource batchAcceptor();
+        @Value.Parameter
+        BatchPaxosLearnerResource batchLearner();
+    }
+
+}


### PR DESCRIPTION
_**Note**: Taking a small detour to wire in the batch endpoints but for timestamp paxos (separate from leader election). Anything ironed out here will effectively solve the same issue for when the batch endpoints are integrated for leader election._

**Goals (and why)**:
It's usually quite convenient to use the same logical class as the rpc layer when you have things like feign etc. It does mean however, we can be quite inefficient in our resource usage if not careful. Here I want to reuse the same client but for a *different* use case i.e. for leader paxos. We shouldn't need to create two clients that point to the same thing with a different use case. We also shouldn't need to know about the different intricacies when dealing with a `BatchPaxos(Acceptor|Learner)`. 

**Implementation Description (bullets)**:

* `BatchPaxos(Acceptor|Learner)`no longer has any rpc annotations on. We have a separate rpc client for that `BatchPaxos(Acceptor|Learner)RpcClient`. 
* We introduce wrappers `UseCaseAwareBatchPaxos(Acceptor|Learner)Adaptor` to get `BatchPaxos(A|L)s`.
* We move the rpc annotations on to the actual resource itself i.e. `BatchPaxos(A|L)Resource`. Note that they're not use case aware => we can reuse them for leader paxos i.e. we have 3 classes as opposed to 4 . It's still a `BatchPaxos(A|L)` to stop the proliferation of a million wrappers, and it's compatible with the rpc form since it's not use case aware etc.
* We create a delegating resource that is use case aware i.e. `UseCaseAwareBatchPaxosResource` that will deal with the `PaxosUseCase` parameter. 
* `PaxosUseCase` is an enum which only allows `clientPaxos` and `leaderPaxos`, which is pretty neat.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Unit tests won't catch anything useful here, it's all about integration tests since we're dealing with external dependencies i.e. dropwizard + feign + okhttp etc. These are coming in the next PR.

**Concerns (what feedback would you like?)**:
No concerns about existing behaviour since this isn't wired up yet.

**Where should we start reviewing?**:
* `PaxosUseCase`
* `UseCaseAwareBatchPaxosResource`
* `BatchPaxos(A|L)RpcClient`
* `UseCaseAwareBatchPaxos(A|L)Adaptor`

**Priority (whenever / two weeks / yesterday)**:
ASAP 👨‍🚒 🎆 🔥 🚒 

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
