### PR TITLE
CachingTransaction correctly handles cache misses in #getRows.

### DIFF
--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/CachingTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/CachingTransactionTest.java
@@ -53,14 +53,14 @@ public class CachingTransactionTest {
         final SortedMap<byte[], RowResult<byte[]>> emptyResults =
                 ImmutableSortedMap.<byte[], RowResult<byte[]>>orderedBy(PtBytes.BYTES_COMPARATOR).build();
 
+        final Set<byte[]> noRows = ImmutableSortedSet.orderedBy(PtBytes.BYTES_COMPARATOR).build();
+
         mockery.checking(new Expectations() {
             {
-                // the cache doesn't actually cache empty results in this case
-                // this is probably an oversight, but this has been the behavior for a long time
                 oneOf(txn).getRows(table, oneRow, oneColumn);
                 will(returnValue(emptyResults));
 
-                oneOf(txn).getRows(table, oneRow, oneColumn);
+                oneOf(txn).getRows(table, noRows, oneColumn);
                 will(returnValue(emptyResults));
             }
         });

--- a/changelog/@unreleased/pr-4191.v2.yml
+++ b/changelog/@unreleased/pr-4191.v2.yml
@@ -2,10 +2,5 @@ type: improvement
 improvement:
   description: |-
     CachingTransaction correctly handles cache misses in #getRows invocations with a known set of columns.
-    <!---
-    Please remember to:
-    - Add any necessary release notes (including breaking changes)
-    - Make sure the documentation is up to date for your change
-    --->
   links:
   - https://github.com/palantir/atlasdb/pull/4191

--- a/changelog/@unreleased/pr-4191.v2.yml
+++ b/changelog/@unreleased/pr-4191.v2.yml
@@ -1,6 +1,6 @@
 type: improvement
 improvement:
-  description: |-
-    CachingTransaction correctly handles cache misses in #getRows invocations with a known set of columns.
+  description: 'CachingTransaction correctly handles cache misses in #getRows invocations
+    with a known set of columns. '
   links:
   - https://github.com/palantir/atlasdb/pull/4191

--- a/changelog/@unreleased/pr-4191.v2.yml
+++ b/changelog/@unreleased/pr-4191.v2.yml
@@ -1,0 +1,11 @@
+type: improvement
+improvement:
+  description: |-
+    CachingTransaction correctly handles cache misses in #getRows invocations with a known set of columns.
+    <!---
+    Please remember to:
+    - Add any necessary release notes (including breaking changes)
+    - Make sure the documentation is up to date for your change
+    --->
+  links:
+  - https://github.com/palantir/atlasdb/pull/4191


### PR DESCRIPTION
**Goals (and why)**:

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
