### PR TITLE
[Conjure Java Runtime] Part 14: Experiment Running Proxy and Data Collection

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/common/proxy/ExperimentRunningProxy.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/proxy/ExperimentRunningProxy.java
@@ -1,0 +1,91 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.common.proxy;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.reflect.AbstractInvocationHandler;
+import com.palantir.exception.NotInitializedException;
+
+public final class ExperimentRunningProxy<T> extends AbstractInvocationHandler {
+    private static final Logger log = LoggerFactory.getLogger(ExperimentRunningProxy.class);
+    private static final Duration REFRESH_INTERVAL = Duration.ofMinutes(10);
+
+    private final T experimentalService;
+    private final T fallbackService;
+    private final BooleanSupplier useExperimental;
+    private final Clock clock;
+
+    private final AtomicReference<Instant> nextPermittedExperiment = new AtomicReference<>(Instant.MIN);
+
+    ExperimentRunningProxy(
+            T experimentalService,
+            T fallbackService,
+            BooleanSupplier useExperimental,
+            Clock clock) {
+        this.experimentalService = experimentalService;
+        this.fallbackService = fallbackService;
+        this.useExperimental = useExperimental;
+        this.clock = clock;
+    }
+
+    public static <T> T newProxyInstance(
+            T experimentalService, T fallbackService, BooleanSupplier useExperimental, Class<T> clazz) {
+        ExperimentRunningProxy<T> service =
+                new ExperimentRunningProxy<>(experimentalService, fallbackService, useExperimental, Clock.systemUTC());
+        return (T) Proxy.newProxyInstance(
+                clazz.getClassLoader(),
+                new Class[] { clazz },
+                service);
+    }
+
+    @Override
+    protected Object handleInvocation(Object proxy, Method method, Object[] args) throws Throwable {
+        boolean runExperiment = useExperimental();
+        Object target = runExperiment ? experimentalService : fallbackService;
+        try {
+            return method.invoke(target, args);
+        } catch (InvocationTargetException e) {
+            if (runExperiment) {
+                markExperimentFailure();
+            }
+            if (e.getTargetException() instanceof NotInitializedException) {
+                log.warn("Resource is not initialized yet!");
+            }
+            throw e.getTargetException();
+        }
+    }
+
+    private boolean useExperimental() {
+        return useExperimental.getAsBoolean() && Instant.now(clock).compareTo(nextPermittedExperiment.get()) > 0;
+    }
+
+    private void markExperimentFailure() {
+        nextPermittedExperiment.accumulateAndGet(Instant.now(clock).plus(REFRESH_INTERVAL),
+                (existing, current) -> existing.compareTo(current) > 0 ? existing : current);
+    }
+}

--- a/atlasdb-commons/src/main/java/com/palantir/common/proxy/ExperimentRunningProxy.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/proxy/ExperimentRunningProxy.java
@@ -35,7 +35,7 @@ import com.palantir.logsafe.SafeArg;
 
 public final class ExperimentRunningProxy<T> extends AbstractInvocationHandler {
     private static final Logger log = LoggerFactory.getLogger(ExperimentRunningProxy.class);
-    private static final Duration REFRESH_INTERVAL = Duration.ofMinutes(10);
+    static final Duration REFRESH_INTERVAL = Duration.ofMinutes(10);
 
     private final T experimentalService;
     private final T fallbackService;
@@ -90,7 +90,7 @@ public final class ExperimentRunningProxy<T> extends AbstractInvocationHandler {
     private void markExperimentFailure(Exception exception) {
         nextPermittedExperiment.accumulateAndGet(Instant.now(clock).plus(REFRESH_INTERVAL),
                 (existing, current) -> existing.compareTo(current) > 0 ? existing : current);
-        log.info("Experiment failed; we will revert to the fallback service. We will allow attempting to use"
-                + " the experimental service again in {}.", SafeArg.of("retryDuration", REFRESH_INTERVAL), exception);
+        log.info("Experiment failed; we will revert to the fallback service. We will allow attempting to use the"
+                + " experimental service again after a timeout.", SafeArg.of("timeout", REFRESH_INTERVAL), exception);
     }
 }

--- a/atlasdb-commons/src/main/java/com/palantir/common/proxy/ExperimentRunningProxy.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/proxy/ExperimentRunningProxy.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.reflect.AbstractInvocationHandler;
 import com.palantir.exception.NotInitializedException;
+import com.palantir.logsafe.SafeArg;
 
 public final class ExperimentRunningProxy<T> extends AbstractInvocationHandler {
     private static final Logger log = LoggerFactory.getLogger(ExperimentRunningProxy.class);
@@ -73,6 +74,10 @@ public final class ExperimentRunningProxy<T> extends AbstractInvocationHandler {
             return method.invoke(target, args);
         } catch (InvocationTargetException e) {
             if (runExperiment) {
+                log.info("Experiment failed; we will revert to the fallback service. We will allow attempting to"
+                                + " use the experimental service again in {} milliseconds.",
+                        SafeArg.of("retryDurationMillis", REFRESH_INTERVAL.toMillis()),
+                        e);
                 markExperimentFailure();
             }
             if (e.getTargetException() instanceof NotInitializedException) {

--- a/atlasdb-commons/src/main/java/com/palantir/common/proxy/ExperimentRunningProxy.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/proxy/ExperimentRunningProxy.java
@@ -28,6 +28,7 @@ import java.util.function.BooleanSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.reflect.AbstractInvocationHandler;
 import com.palantir.exception.NotInitializedException;
 
@@ -42,6 +43,7 @@ public final class ExperimentRunningProxy<T> extends AbstractInvocationHandler {
 
     private final AtomicReference<Instant> nextPermittedExperiment = new AtomicReference<>(Instant.MIN);
 
+    @VisibleForTesting
     ExperimentRunningProxy(
             T experimentalService,
             T fallbackService,

--- a/atlasdb-commons/src/test/java/com/palantir/common/proxy/ExperimentRunningProxyTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/common/proxy/ExperimentRunningProxyTest.java
@@ -1,0 +1,91 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.common.proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Proxy;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.function.BooleanSupplier;
+import java.util.function.IntSupplier;
+
+import org.junit.Test;
+
+public class ExperimentRunningProxyTest {
+    private static final int EXPERIMENTAL_INT = 123;
+    private static final int FALLBACK_INT = 1;
+    private static final RuntimeException RUNTIME_EXCEPTION = new RuntimeException("foo");
+
+    private final IntSupplier experimentalIntSupplier = mock(IntSupplier.class);
+    private final IntSupplier fallbackIntSupplier = mock(IntSupplier.class);
+    private final BooleanSupplier useExperimental = mock(BooleanSupplier.class);
+    private final Clock clock = mock(Clock.class);
+    private final ExperimentRunningProxy<IntSupplier> proxy = new ExperimentRunningProxy<>(
+            experimentalIntSupplier, fallbackIntSupplier, useExperimental, clock);
+    private final IntSupplier experimentSupplier = (IntSupplier) Proxy.newProxyInstance(
+            IntSupplier.class.getClassLoader(),
+            new Class[] { IntSupplier.class },
+            proxy);
+
+    @Test
+    public void doesNotAttemptExperimentIfNotRequested() {
+        when(fallbackIntSupplier.getAsInt()).thenReturn(FALLBACK_INT);
+        when(useExperimental.getAsBoolean()).thenReturn(false);
+
+        assertThat(experimentSupplier.getAsInt()).isEqualTo(FALLBACK_INT);
+    }
+
+    @Test
+    public void attemptsExperimentIfRequested() {
+        when(experimentalIntSupplier.getAsInt()).thenReturn(EXPERIMENTAL_INT);
+        when(useExperimental.getAsBoolean()).thenReturn(true);
+        when(clock.instant()).thenReturn(Instant.ofEpochSecond(0));
+
+        assertThat(experimentSupplier.getAsInt()).isEqualTo(EXPERIMENTAL_INT);
+    }
+
+    @Test
+    public void canFallBackIfExperimentFails() {
+        when(experimentalIntSupplier.getAsInt()).thenThrow(RUNTIME_EXCEPTION);
+        when(fallbackIntSupplier.getAsInt()).thenReturn(FALLBACK_INT);
+        when(useExperimental.getAsBoolean()).thenReturn(true);
+        when(clock.instant()).thenReturn(Instant.ofEpochSecond(0));
+
+        assertThatThrownBy(experimentSupplier::getAsInt).isEqualTo(RUNTIME_EXCEPTION);
+        assertThat(experimentSupplier.getAsInt()).isEqualTo(FALLBACK_INT);
+    }
+
+    @Test
+    public void attemptsExperimentAgainAfterEnoughTimeHasElapsed() {
+        when(experimentalIntSupplier.getAsInt())
+                .thenThrow(RUNTIME_EXCEPTION)
+                .thenReturn(EXPERIMENTAL_INT);
+        when(fallbackIntSupplier.getAsInt()).thenReturn(FALLBACK_INT);
+        when(useExperimental.getAsBoolean()).thenReturn(true);
+        when(clock.instant()).thenReturn(Instant.ofEpochSecond(0));
+
+        assertThatThrownBy(experimentSupplier::getAsInt).isEqualTo(RUNTIME_EXCEPTION);
+        assertThat(experimentSupplier.getAsInt()).isEqualTo(FALLBACK_INT);
+
+        when(clock.instant()).thenReturn(Instant.ofEpochSecond(1_000));
+        assertThat(experimentSupplier.getAsInt()).isEqualTo(EXPERIMENTAL_INT);
+    }
+}

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/VersionSelectingClients.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/VersionSelectingClients.java
@@ -22,7 +22,7 @@ import java.util.function.DoubleSupplier;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
-import com.palantir.common.proxy.PredicateSwitchedProxy;
+import com.palantir.common.proxy.ExperimentRunningProxy;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 
 /**
@@ -49,7 +49,7 @@ final class VersionSelectingClients {
         T instrumentedLegacyClient = instrumentWithClientVersionTag(
                 taggedMetricRegistry, legacyClient, clazz);
 
-        return PredicateSwitchedProxy.newProxyInstance(
+        return ExperimentRunningProxy.newProxyInstance(
                 instrumentedNewClient,
                 instrumentedLegacyClient,
                 () -> ThreadLocalRandom.current().nextDouble() < newClientProbabilitySupplier.getAsDouble(),

--- a/atlasdb-feign/src/main/java/com/palantir/atlasdb/config/RemotingClientConfig.java
+++ b/atlasdb-feign/src/main/java/com/palantir/atlasdb/config/RemotingClientConfig.java
@@ -31,7 +31,7 @@ public interface RemotingClientConfig {
 
     @Value.Default
     default double maximumConjureRemotingProbability() {
-        return 0.0;
+        return 0.01;
     }
 
     @Value.Check

--- a/atlasdb-feign/src/main/java/com/palantir/atlasdb/config/RemotingClientConfig.java
+++ b/atlasdb-feign/src/main/java/com/palantir/atlasdb/config/RemotingClientConfig.java
@@ -31,7 +31,7 @@ public interface RemotingClientConfig {
 
     @Value.Default
     default double maximumConjureRemotingProbability() {
-        return 0.01;
+        return 0.0;
     }
 
     @Value.Check


### PR DESCRIPTION
**Goals (and why)**:
- Allow users to enable conjure java runtime while still having a safeguard against failures/gross misconfiguration. 

**Implementation Description (bullets)**:
- Users can set the conjure java runtime probability above 0; in the event of a failure, we knock the probability down to 0, so we only use Feign.
- We can attempt 10 minutes later to make a request via CJR again (probability reverts to its above-0 value).
- Note that we probably *don't* want people to actually run experiments just yet - we need to declare a product dependency on suitable versions of timelock-server before we can be sure that the values are meaningful. It won't explode in that CJR clients will behave correctly (if inefficiently) with legacy servers, but the perf numbers won't be representative.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Added tests for the new class.

**Concerns (what feedback would you like?)**:
- Is setting the default maximum CJR probability to 1% right off the bat too aggressive? If this causes problems we can quickly mitigate the damage by setting the config explicitly to zero.
- Are there possible unexpected race conditions inside the proxy?
- Should I have implemented a slow ramp-up to the user's specified max probability? I think that is more work than is necessary.

**Where should we start reviewing?**: ExperimentRunningProxy.java

**Priority (whenever / two weeks / yesterday)**: this week please
