### PR TITLE
[Conjure Java Runtime] Part 7: Namespaced Timestamp Management RPC Client

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -155,6 +155,8 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.timestamp.ManagedTimestampService;
+import com.palantir.timestamp.RemoteTimestampManagementAdapter;
+import com.palantir.timestamp.TimestampManagementRpcClient;
 import com.palantir.timestamp.TimestampManagementService;
 import com.palantir.timestamp.TimestampService;
 import com.palantir.timestamp.TimestampStoreInvalidator;
@@ -928,8 +930,8 @@ public abstract class TransactionManagers {
                 = new NamespacedTimelockRpcClient(timelockClient, timelockNamespace);
         RemoteTimelockServiceAdapter remoteTimelockServiceAdapter
                 = RemoteTimelockServiceAdapter.create(namespacedTimelockRpcClient);
-        TimestampManagementService timestampManagementService
-                = creator.createServiceWithNamespacedUris(TimestampManagementService.class, timelockNamespace);
+        TimestampManagementService timestampManagementService = new RemoteTimestampManagementAdapter(
+                creator.createService(TimestampManagementRpcClient.class), timelockNamespace);
 
         return ImmutableLockAndTimestampServices.builder()
                 .lock(lockService)

--- a/timestamp-api/src/main/java/com/palantir/timestamp/RemoteTimestampManagementAdapter.java
+++ b/timestamp-api/src/main/java/com/palantir/timestamp/RemoteTimestampManagementAdapter.java
@@ -1,0 +1,37 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.timestamp;
+
+public class RemoteTimestampManagementAdapter implements TimestampManagementService {
+    private final TimestampManagementRpcClient rpcClient;
+    private final String namespace;
+
+    public RemoteTimestampManagementAdapter(TimestampManagementRpcClient rpcClient, String namespace) {
+        this.rpcClient = rpcClient;
+        this.namespace = namespace;
+    }
+
+    @Override
+    public void fastForwardTimestamp(long fastForwardTimestamp) {
+        rpcClient.fastForwardTimestamp(namespace, fastForwardTimestamp);
+    }
+
+    @Override
+    public String ping() {
+        return rpcClient.ping(namespace);
+    }
+}

--- a/timestamp-api/src/main/java/com/palantir/timestamp/TimestampManagementRpcClient.java
+++ b/timestamp-api/src/main/java/com/palantir/timestamp/TimestampManagementRpcClient.java
@@ -18,7 +18,6 @@ package com.palantir.timestamp;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.meta.When;
-import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -31,34 +30,15 @@ import com.palantir.logsafe.Safe;
 
 @Path("{namespace}/timestamp-management")
 public interface TimestampManagementRpcClient {
-    long SENTINEL_TIMESTAMP = Long.MIN_VALUE;
-    String SENTINEL_TIMESTAMP_STRING =
-            SENTINEL_TIMESTAMP + ""; // can't use valueOf/toString because we need a compile time constant!
-    String PING_RESPONSE = "pong";
-
-    /**
-     * Updates the timestamp service to the currentTimestamp to ensure that all fresh timestamps issued after
-     * this request are greater than the current timestamp.
-     * The caller of this is responsible for not using any of the fresh timestamps previously served to it,
-     * and must call getFreshTimestamps() to ensure it is using timestamps after the fastforward point.
-     *
-     * If currentTimestamp is unspecified (e.g. in a remote request), we will fast forward to the SENTINEL_TIMESTAMP.
-     * This is intended to be Long.MIN_VALUE, so that regardless of the current state of the timestamp service
-     * it is effectively a no-op. To improve usability, this method is also allowed to throw an exception in this case.
-     *
-     * @param currentTimestamp the largest timestamp issued until the fast-forward call
-     */
     @POST
     @Path("fast-forward")
     @Produces(MediaType.APPLICATION_JSON)
     void fastForwardTimestamp(
-            @PathParam("namespace") String namespace,
-            @Safe @QueryParam("currentTimestamp") @DefaultValue(SENTINEL_TIMESTAMP_STRING) long currentTimestamp);
+            @PathParam("namespace") String namespace, @Safe @QueryParam("currentTimestamp") long currentTimestamp);
 
     @GET
     @Path("ping")
     @Produces(MediaType.TEXT_PLAIN)
     @CheckReturnValue(when = When.NEVER)
     String ping(@PathParam("namespace") String namespace);
-
 }

--- a/timestamp-api/src/main/java/com/palantir/timestamp/TimestampManagementRpcClient.java
+++ b/timestamp-api/src/main/java/com/palantir/timestamp/TimestampManagementRpcClient.java
@@ -1,0 +1,64 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.timestamp;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.meta.When;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import com.palantir.logsafe.Safe;
+
+@Path("{namespace}/timestamp-management")
+public interface TimestampManagementRpcClient {
+    long SENTINEL_TIMESTAMP = Long.MIN_VALUE;
+    String SENTINEL_TIMESTAMP_STRING =
+            SENTINEL_TIMESTAMP + ""; // can't use valueOf/toString because we need a compile time constant!
+    String PING_RESPONSE = "pong";
+
+    /**
+     * Updates the timestamp service to the currentTimestamp to ensure that all fresh timestamps issued after
+     * this request are greater than the current timestamp.
+     * The caller of this is responsible for not using any of the fresh timestamps previously served to it,
+     * and must call getFreshTimestamps() to ensure it is using timestamps after the fastforward point.
+     *
+     * If currentTimestamp is unspecified (e.g. in a remote request), we will fast forward to the SENTINEL_TIMESTAMP.
+     * This is intended to be Long.MIN_VALUE, so that regardless of the current state of the timestamp service
+     * it is effectively a no-op. To improve usability, this method is also allowed to throw an exception in this case.
+     *
+     * @param currentTimestamp the largest timestamp issued until the fast-forward call
+     */
+    @POST
+    @Path("fast-forward")
+    @Produces(MediaType.APPLICATION_JSON)
+    void fastForwardTimestamp(
+            @PathParam("namespace") String namespace,
+            @Safe @QueryParam("currentTimestamp") @DefaultValue(SENTINEL_TIMESTAMP_STRING) long currentTimestamp);
+
+    @GET
+    @Path("ping")
+    @Produces(MediaType.TEXT_PLAIN)
+    @CheckReturnValue(when = When.NEVER)
+    String ping(@PathParam("namespace") String namespace);
+
+}


### PR DESCRIPTION
**Goals (and why)**:
- Support base URIs for TimeLock connections that don't directly include the namespace.

**Implementation Description (bullets)**:
- Implement an interface which does take in the namespace, and an adapter to that interface.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Existing integration tests passing should suffice.

**Concerns (what feedback would you like?)**: nothing in particular

**Where should we start reviewing?**: TimestampManagementRpcClient.java

**Priority (whenever / two weeks / yesterday)**: this week
