### PR TITLE
[Timelock Partitioning] Part 39: Have separate paxos leadership remote clients.

### DIFF
--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClients.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClients.java
@@ -19,6 +19,8 @@ package com.palantir.atlasdb.timelock.paxos;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import javax.ws.rs.Path;
+
 import org.immutables.value.Value;
 
 import com.google.common.collect.ImmutableMap;
@@ -26,6 +28,8 @@ import com.palantir.atlasdb.config.AuxiliaryRemotingParameters;
 import com.palantir.atlasdb.http.AtlasDbHttpClients;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
 import com.palantir.conjure.java.api.config.service.UserAgents;
+import com.palantir.paxos.PaxosAcceptor;
+import com.palantir.paxos.PaxosLearner;
 import com.palantir.timelock.paxos.TimelockPaxosAcceptorRpcClient;
 import com.palantir.timelock.paxos.TimelockPaxosLearnerRpcClient;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
@@ -40,13 +44,27 @@ public abstract class PaxosRemoteClients {
     public abstract TaggedMetricRegistry metrics();
 
     @Value.Derived
-    public List<TimelockPaxosAcceptorRpcClient> nonBatchAcceptor() {
+    public List<TimelockPaxosAcceptorRpcClient> nonBatchTimestampAcceptor() {
         return createInstrumentedRemoteProxies(TimelockPaxosAcceptorRpcClient.class, "paxos-acceptor-rpc-client");
     }
 
     @Value.Derived
-    public List<TimelockPaxosLearnerRpcClient> nonBatchLearner() {
+    public List<TimelockPaxosLearnerRpcClient> nonBatchTimestampLearner() {
         return createInstrumentedRemoteProxies(TimelockPaxosLearnerRpcClient.class, "paxos-learner-rpc-client");
+    }
+
+    @Value.Derived
+    public List<TimelockSingleLeaderPaxosLearnerRpcClient> singleLeaderLearner() {
+        return createInstrumentedRemoteProxies(
+                TimelockSingleLeaderPaxosLearnerRpcClient.class,
+                "paxos-leader-learner-rpc-client");
+    }
+
+    @Value.Derived
+    public List<TimelockSingleLeaderPaxosAcceptorRpcClient> singleLeaderAcceptor() {
+        return createInstrumentedRemoteProxies(
+                TimelockSingleLeaderPaxosAcceptorRpcClient.class,
+                "paxos-leader-acceptor  -rpc-client");
     }
 
     @Value.Derived
@@ -82,5 +100,17 @@ public abstract class PaxosRemoteClients {
                         name,
                         _unused -> ImmutableMap.of()))
                 .collect(Collectors.toList());
+    }
+
+    @Path("/" + PaxosTimeLockConstants.INTERNAL_NAMESPACE
+            + "/" + PaxosTimeLockConstants.LEADER_PAXOS_NAMESPACE)
+    public interface TimelockSingleLeaderPaxosLearnerRpcClient extends PaxosLearner {
+
+    }
+
+    @Path("/" + PaxosTimeLockConstants.INTERNAL_NAMESPACE
+            + "/" + PaxosTimeLockConstants.LEADER_PAXOS_NAMESPACE)
+    public interface TimelockSingleLeaderPaxosAcceptorRpcClient extends PaxosAcceptor {
+
     }
 }

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClients.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClients.java
@@ -64,7 +64,7 @@ public abstract class PaxosRemoteClients {
     public List<TimelockSingleLeaderPaxosAcceptorRpcClient> singleLeaderAcceptor() {
         return createInstrumentedRemoteProxies(
                 TimelockSingleLeaderPaxosAcceptorRpcClient.class,
-                "paxos-leader-acceptor  -rpc-client");
+                "paxos-leader-acceptor-rpc-client");
     }
 
     @Value.Derived

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/SingleLeaderNetworkClientFactories.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/SingleLeaderNetworkClientFactories.java
@@ -44,7 +44,7 @@ abstract class SingleLeaderNetworkClientFactories {
     NetworkClientFactories factories() {
         Factory<PaxosAcceptorNetworkClient> acceptorClientFactory = client -> {
             List<PaxosAcceptor> remoteAcceptors = TimelockPaxosAcceptorAdapter
-                    .wrap(useCase(), remoteClients().nonBatchAcceptor())
+                    .wrap(useCase(), remoteClients())
                     .apply(client);
             PaxosAcceptor localAcceptor = components().acceptor(client);
             LocalAndRemotes<PaxosAcceptor> allAcceptors = metrics().instrumentLocalAndRemotesFor(
@@ -61,7 +61,7 @@ abstract class SingleLeaderNetworkClientFactories {
 
         Factory<PaxosLearnerNetworkClient> learnerClientFactory = client -> {
             List<PaxosLearner> remoteLearners = TimelockPaxosLearnerAdapter
-                    .wrap(useCase(), remoteClients().nonBatchLearner())
+                    .wrap(useCase(), remoteClients())
                     .apply(client);
             PaxosLearner localLearner = components().learner(client);
             LocalAndRemotes<PaxosLearner> allLearners = metrics().instrumentLocalAndRemotesFor(


### PR DESCRIPTION
**Goals (and why)**:
I thought I could use `TimelockPaxos(Acceptor|Learner)Adapter` for both timestamp and non-partitioned acceptor/learner remote clients. This was not true.

The former produces URLs in the form:

    /.internal/leaderPaxos/leaderPaxos/learner/learned-values

where `leaderPaxos` is both the `useCase` and the `client`. Which doesn't have a matching resource, server side, where the server side expects

   /.internal/leaderPaxos/learner/learned-values

I thought I had a hack where I would produce a string client with value `""`. But it turns out that

    /.internal/leaderPaxos//learner/learned-values

is not recognised by the server.

I previously added new endpoints to `LeadershipResource` but that's not backwards compatible even when not using partitioned timelock. So we have to make the current clients still speak to the old endpoints.

**Implementation Description (bullets)**:
Have a new interface that extends `PaxosLearner` and `PaxosAcceptor`, but just with a different base.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Tested in a future branch, this code is unused for now, trying to merge some changes in incrementally.

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:
ASAP

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
