### PR TITLE
Async get on transactions

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
@@ -70,6 +70,17 @@ public interface Transaction {
     Map<Cell, byte[]> get(TableReference tableRef, Set<Cell> cells);
 
     /**
+     * Gets the values associated for each {@code cells} from table specified by {@code tableRef}. It is not guaranteed
+     * that the actual implementations are in fact asynchronous.
+     *
+     * @param tableRef the table from which to get the values
+     * @param cells the cells for which we want to get the values
+     * @return a {@link Map} from {@link Cell} to {@code byte[]} representing cell/value pairs
+     */
+    @Idempotent
+    ListenableFuture<Map<Cell, byte[]>> getAsync(TableReference tableRef, Set<Cell> cells);
+
+    /**
      * Creates a visitable that scans the provided range.
      *
      * @param tableRef the table to scan
@@ -239,7 +250,4 @@ public interface Transaction {
     default void disableReadWriteConflictChecking(TableReference tableRef) {
         throw new UnsupportedOperationException();
     }
-
-    @Idempotent
-    ListenableFuture<Map<Cell, byte[]>> getAsync(TableReference tableRef, Set<Cell> cells);
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
@@ -22,6 +22,7 @@ import java.util.SortedMap;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
@@ -238,4 +239,7 @@ public interface Transaction {
     default void disableReadWriteConflictChecking(TableReference tableRef) {
         throw new UnsupportedOperationException();
     }
+
+    @Idempotent
+    ListenableFuture<Map<Cell, byte[]>> getAsync(TableReference tableRef, Set<Cell> cells);
 }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTransactionIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTransactionIntegrationTest.java
@@ -21,8 +21,8 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
@@ -62,8 +62,8 @@ public class CassandraKeyValueServiceTransactionIntegrationTest extends Abstract
     @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> data() {
         Object[][] data = new Object[][] {
-                {SYNC, (Function<Transaction, Transaction>) GetSynchronousDelegate::new},
-                {ASYNC, (Function<Transaction, Transaction>) GetAsyncDelegate::new}
+                {SYNC, (UnaryOperator<Transaction>) GetSynchronousDelegate::new},
+                {ASYNC, (UnaryOperator<Transaction>) GetAsyncDelegate::new}
         };
         return Arrays.asList(data);
     }
@@ -78,11 +78,11 @@ public class CassandraKeyValueServiceTransactionIntegrationTest extends Abstract
     @Rule
     public final TestRule flakeRetryingRule = new FlakeRetryingRule();
     private final String name;
-    private final Function<Transaction, Transaction> transactionWrapper;
+    private final UnaryOperator<Transaction> transactionWrapper;
 
     public CassandraKeyValueServiceTransactionIntegrationTest(
             String name,
-            Function<Transaction, Transaction> transactionWrapper) {
+            UnaryOperator<Transaction> transactionWrapper) {
         super(CASSANDRA, CASSANDRA);
         this.name = name;
         this.transactionWrapper = transactionWrapper;

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTransactionIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTransactionIntegrationTest.java
@@ -15,10 +15,15 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
@@ -28,13 +33,19 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import com.google.common.base.Suppliers;
 import com.google.common.util.concurrent.Futures;
 import com.palantir.atlasdb.containers.CassandraResource;
+import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.impl.AbstractTransactionTest;
+import com.palantir.atlasdb.transaction.impl.ForwardingTransaction;
 import com.palantir.atlasdb.transaction.impl.TransactionTables;
 import com.palantir.atlasdb.transaction.service.SimpleTransactionService;
 import com.palantir.atlasdb.transaction.service.TransactionService;
@@ -44,9 +55,21 @@ import com.palantir.flake.ShouldRetry;
 import com.palantir.timestamp.TimestampManagementService;
 
 @ShouldRetry // The first test can fail with a TException: No host tried was able to create the keyspace requested.
+@RunWith(Parameterized.class)
 public class CassandraKeyValueServiceTransactionIntegrationTest extends AbstractTransactionTest {
+    private static final String SYNC = "sync";
+    private static final String ASYNC = "async";
     private static final Supplier<KeyValueService> KVS_SUPPLIER =
             Suppliers.memoize(CassandraKeyValueServiceTransactionIntegrationTest::createAndRegisterKeyValueService);
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> data() {
+        Object[][] data = new Object[][] {
+                {SYNC, (Function<Transaction, Transaction>) SynchronousDelegate::new},
+                {ASYNC, (Function<Transaction, Transaction>) AsyncDelegate::new}
+        };
+        return Arrays.asList(data);
+    }
 
     @ClassRule
     public static final CassandraResource CASSANDRA = new CassandraResource(KVS_SUPPLIER);
@@ -57,9 +80,15 @@ public class CassandraKeyValueServiceTransactionIntegrationTest extends Abstract
 
     @Rule
     public final TestRule flakeRetryingRule = new FlakeRetryingRule();
+    private final String name;
+    private final Function<Transaction, Transaction> transactionWrapper;
 
-    public CassandraKeyValueServiceTransactionIntegrationTest() {
+    public CassandraKeyValueServiceTransactionIntegrationTest(
+            String name,
+            Function<Transaction, Transaction> transactionWrapper) {
         super(CASSANDRA, CASSANDRA);
+        this.name = name;
+        this.transactionWrapper = transactionWrapper;
     }
 
     @Before
@@ -106,4 +135,48 @@ public class CassandraKeyValueServiceTransactionIntegrationTest extends Abstract
         return false;
     }
 
+    @Override
+    protected Transaction startTransaction() {
+        return transactionWrapper.apply(super.startTransaction());
+    }
+
+    private static class SynchronousDelegate extends ForwardingTransaction {
+        private final Transaction delegate;
+
+        SynchronousDelegate(Transaction transaction) {
+            this.delegate = transaction;
+        }
+
+        @Override
+        public Transaction delegate() {
+            return delegate;
+        }
+
+        @Override
+        public Map<Cell, byte[]> get(TableReference tableRef, Set<Cell> cells) {
+            return delegate.get(tableRef, cells);
+        }
+    }
+
+    private static class AsyncDelegate extends ForwardingTransaction {
+        private final Transaction delegate;
+
+        AsyncDelegate(Transaction transaction) {
+            this.delegate = transaction;
+        }
+
+        @Override
+        public Transaction delegate() {
+            return delegate;
+        }
+
+        @Override
+        public Map<Cell, byte[]> get(TableReference tableRef, Set<Cell> cells) {
+            try {
+                return delegate.getAsync(tableRef, cells).get();
+            } catch (Exception e) {
+                throw new RuntimeException(e.getCause());
+            }
+        }
+    }
 }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTransactionIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTransactionIntegrationTest.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -174,8 +175,8 @@ public class CassandraKeyValueServiceTransactionIntegrationTest extends Abstract
         public Map<Cell, byte[]> get(TableReference tableRef, Set<Cell> cells) {
             try {
                 return delegate.getAsync(tableRef, cells).get();
-            } catch (Exception e) {
-                throw new RuntimeException(e.getCause());
+            } catch (InterruptedException | ExecutionException e) {
+                throw com.palantir.common.base.Throwables.rewrapAndThrowUncheckedException(e.getCause());
             }
         }
     }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsSerializableTransactionTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsSerializableTransactionTest.java
@@ -43,46 +43,6 @@ public class CassandraKvsSerializableTransactionTest extends AbstractSerializabl
     @ClassRule
     public static final CassandraResource CASSANDRA = new CassandraResource();
 
-    private static class SynchronousDelegate extends ForwardingTransaction {
-        private final Transaction delegate;
-
-        SynchronousDelegate(Transaction transaction) {
-            this.delegate = transaction;
-        }
-
-        @Override
-        public Transaction delegate() {
-            return delegate;
-        }
-
-        @Override
-        public Map<Cell, byte[]> get(TableReference tableRef, Set<Cell> cells) {
-            return delegate.get(tableRef, cells);
-        }
-    }
-
-    private static class AsyncDelegate extends ForwardingTransaction {
-        private final Transaction delegate;
-
-        AsyncDelegate(Transaction transaction) {
-            this.delegate = transaction;
-        }
-
-        @Override
-        public Transaction delegate() {
-            return delegate;
-        }
-
-        @Override
-        public Map<Cell, byte[]> get(TableReference tableRef, Set<Cell> cells) {
-            try {
-                return delegate.getAsync(tableRef, cells).get();
-            } catch (Exception e) {
-                throw new RuntimeException(e.getCause());
-            }
-        }
-    }
-
     @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> data() {
         Object[][] data = new Object[][] {
@@ -126,4 +86,43 @@ public class CassandraKvsSerializableTransactionTest extends AbstractSerializabl
         return false;
     }
 
+    private static class SynchronousDelegate extends ForwardingTransaction {
+        private final Transaction delegate;
+
+        SynchronousDelegate(Transaction transaction) {
+            this.delegate = transaction;
+        }
+
+        @Override
+        public Transaction delegate() {
+            return delegate;
+        }
+
+        @Override
+        public Map<Cell, byte[]> get(TableReference tableRef, Set<Cell> cells) {
+            return delegate.get(tableRef, cells);
+        }
+    }
+
+    private static class AsyncDelegate extends ForwardingTransaction {
+        private final Transaction delegate;
+
+        AsyncDelegate(Transaction transaction) {
+            this.delegate = transaction;
+        }
+
+        @Override
+        public Transaction delegate() {
+            return delegate;
+        }
+
+        @Override
+        public Map<Cell, byte[]> get(TableReference tableRef, Set<Cell> cells) {
+            try {
+                return delegate.getAsync(tableRef, cells).get();
+            } catch (Exception e) {
+                throw new RuntimeException(e.getCause());
+            }
+        }
+    }
 }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsSerializableTransactionTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsSerializableTransactionTest.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 
 import org.junit.ClassRule;
@@ -120,8 +121,8 @@ public class CassandraKvsSerializableTransactionTest extends AbstractSerializabl
         public Map<Cell, byte[]> get(TableReference tableRef, Set<Cell> cells) {
             try {
                 return delegate.getAsync(tableRef, cells).get();
-            } catch (Exception e) {
-                throw new RuntimeException(e.getCause());
+            } catch (InterruptedException | ExecutionException e) {
+                throw com.palantir.common.base.Throwables.rewrapAndThrowUncheckedException(e.getCause());
             }
         }
     }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsSerializableTransactionTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsSerializableTransactionTest.java
@@ -19,7 +19,7 @@ import static org.mockito.Mockito.mock;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
@@ -39,21 +39,23 @@ import com.palantir.atlasdb.transaction.impl.GetSynchronousDelegate;
 public class CassandraKvsSerializableTransactionTest extends AbstractSerializableTransactionTest {
     @ClassRule
     public static final CassandraResource CASSANDRA = new CassandraResource();
+    private static final String SYNC = "sync";
+    private static final String ASYNC = "async";
 
     @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> data() {
         Object[][] data = new Object[][] {
-                {"sync", (Function<Transaction, Transaction>) GetSynchronousDelegate::new},
-                {"async", (Function<Transaction, Transaction>) GetAsyncDelegate::new}
+                {SYNC, (UnaryOperator<Transaction>) GetSynchronousDelegate::new},
+                {ASYNC, (UnaryOperator<Transaction>) GetAsyncDelegate::new}
         };
         return Arrays.asList(data);
     }
 
-    private final Function<Transaction, Transaction> transactionWrapper;
+    private final UnaryOperator<Transaction> transactionWrapper;
 
     public CassandraKvsSerializableTransactionTest(
             String name,
-            Function<Transaction, Transaction> transactionWrapper) {
+            UnaryOperator<Transaction> transactionWrapper) {
         super(CASSANDRA, CASSANDRA);
         this.transactionWrapper = transactionWrapper;
     }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/ThrowingCqlClientImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/ThrowingCqlClientImpl.java
@@ -34,9 +34,4 @@ public final class ThrowingCqlClientImpl implements CqlClient {
     public <V> ListenableFuture<V> executeQuery(CqlQuerySpec<V> querySpec) {
         throw new UnsupportedOperationException("Not configured to use CQL client, check your KVS config file.");
     }
-
-    @Override
-    public <R> ListenableFuture<R> execute(Executable<R> executable) {
-        throw new UnsupportedOperationException("Not configured to use CQL client, check your KVS config file.");
-    }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/ThrowingCqlClientImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/ThrowingCqlClientImpl.java
@@ -34,4 +34,9 @@ public final class ThrowingCqlClientImpl implements CqlClient {
     public <V> ListenableFuture<V> executeQuery(CqlQuerySpec<V> querySpec) {
         throw new UnsupportedOperationException("Not configured to use CQL client, check your KVS config file.");
     }
+
+    @Override
+    public <R> ListenableFuture<R> execute(Executable<R> executable) {
+        throw new UnsupportedOperationException("Not configured to use CQL client, check your KVS config file.");
+    }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/logging/KvsProfilingLogger.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/logging/KvsProfilingLogger.java
@@ -23,7 +23,6 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
-import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -158,7 +157,7 @@ public class KvsProfilingLogger {
                     slowLogPredicate);
             Futures.addCallback(future, new FutureCallback<T>() {
                 @Override
-                public void onSuccess(@NullableDecl T result) {
+                public void onSuccess(T result) {
                     monitor.registerResult(result);
                     monitor.log();
                 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/logging/KvsProfilingLogger.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/logging/KvsProfilingLogger.java
@@ -23,6 +23,8 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+import javax.annotation.Nullable;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -157,7 +159,7 @@ public class KvsProfilingLogger {
                     slowLogPredicate);
             Futures.addCallback(future, new FutureCallback<T>() {
                 @Override
-                public void onSuccess(T result) {
+                public void onSuccess(@Nullable T result) {
                     monitor.registerResult(result);
                     monitor.log();
                 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/CachingTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/CachingTransaction.java
@@ -119,7 +119,7 @@ public class CachingTransaction extends ForwardingTransaction {
     @Override
     public Map<Cell, byte[]> get(TableReference tableRef, Set<Cell> cells) {
         try {
-            return get(
+            return getWithLoader(
                     tableRef,
                     cells,
                     (tableReference, toRead) -> Futures.immediateFuture(super.get(tableReference, toRead))).get();
@@ -130,10 +130,13 @@ public class CachingTransaction extends ForwardingTransaction {
 
     @Override
     public ListenableFuture<Map<Cell, byte[]>> getAsync(TableReference tableRef, Set<Cell> cells) {
-        return get(tableRef, cells, (super::getAsync));
+        return getWithLoader(tableRef, cells, super::getAsync);
     }
 
-    private ListenableFuture<Map<Cell, byte[]>> get(TableReference tableRef, Set<Cell> cells, CellLoader cellLoader) {
+    private ListenableFuture<Map<Cell, byte[]>> getWithLoader(
+            TableReference tableRef,
+            Set<Cell> cells,
+            CellLoader cellLoader) {
         if (cells.isEmpty()) {
             return Futures.immediateFuture(ImmutableMap.of());
         }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransaction.java
@@ -24,6 +24,7 @@ import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
 import com.google.common.collect.ForwardingObject;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
@@ -174,5 +175,10 @@ public abstract class ForwardingTransaction extends ForwardingObject implements 
     @Override
     public void disableReadWriteConflictChecking(TableReference tableRef) {
         delegate().disableReadWriteConflictChecking(tableRef);
+    }
+
+    @Override
+    public ListenableFuture<Map<Cell, byte[]>> getAsync(TableReference tableRef, Set<Cell> cells) {
+        return delegate().getAsync(tableRef, cells);
     }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/NoDuplicateWritesTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/NoDuplicateWritesTransaction.java
@@ -50,7 +50,7 @@ public class NoDuplicateWritesTransaction extends ForwardingTransaction {
             new CacheLoader<TableReference, Map<Cell, byte[]>>() {
                 @Override
                 public Map<Cell, byte[]> load(TableReference input) {
-                    return Collections.synchronizedMap(Maps.<Cell, byte[]>newHashMap());
+                    return Collections.synchronizedMap(Maps.newHashMap());
                 }
             });
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ReadTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ReadTransaction.java
@@ -148,5 +148,4 @@ public class ReadTransaction extends ForwardingTransaction {
         checkTableName(tableRef);
         return delegate().getAsync(tableRef, cells);
     }
-
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ReadTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ReadTransaction.java
@@ -22,6 +22,7 @@ import java.util.SortedMap;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
@@ -140,6 +141,12 @@ public class ReadTransaction extends ForwardingTransaction {
     @Override
     public void delete(TableReference tableRef, Set<Cell> keys) {
         throw new SafeIllegalArgumentException("This is a read only transaction.");
+    }
+
+    @Override
+    public ListenableFuture<Map<Cell, byte[]>> getAsync(TableReference tableRef, Set<Cell> cells) {
+        checkTableName(tableRef);
+        return delegate().getAsync(tableRef, cells);
     }
 
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -277,6 +277,16 @@ public class SerializableTransaction extends SnapshotTransaction {
     }
 
     @Override
+    public ListenableFuture<Map<Cell, byte[]>> getAsync(TableReference tableRef, Set<Cell> cells) {
+        return Futures.transform(super.getAsync(tableRef, cells),
+                ret -> {
+                    markCellsRead(tableRef, cells, ret);
+                    return ret;
+                },
+                MoreExecutors.directExecutor());
+    }
+
+    @Override
     @Idempotent
     public BatchingVisitable<RowResult<byte[]>> getRange(TableReference tableRef, RangeRequest rangeRequest) {
         final BatchingVisitable<RowResult<byte[]>> ret = super.getRange(tableRef, rangeRequest);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -1036,7 +1036,8 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             TableReference tableRef,
             Iterator<Map.Entry<Cell, byte[]>> mergeIterators) {
         List<Map.Entry<Cell, byte[]>> mergedWritesWithoutEmptyValues = new ArrayList<>();
-        Predicate<Map.Entry<Cell, byte[]>> nonEmptyValuePredicate = Predicates.compose(Predicates.not(Value::isTombstone),
+        Predicate<Map.Entry<Cell, byte[]>> nonEmptyValuePredicate = Predicates.compose(
+                Predicates.not(Value::isTombstone),
                 MapEntries.getValueFunction());
         long numEmptyValues = 0;
         while (mergeIterators.hasNext()) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -583,9 +583,10 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     }
 
     @Override
+    @Idempotent
     public Map<Cell, byte[]> get(TableReference tableRef, Set<Cell> cells) {
         try {
-            return get(
+            return getWithLoader(
                     "get",
                     tableRef,
                     cells,
@@ -599,10 +600,10 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     @Override
     @Idempotent
     public ListenableFuture<Map<Cell, byte[]>> getAsync(TableReference tableRef, Set<Cell> cells) {
-        return get("getAsync", tableRef, cells, keyValueService::getAsync);
+        return getWithLoader("getAsync", tableRef, cells, keyValueService::getAsync);
     }
 
-    private ListenableFuture<Map<Cell, byte[]>> get(
+    private ListenableFuture<Map<Cell, byte[]>> getWithLoader(
             String operationName,
             TableReference tableRef,
             Set<Cell> cells,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -686,23 +686,6 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         ListenableFuture<Map<Cell, Value>> load(TableReference tableReference, Map<Cell, Long> toRead);
     }
 
-    /**
-     * This will load the given keys from the underlying key value service and apply postFiltering
-     * so we have snapshot isolation.  If the value in the key value service is the empty array
-     * this will be included here and needs to be filtered out.
-     */
-    private ListenableFuture<Map<Cell, byte[]>> getFromKeyValueServiceAsync(TableReference tableRef, Set<Cell> cells) {
-        ImmutableMap.Builder<Cell, byte[]> result = ImmutableMap.builderWithExpectedSize(cells.size());
-        Map<Cell, Long> toRead = Cells.constantValueMap(cells, getStartTimestamp());
-        return Futures.transform(
-                keyValueService.getAsync(tableRef, toRead),
-                rawResults -> {
-                    getWithPostFiltering(tableRef, rawResults, result, Value.GET_VALUE);
-                    return result.build();
-                },
-                MoreExecutors.directExecutor());
-    }
-
     private static byte[] getNextStartRowName(
             RangeRequest range,
             TokenBackedBasicResultsPage<RowResult<Value>, byte[]> prePostFilter) {

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/GetAsyncDelegate.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/GetAsyncDelegate.java
@@ -42,7 +42,9 @@ public class GetAsyncDelegate extends ForwardingTransaction {
     public Map<Cell, byte[]> get(TableReference tableRef, Set<Cell> cells) {
         try {
             return super.getAsync(tableRef, cells).get();
-        } catch (InterruptedException | ExecutionException e) {
+        } catch (InterruptedException e) {
+            throw Throwables.rewrapAndThrowUncheckedException(e);
+        } catch (ExecutionException e) {
             throw Throwables.rewrapAndThrowUncheckedException(e.getCause());
         }
     }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/GetAsyncDelegate.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/GetAsyncDelegate.java
@@ -1,0 +1,49 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.common.base.Throwables;
+
+public class GetAsyncDelegate extends ForwardingTransaction {
+
+    private final Transaction delegate;
+
+    public GetAsyncDelegate(Transaction transaction) {
+        this.delegate = transaction;
+    }
+
+    @Override
+    public Transaction delegate() {
+        return delegate;
+    }
+
+    @Override
+    public Map<Cell, byte[]> get(TableReference tableRef, Set<Cell> cells) {
+        try {
+            return super.getAsync(tableRef, cells).get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw Throwables.rewrapAndThrowUncheckedException(e.getCause());
+        }
+    }
+}

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/GetSynchronousDelegate.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/GetSynchronousDelegate.java
@@ -1,0 +1,43 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl;
+
+import java.util.Map;
+import java.util.Set;
+
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.transaction.api.Transaction;
+
+public class GetSynchronousDelegate extends ForwardingTransaction {
+
+    private final Transaction delegate;
+
+    public GetSynchronousDelegate(Transaction delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Transaction delegate() {
+        return delegate;
+    }
+
+    @Override
+    public Map<Cell, byte[]> get(TableReference tableRef, Set<Cell> cells) {
+        return super.get(tableRef, cells);
+    }
+}

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManager.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManager.java
@@ -24,4 +24,5 @@ public interface TestTransactionManager extends TransactionManager {
     Transaction commitAndStartNewTransaction(Transaction txn);
     Transaction createNewTransaction();
     void overrideConflictHandlerForTable(TableReference table, ConflictHandler conflictHandler);
+    void setUnreadableTimestamp(long timestamp);
 }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -166,6 +166,7 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
         return unreadableTs.orElseGet(super::getUnreadableTimestamp);
     }
 
+    @Override
     public void setUnreadableTimestamp(long timestamp) {
         unreadableTs = Optional.of(timestamp);
     }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/WrappingTestTransactionManager.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/WrappingTestTransactionManager.java
@@ -42,4 +42,9 @@ public abstract class WrappingTestTransactionManager extends WrappingTransaction
     public void overrideConflictHandlerForTable(TableReference table, ConflictHandler conflictHandler) {
         delegate.overrideConflictHandlerForTable(table, conflictHandler);
     }
+
+    @Override
+    public void setUnreadableTimestamp(long timestamp) {
+        delegate.setUnreadableTimestamp(timestamp);
+    }
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
@@ -91,8 +91,8 @@ public class AtlasDbTestCase {
                 () -> txManager.getUnreadableTimestamp(), () -> txManager.getImmutableTimestamp());
     }
 
-    protected void setUpTransactionManagers() {
-        serializableTxManager = new TestTransactionManagerImpl(
+    private void setUpTransactionManagers() {
+        serializableTxManager = wrapTestTransactionManager(new TestTransactionManagerImpl(
                 metricsManager,
                 keyValueService,
                 timestampService,
@@ -103,9 +103,13 @@ public class AtlasDbTestCase {
                 conflictDetectionManager,
                 sweepStrategyManager,
                 sweepQueue,
-                MoreExecutors.newDirectExecutorService());
+                MoreExecutors.newDirectExecutorService()));
 
         txManager = new CachingTestTransactionManager(serializableTxManager);
+    }
+
+    protected TestTransactionManager wrapTestTransactionManager(TestTransactionManager testTransactionManager) {
+        return testTransactionManager;
     }
 
     protected KeyValueService getBaseKeyValueService() {

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/CachingTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/CachingTransactionTest.java
@@ -15,6 +15,9 @@
  */
 package com.palantir.atlasdb.transaction.impl;
 
+
+import static org.junit.Assert.assertEquals;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
@@ -22,10 +25,10 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -54,8 +57,8 @@ public class CachingTransactionTest {
     @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> data() {
         Object[][] data = new Object[][] {
-                {SYNC, (Function<Transaction, Transaction>) GetSynchronousDelegate::new},
-                {ASYNC, (Function<Transaction, Transaction>) GetAsyncDelegate::new}
+                {SYNC, (UnaryOperator<Transaction>) GetSynchronousDelegate::new},
+                {ASYNC, (UnaryOperator<Transaction>) GetAsyncDelegate::new}
         };
         return Arrays.asList(data);
     }
@@ -95,8 +98,8 @@ public class CachingTransactionTest {
             }
         });
 
-        Assert.assertEquals(emptyResults, cachingTransaction.getRows(table, oneRow, oneColumn));
-        Assert.assertEquals(emptyResults, cachingTransaction.getRows(table, oneRow, oneColumn));
+        assertEquals(emptyResults, cachingTransaction.getRows(table, oneRow, oneColumn));
+        assertEquals(emptyResults, cachingTransaction.getRows(table, oneRow, oneColumn));
 
         mockery.assertIsSatisfied();
     }
@@ -127,8 +130,8 @@ public class CachingTransactionTest {
             }
         });
 
-        Assert.assertEquals(oneResult, cachingTransaction.getRows(table, oneRow, oneColumn));
-        Assert.assertEquals(oneResult, cachingTransaction.getRows(table, oneRow, oneColumn));
+        assertEquals(oneResult, cachingTransaction.getRows(table, oneRow, oneColumn));
+        assertEquals(oneResult, cachingTransaction.getRows(table, oneRow, oneColumn));
 
         mockery.assertIsSatisfied();
     }
@@ -157,8 +160,8 @@ public class CachingTransactionTest {
         final Set<Cell> cellSet = ImmutableSet.of(cell);
         mockery.checking(expectationsMapping.get(name).apply(cellSet, cellValueMap));
 
-        Assert.assertEquals(cellValueMap, cachingTransaction.get(table, cellSet));
-        Assert.assertEquals(cellValueMap, cachingTransaction.get(table, cellSet));
+        assertEquals(cellValueMap, cachingTransaction.get(table, cellSet));
+        assertEquals(cellValueMap, cachingTransaction.get(table, cellSet));
 
         mockery.assertIsSatisfied();
     }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/CachingTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/CachingTransactionTest.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.concurrent.ExecutionException;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -209,8 +210,8 @@ public class CachingTransactionTest {
         public Map<Cell, byte[]> get(TableReference tableRef, Set<Cell> cells) {
             try {
                 return super.getAsync(tableRef, cells).get();
-            } catch (Exception e) {
-                throw new RuntimeException(e.getCause());
+            } catch (InterruptedException | ExecutionException e) {
+                throw com.palantir.common.base.Throwables.rewrapAndThrowUncheckedException(e.getCause());
             }
         }
     }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/CachingTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/CachingTransactionTest.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
-import java.util.concurrent.ExecutionException;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -55,16 +54,16 @@ public class CachingTransactionTest {
     @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> data() {
         Object[][] data = new Object[][] {
-                {SYNC, (Function<CachingTransaction, CachingTransaction>) SynchronousDelegate::new},
-                {ASYNC, (Function<CachingTransaction, CachingTransaction>) AsyncDelegate::new}
+                {SYNC, (Function<Transaction, Transaction>) GetSynchronousDelegate::new},
+                {ASYNC, (Function<Transaction, Transaction>) GetAsyncDelegate::new}
         };
         return Arrays.asList(data);
     }
 
     private final TableReference table = TableReference.createWithEmptyNamespace("table");
     private final Mockery mockery = new Mockery();
-    private final Transaction txn = mockery.mock(Transaction.class);
-    private final CachingTransaction ct;
+    private final Transaction transaction = mockery.mock(Transaction.class);
+    private final Transaction cachingTransaction;
     private final String name;
     private final Map<String, BiFunction<Set<Cell>, Map<Cell, byte[]>, Expectations>> expectationsMapping =
             ImmutableMap.<String, BiFunction<Set<Cell>, Map<Cell, byte[]>, Expectations>>builder()
@@ -72,9 +71,9 @@ public class CachingTransactionTest {
                     .put(ASYNC, CachingTransactionTest.this::asyncGetExpectation)
                     .build();
 
-    public CachingTransactionTest(String name, Function<CachingTransaction, CachingTransaction> transactionWrapper) {
+    public CachingTransactionTest(String name, Function<Transaction, Transaction> transactionWrapper) {
         this.name = name;
-        ct = transactionWrapper.apply(new CachingTransaction(txn));
+        cachingTransaction = transactionWrapper.apply(new CachingTransaction(transaction));
     }
 
     @Test
@@ -88,16 +87,16 @@ public class CachingTransactionTest {
 
         mockery.checking(new Expectations() {
             {
-                oneOf(txn).getRows(table, oneRow, oneColumn);
+                oneOf(transaction).getRows(table, oneRow, oneColumn);
                 will(returnValue(emptyResults));
 
-                oneOf(txn).getRows(table, noRows, oneColumn);
+                oneOf(transaction).getRows(table, noRows, oneColumn);
                 will(returnValue(emptyResults));
             }
         });
 
-        Assert.assertEquals(emptyResults, ct.getRows(table, oneRow, oneColumn));
-        Assert.assertEquals(emptyResults, ct.getRows(table, oneRow, oneColumn));
+        Assert.assertEquals(emptyResults, cachingTransaction.getRows(table, oneRow, oneColumn));
+        Assert.assertEquals(emptyResults, cachingTransaction.getRows(table, oneRow, oneColumn));
 
         mockery.assertIsSatisfied();
     }
@@ -120,16 +119,16 @@ public class CachingTransactionTest {
         mockery.checking(new Expectations() {
             {
                 // row result is cached after first call, so second call requests no rows
-                oneOf(txn).getRows(table, oneRow, oneColumn);
+                oneOf(transaction).getRows(table, oneRow, oneColumn);
                 will(returnValue(oneResult));
 
-                oneOf(txn).getRows(table, noRows, oneColumn);
+                oneOf(transaction).getRows(table, noRows, oneColumn);
                 will(returnValue(emptyResults));
             }
         });
 
-        Assert.assertEquals(oneResult, ct.getRows(table, oneRow, oneColumn));
-        Assert.assertEquals(oneResult, ct.getRows(table, oneRow, oneColumn));
+        Assert.assertEquals(oneResult, cachingTransaction.getRows(table, oneRow, oneColumn));
+        Assert.assertEquals(oneResult, cachingTransaction.getRows(table, oneRow, oneColumn));
 
         mockery.assertIsSatisfied();
     }
@@ -158,8 +157,8 @@ public class CachingTransactionTest {
         final Set<Cell> cellSet = ImmutableSet.of(cell);
         mockery.checking(expectationsMapping.get(name).apply(cellSet, cellValueMap));
 
-        Assert.assertEquals(cellValueMap, ct.get(table, cellSet));
-        Assert.assertEquals(cellValueMap, ct.get(table, cellSet));
+        Assert.assertEquals(cellValueMap, cachingTransaction.get(table, cellSet));
+        Assert.assertEquals(cellValueMap, cachingTransaction.get(table, cellSet));
 
         mockery.assertIsSatisfied();
     }
@@ -167,10 +166,10 @@ public class CachingTransactionTest {
     private Expectations syncGetExpectation(Set<Cell> cellSet, Map<Cell, byte[]> cellValueMap) {
         return new Expectations() {
             {
-                oneOf(txn).get(table, cellSet);
+                oneOf(transaction).get(table, cellSet);
                 will(returnValue(cellValueMap));
 
-                oneOf(txn).get(table, ImmutableSet.of());
+                oneOf(transaction).get(table, ImmutableSet.of());
                 will(returnValue(ImmutableMap.of()));
             }
         };
@@ -179,40 +178,13 @@ public class CachingTransactionTest {
     private Expectations asyncGetExpectation(Set<Cell> cellSet, Map<Cell, byte[]> cellValueMap) {
         return new Expectations() {
             {
-                oneOf(txn).getAsync(table, cellSet);
+                oneOf(transaction).getAsync(table, cellSet);
                 will(returnValue(Futures.immediateFuture(cellValueMap)));
 
-                oneOf(txn).getAsync(table, ImmutableSet.of());
+                oneOf(transaction).getAsync(table, ImmutableSet.of());
                 will(returnValue(Futures.immediateFuture(ImmutableMap.of())));
             }
         };
     }
 
-    private static class SynchronousDelegate extends CachingTransaction {
-
-        SynchronousDelegate(CachingTransaction transaction) {
-            super(transaction.delegate());
-        }
-
-        @Override
-        public Map<Cell, byte[]> get(TableReference tableRef, Set<Cell> cells) {
-            return super.get(tableRef, cells);
-        }
-    }
-
-    private static class AsyncDelegate extends CachingTransaction {
-
-        AsyncDelegate(CachingTransaction transaction) {
-            super(transaction.delegate());
-        }
-
-        @Override
-        public Map<Cell, byte[]> get(TableReference tableRef, Set<Cell> cells) {
-            try {
-                return super.getAsync(tableRef, cells).get();
-            } catch (InterruptedException | ExecutionException e) {
-                throw com.palantir.common.base.Throwables.rewrapAndThrowUncheckedException(e.getCause());
-            }
-        }
-    }
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -753,7 +753,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
         tasks.add(Pair.of("getRowsColumnRangeIterator",
                 (t, heldLocks) -> {
                     Collection<Iterator<Map.Entry<Cell, byte[]>>> results =
-                            t.getRowsColumnRangeIterator(TABLE_SWEPT_THOROUGH,
+                            t.getRowsColumnRangeIterator(
+                                    TABLE_SWEPT_THOROUGH,
                                     Collections.singleton(PtBytes.toBytes("row1")),
                                     BatchColumnRangeSelection.create(new ColumnRangeSelection(null, null), batchHint))
                                     .values();
@@ -901,16 +902,19 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
 
     @Test
     public void commitIfPreCommitConditionSucceeds() {
-        wrappedSerializableTxManager.runTaskWithConditionThrowOnConflict(PreCommitConditions.NO_OP, (tx, condition) -> {
-            tx.put(TABLE, ImmutableMap.of(TEST_CELL, PtBytes.toBytes("value")));
-            return null;
-        });
+        wrappedSerializableTxManager.runTaskWithConditionThrowOnConflict(
+                PreCommitConditions.NO_OP,
+                (tx, condition) -> {
+                    tx.put(TABLE, ImmutableMap.of(TEST_CELL, PtBytes.toBytes("value")));
+                    return null;
+                });
     }
 
     @Test
     public void failToCommitIfPreCommitConditionFails() {
         try {
-            wrappedSerializableTxManager.runTaskWithConditionThrowOnConflict(ALWAYS_FAILS_CONDITION,
+            wrappedSerializableTxManager.runTaskWithConditionThrowOnConflict(
+                    ALWAYS_FAILS_CONDITION,
                     (tx, condition) -> {
                         tx.put(TABLE, ImmutableMap.of(TEST_CELL, PtBytes.toBytes("value")));
                         return null;
@@ -927,10 +931,12 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
         when(conditionSupplier.get()).thenReturn(ALWAYS_FAILS_CONDITION)
                 .thenReturn(PreCommitConditions.NO_OP);
 
-        wrappedSerializableTxManager.runTaskWithConditionWithRetry(conditionSupplier, (tx, condition) -> {
-            tx.put(TABLE, ImmutableMap.of(TEST_CELL, PtBytes.toBytes("value")));
-            return null;
-        });
+        wrappedSerializableTxManager.runTaskWithConditionWithRetry(
+                conditionSupplier,
+                (tx, condition) -> {
+                    tx.put(TABLE, ImmutableMap.of(TEST_CELL, PtBytes.toBytes("value")));
+                    return null;
+                });
     }
 
     @Test
@@ -981,10 +987,12 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
         };
         Supplier<PreCommitCondition> conditionSupplier = Suppliers.ofInstance(nonRetriableFailure);
         try {
-            wrappedSerializableTxManager.runTaskWithConditionWithRetry(conditionSupplier, (tx, condition) -> {
-                tx.put(TABLE, ImmutableMap.of(TEST_CELL, PtBytes.toBytes("value")));
-                return null;
-            });
+            wrappedSerializableTxManager.runTaskWithConditionWithRetry(
+                    conditionSupplier,
+                    (tx, condition) -> {
+                        tx.put(TABLE, ImmutableMap.of(TEST_CELL, PtBytes.toBytes("value")));
+                        return null;
+                    });
             fail();
         } catch (TransactionFailedNonRetriableException e) {
             assertThat(e.getMessage(), containsString("Condition failed"));
@@ -993,7 +1001,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
 
     @Test
     public void readTransactionSucceedsIfConditionSucceeds() {
-        wrappedSerializableTxManager.runTaskWithConditionReadOnly(PreCommitConditions.NO_OP,
+        wrappedSerializableTxManager.runTaskWithConditionReadOnly(
+                PreCommitConditions.NO_OP,
                 (tx, condition) -> tx.get(TABLE, ImmutableSet.of(TEST_CELL)));
         TransactionOutcomeMetricsAssert.assertThat(transactionOutcomeMetrics)
                 .hasSuccessfulCommits(1);
@@ -1002,7 +1011,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
     @Test
     public void readTransactionFailsIfConditionFails() {
         try {
-            wrappedSerializableTxManager.runTaskWithConditionReadOnly(ALWAYS_FAILS_CONDITION,
+            wrappedSerializableTxManager.runTaskWithConditionReadOnly(
+                    ALWAYS_FAILS_CONDITION,
                     (tx, condition) -> tx.get(TABLE, ImmutableSet.of(TEST_CELL)));
             fail();
         } catch (TransactionFailedRetriableException e) {
@@ -1025,10 +1035,12 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
             }
         };
 
-        wrappedSerializableTxManager.runTaskWithConditionThrowOnConflict(succeedsCondition, (tx, condition) -> {
-            tx.put(TABLE, ImmutableMap.of(TEST_CELL, PtBytes.toBytes("value")));
-            return null;
-        });
+        wrappedSerializableTxManager.runTaskWithConditionThrowOnConflict(
+                succeedsCondition,
+                (tx, condition) -> {
+                    tx.put(TABLE, ImmutableMap.of(TEST_CELL, PtBytes.toBytes("value")));
+                    return null;
+                });
         assertThat(counter.intValue(), is(1));
 
         wrappedSerializableTxManager.runTaskWithConditionReadOnly(succeedsCondition,
@@ -1387,7 +1399,9 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
 
     private RowResult<byte[]> readRow(byte[] defaultRow) {
         Transaction readTransaction = txManager.createNewTransaction();
-        SortedMap<byte[], RowResult<byte[]>> allRows = readTransaction.getRows(TABLE, ImmutableSet.of(defaultRow),
+        SortedMap<byte[], RowResult<byte[]>> allRows = readTransaction.getRows(
+                TABLE,
+                ImmutableSet.of(defaultRow),
                 ColumnSelection.all());
         return allRows.get(defaultRow);
     }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -287,7 +287,6 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
 
         txManager = new WrappingTestTransactionManager(txManager, transactionWrapper);
         wrappedSerializableTxManager = new WrappingTestTransactionManager(serializableTxManager, transactionWrapper);
-
         transactionConfig = ImmutableTransactionConfig.builder().build();
 
         keyValueService.createTable(TABLE, AtlasDbConstants.GENERIC_TABLE_METADATA);

--- a/changelog/@unreleased/pr-4301.v2.yml
+++ b/changelog/@unreleased/pr-4301.v2.yml
@@ -1,6 +1,6 @@
 type: feature
 feature:
   description: |
-    `Transaction` can now support asynchronous get operations. Feature is designed for direct users of the `Transaction` api.
+    Transactions can now support asynchronous get operations. This feature is designed for direct users of the `Transaction` API.
   links:
   - https://github.com/palantir/atlasdb/pull/4301

--- a/changelog/@unreleased/pr-4301.v2.yml
+++ b/changelog/@unreleased/pr-4301.v2.yml
@@ -1,6 +1,6 @@
 type: feature
 feature:
   description: |
-    Transactions can now support asynchronous get operations. This has been implemented for all transaction types. Feature is designed for direct uses of transactions.
+    `Transaction` can now support asynchronous get operations. Feature is designed for direct users of the `Transaction` api.
   links:
   - https://github.com/palantir/atlasdb/pull/4301

--- a/changelog/@unreleased/pr-4301.v2.yml
+++ b/changelog/@unreleased/pr-4301.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: |
+    Transactions can now support asynchronous get operations. This has been implemented for all transaction types. Feature is designed for direct uses of transactions.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4301


### PR DESCRIPTION
**Goals (and why)**:
Add async get to `Transaction` API. Expose the asynchronous API from the `KVS` to the transactional layer.

**Implementation Description (bullets)**:
- straightforward propagation of `getAsync` from the `KVS` layer to the `Transaction`

**Testing (What was existing testing like?  What have you done to improve it?)**:
- tests are now parametrized to run with delegating get once to synchronous and once to asynchronous get
- parameterized tests should cover all the cases

**Concerns (what feedback would you like?)**:
- if all transaction types have a correct implementation of the `getAsync`
- should the code in tests be refactored to be more centralized (with respect to delegates)

**Where should we start reviewing?**:
- `Transaction`

**Priority (whenever / two weeks / yesterday)**:
tomorrow

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
