### PR TITLE
[Timelock Partitioning] Part 24: Further separation of rpc layer and logical layer.

### DIFF
--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosAcceptorResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosAcceptorResource.java
@@ -46,10 +46,10 @@ public class BatchPaxosAcceptorResource {
 
     private static final Logger log = LoggerFactory.getLogger(BatchPaxosAcceptorResource.class);
 
-    private final BatchPaxosAcceptor localBatchPaxosAcceptor;
+    private final BatchPaxosAcceptor batchPaxosAcceptor;
 
-    BatchPaxosAcceptorResource(BatchPaxosAcceptor localBatchPaxosAcceptor) {
-        this.localBatchPaxosAcceptor = localBatchPaxosAcceptor;
+    BatchPaxosAcceptorResource(BatchPaxosAcceptor batchPaxosAcceptor) {
+        this.batchPaxosAcceptor = batchPaxosAcceptor;
     }
 
     @POST
@@ -58,7 +58,7 @@ public class BatchPaxosAcceptorResource {
     @Consumes(MediaType.APPLICATION_JSON)
     public SetMultimap<Client, WithSeq<PaxosPromise>> prepare(
             SetMultimap<Client, WithSeq<PaxosProposalId>> promiseWithSeqRequestsByClient) {
-        return localBatchPaxosAcceptor.prepare(promiseWithSeqRequestsByClient);
+        return batchPaxosAcceptor.prepare(promiseWithSeqRequestsByClient);
     }
 
     @POST
@@ -67,7 +67,7 @@ public class BatchPaxosAcceptorResource {
     @Consumes(MediaType.APPLICATION_JSON)
     public SetMultimap<Client, WithSeq<BooleanPaxosResponse>> accept(
             SetMultimap<Client, PaxosProposal> proposalRequestsByClient) {
-        return localBatchPaxosAcceptor.accept(proposalRequestsByClient);
+        return batchPaxosAcceptor.accept(proposalRequestsByClient);
     }
 
     @POST
@@ -78,7 +78,7 @@ public class BatchPaxosAcceptorResource {
             @QueryParam(HttpHeaders.IF_MATCH) Optional<AcceptorCacheKey> maybeCacheKey,
             Set<Client> clients) {
         try {
-            return localBatchPaxosAcceptor.latestSequencesPreparedOrAccepted(maybeCacheKey, clients);
+            return batchPaxosAcceptor.latestSequencesPreparedOrAccepted(maybeCacheKey, clients);
         } catch (InvalidAcceptorCacheKeyException e) {
             log.info("Cache key is invalid", e);
             throw Errors.invalidCacheKeyException(e.cacheKey());
@@ -94,7 +94,7 @@ public class BatchPaxosAcceptorResource {
             throw Errors.invalidCacheKeyException(null);
         }
         try {
-            return localBatchPaxosAcceptor.latestSequencesPreparedOrAcceptedCached(cacheKey.get());
+            return batchPaxosAcceptor.latestSequencesPreparedOrAcceptedCached(cacheKey.get());
         } catch (InvalidAcceptorCacheKeyException e) {
             log.info("Cache key is invalid", e);
             throw Errors.invalidCacheKeyException(e.cacheKey());

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosAcceptorRpcClient.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosAcceptorRpcClient.java
@@ -131,7 +131,7 @@ public interface BatchPaxosAcceptorRpcClient {
      *
      * @param paxosUseCase whether this is a timestamp paxos or leader paxos batch call
      * @return {@code 204 No Content} if there is no update, a digest containing updates plus a new cache key, or a
-     * {@code 404 Precondition Failed} if the cache key is not valid.
+     * {@code 404 Not Found} if the cache key is not valid.
      */
     @POST
     @Path("latest-sequences-prepared-or-accepted/cached")

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosLatestSequenceCache.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosLatestSequenceCache.java
@@ -57,7 +57,7 @@ final class BatchingPaxosLatestSequenceCache implements CoalescingRequestFunctio
         try {
             return unsafeGetLatest(clients);
         } catch (InvalidAcceptorCacheKeyException e) {
-            log.info("Cache key is invalid, invalidting cache - using deprecated detection method");
+            log.info("Cache key is invalid, invalidating cache - using deprecated detection method");
             return handleCacheMiss(clients);
         }
     }
@@ -72,7 +72,7 @@ final class BatchingPaxosLatestSequenceCache implements CoalescingRequestFunctio
         try {
             return unsafeGetLatest(allClients);
         } catch (InvalidAcceptorCacheKeyException e) {
-            log.warn("");
+            log.warn("Empty cache key is still invalid indicates product bug, failing request.");
             throw new RuntimeException(e);
         }
     }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosLatestSequenceCache.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosLatestSequenceCache.java
@@ -31,7 +31,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.autobatch.CoalescingRequestFunction;
 import com.palantir.common.streams.KeyedStream;
-import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.paxos.PaxosLong;
 
 /*
@@ -57,23 +56,9 @@ final class BatchingPaxosLatestSequenceCache implements CoalescingRequestFunctio
     public Map<Client, PaxosLong> apply(Set<Client> clients) {
         try {
             return unsafeGetLatest(clients);
-        } catch (RemoteException e) {
-            if (e.getError().errorName().equals(BatchPaxosAcceptor.CACHE_KEY_NOT_FOUND.name())) {
-                log.info("Cache key is invalid, invalidating cache");
-                return handleCacheMiss(clients);
-            }
-
-            log.warn("received remote exception that is not a cache key miss", e);
-            throw e;
-        } catch (RuntimeException e) {
-            // TODO(fdesouza): Remove this once we've moved to CJR properly and the above works.
-            if (e.getMessage().contains(BatchPaxosAcceptor.CACHE_KEY_NOT_FOUND.name())) {
-                log.info("Cache key is invalid, invalidating cache - using deprecated detection method");
-                return handleCacheMiss(clients);
-            }
-
-            log.warn("received unexpected runtime exception", e);
-            throw e;
+        } catch (InvalidAcceptorCacheKeyException e) {
+            log.info("Cache key is invalid, invalidting cache - using deprecated detection method");
+            return handleCacheMiss(clients);
         }
     }
 
@@ -84,10 +69,15 @@ final class BatchingPaxosLatestSequenceCache implements CoalescingRequestFunctio
                 .addAll(cachedEntries.keySet())
                 .build();
         cachedEntries.clear();
-        return unsafeGetLatest(allClients);
+        try {
+            return unsafeGetLatest(allClients);
+        } catch (InvalidAcceptorCacheKeyException e) {
+            log.warn("");
+            throw new RuntimeException(e);
+        }
     }
 
-    private Map<Client, PaxosLong> unsafeGetLatest(Set<Client> clients) {
+    private Map<Client, PaxosLong> unsafeGetLatest(Set<Client> clients) throws InvalidAcceptorCacheKeyException {
         if (cacheKey == null) {
             processDigest(delegate.latestSequencesPreparedOrAccepted(Optional.empty(), clients));
             return getResponseMap(clients);

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/InvalidAcceptorCacheKeyException.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/InvalidAcceptorCacheKeyException.java
@@ -44,4 +44,8 @@ public class InvalidAcceptorCacheKeyException extends Exception implements SafeL
         return ImmutableList.of(SafeArg.of("cacheKey", cacheKey));
     }
 
+    public AcceptorCacheKey cacheKey() {
+        return cacheKey;
+    }
+
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalBatchPaxosAcceptor.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalBatchPaxosAcceptor.java
@@ -1,0 +1,111 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import static java.util.stream.Collectors.toSet;
+
+import java.util.Optional;
+import java.util.Set;
+
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.HttpHeaders;
+
+import com.google.common.collect.SetMultimap;
+import com.palantir.common.streams.KeyedStream;
+import com.palantir.paxos.BooleanPaxosResponse;
+import com.palantir.paxos.PaxosAcceptor;
+import com.palantir.paxos.PaxosPromise;
+import com.palantir.paxos.PaxosProposal;
+import com.palantir.paxos.PaxosProposalId;
+
+public class LocalBatchPaxosAcceptor implements BatchPaxosAcceptor {
+
+    private final AcceptorCache acceptorCache;
+    private final PaxosComponents paxosComponents;
+
+    LocalBatchPaxosAcceptor(PaxosComponents paxosComponents, AcceptorCache acceptorCache) {
+        this.paxosComponents = paxosComponents;
+        this.acceptorCache = acceptorCache;
+    }
+
+    @Override
+    public SetMultimap<Client, WithSeq<PaxosPromise>> prepare(
+            SetMultimap<Client, WithSeq<PaxosProposalId>> promiseWithSeqRequestsByClient) {
+        SetMultimap<Client, WithSeq<PaxosPromise>> results = KeyedStream.stream(
+                promiseWithSeqRequestsByClient)
+                .map((client, paxosProposalIdWithSeq) -> {
+                    PaxosPromise promise = paxosComponents.acceptor(client)
+                            .prepare(paxosProposalIdWithSeq.seq(), paxosProposalIdWithSeq.value());
+                    return paxosProposalIdWithSeq.withNewValue(promise);
+                })
+                .collectToSetMultimap();
+        primeCache(promiseWithSeqRequestsByClient.keySet());
+        return results;
+    }
+
+    @Override
+    public SetMultimap<Client, WithSeq<BooleanPaxosResponse>> accept(
+            SetMultimap<Client, PaxosProposal> proposalRequestsByClient) {
+        SetMultimap<Client, WithSeq<BooleanPaxosResponse>> results = KeyedStream.stream(proposalRequestsByClient)
+                .map((client, paxosProposal) -> {
+                    long seq = paxosProposal.getValue().getRound();
+                    BooleanPaxosResponse ack = paxosComponents.acceptor(client)
+                            .accept(seq, paxosProposal);
+                    return WithSeq.of(ack, seq);
+                })
+                .collectToSetMultimap();
+        primeCache(proposalRequestsByClient.keySet());
+        return results;
+    }
+
+    @Override
+    public AcceptorCacheDigest latestSequencesPreparedOrAccepted(
+            @QueryParam(HttpHeaders.IF_MATCH) Optional<AcceptorCacheKey> maybeCacheKey,
+            Set<Client> clients) throws InvalidAcceptorCacheKeyException {
+        primeCache(clients);
+        if (!maybeCacheKey.isPresent()) {
+            return acceptorCache.getAllUpdates();
+        }
+
+        AcceptorCacheKey cacheKey = maybeCacheKey.get();
+        return latestSequencesPreparedOrAcceptedCached(cacheKey)
+                .orElseGet(() -> emptyDigest(cacheKey));
+    }
+
+    @Override
+    public Optional<AcceptorCacheDigest> latestSequencesPreparedOrAcceptedCached(AcceptorCacheKey cacheKey)
+            throws InvalidAcceptorCacheKeyException {
+        return acceptorCache.updatesSinceCacheKey(cacheKey);
+    }
+
+    private static AcceptorCacheDigest emptyDigest(AcceptorCacheKey cacheKey) {
+        return ImmutableAcceptorCacheDigest.builder()
+                .newCacheKey(cacheKey)
+                .build();
+    }
+
+    private void primeCache(Set<Client> clients) {
+        Set<WithSeq<Client>> latestSequences = KeyedStream.of(clients)
+                .map(paxosComponents::acceptor)
+                .map(PaxosAcceptor::getLatestSequencePreparedOrAccepted)
+                .map(WithSeq::of)
+                .values()
+                .collect(toSet());
+
+        acceptorCache.updateSequenceNumbers(latestSequences);
+    }
+}

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/UseCaseAwareBatchPaxosAcceptorAdapter.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/UseCaseAwareBatchPaxosAcceptorAdapter.java
@@ -16,18 +16,26 @@
 
 package com.palantir.atlasdb.timelock.paxos;
 
+import static com.palantir.atlasdb.timelock.paxos.BatchPaxosAcceptorRpcClient.CACHE_KEY_NOT_FOUND;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.collect.SetMultimap;
+import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.paxos.BooleanPaxosResponse;
 import com.palantir.paxos.PaxosPromise;
 import com.palantir.paxos.PaxosProposal;
 import com.palantir.paxos.PaxosProposalId;
 
 public class UseCaseAwareBatchPaxosAcceptorAdapter implements BatchPaxosAcceptor {
+
+    private static final Logger log = LoggerFactory.getLogger(UseCaseAwareBatchPaxosAcceptorAdapter.class);
 
     private final PaxosUseCase useCase;
     private final BatchPaxosAcceptorRpcClient rpcClient;
@@ -52,13 +60,41 @@ public class UseCaseAwareBatchPaxosAcceptorAdapter implements BatchPaxosAcceptor
     @Override
     public AcceptorCacheDigest latestSequencesPreparedOrAccepted(
             Optional<AcceptorCacheKey> cacheKey,
-            Set<Client> clients) {
-        return rpcClient.latestSequencesPreparedOrAccepted(useCase, cacheKey.orElse(null), clients);
+            Set<Client> clients) throws InvalidAcceptorCacheKeyException {
+        try {
+            return rpcClient.latestSequencesPreparedOrAccepted(useCase, cacheKey.orElse(null), clients);
+        } catch (RuntimeException e) {
+            if (isMissingOrInvalidCacheKey(e)) {
+                throw new InvalidAcceptorCacheKeyException(cacheKey.orElse(null));
+            }
+
+            log.warn("received unexpected runtime exception that is not a cache key miss", e);
+            throw e;
+        }
     }
 
     @Override
-    public Optional<AcceptorCacheDigest> latestSequencesPreparedOrAcceptedCached(AcceptorCacheKey cacheKey) {
-        return rpcClient.latestSequencesPreparedOrAcceptedCached(useCase, cacheKey);
+    public Optional<AcceptorCacheDigest> latestSequencesPreparedOrAcceptedCached(AcceptorCacheKey cacheKey)
+            throws InvalidAcceptorCacheKeyException {
+        try {
+            return rpcClient.latestSequencesPreparedOrAcceptedCached(useCase, cacheKey);
+        } catch (RuntimeException e) {
+            if (isMissingOrInvalidCacheKey(e)) {
+                throw new InvalidAcceptorCacheKeyException(cacheKey);
+            }
+
+            log.warn("received unexpected runtime exception that is not a cache key miss", e);
+            throw e;
+        }
+    }
+
+    private static boolean isMissingOrInvalidCacheKey(RuntimeException e) {
+        if (e instanceof RemoteException) {
+            return ((RemoteException) e).getError().errorName().equals(CACHE_KEY_NOT_FOUND.name());
+        } else {
+            // TODO(fdesouza): Remove this once we've moved to CJR properly and the above works.
+            return e.getMessage().contains(CACHE_KEY_NOT_FOUND.name());
+        }
     }
 
     public static List<BatchPaxosAcceptor> wrap(PaxosUseCase useCase, List<BatchPaxosAcceptorRpcClient> remotes) {

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosAcceptorResourceTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/BatchPaxosAcceptorResourceTests.java
@@ -1,0 +1,57 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import static org.mockito.Mockito.when;
+
+import static com.palantir.conjure.java.api.testing.Assertions.assertThatServiceExceptionThrownBy;
+
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.palantir.logsafe.SafeArg;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BatchPaxosAcceptorResourceTests {
+
+    @Mock private BatchPaxosAcceptor acceptorDelegate;
+
+    private BatchPaxosAcceptorResource resource;
+
+    @Before
+    public void setUp() {
+        resource = new BatchPaxosAcceptorResource(acceptorDelegate);
+    }
+
+    @Test
+    public void throwsConjureRuntime404WhenCacheKeyIsNotFound() throws InvalidAcceptorCacheKeyException {
+        AcceptorCacheKey cacheKey = AcceptorCacheKey.newCacheKey();
+        when(acceptorDelegate.latestSequencesPreparedOrAcceptedCached(cacheKey))
+                .thenThrow(new InvalidAcceptorCacheKeyException(cacheKey));
+
+        assertThatServiceExceptionThrownBy(() ->
+                resource.latestSequencesPreparedOrAcceptedCached(Optional.of(cacheKey)))
+                .hasType(BatchPaxosAcceptorRpcClient.CACHE_KEY_NOT_FOUND)
+                .hasArgs(SafeArg.of("cacheKey", cacheKey));
+    }
+
+}

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalBatchPaxosAcceptorTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalBatchPaxosAcceptorTests.java
@@ -20,8 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import static com.palantir.conjure.java.api.testing.Assertions.assertThatServiceExceptionThrownBy;
-
 import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
@@ -36,7 +34,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.SetMultimap;
-import com.palantir.logsafe.SafeArg;
 import com.palantir.paxos.BooleanPaxosResponse;
 import com.palantir.paxos.PaxosPromise;
 import com.palantir.paxos.PaxosProposal;
@@ -45,7 +42,7 @@ import com.palantir.paxos.PaxosValue;
 
 @SuppressWarnings("unchecked")
 @RunWith(MockitoJUnitRunner.class)
-public class BatchPaxosAcceptorResourceTests {
+public class LocalBatchPaxosAcceptorTests {
 
     private static final Client CLIENT_1 = Client.of("client1");
     private static final Client CLIENT_2 = Client.of("client2");
@@ -58,11 +55,11 @@ public class BatchPaxosAcceptorResourceTests {
     @Mock
     private AcceptorCache cache;
 
-    private BatchPaxosAcceptorResource resource;
+    private LocalBatchPaxosAcceptor resource;
 
     @Before
     public void before() {
-        resource = new BatchPaxosAcceptorResource(components, cache);
+        resource = new LocalBatchPaxosAcceptor(components, cache);
     }
 
     @Test
@@ -128,16 +125,16 @@ public class BatchPaxosAcceptorResourceTests {
                 WithSeq.of(CLIENT_2, 2)));
     }
 
-    @Test
-    public void throwsConjureRuntime404WhenCacheKeyIsNotFound() throws InvalidAcceptorCacheKeyException {
-        AcceptorCacheKey cacheKey = AcceptorCacheKey.newCacheKey();
-        when(cache.updatesSinceCacheKey(cacheKey))
-                .thenThrow(new InvalidAcceptorCacheKeyException(cacheKey));
-
-        assertThatServiceExceptionThrownBy(() -> resource.latestSequencesPreparedOrAcceptedCached(cacheKey))
-                .hasType(BatchPaxosAcceptorResource.CACHE_KEY_NOT_FOUND)
-                .hasArgs(SafeArg.of("cacheKey", cacheKey));
-    }
+//    @Test
+//    public void throwsConjureRuntime404WhenCacheKeyIsNotFound() throws InvalidAcceptorCacheKeyException {
+//        AcceptorCacheKey cacheKey = AcceptorCacheKey.newCacheKey();
+//        when(cache.updatesSinceCacheKey(cacheKey))
+//                .thenThrow(new InvalidAcceptorCacheKeyException(cacheKey));
+//
+//        assertThatServiceExceptionThrownBy(() -> resource.latestSequencesPreparedOrAcceptedCached(cacheKey))
+//                .hasType(BatchPaxosAcceptorResource.CACHE_KEY_NOT_FOUND)
+//                .hasArgs(SafeArg.of("cacheKey", cacheKey));
+//    }
 
     @Test
     public void cachedEndpointDelegatesToCache() throws InvalidAcceptorCacheKeyException {
@@ -151,7 +148,7 @@ public class BatchPaxosAcceptorResourceTests {
     }
 
     @Test
-    public void returnsEverythingIfCacheKeyIsNotProvided() {
+    public void returnsEverythingIfCacheKeyIsNotProvided() throws InvalidAcceptorCacheKeyException {
         when(components.acceptor(CLIENT_1).getLatestSequencePreparedOrAccepted()).thenReturn(1L);
         when(components.acceptor(CLIENT_2).getLatestSequencePreparedOrAccepted()).thenReturn(2L);
 

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalBatchPaxosAcceptorTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalBatchPaxosAcceptorTests.java
@@ -125,17 +125,6 @@ public class LocalBatchPaxosAcceptorTests {
                 WithSeq.of(CLIENT_2, 2)));
     }
 
-//    @Test
-//    public void throwsConjureRuntime404WhenCacheKeyIsNotFound() throws InvalidAcceptorCacheKeyException {
-//        AcceptorCacheKey cacheKey = AcceptorCacheKey.newCacheKey();
-//        when(cache.updatesSinceCacheKey(cacheKey))
-//                .thenThrow(new InvalidAcceptorCacheKeyException(cacheKey));
-//
-//        assertThatServiceExceptionThrownBy(() -> resource.latestSequencesPreparedOrAcceptedCached(cacheKey))
-//                .hasType(BatchPaxosAcceptorResource.CACHE_KEY_NOT_FOUND)
-//                .hasArgs(SafeArg.of("cacheKey", cacheKey));
-//    }
-
     @Test
     public void cachedEndpointDelegatesToCache() throws InvalidAcceptorCacheKeyException {
         AcceptorCacheKey cacheKey = AcceptorCacheKey.newCacheKey();


### PR DESCRIPTION
_**Note**: Taking a small detour to wire in the batch endpoints but for timestamp paxos (separate from leader election). Anything ironed out here will effectively solve the same issue for when the batch endpoints are integrated for leader election._

**Goals (and why)**:
Artifacts of the rpc layer are leaking into the logical layer and making it somewhat annoying to work with. We extend the work done in #4177 to encapsulate all RPC related code into its own class.

**Implementation Description (bullets)**:
* RPC layer deals with `RemoteException` and it also deals with the CJR bug.
* `BatchPaxosAcceptor` only deals in terms of `InvalidCacheKeyException` and `Optional`'s no mention of HTTP status codes or `RemoteException`s anywhere, that's all been pushed into `BatchPaxosAcceptorRpcClient`.
* As a result of this, the `BatchPaxosAcceptorResource` also deals with `Optional<..>` and any related remoting bits and then delegates to a `LocalBatchPaxosAcceptor` which as in the interface suggests deals with *just* the logical layer. 
  * turns out not doing this meant that different exceptions would be thrown depending on when you'd use a local acceptor or a remote one (the remote would do the right thing with the exceptions, the local (which would just be a resource) would be throwing the server side remote exceptions, meaning cache misses never caught. So this separation is pretty useful.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Mainly mechanical refactor, testing done in future branch should still hold, fortunately this is not out so I can amend at a later date if need to.

**Where should we start reviewing?**:
* `BatchPaxosAcceptorResource` & `LocalBatchPaxosAcceptor`
* `UseCaseBatchPaxosAcceptorAdapter` for localising rpc weirdness, converts rpc client into a logical client.
* `BatchingPaxosLatestSequenceCache`

**Priority (whenever / two weeks / yesterday)**:
ASAP
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
