### PR TITLE
add logging and reaping of leaked atlas locks

### DIFF
--- a/changelog/@unreleased/pr-4181.v2.yml
+++ b/changelog/@unreleased/pr-4181.v2.yml
@@ -1,16 +1,7 @@
 type: improvement
 improvement:
   description: |-
-    add logging and reaping of leaked atlas locks
+    Add logging and reaping of leaked atlas locks
 
-    **Goals (and why)**:
-    There's at least three different cases I've found in prod where locks are leaked and constantly refreshed by the LockRefreshingLockService ad infinitum despite their original threads being long-dead.
-    This is bad, but is critically bad when the locks are from old transactions and are suppressing the immutable timestamp.
-
-    I'm proposing this as a band-aid fix while we're track down every case of locks being leaked. This is essentially automating the action that an FDE is currently doing manually to get his stack unblocked, using a dashboard that I wrote that tracks the immutable timestamp getting stuck along with a CLI that dumps lock state and another CLI that allows manual unlocking.
-
-    PDS-94791
-    PG-127836
-    PG-128400
   links:
   - https://github.com/palantir/atlasdb/pull/4181

--- a/changelog/@unreleased/pr-4181.v2.yml
+++ b/changelog/@unreleased/pr-4181.v2.yml
@@ -1,0 +1,16 @@
+type: improvement
+improvement:
+  description: |-
+    add logging and reaping of leaked atlas locks
+
+    **Goals (and why)**:
+    There's at least three different cases I've found in prod where locks are leaked and constantly refreshed by the LockRefreshingLockService ad infinitum despite their original threads being long-dead.
+    This is bad, but is critically bad when the locks are from old transactions and are suppressing the immutable timestamp.
+
+    I'm proposing this as a band-aid fix while we're track down every case of locks being leaked. This is essentially automating the action that an FDE is currently doing manually to get his stack unblocked, using a dashboard that I wrote that tracks the immutable timestamp getting stuck along with a CLI that dumps lock state and another CLI that allows manual unlocking.
+
+    PDS-94791
+    PG-127836
+    PG-128400
+  links:
+  - https://github.com/palantir/atlasdb/pull/4181

--- a/lock-api/src/main/java/com/palantir/lock/LockServerOptions.java
+++ b/lock-api/src/main/java/com/palantir/lock/LockServerOptions.java
@@ -108,6 +108,14 @@ public class LockServerOptions implements Serializable {
     }
 
     /**
+     * This setting should equal or exceed the Atlas transaction timeout
+     */
+    @Value.Default
+    public TimeDuration getStuckTransactionTimeout() {
+        return SimpleTimeDuration.of(1, TimeUnit.DAYS);
+    }
+
+    /**
      * Warn level logging for any lock request that receives a response after given time.
      * If the duration is zero or negative, slow lock logging will be disabled.
      */

--- a/lock-api/src/main/java/com/palantir/lock/LockServerOptions.java
+++ b/lock-api/src/main/java/com/palantir/lock/LockServerOptions.java
@@ -108,7 +108,7 @@ public class LockServerOptions implements Serializable {
     }
 
     /**
-     * This setting should equal or exceed the Atlas transaction timeout
+     * This setting should equal or exceed the Atlas transaction timeout.
      */
     @Value.Default
     public TimeDuration getStuckTransactionTimeout() {
@@ -140,6 +140,7 @@ public class LockServerOptions implements Serializable {
                 && Objects.equal(getMaxAllowedBlockingDuration(), other.getMaxAllowedBlockingDuration())
                 && Objects.equal(getMaxNormalLockAge(), other.getMaxNormalLockAge())
                 && Objects.equal(getRandomBitCount(), other.getRandomBitCount())
+                && Objects.equal(getStuckTransactionTimeout(), other.getStuckTransactionTimeout())
                 && Objects.equal(getLockStateLoggerDir(), other.getLockStateLoggerDir())
                 && Objects.equal(slowLogTriggerMillis(), other.slowLogTriggerMillis());
     }
@@ -152,6 +153,7 @@ public class LockServerOptions implements Serializable {
                 getMaxAllowedBlockingDuration(),
                 getMaxNormalLockAge(),
                 getRandomBitCount(),
+                getStuckTransactionTimeout(),
                 getLockStateLoggerDir(),
                 slowLogTriggerMillis());
     }
@@ -165,6 +167,7 @@ public class LockServerOptions implements Serializable {
                 .add("maxAllowedBlockingDuration", getMaxAllowedBlockingDuration())
                 .add("maxNormalLockAge", getMaxNormalLockAge())
                 .add("randomBitCount", getRandomBitCount())
+                .add("stuckTransactionTimeout", getStuckTransactionTimeout())
                 .add("lockStateLoggerDir", getLockStateLoggerDir())
                 .add("slowLogTriggerMillis", slowLogTriggerMillis())
                 .toString();
@@ -199,6 +202,7 @@ public class LockServerOptions implements Serializable {
         private final SimpleTimeDuration maxAllowedBlockingDuration;
         private final SimpleTimeDuration maxNormalLockAge;
         private final int randomBitCount;
+        private final SimpleTimeDuration stuckTransactionTimeout;
         private final String lockStateLoggerDir;
         private final long slowLogTriggerMillis;
 
@@ -213,6 +217,8 @@ public class LockServerOptions implements Serializable {
             maxNormalLockAge = SimpleTimeDuration.of(
                     lockServerOptions.getMaxNormalLockAge());
             randomBitCount = lockServerOptions.getRandomBitCount();
+            stuckTransactionTimeout = SimpleTimeDuration.of(
+                    lockServerOptions.getStuckTransactionTimeout());
             lockStateLoggerDir = lockServerOptions.getLockStateLoggerDir();
             slowLogTriggerMillis = lockServerOptions.slowLogTriggerMillis();
         }
@@ -223,6 +229,7 @@ public class LockServerOptions implements Serializable {
                 @JsonProperty("maxAllowedClockDrift") SimpleTimeDuration maxAllowedClockDrift,
                 @JsonProperty("maxAllowedBlockingDuration") SimpleTimeDuration maxAllowedBlockingDuration,
                 @JsonProperty("maxNormalLockAge") SimpleTimeDuration maxNormalLockAge,
+                @JsonProperty("stuckTransactionTimeout") SimpleTimeDuration stuckTransactionTimeout,
                 @JsonProperty("randomBitCount") int randomBitCount,
                 @JsonProperty("lockStateLoggerDir") String lockStateLoggerDir,
                 @JsonProperty("slowLogTriggerMillis") long slowLogTriggerMillis) {
@@ -232,6 +239,7 @@ public class LockServerOptions implements Serializable {
             this.maxAllowedBlockingDuration = maxAllowedBlockingDuration;
             this.maxNormalLockAge = maxNormalLockAge;
             this.randomBitCount = randomBitCount;
+            this.stuckTransactionTimeout = stuckTransactionTimeout;
             this.lockStateLoggerDir = lockStateLoggerDir;
             this.slowLogTriggerMillis = slowLogTriggerMillis;
         }
@@ -248,6 +256,7 @@ public class LockServerOptions implements Serializable {
                     .maxAllowedBlockingDuration(maxAllowedBlockingDuration)
                     .maxNormalLockAge(maxNormalLockAge)
                     .randomBitCount(randomBitCount)
+                    .stuckTransactionTimeout(stuckTransactionTimeout)
                     .lockStateLoggerDir(lockStateLoggerDir)
                     .slowLogTriggerMillis(slowLogTriggerMillis)
                     .build();

--- a/lock-api/src/main/java/com/palantir/lock/client/LockRefreshingLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockRefreshingLockService.java
@@ -38,8 +38,7 @@ import com.palantir.lock.LockService;
 import com.palantir.lock.SimpleHeldLocksToken;
 import com.palantir.lock.SimplifyingLockService;
 
-@SuppressWarnings("checkstyle:FinalClass") // Avoid breaking API in case someone extended this
-public class LockRefreshingLockService extends SimplifyingLockService {
+public final class LockRefreshingLockService extends SimplifyingLockService {
     public static final int REFRESH_BATCH_SIZE = 500_000;
     private static final Logger log = LoggerFactory.getLogger(LockRefreshingLockService.class);
 


### PR DESCRIPTION
**Goals (and why)**:
There's at least three different cases I've found in prod where locks are leaked and constantly refreshed by the LockRefreshingLockService ad infinitum despite their original threads being long-dead.
This is bad, but is critically bad when the locks are from old transactions and are suppressing the immutable timestamp.

I'm proposing this as a band-aid fix while we track down every case of locks being leaked. This is essentially automating the action that an FDE is currently doing manually to get his stack unblocked, using a dashboard that I wrote that tracks the immutable timestamp getting stuck along with a CLI that dumps lock state and another CLI that allows manual unlocking.

PDS-94791
PG-127836
PG-128400