### PR TITLE
Only whitelist certain KeyValueService methods for metrics.

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -297,6 +297,7 @@ public interface KeyValueService extends AutoCloseable {
      * @param checkAndSetRequest the request, including table, cell, old value and new value.
      * @throws CheckAndSetException if the stored value for the cell was not as expected.
      */
+    @Timed
     void checkAndSet(CheckAndSetRequest checkAndSetRequest) throws CheckAndSetException;
 
     /**

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -22,6 +22,7 @@ import java.util.Set;
 
 import com.google.common.collect.Multimap;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.atlasdb.metrics.Timed;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.common.annotation.Idempotent;
 import com.palantir.common.annotation.NonIdempotent;
@@ -65,6 +66,7 @@ public interface KeyValueService extends AutoCloseable {
      *         (e.g., attempting to retrieve values from a non-existent table).
      */
     @Idempotent
+    @Timed
     Map<Cell, Value> getRows(TableReference tableRef,
                              Iterable<byte[]> rows,
                              ColumnSelection columnSelection,
@@ -84,6 +86,7 @@ public interface KeyValueService extends AutoCloseable {
      * @throws IllegalArgumentException if {@code rows} contains duplicates.
      */
     @Idempotent
+    @Timed
     Map<byte[], RowColumnRangeIterator> getRowsColumnRange(
             TableReference tableRef,
             Iterable<byte[]> rows,
@@ -109,6 +112,7 @@ public interface KeyValueService extends AutoCloseable {
      * @throws IllegalArgumentException if {@code rows} contains duplicates.
      */
     @Idempotent
+    @Timed
     RowColumnRangeIterator getRowsColumnRange(
             TableReference tableRef,
             Iterable<byte[]> rows,
@@ -129,6 +133,7 @@ public interface KeyValueService extends AutoCloseable {
      *         (e.g., attempting to retrieve values from a non-existent table).
      */
     @Idempotent
+    @Timed
     Map<Cell, Value> get(TableReference tableRef, Map<Cell, Long> timestampByCell);
 
     /**
@@ -145,6 +150,7 @@ public interface KeyValueService extends AutoCloseable {
      *         (e.g., attempting to retrieve values from a non-existent table).
      */
     @Idempotent
+    @Timed
     Map<Cell, Long> getLatestTimestamps(TableReference tableRef, Map<Cell, Long> timestampByCell);
 
     /**
@@ -168,6 +174,7 @@ public interface KeyValueService extends AutoCloseable {
      * @param timestamp must be non-negative and not equal to {@link Long#MAX_VALUE}
      */
     @Idempotent
+    @Timed
     void put(TableReference tableRef,
              Map<Cell, byte[]> values,
              long timestamp) throws KeyAlreadyExistsException;
@@ -192,6 +199,7 @@ public interface KeyValueService extends AutoCloseable {
      * @param timestamp must be non-negative and not equal to {@link Long#MAX_VALUE}
      */
     @Idempotent
+    @Timed
     void multiPut(Map<TableReference, ? extends Map<Cell, byte[]>> valuesByTable,
                   long timestamp) throws KeyAlreadyExistsException;
 
@@ -220,6 +228,7 @@ public interface KeyValueService extends AutoCloseable {
      */
     @NonIdempotent
     @Idempotent
+    @Timed
     void putWithTimestamps(TableReference tableRef,
                            Multimap<Cell, Value> cellValues) throws KeyAlreadyExistsException;
 
@@ -245,6 +254,7 @@ public interface KeyValueService extends AutoCloseable {
      * @throws KeyAlreadyExistsException If you are putting a Cell with the same timestamp as
      *                                      one that already exists.
      */
+    @Timed
     void putUnlessExists(TableReference tableRef,
                          Map<Cell, byte[]> values) throws KeyAlreadyExistsException;
 
@@ -312,6 +322,7 @@ public interface KeyValueService extends AutoCloseable {
      * @param keys map containing the keys to delete values for; the map should specify, for each
      */
     @Idempotent
+    @Timed
     void delete(TableReference tableRef, Multimap<Cell, Long> keys);
 
     /**
@@ -328,6 +339,7 @@ public interface KeyValueService extends AutoCloseable {
      * @param range the range to delete
      */
     @Idempotent
+    @Timed
     void deleteRange(TableReference tableRef, RangeRequest range);
 
     /**
@@ -348,6 +360,7 @@ public interface KeyValueService extends AutoCloseable {
      * @param rows rows to delete
      */
     @Idempotent
+    @Timed
     void deleteRows(TableReference tableRef, Iterable<byte[]> rows);
 
     /**
@@ -361,6 +374,7 @@ public interface KeyValueService extends AutoCloseable {
      * @param deletes cells to be deleted, and the ranges of timestamps to delete for each cell
      */
     @Idempotent
+    @Timed
     void deleteAllTimestamps(TableReference tableRef, Map<Cell, TimestampRangeDelete> deletes)
             throws InsufficientConsistencyException;
 
@@ -400,6 +414,7 @@ public interface KeyValueService extends AutoCloseable {
      * @param timestamp specifies the maximum timestamp (exclusive) at which to retrieve each rows's
      */
     @Idempotent
+    @Timed
     ClosableIterator<RowResult<Value>> getRange(TableReference tableRef,
                                                 RangeRequest rangeRequest,
                                                 long timestamp);
@@ -424,6 +439,7 @@ public interface KeyValueService extends AutoCloseable {
      */
     @Idempotent
     @Deprecated
+    @Timed
     ClosableIterator<RowResult<Set<Long>>> getRangeOfTimestamps(
             TableReference tableRef,
             RangeRequest rangeRequest,
@@ -444,6 +460,7 @@ public interface KeyValueService extends AutoCloseable {
      * We return an iterator of lists instead of a "flat" iterator of results so that we preserve the information
      * about batching. The caller can always use Iterators.concat() or similar if this is undesired.
      */
+    @Timed
     ClosableIterator<List<CandidateCellForSweeping>> getCandidateCellsForSweeping(
             TableReference tableRef,
             CandidateCellForSweepingRequest request);
@@ -465,6 +482,7 @@ public interface KeyValueService extends AutoCloseable {
      * moreResultsAvailable set to false.
      */
     @Idempotent
+    @Timed
     Map<RangeRequest, TokenBackedBasicResultsPage<RowResult<Value>, byte[]>> getFirstBatchForRanges(
             TableReference tableRef,
             Iterable<RangeRequest> rangeRequests,
@@ -554,6 +572,7 @@ public interface KeyValueService extends AutoCloseable {
      * a value already exists at that time stamp, nothing is written for that cell.
      */
     @Idempotent
+    @Timed
     void addGarbageCollectionSentinelValues(TableReference tableRef, Iterable<Cell> cells);
 
     /**
@@ -572,6 +591,7 @@ public interface KeyValueService extends AutoCloseable {
      * @return multimap of timestamps by cell
      */
     @Idempotent
+    @Timed
     Multimap<Cell, Long> getAllTimestamps(TableReference tableRef, Set<Cell> cells, long timestamp)
             throws AtlasDbDependencyException;
 
@@ -581,12 +601,14 @@ public interface KeyValueService extends AutoCloseable {
      *
      * This call must be implemented so that it completes synchronously.
      */
+    @Timed
     void compactInternally(TableReference tableRef);
 
     /**
      * Some compaction operations might block reads and writes.
      * These operations will trigger only if inMaintenanceMode is set to true.
      */
+    @Timed
     default void compactInternally(TableReference tableRef, boolean inMaintenanceMode) {
         compactInternally(tableRef);
     }
@@ -604,6 +626,7 @@ public interface KeyValueService extends AutoCloseable {
      * <p>
      * This call must be implemented so that it completes synchronously.
      */
+    @Timed
     ClusterAvailabilityStatus getClusterAvailabilityStatus();
 
     ////////////////////////////////////////////////////////////
@@ -648,5 +671,6 @@ public interface KeyValueService extends AutoCloseable {
      *         because they were deleted or never created in the first place) are simply not returned.
      */
     @Idempotent
+    @Timed
     ListenableFuture<Map<Cell, Value>> getAsync(TableReference tableRef, Map<Cell, Long> timestampByCell);
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/AtlasDbMetrics.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/AtlasDbMetrics.java
@@ -44,6 +44,11 @@ public final class AtlasDbMetrics {
         return instrument(metricRegistry, serviceInterface, service, serviceInterface.getName(), instrumentTimedOnly());
     }
 
+    public static <T, U extends T> T instrumentTimed(
+            MetricRegistry metricRegistry, Class<T> serviceInterface, U service, String name) {
+        return instrument(metricRegistry, serviceInterface, service, name, instrumentTimedOnly());
+    }
+
     /**
      * @deprecated use {@link #instrumentTimed(MetricRegistry, Class, Object)}
      */
@@ -53,6 +58,10 @@ public final class AtlasDbMetrics {
         return instrument(metricRegistry, serviceInterface, service, serviceInterface.getName());
     }
 
+    /**
+     * @deprecated use {@link #instrumentTimed(MetricRegistry, Class, Object, String)}
+     */
+    @Deprecated
     public static <T, U extends T> T instrument(
             MetricRegistry metricRegistry, Class<T> serviceInterface, U service, String name) {
         return instrument(metricRegistry, serviceInterface, service, name, instrumentAllMethods());

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/util/AtlasDbMetricsTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/util/AtlasDbMetricsTest.java
@@ -28,8 +28,9 @@ public final class AtlasDbMetricsTest {
 
     private static final String CUSTOM_METRIC_NAME = "foo";
     private static final String PING_METHOD = "ping";
+    private static final String PING_NOT_TIMED_METHOD = "pingNotTimed";
     private static final String PING_REQUEST_METRIC = MetricRegistry.name(TestService.class, PING_METHOD);
-    private static final String PING_NOT_TIMED_REQUEST = MetricRegistry.name(TestService.class, "pingNotTimed");
+    private static final String PING_NOT_TIMED_METRIC = MetricRegistry.name(TestService.class, PING_NOT_TIMED_METHOD);
     private static final String PING_RESPONSE = "pong";
 
     private final MetricRegistry metrics = new MetricRegistry();
@@ -50,7 +51,7 @@ public final class AtlasDbMetricsTest {
         TestService service = AtlasDbMetrics.instrumentTimed(metrics, TestService.class, testService);
 
         assertMethodInstrumented(PING_REQUEST_METRIC, service::ping);
-        assertMethodNotInstrumented(PING_NOT_TIMED_REQUEST, service::pingNotTimed);
+        assertMethodNotInstrumented(PING_NOT_TIMED_METRIC, service::pingNotTimed);
     }
 
     @Test
@@ -58,15 +59,27 @@ public final class AtlasDbMetricsTest {
         TestService service = AtlasDbMetrics.instrument(metrics, TestService.class, testService);
 
         assertMethodInstrumented(PING_REQUEST_METRIC, service::ping);
-        assertMethodInstrumented(PING_NOT_TIMED_REQUEST, service::pingNotTimed);
+        assertMethodInstrumented(PING_NOT_TIMED_METRIC, service::pingNotTimed);
     }
 
     @Test
-    public void instrumentWithCustomName() {
+    public void instrumentWithCustomNameTimed() {
+        TestService service = AtlasDbMetrics.instrumentTimed(
+                metrics, TestService.class, testService, CUSTOM_METRIC_NAME);
+
+        assertMethodInstrumented(
+                MetricRegistry.name(CUSTOM_METRIC_NAME, PING_METHOD), service::ping);
+        assertMethodNotInstrumented(
+                MetricRegistry.name(CUSTOM_METRIC_NAME, PING_NOT_TIMED_METHOD), service::pingNotTimed);
+    }
+
+    @Test
+    public void instrumentWithCustomNameAll() {
         TestService service = AtlasDbMetrics.instrument(
                 metrics, TestService.class, testService, CUSTOM_METRIC_NAME);
 
         assertMethodInstrumented(MetricRegistry.name(CUSTOM_METRIC_NAME, PING_METHOD), service::ping);
+        assertMethodInstrumented(MetricRegistry.name(CUSTOM_METRIC_NAME, PING_NOT_TIMED_METHOD), service::pingNotTimed);
     }
 
     private void assertMethodInstrumented(

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -358,7 +358,7 @@ public abstract class TransactionManagers {
             }
 
             kvs = TracingKeyValueService.create(kvs);
-            kvs = AtlasDbMetrics.instrument(metricsManager.getRegistry(),
+            kvs = AtlasDbMetrics.instrumentTimed(metricsManager.getRegistry(),
                     KeyValueService.class,
                     kvs,
                     MetricRegistry.name(KeyValueService.class));


### PR DESCRIPTION
**Goals (and why)**:

**Implementation Description (bullets)**:

KeyValueService methods and their metrics status:

### Not timed:
* close
* getDelegates
* supportsCheckAndSet
* getCheckAndSetCompatibility
* truncateTable/truncateTables/dropTable/dropTables/createTable/createTables/getAllTableNames/getMetadataForTable/getMetadataForTables/putMetadataForTable/putMetadataForTables/: suspect only startup?
* isInitialized
* performanceIsSensitiveToTombstones
* shouldTriggerCompactions


### Timed:
* getRows
* **getRowsColumnRange: there looks like to be two methods with same name - I suspect the metrics are broken here?**
* get
* getLatestTimestamps
* put
* multiPut
* putWithTimestamps
* putUnlessExists
* checkAndSet
* delete
* deleteRange
* deleteRows
* deleteAllTimestamps
* getRange
* getRangeOfTimestamps
* getCandidateCellsForSweeping
* getFirstBatchForRanges
* addGarbageCollectionSentinelValues
* getAllTimestamps
* **compactInternally: again method name is repeated**
* getClusterAvailabilityStatus: I would probably vote for removing this
* getAsync

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
