### PR TITLE
Fail loudly when a closed LockRefreshingLockService is used

### DIFF
--- a/changelog/@unreleased/pr-4358.v2.yml
+++ b/changelog/@unreleased/pr-4358.v2.yml
@@ -1,0 +1,11 @@
+type: improvement
+improvement:
+  description: |-
+    Fail loudly when a closed LockRefreshingLockService is used
+
+    Previously a LockRefreshingLockService could be closed, but
+    still used despite no longer refreshing locks. It's better to
+    fail quickly and deterministically when the service is in an
+    unexpected state.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4358

--- a/lock-api/src/main/java/com/palantir/lock/client/LockRefreshingLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockRefreshingLockService.java
@@ -37,6 +37,7 @@ import com.palantir.lock.LockResponse;
 import com.palantir.lock.LockService;
 import com.palantir.lock.SimpleHeldLocksToken;
 import com.palantir.lock.SimplifyingLockService;
+import com.palantir.logsafe.Preconditions;
 
 public final class LockRefreshingLockService extends SimplifyingLockService {
     public static final int REFRESH_BATCH_SIZE = 500_000;
@@ -79,6 +80,7 @@ public final class LockRefreshingLockService extends SimplifyingLockService {
 
     @Override
     public LockService delegate() {
+        Preconditions.checkState(!isClosed, "LockRefreshingLockService is closed");
         return delegate;
     }
 
@@ -171,8 +173,10 @@ public final class LockRefreshingLockService extends SimplifyingLockService {
 
     @Override
     public void close() {
-        super.close();
-        dispose();
+        if (!isClosed) {
+            super.close();
+            dispose();
+        }
     }
 
     // visible for debugging clients at runtime


### PR DESCRIPTION
Previously a LockRefreshingLockService could be closed, but
still used despite no longer refreshing locks. It's better to
fail quickly and deterministically when the service is in an
unexpected state.
