### PR TITLE
Avoid extending Assert

### DIFF
--- a/atlasdb-commons/src/test/java/com/palantir/common/base/ThrowablesTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/common/base/ThrowablesTest.java
@@ -15,14 +15,18 @@
  */
 package com.palantir.common.base;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.io.IOException;
 import java.sql.SQLException;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ThrowablesTest extends Assert {
+public class ThrowablesTest {
     @Before
     public void setUp() throws Exception {
         NoUsefulConstructorException.noUsefulConstructorCalled = false;

--- a/commons-db/src/test/java/com/palantir/nexus/db/ThreadConfinedProxyTest.java
+++ b/commons-db/src/test/java/com/palantir/nexus/db/ThreadConfinedProxyTest.java
@@ -15,6 +15,10 @@
  */
 package com.palantir.nexus.db;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -25,7 +29,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,7 +37,7 @@ import com.google.common.collect.Iterables;
 import com.palantir.common.proxy.TimingProxy;
 import com.palantir.util.timer.LoggingOperationTimer;
 
-public class ThreadConfinedProxyTest extends Assert {
+public class ThreadConfinedProxyTest {
 
     Logger log = LoggerFactory.getLogger(ThreadConfinedProxyTest.class);
 

--- a/commons-executors/src/test/java/com/palantir/common/concurrent/ExecutorInheritableThreadLocalTest.java
+++ b/commons-executors/src/test/java/com/palantir/common/concurrent/ExecutorInheritableThreadLocalTest.java
@@ -15,6 +15,8 @@
  */
 package com.palantir.common.concurrent;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -34,7 +36,7 @@ import com.google.common.util.concurrent.Callables;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 
-public class ExecutorInheritableThreadLocalTest extends Assert {
+public class ExecutorInheritableThreadLocalTest {
     private static final String orig = "Yo";
     private static List<Integer> outputList = Lists.newLinkedList();
     private final ExecutorService exec = PTExecutors.newCachedThreadPool();


### PR DESCRIPTION
**Goals (and why)**:
https://errorprone.info/bugpattern/ExtendingJUnitAssert

**Implementation Description (bullets)**:

> When only using JUnit Assert's static methods, you should import statically instead of extending.