### PR TITLE
[Build Flakes] Resolve Race Condition in ETE Test Container Setup

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/DefaultCleanerBuilder.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/DefaultCleanerBuilder.java
@@ -16,6 +16,7 @@
 package com.palantir.atlasdb.cleaner;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
@@ -122,7 +123,7 @@ public class DefaultCleanerBuilder {
                 cachingPuncherStore,
                 clock,
                 Suppliers.ofInstance(transactionReadTimeout));
-        return AsyncPuncher.create(simplePuncher, punchIntervalMillis, timestampSeedSource);
+        return AsyncPuncher.create(simplePuncher, punchIntervalMillis, Optional.of(timestampSeedSource));
     }
 
     private Scrubber buildScrubber(Supplier<Long> unreadableTimestampSupplier,

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/cleaner/AsyncPuncherTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/cleaner/AsyncPuncherTest.java
@@ -64,7 +64,7 @@ public class AsyncPuncherTest {
         PuncherStore puncherStore = InMemoryPuncherStore.create();
         Clock clock = new SystemClock();
         Puncher puncher = SimplePuncher.create(puncherStore, clock, Suppliers.ofInstance(TRANSACTION_TIMEOUT));
-        asyncPuncherSeeded = AsyncPuncher.create(puncher, ASYNC_PUNCHER_INTERVAL, Optional.of(PUNCHER_SEED));
+        asyncPuncherSeeded = AsyncPuncher.create(puncher, ASYNC_PUNCHER_INTERVAL, Optional.of(() -> PUNCHER_SEED));
     }
 
     @After

--- a/changelog/@unreleased/pr-4213.v2.yml
+++ b/changelog/@unreleased/pr-4213.v2.yml
@@ -1,9 +1,11 @@
-type: fix
-fix:
-  description: |2
-
-    When seeding the async puncher, run that with a one second timeout, and should that fail just don't seed. This is important for certain internal use cases.
-
-    There is an API break: `AsyncPuncher#create` now takes an `Optional LongSupplier` instead of just an `Optional Long`.
-  links:
-  - https://github.com/palantir/atlasdb/pull/4213
+changes:
+  - type: fix
+    fix:
+      description:  When seeding the async puncher, we now run that with a one second timeout, and should that fail just don't seed; previously, we would block startup on successfully acquiring the seed.
+      links:
+        - https://github.com/palantir/atlasdb/pull/4213
+  - type: break
+    break:
+      description: `AsyncPuncher#create` now takes an `Optional<LongSupplier>` instead of just an `Optional<Long>`.
+      links:
+        - https://github.com/palantir/atlasdb/pull/4213

--- a/changelog/@unreleased/pr-4213.v2.yml
+++ b/changelog/@unreleased/pr-4213.v2.yml
@@ -1,0 +1,9 @@
+type: fix
+fix:
+  description: |2
+
+    When seeding the async puncher, run that with a one second timeout, and should that fail just don't seed. This is important for certain internal use cases.
+
+    There is an API break: `AsyncPuncher#create` now takes an `Optional LongSupplier` instead of just an `Optional Long`.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4213


### PR DESCRIPTION
**Goals (and why)**:
- Actually have builds that work under most normal circumstances, rather than having to retry five or six times before a release gets to prod.

**Implementation Description (bullets)**:
- When seeding the async puncher, run that with a one second timeout, and should that fail just don't seed.
- The builds were flaking because successfully bringing up the ETE Docker containers was dependent on the docker proxy rule having already been set up by the time the ETE server containers talked to one another to elect a leader.
- I hypothesise that the reason this manifested as DbKvs failures (but interestingly much, much less on Cassandra Multinode) was because historically the Cassandra containers take longer than Postgres before they're fully ready, and we need to create tables and indices before we actually get to grabbing the seed timestamp for the puncher.

**Testing (What was existing testing like?  What have you done to improve it?)**:
See internal builds on the branch `jkong/flaky-2`; that is this branch jury-rigged to run seven instances of the DbKvsIntegrationTest on containers 1-7. We have a 14/14 success rate.

**Concerns (what feedback would you like?)**:
- We may have some false positives in the targeted sweep monitor, but given that that pages at P1 I'm not too worried.
- Are there some funky conditions where the executor blows up and is sad?

**Where should we start reviewing?**:
AsyncPuncher

**Priority (whenever / two weeks / yesterday)**: yesterday. Actually the day we made the first PR.