### PR TITLE
Run Tests With Postgres 9.6

### DIFF
--- a/atlasdb-dbkvs-tests/src/test/resources/docker-compose.yml
+++ b/atlasdb-dbkvs-tests/src/test/resources/docker-compose.yml
@@ -2,10 +2,10 @@ version: '2'
 
 services:
   postgres:
-    image: kiasaki/alpine-postgres:9.6
+    image: postgres:9.6-alpine
     environment:
        POSTGRES_PASSWORD: palantir
        POSTGRES_USER: palantir
        POSTGRES_DB: atlas
     ports:
-      - "5432"
+      - "5432:5432"

--- a/atlasdb-dbkvs-tests/src/test/resources/docker-compose.yml
+++ b/atlasdb-dbkvs-tests/src/test/resources/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   postgres:
-    image: kiasaki/alpine-postgres:9.5
+    image: kiasaki/alpine-postgres:9.6
     environment:
        POSTGRES_PASSWORD: palantir
        POSTGRES_USER: palantir

--- a/atlasdb-ete-tests/docker-compose.dbkvs.yml
+++ b/atlasdb-ete-tests/docker-compose.dbkvs.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   postgres:
-    image: kiasaki/alpine-postgres:9.5
+    image: kiasaki/alpine-postgres:9.6
     environment:
        POSTGRES_PASSWORD: palantir
        POSTGRES_USER: palantir

--- a/atlasdb-ete-tests/docker-compose.dbkvs.yml
+++ b/atlasdb-ete-tests/docker-compose.dbkvs.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   postgres:
-    image: kiasaki/alpine-postgres:9.6
+    image: postgres:9.6-alpine
     environment:
        POSTGRES_PASSWORD: palantir
        POSTGRES_USER: palantir

--- a/atlasdb-ete-tests/docker-compose.timelock.database.bound.postgres.yml
+++ b/atlasdb-ete-tests/docker-compose.timelock.database.bound.postgres.yml
@@ -11,7 +11,7 @@ services:
       - "8422"
 
   postgres:
-    image: kiasaki/alpine-postgres:9.6
+    image: postgres:9.6-alpine
     environment:
        POSTGRES_PASSWORD: palantir
        POSTGRES_USER: palantir

--- a/atlasdb-ete-tests/docker-compose.timelock.database.bound.postgres.yml
+++ b/atlasdb-ete-tests/docker-compose.timelock.database.bound.postgres.yml
@@ -11,7 +11,7 @@ services:
       - "8422"
 
   postgres:
-    image: kiasaki/alpine-postgres:9.5
+    image: kiasaki/alpine-postgres:9.6
     environment:
        POSTGRES_PASSWORD: palantir
        POSTGRES_USER: palantir

--- a/atlasdb-perf/src/main/resources/postgres-docker-compose.yml
+++ b/atlasdb-perf/src/main/resources/postgres-docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   postgres:
-    image: kiasaki/alpine-postgres:9.5
+    image: kiasaki/alpine-postgres:9.6
     container_name: atlas_perf_postgres
     environment:
        POSTGRES_PASSWORD: palantir

--- a/atlasdb-perf/src/main/resources/postgres-docker-compose.yml
+++ b/atlasdb-perf/src/main/resources/postgres-docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   postgres:
-    image: kiasaki/alpine-postgres:9.6
+    image: postgres:9.6-alpine
     container_name: atlas_perf_postgres
     environment:
        POSTGRES_PASSWORD: palantir

--- a/scripts/circle-ci/common-containers.yml
+++ b/scripts/circle-ci/common-containers.yml
@@ -5,7 +5,7 @@ cassandra2:
 #  image: palantirtechnologies/docker-cassandra-atlasdb:3.7
 
 postgres:
-  image: kiasaki/alpine-postgres:9.6
+  image: postgres:9.6-alpine
 
 nginx:
   image: 1science/nginx

--- a/scripts/circle-ci/common-containers.yml
+++ b/scripts/circle-ci/common-containers.yml
@@ -5,7 +5,7 @@ cassandra2:
 #  image: palantirtechnologies/docker-cassandra-atlasdb:3.7
 
 postgres:
-  image: kiasaki/alpine-postgres:9.5
+  image: kiasaki/alpine-postgres:9.6
 
 nginx:
   image: 1science/nginx


### PR DESCRIPTION
**Goals (and why)**:
- Prerequisite of #4353

**Implementation Description (bullets)**:
- Change the image we use from `kiasaki` to the official Postgres one
- Upgrade to `9.6-alpine`

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Existing tests pass.

**Concerns (what feedback would you like?)**:
- Was there some reason we didn't want to use the official images? **The `kiasaki` images break on inability to connect**, but I didn't investigate in detail.

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**: ASAP
