### PR TITLE
[Transaction Async get] Part 2: Refactored TransactionService and futures helper.

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/futures/AtlasFutures.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/futures/AtlasFutures.java
@@ -16,7 +16,6 @@
 
 package com.palantir.atlasdb.futures;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
 import com.google.common.util.concurrent.Futures;
@@ -46,7 +45,4 @@ public final class AtlasFutures {
         }
     }
 
-    public interface FutureCallable<R> extends Callable<ListenableFuture<R>> {
-
-    }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/futures/AtlasFutures.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/futures/AtlasFutures.java
@@ -28,9 +28,9 @@ public final class AtlasFutures {
 
     }
 
-    public static <R> R runWithException(FutureCallable<R> futureCallable) {
+    public static <R> R getUnchecked(ListenableFuture<R> listenableFuture) {
         try {
-            return futureCallable.call().get();
+            return listenableFuture.get();
         } catch (ExecutionException e) {
             throw Throwables.rewrapAndThrowUncheckedException(e.getCause());
         } catch (Exception e) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/futures/AtlasFutures.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/futures/AtlasFutures.java
@@ -1,0 +1,52 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.futures;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.common.base.Throwables;
+
+public final class AtlasFutures {
+    private AtlasFutures() {
+
+    }
+
+    public static <R> R runWithException(FutureCallable<R> futureCallable) {
+        try {
+            return futureCallable.call().get();
+        } catch (ExecutionException e) {
+            throw Throwables.rewrapAndThrowUncheckedException(e.getCause());
+        } catch (Exception e) {
+            throw Throwables.rewrapAndThrowUncheckedException(e);
+        }
+    }
+
+    public static <R> R getDone(ListenableFuture<R> resultFuture) {
+        try {
+            return Futures.getDone(resultFuture);
+        } catch (ExecutionException e) {
+            throw Throwables.rewrapAndThrowUncheckedException(e.getCause());
+        }
+    }
+
+    public interface FutureCallable<R> extends Callable<ListenableFuture<R>> {
+
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/AsyncTransactionService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/AsyncTransactionService.java
@@ -1,0 +1,26 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.service;
+
+import java.util.Map;
+
+import com.google.common.util.concurrent.ListenableFuture;
+
+public interface AsyncTransactionService {
+    ListenableFuture<Long> getAsync(long startTimestamp);
+    ListenableFuture<Map<Long, Long>> getAsync(Iterable<Long> startTimestamps);
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/PreStartHandlingTransactionService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/PreStartHandlingTransactionService.java
@@ -51,11 +51,8 @@ public class PreStartHandlingTransactionService implements TransactionService {
     private final TransactionService delegate;
     private final TimestampLoader immediateTimestampLoader;
 
-    public static TransactionService create(TransactionService delegate) {
-        return new PreStartHandlingTransactionService(delegate, TransactionServices.immediateTimestampLoader());
-    }
-
-    PreStartHandlingTransactionService(TransactionService delegate,
+    PreStartHandlingTransactionService(
+            TransactionService delegate,
             TimestampLoader immediateTimestampLoader) {
         this.delegate = delegate;
         this.immediateTimestampLoader = immediateTimestampLoader;
@@ -64,12 +61,12 @@ public class PreStartHandlingTransactionService implements TransactionService {
     @CheckForNull
     @Override
     public Long get(long startTimestamp) {
-        return AtlasFutures.runWithException(() -> getInternal(startTimestamp, immediateTimestampLoader));
+        return AtlasFutures.getUnchecked(getInternal(startTimestamp, immediateTimestampLoader));
     }
 
     @Override
     public Map<Long, Long> get(Iterable<Long> startTimestamps) {
-        return AtlasFutures.runWithException(() -> getInternal(startTimestamps, immediateTimestampLoader));
+        return AtlasFutures.getUnchecked(getInternal(startTimestamps, immediateTimestampLoader));
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/PreStartHandlingTransactionService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/PreStartHandlingTransactionService.java
@@ -103,11 +103,13 @@ public class PreStartHandlingTransactionService implements TransactionService {
                 ImmutableSet.copyOf(classifiedTimestamps.get(false)), unused -> AtlasDbConstants.STARTING_TS - 1));
 
         if (!validTimestamps.isEmpty()) {
-            return Futures.transform(timestampLoader.get(delegate, validTimestamps),
+            return Futures.transform(
+                    timestampLoader.get(delegate, validTimestamps),
                     timestampMap -> {
                         result.putAll(timestampMap);
                         return result;
-                    }, MoreExecutors.directExecutor());
+                    },
+                    MoreExecutors.directExecutor());
         }
         return Futures.immediateFuture(result);
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/PreStartHandlingTransactionService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/PreStartHandlingTransactionService.java
@@ -25,7 +25,11 @@ import javax.annotation.CheckForNull;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.futures.AtlasFutures;
 import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
@@ -44,33 +48,22 @@ import com.palantir.logsafe.exceptions.SafeIllegalStateException;
  */
 public class PreStartHandlingTransactionService implements TransactionService {
     private final TransactionService delegate;
+    private final TimestampLoader immediateTimestampLoader;
 
     public PreStartHandlingTransactionService(TransactionService delegate) {
         this.delegate = delegate;
+        this.immediateTimestampLoader = createImmediateTimestampLoader(delegate);
     }
 
     @CheckForNull
     @Override
     public Long get(long startTimestamp) {
-        if (!isTimestampValid(startTimestamp)) {
-            return AtlasDbConstants.STARTING_TS - 1;
-        }
-        return delegate.get(startTimestamp);
+        return AtlasFutures.runWithException(() -> getInternal(startTimestamp, immediateTimestampLoader));
     }
 
     @Override
     public Map<Long, Long> get(Iterable<Long> startTimestamps) {
-        Map<Boolean, List<Long>> classifiedTimestamps = StreamSupport.stream(startTimestamps.spliterator(), false)
-                .collect(Collectors.partitioningBy(PreStartHandlingTransactionService::isTimestampValid));
-
-        Map<Long, Long> result = Maps.newHashMap();
-        List<Long> validTimestamps = classifiedTimestamps.get(true);
-        if (!validTimestamps.isEmpty()) {
-            result.putAll(delegate.get(validTimestamps));
-        }
-        result.putAll(Maps.asMap(
-                ImmutableSet.copyOf(classifiedTimestamps.get(false)), unused -> AtlasDbConstants.STARTING_TS - 1));
-        return result;
+        return AtlasFutures.runWithException(() -> getInternal(startTimestamps, immediateTimestampLoader));
     }
 
     @Override
@@ -88,7 +81,57 @@ public class PreStartHandlingTransactionService implements TransactionService {
         delegate.close();
     }
 
+    private ListenableFuture<Long> getInternal(long startTimestamp, TimestampLoader timestampLoader) {
+        if (!isTimestampValid(startTimestamp)) {
+            return Futures.immediateFuture(AtlasDbConstants.STARTING_TS - 1);
+        }
+        return timestampLoader.get(startTimestamp);
+    }
+
+    private ListenableFuture<Map<Long, Long>> getInternal(
+            Iterable<Long> startTimestamps,
+            TimestampLoader timestampLoader) {
+        Map<Boolean, List<Long>> classifiedTimestamps = StreamSupport.stream(startTimestamps.spliterator(), false)
+                .collect(Collectors.partitioningBy(PreStartHandlingTransactionService::isTimestampValid));
+
+        List<Long> validTimestamps = classifiedTimestamps.get(true);
+        Map<Long, Long> result = Maps.newHashMap();
+        result.putAll(Maps.asMap(
+                ImmutableSet.copyOf(classifiedTimestamps.get(false)), unused -> AtlasDbConstants.STARTING_TS - 1));
+
+        if (!validTimestamps.isEmpty()) {
+            return Futures.transform(timestampLoader.get(validTimestamps),
+                    timestampMap -> {
+                        result.putAll(timestampMap);
+                        return result;
+                    }, MoreExecutors.directExecutor());
+        }
+        return Futures.immediateFuture(result);
+    }
+
     private static boolean isTimestampValid(Long startTimestamp) {
         return startTimestamp >= AtlasDbConstants.STARTING_TS;
+    }
+
+    private static TimestampLoader createImmediateTimestampLoader(
+            TransactionService delegate) {
+        return new TimestampLoader() {
+            @Override
+            public ListenableFuture<Long> get(long startTimestamp) {
+                return Futures.immediateFuture(delegate.get(startTimestamp));
+            }
+
+            @Override
+            public ListenableFuture<Map<Long, Long>> get(Iterable<Long> startTimestamps) {
+                return Futures.immediateFuture(delegate.get(startTimestamps));
+            }
+        };
+    }
+
+    private interface TimestampLoader {
+
+        ListenableFuture<Long> get(long startTimestamp);
+
+        ListenableFuture<Map<Long, Long>> get(Iterable<Long> startTimestamps);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/SimpleTransactionService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/SimpleTransactionService.java
@@ -105,7 +105,7 @@ public final class SimpleTransactionService implements EncodingTransactionServic
         Cell cell = getTransactionCell(startTimestamp);
         return Futures.transform(
                 asyncCellGetter.get(ImmutableMap.of(cell, MAX_TIMESTAMP)),
-                returnMap -> getTransactionCells(startTimestamp, cell, returnMap),
+                returnMap -> decodeTimestamp(startTimestamp, cell, returnMap),
                 MoreExecutors.directExecutor());
     }
 
@@ -120,13 +120,13 @@ public final class SimpleTransactionService implements EncodingTransactionServic
 
         return Futures.transform(
                 asyncCellGetter.get(startTsMap),
-                rawResults -> decodeTimestamps(rawResults),
+                this::decodeTimestamps,
                 MoreExecutors.directExecutor());
     }
 
-    private Long getTransactionCells(long startTimestamp, Cell cell, Map<Cell, Value> returnMap) {
-        if (returnMap.containsKey(cell)) {
-            return encodingStrategy.decodeValueAsCommitTimestamp(startTimestamp, returnMap.get(cell).getContents());
+    private Long decodeTimestamp(long startTimestamp, Cell cell, Map<Cell, Value> rawResults) {
+        if (rawResults.containsKey(cell)) {
+            return encodingStrategy.decodeValueAsCommitTimestamp(startTimestamp, rawResults.get(cell).getContents());
         }
         return null;
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/SimpleTransactionService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/SimpleTransactionService.java
@@ -118,7 +118,8 @@ public final class SimpleTransactionService implements EncodingTransactionServic
             startTsMap.put(cell, MAX_TIMESTAMP);
         }
 
-        return Futures.transform(asyncCellLoader.get(startTsMap),
+        return Futures.transform(
+                asyncCellLoader.get(startTsMap),
                 rawResults -> decodeTimestamps(rawResults),
                 MoreExecutors.directExecutor());
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/SimpleTransactionService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/SimpleTransactionService.java
@@ -20,6 +20,10 @@ import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.palantir.atlasdb.futures.AtlasFutures;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
@@ -38,12 +42,14 @@ public final class SimpleTransactionService implements EncodingTransactionServic
     // in transaction table.
     // All entries in transaction table are stored with timestamp 0
     private static final long MAX_TIMESTAMP = 1L;
+    private final CellLoader immediateCellLoader;
 
     private SimpleTransactionService(KeyValueService kvs, TimestampEncodingStrategy encodingStrategy,
             TableReference transactionsTable) {
         this.kvs = kvs;
         this.encodingStrategy = encodingStrategy;
         this.transactionsTable = transactionsTable;
+        this.immediateCellLoader = startTsMap -> Futures.immediateFuture(kvs.get(transactionsTable, startTsMap));
     }
 
     public static SimpleTransactionService createV1(KeyValueService kvs) {
@@ -57,32 +63,12 @@ public final class SimpleTransactionService implements EncodingTransactionServic
 
     @Override
     public Long get(long startTimestamp) {
-        Cell cell = getTransactionCell(startTimestamp);
-        Map<Cell, Value> returnMap = kvs.get(transactionsTable, ImmutableMap.of(cell, MAX_TIMESTAMP));
-        if (returnMap.containsKey(cell)) {
-            return encodingStrategy.decodeValueAsCommitTimestamp(startTimestamp, returnMap.get(cell).getContents());
-        } else {
-            return null;
-        }
+        return AtlasFutures.runWithException(() -> getInternal(startTimestamp, immediateCellLoader));
     }
 
     @Override
     public Map<Long, Long> get(Iterable<Long> startTimestamps) {
-        Map<Cell, Long> startTsMap = Maps.newHashMap();
-        for (Long startTimestamp : startTimestamps) {
-            Cell cell = getTransactionCell(startTimestamp);
-            startTsMap.put(cell, MAX_TIMESTAMP);
-        }
-
-        Map<Cell, Value> rawResults = kvs.get(transactionsTable, startTsMap);
-        Map<Long, Long> result = Maps.newHashMapWithExpectedSize(rawResults.size());
-        for (Map.Entry<Cell, Value> e : rawResults.entrySet()) {
-            long startTs = encodingStrategy.decodeCellAsStartTimestamp(e.getKey());
-            long commitTs = encodingStrategy.decodeValueAsCommitTimestamp(startTs, e.getValue().getContents());
-            result.put(startTs, commitTs);
-        }
-
-        return result;
+        return AtlasFutures.runWithException(() -> getInternal(startTimestamps, immediateCellLoader));
     }
 
     @Override
@@ -113,5 +99,46 @@ public final class SimpleTransactionService implements EncodingTransactionServic
     @Override
     public void close() {
         // we do not close the injected kvs
+    }
+
+    private ListenableFuture<Long> getInternal(long startTimestamp, CellLoader cellLoader) {
+        Cell cell = getTransactionCell(startTimestamp);
+        return Futures.transform(cellLoader.get(ImmutableMap.of(cell, MAX_TIMESTAMP)),
+                returnMap -> {
+                    if (returnMap.containsKey(cell)) {
+                        return encodingStrategy.decodeValueAsCommitTimestamp(startTimestamp,
+                                returnMap.get(cell).getContents());
+                    } else {
+                        return null;
+                    }
+                },
+                MoreExecutors.directExecutor());
+    }
+
+    private ListenableFuture<Map<Long, Long>> getInternal(Iterable<Long> startTimestamps, CellLoader cellLoader) {
+        Map<Cell, Long> startTsMap = Maps.newHashMap();
+        for (Long startTimestamp : startTimestamps) {
+            Cell cell = getTransactionCell(startTimestamp);
+            startTsMap.put(cell, MAX_TIMESTAMP);
+        }
+
+        return Futures.transform(cellLoader.get(startTsMap),
+                rawResults -> {
+                    Map<Long, Long> result = Maps.newHashMapWithExpectedSize(rawResults.size());
+                    for (Map.Entry<Cell, Value> e : rawResults.entrySet()) {
+                        long startTs = encodingStrategy.decodeCellAsStartTimestamp(e.getKey());
+                        long commitTs = encodingStrategy
+                                .decodeValueAsCommitTimestamp(startTs, e.getValue().getContents());
+                        result.put(startTs, commitTs);
+                    }
+
+                    return result;
+                },
+                MoreExecutors.directExecutor());
+    }
+
+    private interface CellLoader {
+
+        ListenableFuture<Map<Cell, Value>> get(Map<Cell, Long> startTsMap);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/TransactionServices.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/TransactionServices.java
@@ -50,18 +50,18 @@ public final class TransactionServices {
             KeyValueService keyValueService,
             TransactionSchemaManager transactionSchemaManager) {
         // TODO (jkong): Is there a way to disallow DIRECT -> V2 transaction service in the map?
-        return new PreStartHandlingTransactionService(new SplitKeyDelegatingTransactionService<>(
-                transactionSchemaManager::getTransactionsSchemaVersion,
-                ImmutableMap.of(
-                        TransactionConstants.DIRECT_ENCODING_TRANSACTIONS_SCHEMA_VERSION,
-                        createV1TransactionService(keyValueService),
-                        TransactionConstants.TICKETS_ENCODING_TRANSACTIONS_SCHEMA_VERSION,
-                        createV2TransactionService(keyValueService))));
+        return new PreStartHandlingTransactionService(
+                new SplitKeyDelegatingTransactionService<>(
+                        transactionSchemaManager::getTransactionsSchemaVersion,
+                        ImmutableMap.of(
+                                TransactionConstants.DIRECT_ENCODING_TRANSACTIONS_SCHEMA_VERSION,
+                                createV1TransactionService(keyValueService),
+                                TransactionConstants.TICKETS_ENCODING_TRANSACTIONS_SCHEMA_VERSION,
+                                createV2TransactionService(keyValueService))));
     }
 
     public static TransactionService createV1TransactionService(KeyValueService keyValueService) {
-        return new PreStartHandlingTransactionService(
-                SimpleTransactionService.createV1(keyValueService));
+        return new PreStartHandlingTransactionService(SimpleTransactionService.createV1(keyValueService));
     }
 
     private static TransactionService createV2TransactionService(KeyValueService keyValueService) {
@@ -97,9 +97,10 @@ public final class TransactionServices {
                     false);
             ReadOnlyTransactionSchemaManager readOnlyTransactionSchemaManager
                     = new ReadOnlyTransactionSchemaManager(coordinationService);
-            return new PreStartHandlingTransactionService(new SplitKeyDelegatingTransactionService<>(
-                    readOnlyTransactionSchemaManager::getTransactionsSchemaVersion,
-                    ImmutableMap.of(1, createV1TransactionService(keyValueService))));
+            return new PreStartHandlingTransactionService(
+                    new SplitKeyDelegatingTransactionService<>(
+                            readOnlyTransactionSchemaManager::getTransactionsSchemaVersion,
+                            ImmutableMap.of(1, createV1TransactionService(keyValueService))));
         }
         return createV1TransactionService(keyValueService);
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/WriteBatchingTransactionService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/WriteBatchingTransactionService.java
@@ -88,7 +88,7 @@ public final class WriteBatchingTransactionService implements TransactionService
 
     @Override
     public void putUnlessExists(long startTimestamp, long commitTimestamp) throws KeyAlreadyExistsException {
-        AtlasFutures.runWithException(() -> autobatcher.apply(TimestampPair.of(startTimestamp, commitTimestamp)));
+        AtlasFutures.getUnchecked(autobatcher.apply(TimestampPair.of(startTimestamp, commitTimestamp)));
     }
 
     @Override

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/PreStartHandlingTransactionServiceTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/PreStartHandlingTransactionServiceTest.java
@@ -113,10 +113,9 @@ public class PreStartHandlingTransactionServiceTest {
     @Test
     public void doesNotInvokeDelegateIfNoValidTimestamps() {
         Map<Long, Long> result = preStartHandlingService.get(TWO_INVALID_TIMESTAMPS);
-        assertThat(result).containsExactlyInAnyOrderEntriesOf(
-                ImmutableMap.of(
-                        ZERO_TIMESTAMP, BEFORE_TIME_TIMESTAMP,
-                        NEGATIVE_TIMESTAMP, BEFORE_TIME_TIMESTAMP));
+        assertThat(result).containsOnly(
+                Maps.immutableEntry(ZERO_TIMESTAMP, BEFORE_TIME_TIMESTAMP),
+                Maps.immutableEntry(NEGATIVE_TIMESTAMP, BEFORE_TIME_TIMESTAMP));
     }
 
     @Test

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/PreStartHandlingTransactionServiceTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/PreStartHandlingTransactionServiceTest.java
@@ -42,7 +42,9 @@ import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 
 public class PreStartHandlingTransactionServiceTest {
     private final TransactionService delegate = mock(TransactionService.class);
-    private final TransactionService preStartHandlingService = new PreStartHandlingTransactionService(delegate);
+    private final TransactionService preStartHandlingService = new PreStartHandlingTransactionService(
+            delegate,
+            TransactionServices.immediateTimestampLoader());
 
     private static final long START_TIMESTAMP = 44L;
     private static final long COMMIT_TIMESTAMP = 88L;

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/PreStartHandlingTransactionServiceTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/PreStartHandlingTransactionServiceTest.java
@@ -101,18 +101,20 @@ public class PreStartHandlingTransactionServiceTest {
     @Test
     public void passesThroughOnlyValidTimestampsToDelegateWhenGettingMultiple() {
         Map<Long, Long> result = preStartHandlingService.get(ONE_VALID_ONE_INVALID_TIMESTAMP);
-        assertThat(result).containsExactly(
-                Maps.immutableEntry(START_TIMESTAMP, COMMIT_TIMESTAMP),
-                Maps.immutableEntry(ZERO_TIMESTAMP, BEFORE_TIME_TIMESTAMP));
+        assertThat(result).containsExactlyInAnyOrderEntriesOf(
+                ImmutableMap.of(
+                        START_TIMESTAMP, COMMIT_TIMESTAMP,
+                        ZERO_TIMESTAMP, BEFORE_TIME_TIMESTAMP));
         verify(delegate).get(eq(ImmutableList.of(START_TIMESTAMP)));
     }
 
     @Test
     public void doesNotInvokeDelegateIfNoValidTimestamps() {
         Map<Long, Long> result = preStartHandlingService.get(TWO_INVALID_TIMESTAMPS);
-        assertThat(result).containsExactly(
-                Maps.immutableEntry(ZERO_TIMESTAMP, BEFORE_TIME_TIMESTAMP),
-                Maps.immutableEntry(NEGATIVE_TIMESTAMP, BEFORE_TIME_TIMESTAMP));
+        assertThat(result).containsExactlyInAnyOrderEntriesOf(
+                ImmutableMap.of(
+                        ZERO_TIMESTAMP, BEFORE_TIME_TIMESTAMP,
+                        NEGATIVE_TIMESTAMP, BEFORE_TIME_TIMESTAMP));
     }
 
     @Test

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/PreStartHandlingTransactionServiceTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/PreStartHandlingTransactionServiceTest.java
@@ -42,9 +42,7 @@ import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 
 public class PreStartHandlingTransactionServiceTest {
     private final TransactionService delegate = mock(TransactionService.class);
-    private final TransactionService preStartHandlingService = new PreStartHandlingTransactionService(
-            delegate,
-            TransactionServices.immediateTimestampLoader());
+    private final TransactionService preStartHandlingService = new PreStartHandlingTransactionService(delegate);
 
     private static final long START_TIMESTAMP = 44L;
     private static final long COMMIT_TIMESTAMP = 88L;

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/PreStartHandlingTransactionServiceTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/PreStartHandlingTransactionServiceTest.java
@@ -101,10 +101,9 @@ public class PreStartHandlingTransactionServiceTest {
     @Test
     public void passesThroughOnlyValidTimestampsToDelegateWhenGettingMultiple() {
         Map<Long, Long> result = preStartHandlingService.get(ONE_VALID_ONE_INVALID_TIMESTAMP);
-        assertThat(result).containsExactlyInAnyOrderEntriesOf(
-                ImmutableMap.of(
-                        START_TIMESTAMP, COMMIT_TIMESTAMP,
-                        ZERO_TIMESTAMP, BEFORE_TIME_TIMESTAMP));
+        assertThat(result).containsOnly(
+                Maps.immutableEntry(START_TIMESTAMP, COMMIT_TIMESTAMP),
+                Maps.immutableEntry(ZERO_TIMESTAMP, BEFORE_TIME_TIMESTAMP));
         verify(delegate).get(eq(ImmutableList.of(START_TIMESTAMP)));
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/SplitKeyDelegatingTransactionServiceTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/SplitKeyDelegatingTransactionServiceTest.java
@@ -46,9 +46,9 @@ public class SplitKeyDelegatingTransactionServiceTest {
     private final Map<Long, TransactionService> transactionServiceMap = ImmutableMap.of(
             1L, delegate1, 2L, delegate2, 3L, delegate3);
     private final TransactionService delegatingTransactionService
-            = new SplitKeyDelegatingTransactionService<>(EXTRACT_LAST_DIGIT, transactionServiceMap);
+            = SplitKeyDelegatingTransactionService.create(EXTRACT_LAST_DIGIT, transactionServiceMap);
     private final TransactionService lastDigitFiveImpliesUnknownTransactionService
-            = new SplitKeyDelegatingTransactionService<>(num -> num % 10 == 5 ? null : num % 10, transactionServiceMap);
+            = SplitKeyDelegatingTransactionService.create(num -> num % 10 == 5 ? null : num % 10, transactionServiceMap);
 
     @After
     public void verifyNoMoreInteractions() {
@@ -82,7 +82,7 @@ public class SplitKeyDelegatingTransactionServiceTest {
     @Test
     public void rethrowsExceptionsFromMappingFunction() {
         RuntimeException ex = new IllegalStateException("bad");
-        TransactionService unusableService = new SplitKeyDelegatingTransactionService<>(
+        TransactionService unusableService = SplitKeyDelegatingTransactionService.create(
                 num -> {
                     throw ex;
                 },

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/SplitKeyDelegatingTransactionServiceTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/SplitKeyDelegatingTransactionServiceTest.java
@@ -48,7 +48,9 @@ public class SplitKeyDelegatingTransactionServiceTest {
     private final TransactionService delegatingTransactionService
             = SplitKeyDelegatingTransactionService.create(EXTRACT_LAST_DIGIT, transactionServiceMap);
     private final TransactionService lastDigitFiveImpliesUnknownTransactionService
-            = SplitKeyDelegatingTransactionService.create(num -> num % 10 == 5 ? null : num % 10, transactionServiceMap);
+            = SplitKeyDelegatingTransactionService.create(
+                    num -> num % 10 == 5 ? null : num % 10,
+                    transactionServiceMap);
 
     @After
     public void verifyNoMoreInteractions() {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/SplitKeyDelegatingTransactionServiceTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/SplitKeyDelegatingTransactionServiceTest.java
@@ -46,15 +46,9 @@ public class SplitKeyDelegatingTransactionServiceTest {
     private final Map<Long, TransactionService> transactionServiceMap = ImmutableMap.of(
             1L, delegate1, 2L, delegate2, 3L, delegate3);
     private final TransactionService delegatingTransactionService
-            = new SplitKeyDelegatingTransactionService<>(
-            EXTRACT_LAST_DIGIT,
-            transactionServiceMap,
-            TransactionServices.immediateTimestampLoader());
+            = new SplitKeyDelegatingTransactionService<>(EXTRACT_LAST_DIGIT, transactionServiceMap);
     private final TransactionService lastDigitFiveImpliesUnknownTransactionService
-            = new SplitKeyDelegatingTransactionService<>(
-                    num -> num % 10 == 5 ? null : num % 10,
-                    transactionServiceMap,
-                    TransactionServices.immediateTimestampLoader());
+            = new SplitKeyDelegatingTransactionService<>(num -> num % 10 == 5 ? null : num % 10, transactionServiceMap);
 
     @After
     public void verifyNoMoreInteractions() {
@@ -92,8 +86,7 @@ public class SplitKeyDelegatingTransactionServiceTest {
                 num -> {
                     throw ex;
                 },
-                transactionServiceMap,
-                TransactionServices.immediateTimestampLoader());
+                transactionServiceMap);
 
         assertThatThrownBy(() -> unusableService.get(5L)).isEqualTo(ex);
     }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/SplitKeyDelegatingTransactionServiceTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/SplitKeyDelegatingTransactionServiceTest.java
@@ -88,7 +88,9 @@ public class SplitKeyDelegatingTransactionServiceTest {
                 },
                 transactionServiceMap);
 
-        assertThatThrownBy(() -> unusableService.get(5L)).isEqualTo(ex);
+        assertThatThrownBy(() -> unusableService.get(5L))
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage("bad");
     }
 
     @Test

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/SplitKeyDelegatingTransactionServiceTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/SplitKeyDelegatingTransactionServiceTest.java
@@ -52,9 +52,9 @@ public class SplitKeyDelegatingTransactionServiceTest {
             TransactionServices.immediateTimestampLoader());
     private final TransactionService lastDigitFiveImpliesUnknownTransactionService
             = new SplitKeyDelegatingTransactionService<>(
-            num -> num % 10 == 5 ? null : num % 10,
-            transactionServiceMap,
-            TransactionServices.immediateTimestampLoader());
+                    num -> num % 10 == 5 ? null : num % 10,
+                    transactionServiceMap,
+                    TransactionServices.immediateTimestampLoader());
 
     @After
     public void verifyNoMoreInteractions() {


### PR DESCRIPTION
**Goals (and why)**:
Refactor `TransactionService` for easier addition of async paths.

**Implementation Description (bullets)**:
- same trick used as before (wrap in `Futures.immediateFuture`)

**Testing (What was existing testing like?  What have you done to improve it?)**:
- existing tests should cover this

**Concerns (what feedback would you like?)**:
- is there a way to make loading/getting interfaces sharable

**Where should we start reviewing?**:
- TransactionService

**Priority (whenever / two weeks / yesterday)**:
- this week

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
