### PR TITLE
[Timelock Partitioning] Part 40: `LeaderPinger` returns `PingResult`

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
@@ -171,7 +171,6 @@ public final class Leaders {
         LeaderPinger leaderPinger = new SingleLeaderPinger(
                 createExecutorsForService(metricsManager, otherLeaders, "leader-ping"),
                 config.leaderPingResponseWait(),
-                leadershipEventRecorder,
                 leaderUuid);
 
         LeaderElectionService uninstrumentedLeaderElectionService = new LeaderElectionServiceBuilder()

--- a/leader-election-impl/build.gradle
+++ b/leader-election-impl/build.gradle
@@ -14,6 +14,8 @@ dependencies {
 
   annotationProcessor group: 'org.immutables', name: 'value'
   compileOnly 'org.immutables:value::annotations'
+  annotationProcessor 'org.derive4j:derive4j'
+  compileOnly 'org.derive4j:derive4j-annotation'
 
   testCompile(group: "org.jmock", name: "jmock", version: libVersions.jmock) {
     exclude group: 'org.hamcrest'

--- a/leader-election-impl/src/main/java/com/palantir/paxos/LeaderPingResult.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/LeaderPingResult.java
@@ -1,0 +1,84 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.paxos;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.derive4j.Data;
+
+import com.palantir.leader.PaxosLeaderElectionEventRecorder;
+
+@Data
+public abstract class LeaderPingResult {
+
+    interface Cases<R> {
+        R pingTimedOut();
+        R pingReturnedTrue();
+        R pingReturnedFalse();
+        R pingCallFailure(Throwable exception);
+    }
+
+    public abstract <R> R match(Cases<R> cases);
+
+    public static LeaderPingResult fromBooleanResult(boolean result) {
+        if (result) {
+            return LeaderPingResults.pingReturnedTrue();
+        } else {
+            return LeaderPingResults.pingReturnedFalse();
+        }
+    }
+
+    public void recordEvent(PaxosLeaderElectionEventRecorder eventRecorder) {
+        LeaderPingResults.caseOf(this)
+                .pingTimedOut(wrap(eventRecorder::recordLeaderPingTimeout))
+                .pingReturnedFalse(wrap(eventRecorder::recordLeaderPingReturnedFalse))
+                .pingCallFailure(wrap(eventRecorder::recordLeaderPingFailure))
+                .otherwise_(null);
+    }
+
+    public boolean isSuccessful() {
+        return LeaderPingResults.caseOf(this)
+                .pingReturnedTrue_(true)
+                .otherwise_(false);
+    }
+
+    private static <R> Supplier<R> wrap(Runnable runnable) {
+        return () -> {
+            runnable.run();
+            return null;
+        };
+    }
+
+    private static <T, R> Function<T, R> wrap(Consumer<T> consumer) {
+        return t -> {
+            consumer.accept(t);
+            return null;
+        };
+    }
+
+    @Override
+    public abstract int hashCode();
+
+    @Override
+    public abstract boolean equals(Object obj);
+
+    @Override
+    public abstract String toString();
+
+}

--- a/leader-election-impl/src/main/java/com/palantir/paxos/LeaderPinger.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/LeaderPinger.java
@@ -24,8 +24,9 @@ public interface LeaderPinger {
      * Tries to find the host that has leadership identifier equal to {@code uuid}. If a host is found, it queries
      * whether it is the leader. Every failure case <b>must</b> result in {@code false}.
 
-     * @return whether a leader was found with leadership identifier being {@code uuid}
+     * @return whether a leader was found with leadership identifier being {@code uuid} or a different descriptive
+     * result
      */
-    boolean pingLeaderWithUuid(UUID uuid);
+    LeaderPingResult pingLeaderWithUuid(UUID uuid);
 
 }

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosConsensusTestUtils.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosConsensusTestUtils.java
@@ -32,7 +32,6 @@ import com.google.common.collect.Maps;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.leader.LeaderElectionService;
 import com.palantir.leader.LeaderElectionServiceBuilder;
-import com.palantir.leader.PaxosLeaderElectionEventRecorder;
 import com.palantir.leader.proxy.SimulatingFailingServerProxy;
 import com.palantir.leader.proxy.ToggleableExceptionProxy;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
@@ -88,8 +87,6 @@ public final class PaxosConsensusTestUtils {
             PaxosLearnerNetworkClient learnerNetworkClient = new SingleLeaderLearnerNetworkClient(
                     ourLearner, remoteLearners, quorumSize, Maps.toMap(learners, $ -> executor));
 
-            LeaderPinger leaderPinger = new SingleLeaderPinger(
-                    ImmutableMap.of(), Duration.ZERO, PaxosLeaderElectionEventRecorder.NO_OP, leaderUuid);
             LeaderElectionService leader = new LeaderElectionServiceBuilder()
                     .leaderUuid(leaderUuid)
                     .pingRate(Duration.ZERO)
@@ -97,7 +94,7 @@ public final class PaxosConsensusTestUtils {
                     .knowledge(ourLearner)
                     .acceptorClient(acceptorNetworkClient)
                     .learnerClient(learnerNetworkClient)
-                    .leaderPinger(leaderPinger)
+                    .leaderPinger(new SingleLeaderPinger(ImmutableMap.of(), Duration.ZERO, leaderUuid))
                     .build();
             leaders.add(SimulatingFailingServerProxy.newProxyInstance(
                     LeaderElectionService.class,

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/ClientAwarePingableLeader.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/ClientAwarePingableLeader.java
@@ -19,7 +19,9 @@ package com.palantir.atlasdb.timelock.paxos;
 import java.io.Closeable;
 import java.util.UUID;
 
+import com.palantir.paxos.LeaderPingResult;
+
 interface ClientAwarePingableLeader extends Closeable {
-    boolean ping(Client client);
+    LeaderPingResult ping(Client client);
     UUID uuid();
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PingCoalescingFunction.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PingCoalescingFunction.java
@@ -21,8 +21,9 @@ import java.util.Set;
 
 import com.google.common.collect.Maps;
 import com.palantir.atlasdb.autobatch.CoalescingRequestFunction;
+import com.palantir.paxos.LeaderPingResult;
 
-final class PingCoalescingFunction implements CoalescingRequestFunction<Client, Boolean> {
+final class PingCoalescingFunction implements CoalescingRequestFunction<Client, LeaderPingResult> {
 
     private final BatchPingableLeader batchPingableLeader;
 
@@ -31,8 +32,8 @@ final class PingCoalescingFunction implements CoalescingRequestFunction<Client, 
     }
 
     @Override
-    public Map<Client, Boolean> apply(Set<Client> request) {
-        Set<Client> ping = batchPingableLeader.ping(request);
-        return Maps.toMap(request, ping::contains);
+    public Map<Client, LeaderPingResult> apply(Set<Client> request) {
+        Set<Client> pingResults = batchPingableLeader.ping(request);
+        return Maps.toMap(request, client -> LeaderPingResult.fromBooleanResult(pingResults.contains(client)));
     }
 }

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PingCoalescingFunctionTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PingCoalescingFunctionTests.java
@@ -27,6 +27,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.collect.ImmutableSet;
+import com.palantir.paxos.LeaderPingResults;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PingCoalescingFunctionTests {
@@ -45,9 +46,9 @@ public class PingCoalescingFunctionTests {
 
         PingCoalescingFunction function = new PingCoalescingFunction(remote);
         assertThat(function.apply(clients))
-                .containsEntry(CLIENT_1, true)
-                .containsEntry(CLIENT_3, true)
-                .doesNotContainEntry(CLIENT_2, true)
-                .containsEntry(CLIENT_2, false);
+                .containsEntry(CLIENT_1, LeaderPingResults.pingReturnedTrue())
+                .containsEntry(CLIENT_3, LeaderPingResults.pingReturnedTrue())
+                .doesNotContainEntry(CLIENT_2, LeaderPingResults.pingReturnedTrue())
+                .containsEntry(CLIENT_2, LeaderPingResults.pingReturnedFalse());
     }
 }

--- a/versions.props
+++ b/versions.props
@@ -62,6 +62,7 @@ org.awaitility:awaitility = 3.1.3
 org.checkerframework:checker-compat-qual = 2.3.0
 org.clojure:clojure = 1.8.0
 org.codehaus.groovy:* = 2.4.4
+org.derive4j:* = 1.1.1
 org.eclipse.jetty.http2:* = 9.3.9.v20160517
 org.glassfish.hk2.external:javax.inject = 2.5.0-b05
 org.glassfish.jersey.containers:jersey-container-servlet-core = 2.23.2


### PR DESCRIPTION
**Goals (and why)**:
`LeaderPinger` now returns a `LeaderPingResult`, meaning each implementation no longer needs to know about a `PaxosLeadershipEventRecorder` (which is client scoped, meaning annoying dependency injection), 

Recording the event will all be handled by the `PaxosLeaderElectionService` which it partially does already.

**Implementation Description (bullets)**:
* Introduce a new type (using derive4j) representing the different states a leader ping will return.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Amend existing tests.

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:
* `LeaderPingResult`
* `SingleLeaderPinger`
* `AutobatchingLeaderPinger`

**Priority (whenever / two weeks / yesterday)**:
ASAP 💃 

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
