### PR TITLE
Route 25% of queries to the same AZ for all services that use AtlasDB

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -132,12 +132,12 @@ public interface CassandraKeyValueServiceConfig extends KeyValueServiceConfig {
     }
 
     /**
-     * This increases the likelihood of selecting an instance that is hosted in the same data centre as the process.
-     * Weighting is a ratio from 0 to 1, where 0 disables the feature and 1 forces the same data centre if possible.
+     * This increases the likelihood of selecting an instance that is hosted in the same rack as the process.
+     * Weighting is a ratio from 0 to 1, where 0 disables the feature and 1 forces the same rack if possible.
      */
     @Value.Default
     default double localHostWeighting() {
-        return 0.0;
+        return 0.25;
     }
 
     /**

--- a/changelog/@unreleased/pr-4296.v2.yml
+++ b/changelog/@unreleased/pr-4296.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: |-
+    Update value in CKVSC
+
+    Increase the local host routing probability from 0 to 25% for all services that use AtlasDB. Also correct specific term in the docs for localHostWeighting.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4296


### PR DESCRIPTION
Increase the local host routing probability from 0 to 25% for all services that use AtlasDB. Also correct specific term in the docs for localHostWeighting.
