### PR TITLE
[Timelock Partitioning] Part 33: Clearer `LeadershipObserver`

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
@@ -121,11 +121,10 @@ public final class Leaders {
             Supplier<LeadershipObserver> leadershipObserverFactory) {
         UUID leaderUuid = UUID.randomUUID();
 
-        LeadershipObserver leadershipObserver = leadershipObserverFactory.get();
         PaxosLeadershipEventRecorder leadershipEventRecorder = PaxosLeadershipEventRecorder.create(
                 metricsManager.getTaggedRegistry(),
                 leaderUuid.toString(),
-                leadershipObserver,
+                leadershipObserverFactory.get(),
                 ImmutableList.of());
 
         PaxosAcceptor ourAcceptor = AtlasDbMetrics.instrument(metricsManager.getRegistry(),
@@ -198,7 +197,6 @@ public final class Leaders {
                 .ourLearner(ourLearner)
                 .leaderElectionService(new BatchingLeaderElectionService(leaderElectionService))
                 .pingableLeader(pingableLeader)
-                .leadershipObserver(leadershipObserver)
                 .isCurrentSuspectedLeader(paxosLeaderElectionService::ping)
                 .build();
     }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
@@ -44,7 +44,6 @@ import com.palantir.atlasdb.config.AuxiliaryRemotingParameters;
 import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.config.LeaderRuntimeConfig;
 import com.palantir.atlasdb.http.AtlasDbHttpClients;
-import com.palantir.atlasdb.http.AtlasDbRemotingConstants;
 import com.palantir.atlasdb.http.NotCurrentLeaderExceptionMapper;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
 import com.palantir.atlasdb.util.MetricsManager;
@@ -75,16 +74,6 @@ public final class Leaders {
      * Creates a LeaderElectionService using the supplied configuration and registers appropriate endpoints for that
      * service.
      */
-    public static LeaderElectionService create(MetricsManager metricsManager,
-            Consumer<Object> env, LeaderConfig config, Supplier<LeaderRuntimeConfig> runtime) {
-        return create(metricsManager, env, config, runtime, AtlasDbRemotingConstants.DEFAULT_USER_AGENT);
-    }
-
-    public static LeaderElectionService create(MetricsManager metricsManager,
-            Consumer<Object> env, LeaderConfig config, Supplier<LeaderRuntimeConfig> runtime, UserAgent userAgent) {
-        return createAndRegisterLocalServices(metricsManager, env, config, runtime, userAgent).leaderElectionService();
-    }
-
     public static LocalPaxosServices createAndRegisterLocalServices(
             MetricsManager metricsManager,
             Consumer<Object> env,
@@ -114,7 +103,13 @@ public final class Leaders {
                 .remoteAcceptorUris(remoteLeaderUris)
                 .remoteLearnerUris(remoteLeaderUris)
                 .build();
-        return createInstrumentedLocalServices(metricsManager, config, runtime, remotePaxosServerSpec, userAgent);
+        return createInstrumentedLocalServices(
+                metricsManager,
+                config,
+                runtime,
+                remotePaxosServerSpec,
+                userAgent,
+                AsyncLeadershipObserver::create);
     }
 
     public static LocalPaxosServices createInstrumentedLocalServices(
@@ -122,10 +117,11 @@ public final class Leaders {
             LeaderConfig config,
             Supplier<LeaderRuntimeConfig> runtime,
             RemotePaxosServerSpec remotePaxosServerSpec,
-            UserAgent userAgent) {
+            UserAgent userAgent,
+            Supplier<LeadershipObserver> leadershipObserverFactory) {
         UUID leaderUuid = UUID.randomUUID();
 
-        AsyncLeadershipObserver leadershipObserver = AsyncLeadershipObserver.create();
+        LeadershipObserver leadershipObserver = leadershipObserverFactory.get();
         PaxosLeadershipEventRecorder leadershipEventRecorder = PaxosLeadershipEventRecorder.create(
                 metricsManager.getTaggedRegistry(),
                 leaderUuid.toString(),
@@ -274,7 +270,6 @@ public final class Leaders {
         PaxosLearner ourLearner();
         LeaderElectionService leaderElectionService();
         PingableLeader pingableLeader();
-        LeadershipObserver leadershipObserver();
         Supplier<Boolean> isCurrentSuspectedLeader();
     }
 

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/ServiceCreator.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/ServiceCreator.java
@@ -93,7 +93,7 @@ public final class ServiceCreator {
                 parameters);
     }
 
-    public static <T> T createInstrumentedService(MetricRegistry metricRegistry, T service, Class<T> serviceClass) {
+    public static <T> T instrumentService(MetricRegistry metricRegistry, T service, Class<T> serviceClass) {
         return AtlasDbMetrics.instrument(
                 metricRegistry,
                 serviceClass,

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -981,7 +981,7 @@ public abstract class TransactionManagers {
                 () -> defaultRuntime,
                 userAgent);
         LeaderElectionService leader = localPaxosServices.leaderElectionService();
-        LockService localLock = ServiceCreator.createInstrumentedService(
+        LockService localLock = ServiceCreator.instrumentService(
                 metricsManager.getRegistry(),
                 AwaitingLeadershipProxy.newProxyInstance(LockService.class, lock::get, leader),
                 LockService.class);
@@ -989,12 +989,12 @@ public abstract class TransactionManagers {
         ManagedTimestampService managedTimestampProxy =
                 AwaitingLeadershipProxy.newProxyInstance(ManagedTimestampService.class, time::get, leader);
 
-        TimestampService localTime = ServiceCreator.createInstrumentedService(
+        TimestampService localTime = ServiceCreator.instrumentService(
                 metricsManager.getRegistry(),
                 managedTimestampProxy,
                 TimestampService.class);
 
-        TimestampManagementService localManagement = ServiceCreator.createInstrumentedService(
+        TimestampManagementService localManagement = ServiceCreator.instrumentService(
                 metricsManager.getRegistry(),
                 managedTimestampProxy,
                 TimestampManagementService.class);
@@ -1102,14 +1102,14 @@ public abstract class TransactionManagers {
             Consumer<Object> env,
             Supplier<LockService> lock,
             Supplier<ManagedTimestampService> managedTimestampServiceSupplier) {
-        LockService lockService = ServiceCreator.createInstrumentedService(
+        LockService lockService = ServiceCreator.instrumentService(
                 metricsManager.getRegistry(), lock.get(), LockService.class);
 
         ManagedTimestampService managedTimestampService = managedTimestampServiceSupplier.get();
 
-        TimestampService timeService = ServiceCreator.createInstrumentedService(
+        TimestampService timeService = ServiceCreator.instrumentService(
                 metricsManager.getRegistry(), managedTimestampService, TimestampService.class);
-        TimestampManagementService timestampManagementService = ServiceCreator.createInstrumentedService(
+        TimestampManagementService timestampManagementService = ServiceCreator.instrumentService(
                 metricsManager.getRegistry(), managedTimestampService, TimestampManagementService.class);
 
         env.accept(lockService);

--- a/leader-election-impl/src/main/java/com/palantir/leader/AsyncLeadershipObserver.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/AsyncLeadershipObserver.java
@@ -36,6 +36,13 @@ public class AsyncLeadershipObserver implements LeadershipObserver {
         return new AsyncLeadershipObserver(PTExecutors.newSingleThreadExecutor(true));
     }
 
+    public static AsyncLeadershipObserver create(Runnable gainedLeadershipTask, Runnable lostLeadershipTask) {
+        AsyncLeadershipObserver asyncLeadershipObserver = create();
+        asyncLeadershipObserver.executeWhenGainedLeadership(gainedLeadershipTask);
+        asyncLeadershipObserver.executeWhenLostLeadership(lostLeadershipTask);
+        return asyncLeadershipObserver;
+    }
+
     @VisibleForTesting
     AsyncLeadershipObserver(ExecutorService executorService) {
         this.executorService = executorService;

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/AsyncTimeLockServicesCreator.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/AsyncTimeLockServicesCreator.java
@@ -15,20 +15,15 @@
  */
 package com.palantir.timelock.paxos;
 
-import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.InstrumentedScheduledExecutorService;
-import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Suppliers;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import com.palantir.atlasdb.AtlasDbMetricNames;
 import com.palantir.atlasdb.timelock.AsyncTimelockResource;
 import com.palantir.atlasdb.timelock.AsyncTimelockService;
 import com.palantir.atlasdb.timelock.AsyncTimelockServiceImpl;
@@ -38,14 +33,11 @@ import com.palantir.atlasdb.timelock.config.TargetedSweepLockControlConfig.RateL
 import com.palantir.atlasdb.timelock.lock.AsyncLockService;
 import com.palantir.atlasdb.timelock.lock.LockLog;
 import com.palantir.atlasdb.timelock.lock.NonTransactionalLockService;
-import com.palantir.atlasdb.util.AtlasDbMetrics;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.lock.LockService;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.timestamp.ManagedTimestampService;
-import com.palantir.tritium.metrics.registry.MetricName;
-import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 
 public class AsyncTimeLockServicesCreator implements TimeLockServicesCreator {
     private static final Logger log = LoggerFactory.getLogger(AsyncTimeLockServicesCreator.class);
@@ -72,37 +64,22 @@ public class AsyncTimeLockServicesCreator implements TimeLockServicesCreator {
             Supplier<ManagedTimestampService> rawTimestampServiceSupplier,
             Supplier<LockService> rawLockServiceSupplier) {
         log.info("Creating async timelock services for client {}", SafeArg.of("client", client));
-        AsyncTimelockService asyncTimelockService = instrumentInLeadershipProxy(
-                metricsManager.getTaggedRegistry(),
-                AsyncTimelockService.class,
+        AsyncTimelockService asyncTimelockService = leadershipCreator.wrapInLeadershipProxy(
                 () -> createRawAsyncTimelockService(client, rawTimestampServiceSupplier),
+                AsyncTimelockService.class,
                 client);
         AsyncTimelockResource asyncTimelockResource = new AsyncTimelockResource(lockLog, asyncTimelockService);
 
-        LockService lockService = instrumentInLeadershipProxy(
-                metricsManager.getTaggedRegistry(),
-                LockService.class,
+        LockService lockService = leadershipCreator.wrapInLeadershipProxy(
                 Suppliers.compose(NonTransactionalLockService::new, rawLockServiceSupplier::get),
+                LockService.class,
                 client);
-
-        leadershipCreator.executeWhenLostLeadership(() ->
-                metricsManager.deregisterTaggedMetrics(withTagIsCurrentSuspectedLeader(true)));
-
-        leadershipCreator.executeWhenGainedLeadership(() ->
-                metricsManager.deregisterTaggedMetrics(withTagIsCurrentSuspectedLeader(false)));
 
         return TimeLockServices.create(
                 asyncTimelockService,
                 lockService,
                 asyncTimelockResource,
                 asyncTimelockService);
-    }
-
-    private static Predicate<MetricName> withTagIsCurrentSuspectedLeader(boolean currentLeader) {
-        return metricName ->
-                Optional.ofNullable(metricName.safeTags().get(AtlasDbMetricNames.TAG_CURRENT_SUSPECTED_LEADER))
-                        .filter(x -> x.equals(String.valueOf(currentLeader)))
-                        .isPresent();
     }
 
     private AsyncTimelockService createRawAsyncTimelockService(
@@ -127,18 +104,4 @@ public class AsyncTimeLockServicesCreator implements TimeLockServicesCreator {
         return () -> lockControlConfigSupplier.get().rateLimitConfig(client);
     }
 
-    private <T> T instrumentInLeadershipProxy(TaggedMetricRegistry taggedMetrics, Class<T> serviceClass,
-            Supplier<T> serviceSupplier, String client) {
-        return instrument(taggedMetrics, serviceClass,
-                leadershipCreator.wrapInLeadershipProxy(serviceSupplier, serviceClass), client);
-    }
-
-    private <T> T instrument(TaggedMetricRegistry metricRegistry, Class<T> serviceClass, T service, String client) {
-        return AtlasDbMetrics.instrumentWithTaggedMetrics(
-                metricRegistry, serviceClass, service, MetricRegistry.name(serviceClass),
-                context -> ImmutableMap.of(
-                        AtlasDbMetricNames.TAG_CLIENT, client,
-                        AtlasDbMetricNames.TAG_CURRENT_SUSPECTED_LEADER, String.valueOf(
-                                leadershipCreator.isCurrentSuspectedLeader())));
-    }
 }


### PR DESCRIPTION
**Goals (and why)**:
Previously, we would create a leadership observer once. We would then for each *client* add a task that would deregister metrics when leadership changed. This involves going through all the metrics and removing any that match. This seems rather redundant as you will likely process all of them when the first client has run the action. All of these events are tied to leader election and effectively the `LeaderElectionService` not the client itself.

Note, this somewhat becomes redundant since each client will likely have their own `LeaderElectionService`. But it removes the logic/complexity from `AsyncTimelockServicesCreator` which shouldn't really concern itself with all of that.

**Implementation Description (bullets)**:
* Get rid of some unused methods, they're not used in big internal product or anywhere else for that matter.
* `ServiceCreator` doesn't create instrumented services, it instruments already created services. So I named it correctly.
* Move most of the logic to `PaxosLeadershipCreator` since it's tied to events emitted by the `LeaderElectionService` as opposed to client creation.

**Testing (What was existing testing like?  What have you done to improve it?)**:
A refactor, with some potential semantics changes, wasn't really tested before, and don't think the test here is meaningful without having the old code checked in.

**Where should we start reviewing?**:
* `PaxosLeadershipCreator`
* `AsyncTimeLockServicesCreator`


**Priority (whenever / two weeks / yesterday)**:
ASAP

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
