### PR TITLE
Fix Ec2HostLocationSupplier using a different format to Cassandra

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/Ec2HostLocationSupplier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/Ec2HostLocationSupplier.java
@@ -67,8 +67,9 @@ public final class Ec2HostLocationSupplier implements Supplier<HostLocation> {
 
         // hack for CASSANDRA-4026
         ec2region = az.substring(0, az.length() - 1);
-        if (ec2region.endsWith("1"))
+        if (ec2region.endsWith("1")) {
             ec2region = az.substring(0, az.length() - 3);
+        }
 
         return HostLocation.of(ec2region, ec2zone);
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/Ec2HostLocationSupplier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/Ec2HostLocationSupplier.java
@@ -54,25 +54,19 @@ public final class Ec2HostLocationSupplier implements Supplier<HostLocation> {
     }
 
     @VisibleForTesting
-    static HostLocation parseHostLocation(String az) {
-        // Code is copied from Cassandra's Ec2Snitch. The result of this parsing must match Cassandra's as closely as
-        // possible, as the strings are later matched exactly.
+    static HostLocation parseHostLocation(String responseBody) {
+        // The result of this parsing must match Cassandra's as closely as possible, as the output is later matched.
 
-        String ec2region;
-        String ec2zone;
+        // Split strings such as "us-east-1a" into "us-east" and "1a"
+        String[] splitResponse = responseBody.split("-");
+        String rack = splitResponse[splitResponse.length - 1];
 
-        // Split "us-east-1a" or "asia-1a" into "us-east"/"1a" and "asia"/"1a".
-        String[] splits = az.split("-");
-        ec2zone = splits[splits.length - 1];
-
-        // hack for CASSANDRA-4026
-        ec2region = az.substring(0, az.length() - 1);
-        if (ec2region.endsWith("1")) {
-            ec2region = az.substring(0, az.length() - 3);
+        // this hack accounts for certain Cassandra cases
+        String datacenter = responseBody.substring(0, responseBody.length() - 1);
+        if (datacenter.endsWith("1")) {
+            datacenter = responseBody.substring(0, responseBody.length() - 3);
         }
 
-        return HostLocation.of(ec2region, ec2zone);
-
-
+        return HostLocation.of(datacenter, rack);
     }
 }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostLocationSupplierTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostLocationSupplierTest.java
@@ -81,4 +81,10 @@ public class HostLocationSupplierTest {
         assertThat(hostLocationSupplier.get()).isNotPresent();
     }
 
+    @Test
+    public void shouldReturnHostLocationInCassandraStyle() {
+        HostLocation awsLocation = HostLocation.of("us-east", "1a");
+        assertThat(Ec2HostLocationSupplier.parseHostLocation("us-east-1a")).isEqualTo(awsLocation);
+    }
+
 }

--- a/changelog/@unreleased/pr-4283.v2.yml
+++ b/changelog/@unreleased/pr-4283.v2.yml
@@ -1,0 +1,18 @@
+type: improvement
+improvement:
+  description: |-
+    Fix Ec2HostLocationSupplier using a different format to Cassandra
+
+    **Goals (and why)**:
+    Modify Ec2HostLocationSupplier to emulate Cassandra's Ec2Snitch logic (as it is later comparing against parsed info from that class).
+
+    **Implementation Description (bullets)**:
+    The response string from the AWS endpoint is now parsed using code copied from Cassandra's implementation (or as close as possible)
+
+    **Testing (What was existing testing like?  What have you done to improve it?)**:
+    Added a test to make sure that the parsing gives the expected result
+
+    **Priority (whenever / two weeks / yesterday)**:
+    Today
+  links:
+  - https://github.com/palantir/atlasdb/pull/4283

--- a/changelog/@unreleased/pr-4283.v2.yml
+++ b/changelog/@unreleased/pr-4283.v2.yml
@@ -1,18 +1,8 @@
-type: improvement
-improvement:
-  description: |-
-    Fix Ec2HostLocationSupplier using a different format to Cassandra
-
-    **Goals (and why)**:
-    Modify Ec2HostLocationSupplier to emulate Cassandra's Ec2Snitch logic (as it is later comparing against parsed info from that class).
-
-    **Implementation Description (bullets)**:
-    The response string from the AWS endpoint is now parsed using code copied from Cassandra's implementation (or as close as possible)
-
-    **Testing (What was existing testing like?  What have you done to improve it?)**:
-    Added a test to make sure that the parsing gives the expected result
-
-    **Priority (whenever / two weeks / yesterday)**:
-    Today
+type: fix
+fix:
+  description: Modify Ec2HostLocationSupplier to emulate Cassandra's Ec2Snitch logic.
+    Previously, Ec2HostLocationSupplier may have produced results inconsistent with
+    Cassandra's Ec2Snitch, meaning that our feature to send more traffic to local
+    nodes wouldn't work properly
   links:
   - https://github.com/palantir/atlasdb/pull/4283


### PR DESCRIPTION
**Goals (and why)**:
Modify Ec2HostLocationSupplier to emulate Cassandra's Ec2Snitch logic (as it is later comparing against parsed info from that class).

**Implementation Description (bullets)**:
The response string from the AWS endpoint is now parsed using code copied from Cassandra's implementation (or as close as possible)

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added a test to make sure that the parsing gives the expected result

**Priority (whenever / two weeks / yesterday)**:
Today