### PR TITLE
[Transaction Async get] Part 4: Listenable futures for getCommitTimestamps.

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -809,13 +809,13 @@ public class SerializableTransaction extends SnapshotTransaction {
 
                 return Futures.whenAllComplete(commitTimestampsForPreStart, commitTimestampsForPostStart).call(
                         () -> {
-                            Map<Long, Long> startToCommitTimestampMap = ImmutableMap.<Long, Long>builder()
-                                    .putAll(AtlasFutures.getDone(commitTimestampsForPostStart))
-                                    .putAll(AtlasFutures.getDone(commitTimestampsForPreStart))
-                                    .build();
+                            ImmutableMap.Builder<Long, Long> startToCommitTimestampsBuilder =
+                                    ImmutableMap.<Long, Long>builder()
+                                            .putAll(AtlasFutures.getDone(commitTimestampsForPostStart))
+                                            .putAll(AtlasFutures.getDone(commitTimestampsForPreStart));
                             partitionedTimestamps.splittingTimestamp()
-                                    .ifPresent(start -> startToCommitTimestampMap.put(start, commitTs));
-                            return startToCommitTimestampMap;
+                                    .ifPresent(start -> startToCommitTimestampsBuilder.put(start, commitTs));
+                            return startToCommitTimestampsBuilder.build();
                         },
                         MoreExecutors.directExecutor());
             }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -853,11 +853,7 @@ public class SerializableTransaction extends SnapshotTransaction {
             }
 
             /**
-             * Partitions {@code startTimestamps} in two sets. Returns a {@link PartitionedTimestamps} such that
-             * {@link PartitionedTimestamps#afterStart()} returns timestamps which are greater than {@code myStart},
-             * {@link PartitionedTimestamps#beforeStart()} returns timestamps which are less than {@code myStart} and
-             * {@link PartitionedTimestamps#splittingTimestamp()} contains {@code myStart} if it is contained in
-             * {@code startTimestamps}.
+             * Partitions {@code startTimestamps} in two sets, based on their relation to the start timestamp provided.
              *
              * @param myStart start timestamp of this transaction
              * @param startTimestamps of transactions we are interested in

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -810,15 +810,17 @@ public class SerializableTransaction extends SnapshotTransaction {
                         asyncTransactionService);
 
                 return Futures.whenAllComplete(commitTimestampsForPreStart, commitTimestampsForPostStart).call(
-                    () -> {
-                        Map<Long, Long> startToCommitTimestampMap = AtlasFutures.getDone(commitTimestampsForPostStart);
-                        startToCommitTimestampMap.putAll(AtlasFutures.getDone(commitTimestampsForPreStart));
-                        if (containsMyStartFinal) {
-                            startToCommitTimestampMap.put(myStart, commitTs);
-                        }
-                        return startToCommitTimestampMap;
-                    },
-                    MoreExecutors.directExecutor());
+                        () -> {
+                            Map<Long, Long> startToCommitTimestampMap = ImmutableMap.<Long, Long>builder()
+                                    .putAll(AtlasFutures.getDone(commitTimestampsForPostStart))
+                                    .putAll(AtlasFutures.getDone(commitTimestampsForPreStart))
+                                    .build();
+                            if (containsMyStartFinal) {
+                                startToCommitTimestampMap.put(myStart, commitTs);
+                            }
+                            return startToCommitTimestampMap;
+                        },
+                        MoreExecutors.directExecutor());
             }
 
             private ListenableFuture<Map<Long, Long>> getStartToCommitTimestampsAfterMyStart(

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -2059,13 +2059,13 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
 
     private void traceGetCommitTimestamps(@Nullable TableReference tableRef, Set<Long> gets) {
         if (tableRef != null) {
-            log.trace("Getting commit timestamps for a read",
+            log.trace("Getting commit timestamps for a read while reading table.",
                     SafeArg.of("numTimestamps", gets.size()),
                     LoggingArgs.tableRef(tableRef));
             return;
         }
 
-        log.trace("Getting commit timestamps", SafeArg.of("numTimestamps", gets.size()));
+        log.trace("Getting commit timestamps.", SafeArg.of("numTimestamps", gets.size()));
 
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -177,7 +177,6 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
 
     private static final int BATCH_SIZE_GET_FIRST_PAGE = 1000;
 
-
     private enum State {
         UNCOMMITTED,
         COMMITTED,
@@ -2049,11 +2048,11 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         long waitForCommitTsMillis = TimeUnit.NANOSECONDS.toMillis(timer.stop());
 
         if (tableRef != null) {
-            perfLogger.debug("Waited get commit timestamps.",
+            perfLogger.debug("Waited to get commit timestamps when reading from a known table.",
                     SafeArg.of("commitTsMillis", waitForCommitTsMillis),
                     LoggingArgs.tableRef(tableRef));
         } else {
-            perfLogger.debug("Waited to get commit timestamps",
+            perfLogger.debug("Waited to get commit timestamps.",
                     SafeArg.of("commitTsMillis", waitForCommitTsMillis));
         }
     }
@@ -2066,8 +2065,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             return;
         }
 
-        log.trace("Getting commit timestamps",
-                SafeArg.of("numTimestamps", gets.size()));
+        log.trace("Getting commit timestamps", SafeArg.of("numTimestamps", gets.size()));
 
     }
 
@@ -2075,12 +2073,9 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         log.info(
                 "Looking up a large number of transactions.",
                 SafeArg.of("numberOfTransactionIds", gets.size()),
-                tableRef == null
-                        ? SafeArg.of("tableRef", "no_table")
-                        : LoggingArgs.tableRef(tableRef)
+                tableRef == null ? SafeArg.of("tableRef", "no_table") : LoggingArgs.tableRef(tableRef)
         );
     }
-
 
     private ListenableFuture<Map<Long, Long>> loadCommitTimestamps(
             AsyncTransactionService asyncTransactionService,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/SimpleTransactionService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/SimpleTransactionService.java
@@ -45,7 +45,9 @@ public final class SimpleTransactionService implements EncodingTransactionServic
     private final AsyncCellGetter immediateAsyncCellGetter;
     private final AsyncCellGetter asyncCellGetter;
 
-    private SimpleTransactionService(KeyValueService kvs, TimestampEncodingStrategy encodingStrategy,
+    private SimpleTransactionService(
+            KeyValueService kvs,
+            TimestampEncodingStrategy encodingStrategy,
             TableReference transactionsTable) {
         this.kvs = kvs;
         this.encodingStrategy = encodingStrategy;
@@ -93,11 +95,9 @@ public final class SimpleTransactionService implements EncodingTransactionServic
     @Override
     public void putUnlessExistsMultiple(Map<Long, Long> startTimestampToCommitTimestamp) {
         Map<Cell, byte[]> values = new HashMap<>(startTimestampToCommitTimestamp.size());
-        startTimestampToCommitTimestamp.forEach(
-                (start, commit) ->
-                        values.put(
-                                getTransactionCell(start),
-                                encodingStrategy.encodeCommitTimestampAsValue(start, commit)));
+        startTimestampToCommitTimestamp.forEach((start, commit) -> values.put(
+                getTransactionCell(start),
+                encodingStrategy.encodeCommitTimestampAsValue(start, commit)));
         kvs.putUnlessExists(transactionsTable, values);
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/SimpleTransactionService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/SimpleTransactionService.java
@@ -93,9 +93,11 @@ public final class SimpleTransactionService implements EncodingTransactionServic
     @Override
     public void putUnlessExistsMultiple(Map<Long, Long> startTimestampToCommitTimestamp) {
         Map<Cell, byte[]> values = new HashMap<>(startTimestampToCommitTimestamp.size());
-        startTimestampToCommitTimestamp.forEach((start, commit) -> values.put(
-                getTransactionCell(start),
-                encodingStrategy.encodeCommitTimestampAsValue(start, commit)));
+        startTimestampToCommitTimestamp.forEach(
+                (start, commit) ->
+                        values.put(
+                                getTransactionCell(start),
+                                encodingStrategy.encodeCommitTimestampAsValue(start, commit)));
         kvs.putUnlessExists(transactionsTable, values);
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/TransactionServices.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/TransactionServices.java
@@ -111,7 +111,7 @@ public final class TransactionServices {
      * @param transactionService on which to call synchronous requests
      * @return {@link AsyncTransactionService} which delegates to synchronous methods
      */
-    static AsyncTransactionService synchronousAsAsyncTransactionService(TransactionService transactionService) {
+    public static AsyncTransactionService synchronousAsAsyncTransactionService(TransactionService transactionService) {
         return new AsyncTransactionService() {
             @Override
             public ListenableFuture<Long> getAsync(long startTimestamp) {


### PR DESCRIPTION
**Goals (and why)**:
Refactor `getCommitTimestamps` to return `ListenableFutures`. It is only called in a synchronous manner.

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:
-current tests should catch any problems

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:
- `SnapshotTransaction`

**Priority (whenever / two weeks / yesterday)**:
-until next Tuesday(depends on the speed of other PR)
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
