### PR TITLE
[Conjure Java Runtime] Part 3: Target Factory

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
@@ -30,13 +30,8 @@ import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
 import com.palantir.conjure.java.config.ssl.TrustContext;
 
 public final class AtlasDbHttpClients {
-    // add some padding to the feign timeout, as in many cases lock requests default to a 60 second timeout,
-    // and we don't want it to exactly align with the feign timeout
-    private static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = 10_000;
-    private static final int DEFAULT_READ_TIMEOUT_MILLIS = 65_000;
-
-    private static final int QUICK_FEIGN_TIMEOUT_MILLIS = 100;
-    private static final int QUICK_MAX_BACKOFF_MILLIS = 100;
+    private static final TargetFactory DEFAULT_TARGET_FACTORY = AtlasDbFeignTargetFactory.DEFAULT;
+    private static final TargetFactory TESTING_TARGET_FACTORY = AtlasDbFeignTargetFactory.FAST_FAIL_FOR_TESTING;
 
     private AtlasDbHttpClients() {
         // Utility class
@@ -64,8 +59,7 @@ public final class AtlasDbHttpClients {
         return AtlasDbMetrics.instrument(
                 metricRegistry,
                 type,
-                AtlasDbFeignTargetFactory
-                        .createProxy(trustContext, uri, type, userAgent, limitPayloadSize),
+                DEFAULT_TARGET_FACTORY.createProxy(trustContext, uri, type, userAgent, limitPayloadSize),
                 MetricRegistry.name(type));
     }
 
@@ -79,8 +73,7 @@ public final class AtlasDbHttpClients {
         return AtlasDbMetrics.instrument(
                 metricRegistry,
                 type,
-                AtlasDbFeignTargetFactory
-                        .createProxyWithoutRetrying(trustContext, uri, type, userAgent, limitPayloadSize),
+                DEFAULT_TARGET_FACTORY.createProxyWithoutRetrying(trustContext, uri, type, userAgent, limitPayloadSize),
                 MetricRegistry.name(type));
     }
 
@@ -101,13 +94,10 @@ public final class AtlasDbHttpClients {
         return AtlasDbMetrics.instrument(
                 metricRegistry,
                 type,
-                AtlasDbFeignTargetFactory.createProxyWithFailover(
+                DEFAULT_TARGET_FACTORY.createProxyWithFailover(
                         trustContext,
                         proxySelector,
                         endpointUris,
-                        DEFAULT_CONNECT_TIMEOUT_MILLIS,
-                        DEFAULT_READ_TIMEOUT_MILLIS,
-                        FailoverFeignTarget.DEFAULT_MAX_BACKOFF.toMillis(),
                         type,
                         userAgent,
                         false),
@@ -125,13 +115,10 @@ public final class AtlasDbHttpClients {
         return AtlasDbMetrics.instrument(
                 metricRegistry,
                 type,
-                AtlasDbFeignTargetFactory.createLiveReloadingProxyWithFailover(
+                DEFAULT_TARGET_FACTORY.createLiveReloadingProxyWithFailover(
                         serverListConfigSupplier,
                         trustContextCreator,
                         proxySelectorCreator,
-                        DEFAULT_CONNECT_TIMEOUT_MILLIS,
-                        DEFAULT_READ_TIMEOUT_MILLIS,
-                        FailoverFeignTarget.DEFAULT_MAX_BACKOFF.toMillis(),
                         type,
                         userAgent,
                         limitPayload),
@@ -149,13 +136,10 @@ public final class AtlasDbHttpClients {
         return AtlasDbMetrics.instrument(
                 metricRegistry,
                 type,
-                AtlasDbFeignTargetFactory.createLiveReloadingProxyWithFailover(
+                TESTING_TARGET_FACTORY.createLiveReloadingProxyWithFailover(
                         serverListConfigSupplier,
                         trustContextCreator,
                         proxySelectorCreator,
-                        QUICK_FEIGN_TIMEOUT_MILLIS,
-                        QUICK_FEIGN_TIMEOUT_MILLIS,
-                        QUICK_MAX_BACKOFF_MILLIS,
                         type,
                         userAgent,
                         false),
@@ -172,13 +156,10 @@ public final class AtlasDbHttpClients {
         return AtlasDbMetrics.instrument(
                 metricRegistry,
                 type,
-                AtlasDbFeignTargetFactory.createProxyWithFailover(
+                TESTING_TARGET_FACTORY.createProxyWithFailover(
                         trustContext,
                         proxySelector,
                         endpointUris,
-                        QUICK_FEIGN_TIMEOUT_MILLIS,
-                        QUICK_FEIGN_TIMEOUT_MILLIS,
-                        QUICK_MAX_BACKOFF_MILLIS,
                         type,
                         UserAgents.DEFAULT_USER_AGENT,
                         false),

--- a/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/AtlasDbFeignTargetFactory.java
+++ b/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/AtlasDbFeignTargetFactory.java
@@ -54,7 +54,8 @@ public final class AtlasDbFeignTargetFactory implements TargetFactory {
     private static final int QUICK_FEIGN_TIMEOUT_MILLIS = 100;
     private static final int QUICK_MAX_BACKOFF_MILLIS = 100;
 
-    static final TargetFactory DEFAULT = new AtlasDbFeignTargetFactory(
+    // TODO (jkong): Decide what to do with usage in benchmarking infrastructure
+    public static final TargetFactory DEFAULT = new AtlasDbFeignTargetFactory(
             DEFAULT_CONNECT_TIMEOUT_MILLIS,
             DEFAULT_READ_TIMEOUT_MILLIS,
             FailoverFeignTarget.DEFAULT_MAX_BACKOFF.toMillis());

--- a/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/AtlasDbFeignTargetFactory.java
+++ b/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/AtlasDbFeignTargetFactory.java
@@ -54,11 +54,11 @@ public final class AtlasDbFeignTargetFactory implements TargetFactory {
     private static final int QUICK_FEIGN_TIMEOUT_MILLIS = 100;
     private static final int QUICK_MAX_BACKOFF_MILLIS = 100;
 
-    public static final TargetFactory STANDARD = new AtlasDbFeignTargetFactory(
+    static final TargetFactory DEFAULT = new AtlasDbFeignTargetFactory(
             DEFAULT_CONNECT_TIMEOUT_MILLIS,
             DEFAULT_READ_TIMEOUT_MILLIS,
             FailoverFeignTarget.DEFAULT_MAX_BACKOFF.toMillis());
-    public static final TargetFactory FAST_FAIL_FOR_TESTING = new AtlasDbFeignTargetFactory(
+    static final TargetFactory FAST_FAIL_FOR_TESTING = new AtlasDbFeignTargetFactory(
             QUICK_FEIGN_TIMEOUT_MILLIS,
             QUICK_FEIGN_TIMEOUT_MILLIS,
             QUICK_MAX_BACKOFF_MILLIS);

--- a/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/TargetFactory.java
+++ b/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/TargetFactory.java
@@ -1,0 +1,60 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.http;
+
+import java.net.ProxySelector;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import com.palantir.atlasdb.config.ServerListConfig;
+import com.palantir.conjure.java.api.config.service.ProxyConfiguration;
+import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
+import com.palantir.conjure.java.config.ssl.TrustContext;
+
+public interface TargetFactory {
+    <T> T createProxyWithoutRetrying(
+            Optional<TrustContext> trustContext,
+            String uri,
+            Class<T> type,
+            String userAgent,
+            boolean limitPayloadSize);
+
+    <T> T createProxy(
+            Optional<TrustContext> trustContext,
+            String uri,
+            Class<T> type,
+            String userAgent,
+            boolean limitPayloadSize);
+
+    <T> T createProxyWithFailover(
+            Optional<TrustContext> trustContext,
+            Optional<ProxySelector> proxySelector,
+            Collection<String> endpointUris,
+            Class<T> type,
+            String userAgent,
+            boolean limitPayloadSize);
+
+    <T> T createLiveReloadingProxyWithFailover(
+            Supplier<ServerListConfig> serverListConfigSupplier,
+            Function<SslConfiguration, TrustContext> trustContextCreator,
+            Function<ProxyConfiguration, ProxySelector> proxySelectorCreator,
+            Class<T> type,
+            String userAgent,
+            boolean limitPayload);
+}

--- a/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/runner/BenchmarkRunnerBase.java
+++ b/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/runner/BenchmarkRunnerBase.java
@@ -62,14 +62,11 @@ public class BenchmarkRunnerBase {
         }
     }
 
-    protected static final BenchmarksService createClient() {
-        return AtlasDbFeignTargetFactory.createProxyWithFailover(
+    protected static BenchmarksService createClient() {
+        return AtlasDbFeignTargetFactory.DEFAULT.createProxyWithFailover(
                 Optional.empty(),
                 Optional.empty(),
                 ImmutableSet.of(BENCHMARK_SERVER),
-                10_000,
-                1_000_000,
-                1_000,
                 BenchmarksService.class,
                 "benchmarks",
                 false);


### PR DESCRIPTION
**Goals (and why)**:
- We want to have a mechanism that allows us to switch how we talk to timelock, perhaps dynamically. This is the first step in refactors that should take us in that direction.

**Implementation Description (bullets)**:
- Extract a `TargetFactory` interface, and express `AtlasDbHttpClients` in terms of that as opposed to explicitly depending on `AtlasDbFeignTargetFactory`.

**Testing (What was existing testing like?  What have you done to improve it?)**: Deferring to paxos/timelock integration tests and AtlasDB ETE tests still passing to exercise this.

**Concerns (what feedback would you like?)**: Nothing in particular.

**Where should we start reviewing?**: TargetFactory.java

**Priority (whenever / two weeks / yesterday)**: this week