### PR TITLE
[Timelock Partitioning] Part 37: Leadership components

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbMetricNames.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbMetricNames.java
@@ -65,6 +65,7 @@ public final class AtlasDbMetricNames {
 
     public static final String TAG_CURRENT_SUSPECTED_LEADER = "isCurrentSuspectedLeader";
     public static final String TAG_CLIENT = "client";
+    public static final String TAG_PAXOS_USE_CASE = "paxosUseCase";
 
     public static final String COORDINATION_LAST_VALID_BOUND = "lastValidBound";
     public static final String COORDINATION_CURRENT_TRANSACTIONS_SCHEMA_VERSION = "currentTransactionsSchemaVersion";

--- a/leader-election-impl/src/main/java/com/palantir/leader/BatchingLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/BatchingLeaderElectionService.java
@@ -16,6 +16,7 @@
 
 package com.palantir.leader;
 
+import java.io.Closeable;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
@@ -24,7 +25,7 @@ import com.palantir.atlasdb.autobatch.Autobatchers;
 import com.palantir.atlasdb.autobatch.BatchElement;
 import com.palantir.atlasdb.autobatch.DisruptorAutobatcher;
 
-public class BatchingLeaderElectionService implements LeaderElectionService {
+public class BatchingLeaderElectionService implements LeaderElectionService, Closeable {
     private final LeaderElectionService delegate;
     private final DisruptorAutobatcher<Void, LeadershipToken> batcher;
 
@@ -76,5 +77,10 @@ public class BatchingLeaderElectionService implements LeaderElectionService {
             Thread.currentThread().interrupt();
             batch.forEach(request -> request.result().setException(e));
         }
+    }
+
+    @Override
+    public void close() {
+        batcher.close();
     }
 }

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipComponents.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipComponents.java
@@ -152,7 +152,7 @@ public class LeadershipComponents {
     }
 
     @Value.Immutable
-    static abstract class LeadershipContext {
+    abstract static class LeadershipContext {
         abstract LeaderElectionService leaderElectionService();
         abstract TimelockLeadershipMetrics leadershipMetrics();
         abstract List<Closeable> closeables();

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipComponents.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipComponents.java
@@ -1,0 +1,150 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Supplier;
+
+import org.immutables.value.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import com.google.common.io.Closer;
+import com.palantir.atlasdb.timelock.paxos.NetworkClientFactories.Factory;
+import com.palantir.leader.BatchingLeaderElectionService;
+import com.palantir.leader.LeaderElectionService;
+import com.palantir.leader.NotCurrentLeaderException;
+import com.palantir.leader.proxy.AwaitingLeadershipProxy;
+
+public class LeadershipComponents {
+
+    private static final Logger log = LoggerFactory.getLogger(LeadershipComponents.class);
+
+    private final ConcurrentMap<Client, LeadershipContext> leadershipContextByClient = Maps.newConcurrentMap();
+    private final ShutdownAwareCloser closer = new ShutdownAwareCloser();
+
+    private final TimelockPaxosMetrics metrics;
+    private final Factory<LeadershipContext> leadershipContextFactory;
+
+    public LeadershipComponents(TimelockPaxosMetrics metrics, Factory<LeadershipContext> leadershipContextFactory) {
+        this.metrics = metrics;
+        this.leadershipContextFactory = leadershipContextFactory;
+    }
+
+    public <T> T wrapInLeadershipProxy(Client client, String name, Class<T> clazz, Supplier<T> delegateSupplier) {
+        LeadershipContext context = getOrCreateNewLeadershipContext(client);
+        T instance = AwaitingLeadershipProxy.newProxyInstance(clazz, delegateSupplier, context.leaderElectionService());
+
+        // this is acceptable since the proxy returned implements Closeable and needs to be closed
+        Closeable closeableInstance = (Closeable) instance;
+        closer.register(closeableInstance);
+
+        return context.leadershipMetrics().instrument(name, clazz, instance);
+    }
+
+    public void shutdown() {
+        closer.shutdown();
+    }
+
+    private LeadershipContext getOrCreateNewLeadershipContext(Client client) {
+        return leadershipContextByClient.computeIfAbsent(client, this::createNewLeadershipContext);
+    }
+
+    private LeadershipContext createNewLeadershipContext(Client client) {
+        LeadershipContext uninstrumentedLeadershipContext = leadershipContextFactory.create(client);
+        closer.register(uninstrumentedLeadershipContext.closeables());
+
+        BatchingLeaderElectionService batchingLeaderElectionService =
+                new BatchingLeaderElectionService(uninstrumentedLeadershipContext.leaderElectionService());
+        closer.register(batchingLeaderElectionService);
+
+        LeaderElectionService leaderElectionService = metrics.instrument(
+                LeaderElectionService.class,
+                batchingLeaderElectionService,
+                "leader-election-service",
+                client);
+        closer.register(() -> shutdownLeaderElectionService(leaderElectionService));
+
+        return ImmutableLeadershipContext.builder()
+                .from(uninstrumentedLeadershipContext)
+                .leaderElectionService(leaderElectionService)
+                .build();
+    }
+
+    private static void shutdownLeaderElectionService(LeaderElectionService leaderElectionService) {
+        leaderElectionService.markNotEligibleForLeadership();
+        leaderElectionService.stepDown();
+    }
+
+    private static class ShutdownAwareCloser {
+        private boolean isShutdown = false;
+        private final Closer closer = Closer.create();
+
+        synchronized void register(Closeable closeable) {
+            register(ImmutableList.of(closeable));
+        }
+
+        /**
+         * Attempts to register a collection of {@link Closeable}s to be closed when shutting down Timelock.
+         * If timelock has already been shutdown, any {@link Closeable}s passed here will be <em>immediately</em>
+         * closed, and a {@link NotCurrentLeaderException} will be thrown.
+         *
+         * @param closeables collection of {@link Closeable}s to be closed when timelock shuts down.
+         */
+        synchronized void register(Collection<Closeable> closeables) {
+            if (isShutdown) {
+                ShutdownAwareCloser immediateCloser = new ShutdownAwareCloser();
+                immediateCloser.register(closeables);
+                immediateCloser.shutdown();
+                throw new NotCurrentLeaderException("This timelock node is being shutdown");
+            } else {
+                closeables.forEach(closer::register);
+            }
+        }
+
+        /**
+         * This is to be called when timelock is shutting down. It will close in LIFO order any resources that were
+         * registered during their creation.
+         */
+        synchronized void shutdown() {
+            if (isShutdown) {
+                return;
+            }
+
+            try {
+                closer.close();
+            } catch (IOException e) {
+                log.warn("Received exceptions whilst trying to shutdown this timelock node.", e);
+            } finally {
+                isShutdown = true;
+            }
+        }
+    }
+
+    @Value.Immutable
+    static abstract class LeadershipContext {
+        abstract LeaderElectionService leaderElectionService();
+        abstract TimelockLeadershipMetrics leadershipMetrics();
+        abstract List<Closeable> closeables();
+    }
+}

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipComponents.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipComponents.java
@@ -35,6 +35,7 @@ import com.palantir.leader.BatchingLeaderElectionService;
 import com.palantir.leader.LeaderElectionService;
 import com.palantir.leader.NotCurrentLeaderException;
 import com.palantir.leader.proxy.AwaitingLeadershipProxy;
+import com.palantir.timelock.paxos.LeaderPingHealthCheck;
 
 public class LeadershipComponents {
 
@@ -45,10 +46,15 @@ public class LeadershipComponents {
 
     private final TimelockPaxosMetrics metrics;
     private final Factory<LeadershipContext> leadershipContextFactory;
+    private final LeaderPingHealthCheck leaderPingHealthCheck;
 
-    public LeadershipComponents(TimelockPaxosMetrics metrics, Factory<LeadershipContext> leadershipContextFactory) {
+    public LeadershipComponents(
+            TimelockPaxosMetrics metrics,
+            Factory<LeadershipContext> leadershipContextFactory,
+            LeaderPingHealthCheck leaderPingHealthCheck) {
         this.metrics = metrics;
         this.leadershipContextFactory = leadershipContextFactory;
+        this.leaderPingHealthCheck = leaderPingHealthCheck;
     }
 
     public <T> T wrapInLeadershipProxy(Client client, String name, Class<T> clazz, Supplier<T> delegateSupplier) {
@@ -64,6 +70,10 @@ public class LeadershipComponents {
 
     public void shutdown() {
         closer.shutdown();
+    }
+
+    public LeaderPingHealthCheck healthCheck() {
+        return leaderPingHealthCheck;
     }
 
     private LeadershipContext getOrCreateNewLeadershipContext(Client client) {

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipComponents.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipComponents.java
@@ -59,7 +59,7 @@ public class LeadershipComponents {
         Closeable closeableInstance = (Closeable) instance;
         closer.register(closeableInstance);
 
-        return context.leadershipMetrics().instrument(name, clazz, instance);
+        return context.leadershipMetrics().instrument(client, name, clazz, instance);
     }
 
     public void shutdown() {

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/TimelockLeadershipMetrics.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/TimelockLeadershipMetrics.java
@@ -76,7 +76,7 @@ public abstract class TimelockLeadershipMetrics {
     private static Predicate<MetricName> withTagIsCurrentSuspectedLeader(boolean currentLeader) {
         return metricName ->
                 Optional.ofNullable(metricName.safeTags().get(AtlasDbMetricNames.TAG_CURRENT_SUSPECTED_LEADER))
-                        .filter(x -> x.equals(String.valueOf(currentLeader)))
+                        .filter(String.valueOf(currentLeader)::equals)
                         .isPresent();
     }
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/TimelockLeadershipMetrics.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/TimelockLeadershipMetrics.java
@@ -44,23 +44,20 @@ public abstract class TimelockLeadershipMetrics {
     @Value.Parameter
     abstract PingableLeader localPingableLeader();
 
-    @Value.Parameter
-    abstract Client client();
-
     @Value.Derived
     MetricsManager metricsManager() {
         // we don't use the normal metric registry so we don't care about this
         return MetricsManagers.of(new MetricRegistry(), metrics().metrics());
     }
 
-    public <T> T instrument(String name, Class<T> clazz, T instance) {
+    public <T> T instrument(Client client, String name, Class<T> clazz, T instance) {
         return AtlasDbMetrics.instrumentWithTaggedMetrics(
                 metrics().metrics(),
                 clazz,
                 instance,
                 name,
                 _context -> ImmutableMap.of(
-                        AtlasDbMetricNames.TAG_CLIENT, client().value(),
+                        AtlasDbMetricNames.TAG_CLIENT, client.value(),
                         AtlasDbMetricNames.TAG_CURRENT_SUSPECTED_LEADER, String.valueOf(localPingableLeader().ping())));
     }
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/TimelockLeadershipMetrics.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/TimelockLeadershipMetrics.java
@@ -1,0 +1,85 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import org.immutables.value.Value;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.palantir.atlasdb.AtlasDbMetricNames;
+import com.palantir.atlasdb.util.AtlasDbMetrics;
+import com.palantir.atlasdb.util.MetricsManager;
+import com.palantir.atlasdb.util.MetricsManagers;
+import com.palantir.leader.AsyncLeadershipObserver;
+import com.palantir.leader.LeadershipObserver;
+import com.palantir.leader.PingableLeader;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.tritium.metrics.registry.MetricName;
+
+@Value.Immutable
+public abstract class TimelockLeadershipMetrics {
+
+    @Value.Parameter
+    abstract TimelockPaxosMetrics metrics();
+
+    @Value.Parameter
+    abstract PingableLeader localPingableLeader();
+
+    @Value.Parameter
+    abstract Client client();
+
+    @Value.Derived
+    MetricsManager metricsManager() {
+        // we don't use the normal metric registry so we don't care about this
+        return MetricsManagers.of(new MetricRegistry(), metrics().metrics());
+    }
+
+    public <T> T instrument(String name, Class<T> clazz, T instance) {
+        return AtlasDbMetrics.instrumentWithTaggedMetrics(
+                metrics().metrics(),
+                clazz,
+                instance,
+                name,
+                _context -> ImmutableMap.of(
+                        AtlasDbMetricNames.TAG_CLIENT, client().value(),
+                        AtlasDbMetricNames.TAG_CURRENT_SUSPECTED_LEADER, String.valueOf(localPingableLeader().ping())));
+    }
+
+    @Value.Derived
+    public LeadershipObserver leadershipObserver() {
+        return AsyncLeadershipObserver.create(
+                () -> metricsManager().deregisterTaggedMetrics(withTagIsCurrentSuspectedLeader(false)),
+                () -> metricsManager().deregisterTaggedMetrics(withTagIsCurrentSuspectedLeader(true)));
+    }
+
+    @Value.Derived
+    public List<SafeArg<Object>> namespaceAsArgs() {
+        return ImmutableList.of(SafeArg.of(AtlasDbMetricNames.TAG_PAXOS_USE_CASE, metrics().paxosUseCase().toString()));
+    }
+
+    private static Predicate<MetricName> withTagIsCurrentSuspectedLeader(boolean currentLeader) {
+        return metricName ->
+                Optional.ofNullable(metricName.safeTags().get(AtlasDbMetricNames.TAG_CURRENT_SUSPECTED_LEADER))
+                        .filter(x -> x.equals(String.valueOf(currentLeader)))
+                        .isPresent();
+    }
+}

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/TimelockLeadershipMetrics.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/TimelockLeadershipMetrics.java
@@ -29,8 +29,6 @@ import com.palantir.atlasdb.AtlasDbMetricNames;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.atlasdb.util.MetricsManagers;
-import com.palantir.leader.AsyncLeadershipObserver;
-import com.palantir.leader.LeadershipObserver;
 import com.palantir.leader.PingableLeader;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.tritium.metrics.registry.MetricName;
@@ -59,13 +57,6 @@ public abstract class TimelockLeadershipMetrics {
                 _context -> ImmutableMap.of(
                         AtlasDbMetricNames.TAG_CLIENT, client.value(),
                         AtlasDbMetricNames.TAG_CURRENT_SUSPECTED_LEADER, String.valueOf(localPingableLeader().ping())));
-    }
-
-    @Value.Derived
-    public LeadershipObserver leadershipObserver() {
-        return AsyncLeadershipObserver.create(
-                () -> metricsManager().deregisterTaggedMetrics(withTagIsCurrentSuspectedLeader(false)),
-                () -> metricsManager().deregisterTaggedMetrics(withTagIsCurrentSuspectedLeader(true)));
     }
 
     @Value.Derived


### PR DESCRIPTION
**Goals (and why)**:
Akin to `PaxosComponents`, we want to be able to get (potentially) different leader election services per client, and wrap proxies with them. This is a holder for that.

**Implementation Description (bullets)**:
Since we have multiple clients => multiple leaders, shutdown becomes a bit more tricky, as now we need to step down and not try and propose leadership again. I've  somewhat misused a `Closer` here, since it's not a try-with-resources thing, which has allowed me keep track of things I need to close in a LIFO manner which is pretty good.

**Testing (What was existing testing like?  What have you done to improve it?)**:
N/A

**Concerns (what feedback would you like?)**:
Are the interactions re shutdown reasonable?

**Where should we start reviewing?**:
`LeadershipComponents`

**Priority (whenever / two weeks / yesterday)**:
asap please

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
