### PR TITLE
[Timelock Partitioning] Part 30: Ensure everything is instrumented

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
@@ -30,7 +30,7 @@ import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
 import com.palantir.conjure.java.config.ssl.TrustContext;
 
 public final class AtlasDbHttpClients {
-    private static final TargetFactory DEFAULT_TARGET_FACTORY = AtlasDbFeignTargetFactory.DEFAULT;
+    public static final TargetFactory DEFAULT_TARGET_FACTORY = AtlasDbFeignTargetFactory.DEFAULT;
     private static final TargetFactory TESTING_TARGET_FACTORY = AtlasDbFeignTargetFactory.FAST_FAIL_FOR_TESTING;
 
     private AtlasDbHttpClients() {

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/AsyncLockClient.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/AsyncLockClient.java
@@ -37,7 +37,8 @@ public final class AsyncLockClient implements JepsenLockClient<LockToken> {
     }
 
     public static AsyncLockClient create(MetricRegistry metricRegistry, List<String> hosts) {
-        return new AsyncLockClient(TimelockUtils.createClient(metricRegistry, hosts, NamespacedTimelockRpcClient.class));
+        return new AsyncLockClient(TimelockUtils.createClient(metricRegistry, hosts,
+                NamespacedTimelockRpcClient.class));
     }
 
     @Override

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchingNetworkClientFactories.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchingNetworkClientFactories.java
@@ -52,7 +52,7 @@ abstract class BatchingNetworkClientFactories {
         List<BatchPaxosLearner> allBatchLearners = proxyFactories()
                 .instrumentLocalAndRemotesFor(
                         BatchPaxosLearner.class,
-                        resource().learner(PaxosUseCase.TIMESTAMP),
+                        resource().learner(PaxosUseCase.TIMESTAMP).asLocalBatchPaxosLearner(),
                         UseCaseAwareBatchPaxosLearnerAdapter.wrap(PaxosUseCase.TIMESTAMP, remoteBatchLearners),
                         "batch-paxos-learner")
                 .all();

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchingNetworkClientFactories.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchingNetworkClientFactories.java
@@ -32,25 +32,29 @@ abstract class BatchingNetworkClientFactories {
     public NetworkClientFactories factories() {
         // TODO(fdesouza): pass these in, as they become use case aware
         List<BatchPaxosAcceptorRpcClient> remoteBatchAcceptors = proxyFactories()
-                .createRemoteProxies(BatchPaxosAcceptorRpcClient.class, "timestamp-bound-store.batch-acceptor");
+                .createInstrumentedRemoteProxies(BatchPaxosAcceptorRpcClient.class, "batch-paxos-acceptor-rpc-client");
 
-        List<BatchPaxosAcceptor> allBatchAcceptors = proxyFactories().instrumentLocalAndRemotesFor(
-                BatchPaxosAcceptor.class,
-                resource().acceptor(PaxosUseCase.TIMESTAMP).asLocalBatchPaxosAcceptor(),
-                UseCaseAwareBatchPaxosAcceptorAdapter.wrap(PaxosUseCase.TIMESTAMP, remoteBatchAcceptors)).all();
+        List<BatchPaxosAcceptor> allBatchAcceptors = proxyFactories()
+                .instrumentLocalAndRemotesFor(
+                        BatchPaxosAcceptor.class,
+                        resource().acceptor(PaxosUseCase.TIMESTAMP).asLocalBatchPaxosAcceptor(),
+                        UseCaseAwareBatchPaxosAcceptorAdapter.wrap(PaxosUseCase.TIMESTAMP, remoteBatchAcceptors),
+                        "batch-paxos-acceptor")
+                .all();
 
         AutobatchingPaxosAcceptorNetworkClientFactory acceptorFactory =
                 AutobatchingPaxosAcceptorNetworkClientFactory.create(allBatchAcceptors, sharedExecutor(), quorumSize());
 
         // TODO(fdesouza): pass these in as they become use case aware
         List<BatchPaxosLearnerRpcClient> remoteBatchLearners = proxyFactories()
-                .createRemoteProxies(BatchPaxosLearnerRpcClient.class, "timestamp-bound-store.batch-learner");
+                .createInstrumentedRemoteProxies(BatchPaxosLearnerRpcClient.class, "batch-paxos-learner-rpc-client");
 
         List<BatchPaxosLearner> allBatchLearners = proxyFactories()
                 .instrumentLocalAndRemotesFor(
                         BatchPaxosLearner.class,
                         resource().learner(PaxosUseCase.TIMESTAMP),
-                        UseCaseAwareBatchPaxosLearnerAdapter.wrap(PaxosUseCase.TIMESTAMP, remoteBatchLearners))
+                        UseCaseAwareBatchPaxosLearnerAdapter.wrap(PaxosUseCase.TIMESTAMP, remoteBatchLearners),
+                        "batch-paxos-learner")
                 .all();
 
         AutobatchingPaxosLearnerNetworkClientFactory learnerFactory =

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/ClientPaxosResourceFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/ClientPaxosResourceFactory.java
@@ -43,7 +43,8 @@ public final class ClientPaxosResourceFactory {
             TimeLockInstallConfiguration install,
             Supplier<PaxosRuntimeConfiguration> paxosRuntime,
             ExecutorService sharedExecutor) {
-        TimelockPaxosMetrics timelockMetrics = TimelockPaxosMetrics.of(PaxosUseCase.TIMESTAMP, metrics.getTaggedRegistry());
+        TimelockPaxosMetrics timelockMetrics =
+                TimelockPaxosMetrics.of(PaxosUseCase.TIMESTAMP, metrics.getTaggedRegistry());
         PaxosComponents paxosComponents = new PaxosComponents(timelockMetrics, logDirectory);
 
         AcceptorCache acceptorCache = timelockMetrics

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/TimelockProxyFactories.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/TimelockProxyFactories.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 
 import org.immutables.value.Value;
 
-import com.palantir.atlasdb.http.AtlasDbFeignTargetFactory;
+import com.palantir.atlasdb.http.AtlasDbHttpClients;
 import com.palantir.conjure.java.config.ssl.SslSocketFactories;
 import com.palantir.conjure.java.config.ssl.TrustContext;
 import com.palantir.timelock.config.TimeLockInstallConfiguration;
@@ -33,7 +33,7 @@ import com.palantir.timelock.paxos.PaxosRemotingUtils;
 public abstract class TimelockProxyFactories {
 
     abstract TimeLockInstallConfiguration install();
-    abstract TimelockMetrics metrics();
+    abstract TimelockPaxosMetrics metrics();
 
     <T> List<T> createInstrumentedRemoteProxies(Class<T> clazz, String name) {
         Set<String> remoteUris = PaxosRemotingUtils.getRemoteServerPaths(install());
@@ -41,7 +41,7 @@ public abstract class TimelockProxyFactories {
                 .getSslConfigurationOptional(install())
                 .map(SslSocketFactories::createTrustContext);
         return remoteUris.stream()
-                .map(uri -> AtlasDbFeignTargetFactory.DEFAULT.createProxy(
+                .map(uri -> AtlasDbHttpClients.DEFAULT_TARGET_FACTORY.createProxy(
                         trustContext,
                         uri,
                         clazz,

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/TimelockProxyFactories.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/TimelockProxyFactories.java
@@ -23,9 +23,7 @@ import java.util.stream.Collectors;
 
 import org.immutables.value.Value;
 
-import com.codahale.metrics.MetricRegistry;
-import com.palantir.atlasdb.factory.ServiceCreator;
-import com.palantir.atlasdb.http.AtlasDbHttpClients;
+import com.palantir.atlasdb.http.AtlasDbFeignTargetFactory;
 import com.palantir.conjure.java.config.ssl.SslSocketFactories;
 import com.palantir.conjure.java.config.ssl.TrustContext;
 import com.palantir.timelock.config.TimeLockInstallConfiguration;
@@ -35,26 +33,37 @@ import com.palantir.timelock.paxos.PaxosRemotingUtils;
 public abstract class TimelockProxyFactories {
 
     abstract TimeLockInstallConfiguration install();
-    abstract MetricRegistry metrics();
+    abstract TimelockMetrics metrics();
 
-    <T> List<T> createRemoteProxies(Class<T> clazz, String userAgent) {
+    <T> List<T> createInstrumentedRemoteProxies(Class<T> clazz, String name) {
         Set<String> remoteUris = PaxosRemotingUtils.getRemoteServerPaths(install());
-        Optional<TrustContext> trustContext = PaxosRemotingUtils.getSslConfigurationOptional(install())
+        Optional<TrustContext> trustContext = PaxosRemotingUtils
+                .getSslConfigurationOptional(install())
                 .map(SslSocketFactories::createTrustContext);
         return remoteUris.stream()
-                .map(uri -> AtlasDbHttpClients.createProxy(
-                        metrics(),
+                .map(uri -> AtlasDbFeignTargetFactory.DEFAULT.createProxy(
                         trustContext,
                         uri,
                         clazz,
-                        userAgent,
+                        name,
                         false))
+                .map(proxy -> metrics().instrument(clazz, proxy, name))
                 .collect(Collectors.toList());
     }
 
-    <T> LocalAndRemotes<T> instrumentLocalAndRemotesFor(Class<T> clazz, T local, List<T> remotes) {
+    <T> LocalAndRemotes<T> instrumentLocalAndRemotesFor(Class<T> clazz, T local, List<T> remotes, String name) {
         return LocalAndRemotes.of(local, remotes)
-                .map(instance -> ServiceCreator.createInstrumentedService(metrics(), instance, clazz));
+                .map(instance -> metrics().instrument(clazz, instance, name));
+    }
+
+    <T> LocalAndRemotes<T> instrumentLocalAndRemotesFor(
+            Class<T> clazz,
+            T local,
+            List<T> remotes,
+            String name,
+            Client client) {
+        return LocalAndRemotes.of(local, remotes)
+                .map(instance -> metrics().instrument(clazz, instance, name, client));
     }
 
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosComponents.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosComponents.java
@@ -29,11 +29,11 @@ import com.palantir.paxos.PaxosLearnerImpl;
 
 public class PaxosComponents {
 
-    private final TimelockMetrics metrics;
+    private final TimelockPaxosMetrics metrics;
     private final Path logDirectory;
     private final Map<Client, Components> componentsByClient = Maps.newConcurrentMap();
 
-    PaxosComponents(TimelockMetrics metrics, Path logDirectory) {
+    PaxosComponents(TimelockPaxosMetrics metrics, Path logDirectory) {
         this.metrics = metrics;
         this.logDirectory = logDirectory;
     }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosComponents.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosComponents.java
@@ -21,25 +21,20 @@ import java.util.Map;
 
 import org.immutables.value.Value;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
-import com.palantir.atlasdb.util.AtlasDbMetrics;
 import com.palantir.paxos.PaxosAcceptor;
 import com.palantir.paxos.PaxosAcceptorImpl;
 import com.palantir.paxos.PaxosLearner;
 import com.palantir.paxos.PaxosLearnerImpl;
-import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 
 public class PaxosComponents {
 
-    private final TaggedMetricRegistry metrics;
-    private final String useCase;
+    private final TimelockMetrics metrics;
     private final Path logDirectory;
     private final Map<Client, Components> componentsByClient = Maps.newConcurrentMap();
 
-    PaxosComponents(TaggedMetricRegistry metrics, String useCase, Path logDirectory) {
+    PaxosComponents(TimelockMetrics metrics, Path logDirectory) {
         this.metrics = metrics;
-        this.useCase = useCase;
         this.logDirectory = logDirectory;
     }
 
@@ -59,36 +54,23 @@ public class PaxosComponents {
         Path clientDirectory = logDirectory.resolve(client.value());
         Path learnerLogDir = Paths.get(clientDirectory.toString(), PaxosTimeLockConstants.LEARNER_SUBDIRECTORY_PATH);
 
-        PaxosLearner learner = instrument(
+        PaxosLearner learner = metrics.instrument(
                 PaxosLearner.class,
                 PaxosLearnerImpl.newLearner(learnerLogDir.toString()),
-                "timelock.paxos-learner",
+                "paxos-learner",
                 client);
 
         Path acceptorLogDir = Paths.get(clientDirectory.toString(), PaxosTimeLockConstants.ACCEPTOR_SUBDIRECTORY_PATH);
-        PaxosAcceptor acceptor = instrument(
+        PaxosAcceptor acceptor = metrics.instrument(
                 PaxosAcceptor.class,
                 PaxosAcceptorImpl.newAcceptor(acceptorLogDir.toString()),
-                "timelock.paxos-acceptor",
+                "paxos-acceptor",
                 client);
 
         return ImmutableComponents.builder()
                 .acceptor(acceptor)
                 .learner(learner)
                 .build();
-    }
-
-    private <T, U extends T> T instrument(Class<T> clazz, U instance, String name, Client client) {
-        ImmutableMap<String, String> tags = ImmutableMap.<String, String>builder()
-                .put("client", client.value())
-                .put("useCase", useCase)
-                .build();
-        return AtlasDbMetrics.instrumentWithTaggedMetrics(
-                metrics,
-                clazz,
-                instance,
-                name,
-                unused -> tags);
     }
 
     @Value.Immutable

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResource.java
@@ -20,7 +20,6 @@ import javax.ws.rs.PathParam;
 
 import com.palantir.paxos.PaxosAcceptor;
 import com.palantir.paxos.PaxosLearner;
-import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 
 @Path("/" + PaxosTimeLockConstants.INTERNAL_NAMESPACE
         + "/" + PaxosTimeLockConstants.CLIENT_PAXOS_NAMESPACE
@@ -30,10 +29,6 @@ public final class PaxosResource {
 
     PaxosResource(PaxosComponents paxosComponents) {
         this.paxosComponents = paxosComponents;
-    }
-
-    public static PaxosResource create(TaggedMetricRegistry metricRegistry, java.nio.file.Path logDirectory) {
-        return new PaxosResource(new PaxosComponents(metricRegistry, "bound-store", logDirectory));
     }
 
     @Path("/learner")

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/TimelockMetrics.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/TimelockMetrics.java
@@ -1,0 +1,59 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.immutables.value.Value;
+
+import com.google.common.collect.ImmutableMap;
+import com.palantir.atlasdb.util.AtlasDbMetrics;
+import com.palantir.tritium.metrics.registry.SlidingWindowTaggedMetricRegistry;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+
+@Value.Immutable
+public abstract class TimelockMetrics {
+
+    abstract PaxosUseCase paxosUseCase();
+
+    @Value.Derived
+    TaggedMetricRegistry metrics() {
+        return new SlidingWindowTaggedMetricRegistry(35, TimeUnit.SECONDS);
+    }
+
+    public static TimelockMetrics of(PaxosUseCase paxosUseCase, TaggedMetricRegistry parentRegistry) {
+        TimelockMetrics metrics = ImmutableTimelockMetrics.builder().paxosUseCase(paxosUseCase).build();
+        metrics.attachToParentMetricRegistry(parentRegistry);
+        return metrics;
+    }
+
+    private void attachToParentMetricRegistry(TaggedMetricRegistry parent) {
+        parent.addMetrics("paxosUseCase", paxosUseCase().toString(), metrics());
+    }
+
+    public <T, U extends T> T instrument(Class<T> clazz, U instance, String name) {
+        Map<String, String> tags = ImmutableMap.of();
+        return AtlasDbMetrics.instrumentWithTaggedMetrics(metrics(), clazz, instance, name, _context -> tags);
+    }
+
+    public <T, U extends T> T instrument(Class<T> clazz, U instance, String name, Client client) {
+        Map<String, String> tags = ImmutableMap.of("client", client.value());
+        return AtlasDbMetrics.instrumentWithTaggedMetrics(metrics(), clazz, instance, name, _context -> tags);
+    }
+
+}

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/TimelockPaxosMetrics.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/TimelockPaxosMetrics.java
@@ -27,7 +27,7 @@ import com.palantir.tritium.metrics.registry.SlidingWindowTaggedMetricRegistry;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 
 @Value.Immutable
-public abstract class TimelockMetrics {
+public abstract class TimelockPaxosMetrics {
 
     abstract PaxosUseCase paxosUseCase();
 
@@ -36,8 +36,8 @@ public abstract class TimelockMetrics {
         return new SlidingWindowTaggedMetricRegistry(35, TimeUnit.SECONDS);
     }
 
-    public static TimelockMetrics of(PaxosUseCase paxosUseCase, TaggedMetricRegistry parentRegistry) {
-        TimelockMetrics metrics = ImmutableTimelockMetrics.builder().paxosUseCase(paxosUseCase).build();
+    public static TimelockPaxosMetrics of(PaxosUseCase paxosUseCase, TaggedMetricRegistry parentRegistry) {
+        TimelockPaxosMetrics metrics = ImmutableTimelockPaxosMetrics.builder().paxosUseCase(paxosUseCase).build();
         metrics.attachToParentMetricRegistry(parentRegistry);
         return metrics;
     }

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalBatchPaxosLearnerTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalBatchPaxosLearnerTests.java
@@ -39,7 +39,7 @@ import com.google.common.collect.SetMultimap;
 import com.palantir.paxos.PaxosValue;
 
 @RunWith(MockitoJUnitRunner.class)
-public class BatchPaxosLearnerResourceTests {
+public class LocalBatchPaxosLearnerTests {
 
     private static final Client CLIENT_1 = Client.of("client1");
     private static final Client CLIENT_2 = Client.of("client2");
@@ -47,11 +47,11 @@ public class BatchPaxosLearnerResourceTests {
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private PaxosComponents paxosComponents;
 
-    private BatchPaxosLearnerResource resource;
+    private BatchPaxosLearner resource;
 
     @Before
     public void before() {
-        resource = new BatchPaxosLearnerResource(paxosComponents);
+        resource = new LocalBatchPaxosLearner(paxosComponents);
     }
 
     @Test

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosComponentsTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosComponentsTest.java
@@ -54,7 +54,9 @@ public class PaxosComponentsTest {
     @Before
     public void setUp() throws IOException {
         logDirectory = TEMPORARY_FOLDER.newFolder().toPath();
-        paxosComponents = new PaxosComponents(new DefaultTaggedMetricRegistry(), "test", logDirectory);
+        paxosComponents = new PaxosComponents(
+                TimelockMetrics.of(PaxosUseCase.TIMESTAMP, new DefaultTaggedMetricRegistry()),
+                logDirectory);
     }
 
     @Test

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosComponentsTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosComponentsTest.java
@@ -55,7 +55,7 @@ public class PaxosComponentsTest {
     public void setUp() throws IOException {
         logDirectory = TEMPORARY_FOLDER.newFolder().toPath();
         paxosComponents = new PaxosComponents(
-                TimelockMetrics.of(PaxosUseCase.TIMESTAMP, new DefaultTaggedMetricRegistry()),
+                TimelockPaxosMetrics.of(PaxosUseCase.TIMESTAMP, new DefaultTaggedMetricRegistry()),
                 logDirectory);
     }
 

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
@@ -107,8 +107,7 @@ public class PaxosTimestampBoundStoreTest {
         for (int i = 0; i < NUM_NODES; i++) {
             String root = temporaryFolder.getRoot().getAbsolutePath();
             PaxosComponents components = new PaxosComponents(
-                    SharedTaggedMetricRegistries.getSingleton(),
-                    "test",
+                    TimelockMetrics.of(PaxosUseCase.TIMESTAMP, SharedTaggedMetricRegistries.getSingleton()),
                     Paths.get(root, Integer.toString(i)));
 
             AtomicBoolean failureController = new AtomicBoolean(false);

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
@@ -107,7 +107,7 @@ public class PaxosTimestampBoundStoreTest {
         for (int i = 0; i < NUM_NODES; i++) {
             String root = temporaryFolder.getRoot().getAbsolutePath();
             PaxosComponents components = new PaxosComponents(
-                    TimelockMetrics.of(PaxosUseCase.TIMESTAMP, SharedTaggedMetricRegistries.getSingleton()),
+                    TimelockPaxosMetrics.of(PaxosUseCase.TIMESTAMP, SharedTaggedMetricRegistries.getSingleton()),
                     Paths.get(root, Integer.toString(i)));
 
             AtomicBoolean failureController = new AtomicBoolean(false);
@@ -132,7 +132,7 @@ public class PaxosTimestampBoundStoreTest {
                     failureController,
                     EXCEPTION));
 
-            BatchPaxosLearner batchLearner = new BatchPaxosLearnerResource(components);
+            BatchPaxosLearner batchLearner = new LocalBatchPaxosLearner(components);
             batchPaxosLearners.add(ToggleableExceptionProxy.newProxyInstance(
                     BatchPaxosLearner.class,
                     batchLearner,


### PR DESCRIPTION
**Goals (and why)**:
During testing, several metrics were missing. 

**Implementation Description (bullets)**:
* Use tagged metrics everywhere, happy to own changing the boards and what not. Should be easier to navigate imo.
  * Toying with the idea of hierarchical metric registries. In theory, we could use this to get what we want regarding sliding window metrics everywhere (although we would still have to deal with the non tagged metrics :( )
* Pulling out some helper classes, I really wish I was allowed to use dagger here. These will help with further wiring changes coming down the line. Some of them may disappear after everything is done, but we'll see.

**Testing (What was existing testing like?  What have you done to improve it?)**:
This is mainly a refactor + adding metrics, so nothing changed on that front.

**Concerns (what feedback would you like?)**:
* I would like to at some point collapse `timelock-agent` and `timelock-impl`.

**Where should we start reviewing?**:
`TimelockMetrics` perhaps? and `ClientPaxosResourceFactory` to start. So many hoops to jump through when there are circular dependency conflicts.

**Priority (whenever / two weeks / yesterday)**:
Relatively soon.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
