### PR TITLE
Couple more improvements to allocations

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/util/MetricsManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/util/MetricsManager.java
@@ -131,7 +131,7 @@ public class MetricsManager {
     }
 
     public Histogram registerOrGetHistogram(Class clazz, String metricName) {
-        return registerOrGetHistogram(MetricRegistry.name(clazz, metricName));
+        return registerOrGetHistogram(metricNameCache.get(clazz, metricName, ImmutableMap.of()).safeName());
     }
 
     private Histogram registerOrGetHistogram(String fullyQualifiedHistogramName) {
@@ -141,7 +141,7 @@ public class MetricsManager {
     }
 
     public Timer registerOrGetTimer(Class clazz, String metricName) {
-        return registerOrGetTimer(MetricRegistry.name(clazz, metricName));
+        return registerOrGetTimer(metricNameCache.get(clazz, metricName, ImmutableMap.of()).safeName());
     }
 
     private Timer registerOrGetTimer(String fullyQualifiedHistogramName) {

--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -10,6 +10,7 @@ configurations {
 
 dependencies {
   compile group: 'com.palantir.safe-logging', name: 'safe-logging'
+  implementation 'org.conscrypt:conscrypt-openjdk-uber'
 
   explicitShadow (group: 'de.jflex', name: 'jflex', version: '1.6.0') {
     exclude(group: 'org.apache.ant', module: 'ant')

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -304,6 +304,11 @@ public interface CassandraKeyValueServiceConfig extends KeyValueServiceConfig {
         return ssl().orElseGet(sslConfiguration()::isPresent);
     }
 
+    @Value.Default
+    default boolean useConscrypt() {
+        return false;
+    }
+
     @Value.Check
     default void check() {
         servers().visit((thriftServers, cqlServers) -> {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -90,9 +90,9 @@ public final class CassandraVerifier {
     }
 
     private static void createSimpleRfTestKeyspaceIfNotExists(CassandraClient client) throws TException {
-        if (client.describe_keyspaces().stream()
-                .map(KsDef::getName)
-                .noneMatch(keyspace -> Objects.equals(keyspace, CassandraConstants.SIMPLE_RF_TEST_KEYSPACE))) {
+        try {
+            client.describe_keyspace(CassandraConstants.SIMPLE_RF_TEST_KEYSPACE);
+        } catch (NotFoundException e) {
             client.system_add_keyspace(SIMPLE_RF_TEST_KS_DEF);
         }
     }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/AtlasDbMetrics.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/AtlasDbMetrics.java
@@ -45,7 +45,7 @@ public final class AtlasDbMetrics {
     public static <T, U extends T> T instrument(
             MetricRegistry metricRegistry, Class<T> serviceInterface, U service, String name) {
         return Instrumentation.builder(serviceInterface, service)
-                .withHandler(new SlidingWindowMetricsInvocationHandler(metricRegistry, name, serviceInterface))
+                .withHandler(new SlidingWindowMetricsInvocationHandler(metricRegistry, name))
                 .withLogging(
                         LoggerFactory.getLogger("performance." + name),
                         LoggingLevel.TRACE,

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/SlidingWindowMetricsInvocationHandler.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/SlidingWindowMetricsInvocationHandler.java
@@ -17,10 +17,9 @@
 package com.palantir.atlasdb.util;
 
 import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -31,7 +30,6 @@ import org.slf4j.LoggerFactory;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.SlidingTimeWindowArrayReservoir;
 import com.codahale.metrics.Timer;
-import com.google.common.collect.ImmutableMap;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.tritium.event.AbstractInvocationEventHandler;
@@ -46,16 +44,13 @@ public final class SlidingWindowMetricsInvocationHandler extends AbstractInvocat
     private static final Logger logger = LoggerFactory.getLogger(SlidingWindowMetricsInvocationHandler.class);
 
     private final MetricRegistry metricRegistry;
-    private final Map<Method, Timer> timers;
+    private final ConcurrentMap<Method, Timer> timers = new ConcurrentHashMap<>();
     private final String serviceName;
 
-    public SlidingWindowMetricsInvocationHandler(
-            MetricRegistry metricRegistry, String serviceName, Class<?> clazz) {
+    public SlidingWindowMetricsInvocationHandler(MetricRegistry metricRegistry, String serviceName) {
         super(InstrumentationUtils.getEnabledSupplier(serviceName));
         this.metricRegistry = Preconditions.checkNotNull(metricRegistry, "metricRegistry");
         this.serviceName = Preconditions.checkNotNull(serviceName, "serviceName");
-        this.timers = Arrays.stream(clazz.getDeclaredMethods())
-                .collect(ImmutableMap.toImmutableMap(Function.identity(), this::getTimer));
     }
 
     private Timer getTimer(Method method) {
@@ -78,11 +73,7 @@ public final class SlidingWindowMetricsInvocationHandler extends AbstractInvocat
 
         long nanos = System.nanoTime() - context.getStartTimeNanos();
         Method method = context.getMethod();
-        Timer timer = timers.get(method);
-        if (timer == null) {
-            timer = getTimer(method);
-        }
-        timer.update(nanos, TimeUnit.NANOSECONDS);
+        timers.computeIfAbsent(method, this::getTimer).update(nanos, TimeUnit.NANOSECONDS);
     }
 
     @Override

--- a/atlasdb-commons/src/main/java/com/palantir/util/CachedTransformingSupplier.java
+++ b/atlasdb-commons/src/main/java/com/palantir/util/CachedTransformingSupplier.java
@@ -1,0 +1,52 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OU CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.util;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import com.google.common.collect.Maps;
+
+public final class CachedTransformingSupplier<T, U> implements Supplier<U> {
+    private final Supplier<T> inputSupplier;
+    private final Function<T, U> outputFunction;
+
+    private volatile Map.Entry<T, U> cache;
+
+    public CachedTransformingSupplier(Supplier<T> inputSupplier, Function<T, U> outputFunction) {
+        this.inputSupplier = inputSupplier;
+        this.outputFunction = outputFunction;
+    }
+
+    @Override
+    public U get() {
+        T currentInput = inputSupplier.get();
+        Map.Entry<T, U> snapshot = cache;
+        if (snapshot != null && Objects.equals(snapshot.getKey(), currentInput)) {
+            return snapshot.getValue();
+        }
+        synchronized (this) {
+            if (snapshot != null && Objects.equals(snapshot.getKey(), currentInput)) {
+                return snapshot.getValue();
+            }
+            cache = Maps.immutableEntry(currentInput, outputFunction.apply(currentInput));
+            return cache.getValue();
+        }
+    }
+}

--- a/atlasdb-commons/src/test/java/com/palantir/util/CachedTransformingSupplierTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/util/CachedTransformingSupplierTest.java
@@ -1,0 +1,43 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+public class CachedTransformingSupplierTest {
+
+    @Test
+    public void test() {
+        AtomicInteger inputValue = new AtomicInteger();
+        AtomicInteger outputValue = new AtomicInteger();
+
+        CachedTransformingSupplier<Integer, Integer> supplier =
+                new CachedTransformingSupplier<>(inputValue::get, input -> input + outputValue.incrementAndGet());
+
+        assertThat(supplier.get()).isEqualTo(1);
+        assertThat(supplier.get()).isEqualTo(1);
+
+        inputValue.incrementAndGet();
+
+        assertThat(supplier.get()).isEqualTo(3);
+        assertThat(supplier.get()).isEqualTo(3);
+    }
+}

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/ServerListConfigs.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/ServerListConfigs.java
@@ -17,7 +17,6 @@ package com.palantir.atlasdb.config;
 
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 public final class ServerListConfigs {
@@ -26,9 +25,9 @@ public final class ServerListConfigs {
     }
 
     public static ServerListConfig parseInstallAndRuntimeConfigs(TimeLockClientConfig installClientConfig,
-            Supplier<Optional<TimeLockRuntimeConfig>> runtimeConfig,
+            Optional<TimeLockRuntimeConfig> runtimeConfig,
             String namespace) {
-        ServerListConfig nonNamespacedConfig = runtimeConfig.get()
+        ServerListConfig nonNamespacedConfig = runtimeConfig
                 .map(TimeLockRuntimeConfig::serversList)
                 .orElseGet(() -> installClientConfig.serversList());
         return namespaceUris(nonNamespacedConfig, namespace);

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/ServerListConfigsTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/ServerListConfigsTest.java
@@ -71,7 +71,7 @@ public class ServerListConfigsTest {
     public void prioritisesRuntimeConfigIfAvailable() {
         ServerListConfig resolvedConfig = ServerListConfigs.parseInstallAndRuntimeConfigs(
                 INSTALL_CONFIG,
-                () -> Optional.of(RUNTIME_CONFIG),
+                Optional.of(RUNTIME_CONFIG),
                 CLIENT);
         assertThat(resolvedConfig.servers()).containsExactlyInAnyOrder("one/client", "two/client");
     }
@@ -80,7 +80,7 @@ public class ServerListConfigsTest {
     public void prioritisesRuntimeConfigEvenIfThatHasNoClients() {
         ServerListConfig resolvedConfig = ServerListConfigs.parseInstallAndRuntimeConfigs(
                 INSTALL_CONFIG,
-                () -> Optional.of(ImmutableTimeLockRuntimeConfig.builder().build()),
+                Optional.of(ImmutableTimeLockRuntimeConfig.builder().build()),
                 CLIENT);
         assertThat(resolvedConfig.servers()).isEmpty();
     }
@@ -89,7 +89,7 @@ public class ServerListConfigsTest {
     public void fallsBackToInstallConfigIfRuntimeConfigNotAvailable() {
         ServerListConfig resolvedConfig = ServerListConfigs.parseInstallAndRuntimeConfigs(
                 INSTALL_CONFIG,
-                Optional::empty,
+                Optional.empty(),
                 CLIENT);
         assertThat(resolvedConfig.servers()).containsExactlyInAnyOrder("one/client");
     }

--- a/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/FailoverFeignTarget.java
+++ b/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/FailoverFeignTarget.java
@@ -250,7 +250,30 @@ public class FailoverFeignTarget<T> implements Target<T>, Retryer {
         if (input.url().indexOf("http") != 0) {
             input.insert(0, url());
         }
-        return input.request();
+        return fasterRequest(input);
+    }
+
+    /**
+     * Version of {@link RequestTemplate#request} which does not unnecessarily
+     * copy headers and does not copy the whole URL if not necessary.
+     */
+    private Request fasterRequest(RequestTemplate input) {
+        return Request.create(
+                input.method(),
+                fastUrl(input),
+                input.headers(),
+                input.body(),
+                input.charset());
+    }
+
+    private static String fastUrl(RequestTemplate input) {
+        String queryLine = input.queryLine();
+        String url = input.url();
+        if (queryLine.isEmpty()) {
+            return url;
+        } else {
+            return url + queryLine;
+        }
     }
 
     public Client wrapClient(final Client client)  {

--- a/changelog/@unreleased/pr-4250.v2.yml
+++ b/changelog/@unreleased/pr-4250.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Improvements to AtlasDB memory profile.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4250

--- a/versions.props
+++ b/versions.props
@@ -59,6 +59,7 @@ org.awaitility:awaitility = 3.1.3
 org.checkerframework:checker-compat-qual = 2.3.0
 org.clojure:clojure = 1.8.0
 org.codehaus.groovy:* = 2.4.4
+org.conscrypt:conscrypt-openjdk-uber = 1.4.1
 org.eclipse.jetty.http2:* = 9.3.9.v20160517
 org.glassfish.hk2.external:javax.inject = 2.5.0-b05
 org.glassfish.jersey.containers:jersey-container-servlet-core = 2.23.2


### PR DESCRIPTION
1. Enable usage of Conscrypt when talking to Cassandra. We'll use this
internally and see if we have improvements. A lot of our time and our
allocations is spent doing TLS work.
2. The SlidingWindowMetricsInvocationHandler is still not quite working
in some places - fall back to a concurrenthashmap approach.
3. Don't always materialize the metric names in AtlasDbMetrics.
4. In FailoverFeignTarget, avoid copying the URL every usage.
5. Don't construct namespaced timelock urls _every_ call, and instead only do it when they change (aka never).
6. Don't read every single Cassandra schema whenever we check Cassandra health. This reads like 5MB of stuff for every single keyspace we use.