### PR TITLE
[Conjure Java Runtime] Part 4: Server-Side 308 Construction

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/NotCurrentLeaderExceptionMapper.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/NotCurrentLeaderExceptionMapper.java
@@ -66,7 +66,7 @@ public class NotCurrentLeaderExceptionMapper extends ProtocolAwareExceptionMappe
                 return QosException.retryOther(targeter.redirectRequest(uriInfo.getRequestUri().toURL()));
             } catch (MalformedURLException e) {
                 log.warn("Unable to parse context information {} into a URL. Returning generic 503.",
-                        UnsafeArg.of("uri", uriInfo),
+                        UnsafeArg.of("uri", uriInfo.getRequestUri()), // may contain arbitrary query params
                         e);
                 return QosException.unavailable();
             }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/NotCurrentLeaderExceptionMapper.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/NotCurrentLeaderExceptionMapper.java
@@ -19,9 +19,6 @@ import java.util.Optional;
 
 import javax.ws.rs.core.Response;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.palantir.conjure.java.api.errors.QosException;
 import com.palantir.leader.NotCurrentLeaderException;
 
@@ -35,8 +32,6 @@ import com.palantir.leader.NotCurrentLeaderException;
  * @author carrino
  */
 public class NotCurrentLeaderExceptionMapper extends ProtocolAwareExceptionMapper<NotCurrentLeaderException> {
-    private static final Logger log = LoggerFactory.getLogger(NotCurrentLeaderExceptionMapper.class);
-
     private final Optional<RedirectRetryTargeter> redirectRetryTargeter;
 
     public NotCurrentLeaderExceptionMapper() {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/RedirectRetryTargeter.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/RedirectRetryTargeter.java
@@ -1,0 +1,61 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.http;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
+
+public class RedirectRetryTargeter {
+    private final URL localServerBaseUrl;
+    private final URL nextServerBaseUrl;
+
+    public RedirectRetryTargeter(URL localServerBaseUrl, URL nextServerBaseUrl) {
+        this.localServerBaseUrl = localServerBaseUrl;
+        this.nextServerBaseUrl = nextServerBaseUrl;
+    }
+
+    // Precondition: requestUrl is a suffix of the local server's base URL.
+    public URL redirectRequest(URL requestUrl) {
+        String requestContextPath = getRequestContextPath(requestUrl);
+        try {
+            return new URL(
+                    nextServerBaseUrl.getProtocol(),
+                    nextServerBaseUrl.getHost(),
+                    nextServerBaseUrl.getPort(),
+                    nextServerBaseUrl.getFile() + requestContextPath);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("Error when constructing a URL in RedirectRetryTargeter. This is"
+                    + " a product bug. The path of this URL was " + nextServerBaseUrl.getFile() + requestContextPath);
+        }
+    }
+
+    private String getRequestContextPath(URL requestUrl) {
+        String localServerContextPath = localServerBaseUrl.getPath();
+        String requestPath = requestUrl.getPath();
+        Preconditions.checkState(requestPath.startsWith(localServerContextPath),
+                "We attempted to process a request in an application-specific exception mapper that is not"
+                        + " in our context path. This is strange, and a product bug.",
+                SafeArg.of("localServerBaseUrl", localServerBaseUrl),
+                UnsafeArg.of("requestUrl", requestUrl)); // unsafe since this is user-provided
+
+        return requestPath.substring(localServerContextPath.length());
+    }
+}

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/RedirectRetryTargeter.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/RedirectRetryTargeter.java
@@ -27,11 +27,11 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 
-class RedirectRetryTargeter {
+public class RedirectRetryTargeter {
     private final URL localServerBaseUrl;
     private final URL nextServerBaseUrl;
 
-    RedirectRetryTargeter(URL localServerBaseUrl, URL nextServerBaseUrl) {
+    public RedirectRetryTargeter(URL localServerBaseUrl, URL nextServerBaseUrl) {
         this.localServerBaseUrl = localServerBaseUrl;
         this.nextServerBaseUrl = nextServerBaseUrl;
     }
@@ -61,5 +61,13 @@ class RedirectRetryTargeter {
                 UnsafeArg.of("requestUrl", requestUrl)); // unsafe since this is user-provided
 
         return requestPath.substring(localServerContextPath.length());
+    }
+
+    @Override
+    public String toString() {
+        return "RedirectRetryTargeter{" +
+                "localServerBaseUrl=" + localServerBaseUrl +
+                ", nextServerBaseUrl=" + nextServerBaseUrl +
+                '}';
     }
 }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/RedirectRetryTargeter.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/RedirectRetryTargeter.java
@@ -22,7 +22,7 @@ import java.util.List;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 
-public class RedirectRetryTargeter {
+public final class RedirectRetryTargeter {
     private final URL nextServerBaseUrl;
 
     private RedirectRetryTargeter(URL nextServerBaseUrl) {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/RedirectRetryTargeter.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/RedirectRetryTargeter.java
@@ -65,9 +65,9 @@ public class RedirectRetryTargeter {
 
     @Override
     public String toString() {
-        return "RedirectRetryTargeter{" +
-                "localServerBaseUrl=" + localServerBaseUrl +
-                ", nextServerBaseUrl=" + nextServerBaseUrl +
-                '}';
+        return "RedirectRetryTargeter{"
+                + "localServerBaseUrl=" + localServerBaseUrl
+                + ", nextServerBaseUrl=" + nextServerBaseUrl
+                + '}';
     }
 }

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/RedirectRetryTargeterTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/RedirectRetryTargeterTest.java
@@ -35,7 +35,7 @@ public class RedirectRetryTargeterTest {
     private static final int PORT_2 = 4222;
 
     private static final String PATH_1 = "/api/masyu/";
-    private static final String PATH_2 = "/api/snake/";
+    private static final String PATH_2 = "/kpi/snake/";
     private static final String REQUEST_PATH_1 = "request/jewelled-branch-of-hourai";
     private static final String REQUEST_PATH_2 = "/request/swallows-cowrie-shell";
 

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/RedirectRetryTargeterTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/RedirectRetryTargeterTest.java
@@ -1,0 +1,97 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.junit.Test;
+
+public class RedirectRetryTargeterTest {
+    private static final String SCHEME_1 = "http";
+    private static final String SCHEME_2 = "https";
+
+    private static final String HOST_1 = "hostage";
+    private static final String HOST_2 = "hostile";
+
+    private static final int PORT_1 = 42;
+    private static final int PORT_2 = 4222;
+
+    private static final String PATH_1 = "/api/masyu/";
+    private static final String PATH_2 = "/api/snake/";
+    private static final String REQUEST_PATH_1 = "request/jewelled-branch-of-hourai";
+    private static final String REQUEST_PATH_2 = "/request/swallows-cowrie-shell";
+
+    private static final URL BASE_URL_1;
+    private static final URL BASE_URL_2;
+
+    static {
+        try {
+            BASE_URL_1 = new URL(SCHEME_1, HOST_1, PORT_1, PATH_1);
+            BASE_URL_2 = new URL(SCHEME_2, HOST_2, PORT_2, PATH_2);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static final RedirectRetryTargeter SELF_TARGETER = new RedirectRetryTargeter(BASE_URL_1, BASE_URL_1);
+    private static final RedirectRetryTargeter REDIRECTING_TARGETER = new RedirectRetryTargeter(BASE_URL_1, BASE_URL_2);
+
+    @Test
+    public void getRequestPathAvoidsContext() throws MalformedURLException {
+        URL requestUrl = new URL(SCHEME_1, HOST_1, PORT_1, PATH_1 + REQUEST_PATH_1);
+        assertThat(REDIRECTING_TARGETER.getRequestPath(requestUrl)).isEqualTo(REQUEST_PATH_1);
+    }
+
+    @Test
+    public void getRequestPathThrowsIfPathIsNotContextPrefixed() throws MalformedURLException {
+        URL requestUrl = new URL(SCHEME_1, HOST_1, PORT_1, REQUEST_PATH_1);
+        assertThatThrownBy(() -> REDIRECTING_TARGETER.getRequestPath(requestUrl))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("not in our context path");
+    }
+
+    @Test
+    public void canRedirectToSelf() throws MalformedURLException {
+        URL requestUrl = new URL(SCHEME_1, HOST_1, PORT_1, PATH_1 + REQUEST_PATH_1);
+        assertThat(SELF_TARGETER.redirectRequest(requestUrl)).isEqualTo(requestUrl);
+    }
+
+    @Test
+    public void canRedirectToOtherNodes() throws MalformedURLException {
+        URL requestUrl = new URL(SCHEME_1, HOST_1, PORT_1, PATH_1 + REQUEST_PATH_1);
+        assertThat(REDIRECTING_TARGETER.redirectRequest(requestUrl)).isEqualTo(
+                new URL(SCHEME_2, HOST_2, PORT_2, PATH_2 + REQUEST_PATH_1));
+    }
+
+    @Test
+    public void handlesRepeatedContextPathCorrectly() throws MalformedURLException {
+        URL requestUrl = new URL(SCHEME_1, HOST_1, PORT_1, PATH_1 + PATH_1.substring(1));
+        assertThat(REDIRECTING_TARGETER.redirectRequest(requestUrl)).isEqualTo(
+                new URL(SCHEME_2, HOST_2, PORT_2, PATH_2 + PATH_1.substring(1)));
+    }
+
+    @Test
+    public void handlesRequestPathWithLeadingSlash() throws MalformedURLException {
+        URL requestUrl = new URL(SCHEME_1, HOST_1, PORT_1, PATH_1 + REQUEST_PATH_2);
+        assertThat(REDIRECTING_TARGETER.redirectRequest(requestUrl)).isEqualTo(
+                new URL(SCHEME_2, HOST_2, PORT_2, PATH_2 + REQUEST_PATH_2.substring(1)));
+    }
+}

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/RedirectRetryTargeterTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/RedirectRetryTargeterTest.java
@@ -27,19 +27,9 @@ import org.junit.Test;
 import com.google.common.collect.ImmutableList;
 
 public class RedirectRetryTargeterTest {
-    private static final URL URL_1;
-    private static final URL URL_2;
-    private static final URL URL_3;
-
-    static {
-        try {
-            URL_1 = new URL("https", "hostage", 42, "/request/hourai-branch");
-            URL_2 = new URL("http", "hostile", 424, "/request/swallows-cowrie-shell");
-            URL_3 = new URL("https", "hostel", 4242, "/request/fire-rat-robe");
-        } catch (MalformedURLException e) {
-            throw new RuntimeException(e);
-        }
-    }
+    private static final URL URL_1 = createUrlUnchecked("https", "hostage", 42, "/request/hourai-branch");
+    private static final URL URL_2 = createUrlUnchecked("https", "hostile", 424, "/request/swallows-cowrie-shell");
+    private static final URL URL_3 = createUrlUnchecked("https", "hostel", 4242, "/request/fire-rat-robe");
 
     @Test
     public void redirectsToSelfIfOnlyOneNode() {
@@ -64,5 +54,13 @@ public class RedirectRetryTargeterTest {
         assertThatThrownBy(() -> RedirectRetryTargeter.create(URL_3, ImmutableList.of(URL_1)))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Local server not found in the list of cluster URLs.");
+    }
+
+    private static URL createUrlUnchecked(String protocol, String host, int port, String path) {
+        try {
+            return new URL(protocol, host, port, path);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/changelog/@unreleased/pr-4205.v1.yml
+++ b/changelog/@unreleased/pr-4205.v1.yml
@@ -1,0 +1,5 @@
+type: improvement
+  improvement:
+    description:  "`NotCurrentLeaderExceptionMapper` now returns 308s correctly if dealing with v2 AtlasDB remoting clients."
+    links:
+      - https://github.com/palantir/atlasdb/pull/4205

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/PaxosRemotingUtils.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/PaxosRemotingUtils.java
@@ -15,10 +15,15 @@
  */
 package com.palantir.timelock.paxos;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import javax.ws.rs.core.UriBuilder;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -65,5 +70,19 @@ public final class PaxosRemotingUtils {
         return addresses.stream()
                 .map(address -> addProtocol(install, address))
                 .collect(Collectors.toSet());
+    }
+
+    public static URL convertAddressToUrl(TimeLockInstallConfiguration install, String address) {
+        try {
+            return UriBuilder.fromPath(addProtocol(install, address)).build().toURL();
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static List<URL> convertAddressesToUrls(TimeLockInstallConfiguration install, List<String> addresses) {
+        return addresses.stream()
+                .map(address -> convertAddressToUrl(install, address))
+                .collect(Collectors.toList());
     }
 }

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -200,7 +200,7 @@ public class TimeLockAgent {
 
     private void registerExceptionMappers() {
         registrar.accept(new BlockingTimeoutExceptionMapper());
-        registrar.accept(new NotCurrentLeaderExceptionMapper());
+        registrar.accept(new NotCurrentLeaderExceptionMapper(redirectRetryTargeter));
         registrar.accept(new TooManyRequestsExceptionMapper());
     }
 

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -15,10 +15,14 @@
  */
 package com.palantir.timelock.paxos;
 
+import java.net.URL;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.InstrumentedExecutorService;
 import com.codahale.metrics.InstrumentedThreadFactory;
@@ -28,6 +32,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.palantir.atlasdb.config.ImmutableLeaderConfig;
 import com.palantir.atlasdb.http.BlockingTimeoutExceptionMapper;
 import com.palantir.atlasdb.http.NotCurrentLeaderExceptionMapper;
+import com.palantir.atlasdb.http.RedirectRetryTargeter;
 import com.palantir.atlasdb.timelock.TimeLockResource;
 import com.palantir.atlasdb.timelock.TimeLockServices;
 import com.palantir.atlasdb.timelock.TooManyRequestsExceptionMapper;
@@ -50,6 +55,8 @@ import com.palantir.timestamp.ManagedTimestampService;
 
 @SuppressWarnings("checkstyle:FinalClass") // This is mocked internally
 public class TimeLockAgent {
+    private static final Logger log = LoggerFactory.getLogger(TimeLockAgent.class);
+
     private static final Long SCHEMA_VERSION = 1L;
 
     private final MetricsManager metricsManager;
@@ -200,7 +207,14 @@ public class TimeLockAgent {
 
     private void registerExceptionMappers() {
         registrar.accept(new BlockingTimeoutExceptionMapper());
-        registrar.accept(new NotCurrentLeaderExceptionMapper(redirectRetryTargeter));
+        URL localServerBaseUrl = PaxosRemotingUtils.convertAddressToUrl(install, install.cluster().localServer());
+        List<URL> baseUrls = PaxosRemotingUtils.convertAddressesToUrls(install, install.cluster().clusterMembers());
+
+        registrar.accept(new NotCurrentLeaderExceptionMapper(
+                new RedirectRetryTargeter(
+                        localServerBaseUrl,
+                        baseUrls.get((baseUrls.indexOf(localServerBaseUrl) + 1) % baseUrls.size()))));
+
         registrar.accept(new TooManyRequestsExceptionMapper());
     }
 

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -207,13 +207,10 @@ public class TimeLockAgent {
 
     private void registerExceptionMappers() {
         registrar.accept(new BlockingTimeoutExceptionMapper());
-        URL localServerBaseUrl = PaxosRemotingUtils.convertAddressToUrl(install, install.cluster().localServer());
-        List<URL> baseUrls = PaxosRemotingUtils.convertAddressesToUrls(install, install.cluster().clusterMembers());
 
-        registrar.accept(new NotCurrentLeaderExceptionMapper(
-                new RedirectRetryTargeter(
-                        localServerBaseUrl,
-                        baseUrls.get((baseUrls.indexOf(localServerBaseUrl) + 1) % baseUrls.size()))));
+        URL localServer = PaxosRemotingUtils.convertAddressToUrl(install, install.cluster().localServer());
+        List<URL> clusterUrls = PaxosRemotingUtils.convertAddressesToUrls(install, install.cluster().clusterMembers());
+        registrar.accept(new NotCurrentLeaderExceptionMapper(RedirectRetryTargeter.create(localServer, clusterUrls)));
 
         registrar.accept(new TooManyRequestsExceptionMapper());
     }

--- a/timelock-agent/src/test/java/com/palantir/timelock/paxos/PaxosRemotingUtilsTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/paxos/PaxosRemotingUtilsTest.java
@@ -19,6 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
@@ -149,4 +151,15 @@ public class PaxosRemotingUtilsTest {
                 .containsExactlyInAnyOrder("https://foo:1", "https://bar:2");
     }
 
+    @Test
+    public void convertAddressToUrlCreatesComponentsCorrectly_NoSsl() throws MalformedURLException {
+        assertThat(PaxosRemotingUtils.convertAddressToUrl(NO_SSL_TIMELOCK, "foo:42/timelock/api/timelock"))
+                .isEqualTo(new URL("http", "foo", 42, "/timelock/api/timelock"));
+    }
+
+    @Test
+    public void convertAddressToUrlCreatesComponentsCorrectly_Ssl() throws MalformedURLException {
+        assertThat(PaxosRemotingUtils.convertAddressToUrl(SSL_TIMELOCK, "foo:42/api/bar/baz/bzzt"))
+                .isEqualTo(new URL("https", "foo", 42, "/api/bar/baz/bzzt"));
+    }
 }


### PR DESCRIPTION
**Goals (and why)**:
- Support not-current-leader style workflows with 308s in CJR land.

**Implementation Description (bullets)**:
- Extend NCLEM to be able to fire not-current-leader-exceptions that are 308 with a location header for Conjure Java Runtime.
- Have a RedirectRetryTargeter that figures out where to point at.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Added a couple of tests for the RedirectRetryTargeter, plus a quick one for PaxosRemotingUtils.

**Concerns (what feedback would you like?)**:
- Technically the `RedirectRetryTargeter` does two things: it picks a new base URI, and then it does prefix matching, so if you have `Scheme1Host1:Port1Path1` and `Scheme2Host2:Port2Path2` as base URIs and a request made to `Scheme1Host1:Port1Path1Path3`, then this needs to return `Scheme2Host2:Port2Path2Path3`. I thought about splitting out the first piece to a separate class/interface (possible future work to re-enable leader hinting, for example), but it felt like there were a lot of small classes.
- I made `RedirectRetryTargeter` an `Optional` in `NotCurrentLeaderExceptionMapper` to avoid breaking the API, and to play nicely with consumers that use a leader block. These don't have information about hosts and just fall back to 503. Is this a reasonable thing to do? 
- If retry targeting blows up we generally just fall back to 503s. Does this make sense? I think it does as remoting will recover and find the right node, just perhaps with some maybe less-than-desirable exponential backoff in between.
- The manipulating of URL components feels a bit fragile to me, though I don't really see a better way to do this, and lifting components directly off the config and just returning that doesn't work, because remoting requires that the hint comes from the same set of base URLs that the client knows about, which is crucially *not* the same as that on the server.

**Where should we start reviewing?**: `RedirectRetryTargeterTest`, probably.

**Priority (whenever / two weeks / yesterday)**: this week
