### PR TITLE
CommitTsCache for targeted sweep expires entries after 5 minutes

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/AbortingCommitTsLoader.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/AbortingCommitTsLoader.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.CacheLoader;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Streams;
@@ -33,7 +33,7 @@ import com.palantir.atlasdb.transaction.impl.TransactionConstants;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.logsafe.SafeArg;
 
-public class AbortingCommitTsLoader extends CacheLoader<Long, Long> {
+public class AbortingCommitTsLoader implements CacheLoader<Long, Long> {
     private static final Logger log = LoggerFactory.getLogger(AbortingCommitTsLoader.class);
     private final TransactionService transactionService;
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/CommitTsCache.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/CommitTsCache.java
@@ -18,19 +18,21 @@ package com.palantir.atlasdb.sweep;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.palantir.atlasdb.transaction.service.TransactionService;
-import com.palantir.common.base.Throwables;
 
 public final class CommitTsCache {
     private static final Long ONE_MILLION = 1_000_000L;
     private LoadingCache<Long, Long> cache;
 
     private CommitTsCache(TransactionService transactionService, long maxSize) {
-        cache = CacheBuilder.newBuilder().maximumSize(maxSize).build(new AbortingCommitTsLoader(transactionService));
+        cache = Caffeine.newBuilder()
+                .maximumSize(maxSize)
+                .expireAfterAccess(5, TimeUnit.MINUTES)
+                .build(new AbortingCommitTsLoader(transactionService));
     }
 
     public static CommitTsCache create(TransactionService transactionService) {
@@ -42,7 +44,7 @@ public final class CommitTsCache {
     }
 
     public long load(long startTs) {
-        return cache.getUnchecked(startTs);
+        return cache.get(startTs);
     }
 
     /**
@@ -50,10 +52,6 @@ public final class CommitTsCache {
      * does batched lookups for non-cached start timestamps.
      */
     public Map<Long, Long> loadBatch(Collection<Long> timestamps) {
-        try {
-            return cache.getAll(timestamps);
-        } catch (ExecutionException e) {
-            throw Throwables.rewrapAndThrowUncheckedException(e);
-        }
+        return cache.getAll(timestamps);
     }
 }

--- a/changelog/@unreleased/pr-4197.v2.yml
+++ b/changelog/@unreleased/pr-4197.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: CommitTsCache for targeted sweep expires entries after 5 minutes
+  links:
+  - https://github.com/palantir/atlasdb/pull/4197


### PR DESCRIPTION
Right now, if you have e.g. 50 AtlasDB txn managers, the sweep commit
ts cache will hold onto 1MM start timestamps each, at a cost of about
40GB ram.

This code is also not instantiated in a dependency-injection friendly
fashion, and so it's not particularly fun to configure this.

I modify to use Caffeine (because Caffeine is better in every case than
Guava) and have a 5 minute expiry, to ensure that unused entries get
evicted and hopefully using much less ram in the long term.

It's expected that this cache doesn't even really hit that much, so it shouldn't
be a big hit. I'd instrument this for metrics, but as said before, AtlasDB makes
this hard and it seems in the past that this was an impediment to configuring
this properly.