### PR TITLE
[Timelock Partitioning] Part 29: Add in ability for use case aware single leader clients

### DIFF
--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimelockPaxosAcceptorAdapter.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimelockPaxosAcceptorAdapter.java
@@ -58,7 +58,8 @@ public final class TimelockPaxosAcceptorAdapter implements PaxosAcceptor {
     }
 
     /**
-     * Given a list of {@link TimelockPaxosAcceptorRpcClient}s, returns a function allowing for injection of the client name.
+     * Given a list of {@link TimelockPaxosAcceptorRpcClient}s, returns a function allowing for injection of the client
+     * name.
      */
     public static Function<Client, List<PaxosAcceptor>> wrap(
             PaxosUseCase paxosUseCase,

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimelockPaxosAcceptorAdapter.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimelockPaxosAcceptorAdapter.java
@@ -21,43 +21,50 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import com.palantir.atlasdb.timelock.paxos.Client;
+import com.palantir.atlasdb.timelock.paxos.PaxosUseCase;
 import com.palantir.paxos.BooleanPaxosResponse;
 import com.palantir.paxos.PaxosAcceptor;
 import com.palantir.paxos.PaxosPromise;
 import com.palantir.paxos.PaxosProposal;
 import com.palantir.paxos.PaxosProposalId;
 
-
-public final class ClientAwarePaxosAcceptorAdapter implements PaxosAcceptor {
+public final class TimelockPaxosAcceptorAdapter implements PaxosAcceptor {
+    private final PaxosUseCase paxosUseCase;
     private final String client;
-    private final ClientAwarePaxosAcceptor clientAwarePaxosAcceptor;
+    private final TimelockPaxosAcceptorRpcClient timelockPaxosAcceptorRpcClient;
 
-    private ClientAwarePaxosAcceptorAdapter(Client client, ClientAwarePaxosAcceptor clientAwarePaxosAcceptor) {
+    private TimelockPaxosAcceptorAdapter(
+            PaxosUseCase paxosUseCase,
+            Client client,
+            TimelockPaxosAcceptorRpcClient timelockPaxosAcceptorRpcClient) {
+        this.paxosUseCase = paxosUseCase;
         this.client = client.value();
-        this.clientAwarePaxosAcceptor = clientAwarePaxosAcceptor;
+        this.timelockPaxosAcceptorRpcClient = timelockPaxosAcceptorRpcClient;
     }
 
     @Override
     public PaxosPromise prepare(long seq, PaxosProposalId pid) {
-        return clientAwarePaxosAcceptor.prepare(client, seq, pid);
+        return timelockPaxosAcceptorRpcClient.prepare(paxosUseCase, client, seq, pid);
     }
 
     @Override
     public BooleanPaxosResponse accept(long seq, PaxosProposal proposal) {
-        return clientAwarePaxosAcceptor.accept(client, seq, proposal);
+        return timelockPaxosAcceptorRpcClient.accept(paxosUseCase, client, seq, proposal);
     }
 
     @Override
     public long getLatestSequencePreparedOrAccepted() {
-        return clientAwarePaxosAcceptor.getLatestSequencePreparedOrAccepted(client);
+        return timelockPaxosAcceptorRpcClient.getLatestSequencePreparedOrAccepted(paxosUseCase, client);
     }
 
     /**
-     * Given a list of {@link ClientAwarePaxosAcceptor}s, returns a function allowing for injection of the client name.
+     * Given a list of {@link TimelockPaxosAcceptorRpcClient}s, returns a function allowing for injection of the client name.
      */
-    public static Function<Client, List<PaxosAcceptor>> wrap(List<ClientAwarePaxosAcceptor> acceptors) {
+    public static Function<Client, List<PaxosAcceptor>> wrap(
+            PaxosUseCase paxosUseCase,
+            List<TimelockPaxosAcceptorRpcClient> acceptors) {
         return client -> acceptors.stream()
-                .map(acceptor -> new ClientAwarePaxosAcceptorAdapter(client, acceptor))
+                .map(acceptor -> new TimelockPaxosAcceptorAdapter(paxosUseCase, client, acceptor))
                 .collect(Collectors.toList());
     }
 }

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimelockPaxosLearnerAdapter.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimelockPaxosLearnerAdapter.java
@@ -67,7 +67,8 @@ public final class TimelockPaxosLearnerAdapter implements PaxosLearner {
     }
 
     /**
-     * Given a list of {@link TimelockPaxosLearnerRpcClient}s, returns a function allowing for injection of the client name.
+     * Given a list of {@link TimelockPaxosLearnerRpcClient}s, returns a function allowing for injection of the client
+     * name.
      */
     public static Function<Client, List<PaxosLearner>> wrap(
             PaxosUseCase paxosUseCase,


### PR DESCRIPTION
**Goals (and why)**:
As we move to implementing the batch leader paxos, we need the same interfaces, and it's similar to what we did in [Part 23](https://github.com/palantir/atlasdb/pull/4177).

**Implementation Description (bullets)**:
* Parameterise the `PaxosUseCase` when creating the feign proxy.

**Testing (What was existing testing like?  What have you done to improve it?)**:
This should be covered by integration tests.

**Concerns (what feedback would you like?)**:
I've sold out and just prefixed the name with Timelock lol, but I think it works 💃 unless you think otherwise @jeremyk-91 🙃 

**Where should we start reviewing?**:
Wherever

**Priority (whenever / two weeks / yesterday)**:
Relatively soon.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
