### PR TITLE
Remove SweepOutcome.SHUTDOWN.

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweepThread.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweepThread.java
@@ -126,8 +126,6 @@ public class BackgroundSweepThread implements Runnable {
             log.info(
                     "Shutting down background sweeper. Please restart the service to rerun background sweep.");
             closeTableLockIfHeld();
-            sweepOutcomeMetrics.registerOccurrenceOf(
-                    SweepOutcome.SHUTDOWN);
         } catch (Throwable t) {
             log.error("BackgroundSweeper failed fatally and will not rerun until restarted: {}",
                     UnsafeArg.of("message", t.getMessage()), t);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweeperImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweeperImpl.java
@@ -23,7 +23,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Sets;
-import com.palantir.atlasdb.sweep.metrics.SweepOutcome;
 import com.palantir.atlasdb.sweep.metrics.SweepOutcomeMetrics;
 import com.palantir.atlasdb.sweep.priority.NextTableToSweepProvider;
 import com.palantir.atlasdb.sweep.priority.SweepPriorityOverrideConfig;
@@ -125,7 +124,6 @@ public final class BackgroundSweeperImpl implements BackgroundSweeper, AutoClose
 
     @Override
     public synchronized void shutdown() {
-        sweepOutcomeMetrics.registerOccurrenceOf(SweepOutcome.SHUTDOWN);
         if (daemons == null) {
             return;
         }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/metrics/SweepOutcome.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/metrics/SweepOutcome.java
@@ -18,5 +18,5 @@ package com.palantir.atlasdb.sweep.metrics;
 public enum SweepOutcome {
     SUCCESS, NOTHING_TO_SWEEP, DISABLED, UNABLE_TO_ACQUIRE_LOCKS,
     NOT_ENOUGH_DB_NODES_ONLINE, TABLE_DROPPED_WHILE_SWEEPING, ERROR,
-    SHUTDOWN, FATAL
+    FATAL
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/metrics/SweepOutcomeMetrics.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/metrics/SweepOutcomeMetrics.java
@@ -34,7 +34,6 @@ public final class SweepOutcomeMetrics {
             SweepOutcome.DISABLED, SweepOutcome.SUCCESS, SweepOutcome.ERROR, SweepOutcome.NOTHING_TO_SWEEP);
 
     private final Reservoir reservoir;
-    private volatile boolean shutdown = false;
     private volatile boolean fatal = false;
 
     private SweepOutcomeMetrics() {
@@ -64,9 +63,6 @@ public final class SweepOutcomeMetrics {
     }
 
     private Long getOutcomeCount(SweepOutcome outcome) {
-        if (outcome == SweepOutcome.SHUTDOWN) {
-            return shutdown ? 1L : 0L;
-        }
         if (outcome == SweepOutcome.FATAL) {
             return fatal ? 1L : 0L;
         }
@@ -77,10 +73,6 @@ public final class SweepOutcomeMetrics {
     }
 
     public void registerOccurrenceOf(SweepOutcome outcome) {
-        if (outcome == SweepOutcome.SHUTDOWN) {
-            shutdown = true;
-            return;
-        }
         if (outcome == SweepOutcome.FATAL) {
             fatal = true;
             return;

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/metrics/SweepOutcomeMetricsTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/metrics/SweepOutcomeMetricsTest.java
@@ -69,10 +69,9 @@ public class SweepOutcomeMetricsTest {
     }
 
     @Test
-    public void testShutdownAndFatalAreBinary() {
+    public void testFatalIsBinary() {
         SweepOutcomeMetrics.LEGACY_OUTCOMES.forEach(outcome ->
                 IntStream.range(0, 10).forEach(ignore -> legacyMetrics.registerOccurrenceOf(outcome)));
-        assertThat(metricsManager).hasLegacyOutcomeEqualTo(SweepOutcome.SHUTDOWN, 1L);
         assertThat(metricsManager).hasLegacyOutcomeEqualTo(SweepOutcome.FATAL, 1L);
     }
 
@@ -81,7 +80,7 @@ public class SweepOutcomeMetricsTest {
         SweepOutcomeMetrics.LEGACY_OUTCOMES.forEach(outcome ->
                 IntStream.range(0, 10).forEach(ignore -> legacyMetrics.registerOccurrenceOf(outcome)));
         SweepOutcomeMetrics.LEGACY_OUTCOMES.stream()
-                .filter(outcome -> outcome != SweepOutcome.SHUTDOWN && outcome != SweepOutcome.FATAL)
+                .filter(outcome -> outcome != SweepOutcome.FATAL)
                 .forEach(outcome -> assertThat(metricsManager).hasLegacyOutcomeEqualTo(outcome, 10L));
     }
 


### PR DESCRIPTION
* This should be expected behavior. If something is wrong,
  we have logs.

**Goals (and why)**:

Next PR will do the same trick of only registering the metrics upon first use, so we can get rid of legacy sweep metrics if it is disabled.

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
