### PR TITLE
Lock refresh

### DIFF
--- a/changelog/@unreleased/pr-4232.v2.yml
+++ b/changelog/@unreleased/pr-4232.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Improve logging when lock refreshing fails.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4232

--- a/lock-api/src/main/java/com/palantir/lock/client/LockRefresher.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockRefresher.java
@@ -68,7 +68,8 @@ public class LockRefresher implements AutoCloseable {
             Set<LockToken> refreshFailures = Sets.difference(toRefresh, successfullyRefreshedTokens);
             tokensToRefresh.removeAll(refreshFailures);
             if (!refreshFailures.isEmpty()) {
-                log.info("Failed to refresh {} lock tokens, most likely because they were lost on the server."
+                log.info("Successfully refreshed {}, but failed to refresh {} lock tokens, "
+                                + "most likely because they were lost on the server."
                                 + " The first (up to) 20 of these were {}.",
                         SafeArg.of("successfullyRefreshed", successfullyRefreshedTokens.size()),
                         SafeArg.of("numLockTokens", refreshFailures.size()),

--- a/lock-api/src/main/java/com/palantir/lock/client/LockRefresher.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockRefresher.java
@@ -70,8 +70,10 @@ public class LockRefresher implements AutoCloseable {
             if (!refreshFailures.isEmpty()) {
                 log.info("Failed to refresh {} lock tokens, most likely because they were lost on the server."
                                 + " The first (up to) 20 of these were {}.",
+                        SafeArg.of("successfullyRefreshed", successfullyRefreshedTokens.size()),
                         SafeArg.of("numLockTokens", refreshFailures.size()),
-                        SafeArg.of("firstFailures", Iterables.limit(refreshFailures, 20)));
+                        SafeArg.of("firstFailures",
+                                Iterables.transform(Iterables.limit(refreshFailures, 20), LockToken::getRequestId)));
             }
         } catch (Throwable error) {
             log.warn("Error while refreshing locks. Trying again on next iteration", error);


### PR DESCRIPTION
**Goals (and why)**:

Seeing firstFailures logged as:

```
firstFailures
"[com.palantir.lock.client.LockTokenShare@7c45d29a]"
```

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
