### PR TITLE
[Timelock Partitioning] Part 34: Extract `LocalPingableLeader`from the builder

### DIFF
--- a/leader-election-impl/src/main/java/com/palantir/leader/LocalPingableLeader.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/LocalPingableLeader.java
@@ -1,0 +1,54 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.leader;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import com.palantir.paxos.PaxosLearner;
+import com.palantir.paxos.PaxosValue;
+
+public final class LocalPingableLeader implements PingableLeader {
+
+    private final PaxosLearner knowledge;
+    private final UUID localUuid;
+
+    public LocalPingableLeader(PaxosLearner knowledge, UUID localUuid) {
+        this.knowledge = knowledge;
+        this.localUuid = localUuid;
+    }
+
+    @Override
+    public boolean ping() {
+        return getGreatestLearnedPaxosValue()
+                .map(this::isThisNodeTheLeaderFor)
+                .orElse(false);
+    }
+
+    @Override
+    public String getUUID() {
+        return localUuid.toString();
+    }
+
+    private Optional<PaxosValue> getGreatestLearnedPaxosValue() {
+        return Optional.ofNullable(knowledge.getGreatestLearnedValue());
+    }
+
+    private boolean isThisNodeTheLeaderFor(PaxosValue value) {
+        return value.getLeaderUUID().equals(localUuid.toString());
+    }
+}

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionServiceBuilder.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionServiceBuilder.java
@@ -18,7 +18,6 @@ package com.palantir.leader;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
@@ -35,7 +34,6 @@ import com.palantir.paxos.PaxosLatestRoundVerifierImpl;
 import com.palantir.paxos.PaxosLearner;
 import com.palantir.paxos.PaxosLearnerNetworkClient;
 import com.palantir.paxos.PaxosProposer;
-import com.palantir.paxos.PaxosValue;
 import com.palantir.paxos.SingleLeaderAcceptorNetworkClient;
 import com.palantir.paxos.SingleLeaderLearnerNetworkClient;
 import com.palantir.paxos.SingleLeaderPinger;
@@ -172,39 +170,6 @@ public class PaxosLeaderElectionServiceBuilder {
                 leaderPingResponseWait,
                 eventRecorder,
                 UUID.fromString(proposer.getUuid()));
-    }
-
-    private static final class LocalPingableLeader implements PingableLeader {
-
-        private final PaxosLearner knowledge;
-        private final UUID localUuid;
-
-        LocalPingableLeader(
-                PaxosLearner knowledge,
-                UUID localUuid) {
-            this.knowledge = knowledge;
-            this.localUuid = localUuid;
-        }
-
-        @Override
-        public boolean ping() {
-            return getGreatestLearnedPaxosValue()
-                    .map(this::isThisNodeTheLeaderFor)
-                    .orElse(false);
-        }
-
-        @Override
-        public String getUUID() {
-            return localUuid.toString();
-        }
-
-        private Optional<PaxosValue> getGreatestLearnedPaxosValue() {
-            return Optional.ofNullable(knowledge.getGreatestLearnedValue());
-        }
-
-        private boolean isThisNodeTheLeaderFor(PaxosValue value) {
-            return value.getLeaderUUID().equals(localUuid.toString());
-        }
     }
 
     public PaxosLeaderElectionService build() {


### PR DESCRIPTION
**Goals (and why)**:
Want to use this in big internal product, as it breaks up some cyclic dependencies when trying to construct clients.

**Implementation Description (bullets)**:
Just move the implementation outside of `PaxosLeaderElectionServiceBuilder`.

**Testing (What was existing testing like?  What have you done to improve it?)**:


**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
