### PR TITLE
[0.121.x] Disable ErrorProne to unblock hotfix releases

### DIFF
--- a/gradle/shared.gradle
+++ b/gradle/shared.gradle
@@ -96,4 +96,8 @@ task allCompileDeps(type: DependencyReportTask) {
     configurations = [project.configurations.getByName("compile")]
 }
 
+compileJava {
+    options.compileArgs << '-Xep:StrictUnusedVariable:OFF'
+}
+
 ext.atlasdb_shaded = 'com.palantir.atlasdb.shaded.'

--- a/gradle/shared.gradle
+++ b/gradle/shared.gradle
@@ -96,8 +96,4 @@ task allCompileDeps(type: DependencyReportTask) {
     configurations = [project.configurations.getByName("compile")]
 }
 
-compileJava {
-    options.compilerArgs << '-Xep:StrictUnusedVariable:OFF'
-}
-
 ext.atlasdb_shaded = 'com.palantir.atlasdb.shaded.'

--- a/gradle/shared.gradle
+++ b/gradle/shared.gradle
@@ -97,7 +97,7 @@ task allCompileDeps(type: DependencyReportTask) {
 }
 
 compileJava {
-    options.compileArgs << '-Xep:StrictUnusedVariable:OFF'
+    options.compilerArgs << '-Xep:StrictUnusedVariable:OFF'
 }
 
 ext.atlasdb_shaded = 'com.palantir.atlasdb.shaded.'

--- a/scripts/circle-ci/run-circle-tests.sh
+++ b/scripts/circle-ci/run-circle-tests.sh
@@ -78,5 +78,5 @@ case $CIRCLE_NODE_INDEX in
     4) ./gradlew $BASE_GRADLE_ARGS ${CONTAINER_4[@]} ;;
     5) ./gradlew $BASE_GRADLE_ARGS ${CONTAINER_5[@]} ;;
     6) ./gradlew $BASE_GRADLE_ARGS ${CONTAINER_6[@]} ;;
-    7) ./gradlew $BASE_GRADLE_ARGS ${CONTAINER_7[@]} -PenableErrorProne=true && checkDocsBuild ;;
+    7) ./gradlew $BASE_GRADLE_ARGS ${CONTAINER_7[@]} && checkDocsBuild ;;
 esac


### PR DESCRIPTION
**Goals (and why)**:
- Allow hotfix releases.

**Implementation Description (bullets)**:
- The version of baseline we use has advanced, but Atlas circa 0.121.0 has not, and fixing it seems untenable and a waste of time.

@tpetracca for SA