### PR TITLE
Fix the build

### DIFF
--- a/scripts/circle-ci/download-moreutils.sh
+++ b/scripts/circle-ci/download-moreutils.sh
@@ -2,7 +2,7 @@
 
 set -x -e
 
-MOREUTILS="moreutils_0.63-1_amd64.deb"
+MOREUTILS="moreutils_0.63-1+b1_amd64.deb"
 curl --fail -O "http://http.us.debian.org/debian/pool/main/m/moreutils/$MOREUTILS"
 ar p $MOREUTILS data.tar.xz | sudo tar xJ --strip-components=3 -C /usr/bin/ ./usr/bin/ts
 rm $MOREUTILS

--- a/scripts/circle-ci/download-moreutils.sh
+++ b/scripts/circle-ci/download-moreutils.sh
@@ -3,6 +3,6 @@
 set -x -e
 
 MOREUTILS="moreutils_0.63-1_amd64.deb"
-curl -O "http://http.us.debian.org/debian/pool/main/m/moreutils/$MOREUTILS"
+curl --fail -O "http://http.us.debian.org/debian/pool/main/m/moreutils/$MOREUTILS"
 ar p $MOREUTILS data.tar.xz | sudo tar xJ --strip-components=3 -C /usr/bin/ ./usr/bin/ts
 rm $MOREUTILS


### PR DESCRIPTION
**Goals (and why)**:
`moreutils_0.63-1_amd64.deb` has been replaced by `moreutils_0.63-1+b1_amd64.deb`.
It's blocking the builds.
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
