### PR TITLE
[Conjure Java Runtime] Part 17: 🚨🚚🚨 Optionals for Paxos Learners

### DIFF
--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/LeadersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/LeadersTest.java
@@ -46,8 +46,8 @@ public class LeadersTest {
     @Test
     public void canCreateProxyAndLocalListOfPaxosLearners() {
         PaxosLearner localLearner = mock(PaxosLearner.class);
-        PaxosValue value = mock(PaxosValue.class);
-        when(localLearner.getGreatestLearnedValue()).thenReturn(value);
+        Optional<PaxosValue> presentPaxosValue = Optional.of(mock(PaxosValue.class));
+        when(localLearner.getGreatestLearnedValue()).thenReturn(presentPaxosValue);
 
         List<PaxosLearner> paxosLearners = Leaders.createProxyAndLocalList(
                 new MetricRegistry(),
@@ -59,7 +59,7 @@ public class LeadersTest {
 
         MatcherAssert.assertThat(paxosLearners.size(), is(REMOTE_SERVICE_ADDRESSES.size() + 1));
         paxosLearners.forEach(object -> MatcherAssert.assertThat(object, not(nullValue())));
-        MatcherAssert.assertThat(Iterables.getLast(paxosLearners).getGreatestLearnedValue(), is(value));
+        MatcherAssert.assertThat(Iterables.getLast(paxosLearners).getGreatestLearnedValue(), is(presentPaxosValue));
         verify(localLearner).getGreatestLearnedValue();
         verifyNoMoreInteractions(localLearner);
     }

--- a/changelog/@unreleased/pr-4361.v2.yml
+++ b/changelog/@unreleased/pr-4361.v2.yml
@@ -1,0 +1,9 @@
+type: break
+break:
+  description: The `PaxosLearner` interface now returns `Optional<PaxosValue>` instead
+    of a nullable `PaxosValue` for the `getLearnedValue(seq)` and `getGreatestLearnedValue()`
+    methods. The wire format remains unchanged (so, for example, rolling upgrades
+    of TimeLock, or servers in an embedded leader configuration, are safe). Users
+    who require the old behaviour can use `Optional.orElse(null)`.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4361

--- a/leader-election-api/src/main/java/com/palantir/paxos/PaxosLearner.java
+++ b/leader-election-api/src/main/java/com/palantir/paxos/PaxosLearner.java
@@ -16,9 +16,9 @@
 package com.palantir.paxos;
 
 import java.util.Collection;
+import java.util.Optional;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -44,22 +44,23 @@ public interface PaxosLearner {
     void learn(@PathParam("seq") long seq, PaxosValue val);
 
     /**
-     * Returns learned value or null if non-exists.
+     * Returns the learned value at the specified sequence number, or {@link Optional#empty()} if the learner
+     * does not know such a value.
      */
-    @Nullable
+    @Nonnull
     @GET
     @Path("learned-value/{seq:.+}")
     @Produces(MediaType.APPLICATION_JSON)
-    PaxosValue getLearnedValue(@PathParam("seq") long seq);
+    Optional<PaxosValue> getLearnedValue(@PathParam("seq") long seq);
 
     /**
-     * Returns the learned value for the greatest known round or null if nothing has been learned.
+     * Returns the learned value for the greatest known round or {@link Optional#empty()} if nothing has been learned.
      */
-    @Nullable
+    @Nonnull
     @GET
     @Path("greatest-learned-value")
     @Produces(MediaType.APPLICATION_JSON)
-    PaxosValue getGreatestLearnedValue();
+    Optional<PaxosValue> getGreatestLearnedValue();
 
     /**
      * Returns some collection of learned values since the seq-th round (inclusive).

--- a/leader-election-api/src/main/java/com/palantir/paxos/PaxosLearner.java
+++ b/leader-election-api/src/main/java/com/palantir/paxos/PaxosLearner.java
@@ -18,7 +18,6 @@ package com.palantir.paxos;
 import java.util.Collection;
 import java.util.Optional;
 
-import javax.annotation.Nonnull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -47,7 +46,6 @@ public interface PaxosLearner {
      * Returns the learned value at the specified sequence number, or {@link Optional#empty()} if the learner
      * does not know such a value.
      */
-    @Nonnull
     @GET
     @Path("learned-value/{seq:.+}")
     @Produces(MediaType.APPLICATION_JSON)
@@ -56,7 +54,6 @@ public interface PaxosLearner {
     /**
      * Returns the learned value for the greatest known round or {@link Optional#empty()} if nothing has been learned.
      */
-    @Nonnull
     @GET
     @Path("greatest-learned-value")
     @Produces(MediaType.APPLICATION_JSON)
@@ -68,7 +65,6 @@ public interface PaxosLearner {
      * @param seq lower round cutoff for returned values
      * @return some set of learned values for rounds since the seq-th round
      */
-    @Nonnull
     @GET
     @Path("learned-values-since/{seq:.+}")
     @Produces(MediaType.APPLICATION_JSON)

--- a/leader-election-impl/src/main/java/com/palantir/leader/LocalPingableLeader.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/LocalPingableLeader.java
@@ -16,7 +16,6 @@
 
 package com.palantir.leader;
 
-import java.util.Optional;
 import java.util.UUID;
 
 import com.palantir.paxos.PaxosLearner;
@@ -34,7 +33,7 @@ public final class LocalPingableLeader implements PingableLeader {
 
     @Override
     public boolean ping() {
-        return getGreatestLearnedPaxosValue()
+        return knowledge.getGreatestLearnedValue()
                 .map(this::isThisNodeTheLeaderFor)
                 .orElse(false);
     }
@@ -42,10 +41,6 @@ public final class LocalPingableLeader implements PingableLeader {
     @Override
     public String getUUID() {
         return localUuid.toString();
-    }
-
-    private Optional<PaxosValue> getGreatestLearnedPaxosValue() {
-        return Optional.ofNullable(knowledge.getGreatestLearnedValue());
     }
 
     private boolean isThisNodeTheLeaderFor(PaxosValue value) {

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
@@ -252,7 +252,7 @@ public class PaxosLeaderElectionService implements LeaderElectionService {
         for (PaxosUpdate update : updates.get()) {
             ImmutableCollection<PaxosValue> values = update.getValues();
             for (PaxosValue value : values) {
-                if (knowledge.getLearnedValue(value.getRound()) == null) {
+                if (!knowledge.getLearnedValue(value.getRound()).isPresent()) {
                     knowledge.learn(value.getRound(), value);
                     learned = true;
                 }

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
@@ -144,7 +144,7 @@ public class PaxosLeaderElectionService implements LeaderElectionService {
     }
 
     private LeadershipState determineLeadershipState() {
-        Optional<PaxosValue> greatestLearnedValue = getGreatestLearnedPaxosValue();
+        Optional<PaxosValue> greatestLearnedValue = knowledge.getGreatestLearnedValue();
         StillLeadingStatus leadingStatus = determineLeadershipStatus(greatestLearnedValue);
 
         return LeadershipState.of(greatestLearnedValue, leadingStatus);
@@ -179,10 +179,6 @@ public class PaxosLeaderElectionService implements LeaderElectionService {
         } finally {
             lock.unlock();
         }
-    }
-
-    private Optional<PaxosValue> getGreatestLearnedPaxosValue() {
-        return Optional.ofNullable(knowledge.getGreatestLearnedValue());
     }
 
     @Override
@@ -224,7 +220,7 @@ public class PaxosLeaderElectionService implements LeaderElectionService {
     }
 
     private boolean isLatestRound(Optional<PaxosValue> valueIfAny) {
-        return valueIfAny.equals(getGreatestLearnedPaxosValue());
+        return valueIfAny.equals(knowledge.getGreatestLearnedValue());
     }
 
     private void recordLeadershipStatus(

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosLearnerImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosLearnerImpl.java
@@ -107,9 +107,9 @@ public final class PaxosLearnerImpl implements PaxosLearner {
 
     @Override
     public Optional<PaxosValue> getGreatestLearnedValue() {
-        if (!state.isEmpty()) {
-            return Optional.ofNullable(state.get(state.lastKey()));
+        if (state.isEmpty()) {
+            return Optional.empty();
         }
-        return Optional.empty();
+        return Optional.ofNullable(state.get(state.lastKey()));
     }
 }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosLearnerImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosLearnerImpl.java
@@ -16,14 +16,17 @@
 package com.palantir.paxos;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.SortedMap;
 import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.ImmutableList;
 import com.palantir.leader.PaxosKnowledgeEventRecorder;
 import com.palantir.logsafe.SafeArg;
 
@@ -69,7 +72,7 @@ public final class PaxosLearnerImpl implements PaxosLearner {
     }
 
     @Override
-    public PaxosValue getLearnedValue(long seq) {
+    public Optional<PaxosValue> getLearnedValue(long seq) {
         try {
             if (!state.containsKey(seq)) {
                 byte[] bytes = log.readRound(seq);
@@ -78,38 +81,35 @@ public final class PaxosLearnerImpl implements PaxosLearner {
                     state.put(seq, value);
                 }
             }
-            return state.get(seq);
+            return Optional.ofNullable(state.get(seq));
         } catch (IOException e) {
             logger.error("Unable to get corrupt learned value for sequence {}",
-                    SafeArg.of("sequence", seq), e);
-            return null;
+                    SafeArg.of("sequence", seq),
+                    e);
+            return Optional.empty();
         }
     }
 
     @Override
     public Collection<PaxosValue> getLearnedValuesSince(long seq) {
-        PaxosValue greatestLearnedValue = getGreatestLearnedValue();
-        long greatestSeq = -1L;
-        if (greatestLearnedValue != null) {
-            greatestSeq = greatestLearnedValue.seq;
+        Optional<Long> greatestSeq = getGreatestLearnedValue().map(PaxosValue::getRound);
+        if (!greatestSeq.isPresent()) {
+            return ImmutableList.of();
         }
 
-        Collection<PaxosValue> values = new ArrayList<>();
-        for (long i = seq; i <= greatestSeq; i++) {
-            PaxosValue value;
-            value = getLearnedValue(i);
-            if (value != null) {
-                values.add(value);
-            }
-        }
-        return values;
+        return LongStream.rangeClosed(seq, greatestSeq.get())
+                .boxed()
+                .map(this::getLearnedValue)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toList());
     }
 
     @Override
-    public PaxosValue getGreatestLearnedValue() {
+    public Optional<PaxosValue> getGreatestLearnedValue() {
         if (!state.isEmpty()) {
-            return state.get(state.lastKey());
+            return Optional.ofNullable(state.get(state.lastKey()));
         }
-        return null;
+        return Optional.empty();
     }
 }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderLearnerNetworkClient.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderLearnerNetworkClient.java
@@ -84,7 +84,7 @@ public class SingleLeaderLearnerNetworkClient implements PaxosLearnerNetworkClie
             Function<Optional<PaxosValue>, T> mapper) {
         return PaxosQuorumChecker.collectQuorumResponses(
                 allLearners,
-                learner -> mapper.apply(Optional.ofNullable(learner.getLearnedValue(seq))),
+                learner -> mapper.apply(learner.getLearnedValue(seq)),
                 quorumSize,
                 executors,
                 PaxosQuorumChecker.DEFAULT_REMOTE_REQUESTS_TIMEOUT).withoutRemotes();

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimelockPaxosLearnerAdapter.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimelockPaxosLearnerAdapter.java
@@ -18,6 +18,7 @@ package com.palantir.timelock.paxos;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -52,13 +53,13 @@ public final class TimelockPaxosLearnerAdapter implements PaxosLearner {
 
     @Nullable
     @Override
-    public PaxosValue getLearnedValue(long seq) {
+    public Optional<PaxosValue> getLearnedValue(long seq) {
         return clientAwarePaxosLearner.getLearnedValue(paxosUseCase, client, seq);
     }
 
     @Nullable
     @Override
-    public PaxosValue getGreatestLearnedValue() {
+    public Optional<PaxosValue> getGreatestLearnedValue() {
         return clientAwarePaxosLearner.getGreatestLearnedValue(paxosUseCase, client);
     }
 

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimelockPaxosLearnerAdapter.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimelockPaxosLearnerAdapter.java
@@ -22,9 +22,6 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
 import com.palantir.atlasdb.timelock.paxos.Client;
 import com.palantir.atlasdb.timelock.paxos.PaxosRemoteClients;
 import com.palantir.atlasdb.timelock.paxos.PaxosUseCase;
@@ -51,19 +48,16 @@ public final class TimelockPaxosLearnerAdapter implements PaxosLearner {
         clientAwarePaxosLearner.learn(paxosUseCase, client, seq, val);
     }
 
-    @Nullable
     @Override
     public Optional<PaxosValue> getLearnedValue(long seq) {
         return clientAwarePaxosLearner.getLearnedValue(paxosUseCase, client, seq);
     }
 
-    @Nullable
     @Override
     public Optional<PaxosValue> getGreatestLearnedValue() {
         return clientAwarePaxosLearner.getGreatestLearnedValue(paxosUseCase, client);
     }
 
-    @Nonnull
     @Override
     public Collection<PaxosValue> getLearnedValuesSince(long seq) {
         return clientAwarePaxosLearner.getLearnedValuesSince(paxosUseCase, client, seq);

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimelockPaxosLearnerRpcClient.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimelockPaxosLearnerRpcClient.java
@@ -19,7 +19,6 @@ package com.palantir.timelock.paxos;
 import java.util.Collection;
 import java.util.Optional;
 
-import javax.annotation.Nonnull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -54,7 +53,6 @@ public interface TimelockPaxosLearnerRpcClient {
             @PathParam("seq") long seq,
             PaxosValue val);
 
-    @Nonnull
     @GET
     @Path("learned-value/{seq}")
     @Produces(MediaType.APPLICATION_JSON)
@@ -63,7 +61,6 @@ public interface TimelockPaxosLearnerRpcClient {
             @PathParam("client") String client,
             @PathParam("seq") long seq);
 
-    @Nonnull
     @GET
     @Path("greatest-learned-value")
     @Produces(MediaType.APPLICATION_JSON)
@@ -71,7 +68,6 @@ public interface TimelockPaxosLearnerRpcClient {
             @PathParam("useCase") PaxosUseCase paxosUseCase,
             @PathParam("client") String client);
 
-    @Nonnull
     @GET
     @Path("learned-values-since/{seq}")
     @Produces(MediaType.APPLICATION_JSON)

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimelockPaxosLearnerRpcClient.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimelockPaxosLearnerRpcClient.java
@@ -17,9 +17,9 @@
 package com.palantir.timelock.paxos;
 
 import java.util.Collection;
+import java.util.Optional;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -54,20 +54,20 @@ public interface TimelockPaxosLearnerRpcClient {
             @PathParam("seq") long seq,
             PaxosValue val);
 
-    @Nullable
+    @Nonnull
     @GET
     @Path("learned-value/{seq}")
     @Produces(MediaType.APPLICATION_JSON)
-    PaxosValue getLearnedValue(
+    Optional<PaxosValue> getLearnedValue(
             @PathParam("useCase") PaxosUseCase paxosUseCase,
             @PathParam("client") String client,
             @PathParam("seq") long seq);
 
-    @Nullable
+    @Nonnull
     @GET
     @Path("greatest-learned-value")
     @Produces(MediaType.APPLICATION_JSON)
-    PaxosValue getGreatestLearnedValue(
+    Optional<PaxosValue> getGreatestLearnedValue(
             @PathParam("useCase") PaxosUseCase paxosUseCase,
             @PathParam("client") String client);
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPingableLeaderResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPingableLeaderResource.java
@@ -16,7 +16,7 @@
 
 package com.palantir.atlasdb.timelock.paxos;
 
-import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -40,7 +40,8 @@ public class BatchPingableLeaderResource implements BatchPingableLeader {
         return KeyedStream.of(clients)
                 .map(components::learner)
                 .map(PaxosLearner::getGreatestLearnedValue)
-                .filter(Objects::nonNull)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
                 .filter(this::isThisNodeTheLeaderFor)
                 .keys()
                 .collect(Collectors.toSet());

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalBatchPaxosLearner.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalBatchPaxosLearner.java
@@ -18,7 +18,7 @@ package com.palantir.atlasdb.timelock.paxos;
 
 import java.util.Collection;
 import java.util.Map;
-import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import com.google.common.collect.SetMultimap;
@@ -45,7 +45,8 @@ public class LocalBatchPaxosLearner implements BatchPaxosLearner {
                 .mapKeys(WithSeq::value)
                 .map(WithSeq::seq)
                 .map((client, seq) -> paxosComponents.learner(client).getLearnedValue(seq))
-                .filter(Objects::nonNull)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
                 .collectToSetMultimap();
     }
 

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/BatchPingableLeaderResourceTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/BatchPingableLeaderResourceTests.java
@@ -19,6 +19,7 @@ package com.palantir.atlasdb.timelock.paxos;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
 
@@ -80,13 +81,13 @@ public class BatchPingableLeaderResourceTests {
         when(components.learner(CLIENT_1).getGreatestLearnedValue())
                 .thenReturn(paxosValue(LEADER_UUID));
         when(components.learner(clientWhereNothingHasBeenLearnt).getGreatestLearnedValue())
-                .thenReturn(null);
+                .thenReturn(Optional.empty());
 
         assertThat(resource.ping(ImmutableSet.of(CLIENT_1, clientWhereNothingHasBeenLearnt)))
                 .containsOnly(CLIENT_1);
     }
 
-    private static PaxosValue paxosValue(UUID uuid) {
-        return new PaxosValue(uuid.toString(), new Random().nextLong(), null);
+    private static Optional<PaxosValue> paxosValue(UUID uuid) {
+        return Optional.of(new PaxosValue(uuid.toString(), new Random().nextLong(), null));
     }
 }

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalBatchPaxosLearnerTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalBatchPaxosLearnerTests.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -75,10 +76,10 @@ public class LocalBatchPaxosLearnerTests {
     public void weProxyGetLearnedValuesThrough() {
         PaxosValue paxosValue1 = paxosValue(1);
         PaxosValue paxosValue2 = paxosValue(2);
-        when(paxosComponents.learner(CLIENT_1).getLearnedValue(1)).thenReturn(paxosValue1);
-        when(paxosComponents.learner(CLIENT_1).getLearnedValue(2)).thenReturn(null);
-        when(paxosComponents.learner(CLIENT_2).getLearnedValue(1)).thenReturn(paxosValue1);
-        when(paxosComponents.learner(CLIENT_2).getLearnedValue(2)).thenReturn(paxosValue2);
+        when(paxosComponents.learner(CLIENT_1).getLearnedValue(1)).thenReturn(Optional.of(paxosValue1));
+        when(paxosComponents.learner(CLIENT_1).getLearnedValue(2)).thenReturn(Optional.empty());
+        when(paxosComponents.learner(CLIENT_2).getLearnedValue(1)).thenReturn(Optional.of(paxosValue1));
+        when(paxosComponents.learner(CLIENT_2).getLearnedValue(2)).thenReturn(Optional.of(paxosValue2));
 
         SetMultimap<Client, PaxosValue> expected = ImmutableSetMultimap.<Client, PaxosValue>builder()
                 .putAll(CLIENT_1, paxosValue1)

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponentsTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponentsTest.java
@@ -67,7 +67,6 @@ public class LocalPaxosComponentsTest {
         learner.learn(PAXOS_ROUND_ONE, PAXOS_VALUE);
 
         assertThat(learner.getGreatestLearnedValue())
-                .isPresent()
                 .hasValueSatisfying(paxosValue -> {
                     assertThat(paxosValue.getLeaderUUID()).isEqualTo(PAXOS_UUID);
                     assertThat(paxosValue.getData()).isEqualTo(PAXOS_DATA);

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponentsTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponentsTest.java
@@ -66,11 +66,8 @@ public class LocalPaxosComponentsTest {
         PaxosLearner learner = paxosComponents.learner(CLIENT);
         learner.learn(PAXOS_ROUND_ONE, PAXOS_VALUE);
 
-        assertThat(learner.getGreatestLearnedValue())
-                .hasValueSatisfying(paxosValue -> {
-                    assertThat(paxosValue.getLeaderUUID()).isEqualTo(PAXOS_UUID);
-                    assertThat(paxosValue.getData()).isEqualTo(PAXOS_DATA);
-                });
+        assertThat(learner.getGreatestLearnedValue()).map(PaxosValue::getLeaderUUID).isEqualTo(PAXOS_UUID);
+        assertThat(learner.getGreatestLearnedValue()).map(PaxosValue::getData).isEqualTo(PAXOS_DATA);
 
         PaxosAcceptor acceptor = paxosComponents.acceptor(CLIENT);
         acceptor.accept(PAXOS_ROUND_TWO, PAXOS_PROPOSAL);

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponentsTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponentsTest.java
@@ -65,9 +65,13 @@ public class LocalPaxosComponentsTest {
     public void newClientCanBeCreated() {
         PaxosLearner learner = paxosComponents.learner(CLIENT);
         learner.learn(PAXOS_ROUND_ONE, PAXOS_VALUE);
-        assertThat(learner.getGreatestLearnedValue()).isNotNull();
-        assertThat(learner.getGreatestLearnedValue().getLeaderUUID()).isEqualTo(PAXOS_UUID);
-        assertThat(learner.getGreatestLearnedValue().getData()).isEqualTo(PAXOS_DATA);
+
+        assertThat(learner.getGreatestLearnedValue())
+                .isPresent()
+                .hasValueSatisfying(paxosValue -> {
+                    assertThat(paxosValue.getLeaderUUID()).isEqualTo(PAXOS_UUID);
+                    assertThat(paxosValue.getData()).isEqualTo(PAXOS_DATA);
+                });
 
         PaxosAcceptor acceptor = paxosComponents.acceptor(CLIENT);
         acceptor.accept(PAXOS_ROUND_TWO, PAXOS_PROPOSAL);

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponentsTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponentsTest.java
@@ -66,8 +66,8 @@ public class LocalPaxosComponentsTest {
         PaxosLearner learner = paxosComponents.learner(CLIENT);
         learner.learn(PAXOS_ROUND_ONE, PAXOS_VALUE);
 
-        assertThat(learner.getGreatestLearnedValue()).map(PaxosValue::getLeaderUUID).isEqualTo(PAXOS_UUID);
-        assertThat(learner.getGreatestLearnedValue()).map(PaxosValue::getData).isEqualTo(PAXOS_DATA);
+        assertThat(learner.getGreatestLearnedValue()).map(PaxosValue::getLeaderUUID).contains(PAXOS_UUID);
+        assertThat(learner.getGreatestLearnedValue()).map(PaxosValue::getData).contains(PAXOS_DATA);
 
         PaxosAcceptor acceptor = paxosComponents.acceptor(CLIENT);
         acceptor.accept(PAXOS_ROUND_TWO, PAXOS_PROPOSAL);


### PR DESCRIPTION
**Goals (and why)**:
- Fulfil a prerequisite for internode communication via Conjure Java Runtime

**Implementation Description (bullets)**:
- Switch `PaxosLearner` to return `Optional<PaxosValue>` and fix attendant breaks.
- Also switched `TimelockPaxosLearnerRpcClient` to use this.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Updated tests that used to use nullable values to now use Optionals. These passing should be sufficient.

**Concerns (what feedback would you like?)**:
- This is obviously an API break, is it unforgivably large?
- There is no wire break (a wire break would obviously be disastrous) - please confirm this.

**Where should we start reviewing?**: `PaxosLearner`

**Priority (whenever / two weeks / yesterday)**: this week please
