### PR TITLE
Use our own jackson decoder/encoder

### DIFF
--- a/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/AtlasDbFeignTargetFactory.java
+++ b/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/AtlasDbFeignTargetFactory.java
@@ -41,8 +41,6 @@ import feign.Retryer;
 import feign.codec.Decoder;
 import feign.codec.Encoder;
 import feign.codec.ErrorDecoder;
-import feign.jackson.JacksonDecoder;
-import feign.jackson.JacksonEncoder;
 import feign.jaxrs.JAXRSContract;
 
 public final class AtlasDbFeignTargetFactory implements TargetFactory {
@@ -69,9 +67,9 @@ public final class AtlasDbFeignTargetFactory implements TargetFactory {
             .registerModule(new JavaTimeModule())
             .registerModule(new GuavaModule());
     private static final Contract contract = new JAXRSContract();
-    private static final Encoder encoder = new JacksonEncoder(mapper);
+    private static final Encoder encoder = new AtlasDbJacksonEncoder(mapper);
     private static final Decoder decoder = new TextDelegateDecoder(
-            new OptionalAwareDecoder(new JacksonDecoder(mapper)));
+            new OptionalAwareDecoder(new AtlasDbJacksonDecoder(mapper)));
     private static final ErrorDecoder errorDecoder = new AtlasDbErrorDecoder();
 
     private final int connectTimeout;

--- a/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/AtlasDbJacksonDecoder.java
+++ b/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/AtlasDbJacksonDecoder.java
@@ -44,12 +44,12 @@ class AtlasDbJacksonDecoder implements Decoder {
 
     @Override
     public Object decode(Response response, Type type) throws IOException {
-      if (response.status() == 404) {
-        return Util.emptyValueOf(type);
-      }
-      if (response.body() == null) {
-        return null;
-      }
+        if (response.status() == 404) {
+            return Util.emptyValueOf(type);
+        }
+        if (response.body() == null) {
+            return null;
+        }
         InputStream stream = response.body().asInputStream();
         if (!stream.markSupported()) {
             stream = new BufferedInputStream(stream, 1);

--- a/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/AtlasDbJacksonDecoder.java
+++ b/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/AtlasDbJacksonDecoder.java
@@ -1,0 +1,72 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Changes made:
+ * - Rename to AtlasDbJacksonDecoder
+ * - Checkstyle
+ * - Use inputstreams and not stream readers - avoids creating a 16kB buffer on every response.
+ * - Remove unused constructors
+ */
+package com.palantir.atlasdb.http;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Type;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.RuntimeJsonMappingException;
+
+import feign.Response;
+import feign.Util;
+import feign.codec.Decoder;
+
+class AtlasDbJacksonDecoder implements Decoder {
+    private final ObjectMapper mapper;
+
+    AtlasDbJacksonDecoder(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    @Override
+    public Object decode(Response response, Type type) throws IOException {
+      if (response.status() == 404) {
+        return Util.emptyValueOf(type);
+      }
+      if (response.body() == null) {
+        return null;
+      }
+        InputStream stream = response.body().asInputStream();
+        if (!stream.markSupported()) {
+            stream = new BufferedInputStream(stream, 1);
+        }
+        try {
+            // Read the first byte to see if we have any data
+            stream.mark(1);
+            if (stream.read() == -1) {
+                return null; // Eagerly returning null avoids "No content to map due to end-of-input"
+            }
+            stream.reset();
+            return mapper.readValue(stream, mapper.constructType(type));
+        } catch (RuntimeJsonMappingException e) {
+            if (e.getCause() != null && e.getCause() instanceof IOException) {
+                throw IOException.class.cast(e.getCause());
+            }
+            throw e;
+        }
+    }
+}

--- a/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/AtlasDbJacksonEncoder.java
+++ b/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/AtlasDbJacksonEncoder.java
@@ -1,0 +1,52 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Changes made:
+ * - Make checkstyle pass
+ * - Use byte array jackson methods not char array
+ * - Remove some constructors
+ */
+package com.palantir.atlasdb.http;
+
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import feign.RequestTemplate;
+import feign.codec.EncodeException;
+import feign.codec.Encoder;
+
+class AtlasDbJacksonEncoder implements Encoder {
+    private final ObjectMapper mapper;
+
+    AtlasDbJacksonEncoder(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    @Override
+    public void encode(Object object, Type bodyType, RequestTemplate template) {
+        try {
+            JavaType javaType = mapper.getTypeFactory().constructType(bodyType);
+            template.body(mapper.writerFor(javaType).writeValueAsBytes(object), StandardCharsets.UTF_8);
+        } catch (JsonProcessingException e) {
+            throw new EncodeException(e.getMessage(), e);
+        }
+    }
+}

--- a/changelog/@unreleased/http-allocations.v2.yml
+++ b/changelog/@unreleased/http-allocations.v2.yml
@@ -1,0 +1,4 @@
+type: improvement
+improvement:
+  description: |
+    AtlasDB makes fewer allocations when making HTTP calls


### PR DESCRIPTION
The feign ones use Java BufferedReaders/String classes - in practice
this causes very many unnecessary allocations, which Jackson would pool
internally (it's about 90% of the allocations of a cassandra request
thread, which for a single connection might represent 1.2GB in 5 minutes)