### PR TITLE
Use ThreadLocalRandom correctly.

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionRetryStrategy.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionRetryStrategy.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.function.IntPredicate;
+import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,7 +46,7 @@ import com.palantir.logsafe.SafeArg;
 public final class TransactionRetryStrategy {
     public enum Strategies {
         LEGACY(createLegacy(BlockStrategies.threadSleepStrategy())),
-        EXPONENTIAL(createExponential(BlockStrategies.threadSleepStrategy(), ThreadLocalRandom.current()));
+        EXPONENTIAL(createExponential(BlockStrategies.threadSleepStrategy(), ThreadLocalRandom::current));
 
         private final TransactionRetryStrategy strategy;
 
@@ -165,9 +166,9 @@ public final class TransactionRetryStrategy {
     }
 
     @VisibleForTesting
-    static TransactionRetryStrategy createExponential(BlockStrategy blockStrategy, ThreadLocalRandom random) {
+    static TransactionRetryStrategy createExponential(BlockStrategy blockStrategy, Supplier<ThreadLocalRandom> random) {
         return new TransactionRetryStrategy(
-                randomize(random, WaitStrategies.exponentialWait(100, 1, TimeUnit.MINUTES)),
+                randomize(random.get(), WaitStrategies.exponentialWait(100, 1, TimeUnit.MINUTES)),
                 blockStrategy);
     }
 }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/transaction/impl/TransactionRetryStrategyTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/transaction/impl/TransactionRetryStrategyTest.java
@@ -66,7 +66,7 @@ public class TransactionRetryStrategyTest {
         when(random.nextLong(anyLong())).thenAnswer(inv -> (long) inv.getArgument(0) - 1);
         mockRetries(1);
         legacy = TransactionRetryStrategy.createLegacy(blockStrategy);
-        exponential = TransactionRetryStrategy.createExponential(blockStrategy, random);
+        exponential = TransactionRetryStrategy.createExponential(blockStrategy, () -> random);
     }
 
     private String runExponential() throws Exception {


### PR DESCRIPTION
**Goals (and why)**:

``ThreadLocalRandom`` is clever and weird. If you inspect the source of #current, you can see that it does something magical:

```
if (UNSAFE.getInt(Thread.currentThread(), PROBE) == 0)
            localInit();
        return instance;
```

This basically optionally initializes the seed for *current* thread by (!sic) looking up an UNSAFE field on the Thread instance defined thus:

```
    /** Probe hash value; nonzero if threadLocalRandomSeed initialized */
    @sun.misc.Contended("tlr")
    int threadLocalRandomProbe;
```

And then it returns a global instance of ThreadLocalRandom. So by storing ThreadLocalRandom in a variable and passing it to somewhere (instead of calling ThreadLocalRandom#current every time), one can unknowingly skip seed initialization for whatever thread is actually trying to figure out their sleep.

For reference here's #nextSeed:

```
final long nextSeed() {
        Thread t; long r; // read and update per-thread seed
        UNSAFE.putLong(t = Thread.currentThread(), SEED,
                       r = UNSAFE.getLong(t, SEED) + GAMMA);
        return r;
    }
```

So it operates on the thread local state directly, and does not check for initialization.

Please check if I missed something, but I think this is basically a rather footgunny API. Granted it's not really that important here, but it's nice to be correct.

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
