### PR TITLE
[Conjure Java Runtime] Part 15: Revise Parameters for ClientOptions

### DIFF
--- a/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/v2/ClientOptions.java
+++ b/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/v2/ClientOptions.java
@@ -34,12 +34,13 @@ import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 @Value.Immutable
 public abstract class ClientOptions {
     // TODO (jkong): Re-enable client QoS after response body leaks are handled correctly.
+    // Throws after expected outages of 1/2 * 0.01 * (2^11 - 1) = 10.24 s
     public static final ClientOptions DEFAULT_RETRYING = ImmutableClientOptions.builder()
             .connectTimeout(Duration.ofSeconds(10))
             .readTimeout(Duration.ofSeconds(65))
-            .backoffSlotSize(Duration.ofMillis(100))
+            .backoffSlotSize(Duration.ofMillis(10))
             .failedUrlCooldown(Duration.ofMillis(100))
-            .maxNumRetries(5)
+            .maxNumRetries(11)
             .clientQoS(ClientConfiguration.ClientQoS.DANGEROUS_DISABLE_SYMPATHETIC_CLIENT_QOS)
             .build();
 

--- a/changelog/@unreleased/pr-4318.v2.yml
+++ b/changelog/@unreleased/pr-4318.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: Our Conjure-Java-Runtime client is now more resilient to transient
+    failures or rolling upgrades of TimeLock Server. Previously, we would give up
+    after an expected 1.5 seconds of being unable to contact TimeLock; we now try
+    for an expected 10 seconds.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4318

--- a/changelog/@unreleased/pr-4318.v2.yml
+++ b/changelog/@unreleased/pr-4318.v2.yml
@@ -3,6 +3,6 @@ improvement:
   description: Our Conjure-Java-Runtime client is now more resilient to transient
     failures or rolling upgrades of TimeLock Server. Previously, we would give up
     after an expected 1.5 seconds of being unable to contact TimeLock; we now try
-    for an expected 10 seconds.
+    for an expected 10 seconds. Feign client users are unaffected.
   links:
   - https://github.com/palantir/atlasdb/pull/4318


### PR DESCRIPTION
**Goals (and why)**:
- See internal fjord product channel. Failures were reported for around two seconds when TimeLock was rolling bounced, plausibly because we now give up _a lot_ faster when unable to talk to the server than in the past. This restores some resilience to such failures.

**Implementation Description (bullets)**:
- Modify the default `ClientOptions` parameters.
- Add an expected calculation of what length of outage we would retry for before giving up.

**Testing (What was existing testing like?  What have you done to improve it?)**: None.

**Concerns (what feedback would you like?)**:
- Are these now too generous? I think this is still quite a bit tighter than the v1 target in Feign.

**Where should we start reviewing?**: `ClientOptions.java

**Priority (whenever / two weeks / yesterday)**: today? 🔥 
