### PR TITLE
[Timelock Partitioning] Part 35: Learn should not be a quorum call

### DIFF
--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchingNetworkClientFactories.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchingNetworkClientFactories.java
@@ -43,13 +43,12 @@ abstract class BatchingNetworkClientFactories {
         AutobatchingPaxosAcceptorNetworkClientFactory acceptorFactory =
                 AutobatchingPaxosAcceptorNetworkClientFactory.create(allBatchAcceptors, sharedExecutor(), quorumSize());
 
-        List<BatchPaxosLearner> allBatchLearners = metrics()
+        LocalAndRemotes<BatchPaxosLearner> allBatchLearners = metrics()
                 .instrumentLocalAndRemotesFor(
                         BatchPaxosLearner.class,
                         components().batchLearner(),
                         UseCaseAwareBatchPaxosLearnerAdapter.wrap(useCase(), remoteClients().batchLearner()),
-                        "batch-paxos-learner")
-                .all();
+                        "batch-paxos-learner");
 
         AutobatchingPaxosLearnerNetworkClientFactory learnerFactory =
                 AutobatchingPaxosLearnerNetworkClientFactory.create(allBatchLearners, sharedExecutor(), quorumSize());

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
@@ -180,7 +180,6 @@ public class PaxosTimestampBoundStoreTest {
     public void tearDown() throws InterruptedException {
         if (learnerNetworkClientFactories != null) {
             for (AutobatchingPaxosLearnerNetworkClientFactory learnerFactory : learnerNetworkClientFactories) {
-
                 try {
                     learnerFactory.close();
                 } catch (Exception e) {


### PR DESCRIPTION
**Goals (and why)**:
In my haste, I made the batching version of the `PaxosLearnerNetworkClient` treat the `learn` call as a quorum call. This is why we were seeing flakes because we would propose something and then we won't necessarily see it, thus getting null pointers. This is likely to be the case because we would try to learn, but to the "remote" learners, and achieve quorum that way, but then give up on our local knowledge.

**Implementation Description (bullets)**:
Has a near identical implementation to `SingleLeaderLearnerNetworkClient` just that it uses the `BatchPaxosLearner` instead.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Amended the tests to make sure we're broadcasting the value to everyone despite potential for failures.

**Concerns (what feedback would you like?)**:
This also somewhat exposes weirdness in the api which should be addressed by CJR that the `getLearnedValue` call returns a `@Nullable PaxosValue` and effectively we've assumed that we'd always read our own proposals (which is fine), but when we change this to `Optional` how are we supposed to interpret that? As we'd *have* to handle the empty case.

Would it just be that we're not the leader i.e. we've tried to propose, and instead we got back a different value for the same sequence number that we weren't aware of?

**Where should we start reviewing?**:
`LearnCoalescingConsumer`

**Priority (whenever / two weeks / yesterday)**:
ASAP if you want your flakes to go away 😛 
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
