### PR TITLE
A quick hack to see the viability of table level conflict handling

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -16,7 +16,9 @@
 package com.palantir.atlasdb.transaction.impl;
 
 import java.nio.ByteBuffer;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -38,6 +40,7 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Functions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
@@ -132,7 +135,8 @@ public class SerializableTransaction extends SnapshotTransaction {
                                    MultiTableSweepQueueWriter sweepQueue,
                                    ExecutorService deleteExecutor,
                                    boolean validateLocksOnReads,
-                                   Supplier<TransactionConfig> transactionConfig) {
+                                   Supplier<TransactionConfig> transactionConfig,
+                                   TableTransactionConflictManager.RunningTransaction tableConflictsTransaction) {
         super(metricsManager,
               keyValueService,
               timelockService,
@@ -154,7 +158,8 @@ public class SerializableTransaction extends SnapshotTransaction {
               sweepQueue,
               deleteExecutor,
               validateLocksOnReads,
-              transactionConfig);
+              transactionConfig,
+              tableConflictsTransaction);
     }
 
     @Override
@@ -442,13 +447,49 @@ public class SerializableTransaction extends SnapshotTransaction {
         super.put(tableRef, values);
     }
 
+    // for now, ignores negative lookups because this method is for metrics and that doesn't rely on it
+    private Set<TableReference> someTablesReadExcludingWrites() {
+        Set<TableReference> tablesRead = new HashSet<>();
+        tablesRead.addAll(Maps.filterEntries(readsByTable,
+                entry -> !writesByTable.containsKey(entry.getKey())
+                        || !writesByTable.get(entry.getKey()).keySet().containsAll(entry.getValue().keySet()))
+                .keySet());
+        return tablesRead;
+    }
+
+    private static String tableConflictMetricName(String name) {
+        return MetricRegistry.name(SerializableTransaction.class, "tableConflictHandling", name);
+    }
+
     @Override
     protected void throwIfReadWriteConflictForSerializable(long commitTimestamp) {
-        Transaction ro = getReadOnlyTransaction(commitTimestamp);
-        verifyRanges(ro);
-        verifyColumnRanges(ro);
-        verifyCells(ro);
-        verifyRows(ro);
+        TableTransactionConflictManager.Status status =
+                tableConflictsTransaction.commit(
+                        commitTimestamp,
+                        writesByTable.keySet(),
+                        someTablesReadExcludingWrites());
+        if (status == TableTransactionConflictManager.Status.ERROR) {
+            metricsManager.getRegistry().meter(tableConflictMetricName("error")).mark();
+        }
+        try {
+            Transaction ro = getReadOnlyTransaction(commitTimestamp);
+            verifyRanges(ro);
+            verifyColumnRanges(ro);
+            verifyCells(ro);
+            verifyRows(ro);
+        } catch (TransactionSerializableConflictException e) {
+            if (status == TableTransactionConflictManager.Status.NO_READ_WRITE_CONFLICTS) {
+                metricsManager.getRegistry().meter(tableConflictMetricName("unnecessaryConflicts")).mark();
+            }
+            throw e;
+        }
+        if (status == TableTransactionConflictManager.Status.NO_READ_WRITE_CONFLICTS) {
+            metricsManager.getRegistry().meter(tableConflictMetricName("couldBeAvoided.txns")).mark();
+            metricsManager.getRegistry().meter(tableConflictMetricName("couldBeAvoided.cellLoads"))
+                    .mark(cellsRead.values().stream().mapToInt(Collection::size).asLongStream().sum());
+        } else if (status == TableTransactionConflictManager.Status.CANNOT_ADVISE) {
+            metricsManager.getRegistry().meter(tableConflictMetricName("couldNotAdvise")).mark();
+        }
     }
 
     private void verifyRows(Transaction ro) {
@@ -745,7 +786,8 @@ public class SerializableTransaction extends SnapshotTransaction {
                 MultiTableSweepQueueWriter.NO_OP,
                 deleteExecutor,
                 validateLocksOnReads,
-                transactionConfig) {
+                transactionConfig,
+                TableTransactionConflictManager.NoOpRunningTransaction.INSTANCE) {
             @Override
             protected Map<Long, Long> getCommitTimestamps(TableReference tableRef,
                                                           Iterable<Long> startTimestamps,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -499,7 +499,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 sweepQueueWriter,
                 deleteExecutor,
                 validateLocksOnReads,
-                transactionConfig);
+                transactionConfig,
+                tableTransactionConflictManager.startTransaction(startTimestampSupplier.get()));
     }
 
     @VisibleForTesting

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ShouldNotDeleteAndRollbackTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ShouldNotDeleteAndRollbackTransaction.java
@@ -100,7 +100,8 @@ public class ShouldNotDeleteAndRollbackTransaction extends SnapshotTransaction {
                 MultiTableSweepQueueWriter.NO_OP,
                 IGNORING_EXECUTOR,
                 true,
-                transactionConfig);
+                transactionConfig,
+                TableTransactionConflictManager.NoOpRunningTransaction.INSTANCE);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -219,6 +219,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     protected final TransactionOutcomeMetrics transactionOutcomeMetrics;
     protected final boolean validateLocksOnReads;
     protected final Supplier<TransactionConfig> transactionConfig;
+    protected final TableTransactionConflictManager.RunningTransaction tableConflictsTransaction;
 
     protected volatile boolean hasReads;
 
@@ -249,7 +250,8 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             MultiTableSweepQueueWriter sweepQueue,
             ExecutorService deleteExecutor,
             boolean validateLocksOnReads,
-            Supplier<TransactionConfig> transactionConfig) {
+            Supplier<TransactionConfig> transactionConfig,
+            TableTransactionConflictManager.RunningTransaction tableConflictsTransaction) {
         this.metricsManager = metricsManager;
         this.transactionTimerContext = getTimer("transactionMillis").time();
         this.keyValueService = keyValueService;
@@ -275,6 +277,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         this.transactionOutcomeMetrics = TransactionOutcomeMetrics.create(metricsManager);
         this.validateLocksOnReads = validateLocksOnReads;
         this.transactionConfig = transactionConfig;
+        this.tableConflictsTransaction = tableConflictsTransaction;
     }
 
     @Override
@@ -1306,6 +1309,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                 if (hasWrites()) {
                     throwIfPreCommitRequirementsNotMet(null, getStartTimestamp());
                 }
+                tableConflictsTransaction.abort();
                 transactionOutcomeMetrics.markAbort();
                 return;
             }
@@ -1383,6 +1387,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                 transactionOutcomeMetrics.markSuccessfulCommit();
             } else {
                 state.set(State.FAILED);
+                tableConflictsTransaction.abort();
                 transactionOutcomeMetrics.markFailedCommit();
             }
         }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -82,6 +82,7 @@ import com.palantir.timestamp.TimestampService;
     final MultiTableSweepQueueWriter sweepQueueWriter;
     final boolean validateLocksOnReads;
     final Supplier<TransactionConfig> transactionConfig;
+    final TableTransactionConflictManager tableTransactionConflictManager = new TableTransactionConflictManager();
 
     final List<Runnable> closingCallbacks;
     final AtomicBoolean isClosed;
@@ -241,7 +242,8 @@ import com.palantir.timestamp.TimestampService;
                 sweepQueueWriter,
                 deleteExecutor,
                 validateLocksOnReads,
-                transactionConfig);
+                transactionConfig,
+                TableTransactionConflictManager.NoOpRunningTransaction.INSTANCE); // this method is not used in prod
     }
     @Override
     public <T, C extends PreCommitCondition, E extends Exception> T runTaskWithConditionReadOnly(
@@ -279,7 +281,8 @@ import com.palantir.timestamp.TimestampService;
                 sweepQueueWriter,
                 deleteExecutor,
                 validateLocksOnReads,
-                transactionConfig);
+                transactionConfig,
+                TableTransactionConflictManager.NoOpRunningTransaction.INSTANCE); // read transactions cannot conflict
         try {
             return runTaskThrowOnConflict(txn -> task.execute(txn, condition),
                     new ReadTransaction(transaction, sweepStrategyManager));

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TableTransactionConflictManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TableTransactionConflictManager.java
@@ -184,6 +184,7 @@ public final class TableTransactionConflictManager {
         }
     }
 
+    @SuppressWarnings("GuardedBy") // Errorprone does not deal with lambdas properly
     private synchronized Status commitTransaction(
             long startTimestamp,
             long commitTimestamp,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TableTransactionConflictManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TableTransactionConflictManager.java
@@ -1,0 +1,260 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+
+import javax.annotation.concurrent.GuardedBy;
+
+import org.immutables.value.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Maps;
+import com.google.common.collect.SetMultimap;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+
+/**
+ * An advisory implementation of
+ * <a href="https://www.cse.iitb.ac.in/infolab/Data/Courses/CS632/2009/Papers/p492-fekete.pdf">
+ *     Making Snapshot Isolation Serializable</a>.
+ * Hypothesis - read write sets are non-conflicting enough at the level of a whole table that we can avoid
+ * significant numbers of conflicts by performing more elaborate conflict checking at this level.
+ *
+ * Idea here is to provide this as an advisory thing which can be run on all AtlasDB nodes in a high performance
+ * fashion in order to see whether making this kind of change part of the AtlasDB commit protocol can result
+ * in significant improvements.
+ *
+ * Example of hypothesis from internal use case:
+ * Imagine I have a data table, with values that are frequently overwritten. A cleanup task deletes the values
+ * if they have not been written in the last 30 days. This cleanup task will conflict with any values that are
+ * being frequently overwritten, but this does not affect serializability.
+ */
+public final class TableTransactionConflictManager {
+    private static final int OVERHEADS = 40;
+    private static final int MAX_MEMORY = 10_000_000;
+    private static final Logger log = LoggerFactory.getLogger(TableTransactionConflictManager.class);
+
+    @GuardedBy("this")
+    private final NavigableMap<Long, TransactionState> runningTransactions = new TreeMap<>();
+    @GuardedBy("this")
+    private final SetMultimap<TableReference, Long> lastUpdated = HashMultimap.create();
+    @GuardedBy("this")
+    private final SetMultimap<TableReference, Long> reads = HashMultimap.create();
+
+    enum Status {
+        NO_READ_WRITE_CONFLICTS, CANNOT_ADVISE, ERROR;
+    }
+
+    @Value.Immutable
+    interface TransactionState {
+        TransactionState NEW = ImmutableTransactionState.builder()
+                .inConflict(false)
+                .outConflict(false)
+                .build();
+
+        Optional<Long> commitTimestamp();
+        Set<TableReference> writeSet();
+        Set<TableReference> readSet();
+        boolean inConflict();
+        boolean outConflict();
+
+        TransactionState withCommitTimestamp(Optional<Long> commitTimestamp);
+        TransactionState withWriteSet(Iterable<? extends TableReference> writeSet);
+        TransactionState withReadSet(Iterable<? extends TableReference> readSet);
+        TransactionState withInConflict(boolean inConflict);
+        TransactionState withOutConflict(boolean outConflict);
+    }
+
+    private long bytesUsed() {
+        return runningTransactions.values().stream()
+                .mapToInt(txn -> OVERHEADS + 30 * (txn.readSet().size() + txn.writeSet().size()))
+                .asLongStream()
+                .sum();
+    }
+
+    private Optional<Long> getFirstRunningTransaction() {
+        return Maps.filterValues(runningTransactions, state -> !state.commitTimestamp().isPresent())
+                .keySet().stream().findFirst();
+    }
+
+    private void cleanUp() {
+        Optional<Long> maybeMinRunning = getFirstRunningTransaction();
+        if (!maybeMinRunning.isPresent() || bytesUsed() >= MAX_MEMORY) {
+            runningTransactions.clear();
+            lastUpdated.clear();
+            reads.clear();
+            return;
+        }
+        long minRunning = maybeMinRunning.get();
+        Iterator<Map.Entry<Long, TransactionState>> iterator = runningTransactions.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<Long, TransactionState> current = iterator.next();
+            Long transactionTimestamp = current.getKey();
+            if (minRunning < transactionTimestamp) {
+                return;
+            }
+            TransactionState state = current.getValue();
+            if (state.commitTimestamp().map(commitTs -> minRunning < commitTs).orElse(true)) {
+                return;
+            }
+            state.readSet().forEach(table -> reads.remove(table, transactionTimestamp));
+            state.writeSet().forEach(table -> lastUpdated.remove(table, transactionTimestamp));
+            // cleanup last updated
+            iterator.remove();
+        }
+    }
+
+    interface RunningTransaction {
+        Status commit(long commitTimestamp, Set<TableReference> tablesRead, Set<TableReference> tablesWritten);
+        void abort();
+        void abortIfNotComplete();
+    }
+
+    public enum NoOpRunningTransaction implements RunningTransaction {
+        INSTANCE;
+
+        @Override
+        public Status commit(long commitTimestamp, Set<TableReference> tablesRead,
+                Set<TableReference> tablesWritten) {
+            log.info("Did not expect commit from a no-op transaction");
+            return Status.CANNOT_ADVISE;
+        }
+
+        @Override
+        public void abort() {}
+
+        @Override
+        public void abortIfNotComplete() {}
+    }
+
+    public synchronized RunningTransaction startTransaction(long startTimestamp) {
+        runningTransactions.put(startTimestamp, TransactionState.NEW);
+        return new RunningTransaction() {
+            @Override
+            public Status commit(
+                    long commitTimestamp, Set<TableReference> tablesRead, Set<TableReference> tablesWritten) {
+                return commitTransaction(startTimestamp, commitTimestamp, tablesRead, tablesWritten);
+            }
+
+            @Override
+            public void abort() {
+                abortTransaction(startTimestamp);
+            }
+
+            @Override
+            public void abortIfNotComplete() {
+                abortTransactionIfNotComplete(startTimestamp);
+            }
+        };
+    }
+
+    private synchronized void abortTransaction(long startTimestamp) {
+        runningTransactions.remove(startTimestamp);
+        cleanUp();
+    }
+
+    private synchronized void abortTransactionIfNotComplete(long startTimestamp) {
+        TransactionState state = runningTransactions.get(startTimestamp);
+        if (state != null && !state.commitTimestamp().isPresent()) {
+            runningTransactions.remove(startTimestamp);
+        }
+    }
+
+    private synchronized Status commitTransaction(
+            long startTimestamp,
+            long commitTimestamp,
+            Set<TableReference> tablesRead,
+            Set<TableReference> tablesWritten) {
+        try {
+            if (!runningTransactions.containsKey(startTimestamp)) {
+                cleanUp();
+                return Status.ERROR;
+            }
+            for (TableReference write : tablesWritten) {
+                registerWriteConflicts(startTimestamp, write);
+            }
+
+            for (TableReference read : tablesRead) {
+                if (isConflictingRead(startTimestamp, read)) {
+                    runningTransactions.remove(startTimestamp);
+                    cleanUp();
+                    return Status.CANNOT_ADVISE;
+                }
+            }
+
+            TransactionState state = runningTransactions.get(startTimestamp);
+            if (state.inConflict() && state.outConflict()) {
+                runningTransactions.remove(startTimestamp);
+                cleanUp();
+                return Status.CANNOT_ADVISE;
+            }
+
+            runningTransactions.put(startTimestamp, state.withWriteSet(tablesWritten)
+                    .withReadSet(tablesRead)
+                    .withCommitTimestamp(Optional.of(commitTimestamp)));
+            tablesWritten.forEach(write -> lastUpdated.put(write, startTimestamp));
+            tablesRead.forEach(read -> reads.put(read, startTimestamp));
+            cleanUp();
+            return Status.NO_READ_WRITE_CONFLICTS;
+        } catch (RuntimeException e) {
+            log.warn("Error thrown while processing conflicts", e);
+            return Status.ERROR;
+        }
+    }
+
+    private boolean isConflictingRead(long startTimestamp, TableReference table) {
+        TransactionState ourState = runningTransactions.get(startTimestamp);
+        Set<Long> otherWriteStartTimestamps = lastUpdated.get(table);
+        for (Long otherStartTimestamp : otherWriteStartTimestamps) {
+            if (otherStartTimestamp == startTimestamp) {
+                continue;
+            }
+            TransactionState otherState = runningTransactions.get(otherStartTimestamp);
+            if (otherState.commitTimestamp().get() > startTimestamp && otherState.outConflict()) {
+                return true;
+            } else {
+                runningTransactions.put(otherStartTimestamp, otherState.withInConflict(true));
+                ourState = ourState.withOutConflict(true);
+                runningTransactions.put(startTimestamp, ourState);
+            }
+        }
+        return false;
+    }
+
+    private void registerWriteConflicts(long startTimestamp, TableReference table) {
+        Set<Long> readStartTimestamps = reads.get(table);
+        for (Long readStartTimestamp : readStartTimestamps) {
+            if (readStartTimestamp == startTimestamp) {
+                continue;
+            }
+            TransactionState readState = runningTransactions.get(readStartTimestamp);
+            if (readState.commitTimestamp().get() > startTimestamp && readState.inConflict()) {
+                continue;
+            } else {
+                runningTransactions.put(readStartTimestamp, readState.withOutConflict(true));
+                runningTransactions.compute(startTimestamp, (key, value) -> value.withInConflict(true));
+            }
+        }
+    }
+}

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -139,7 +139,8 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
                 MultiTableSweepQueueWriter.NO_OP,
                 MoreExecutors.newDirectExecutorService(),
                 true,
-                () -> TRANSACTION_CONFIG);
+                () -> TRANSACTION_CONFIG,
+                tableTransactionConflictManager.startTransaction(startTimestamp));
     }
 
     @Test

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -148,7 +148,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 sweepQueueWriter,
                 deleteExecutor,
                 validateLocksOnReads,
-                () -> TRANSACTION_CONFIG);
+                () -> TRANSACTION_CONFIG,
+                tableTransactionConflictManager.startTransaction(startTimestamp));
     }
 
     @Override

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTestSetup.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTestSetup.java
@@ -80,6 +80,8 @@ public abstract class TransactionTestSetup {
     protected final TimestampCache timestampCache = new DefaultTimestampCache(
             new MetricRegistry(),
             () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
+    protected final TableTransactionConflictManager tableTransactionConflictManager =
+            new TableTransactionConflictManager();
 
     protected TransactionTestSetup(KvsManager kvsManager, TransactionManagerManager tmManager) {
         this.kvsManager = kvsManager;

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -308,7 +308,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 MultiTableSweepQueueWriter.NO_OP,
                 MoreExecutors.newDirectExecutorService(),
                 true,
-                () -> transactionConfig);
+                () -> transactionConfig,
+                TableTransactionConflictManager.NoOpRunningTransaction.INSTANCE);
         try {
             snapshot.get(TABLE, ImmutableSet.of(cell));
             fail();
@@ -374,7 +375,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 MultiTableSweepQueueWriter.NO_OP,
                 MoreExecutors.newDirectExecutorService(),
                 true,
-                () -> transactionConfig);
+                () -> transactionConfig,
+                TableTransactionConflictManager.NoOpRunningTransaction.INSTANCE);
         snapshot.delete(TABLE, ImmutableSet.of(cell));
         snapshot.commit();
 
@@ -1302,7 +1304,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 MultiTableSweepQueueWriter.NO_OP,
                 MoreExecutors.newDirectExecutorService(),
                 validateLocksOnReads,
-                () -> transactionConfig);
+                () -> transactionConfig,
+                TableTransactionConflictManager.NoOpRunningTransaction.INSTANCE);
     }
 
     private void writeCells(TableReference table, ImmutableMap<Cell, byte[]> cellsToWrite) {


### PR DESCRIPTION
This should represent ~= 0 overhead for our current users, and won't use
a huge amount of memory for anyone. That said, the code is kind of
crappy so I will probably refactor it.

Anyway, it's a try-out to get metrics as to the viability of:

What if timelock were able to do some very simple conflict checking
(e.g. check conflicts on tables or other very high level concepts only
(e.g. topics)). Would we be able to significantly reduce the number of
serializable transactions that get rolled back?

Obviously it's incomplete - if enabling serializable txns were lower
overhead, people would do it more. But it covers a good chunk of ground.