### PR TITLE
Stop publishing with Jdk7

### DIFF
--- a/atlasdb-config/build.gradle
+++ b/atlasdb-config/build.gradle
@@ -24,7 +24,6 @@ dependencies {
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
     compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml'
     compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8'
-    compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk7'
     compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310'
 
     // This is added so that AtlasDB clients can specify the javaAgent as a JVM argument to load jars needed for HTTP/2

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfigs.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfigs.java
@@ -29,7 +29,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.fasterxml.jackson.datatype.jdk7.Jdk7Module;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.base.Strings;
 import com.palantir.config.crypto.DecryptingVariableSubstitutor;
@@ -47,7 +46,6 @@ public final class AtlasDbConfigs {
             .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER))
             .setSubtypeResolver(new DiscoverableSubtypeResolver(DISCOVERED_SUBTYPE_MARKER))
             .registerModule(new GuavaModule())
-            .registerModule(new Jdk7Module())
             .registerModule(new Jdk8Module());
 
     private AtlasDbConfigs() {

--- a/changelog/@unreleased/pr-4178.v2.yml
+++ b/changelog/@unreleased/pr-4178.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: atlasdb-config no longer depends on jackson-datatype-jdk7
+  links:
+  - https://github.com/palantir/atlasdb/pull/4178

--- a/versions.props
+++ b/versions.props
@@ -1,6 +1,7 @@
 ch.qos.logback:* = 1.1.7
 com.ea.agentloader:ea-agent-loader = 1.0.3
 com.fasterxml.jackson.*:* = 2.9.7
+com.fasterxml.jackson.datatype:jackson-datatype-jdk7 = 2.6.7
 com.github.ben-manes.caffeine:caffeine = 2.6.2
 com.github.rholder:guava-retrying = 2.0.0
 com.github.stefanbirkner:system-rules = 1.19.0

--- a/versions.props
+++ b/versions.props
@@ -1,7 +1,6 @@
 ch.qos.logback:* = 1.1.7
 com.ea.agentloader:ea-agent-loader = 1.0.3
 com.fasterxml.jackson.*:* = 2.9.7
-com.fasterxml.jackson.datatype:jackson-datatype-jdk7 = 2.6.7
 com.github.ben-manes.caffeine:caffeine = 2.6.2
 com.github.rholder:guava-retrying = 2.0.0
 com.github.stefanbirkner:system-rules = 1.19.0


### PR DESCRIPTION
It causes issues internally and everyone uses a new enough version of Jackson that they don't need it.