### PR TITLE
Tagged Metrics Event Invocation Handler Memory Optimisations

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/AtlasDbMetrics.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/AtlasDbMetrics.java
@@ -17,7 +17,6 @@ package com.palantir.atlasdb.util;
 
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -25,7 +24,6 @@ import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.benmanes.caffeine.cache.Cache;
-import com.palantir.tritium.event.InvocationContext;
 import com.palantir.tritium.event.log.LoggingInvocationEventHandler;
 import com.palantir.tritium.event.log.LoggingLevel;
 import com.palantir.tritium.metrics.caffeine.CaffeineCacheStats;
@@ -58,9 +56,9 @@ public final class AtlasDbMetrics {
             Class<T> serviceInterface,
             U service,
             String name,
-            Function<InvocationContext, Map<String, String>> tagFunction) {
+            Map<String, String> tags) {
         return Instrumentation.builder(serviceInterface, service)
-                .withHandler(new TaggedMetricsInvocationEventHandler(taggedMetrics, name, tagFunction))
+                .withHandler(new TaggedMetricsInvocationEventHandler(taggedMetrics, name, tags))
                 .withLogging(
                         LoggerFactory.getLogger("performance." + name),
                         LoggingLevel.TRACE,

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosComponents.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosComponents.java
@@ -88,7 +88,7 @@ public class PaxosComponents {
                 clazz,
                 instance,
                 name,
-                unused -> tags);
+                tags);
     }
 
     @Value.Immutable


### PR DESCRIPTION
**Goals (and why)**:
- See #4219, specifically @carterkozak's comment there

**Implementation Description (bullets)**:
- Have a loading cache mapping Methods to Timers, rather than reconstructing the MetricName object every time.
- Extract a single global failure meter.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Existing tests not breaking should suffice.

**Concerns (what feedback would you like?)**:
- There is an API break, though all functions passed in never actually used the context.

**Where should we start reviewing?**: TaggedMetricsEventInvocationHandler.java

**Priority (whenever / two weeks / yesterday)**: this week
