### PR TITLE
[WIP] Cleanup metrics.

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/persistence/CoordinationServices.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/persistence/CoordinationServices.java
@@ -50,7 +50,7 @@ public final class CoordinationServices {
                 MetricsManager metricsManager,
                 boolean initializeAsync) {
         CoordinationService<VersionedInternalSchemaMetadata> versionedService = new CoordinationServiceImpl<>(
-                createCoordinationStore(keyValueService, timestampSupplier, metricsManager, initializeAsync));
+                createCoordinationStore(keyValueService, timestampSupplier, initializeAsync));
 
         @SuppressWarnings("unchecked") // The service has the same type as the version-hiding service.
         CoordinationService<InternalSchemaMetadata> instrumentedService = AtlasDbMetrics.instrument(
@@ -63,17 +63,8 @@ public final class CoordinationServices {
     private static CoordinationStore<VersionedInternalSchemaMetadata> createCoordinationStore(
             KeyValueService keyValueService,
             LongSupplier timestampSupplier,
-            MetricsManager metricsManager,
             boolean initializeAsync) {
-        CoordinationStore<VersionedInternalSchemaMetadata> rawCoordinationStore
-                = createRawCoordinationStore(keyValueService, timestampSupplier, initializeAsync);
-
-        @SuppressWarnings("unchecked") // The store has the same type as the rawCoordinationStore.
-        CoordinationStore<VersionedInternalSchemaMetadata> store = AtlasDbMetrics.instrument(
-                metricsManager.getRegistry(),
-                CoordinationStore.class,
-                rawCoordinationStore);
-        return store;
+        return createRawCoordinationStore(keyValueService, timestampSupplier, initializeAsync);
     }
 
     private static CoordinationStore<VersionedInternalSchemaMetadata> createRawCoordinationStore(

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/persistence/CoordinationServices.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/persistence/CoordinationServices.java
@@ -61,13 +61,6 @@ public final class CoordinationServices {
     }
 
     private static CoordinationStore<VersionedInternalSchemaMetadata> createCoordinationStore(
-            KeyValueService keyValueService,
-            LongSupplier timestampSupplier,
-            boolean initializeAsync) {
-        return createRawCoordinationStore(keyValueService, timestampSupplier, initializeAsync);
-    }
-
-    private static CoordinationStore<VersionedInternalSchemaMetadata> createRawCoordinationStore(
             KeyValueService keyValueService, LongSupplier timestampSupplier, boolean initializeAsync) {
         return KeyValueServiceCoordinationStore.create(
                 ObjectMappers.newServerObjectMapper(),


### PR DESCRIPTION
**Goals (and why)**:

Cleanup metrics.

**Implementation Description (bullets)**:

The below will be explaining how those metrics scale per TransactionManager (so if an app uses multiple TransactionManagers, the number of series should be multipled by that):

Timer: 4 series (it's actually 6, but we usually filter out 2)
Histogram: dunno if we filter any, but we log 5 series
Meter: 2 series, again not sure about filtering

### Per table metrics
* com.palantir.atlasdb.transaction.impl.SnapshotTransaction.transactionsReadFromDB: histogram
* com.palantir.atlasdb.transaction.impl.SnapshotTransaction.emptyValuesCellFilterCount: meter
* com.palantir.atlasdb.transaction.impl.SnapshotTransaction.numCellsRead: meter

### Not interesting metrics
* ~CoordinationStore: not a useful set of metrics: 3 methods x 4 series each = 12 series~

### Expensive metrics

* com.palantir.atlasdb.sweep.metrics.TargetedSweepMetrics.outcome: this one explodes quite badly, because it registers about 10 metrics per Transaction manager: 2 Strategies ("thorough" and "conservative") x 5 SweepOutcome values = 10 series
* com.palantir.atlasdb.sweep.BackgroundSweeperImpl.outcome: one per SweepOutcomes value = 9 series

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
