### PR TITLE
Add Timed annotation and remove instrumentation from some TransactionManager methods

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/metrics/Timed.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/metrics/Timed.java
@@ -22,7 +22,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD})
+@Target(ElementType.METHOD)
 public @interface Timed {
 }
 

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/metrics/Timed.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/metrics/Timed.java
@@ -1,0 +1,28 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.metrics;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface Timed {
+}
+

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
@@ -366,7 +366,6 @@ public interface TransactionManager extends AutoCloseable {
      * <p>
      * This call must be implemented so that it completes synchronously.
      */
-    // There are metrics for the individual call
     KeyValueServiceStatus getKeyValueServiceStatus();
 
     /**
@@ -377,7 +376,6 @@ public interface TransactionManager extends AutoCloseable {
      *
      * @return status of the timelock service
      */
-    // Just looks at in-memory metrics
     TimelockServiceStatus getTimelockServiceStatus();
 
     /**
@@ -394,14 +392,12 @@ public interface TransactionManager extends AutoCloseable {
      *
      * @throws IllegalStateException if the transaction manager has been closed.
      */
-    // I would say we don't really care about this? If we want this metric it should be in the puncher store.
     long getUnreadableTimestamp();
 
     /**
      * Clear the timestamp cache. This is mostly useful for tests that perform operations that would invalidate
      * the cache, although this can also be used to free up some memory.
      */
-    //
     void clearTimestampCache();
 
     /**
@@ -424,6 +420,7 @@ public interface TransactionManager extends AutoCloseable {
      * @return the transaction and associated immutable timestamp lock for the task
      */
     @Deprecated
+    @Timed
     TransactionAndImmutableTsLock setupRunTaskWithConditionThrowOnConflict(PreCommitCondition condition);
 
     /**
@@ -436,6 +433,7 @@ public interface TransactionManager extends AutoCloseable {
      * @return value returned by the task
      */
     @Deprecated
+    @Timed
     <T, E extends Exception> T finishRunTaskWithLockThrowOnConflict(TransactionAndImmutableTsLock tx,
             TransactionTask<T, E> task)
             throws E, TransactionFailedRetriableException;

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
@@ -392,6 +392,7 @@ public interface TransactionManager extends AutoCloseable {
      *
      * @throws IllegalStateException if the transaction manager has been closed.
      */
+    @Timed
     long getUnreadableTimestamp();
 
     /**

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/AtlasDbMetrics.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/AtlasDbMetrics.java
@@ -72,21 +72,6 @@ public final class AtlasDbMetrics {
                 instrumentAllMethods());
     }
 
-    public static <T, U extends T> T instrumentWithTaggedMetricsTimed(
-            TaggedMetricRegistry taggedMetrics,
-            Class<T> serviceInterface,
-            U service,
-            String name,
-            Function<InvocationContext, Map<String, String>> tagFunction) {
-        return instrumentWithTaggedMetrics(
-                taggedMetrics,
-                serviceInterface,
-                service,
-                name,
-                tagFunction,
-                instrumentTimedOnly());
-    }
-
     public static void registerCache(MetricRegistry metricRegistry, Cache<?, ?> cache, String metricsPrefix) {
         Set<String> existingMetrics = metricRegistry.getMetrics().keySet().stream()
                 .filter(name -> name.startsWith(metricsPrefix))

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/AtlasDbMetrics.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/AtlasDbMetrics.java
@@ -25,6 +25,8 @@ import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.benmanes.caffeine.cache.Cache;
+import com.palantir.tritium.api.event.InstrumentationFilter;
+import com.palantir.tritium.event.InstrumentationFilters;
 import com.palantir.tritium.event.InvocationContext;
 import com.palantir.tritium.event.log.LoggingInvocationEventHandler;
 import com.palantir.tritium.event.log.LoggingLevel;
@@ -37,20 +39,27 @@ public final class AtlasDbMetrics {
 
     private AtlasDbMetrics() {}
 
+    public static <T, U extends T> T instrumentTimed(
+            MetricRegistry metricRegistry, Class<T> serviceInterface, U service) {
+        return instrument(metricRegistry, serviceInterface, service, serviceInterface.getName(), instrumentTimedOnly());
+    }
+
+    /**
+     * @deprecated use {@link #instrumentTimed(MetricRegistry, Class, Object)}
+     */
+    @Deprecated
     public static <T, U extends T> T instrument(
             MetricRegistry metricRegistry, Class<T> serviceInterface, U service) {
         return instrument(metricRegistry, serviceInterface, service, serviceInterface.getName());
     }
 
+    /**
+     * @deprecated use {@link #instrumentTimed(MetricRegistry, Class, Object)}
+     */
+    @Deprecated
     public static <T, U extends T> T instrument(
             MetricRegistry metricRegistry, Class<T> serviceInterface, U service, String name) {
-        return Instrumentation.builder(serviceInterface, service)
-                .withHandler(new SlidingWindowMetricsInvocationHandler(metricRegistry, name))
-                .withLogging(
-                        LoggerFactory.getLogger("performance." + name),
-                        LoggingLevel.TRACE,
-                        LoggingInvocationEventHandler.LOG_DURATIONS_GREATER_THAN_1_MICROSECOND)
-                .build();
+        return instrument(metricRegistry, serviceInterface, service, name, instrumentAllMethods());
     }
 
     public static <T, U extends T> T instrumentWithTaggedMetrics(
@@ -59,13 +68,23 @@ public final class AtlasDbMetrics {
             U service,
             String name,
             Function<InvocationContext, Map<String, String>> tagFunction) {
-        return Instrumentation.builder(serviceInterface, service)
-                .withHandler(new TaggedMetricsInvocationEventHandler(taggedMetrics, name, tagFunction))
-                .withLogging(
-                        LoggerFactory.getLogger("performance." + name),
-                        LoggingLevel.TRACE,
-                        LoggingInvocationEventHandler.LOG_DURATIONS_GREATER_THAN_1_MICROSECOND)
-                .build();
+        return instrumentWithTaggedMetrics(taggedMetrics, serviceInterface, service, name, tagFunction,
+                instrumentAllMethods());
+    }
+
+    public static <T, U extends T> T instrumentWithTaggedMetricsTimed(
+            TaggedMetricRegistry taggedMetrics,
+            Class<T> serviceInterface,
+            U service,
+            String name,
+            Function<InvocationContext, Map<String, String>> tagFunction) {
+        return instrumentWithTaggedMetrics(
+                taggedMetrics,
+                serviceInterface,
+                service,
+                name,
+                tagFunction,
+                instrumentTimedOnly());
     }
 
     public static void registerCache(MetricRegistry metricRegistry, Cache<?, ?> cache, String metricsPrefix) {
@@ -78,5 +97,46 @@ public final class AtlasDbMetrics {
             log.info("Not registering cache with prefix '{}' as metric registry already contains metrics: {}",
                     metricsPrefix, existingMetrics);
         }
+    }
+
+    private static <T, U extends T> T instrument(
+            MetricRegistry metricRegistry,
+            Class<T> serviceInterface,
+            U service,
+            String name,
+            InstrumentationFilter instrumentationFilter) {
+        return Instrumentation.builder(serviceInterface, service)
+                .withFilter(instrumentationFilter)
+                .withHandler(new SlidingWindowMetricsInvocationHandler(metricRegistry, name))
+                .withLogging(
+                        LoggerFactory.getLogger("performance." + name),
+                        LoggingLevel.TRACE,
+                        LoggingInvocationEventHandler.LOG_DURATIONS_GREATER_THAN_1_MICROSECOND)
+                .build();
+    }
+
+    private static <T, U extends T> T instrumentWithTaggedMetrics(
+            TaggedMetricRegistry taggedMetrics,
+            Class<T> serviceInterface,
+            U service,
+            String name,
+            Function<InvocationContext, Map<String, String>> tagFunction,
+            InstrumentationFilter instrumentationFilter) {
+        return Instrumentation.builder(serviceInterface, service)
+                .withFilter(instrumentationFilter)
+                .withHandler(new TaggedMetricsInvocationEventHandler(taggedMetrics, name, tagFunction))
+                .withLogging(
+                        LoggerFactory.getLogger("performance." + name),
+                        LoggingLevel.TRACE,
+                        LoggingInvocationEventHandler.LOG_DURATIONS_GREATER_THAN_1_MICROSECOND)
+                .build();
+    }
+
+    private static InstrumentationFilter instrumentTimedOnly() {
+        return new TimedOnlyInstrumentationFilter();
+    }
+
+    private static InstrumentationFilter instrumentAllMethods() {
+        return InstrumentationFilters.INSTRUMENT_ALL;
     }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/AtlasDbMetrics.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/AtlasDbMetrics.java
@@ -53,10 +53,6 @@ public final class AtlasDbMetrics {
         return instrument(metricRegistry, serviceInterface, service, serviceInterface.getName());
     }
 
-    /**
-     * @deprecated use {@link #instrumentTimed(MetricRegistry, Class, Object)}
-     */
-    @Deprecated
     public static <T, U extends T> T instrument(
             MetricRegistry metricRegistry, Class<T> serviceInterface, U service, String name) {
         return instrument(metricRegistry, serviceInterface, service, name, instrumentAllMethods());

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/TimedOnlyInstrumentationFilter.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/TimedOnlyInstrumentationFilter.java
@@ -31,6 +31,10 @@ final class TimedOnlyInstrumentationFilter implements InstrumentationFilter {
 
     @Override
     public boolean shouldInstrument(@Nonnull Object instance, @Nonnull Method method, @Nonnull Object[] args) {
-        return filtered.computeIfAbsent(method, _method -> method.getAnnotation(Timed.class) != null);
+        return filtered.computeIfAbsent(method, this::shouldInstrument);
+    }
+
+    private boolean shouldInstrument(Method method) {
+        return method.getAnnotation(Timed.class) != null;
     }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/TimedOnlyInstrumentationFilter.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/TimedOnlyInstrumentationFilter.java
@@ -1,0 +1,36 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.util;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.annotation.Nonnull;
+
+import com.palantir.atlasdb.metrics.Timed;
+import com.palantir.tritium.api.event.InstrumentationFilter;
+
+final class TimedOnlyInstrumentationFilter implements InstrumentationFilter {
+
+    private final Map<Method, Boolean> filtered = new ConcurrentHashMap<>();
+
+    @Override
+    public boolean shouldInstrument(@Nonnull Object instance, @Nonnull Method method, @Nonnull Object[] args) {
+        return filtered.computeIfAbsent(method, _method -> method.getAnnotation(Timed.class) != null);
+    }
+}

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/util/AtlasDbMetricsTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/util/AtlasDbMetricsTest.java
@@ -37,14 +37,14 @@ public class AtlasDbMetricsTest {
     private final MetricRegistry metrics = new MetricRegistry();
 
     @Test
-    public void instrumentWithDefaultName() throws Exception {
+    public void instrumentWithDefaultName() {
         TestService service = AtlasDbMetrics.instrument(metrics, TestService.class, () -> PING_RESPONSE);
 
         assertMetricCountIncrementsAfterPing(metrics, service, MetricRegistry.name(TestService.class, PING_REQUEST));
     }
 
     @Test
-    public void instrumentWithCustomName() throws Exception {
+    public void instrumentWithCustomName() {
         TestService service = AtlasDbMetrics.instrument(
                 metrics, TestService.class, () -> PING_RESPONSE, CUSTOM_METRIC_NAME);
 

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/util/AtlasDbMetricsTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/util/AtlasDbMetricsTest.java
@@ -45,7 +45,7 @@ public class AtlasDbMetricsTest {
     };
 
     @Test
-    public void instrumentWithDefaultName() {
+    public void instrumentWithDefaultNameTimed() {
         TestService service = AtlasDbMetrics.instrumentTimed(metrics, TestService.class, testService);
 
         assertMetricCountAfterInvocation(
@@ -56,6 +56,20 @@ public class AtlasDbMetricsTest {
                 MetricRegistry.name(TestService.class, PING_NOT_TIMED_REQUEST),
                 service::pingNotTimed,
                 false);
+    }
+
+    @Test
+    public void instrumentWithDefaultNameAll() {
+        TestService service = AtlasDbMetrics.instrument(metrics, TestService.class, testService);
+
+        assertMetricCountAfterInvocation(
+                MetricRegistry.name(TestService.class, PING_REQUEST),
+                service::ping,
+                true);
+        assertMetricCountAfterInvocation(
+                MetricRegistry.name(TestService.class, PING_NOT_TIMED_REQUEST),
+                service::pingNotTimed,
+                true);
     }
 
     @Test

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/util/TimedOnlyInstrumentationFilterTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/util/TimedOnlyInstrumentationFilterTest.java
@@ -29,9 +29,10 @@ import com.palantir.atlasdb.metrics.Timed;
 @RunWith(MockitoJUnitRunner.class)
 public final class TimedOnlyInstrumentationFilterTest {
 
+    private final TimedOnlyInstrumentationFilter filter = new TimedOnlyInstrumentationFilter();
+
     @Mock
     private TestService testService;
-    private final TimedOnlyInstrumentationFilter filter = new TimedOnlyInstrumentationFilter();
 
     @Test
     public void testFiltersNotAnnotatedMethods() throws NoSuchMethodException {

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/util/TimedOnlyInstrumentationFilterTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/util/TimedOnlyInstrumentationFilterTest.java
@@ -1,0 +1,52 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.assertj.core.api.AbstractBooleanAssert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.palantir.atlasdb.metrics.Timed;
+
+@RunWith(MockitoJUnitRunner.class)
+public final class TimedOnlyInstrumentationFilterTest {
+
+    @Mock
+    private TestService testService;
+    private final TimedOnlyInstrumentationFilter filter = new TimedOnlyInstrumentationFilter();
+
+    @Test
+    public void testFiltersNotAnnotatedMethods() throws NoSuchMethodException {
+        assertShouldInstrument("timed").isTrue();
+        assertShouldInstrument("notTimed").isFalse();
+    }
+
+    private AbstractBooleanAssert<?> assertShouldInstrument(String method) throws NoSuchMethodException {
+        return assertThat(filter.shouldInstrument(testService, TestService.class.getMethod(method), new Object[0]));
+    }
+
+    interface TestService {
+        @Timed
+        void timed();
+
+        void notTimed();
+    }
+}

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -521,7 +521,7 @@ public abstract class TransactionManagers {
                 metricsManager, lockAndTimestampServices, keyValueService);
         TransactionSchemaManager transactionSchemaManager = new TransactionSchemaManager(coordinationService);
 
-        TransactionService transactionService = initializeCloseable(() -> AtlasDbMetrics.instrumentTimed(
+        TransactionService transactionService = initializeCloseable(() -> AtlasDbMetrics.instrument(
                 metricsManager.getRegistry(),
                 TransactionService.class,
                 TransactionServices.createTransactionService(keyValueService, transactionSchemaManager)),

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -521,7 +521,7 @@ public abstract class TransactionManagers {
                 metricsManager, lockAndTimestampServices, keyValueService);
         TransactionSchemaManager transactionSchemaManager = new TransactionSchemaManager(coordinationService);
 
-        TransactionService transactionService = initializeCloseable(() -> AtlasDbMetrics.instrument(
+        TransactionService transactionService = initializeCloseable(() -> AtlasDbMetrics.instrumentTimed(
                 metricsManager.getRegistry(),
                 TransactionService.class,
                 TransactionServices.createTransactionService(keyValueService, transactionSchemaManager)),

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -382,7 +382,7 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 transactionConfig);
 
         if (shouldInstrument) {
-            transactionManager = AtlasDbMetrics.instrument(
+            transactionManager = AtlasDbMetrics.instrumentTimed(
                     metricsManager.getRegistry(),
                     TransactionManager.class,
                     transactionManager);


### PR DESCRIPTION
**Goals (and why)**:

AtlasDBMetrics times all the methods on interfaces, which a lot of the time includes things that are not useful being timed. This PR adds another codepath there where only annotated methods will be timed. This PR just moves TransactionManager to that codepath and I will send PRs for other interfaces later, to keep this PR small.

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

TransactionManager methods:
* isInitialized: not timed
* runTaskWithRetry/runTaskThrowOnConflict/runTaskReadOnly/runTaskWithLocksWithRetry/runTaskWithLocksWithRetry/runTaskWithLocksWithRetry/runTaskWithLocksWithRetry/runTaskWithLocksThrowOnConflict/runTaskWithConditionWithRetry/runTaskWithConditionWithRetry/runTaskWithConditionThrowOnConflict/runTaskWithConditionReadOnly/: timed, but I would like to get rid of those.
* getImmutableTimestamp: not timed, it just delegates and we should have metrics for that on TimestampService.
* getLockService/getTimelockService/getTimestampService/getTimestampManagementService/getTransactionService/getCleaner/getKeyValueService: not timed, in memory instance variable access
* getKeyValueServiceStatus: not timed, we have metrics at KVS layer for individual calls.
* getTimelockServiceStatus: just looks at timelock metrics and returns a value, so not useful.
* getUnreadableTimestamp: timed until we have a more specific metric for this in the Puncher store
* clearTimestampCache: not timed, this is probably just timing guava/caffeine
* registerClosingCallback: not timed
* setupRunTaskWithConditionThrowOnConflict/finishRunTaskWithLockThrowOnConflict: internal product relies on that, but might be able to move off those metrics.
* close: not timed

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
