### PR TITLE
Single C*KVS for CassandraKeyValueServiceTransactionIntegrationTest

### DIFF
--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTestSetup.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTestSetup.java
@@ -17,7 +17,6 @@ package com.palantir.atlasdb.transaction.impl;
 
 import java.util.Map;
 
-import org.junit.After;
 import org.junit.Before;
 
 import com.codahale.metrics.MetricRegistry;

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTestSetup.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTestSetup.java
@@ -17,6 +17,7 @@ package com.palantir.atlasdb.transaction.impl;
 
 import java.util.Map;
 
+import org.junit.After;
 import org.junit.Before;
 
 import com.codahale.metrics.MetricRegistry;


### PR DESCRIPTION
**Goals (and why)**:
Reduce resource requirements of a test by sharing a C*KVS between multiple different test method invocations. While developing async entry points noticed that several tests fail consistently at the same point with a socket exception. It turned out that C*KVS is constructed for each test method invocation without memoizing the instance as was intended (thanks @felixdesouza for helping out). 

**Implementation Description (bullets)**:
- static KVS supplier
- using C*KVS created for testing

**Testing (What was existing testing like?  What have you done to improve it?)**:
- `CassandraKeyValueServiceTransactionIntegrationTest` on my machine took around 1.5 min, now around 20 seconds.

**Concerns (what feedback would you like?)**:
- would it make sense to drop table before each test, based on the `setUp` it could be concluded that that each test should have a completely empty database at start.
- should there be a changelog in this case?

**Where should we start reviewing?**:
`CassandraKeyValueServiceTransactionIntegrationTest`

**Priority (whenever / two weeks / yesterday)**:
whenever
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
