### PR TITLE
Only whitelist certain CassandraClient methods for metrics.

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
@@ -83,7 +83,7 @@ public interface CassandraClient extends Closeable {
             ConsistencyLevel consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, org.apache.thrift.TException;
 
-    // Instrumented manually
+    @Timed
     void batch_mutate(String kvsMethodName,
             Map<ByteBuffer, Map<String, List<Mutation>>> mutation_map,
             ConsistencyLevel consistency_level)
@@ -150,9 +150,6 @@ public interface CassandraClient extends Closeable {
             throws InvalidRequestException, SchemaDisagreementException, TException;
 
     String system_update_keyspace(KsDef ks_def)
-            throws InvalidRequestException, SchemaDisagreementException, TException;
-
-    String system_add_column_family(CfDef cf_def)
             throws InvalidRequestException, SchemaDisagreementException, TException;
 
     String system_update_column_family(CfDef cf_def)

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
@@ -114,7 +114,6 @@ public interface CassandraClient extends Closeable {
             ConsistencyLevel commit_consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, org.apache.thrift.TException;
 
-    @Timed
     CqlResult execute_cql3_query(CqlQuery cqlQuery,
             Compression compression,
             ConsistencyLevel consistency)

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
@@ -44,6 +44,7 @@ import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TProtocol;
 
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.metrics.Timed;
 import com.palantir.processors.AutoDelegate;
 
 @SuppressWarnings({"all"}) // thrift variable names.
@@ -59,6 +60,7 @@ public interface CassandraClient extends Closeable {
 
     String describe_snitch() throws org.apache.thrift.TException;
 
+    @Timed
     Map<ByteBuffer, List<ColumnOrSuperColumn>> multiget_slice(String kvsMethodName,
             TableReference tableRef,
             List<ByteBuffer> keys,
@@ -66,12 +68,14 @@ public interface CassandraClient extends Closeable {
             ConsistencyLevel consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, org.apache.thrift.TException;
 
+    @Timed
     Map<ByteBuffer, List<List<ColumnOrSuperColumn>>> multiget_multislice(String kvsMethodName,
             TableReference tableRef,
             List<KeyPredicate> keyPredicates,
             ConsistencyLevel consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, org.apache.thrift.TException;
 
+    @Timed
     List<KeySlice> get_range_slices(String kvsMethodName,
             TableReference tableRef,
             SlicePredicate predicate,
@@ -79,11 +83,13 @@ public interface CassandraClient extends Closeable {
             ConsistencyLevel consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, org.apache.thrift.TException;
 
+    // Instrumented manually
     void batch_mutate(String kvsMethodName,
             Map<ByteBuffer, Map<String, List<Mutation>>> mutation_map,
             ConsistencyLevel consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, org.apache.thrift.TException;
 
+    @Timed
     ColumnOrSuperColumn get(TableReference tableReference,
             ByteBuffer key,
             byte[] column,
@@ -91,6 +97,7 @@ public interface CassandraClient extends Closeable {
             throws InvalidRequestException, NotFoundException, UnavailableException, TimedOutException,
             org.apache.thrift.TException;
 
+    @Timed
     CASResult cas(TableReference tableReference,
             ByteBuffer key,
             List<Column> expected,
@@ -99,6 +106,7 @@ public interface CassandraClient extends Closeable {
             ConsistencyLevel commit_consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, org.apache.thrift.TException;
 
+    @Timed
     public CASResult put_unless_exists(TableReference tableReference,
             ByteBuffer key,
             List<Column> updates,
@@ -106,12 +114,14 @@ public interface CassandraClient extends Closeable {
             ConsistencyLevel commit_consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, org.apache.thrift.TException;
 
+    @Timed
     CqlResult execute_cql3_query(CqlQuery cqlQuery,
             Compression compression,
             ConsistencyLevel consistency)
             throws InvalidRequestException, UnavailableException, TimedOutException, SchemaDisagreementException,
             org.apache.thrift.TException;
 
+    @Timed
     void remove(String kvsMethodName,
             TableReference tableRef,
             byte[] row,
@@ -151,14 +161,18 @@ public interface CassandraClient extends Closeable {
     String system_drop_column_family(String column_family)
             throws InvalidRequestException, SchemaDisagreementException, TException;
 
+    @Timed
     CqlPreparedResult prepare_cql3_query(ByteBuffer query, Compression compression)
             throws InvalidRequestException, TException;
 
+    @Timed
     CqlResult execute_prepared_cql3_query(int intemId, List<ByteBuffer> values, ConsistencyLevel consistency)
             throws InvalidRequestException, UnavailableException, TimedOutException, SchemaDisagreementException, TException;
 
+    @Timed
     ByteBuffer trace_next_query() throws TException;
 
+    @Timed
     void truncate(String cfname)
             throws InvalidRequestException, UnavailableException, TimedOutException, TException;
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
@@ -87,7 +87,7 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
         client = new ProfilingCassandraClient(client);
         client = new TracingCassandraClient(client);
         // TODO(ssouza): use the kvsMethodName to tag the timers.
-        client = AtlasDbMetrics.instrument(metricsManager.getRegistry(), CassandraClient.class, client);
+        client = AtlasDbMetrics.instrumentTimed(metricsManager.getRegistry(), CassandraClient.class, client);
         client = new InstrumentedCassandraClient(client, metricsManager.getTaggedRegistry());
         client = QosCassandraClient.instrumentWithMetrics(client, metricsManager);
         return client;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientImpl.java
@@ -186,12 +186,6 @@ public class CassandraClientImpl implements CassandraClient {
     }
 
     @Override
-    public String system_add_column_family(CfDef cf_def)
-            throws InvalidRequestException, SchemaDisagreementException, TException {
-        return executeHandlingExceptions(() -> client.system_add_column_family(cf_def));
-    }
-
-    @Override
     public String system_update_column_family(CfDef cf_def)
             throws InvalidRequestException, SchemaDisagreementException, TException {
         return executeHandlingExceptions(() -> client.system_update_column_family(cf_def));


### PR DESCRIPTION
**Goals (and why)**:

**Implementation Description (bullets)**:

CassandraClient methods and their metrics status:

### Not timed:
* isValid: not timed
* describe_snitch: not timed, just a background thing. If there are issues with this, likely there are issues with the cluster?
* getOutputProtocol/getInputProtocol: not timed, seems to be only used for pool management?
* describe_ring: not timed, pool management
* describe_version: not timed, startup checks?
* describe_schema_versions: not timed, startup
* describe_partitioner: not timed, pool management
* describe_keyspace: not timed, seems like mixture of pool management, and startup
* describe_keyspaces: not timed, seems like only used by CassandraVerifier
* system_add_keyspace: not timed, seems like only used by CassandraVerifier; **might be used by internal product?**
* system_update_keyspace: not timed, seems like only used by CassandraVerifier; **might be used by internal product?**
* system_update_column_family: not timed, startup or create tables; **might be used by internal product?**
* system_drop_column_family: not timed, dropping tables.; **might be used by internal product?**

### Timed:
* multiget_slice: timed
* multiget_multislice: timed
* get_range_slices: timed
* batch_mutate: timed, there's additionally some metrics in InstrumentedCassandraClient for this.
* get: timed, although the only usage I can see is in PersistentTimestampServiceImpl? Which seems to query this stuff on startup.
* cas: timed, same as above, what is this stuff?
* put_unless_exists: timed
* execute_cql3_query: timed. It's used in CassandraTableCreator (so only at startup), but also *I think* in other places. We might be able to remove this, but I'm not that fussed.
* remove: timed. used by sweep?

### Other:
* **system_add_column_family: removed, doesn't look like it's used?**

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

Would like a reviewer to go through the list of methods that I chose to stop timing, to double check that we're not missing anything. I have done cursory looking by classifying things quickly into "probably only used at startup, so don't really care about metrics", but could have possibly missed things. If internal products rely on the table/keyspace management methods being timed, we need to check if they have accurate custom metrics for monitoring that.

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
