### PR TITLE
PTExecutors provides reasonable operation names

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/TableMigrator.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/TableMigrator.java
@@ -113,7 +113,7 @@ public class TableMigrator {
             Callable<Void> task = createMigrationTask(
                     range,
                     rangeId);
-            Callable<Void> wrappedTask = PTExecutors.wrap(task);
+            Callable<Void> wrappedTask = PTExecutors.wrap("MigrationTask", task);
             Future<Void> future = executor.submit(wrappedTask);
             futures.add(future);
         }

--- a/changelog/@unreleased/pr-4231.v2.yml
+++ b/changelog/@unreleased/pr-4231.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: PTExecutors provides reasonable tracing operation names
+  links:
+  - https://github.com/palantir/atlasdb/pull/4231

--- a/commons-executors/src/main/java/com/palantir/common/concurrent/AbstractForwardingExecutorService.java
+++ b/commons-executors/src/main/java/com/palantir/common/concurrent/AbstractForwardingExecutorService.java
@@ -35,7 +35,7 @@ public abstract class AbstractForwardingExecutorService extends AbstractExecutor
 
     @Override
     public void execute(Runnable command) {
-        delegate().execute(PTExecutors.wrap(command));
+        delegate().execute(wrap(command));
     }
 
     @Override
@@ -56,5 +56,9 @@ public abstract class AbstractForwardingExecutorService extends AbstractExecutor
     @Override
     public List<Runnable> shutdownNow() {
         return delegate().shutdownNow();
+    }
+
+    protected Runnable wrap(Runnable runnable) {
+        return PTExecutors.wrap(runnable);
     }
 }

--- a/commons-executors/src/main/java/com/palantir/common/concurrent/AbstractForwardingScheduledExecutorService.java
+++ b/commons-executors/src/main/java/com/palantir/common/concurrent/AbstractForwardingScheduledExecutorService.java
@@ -54,30 +54,38 @@ public abstract class AbstractForwardingScheduledExecutorService extends Abstrac
 
     @Override
     public void execute(Runnable command) {
-        delegate().execute(PTExecutors.wrap(command));
+        delegate().execute(wrap(command));
     }
 
     @Override
     public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
-        return delegate().schedule(PTExecutors.wrap(command), delay, unit);
+        return delegate().schedule(wrap(command), delay, unit);
     }
 
     @Override
     public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
-        return delegate().schedule(PTExecutors.wrap(callable), delay, unit);
+        return delegate().schedule(wrap(callable), delay, unit);
     }
 
     @Override
     public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period,
             TimeUnit unit) {
-        return delegate().scheduleAtFixedRate(PTExecutors.wrap(command), initialDelay, period,
+        return delegate().scheduleAtFixedRate(wrap(command), initialDelay, period,
                 unit);
     }
 
     @Override
     public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay,
             long delay, TimeUnit unit) {
-        return delegate().scheduleWithFixedDelay(PTExecutors.wrap(command), initialDelay, delay,
+        return delegate().scheduleWithFixedDelay(wrap(command), initialDelay, delay,
                 unit);
+    }
+
+    protected Runnable wrap(Runnable runnable) {
+        return PTExecutors.wrap(runnable);
+    }
+
+    protected <T> Callable<T> wrap(Callable<T> callable) {
+        return PTExecutors.wrap(callable);
     }
 }

--- a/commons-executors/src/main/java/com/palantir/common/concurrent/NamedThreadFactory.java
+++ b/commons-executors/src/main/java/com/palantir/common/concurrent/NamedThreadFactory.java
@@ -63,4 +63,8 @@ public class NamedThreadFactory implements ThreadFactory {
         thread.setDaemon(isDaemon);
         return thread;
     }
+
+    String getPrefix() {
+        return prefix;
+    }
 }

--- a/commons-executors/src/test/java/com/palantir/common/concurrent/PTExecutorsTest.java
+++ b/commons-executors/src/test/java/com/palantir/common/concurrent/PTExecutorsTest.java
@@ -1,0 +1,54 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.common.concurrent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+import org.junit.Test;
+
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName") // Name matches the class we're testing
+public class PTExecutorsTest {
+
+    @Test
+    public void testExecutorName_namedThreadFactory() {
+        ThreadFactory factory = new NamedThreadFactory("my-prefix");
+        assertThat(PTExecutors.getExecutorName(factory)).isEqualTo("my-prefix");
+    }
+
+    @Test
+    public void testExecutorName_customThreadFactory() {
+        ThreadFactory factory = runnable -> {
+            Thread thread = Executors.defaultThreadFactory().newThread(runnable);
+            thread.setName("foo-3");
+            return thread;
+        };
+        assertThat(PTExecutors.getExecutorName(factory)).isEqualTo("foo");
+    }
+
+    @Test
+    public void testExecutorName_customThreadFactory_fallback() {
+        ThreadFactory factory = runnable -> {
+            Thread thread = Executors.defaultThreadFactory().newThread(runnable);
+            thread.setName("1");
+            return thread;
+        };
+        assertThat(PTExecutors.getExecutorName(factory)).isEqualTo("PTExecutor");
+    }
+}

--- a/gradle/shared.gradle
+++ b/gradle/shared.gradle
@@ -39,6 +39,7 @@ dependencies {
     compile group: 'com.google.code.findbugs', name: 'findbugs-annotations'
     checkstyle group: 'com.puppycrawl.tools', name: 'checkstyle', version: libVersions.checkstyle
     testCompile group: 'junit', name: 'junit'
+    testCompile group: 'org.assertj', name: 'assertj-core'
 }
 
 apply from: rootProject.file('gradle/javadoc.gradle'), to: javadoc


### PR DESCRIPTION
Previously every PTExecutor wrapped executor created tracing
spans with name `DeferredTracer(unnamed operation)`.
Now the executor name is used based on the ThreadFactory.

**Goals (and why)**:
Tracing spans with name `DeferredTracer(unnamed operation)` don't tell me a lot, resulting in more noise than signal.
