### PR TITLE
[WiP] Bump container setup timeout to 10 minutes, rather than 2

### DIFF
--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/EteSetup.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/EteSetup.java
@@ -60,7 +60,7 @@ public abstract class EteSetup {
     private static Duration waitDuration;
 
     public static RuleChain setupComposition(Class<?> eteClass, String composeFile, List<String> availableClientNames) {
-        return setupComposition(eteClass, composeFile, availableClientNames, Duration.TWO_MINUTES);
+        return setupComposition(eteClass, composeFile, availableClientNames, Duration.TEN_MINUTES);
     }
 
     public static RuleChain setupComposition(


### PR DESCRIPTION
**Goals (and why)**: Have less flaky builds

**Implementation Description (bullets)**: Bump container setup timeout to 10m

**Testing (What was existing testing like?  What have you done to improve it?)**: We'll see if builds are happier. In progress.

**Concerns (what feedback would you like?)**: We need to root cause the underlying

**Where should we start reviewing?**: +1/-1

**Priority (whenever / two weeks / yesterday)**: if we're happy with this, yesterday