### PR TITLE
Stream Store Metadata Cleanup Task Recovery

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
@@ -794,13 +794,10 @@ public class StreamStoreRenderer {
                     line("        .map(", StreamIndexRow, "::getId)");
                     line("        .map(", StreamMetadataRow, "::of)");
                     line("        .collect(Collectors.toSet());");
-                    line("Map<", StreamMetadataRow, ", StreamMetadata> currentMetadata = metaTable.getMetadatas(");
-                    line("        Sets.difference(rows, rowsWithNoIndexEntries));");
-                    line("Set<", StreamId, "> toDelete = Sets.newHashSet(rowsWithNoIndexEntries.stream()");
-                    line("        .map(", StreamMetadataRow, "::getId)");
-                    line("        .collect(Collectors.toSet()));");
+                    line("Map<", StreamMetadataRow, ", StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);");
+                    line("Set<", StreamId, "> toDelete = Sets.newHashSet();");
                     line("for (Map.Entry<", StreamMetadataRow, ", StreamMetadata> e : currentMetadata.entrySet()) {"); {
-                        line("if (e.getValue().getStatus() != Status.STORED) {"); {
+                        line("if (e.getValue().getStatus() != Status.STORED || rowsWithNoIndexEntries.contains(e.getKey())) {"); {
                             line("toDelete.add(e.getKey().getId());");
                         } line("}");
                     } line("}");

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
@@ -775,7 +775,7 @@ public class StreamStoreRenderer {
                 line("@Override");
                 line("public boolean cellsCleanedUp(Transaction t, Set<Cell> cells) {"); {
                     line(StreamMetadataTable, " metaTable = tables.get", StreamMetadataTable, "(t);");
-                    line("Collection<", StreamMetadataRow, "> rows = Lists.newArrayListWithCapacity(cells.size());");
+                    line("Set<", StreamMetadataRow, "> rows = Sets.newHashSetWithExpectedSize(cells.size());");
                     line("for (Cell cell : cells) {"); {
                         line("rows.add(", StreamMetadataRow, ".BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));");
                     } line("}");

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
@@ -784,11 +784,11 @@ public class StreamStoreRenderer {
                     line("        .map(", StreamMetadataRow, "::getId)");
                     line("        .map(", StreamIndexRow, "::of)");
                     line("        .collect(Collectors.toSet());");
-                    line("Map<", StreamIndexRow, ", Iterator<", StreamIndexColumnValue, ">> indexIterator");
+                    line("Map<", StreamIndexRow, ", Iterator<", StreamIndexColumnValue, ">> referenceIteratorByStream");
                     line("        = indexTable.getRowsColumnRangeIterator(indexRows,");
                     line("                BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 1));");
-                    line("Set<", StreamMetadataRow, "> rowsWithNoIndexEntries");
-                    line("        = KeyedStream.stream(indexIterator)");
+                    line("Set<", StreamMetadataRow, "> streamsWithNoReferences");
+                    line("        = KeyedStream.stream(referenceIteratorByStream)");
                     line("        .filter(valueIterator -> !valueIterator.hasNext())");
                     line("        .keys()");
                     line("        .map(", StreamIndexRow, "::getId)");
@@ -797,7 +797,7 @@ public class StreamStoreRenderer {
                     line("Map<", StreamMetadataRow, ", StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);");
                     line("Set<", StreamId, "> toDelete = Sets.newHashSet();");
                     line("for (Map.Entry<", StreamMetadataRow, ", StreamMetadata> e : currentMetadata.entrySet()) {"); {
-                        line("if (e.getValue().getStatus() != Status.STORED || rowsWithNoIndexEntries.contains(e.getKey())) {"); {
+                        line("if (e.getValue().getStatus() != Status.STORED || streamsWithNoReferences.contains(e.getKey())) {"); {
                             line("toDelete.add(e.getKey().getId());");
                         } line("}");
                     } line("}");

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
@@ -798,7 +798,7 @@ public class StreamStoreRenderer {
                     line("        Sets.difference(rows, rowsWithNoIndexEntries));");
                     line("Set<", StreamId, "> toDelete = Sets.newHashSet(rowsWithNoIndexEntries.stream()");
                     line("        .map(", StreamMetadataRow, "::getId)");
-                    line("        .collect(Collectors.toSet());");
+                    line("        .collect(Collectors.toSet()));");
                     line("for (Map.Entry<", StreamMetadataRow, ", StreamMetadata> e : currentMetadata.entrySet()) {"); {
                         line("if (e.getValue().getStatus() != Status.STORED) {"); {
                             line("toDelete.add(e.getKey().getId());");

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsMetadataCleanupTask.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsMetadataCleanupTask.java
@@ -1,18 +1,20 @@
 package com.palantir.atlasdb.todo.generated;
 
-import java.util.Collection;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.protos.generated.StreamPersistence.Status;
 import com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata;
-import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.common.streams.KeyedStream;
 
 public class SnapshotsMetadataCleanupTask implements OnCleanupTask {
 
@@ -25,12 +27,30 @@ public class SnapshotsMetadataCleanupTask implements OnCleanupTask {
     @Override
     public boolean cellsCleanedUp(Transaction t, Set<Cell> cells) {
         SnapshotsStreamMetadataTable metaTable = tables.getSnapshotsStreamMetadataTable(t);
-        Collection<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> rows = Lists.newArrayListWithCapacity(cells.size());
+        Set<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> rows = Sets.newHashSetWithExpectedSize(cells.size());
         for (Cell cell : cells) {
             rows.add(SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));
         }
-        Map<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
-        Set<Long> toDelete = Sets.newHashSet();
+        SnapshotsStreamIdxTable indexTable = tables.getSnapshotsStreamIdxTable(t);
+        Set<SnapshotsStreamIdxTable.SnapshotsStreamIdxRow> indexRows = rows.stream()
+                .map(SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow::getId)
+                .map(SnapshotsStreamIdxTable.SnapshotsStreamIdxRow::of)
+                .collect(Collectors.toSet());
+        Map<SnapshotsStreamIdxTable.SnapshotsStreamIdxRow, Iterator<SnapshotsStreamIdxTable.SnapshotsStreamIdxColumnValue>> indexIterator
+                = indexTable.getRowsColumnRangeIterator(indexRows,
+                        BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 1));
+        Set<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> rowsWithNoIndexEntries
+                = KeyedStream.stream(indexIterator)
+                .filter(valueIterator -> !valueIterator.hasNext())
+                .keys()
+                .map(SnapshotsStreamIdxTable.SnapshotsStreamIdxRow::getId)
+                .map(SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow::of)
+                .collect(Collectors.toSet());
+        Map<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(
+                Sets.difference(rows, rowsWithNoIndexEntries));
+        Set<Long> toDelete = Sets.newHashSet(rowsWithNoIndexEntries.stream()
+                .map(SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow::getId)
+                .collect(Collectors.toSet()));
         for (Map.Entry<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
             if (e.getValue().getStatus() != Status.STORED) {
                 toDelete.add(e.getKey().getId());

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataMetadataCleanupTask.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataMetadataCleanupTask.java
@@ -47,13 +47,10 @@ public class DataMetadataCleanupTask implements OnCleanupTask {
                 .map(DataStreamIdxTable.DataStreamIdxRow::getId)
                 .map(DataStreamMetadataTable.DataStreamMetadataRow::of)
                 .collect(Collectors.toSet());
-        Map<DataStreamMetadataTable.DataStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(
-                Sets.difference(rows, rowsWithNoIndexEntries));
-        Set<Long> toDelete = Sets.newHashSet(rowsWithNoIndexEntries.stream()
-                .map(DataStreamMetadataTable.DataStreamMetadataRow::getId)
-                .collect(Collectors.toSet()));
+        Map<DataStreamMetadataTable.DataStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
+        Set<Long> toDelete = Sets.newHashSet();
         for (Map.Entry<DataStreamMetadataTable.DataStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
-            if (e.getValue().getStatus() != Status.STORED) {
+            if (e.getValue().getStatus() != Status.STORED || rowsWithNoIndexEntries.contains(e.getKey())) {
                 toDelete.add(e.getKey().getId());
             }
         }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataMetadataCleanupTask.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataMetadataCleanupTask.java
@@ -1,18 +1,21 @@
 package com.palantir.atlasdb.blob.generated;
 
-import java.util.Collection;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.protos.generated.StreamPersistence.Status;
 import com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.common.streams.KeyedStream;
 
 public class DataMetadataCleanupTask implements OnCleanupTask {
 
@@ -25,12 +28,30 @@ public class DataMetadataCleanupTask implements OnCleanupTask {
     @Override
     public boolean cellsCleanedUp(Transaction t, Set<Cell> cells) {
         DataStreamMetadataTable metaTable = tables.getDataStreamMetadataTable(t);
-        Collection<DataStreamMetadataTable.DataStreamMetadataRow> rows = Lists.newArrayListWithCapacity(cells.size());
+        Set<DataStreamMetadataTable.DataStreamMetadataRow> rows = Sets.newHashSetWithExpectedSize(cells.size());
         for (Cell cell : cells) {
             rows.add(DataStreamMetadataTable.DataStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));
         }
-        Map<DataStreamMetadataTable.DataStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
-        Set<Long> toDelete = Sets.newHashSet();
+        DataStreamIdxTable indexTable = tables.getDataStreamIdxTable(t);
+        Set<DataStreamIdxTable.DataStreamIdxRow> indexRows = rows.stream()
+                .map(DataStreamMetadataTable.DataStreamMetadataRow::getId)
+                .map(DataStreamIdxTable.DataStreamIdxRow::of)
+                .collect(Collectors.toSet());
+        Map<DataStreamIdxTable.DataStreamIdxRow, Iterator<DataStreamIdxTable.DataStreamIdxColumnValue>> indexIterator
+                = indexTable.getRowsColumnRangeIterator(indexRows,
+                        BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 1));
+        Set<DataStreamMetadataTable.DataStreamMetadataRow> rowsWithNoIndexEntries
+                = KeyedStream.stream(indexIterator)
+                .filter(valueIterator -> !valueIterator.hasNext())
+                .keys()
+                .map(DataStreamIdxTable.DataStreamIdxRow::getId)
+                .map(DataStreamMetadataTable.DataStreamMetadataRow::of)
+                .collect(Collectors.toSet());
+        Map<DataStreamMetadataTable.DataStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(
+                Sets.difference(rows, rowsWithNoIndexEntries));
+        Set<Long> toDelete = Sets.newHashSet(rowsWithNoIndexEntries.stream()
+                .map(DataStreamMetadataTable.DataStreamMetadataRow::getId)
+                .collect(Collectors.toSet()));
         for (Map.Entry<DataStreamMetadataTable.DataStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
             if (e.getValue().getStatus() != Status.STORED) {
                 toDelete.add(e.getKey().getId());

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataMetadataCleanupTask.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataMetadataCleanupTask.java
@@ -1,18 +1,21 @@
 package com.palantir.atlasdb.blob.generated;
 
-import java.util.Collection;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.protos.generated.StreamPersistence.Status;
 import com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.common.streams.KeyedStream;
 
 public class HotspottyDataMetadataCleanupTask implements OnCleanupTask {
 
@@ -25,12 +28,30 @@ public class HotspottyDataMetadataCleanupTask implements OnCleanupTask {
     @Override
     public boolean cellsCleanedUp(Transaction t, Set<Cell> cells) {
         HotspottyDataStreamMetadataTable metaTable = tables.getHotspottyDataStreamMetadataTable(t);
-        Collection<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow> rows = Lists.newArrayListWithCapacity(cells.size());
+        Set<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow> rows = Sets.newHashSetWithExpectedSize(cells.size());
         for (Cell cell : cells) {
             rows.add(HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));
         }
-        Map<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
-        Set<Long> toDelete = Sets.newHashSet();
+        HotspottyDataStreamIdxTable indexTable = tables.getHotspottyDataStreamIdxTable(t);
+        Set<HotspottyDataStreamIdxTable.HotspottyDataStreamIdxRow> indexRows = rows.stream()
+                .map(HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow::getId)
+                .map(HotspottyDataStreamIdxTable.HotspottyDataStreamIdxRow::of)
+                .collect(Collectors.toSet());
+        Map<HotspottyDataStreamIdxTable.HotspottyDataStreamIdxRow, Iterator<HotspottyDataStreamIdxTable.HotspottyDataStreamIdxColumnValue>> indexIterator
+                = indexTable.getRowsColumnRangeIterator(indexRows,
+                        BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 1));
+        Set<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow> rowsWithNoIndexEntries
+                = KeyedStream.stream(indexIterator)
+                .filter(valueIterator -> !valueIterator.hasNext())
+                .keys()
+                .map(HotspottyDataStreamIdxTable.HotspottyDataStreamIdxRow::getId)
+                .map(HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow::of)
+                .collect(Collectors.toSet());
+        Map<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(
+                Sets.difference(rows, rowsWithNoIndexEntries));
+        Set<Long> toDelete = Sets.newHashSet(rowsWithNoIndexEntries.stream()
+                .map(HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow::getId)
+                .collect(Collectors.toSet()));
         for (Map.Entry<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
             if (e.getValue().getStatus() != Status.STORED) {
                 toDelete.add(e.getKey().getId());

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataMetadataCleanupTask.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataMetadataCleanupTask.java
@@ -47,13 +47,10 @@ public class HotspottyDataMetadataCleanupTask implements OnCleanupTask {
                 .map(HotspottyDataStreamIdxTable.HotspottyDataStreamIdxRow::getId)
                 .map(HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow::of)
                 .collect(Collectors.toSet());
-        Map<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(
-                Sets.difference(rows, rowsWithNoIndexEntries));
-        Set<Long> toDelete = Sets.newHashSet(rowsWithNoIndexEntries.stream()
-                .map(HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow::getId)
-                .collect(Collectors.toSet()));
+        Map<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
+        Set<Long> toDelete = Sets.newHashSet();
         for (Map.Entry<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
-            if (e.getValue().getStatus() != Status.STORED) {
+            if (e.getValue().getStatus() != Status.STORED || rowsWithNoIndexEntries.contains(e.getKey())) {
                 toDelete.add(e.getKey().getId());
             }
         }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/todo/SimpleTodoResource.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/todo/SimpleTodoResource.java
@@ -62,6 +62,12 @@ public class SimpleTodoResource implements TodoResource {
     }
 
     @Override
+    public void storeUnmarkedSnapshot(String snapshot) {
+        InputStream snapshotStream = new ByteArrayInputStream(snapshot.getBytes());
+        atlas.storeUnmarkedSnapshot(snapshotStream);
+    }
+
+    @Override
     public void runIterationOfTargetedSweep() {
         atlas.runIterationOfTargetedSweep();
     }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/todo/TodoResource.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/todo/TodoResource.java
@@ -61,6 +61,11 @@ public interface TodoResource {
     void storeSnapshot(String snapshot);
 
     @POST
+    @Path("/unmarked-snapshot")
+    @Consumes(MediaType.APPLICATION_JSON)
+    void storeUnmarkedSnapshot(String snapshot);
+
+    @POST
     @Path("/targeted-sweep")
     void runIterationOfTargetedSweep();
 

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TargetedSweepEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TargetedSweepEteTest.java
@@ -99,6 +99,9 @@ public class TargetedSweepEteTest {
         todoClient.storeUnmarkedSnapshot("crackle");
         todoClient.storeUnmarkedSnapshot("pop");
         todoClient.runIterationOfTargetedSweep();
+
+        // Nothing can be deleted from Index because it wasn't written. There should be 3 entries in the other tables
+        // (hash, metadata and value), one per stream, all of which should be cleaned up.
         assertDeleted(0, 3, 3, 3);
     }
 

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TargetedSweepEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TargetedSweepEteTest.java
@@ -93,6 +93,15 @@ public class TargetedSweepEteTest {
         assertDeletedAndSwept(4, 4, 4, 4 * 4);
     }
 
+    @Test
+    public void targetedSweepCleanupUnmarkedStreamsTest() {
+        todoClient.storeUnmarkedSnapshot("snap");
+        todoClient.storeUnmarkedSnapshot("crackle");
+        todoClient.storeUnmarkedSnapshot("pop");
+        todoClient.runIterationOfTargetedSweep();
+        assertDeleted(0, 3, 3, 3);
+    }
+
     private void assertDeleted(long idx, long hash, long meta, long val) {
         Assert.assertThat(todoClient.numberOfCellsDeleted(INDEX_TABLE), equalTo(idx));
         Assert.assertThat(todoClient.numberOfCellsDeleted(HASH_TABLE), equalTo(hash));

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueMetadataCleanupTask.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueMetadataCleanupTask.java
@@ -47,13 +47,10 @@ public class ValueMetadataCleanupTask implements OnCleanupTask {
                 .map(ValueStreamIdxTable.ValueStreamIdxRow::getId)
                 .map(ValueStreamMetadataTable.ValueStreamMetadataRow::of)
                 .collect(Collectors.toSet());
-        Map<ValueStreamMetadataTable.ValueStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(
-                Sets.difference(rows, rowsWithNoIndexEntries));
-        Set<Long> toDelete = Sets.newHashSet(rowsWithNoIndexEntries.stream()
-                .map(ValueStreamMetadataTable.ValueStreamMetadataRow::getId)
-                .collect(Collectors.toSet()));
+        Map<ValueStreamMetadataTable.ValueStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
+        Set<Long> toDelete = Sets.newHashSet();
         for (Map.Entry<ValueStreamMetadataTable.ValueStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
-            if (e.getValue().getStatus() != Status.STORED) {
+            if (e.getValue().getStatus() != Status.STORED || rowsWithNoIndexEntries.contains(e.getKey())) {
                 toDelete.add(e.getKey().getId());
             }
         }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemMetadataCleanupTask.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemMetadataCleanupTask.java
@@ -47,13 +47,10 @@ public class StreamTestMaxMemMetadataCleanupTask implements OnCleanupTask {
                 .map(StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow::getId)
                 .map(StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow::of)
                 .collect(Collectors.toSet());
-        Map<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(
-                Sets.difference(rows, rowsWithNoIndexEntries));
-        Set<Long> toDelete = Sets.newHashSet(rowsWithNoIndexEntries.stream()
-                .map(StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow::getId)
-                .collect(Collectors.toSet()));
+        Map<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
+        Set<Long> toDelete = Sets.newHashSet();
         for (Map.Entry<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
-            if (e.getValue().getStatus() != Status.STORED) {
+            if (e.getValue().getStatus() != Status.STORED || rowsWithNoIndexEntries.contains(e.getKey())) {
                 toDelete.add(e.getKey().getId());
             }
         }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemMetadataCleanupTask.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemMetadataCleanupTask.java
@@ -37,11 +37,11 @@ public class StreamTestMaxMemMetadataCleanupTask implements OnCleanupTask {
                 .map(StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow::getId)
                 .map(StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow::of)
                 .collect(Collectors.toSet());
-        Map<StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow, Iterator<StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxColumnValue>> indexIterator
+        Map<StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow, Iterator<StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxColumnValue>> referenceIteratorByStream
                 = indexTable.getRowsColumnRangeIterator(indexRows,
                         BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 1));
-        Set<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow> rowsWithNoIndexEntries
-                = KeyedStream.stream(indexIterator)
+        Set<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow> streamsWithNoReferences
+                = KeyedStream.stream(referenceIteratorByStream)
                 .filter(valueIterator -> !valueIterator.hasNext())
                 .keys()
                 .map(StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow::getId)
@@ -50,7 +50,7 @@ public class StreamTestMaxMemMetadataCleanupTask implements OnCleanupTask {
         Map<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
         Set<Long> toDelete = Sets.newHashSet();
         for (Map.Entry<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
-            if (e.getValue().getStatus() != Status.STORED || rowsWithNoIndexEntries.contains(e.getKey())) {
+            if (e.getValue().getStatus() != Status.STORED || streamsWithNoReferences.contains(e.getKey())) {
                 toDelete.add(e.getKey().getId());
             }
         }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemMetadataCleanupTask.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemMetadataCleanupTask.java
@@ -1,18 +1,21 @@
 package com.palantir.atlasdb.schema.stream.generated;
 
-import java.util.Collection;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.protos.generated.StreamPersistence.Status;
 import com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.common.streams.KeyedStream;
 
 public class StreamTestMaxMemMetadataCleanupTask implements OnCleanupTask {
 
@@ -25,12 +28,30 @@ public class StreamTestMaxMemMetadataCleanupTask implements OnCleanupTask {
     @Override
     public boolean cellsCleanedUp(Transaction t, Set<Cell> cells) {
         StreamTestMaxMemStreamMetadataTable metaTable = tables.getStreamTestMaxMemStreamMetadataTable(t);
-        Collection<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow> rows = Lists.newArrayListWithCapacity(cells.size());
+        Set<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow> rows = Sets.newHashSetWithExpectedSize(cells.size());
         for (Cell cell : cells) {
             rows.add(StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));
         }
-        Map<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
-        Set<Long> toDelete = Sets.newHashSet();
+        StreamTestMaxMemStreamIdxTable indexTable = tables.getStreamTestMaxMemStreamIdxTable(t);
+        Set<StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow> indexRows = rows.stream()
+                .map(StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow::getId)
+                .map(StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow::of)
+                .collect(Collectors.toSet());
+        Map<StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow, Iterator<StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxColumnValue>> indexIterator
+                = indexTable.getRowsColumnRangeIterator(indexRows,
+                        BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 1));
+        Set<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow> rowsWithNoIndexEntries
+                = KeyedStream.stream(indexIterator)
+                .filter(valueIterator -> !valueIterator.hasNext())
+                .keys()
+                .map(StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow::getId)
+                .map(StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow::of)
+                .collect(Collectors.toSet());
+        Map<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(
+                Sets.difference(rows, rowsWithNoIndexEntries));
+        Set<Long> toDelete = Sets.newHashSet(rowsWithNoIndexEntries.stream()
+                .map(StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow::getId)
+                .collect(Collectors.toSet()));
         for (Map.Entry<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
             if (e.getValue().getStatus() != Status.STORED) {
                 toDelete.add(e.getKey().getId());

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMetadataCleanupTask.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMetadataCleanupTask.java
@@ -1,18 +1,21 @@
 package com.palantir.atlasdb.schema.stream.generated;
 
-import java.util.Collection;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.protos.generated.StreamPersistence.Status;
 import com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.common.streams.KeyedStream;
 
 public class StreamTestMetadataCleanupTask implements OnCleanupTask {
 
@@ -25,12 +28,30 @@ public class StreamTestMetadataCleanupTask implements OnCleanupTask {
     @Override
     public boolean cellsCleanedUp(Transaction t, Set<Cell> cells) {
         StreamTestStreamMetadataTable metaTable = tables.getStreamTestStreamMetadataTable(t);
-        Collection<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow> rows = Lists.newArrayListWithCapacity(cells.size());
+        Set<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow> rows = Sets.newHashSetWithExpectedSize(cells.size());
         for (Cell cell : cells) {
             rows.add(StreamTestStreamMetadataTable.StreamTestStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));
         }
-        Map<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
-        Set<Long> toDelete = Sets.newHashSet();
+        StreamTestStreamIdxTable indexTable = tables.getStreamTestStreamIdxTable(t);
+        Set<StreamTestStreamIdxTable.StreamTestStreamIdxRow> indexRows = rows.stream()
+                .map(StreamTestStreamMetadataTable.StreamTestStreamMetadataRow::getId)
+                .map(StreamTestStreamIdxTable.StreamTestStreamIdxRow::of)
+                .collect(Collectors.toSet());
+        Map<StreamTestStreamIdxTable.StreamTestStreamIdxRow, Iterator<StreamTestStreamIdxTable.StreamTestStreamIdxColumnValue>> indexIterator
+                = indexTable.getRowsColumnRangeIterator(indexRows,
+                        BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 1));
+        Set<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow> rowsWithNoIndexEntries
+                = KeyedStream.stream(indexIterator)
+                .filter(valueIterator -> !valueIterator.hasNext())
+                .keys()
+                .map(StreamTestStreamIdxTable.StreamTestStreamIdxRow::getId)
+                .map(StreamTestStreamMetadataTable.StreamTestStreamMetadataRow::of)
+                .collect(Collectors.toSet());
+        Map<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(
+                Sets.difference(rows, rowsWithNoIndexEntries));
+        Set<Long> toDelete = Sets.newHashSet(rowsWithNoIndexEntries.stream()
+                .map(StreamTestStreamMetadataTable.StreamTestStreamMetadataRow::getId)
+                .collect(Collectors.toSet()));
         for (Map.Entry<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
             if (e.getValue().getStatus() != Status.STORED) {
                 toDelete.add(e.getKey().getId());

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMetadataCleanupTask.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMetadataCleanupTask.java
@@ -47,13 +47,10 @@ public class StreamTestMetadataCleanupTask implements OnCleanupTask {
                 .map(StreamTestStreamIdxTable.StreamTestStreamIdxRow::getId)
                 .map(StreamTestStreamMetadataTable.StreamTestStreamMetadataRow::of)
                 .collect(Collectors.toSet());
-        Map<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(
-                Sets.difference(rows, rowsWithNoIndexEntries));
-        Set<Long> toDelete = Sets.newHashSet(rowsWithNoIndexEntries.stream()
-                .map(StreamTestStreamMetadataTable.StreamTestStreamMetadataRow::getId)
-                .collect(Collectors.toSet()));
+        Map<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
+        Set<Long> toDelete = Sets.newHashSet();
         for (Map.Entry<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
-            if (e.getValue().getStatus() != Status.STORED) {
+            if (e.getValue().getStatus() != Status.STORED || rowsWithNoIndexEntries.contains(e.getKey())) {
                 toDelete.add(e.getKey().getId());
             }
         }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMetadataCleanupTask.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMetadataCleanupTask.java
@@ -37,11 +37,11 @@ public class StreamTestMetadataCleanupTask implements OnCleanupTask {
                 .map(StreamTestStreamMetadataTable.StreamTestStreamMetadataRow::getId)
                 .map(StreamTestStreamIdxTable.StreamTestStreamIdxRow::of)
                 .collect(Collectors.toSet());
-        Map<StreamTestStreamIdxTable.StreamTestStreamIdxRow, Iterator<StreamTestStreamIdxTable.StreamTestStreamIdxColumnValue>> indexIterator
+        Map<StreamTestStreamIdxTable.StreamTestStreamIdxRow, Iterator<StreamTestStreamIdxTable.StreamTestStreamIdxColumnValue>> referenceIteratorByStream
                 = indexTable.getRowsColumnRangeIterator(indexRows,
                         BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 1));
-        Set<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow> rowsWithNoIndexEntries
-                = KeyedStream.stream(indexIterator)
+        Set<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow> streamsWithNoReferences
+                = KeyedStream.stream(referenceIteratorByStream)
                 .filter(valueIterator -> !valueIterator.hasNext())
                 .keys()
                 .map(StreamTestStreamIdxTable.StreamTestStreamIdxRow::getId)
@@ -50,7 +50,7 @@ public class StreamTestMetadataCleanupTask implements OnCleanupTask {
         Map<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
         Set<Long> toDelete = Sets.newHashSet();
         for (Map.Entry<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
-            if (e.getValue().getStatus() != Status.STORED || rowsWithNoIndexEntries.contains(e.getKey())) {
+            if (e.getValue().getStatus() != Status.STORED || streamsWithNoReferences.contains(e.getKey())) {
                 toDelete.add(e.getKey().getId());
             }
         }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashMetadataCleanupTask.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashMetadataCleanupTask.java
@@ -47,13 +47,10 @@ public class StreamTestWithHashMetadataCleanupTask implements OnCleanupTask {
                 .map(StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxRow::getId)
                 .map(StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow::of)
                 .collect(Collectors.toSet());
-        Map<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(
-                Sets.difference(rows, rowsWithNoIndexEntries));
-        Set<Long> toDelete = Sets.newHashSet(rowsWithNoIndexEntries.stream()
-                .map(StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow::getId)
-                .collect(Collectors.toSet()));
+        Map<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
+        Set<Long> toDelete = Sets.newHashSet();
         for (Map.Entry<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
-            if (e.getValue().getStatus() != Status.STORED) {
+            if (e.getValue().getStatus() != Status.STORED || rowsWithNoIndexEntries.contains(e.getKey())) {
                 toDelete.add(e.getKey().getId());
             }
         }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashMetadataCleanupTask.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashMetadataCleanupTask.java
@@ -1,18 +1,21 @@
 package com.palantir.atlasdb.schema.stream.generated;
 
-import java.util.Collection;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.protos.generated.StreamPersistence.Status;
 import com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.common.streams.KeyedStream;
 
 public class StreamTestWithHashMetadataCleanupTask implements OnCleanupTask {
 
@@ -25,12 +28,30 @@ public class StreamTestWithHashMetadataCleanupTask implements OnCleanupTask {
     @Override
     public boolean cellsCleanedUp(Transaction t, Set<Cell> cells) {
         StreamTestWithHashStreamMetadataTable metaTable = tables.getStreamTestWithHashStreamMetadataTable(t);
-        Collection<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow> rows = Lists.newArrayListWithCapacity(cells.size());
+        Set<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow> rows = Sets.newHashSetWithExpectedSize(cells.size());
         for (Cell cell : cells) {
             rows.add(StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));
         }
-        Map<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
-        Set<Long> toDelete = Sets.newHashSet();
+        StreamTestWithHashStreamIdxTable indexTable = tables.getStreamTestWithHashStreamIdxTable(t);
+        Set<StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxRow> indexRows = rows.stream()
+                .map(StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow::getId)
+                .map(StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxRow::of)
+                .collect(Collectors.toSet());
+        Map<StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxRow, Iterator<StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxColumnValue>> indexIterator
+                = indexTable.getRowsColumnRangeIterator(indexRows,
+                        BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 1));
+        Set<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow> rowsWithNoIndexEntries
+                = KeyedStream.stream(indexIterator)
+                .filter(valueIterator -> !valueIterator.hasNext())
+                .keys()
+                .map(StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxRow::getId)
+                .map(StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow::of)
+                .collect(Collectors.toSet());
+        Map<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(
+                Sets.difference(rows, rowsWithNoIndexEntries));
+        Set<Long> toDelete = Sets.newHashSet(rowsWithNoIndexEntries.stream()
+                .map(StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow::getId)
+                .collect(Collectors.toSet()));
         for (Map.Entry<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
             if (e.getValue().getStatus() != Status.STORED) {
                 toDelete.add(e.getKey().getId());

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashMetadataCleanupTask.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashMetadataCleanupTask.java
@@ -37,11 +37,11 @@ public class StreamTestWithHashMetadataCleanupTask implements OnCleanupTask {
                 .map(StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow::getId)
                 .map(StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxRow::of)
                 .collect(Collectors.toSet());
-        Map<StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxRow, Iterator<StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxColumnValue>> indexIterator
+        Map<StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxRow, Iterator<StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxColumnValue>> referenceIteratorByStream
                 = indexTable.getRowsColumnRangeIterator(indexRows,
                         BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 1));
-        Set<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow> rowsWithNoIndexEntries
-                = KeyedStream.stream(indexIterator)
+        Set<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow> streamsWithNoReferences
+                = KeyedStream.stream(referenceIteratorByStream)
                 .filter(valueIterator -> !valueIterator.hasNext())
                 .keys()
                 .map(StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxRow::getId)
@@ -50,7 +50,7 @@ public class StreamTestWithHashMetadataCleanupTask implements OnCleanupTask {
         Map<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
         Set<Long> toDelete = Sets.newHashSet();
         for (Map.Entry<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
-            if (e.getValue().getStatus() != Status.STORED || rowsWithNoIndexEntries.contains(e.getKey())) {
+            if (e.getValue().getStatus() != Status.STORED || streamsWithNoReferences.contains(e.getKey())) {
                 toDelete.add(e.getKey().getId());
             }
         }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsMetadataCleanupTask.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsMetadataCleanupTask.java
@@ -47,13 +47,10 @@ public class TestHashComponentsMetadataCleanupTask implements OnCleanupTask {
                 .map(TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxRow::getId)
                 .map(TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow::of)
                 .collect(Collectors.toSet());
-        Map<TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(
-                Sets.difference(rows, rowsWithNoIndexEntries));
-        Set<Long> toDelete = Sets.newHashSet(rowsWithNoIndexEntries.stream()
-                .map(TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow::getId)
-                .collect(Collectors.toSet()));
+        Map<TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
+        Set<Long> toDelete = Sets.newHashSet();
         for (Map.Entry<TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
-            if (e.getValue().getStatus() != Status.STORED) {
+            if (e.getValue().getStatus() != Status.STORED || rowsWithNoIndexEntries.contains(e.getKey())) {
                 toDelete.add(e.getKey().getId());
             }
         }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsMetadataCleanupTask.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsMetadataCleanupTask.java
@@ -37,11 +37,11 @@ public class TestHashComponentsMetadataCleanupTask implements OnCleanupTask {
                 .map(TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow::getId)
                 .map(TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxRow::of)
                 .collect(Collectors.toSet());
-        Map<TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxRow, Iterator<TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxColumnValue>> indexIterator
+        Map<TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxRow, Iterator<TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxColumnValue>> referenceIteratorByStream
                 = indexTable.getRowsColumnRangeIterator(indexRows,
                         BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 1));
-        Set<TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow> rowsWithNoIndexEntries
-                = KeyedStream.stream(indexIterator)
+        Set<TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow> streamsWithNoReferences
+                = KeyedStream.stream(referenceIteratorByStream)
                 .filter(valueIterator -> !valueIterator.hasNext())
                 .keys()
                 .map(TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxRow::getId)
@@ -50,7 +50,7 @@ public class TestHashComponentsMetadataCleanupTask implements OnCleanupTask {
         Map<TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
         Set<Long> toDelete = Sets.newHashSet();
         for (Map.Entry<TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
-            if (e.getValue().getStatus() != Status.STORED || rowsWithNoIndexEntries.contains(e.getKey())) {
+            if (e.getValue().getStatus() != Status.STORED || streamsWithNoReferences.contains(e.getKey())) {
                 toDelete.add(e.getKey().getId());
             }
         }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsMetadataCleanupTask.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsMetadataCleanupTask.java
@@ -1,18 +1,21 @@
 package com.palantir.atlasdb.schema.stream.generated;
 
-import java.util.Collection;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.protos.generated.StreamPersistence.Status;
 import com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.common.streams.KeyedStream;
 
 public class TestHashComponentsMetadataCleanupTask implements OnCleanupTask {
 
@@ -25,12 +28,30 @@ public class TestHashComponentsMetadataCleanupTask implements OnCleanupTask {
     @Override
     public boolean cellsCleanedUp(Transaction t, Set<Cell> cells) {
         TestHashComponentsStreamMetadataTable metaTable = tables.getTestHashComponentsStreamMetadataTable(t);
-        Collection<TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow> rows = Lists.newArrayListWithCapacity(cells.size());
+        Set<TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow> rows = Sets.newHashSetWithExpectedSize(cells.size());
         for (Cell cell : cells) {
             rows.add(TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));
         }
-        Map<TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
-        Set<Long> toDelete = Sets.newHashSet();
+        TestHashComponentsStreamIdxTable indexTable = tables.getTestHashComponentsStreamIdxTable(t);
+        Set<TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxRow> indexRows = rows.stream()
+                .map(TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow::getId)
+                .map(TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxRow::of)
+                .collect(Collectors.toSet());
+        Map<TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxRow, Iterator<TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxColumnValue>> indexIterator
+                = indexTable.getRowsColumnRangeIterator(indexRows,
+                        BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 1));
+        Set<TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow> rowsWithNoIndexEntries
+                = KeyedStream.stream(indexIterator)
+                .filter(valueIterator -> !valueIterator.hasNext())
+                .keys()
+                .map(TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxRow::getId)
+                .map(TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow::of)
+                .collect(Collectors.toSet());
+        Map<TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(
+                Sets.difference(rows, rowsWithNoIndexEntries));
+        Set<Long> toDelete = Sets.newHashSet(rowsWithNoIndexEntries.stream()
+                .map(TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow::getId)
+                .collect(Collectors.toSet()));
         for (Map.Entry<TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
             if (e.getValue().getStatus() != Status.STORED) {
                 toDelete.add(e.getKey().getId());

--- a/changelog/@unreleased/pr-4201.v2.yml
+++ b/changelog/@unreleased/pr-4201.v2.yml
@@ -1,0 +1,10 @@
+type: fix
+fix:
+  description: |-
+    Stream store metadata cleanup tasks now clear up streams that are stored if they have zero entries in the index table. Previously, if a service crashed between storing a stream non-transactionally and marking it (or otherwise chose not to mark the stream as used), the stream data for the unmarked stream would never be cleared from the database.
+
+    Note that this change does not apply retroactively to streams that were already leaked as described above.
+
+    Users who have checked in the generated AtlasDB schema code will need to regenerate their schemas once they are on this version of AtlasDB. Users that re-generate this via buildscripts do not need to perform any manual tasks.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4201

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosMetadataCleanupTask.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosMetadataCleanupTask.java
@@ -1,18 +1,20 @@
 package com.palantir.example.profile.schema.generated;
 
-import java.util.Collection;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.protos.generated.StreamPersistence.Status;
 import com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata;
-import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.common.streams.KeyedStream;
 
 public class UserPhotosMetadataCleanupTask implements OnCleanupTask {
 
@@ -25,12 +27,30 @@ public class UserPhotosMetadataCleanupTask implements OnCleanupTask {
     @Override
     public boolean cellsCleanedUp(Transaction t, Set<Cell> cells) {
         UserPhotosStreamMetadataTable metaTable = tables.getUserPhotosStreamMetadataTable(t);
-        Collection<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow> rows = Lists.newArrayListWithCapacity(cells.size());
+        Set<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow> rows = Sets.newHashSetWithExpectedSize(cells.size());
         for (Cell cell : cells) {
             rows.add(UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));
         }
-        Map<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
-        Set<Long> toDelete = Sets.newHashSet();
+        UserPhotosStreamIdxTable indexTable = tables.getUserPhotosStreamIdxTable(t);
+        Set<UserPhotosStreamIdxTable.UserPhotosStreamIdxRow> indexRows = rows.stream()
+                .map(UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow::getId)
+                .map(UserPhotosStreamIdxTable.UserPhotosStreamIdxRow::of)
+                .collect(Collectors.toSet());
+        Map<UserPhotosStreamIdxTable.UserPhotosStreamIdxRow, Iterator<UserPhotosStreamIdxTable.UserPhotosStreamIdxColumnValue>> indexIterator
+                = indexTable.getRowsColumnRangeIterator(indexRows,
+                        BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 1));
+        Set<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow> rowsWithNoIndexEntries
+                = KeyedStream.stream(indexIterator)
+                .filter(valueIterator -> !valueIterator.hasNext())
+                .keys()
+                .map(UserPhotosStreamIdxTable.UserPhotosStreamIdxRow::getId)
+                .map(UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow::of)
+                .collect(Collectors.toSet());
+        Map<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(
+                Sets.difference(rows, rowsWithNoIndexEntries));
+        Set<Long> toDelete = Sets.newHashSet(rowsWithNoIndexEntries.stream()
+                .map(UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow::getId)
+                .collect(Collectors.toSet()));
         for (Map.Entry<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
             if (e.getValue().getStatus() != Status.STORED) {
                 toDelete.add(e.getKey().getId());


### PR DESCRIPTION
**Goals (and why)**:
- Fix #4190 - this is an implementation of the method described in the first comment there

**Implementation Description (bullets)**:
- When running the metadata cleanup task, if a stream ID is stored but has zero entries in the index table, delete it.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Existing ETE tests should catch egregious breaks.
- I ~will see if I can~ added one ETE test that requires this behaviour - write streams without marking them, perform an iteration of targeted sweep, and then verify that in this case the stream data is cleared.

**Concerns (what feedback would you like?)**:
- Correctness. Are there any cases where this deletes things that shouldn't be deleted? Consider the proof/argument described on the issue.
- Performance. This is not a hot codepath so I'm less concerned here, but we are basically trying to find rows that are not-stored OR stored AND have nothing in the index table. There may be some clever way of reducing the size of the queries that I haven't thought about.

**Where should we start reviewing?**: `StreamStoreRenderer`

**Priority (whenever / two weeks / yesterday)**: this week
