### PR TITLE
[CJR] Runtime config for disabling experiment fallbacks

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/common/proxy/ExperimentRunningProxy.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/proxy/ExperimentRunningProxy.java
@@ -101,11 +101,15 @@ public final class ExperimentRunningProxy<T> extends AbstractInvocationHandler {
     }
 
     private boolean useExperimental() {
-        return useExperimental.getAsBoolean() && !fallback();
-    }
+        if (!useExperimental.getAsBoolean()) {
+            return false;
+        }
 
-    private boolean fallback() {
-        return enableFallback.getAsBoolean() && !sufficientTimeSinceFailure();
+        if (!enableFallback.getAsBoolean()) {
+            return true;
+        }
+
+        return sufficientTimeSinceFailure();
     }
 
     private boolean sufficientTimeSinceFailure() {

--- a/atlasdb-commons/src/main/java/com/palantir/common/proxy/ExperimentRunningProxy.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/proxy/ExperimentRunningProxy.java
@@ -63,10 +63,20 @@ public final class ExperimentRunningProxy<T> extends AbstractInvocationHandler {
     }
 
     @SuppressWarnings("unchecked")
-    public static <T> T newProxyInstance(T experimentalService, T fallbackService, BooleanSupplier useExperimental,
-            BooleanSupplier enableFallback, Class<T> clazz, Runnable markErrorMetric) {
-        ExperimentRunningProxy<T> service = new ExperimentRunningProxy<>(experimentalService, fallbackService,
-                useExperimental, enableFallback, Clock.systemUTC(), markErrorMetric);
+    public static <T> T newProxyInstance(
+            T experimentalService,
+            T fallbackService,
+            BooleanSupplier useExperimental,
+            BooleanSupplier enableFallback,
+            Class<T> clazz,
+            Runnable markErrorMetric) {
+        ExperimentRunningProxy<T> service = new ExperimentRunningProxy<>(
+                experimentalService,
+                fallbackService,
+                useExperimental,
+                enableFallback,
+                Clock.systemUTC(),
+                markErrorMetric);
         return (T) Proxy.newProxyInstance(
                 clazz.getClassLoader(),
                 new Class[] { clazz },

--- a/atlasdb-commons/src/main/java/com/palantir/common/proxy/ExperimentRunningProxy.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/proxy/ExperimentRunningProxy.java
@@ -40,6 +40,7 @@ public final class ExperimentRunningProxy<T> extends AbstractInvocationHandler {
     private final T experimentalService;
     private final T fallbackService;
     private final BooleanSupplier useExperimental;
+    private final BooleanSupplier enableFallback;
     private final Clock clock;
     private final Runnable errorTask;
 
@@ -50,19 +51,22 @@ public final class ExperimentRunningProxy<T> extends AbstractInvocationHandler {
             T experimentalService,
             T fallbackService,
             BooleanSupplier useExperimental,
+            BooleanSupplier enableFallback,
             Clock clock,
             Runnable errorTask) {
         this.experimentalService = experimentalService;
         this.fallbackService = fallbackService;
         this.useExperimental = useExperimental;
+        this.enableFallback = enableFallback;
         this.clock = clock;
         this.errorTask = errorTask;
     }
 
+    @SuppressWarnings("unchecked")
     public static <T> T newProxyInstance(T experimentalService, T fallbackService, BooleanSupplier useExperimental,
-            Class<T> clazz, Runnable markErrorMetric) {
-        ExperimentRunningProxy<T> service = new ExperimentRunningProxy<>(
-                experimentalService, fallbackService, useExperimental, Clock.systemUTC(), markErrorMetric);
+            BooleanSupplier enableFallback, Class<T> clazz, Runnable markErrorMetric) {
+        ExperimentRunningProxy<T> service = new ExperimentRunningProxy<>(experimentalService, fallbackService,
+                useExperimental, enableFallback, Clock.systemUTC(), markErrorMetric);
         return (T) Proxy.newProxyInstance(
                 clazz.getClassLoader(),
                 new Class[] { clazz },
@@ -87,14 +91,25 @@ public final class ExperimentRunningProxy<T> extends AbstractInvocationHandler {
     }
 
     private boolean useExperimental() {
-        return useExperimental.getAsBoolean() && Instant.now(clock).compareTo(nextPermittedExperiment.get()) > 0;
+        return useExperimental.getAsBoolean() && !fallback();
+    }
+
+    private boolean fallback() {
+        return enableFallback.getAsBoolean() && !sufficientTimeSinceFailure();
+    }
+
+    private boolean sufficientTimeSinceFailure() {
+        return Instant.now(clock).compareTo(nextPermittedExperiment.get()) > 0;
     }
 
     private void markExperimentFailure(Exception exception) {
-        nextPermittedExperiment.accumulateAndGet(Instant.now(clock).plus(REFRESH_INTERVAL),
-                (existing, current) -> existing.compareTo(current) > 0 ? existing : current);
+        if (enableFallback.getAsBoolean()) {
+            nextPermittedExperiment.accumulateAndGet(Instant.now(clock).plus(REFRESH_INTERVAL),
+                    (existing, current) -> existing.compareTo(current) > 0 ? existing : current);
+            log.info("Experiment failed; we will revert to the fallback service. We will allow attempting to use the "
+                    + "experimental service again after a timeout.",
+                    SafeArg.of("timeout", REFRESH_INTERVAL), exception);
+        }
         errorTask.run();
-        log.info("Experiment failed; we will revert to the fallback service. We will allow attempting to use the"
-                + " experimental service again after a timeout.", SafeArg.of("timeout", REFRESH_INTERVAL), exception);
     }
 }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
@@ -25,6 +25,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.google.common.annotations.VisibleForTesting;
 import com.palantir.atlasdb.config.AuxiliaryRemotingParameters;
 import com.palantir.atlasdb.config.ServerListConfig;
+import com.palantir.atlasdb.http.VersionSelectingClients.VersionSelectingConfig;
 import com.palantir.atlasdb.http.v2.ConjureJavaRuntimeTargetFactory;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
 import com.palantir.atlasdb.util.MetricsManager;
@@ -103,7 +104,7 @@ public final class AtlasDbHttpClients {
                     metricsManager,
                     experimentalProxySupplier.get(),
                     fallbackProxy,
-                    () -> clientParameters.remotingClientConfig().get().maximumConjureRemotingProbability(),
+                    VersionSelectingConfig.fromRemotingConfigSupplier(clientParameters.remotingClientConfig()),
                     type);
         } catch (Exception e) {
             log.warn("Error occurred in creating an experimental proxy. Possible causes include"

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/VersionSelectingClients.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/VersionSelectingClients.java
@@ -17,11 +17,16 @@
 package com.palantir.atlasdb.http;
 
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.BooleanSupplier;
 import java.util.function.DoubleSupplier;
+import java.util.function.Supplier;
+
+import org.immutables.value.Value;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.atlasdb.AtlasDbMetricNames;
+import com.palantir.atlasdb.config.RemotingClientConfig;
 import com.palantir.atlasdb.util.AccumulatingValueMetric;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
 import com.palantir.atlasdb.util.MetricsManager;
@@ -45,7 +50,7 @@ final class VersionSelectingClients {
             MetricsManager metricsManager,
             TargetFactory.InstanceAndVersion<T> newClient,
             TargetFactory.InstanceAndVersion<T> legacyClient,
-            DoubleSupplier newClientProbabilitySupplier,
+            VersionSelectingConfig versionSelectingConfig,
             Class<T> clazz) {
         T instrumentedNewClient = instrumentWithClientVersionTag(
                 metricsManager.getTaggedRegistry(), newClient, clazz);
@@ -57,7 +62,8 @@ final class VersionSelectingClients {
         return ExperimentRunningProxy.newProxyInstance(
                 instrumentedNewClient,
                 instrumentedLegacyClient,
-                () -> ThreadLocalRandom.current().nextDouble() < newClientProbabilitySupplier.getAsDouble(),
+                versionSelectingConfig.useNewClient(),
+                versionSelectingConfig.enableFallback(),
                 clazz,
                 errorMetric::increment);
     }
@@ -79,5 +85,23 @@ final class VersionSelectingClients {
                 ExperimentRunningProxy.class,
                 AtlasDbMetricNames.EXPERIMENT_ERRORS,
                 AccumulatingValueMetric::new);
+    }
+
+    @Value.Immutable
+    interface VersionSelectingConfig {
+        BooleanSupplier useNewClient();
+        BooleanSupplier enableFallback();
+
+        static VersionSelectingConfig withNewClientProbability(DoubleSupplier probability, BooleanSupplier fallback) {
+            return ImmutableVersionSelectingConfig.builder()
+                    .useNewClient(() -> ThreadLocalRandom.current().nextDouble() < probability.getAsDouble())
+                    .enableFallback(fallback)
+                    .build();
+        }
+
+        static VersionSelectingConfig fromRemotingConfigSupplier(Supplier<RemotingClientConfig> liveReloadingConfig) {
+            return withNewClientProbability(() -> liveReloadingConfig.get().maximumConjureRemotingProbability(),
+                    () -> liveReloadingConfig.get().enableLegacyClientFallback());
+        }
     }
 }

--- a/atlasdb-feign/src/main/java/com/palantir/atlasdb/config/RemotingClientConfig.java
+++ b/atlasdb-feign/src/main/java/com/palantir/atlasdb/config/RemotingClientConfig.java
@@ -34,6 +34,11 @@ public interface RemotingClientConfig {
         return 0.0;
     }
 
+    @Value.Default
+    default boolean enableLegacyClientFallback() {
+        return true;
+    }
+
     @Value.Check
     default void check() {
         Preconditions.checkState(0.0 <= maximumConjureRemotingProbability()


### PR DESCRIPTION
**Goals (and why)**:
If we really want to test out the CJR client, we need to disable fallbacks. This allows us to do so, while still allowing us to flip the switch if things start going south.

**Concerns (what feedback would you like?)**:
Not happy about effectively leaking the fallback logic into `VersionSelectingClients`, but there really isn't a great way around it.