### PR TITLE
Fix Publishing: Don't publish intermediate artifactless project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,8 +88,11 @@ allprojects {
 
 subprojects {
     apply plugin: 'com.palantir.configuration-resolver'
-    apply from: "$rootDir/gradle/publish-jars.gradle"
     task allDeps(type: DependencyReportTask) {}
+}
+
+configure(subprojects.findAll {!it.getPath().contains(":examples")}) {
+    apply from: "$rootDir/gradle/publish-jars.gradle"
 }
 
 apply from: 'gradle/idea.gradle'

--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,7 @@ subprojects {
     task allDeps(type: DependencyReportTask) {}
 }
 
-configure(subprojects.findAll {!it.getPath().contains(":examples")}) {
+configure(subprojects.findAll {!it.getPath().startsWith(":examples:")}) {
     apply from: "$rootDir/gradle/publish-jars.gradle"
 }
 


### PR DESCRIPTION
**Goals (and why)**:
- Fix internal publishing. Consider internal publishing workflow build#1203.

**Implementation Description (bullets)**:
- Don't apply `publish-jars.gradle` to the example namespace. The issue with applying `publish-jars.gradle` to `subprojects`, generally speaking, is that if you have a namespaced project say `foo:bar:baz`, then as far as Gradle is concerned `foo` and `foo:bar` are legitimate subprojects too, so we attempt to publish artifacts for them that don't exist, making the build fail.

**Testing (What was existing testing like?  What have you done to improve it?)**: no automated tests, but verified from `print it` that only legit subprojects are being considered now

**Concerns (what feedback would you like?)**:
- This is not a good general solution, but I didn't find anything else obvious that would be safe going forward, generally speaking. It may be legitimate to have `foo` and `foo:bar` with the intention of both being published, so saying "only publish leaf nodes" doesn't sit well with me either.

**Where should we start reviewing?**: build.gradle

**Priority (whenever / two weeks / yesterday)**: yesterday 🔥 
