### PR TITLE
[Timelock Partitioning] Part 42: `LeadershipMetrics` propagates its client.

### DIFF
--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeadershipEventRecorder.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeadershipEventRecorder.java
@@ -18,6 +18,7 @@ package com.palantir.leader;
 import java.util.List;
 import java.util.Optional;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -43,8 +44,8 @@ public class PaxosLeadershipEventRecorder implements PaxosKnowledgeEventRecorder
     public static PaxosLeadershipEventRecorder create(
             TaggedMetricRegistry metrics,
             String leaderUuid,
-            LeadershipObserver observer,
-            List<SafeArg<Object>> safeArgs) {
+            @Nullable LeadershipObserver observer,
+            List<SafeArg<String>> safeArgs) {
         return new PaxosLeadershipEventRecorder(
                 new LeadershipEvents(metrics, safeArgs),
                 leaderUuid,

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipComponents.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipComponents.java
@@ -65,7 +65,7 @@ public class LeadershipComponents {
         Closeable closeableInstance = (Closeable) instance;
         closer.register(closeableInstance);
 
-        return context.leadershipMetrics().instrument(client, name, clazz, instance);
+        return context.leadershipMetrics().instrument(name, clazz, instance);
     }
 
     public void shutdown() {

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/PaxosLeadershipCreator.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/PaxosLeadershipCreator.java
@@ -34,6 +34,8 @@ import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.config.LeaderRuntimeConfig;
 import com.palantir.atlasdb.factory.ImmutableRemotePaxosServerSpec;
 import com.palantir.atlasdb.factory.Leaders;
+import com.palantir.atlasdb.timelock.paxos.AutobatchingLeadershipObserverFactory;
+import com.palantir.atlasdb.timelock.paxos.AutobatchingLeadershipObserverFactory.LeadershipEvent;
 import com.palantir.atlasdb.timelock.paxos.Client;
 import com.palantir.atlasdb.timelock.paxos.LeadershipResource;
 import com.palantir.atlasdb.timelock.paxos.PaxosTimeLockConstants;
@@ -47,7 +49,6 @@ import com.palantir.leader.proxy.AwaitingLeadershipProxy;
 import com.palantir.timelock.config.PaxosRuntimeConfiguration;
 import com.palantir.timelock.config.TimeLockInstallConfiguration;
 import com.palantir.timelock.config.TimeLockRuntimeConfiguration;
-import com.palantir.timelock.paxos.AutobatchingLeadershipObserverFactory.LeadershipEvent;
 import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AutobatchingLeadershipObserverFactory.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AutobatchingLeadershipObserverFactory.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.timelock.paxos;
+package com.palantir.atlasdb.timelock.paxos;
 
 import java.io.Closeable;
 import java.util.List;
@@ -26,12 +26,10 @@ import com.google.common.collect.SetMultimap;
 import com.palantir.atlasdb.autobatch.Autobatchers;
 import com.palantir.atlasdb.autobatch.BatchElement;
 import com.palantir.atlasdb.autobatch.DisruptorAutobatcher;
-import com.palantir.atlasdb.timelock.paxos.Client;
-import com.palantir.atlasdb.timelock.paxos.NetworkClientFactories.Factory;
 import com.palantir.common.streams.KeyedStream;
 import com.palantir.leader.LeadershipObserver;
 
-public final class AutobatchingLeadershipObserverFactory implements Factory<LeadershipObserver>, Closeable {
+public final class AutobatchingLeadershipObserverFactory implements Closeable {
 
     private final DisruptorAutobatcher<Map.Entry<Client, LeadershipEvent>, Void> leadershipEventProcessor;
 
@@ -51,7 +49,6 @@ public final class AutobatchingLeadershipObserverFactory implements Factory<Lead
         return new AutobatchingLeadershipObserverFactory(leadershipEventProcessor);
     }
 
-    @Override
     public LeadershipObserver create(Client client) {
         return new AutobatchingMetricsDeregistrator(client);
     }
@@ -78,7 +75,7 @@ public final class AutobatchingLeadershipObserverFactory implements Factory<Lead
         leadershipEventProcessor.close();
     }
 
-    enum LeadershipEvent {
+    public enum LeadershipEvent {
         GAINED_LEADERSHIP(true),
         LOST_LEADERSHIP(false);
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/TimelockPaxosMetrics.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/TimelockPaxosMetrics.java
@@ -22,8 +22,11 @@ import java.util.concurrent.TimeUnit;
 
 import org.immutables.value.Value;
 
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
+import com.palantir.atlasdb.util.MetricsManager;
+import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.tritium.metrics.registry.SlidingWindowTaggedMetricRegistry;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 
@@ -35,6 +38,12 @@ public abstract class TimelockPaxosMetrics {
     @Value.Derived
     TaggedMetricRegistry metrics() {
         return new SlidingWindowTaggedMetricRegistry(35, TimeUnit.SECONDS);
+    }
+
+    @Value.Derived
+    MetricsManager asMetricsManager() {
+        // we don't use the normal metric registry so we don't care about this
+        return MetricsManagers.of(new MetricRegistry(), metrics());
     }
 
     public static TimelockPaxosMetrics of(PaxosUseCase paxosUseCase, TaggedMetricRegistry parentRegistry) {


### PR DESCRIPTION
**Goals (and why)**:
Due to #4327, we can now create a `TimelockLeadershipMetrics` for each client and don't have to worry about maintaining a "global" leadership metrics and then a client aware leadership metrics.

**Implementation Description (bullets)**:
* If we pass `contextArgs` to `LeadershipEvents` we should then make sure any metrics are tagged with those args so it's not just the logging etc.
* Add the ability to create an `AutobatchingLeadershipObserverFactory` that will deregister the right set of things depending on the use case.
  * with single leader, we want to deregister everything, since we only have one `LeaderElectionService`
  * with partitioned leadership, we want to deregister everything that matches the `isCurrentSuspectedLeader` predicate *and* is the client that had a leadership event change.

**Priority (whenever / two weeks / yesterday)**:
ASAP

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
