### PR TITLE
Seed timestamp on node start

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/AsyncPuncher.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/AsyncPuncher.java
@@ -36,7 +36,7 @@ import com.palantir.logsafe.SafeArg;
  */
 public final class AsyncPuncher implements Puncher {
     private static final Logger log = LoggerFactory.getLogger(AsyncPuncher.class);
-    private static final long INVALID_TIMESTAMP = -1L;
+    public static final long INVALID_TIMESTAMP = -1L;
 
     public static AsyncPuncher create(Puncher delegate, long interval, long creationTimestamp) {
         AsyncPuncher asyncPuncher = new AsyncPuncher(delegate, interval, creationTimestamp);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/AsyncPuncher.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/AsyncPuncher.java
@@ -38,8 +38,8 @@ public final class AsyncPuncher implements Puncher {
     private static final Logger log = LoggerFactory.getLogger(AsyncPuncher.class);
     private static final long INVALID_TIMESTAMP = -1L;
 
-    public static AsyncPuncher create(Puncher delegate, long interval) {
-        AsyncPuncher asyncPuncher = new AsyncPuncher(delegate, interval);
+    public static AsyncPuncher create(Puncher delegate, long interval, long creationTimestamp) {
+        AsyncPuncher asyncPuncher = new AsyncPuncher(delegate, interval, creationTimestamp);
         asyncPuncher.start();
         return asyncPuncher;
     }
@@ -49,11 +49,12 @@ public final class AsyncPuncher implements Puncher {
 
     private final Puncher delegate;
     private final long interval;
-    private final AtomicLong lastTimestamp = new AtomicLong(INVALID_TIMESTAMP);
+    private final AtomicLong lastTimestamp;
 
-    private AsyncPuncher(Puncher delegate, long interval) {
+    private AsyncPuncher(Puncher delegate, long interval, long creationTimestamp) {
         this.delegate = delegate;
         this.interval = interval;
+        this.lastTimestamp = new AtomicLong(creationTimestamp);
     }
 
     private void start() {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/AsyncPuncher.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/AsyncPuncher.java
@@ -37,7 +37,7 @@ import com.palantir.logsafe.SafeArg;
  */
 public final class AsyncPuncher implements Puncher {
     private static final Logger log = LoggerFactory.getLogger(AsyncPuncher.class);
-    public static final long INVALID_TIMESTAMP = -1L;
+    private static final long INVALID_TIMESTAMP = -1L;
 
     public static AsyncPuncher create(Puncher delegate, long interval, Optional<Long> creationTimestamp) {
         AsyncPuncher asyncPuncher = new AsyncPuncher(delegate, interval, creationTimestamp.orElse(INVALID_TIMESTAMP));

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/AsyncPuncher.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/AsyncPuncher.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.cleaner;
 
+import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -38,8 +39,8 @@ public final class AsyncPuncher implements Puncher {
     private static final Logger log = LoggerFactory.getLogger(AsyncPuncher.class);
     public static final long INVALID_TIMESTAMP = -1L;
 
-    public static AsyncPuncher create(Puncher delegate, long interval, long creationTimestamp) {
-        AsyncPuncher asyncPuncher = new AsyncPuncher(delegate, interval, creationTimestamp);
+    public static AsyncPuncher create(Puncher delegate, long interval, Optional<Long> creationTimestamp) {
+        AsyncPuncher asyncPuncher = new AsyncPuncher(delegate, interval, creationTimestamp.orElse(INVALID_TIMESTAMP));
         asyncPuncher.start();
         return asyncPuncher;
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/DefaultCleanerBuilder.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/DefaultCleanerBuilder.java
@@ -19,6 +19,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.AtlasDbConstants;
@@ -33,6 +36,8 @@ import com.palantir.lock.v2.TimelockService;
 import com.palantir.timestamp.TimestampService;
 
 public class DefaultCleanerBuilder {
+    private static final Logger log = LoggerFactory.getLogger(DefaultCleanerBuilder.class);
+
     private final KeyValueService keyValueService;
     private final TimelockService timelockService;
     private final List<Follower> followerList;
@@ -153,6 +158,7 @@ public class DefaultCleanerBuilder {
         try {
             return Optional.of(timelockService.getFreshTimestamp());
         } catch (Exception e) {
+            log.info("On node startup quorum not present", e);
             return Optional.empty();
         }
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/DefaultCleanerBuilder.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/DefaultCleanerBuilder.java
@@ -106,7 +106,7 @@ public class DefaultCleanerBuilder {
         return this;
     }
 
-    private Puncher buildPuncher() {
+    private Puncher buildPuncher(long buildTimestamp) {
         PuncherStore keyValuePuncherStore = KeyValueServicePuncherStore.create(keyValueService, initalizeAsync);
         PuncherStore cachingPuncherStore = CachingPuncherStore.create(
                 keyValuePuncherStore,
@@ -116,7 +116,7 @@ public class DefaultCleanerBuilder {
                 cachingPuncherStore,
                 clock,
                 Suppliers.ofInstance(transactionReadTimeout));
-        return AsyncPuncher.create(simplePuncher, punchIntervalMillis);
+        return AsyncPuncher.create(simplePuncher, punchIntervalMillis, buildTimestamp);
     }
 
     private Scrubber buildScrubber(Supplier<Long> unreadableTimestampSupplier,
@@ -138,7 +138,7 @@ public class DefaultCleanerBuilder {
     }
 
     public Cleaner buildCleaner() {
-        Puncher puncher = buildPuncher();
+        Puncher puncher = buildPuncher(timelockService.getFreshTimestamp());
         Supplier<Long> immutableTs = ImmutableTimestampSupplier
                 .createMemoizedWithExpiration(timelockService);
         Scrubber scrubber = buildScrubber(puncher.getTimestampSupplier(), immutableTs);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/DefaultCleanerBuilder.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/DefaultCleanerBuilder.java
@@ -15,8 +15,6 @@
  */
 package com.palantir.atlasdb.cleaner;
 
-import static java.util.Optional.empty;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/cleaner/AsyncPuncherTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/cleaner/AsyncPuncherTest.java
@@ -113,7 +113,7 @@ public class AsyncPuncherTest {
     }
 
     @Test
-    public void testPuncherStartUpSeed() throws Exception{
+    public void testPuncherStartUpSeed() throws Exception {
         checkExpectedValue(asyncPuncherSeeded, PUNCHER_SEED);
     }
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/cleaner/AsyncPuncherTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/cleaner/AsyncPuncherTest.java
@@ -53,17 +53,14 @@ public class AsyncPuncherTest {
         setupSeeded();
     }
 
-    // two methods annotated, do not rely on ordering of the two
-    @Before
-    public void setupNonSeeded() {
+    private void setupNonSeeded() {
         PuncherStore puncherStore = InMemoryPuncherStore.create();
         Clock clock = new SystemClock();
         Puncher puncher = SimplePuncher.create(puncherStore, clock, Suppliers.ofInstance(TRANSACTION_TIMEOUT));
         asyncPuncherNonSeeded = AsyncPuncher.create(puncher, ASYNC_PUNCHER_INTERVAL, Optional.empty());
     }
 
-    @Before
-    public void setupSeeded() {
+    private void setupSeeded() {
         PuncherStore puncherStore = InMemoryPuncherStore.create();
         Clock clock = new SystemClock();
         Puncher puncher = SimplePuncher.create(puncherStore, clock, Suppliers.ofInstance(TRANSACTION_TIMEOUT));

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/cleaner/AsyncPuncherTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/cleaner/AsyncPuncherTest.java
@@ -18,6 +18,8 @@ package com.palantir.atlasdb.cleaner;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -46,7 +48,7 @@ public class AsyncPuncherTest {
         Clock clock = new SystemClock();
         Puncher puncher = SimplePuncher.create(puncherStore, clock, Suppliers.ofInstance(TRANSACTION_TIMEOUT));
         timestampService = new InMemoryTimestampService();
-        asyncPuncher = AsyncPuncher.create(puncher, ASYNC_PUNCHER_INTERVAL, timestampService.getFreshTimestamp());
+        asyncPuncher = AsyncPuncher.create(puncher, ASYNC_PUNCHER_INTERVAL, AsyncPuncher.INVALID_TIMESTAMP);
     }
 
     @After
@@ -57,7 +59,10 @@ public class AsyncPuncherTest {
     @Test
     public void delegatesInitializationCheck() {
         Puncher delegate = mock(Puncher.class);
-        Puncher puncher = AsyncPuncher.create(delegate, ASYNC_PUNCHER_INTERVAL, timestampService.getFreshTimestamp());
+
+        // using invalid timestamp to prevent puncher from punching before the test ends, breaking the test
+        // can not stub punch method as its parameter is not a reference type
+        Puncher puncher = AsyncPuncher.create(delegate, ASYNC_PUNCHER_INTERVAL, AsyncPuncher.INVALID_TIMESTAMP);
 
         when(delegate.isInitialized())
                 .thenReturn(false)

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/cleaner/AsyncPuncherTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/cleaner/AsyncPuncherTest.java
@@ -98,9 +98,9 @@ public class AsyncPuncherTest {
 
     @Test
     public void testPuncherTimestampLessThanFreshTimestamp() throws Exception {
-        Long stored = timestampService.getFreshTimestamp();
+        long stored = timestampService.getFreshTimestamp();
         asyncPuncherNonSeeded.punch(stored);
-        Long retrieved = Long.MIN_VALUE;
+        long retrieved = Long.MIN_VALUE;
         for (int i = 0; i < MAX_INTERVALS_TO_WAIT && retrieved < stored; i++) {
             Thread.sleep(ASYNC_PUNCHER_INTERVAL);
             retrieved = asyncPuncherNonSeeded.getTimestampSupplier().get();
@@ -120,8 +120,8 @@ public class AsyncPuncherTest {
         checkExpectedValue(asyncPuncherSeeded, PUNCHER_UPDATE_TIMESTAMP);
     }
 
-    private void checkExpectedValue(Puncher puncher, Long expected) throws InterruptedException {
-        Long retrieved = Long.MIN_VALUE;
+    private void checkExpectedValue(Puncher puncher, long expected) throws InterruptedException {
+        long retrieved = Long.MIN_VALUE;
         for (int i = 0; i < MAX_INTERVALS_TO_WAIT && retrieved < expected; i++) {
             Thread.sleep(ASYNC_PUNCHER_INTERVAL);
             retrieved = puncher.getTimestampSupplier().get();

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/cleaner/AsyncPuncherTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/cleaner/AsyncPuncherTest.java
@@ -46,7 +46,7 @@ public class AsyncPuncherTest {
         Clock clock = new SystemClock();
         Puncher puncher = SimplePuncher.create(puncherStore, clock, Suppliers.ofInstance(TRANSACTION_TIMEOUT));
         timestampService = new InMemoryTimestampService();
-        asyncPuncher = AsyncPuncher.create(puncher, ASYNC_PUNCHER_INTERVAL);
+        asyncPuncher = AsyncPuncher.create(puncher, ASYNC_PUNCHER_INTERVAL, timestampService.getFreshTimestamp());
     }
 
     @After
@@ -57,7 +57,7 @@ public class AsyncPuncherTest {
     @Test
     public void delegatesInitializationCheck() {
         Puncher delegate = mock(Puncher.class);
-        Puncher puncher = AsyncPuncher.create(delegate, ASYNC_PUNCHER_INTERVAL);
+        Puncher puncher = AsyncPuncher.create(delegate, ASYNC_PUNCHER_INTERVAL, timestampService.getFreshTimestamp());
 
         when(delegate.isInitialized())
                 .thenReturn(false)

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/cleaner/AsyncPuncherTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/cleaner/AsyncPuncherTest.java
@@ -21,6 +21,8 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -46,7 +48,7 @@ public class AsyncPuncherTest {
         Clock clock = new SystemClock();
         Puncher puncher = SimplePuncher.create(puncherStore, clock, Suppliers.ofInstance(TRANSACTION_TIMEOUT));
         timestampService = new InMemoryTimestampService();
-        asyncPuncher = AsyncPuncher.create(puncher, ASYNC_PUNCHER_INTERVAL, AsyncPuncher.INVALID_TIMESTAMP);
+        asyncPuncher = AsyncPuncher.create(puncher, ASYNC_PUNCHER_INTERVAL, Optional.empty());
     }
 
     @After
@@ -60,7 +62,7 @@ public class AsyncPuncherTest {
 
         // using invalid timestamp to prevent puncher from punching before the test ends, breaking the test
         // can not stub punch method as its parameter is not a reference type
-        Puncher puncher = AsyncPuncher.create(delegate, ASYNC_PUNCHER_INTERVAL, AsyncPuncher.INVALID_TIMESTAMP);
+        Puncher puncher = AsyncPuncher.create(delegate, ASYNC_PUNCHER_INTERVAL, Optional.empty());
 
         when(delegate.isInitialized())
                 .thenReturn(false)

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/cleaner/AsyncPuncherTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/cleaner/AsyncPuncherTest.java
@@ -18,8 +18,6 @@ package com.palantir.atlasdb.cleaner;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/changelog/@unreleased/pr-4180.v2.yml
+++ b/changelog/@unreleased/pr-4180.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: AsnycPuncher is now intilized with a seed timestamp if a quorum is present. Public factory method for
+  AsyncPuncher is changed, projects depending on it have to be updated.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4180

--- a/changelog/@unreleased/pr-4180.v2.yml
+++ b/changelog/@unreleased/pr-4180.v2.yml
@@ -1,6 +1,7 @@
-type: improvement
-improvement:
-  description: AsnycPuncher is now intilized with a seed timestamp if a quorum is present. Public factory method for
-  AsyncPuncher is changed, projects depending on it have to be updated.
+type: break
+break:
+  description: AsnycPuncher is now intilized with a seed timestamp if a quorum is present. As a result metrics related
+  to unreadable timestamps on individual with low volume become more accurate. Public factory method for AsyncPuncher
+  is changed, projects depending on it have to be updated.
   links:
   - https://github.com/palantir/atlasdb/pull/4180

--- a/changelog/@unreleased/pr-4180.v2.yml
+++ b/changelog/@unreleased/pr-4180.v2.yml
@@ -1,7 +1,13 @@
-type: break
-break:
-  description: AsnycPuncher is now intilized with a seed timestamp if a quorum is present. As a result metrics related
-  to unreadable timestamps on individual with low volume become more accurate. Public factory method for AsyncPuncher
-  is changed, projects depending on it have to be updated.
-  links:
-  - https://github.com/palantir/atlasdb/pull/4180
+changes:
+  - type: break
+    break:
+      description:  Public factory method for AsyncPuncher now requires an optional timestamp seed, projects depending
+      on it have to be updated.
+      links:
+      - https://github.com/palantir/atlasdb/pull/4180
+  - type: improvement
+    improvement:
+      description: AsyncPuncher is now intialized with a seed timestamp if a quorum is present. As a result metrics
+      related to unreadable timestamps on individual stacks with low volume become more accurate.
+      links:
+        - https://github.com/palantir/atlasdb/pull/4180


### PR DESCRIPTION
**Goals (and why)**:
Fixes #4174, initialize AsyncPuncher with a seed timestamp if quorum is present. Front of the sweep queue can become stale if the service is silent, detailed situation described in the linked issue.
  
**Implementation Description (bullets)**:

- on DefaultCleaner build try to get a seed timestamp
- initialize the AsyncPuncher with the optional seed

**Testing (What was existing testing like?  What have you done to improve it?)**: 

**Concerns (what feedback would you like?)**:
coding style

**Where should we start reviewing?**:
n/a
**Priority (whenever / two weeks / yesterday)**:
whenever
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
