### PR TITLE
Do not log a warning if attempting a try-lock and it fails

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AdvisoryLockConditionSuppliers.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AdvisoryLockConditionSuppliers.java
@@ -76,7 +76,16 @@ public final class AdvisoryLockConditionSuppliers {
             if (response == null) {
                 RuntimeException ex = new LockAcquisitionException(
                         "Failed to lock using the provided lock request: " + lockRequest);
-                log.warn("Could not lock successfully", ex);
+                switch (lockRequest.getBlockingMode()) {
+                    case DO_NOT_BLOCK:
+                        log.debug("Could not lock successfully", ex);
+                        break;
+                    case BLOCK_UNTIL_TIMEOUT:
+                    case BLOCK_INDEFINITELY:
+                    case BLOCK_INDEFINITELY_THEN_RELEASE:
+                        log.warn("Could not lock successfully", ex);
+                        break;
+                }
                 ++failureCount;
                 if (failureCount >= NUM_RETRIES) {
                     log.warn("Failing after {} tries", failureCount, ex);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AdvisoryLockConditionSuppliers.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AdvisoryLockConditionSuppliers.java
@@ -79,17 +79,17 @@ public final class AdvisoryLockConditionSuppliers {
                 switch (lockRequest.getBlockingMode()) {
                     case DO_NOT_BLOCK:
                         log.debug("Could not lock successfully", ex);
-                        break;
+                        throw ex;
                     case BLOCK_UNTIL_TIMEOUT:
                     case BLOCK_INDEFINITELY:
                     case BLOCK_INDEFINITELY_THEN_RELEASE:
                         log.warn("Could not lock successfully", ex);
+                        ++failureCount;
+                        if (failureCount >= NUM_RETRIES) {
+                            log.warn("Failing after {} tries", failureCount, ex);
+                            throw ex;
+                        }
                         break;
-                }
-                ++failureCount;
-                if (failureCount >= NUM_RETRIES) {
-                    log.warn("Failing after {} tries", failureCount, ex);
-                    throw ex;
                 }
             } else {
                 return response;

--- a/changelog/@unreleased/pr-4269.v2.yml
+++ b/changelog/@unreleased/pr-4269.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Attempting to acquire advisory locks with locking mode `DO_NOT_BLOCK`
+    will now log at `DEBUG` instead of `WARN`. In this mode we are generally _trying_
+    the lock, so failure is by no means indicative of a problem.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4269


### PR DESCRIPTION
**Goals (and why)**:

Get rid of extraneous logging. It should not be too surprising if we fail to grab the lock in this scenario.

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
