### PR TITLE
Upgrade jackson to fix flaking MNPTSITest

### DIFF
--- a/changelog/@unreleased/pr-4282.v2.yml
+++ b/changelog/@unreleased/pr-4282.v2.yml
@@ -1,21 +1,5 @@
 type: improvement
 improvement:
-  description: |-
-    Upgrade jackson to fix flaking MNPTSITest
-
-    **Goals (and why)**:
-    Fix annoying flaking test
-
-    **Implementation Description (bullets)**:
-    Seems like we've been hitting the race condition in jackson deserialization https://github.com/FasterXML/jackson-modules-base/issues/49
-
-    **Concerns (what feedback would you like?)**:
-    Any potential problems with the bump?
-
-    **Where should we start reviewing?**:
-    Circle
-
-    **Priority (whenever / two weeks / yesterday)**:
-    ASAP
+  description: Upgraded `com.fasterxml.jackson` from `2.9.7` to `2.9.9`
   links:
   - https://github.com/palantir/atlasdb/pull/4282

--- a/changelog/@unreleased/pr-4282.v2.yml
+++ b/changelog/@unreleased/pr-4282.v2.yml
@@ -1,0 +1,21 @@
+type: improvement
+improvement:
+  description: |-
+    Upgrade jackson to fix flaking MNPTSITest
+
+    **Goals (and why)**:
+    Fix annoying flaking test
+
+    **Implementation Description (bullets)**:
+    Seems like we've been hitting the race condition in jackson deserialization https://github.com/FasterXML/jackson-modules-base/issues/49
+
+    **Concerns (what feedback would you like?)**:
+    Any potential problems with the bump?
+
+    **Where should we start reviewing?**:
+    Circle
+
+    **Priority (whenever / two weeks / yesterday)**:
+    ASAP
+  links:
+  - https://github.com/palantir/atlasdb/pull/4282

--- a/versions.props
+++ b/versions.props
@@ -1,6 +1,6 @@
 ch.qos.logback:* = 1.1.7
 com.ea.agentloader:ea-agent-loader = 1.0.3
-com.fasterxml.jackson.*:* = 2.9.7
+com.fasterxml.jackson.*:* = 2.9.9
 com.fasterxml.jackson.datatype:jackson-datatype-jdk7 = 2.6.7
 com.github.ben-manes.caffeine:caffeine = 2.6.2
 com.github.peterwippermann.junit4:parameterized-suite = 1.1.0


### PR DESCRIPTION
**Goals (and why)**:
Fix annoying flaking test

**Implementation Description (bullets)**:
Seems like we've been hitting the race condition in jackson deserialization https://github.com/FasterXML/jackson-modules-base/issues/49

**Concerns (what feedback would you like?)**:
Any potential problems with the bump?

**Where should we start reviewing?**:
Circle

**Priority (whenever / two weeks / yesterday)**:
ASAP