### PR TITLE
[Timelock Partioning] Part 28: Move timestamp paxos to runtime config.

### DIFF
--- a/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosInstallConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosInstallConfiguration.java
@@ -44,12 +44,6 @@ public interface PaxosInstallConfiguration {
     @JsonProperty("is-new-service")
     boolean isNewService();
 
-    @Value.Default
-    @JsonProperty("client-paxos")
-    default ClientPaxosConfig clientPaxos() {
-        return ClientPaxosConfig.defaultConfig();
-    }
-
     @Value.Check
     default void check() {
         if (isNewService() && dataDirectory().isDirectory()) {
@@ -66,22 +60,6 @@ public interface PaxosInstallConfiguration {
                     + "made a mistake by this point. This is a non-trivial operation and risks service corruption, "
                     + "so contact support for assistance. Otherwise, if this is a new timelock service, please "
                     + "configure paxos.is-new-service to true for the first startup only of each node.");
-        }
-    }
-
-    @Value.Immutable
-    @JsonDeserialize(as = ImmutableClientPaxosConfig.class)
-    @JsonSerialize(as = ImmutableClientPaxosConfig.class)
-    interface ClientPaxosConfig {
-
-        @Value.Default
-        @JsonProperty("use-batch-paxos")
-        default boolean useBatchPaxos() {
-            return false;
-        }
-
-        static ClientPaxosConfig defaultConfig() {
-            return ImmutableClientPaxosConfig.builder().build();
         }
     }
 

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosRuntimeConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosRuntimeConfiguration.java
@@ -50,6 +50,28 @@ public interface PaxosRuntimeConfiguration {
         return true;
     }
 
+    @Value.Default
+    @JsonProperty("timestamp-paxos")
+    default TimestampPaxosConfig timestampPaxos() {
+        return TimestampPaxosConfig.defaultConfig();
+    }
+
+    @Value.Immutable
+    @JsonDeserialize(as = ImmutableTimestampPaxosConfig.class)
+    @JsonSerialize(as = ImmutableTimestampPaxosConfig.class)
+    interface TimestampPaxosConfig {
+
+        @Value.Default
+        @JsonProperty("use-batch-paxos")
+        default boolean useBatchPaxos() {
+            return false;
+        }
+
+        static TimestampPaxosConfig defaultConfig() {
+            return ImmutableTimestampPaxosConfig.builder().build();
+        }
+    }
+
     @Value.Check
     default void check() {
         Preconditions.checkArgument(pingRateMs() > 0,

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -77,6 +77,7 @@ public class TimeLockAgent {
                 metricsManager,
                 install.paxos().dataDirectory().toPath(),
                 install,
+                Suppliers.compose(TimeLockRuntimeConfiguration::paxos, runtime::get),
                 executor);
 
         TimeLockAgent agent = new TimeLockAgent(

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStore.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStore.java
@@ -268,7 +268,7 @@ public class PaxosTimestampBoundStore implements TimestampBoundStore {
      */
     private void checkAgreedBoundIsOurs(long limit, long newSeq, PaxosValue value)
             throws NotCurrentLeaderException {
-        if (!value.getLeaderUUID().equals(proposer.getUuid())) {
+        if (!proposer.getUuid().equals(value.getLeaderUUID())) {
             String errorMsg = String.format(
                     "Timestamp limit changed from under us for sequence '%s' (proposer with UUID '%s' changed"
                             + " it, our UUID is '%s'). This suggests that we have lost leadership, and another timelock"

--- a/timelock-server/src/testCommon/resources/paxosMultiServer0.yml
+++ b/timelock-server/src/testCommon/resources/paxosMultiServer0.yml
@@ -20,6 +20,8 @@ install:
 runtime:
   paxos:
     leader-ping-response-wait-in-ms: 1000
+    timestamp-paxos:
+      use-batch-paxos: false
 
 logging:
   appenders:

--- a/timelock-server/src/testCommon/resources/paxosMultiServer1.yml
+++ b/timelock-server/src/testCommon/resources/paxosMultiServer1.yml
@@ -20,6 +20,8 @@ install:
 runtime:
   paxos:
     leader-ping-response-wait-in-ms: 1000
+    timestamp-paxos:
+      use-batch-paxos: false
 
 logging:
   appenders:

--- a/timelock-server/src/testCommon/resources/paxosMultiServer2.yml
+++ b/timelock-server/src/testCommon/resources/paxosMultiServer2.yml
@@ -20,6 +20,8 @@ install:
 runtime:
   paxos:
     leader-ping-response-wait-in-ms: 1000
+    timestamp-paxos:
+      use-batch-paxos: false
 
 logging:
   appenders:

--- a/timelock-server/src/testCommon/resources/paxosMultiServerBatch0.yml
+++ b/timelock-server/src/testCommon/resources/paxosMultiServerBatch0.yml
@@ -11,10 +11,10 @@ install:
         keyStorePassword: "keystore"
         keyStoreType: "JKS"
       uris:
-      - "localhost:9080"
-      - "localhost:9081"
-      - "localhost:9082"
-    local-server: "localhost:9080"
+      - "localhost:9083"
+      - "localhost:9084"
+      - "localhost:9085"
+    local-server: "localhost:9083"
   timestampBoundPersistence:
 
 runtime:
@@ -36,7 +36,7 @@ server:
 
   applicationConnectors:
   - type: h2
-    port: 9080
+    port: 9083
     keyStorePath: var/security/keyStore.jks
     keyStorePassword: keystore
     trustStorePath: var/security/trustStore.jks
@@ -59,4 +59,4 @@ server:
       - TLS_EMPTY_RENEGOTIATION_INFO_SCSV
   adminConnectors:
     - type: http
-      port: 7090
+      port: 7093

--- a/timelock-server/src/testCommon/resources/paxosMultiServerBatch0.yml
+++ b/timelock-server/src/testCommon/resources/paxosMultiServerBatch0.yml
@@ -2,8 +2,6 @@ install:
   paxos:
     data-directory: "<TEMP_DATA_DIR>"
     is-new-service: false
-    client-paxos:
-      use-batch-paxos: true
   cluster:
     cluster:
       security:
@@ -22,6 +20,8 @@ install:
 runtime:
   paxos:
     leader-ping-response-wait-in-ms: 1000
+    timestamp-paxos:
+      use-batch-paxos: true
 
 logging:
   appenders:

--- a/timelock-server/src/testCommon/resources/paxosMultiServerBatch1.yml
+++ b/timelock-server/src/testCommon/resources/paxosMultiServerBatch1.yml
@@ -2,8 +2,6 @@ install:
   paxos:
     data-directory: "<TEMP_DATA_DIR>"
     is-new-service: false
-    client-paxos:
-      use-batch-paxos: true
   cluster:
     cluster:
       security:
@@ -22,6 +20,8 @@ install:
 runtime:
   paxos:
     leader-ping-response-wait-in-ms: 1000
+    timestamp-paxos:
+      use-batch-paxos: true
 
 logging:
   appenders:

--- a/timelock-server/src/testCommon/resources/paxosMultiServerBatch1.yml
+++ b/timelock-server/src/testCommon/resources/paxosMultiServerBatch1.yml
@@ -11,10 +11,10 @@ install:
         keyStorePassword: "keystore"
         keyStoreType: "JKS"
       uris:
-      - "localhost:9080"
-      - "localhost:9081"
-      - "localhost:9082"
-    local-server: "localhost:9081"
+      - "localhost:9083"
+      - "localhost:9084"
+      - "localhost:9085"
+    local-server: "localhost:9084"
   timestampBoundPersistence:
 
 runtime:
@@ -36,7 +36,7 @@ server:
 
   applicationConnectors:
   - type: h2
-    port: 9081
+    port: 9084
     keyStorePath: var/security/keyStore.jks
     keyStorePassword: keystore
     trustStorePath: var/security/trustStore.jks
@@ -59,4 +59,4 @@ server:
       - TLS_EMPTY_RENEGOTIATION_INFO_SCSV
   adminConnectors:
     - type: http
-      port: 7091
+      port: 7094

--- a/timelock-server/src/testCommon/resources/paxosMultiServerBatch2.yml
+++ b/timelock-server/src/testCommon/resources/paxosMultiServerBatch2.yml
@@ -2,8 +2,6 @@ install:
   paxos:
     data-directory: "<TEMP_DATA_DIR>"
     is-new-service: false
-    client-paxos:
-      use-batch-paxos: true
   cluster:
     cluster:
       security:
@@ -22,6 +20,8 @@ install:
 runtime:
   paxos:
     leader-ping-response-wait-in-ms: 1000
+    timestamp-paxos:
+      use-batch-paxos: true
 
 logging:
   appenders:

--- a/timelock-server/src/testCommon/resources/paxosMultiServerBatch2.yml
+++ b/timelock-server/src/testCommon/resources/paxosMultiServerBatch2.yml
@@ -11,10 +11,10 @@ install:
         keyStorePassword: "keystore"
         keyStoreType: "JKS"
       uris:
-      - "localhost:9080"
-      - "localhost:9081"
-      - "localhost:9082"
-    local-server: "localhost:9082"
+      - "localhost:9083"
+      - "localhost:9084"
+      - "localhost:9085"
+    local-server: "localhost:9085"
   timestampBoundPersistence:
 
 runtime:
@@ -36,7 +36,7 @@ server:
 
   applicationConnectors:
   - type: h2
-    port: 9082
+    port: 9085
     keyStorePath: var/security/keyStore.jks
     keyStorePassword: keystore
     trustStorePath: var/security/trustStore.jks
@@ -59,4 +59,4 @@ server:
       - TLS_EMPTY_RENEGOTIATION_INFO_SCSV
   adminConnectors:
     - type: http
-      port: 7082
+      port: 7095


### PR DESCRIPTION
_**Note**: Taking a small detour to wire in the batch endpoints but for timestamp paxos (separate from leader election). Anything ironed out here will effectively solve the same issue for when the batch endpoints are integrated for leader election._

**Goals (and why)**:
Being able to turn this off via config instead of having to restart an entire cluster seems to be a better fit here.

**Implementation Description (bullets)**:
Abuse usage of `DynamicDecoratingProxy`, seeing as the batch is not a decoration of the single, just a means of switching between the two implementations.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Existing test suite that tests both batch and non batch should cover this.

**Where should we start reviewing?**:
* `ClientPaxosResourceFactory`

**Priority (whenever / two weeks / yesterday)**:
Relatively soon please.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
