### PR TITLE
[Timelock Partitioning] Part 43: `LocalPaxosComponents` knows about `LocalPingableLeader`

### DIFF
--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClients.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClients.java
@@ -28,6 +28,7 @@ import com.palantir.atlasdb.config.AuxiliaryRemotingParameters;
 import com.palantir.atlasdb.http.AtlasDbHttpClients;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
 import com.palantir.conjure.java.api.config.service.UserAgents;
+import com.palantir.leader.PingableLeader;
 import com.palantir.paxos.PaxosAcceptor;
 import com.palantir.paxos.PaxosLearner;
 import com.palantir.timelock.paxos.TimelockPaxosAcceptorRpcClient;
@@ -81,7 +82,16 @@ public abstract class PaxosRemoteClients {
                 "batch-paxos-learner-rpc-client");
     }
 
+    @Value.Derived
+    public List<PingableLeader> nonBatchPingableLeaders() {
+        return createInstrumentedRemoteProxies(PingableLeader.class, "paxos-pingable-leader-rpc-client", false);
+    }
+
     private <T> List<T> createInstrumentedRemoteProxies(Class<T> clazz, String name) {
+        return createInstrumentedRemoteProxies(clazz, name, true);
+    }
+
+    private <T> List<T> createInstrumentedRemoteProxies(Class<T> clazz, String name, boolean shouldRetry) {
         return context().remoteUris().stream()
                 // TODO(fdesouza): wire up the configurable cutover to CJR
                 .map(uri -> AtlasDbHttpClients.LEGACY_FEIGN_TARGET_FACTORY.createProxy(
@@ -91,7 +101,7 @@ public abstract class PaxosRemoteClients {
                         AuxiliaryRemotingParameters.builder()
                                 .userAgent(UserAgents.tryParse(name))
                                 .shouldLimitPayload(false)
-                                .shouldRetry(true)
+                                .shouldRetry(shouldRetry)
                                 .build()).instance())
                 .map(proxy -> AtlasDbMetrics.instrumentWithTaggedMetrics(
                         metrics(),

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResourcesFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResourcesFactory.java
@@ -116,7 +116,8 @@ public final class PaxosResourcesFactory {
 
         LocalPaxosComponents paxosComponents = new LocalPaxosComponents(
                 timelockMetrics,
-                useCase.logDirectoryRelativeToDataDirectory(install.dataDirectory()));
+                useCase.logDirectoryRelativeToDataDirectory(install.dataDirectory()),
+                install.nodeUuid());
 
         NetworkClientFactories batchClientFactories = ImmutableBatchingNetworkClientFactories.builder()
                 .useCase(useCase)

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponentsTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponentsTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.UUID;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -56,7 +57,8 @@ public class LocalPaxosComponentsTest {
         logDirectory = TEMPORARY_FOLDER.newFolder().toPath();
         paxosComponents = new LocalPaxosComponents(
                 TimelockPaxosMetrics.of(PaxosUseCase.TIMESTAMP, new DefaultTaggedMetricRegistry()),
-                logDirectory);
+                logDirectory,
+                UUID.randomUUID());
     }
 
     @Test

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
@@ -109,7 +109,8 @@ public class PaxosTimestampBoundStoreTest {
             String root = temporaryFolder.getRoot().getAbsolutePath();
             LocalPaxosComponents components = new LocalPaxosComponents(
                     TimelockPaxosMetrics.of(PaxosUseCase.TIMESTAMP, SharedTaggedMetricRegistries.getSingleton()),
-                    Paths.get(root, Integer.toString(i)));
+                    Paths.get(root, Integer.toString(i)),
+                    UUID.randomUUID());
 
             AtomicBoolean failureController = new AtomicBoolean(false);
             failureToggles.add(failureController);


### PR DESCRIPTION
**Goals (and why)**:
`LocalPingableLeader` will be queried indirectly for the tagged metrics. All it does is wrap `PaxosLearner`, as such it makes sense for it to live inside `LocalPaxosComponents`.

**Priority (whenever / two weeks / yesterday)**:
ASAP

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
