### PR TITLE
Fix CassandraClient instrumentation.

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/metrics/Timed.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/metrics/Timed.java
@@ -17,10 +17,12 @@
 package com.palantir.atlasdb.metrics;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+@Inherited
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface Timed {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
@@ -84,10 +84,10 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
 
     private CassandraClient instrumentClient(Client rawClient) {
         CassandraClient client = new CassandraClientImpl(rawClient);
-        client = new ProfilingCassandraClient(client);
-        client = new TracingCassandraClient(client);
         // TODO(ssouza): use the kvsMethodName to tag the timers.
         client = AtlasDbMetrics.instrumentTimed(metricsManager.getRegistry(), CassandraClient.class, client);
+        client = new ProfilingCassandraClient(client);
+        client = new TracingCassandraClient(client);
         client = new InstrumentedCassandraClient(client, metricsManager.getTaggedRegistry());
         client = QosCassandraClient.instrumentWithMetrics(client, metricsManager);
         return client;

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/util/AtlasDbMetricsTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/util/AtlasDbMetricsTest.java
@@ -45,6 +45,15 @@ public final class AtlasDbMetricsTest {
             return PING_RESPONSE;
         }
     };
+    private final TestService testServiceDelegate = (TestServiceAutoDelegate) () -> testService;
+
+    @Test
+    public void instrumentWithDefaultNameTimedDoesNotWorkWithDelegates() {
+        TestService service = AtlasDbMetrics.instrumentTimed(metrics, TestService.class, testServiceDelegate);
+
+        assertMethodNotInstrumented(PING_REQUEST_METRIC, service::ping);
+        assertMethodNotInstrumented(PING_NOT_TIMED_METRIC, service::pingNotTimed);
+    }
 
     @Test
     public void instrumentWithDefaultNameTimed() {
@@ -118,5 +127,20 @@ public final class AtlasDbMetricsTest {
         String ping();
 
         String pingNotTimed();
+    }
+
+    public interface TestServiceAutoDelegate extends TestService {
+
+        TestService getDelegate();
+
+        @Override
+        default String ping() {
+            return getDelegate().ping();
+        }
+
+        @Override
+        default String pingNotTimed() {
+            return getDelegate().pingNotTimed();
+        }
     }
 }

--- a/changelog/@unreleased/pr-4348.v2.yml
+++ b/changelog/@unreleased/pr-4348.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Bring back CassandraClient instrumentation.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4348


### PR DESCRIPTION
* AutoDelegate defeats the filter, because it overrides
  methods with default implementation, without copying the annotations.
* Sending a fix for the specific case first, until I figure out
  a better solution.

**Goals (and why)**:

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

None. CassandraClientImpl implements the CassandraClient interface directly, so it's fine.

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
