### PR TITLE
Remove redundant default annotation in CassandraKeyValueServiceConfig

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -141,11 +141,7 @@ public interface CassandraKeyValueServiceConfig extends KeyValueServiceConfig {
     /**
      * Overrides the behaviour of the host location supplier.
      */
-    @Value.Default
-    default Optional<HostLocation> overrideHostLocation() {
-        return Optional.empty();
-    }
-
+    Optional<HostLocation> overrideHostLocation();
 
     @JsonIgnore
     @Value.Lazy

--- a/changelog/@unreleased/pr-4288.v2.yml
+++ b/changelog/@unreleased/pr-4288.v2.yml
@@ -1,0 +1,8 @@
+type: fix
+fix:
+  description: |-
+    Remove redundant default annotation in CassandraKeyValueServiceConfig
+
+    Small change that removes the redundant default annotation, as the default behaviour of an Optional in the config is to return Optional.empty anyway.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4288

--- a/changelog/@unreleased/pr-4288.v2.yml
+++ b/changelog/@unreleased/pr-4288.v2.yml
@@ -1,8 +1,0 @@
-type: fix
-fix:
-  description: |-
-    Remove redundant default annotation in CassandraKeyValueServiceConfig
-
-    Small change that removes the redundant default annotation, as the default behaviour of an Optional in the config is to return Optional.empty anyway.
-  links:
-  - https://github.com/palantir/atlasdb/pull/4288


### PR DESCRIPTION
Small change that removes the redundant default annotation, as the default behaviour of an Optional in the config is to return Optional.empty anyway.