### PR TITLE
Explicitly authorize KeyedStream.keys() in stream stores

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
@@ -790,7 +790,7 @@ public class StreamStoreRenderer {
                     line("Set<", StreamMetadataRow, "> streamsWithNoReferences");
                     line("        = KeyedStream.stream(referenceIteratorByStream)");
                     line("        .filter(valueIterator -> !valueIterator.hasNext())");
-                    line("        .keys()");
+                    line("        .keys() // (authorized)"); // required for large internal product
                     line("        .map(", StreamIndexRow, "::getId)");
                     line("        .map(", StreamMetadataRow, "::of)");
                     line("        .collect(Collectors.toSet());");

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsMetadataCleanupTask.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsMetadataCleanupTask.java
@@ -43,7 +43,7 @@ public class SnapshotsMetadataCleanupTask implements OnCleanupTask {
         Set<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> streamsWithNoReferences
                 = KeyedStream.stream(referenceIteratorByStream)
                 .filter(valueIterator -> !valueIterator.hasNext())
-                .keys()
+                .keys() // (authorized)
                 .map(SnapshotsStreamIdxTable.SnapshotsStreamIdxRow::getId)
                 .map(SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow::of)
                 .collect(Collectors.toSet());

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataMetadataCleanupTask.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataMetadataCleanupTask.java
@@ -43,7 +43,7 @@ public class DataMetadataCleanupTask implements OnCleanupTask {
         Set<DataStreamMetadataTable.DataStreamMetadataRow> streamsWithNoReferences
                 = KeyedStream.stream(referenceIteratorByStream)
                 .filter(valueIterator -> !valueIterator.hasNext())
-                .keys()
+                .keys() // (authorized)
                 .map(DataStreamIdxTable.DataStreamIdxRow::getId)
                 .map(DataStreamMetadataTable.DataStreamMetadataRow::of)
                 .collect(Collectors.toSet());

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataMetadataCleanupTask.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataMetadataCleanupTask.java
@@ -43,7 +43,7 @@ public class HotspottyDataMetadataCleanupTask implements OnCleanupTask {
         Set<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow> streamsWithNoReferences
                 = KeyedStream.stream(referenceIteratorByStream)
                 .filter(valueIterator -> !valueIterator.hasNext())
-                .keys()
+                .keys() // (authorized)
                 .map(HotspottyDataStreamIdxTable.HotspottyDataStreamIdxRow::getId)
                 .map(HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow::of)
                 .collect(Collectors.toSet());

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueMetadataCleanupTask.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueMetadataCleanupTask.java
@@ -43,7 +43,7 @@ public class ValueMetadataCleanupTask implements OnCleanupTask {
         Set<ValueStreamMetadataTable.ValueStreamMetadataRow> streamsWithNoReferences
                 = KeyedStream.stream(referenceIteratorByStream)
                 .filter(valueIterator -> !valueIterator.hasNext())
-                .keys()
+                .keys() // (authorized)
                 .map(ValueStreamIdxTable.ValueStreamIdxRow::getId)
                 .map(ValueStreamMetadataTable.ValueStreamMetadataRow::of)
                 .collect(Collectors.toSet());

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemMetadataCleanupTask.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemMetadataCleanupTask.java
@@ -43,7 +43,7 @@ public class StreamTestMaxMemMetadataCleanupTask implements OnCleanupTask {
         Set<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow> streamsWithNoReferences
                 = KeyedStream.stream(referenceIteratorByStream)
                 .filter(valueIterator -> !valueIterator.hasNext())
-                .keys()
+                .keys() // (authorized)
                 .map(StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow::getId)
                 .map(StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow::of)
                 .collect(Collectors.toSet());

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMetadataCleanupTask.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMetadataCleanupTask.java
@@ -43,7 +43,7 @@ public class StreamTestMetadataCleanupTask implements OnCleanupTask {
         Set<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow> streamsWithNoReferences
                 = KeyedStream.stream(referenceIteratorByStream)
                 .filter(valueIterator -> !valueIterator.hasNext())
-                .keys()
+                .keys() // (authorized)
                 .map(StreamTestStreamIdxTable.StreamTestStreamIdxRow::getId)
                 .map(StreamTestStreamMetadataTable.StreamTestStreamMetadataRow::of)
                 .collect(Collectors.toSet());

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashMetadataCleanupTask.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashMetadataCleanupTask.java
@@ -43,7 +43,7 @@ public class StreamTestWithHashMetadataCleanupTask implements OnCleanupTask {
         Set<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow> streamsWithNoReferences
                 = KeyedStream.stream(referenceIteratorByStream)
                 .filter(valueIterator -> !valueIterator.hasNext())
-                .keys()
+                .keys() // (authorized)
                 .map(StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxRow::getId)
                 .map(StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow::of)
                 .collect(Collectors.toSet());

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsMetadataCleanupTask.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsMetadataCleanupTask.java
@@ -43,7 +43,7 @@ public class TestHashComponentsMetadataCleanupTask implements OnCleanupTask {
         Set<TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow> streamsWithNoReferences
                 = KeyedStream.stream(referenceIteratorByStream)
                 .filter(valueIterator -> !valueIterator.hasNext())
-                .keys()
+                .keys() // (authorized)
                 .map(TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxRow::getId)
                 .map(TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow::of)
                 .collect(Collectors.toSet());

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosMetadataCleanupTask.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosMetadataCleanupTask.java
@@ -43,7 +43,7 @@ public class UserPhotosMetadataCleanupTask implements OnCleanupTask {
         Set<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow> streamsWithNoReferences
                 = KeyedStream.stream(referenceIteratorByStream)
                 .filter(valueIterator -> !valueIterator.hasNext())
-                .keys()
+                .keys() // (authorized)
                 .map(UserPhotosStreamIdxTable.UserPhotosStreamIdxRow::getId)
                 .map(UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow::of)
                 .collect(Collectors.toSet());


### PR DESCRIPTION
**Goals (and why)**:
- Large internal product has its own static analysis rules (different from baseline). As part of these, they have a check banning `Multimap.keys()` (recommending `keySet()` instead). The check isn't sophisticated enough to distinguish that from `KeyedStream.keys()`, which we use in the stream store renderer for the cleanup tasks now.
- See internal alternative VCS 328401.

**Implementation Description (bullets)**:
- Add an explicit authorization to this call of the `keys()` method.

**Testing (What was existing testing like?  What have you done to improve it?)**: not much

**Concerns (what feedback would you like?)**: Did I miss any of the stream stores?

**Where should we start reviewing?**: StreamStoreRenderer.java

**Priority (whenever / two weeks / yesterday)**: yesterday 🔥 
