### PR TITLE
[Conjure Java Runtime] Part 18: Internode Support

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -112,6 +112,24 @@ acceptedBreaks:
       old: "field com.palantir.atlasdb.http.AtlasDbHttpClients.DEFAULT_TARGET_FACTORY"
       new: null
       justification: "Clean slate"
+  0.170.0:
+    com.palantir.atlasdb:atlasdb-config:
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter <T> T com.palantir.atlasdb.http.AtlasDbHttpClients::createProxy(===com.codahale.metrics.MetricRegistry===,\
+        \ java.util.Optional<com.palantir.conjure.java.config.ssl.TrustContext>, java.lang.String,\
+        \ java.lang.Class<T>, com.palantir.atlasdb.config.AuxiliaryRemotingParameters)"
+      new: "parameter <T> T com.palantir.atlasdb.http.AtlasDbHttpClients::createProxy(===com.palantir.atlasdb.util.MetricsManager===,\
+        \ java.util.Optional<com.palantir.conjure.java.config.ssl.TrustContext>, java.lang.String,\
+        \ java.lang.Class<T>, com.palantir.atlasdb.config.AuxiliaryRemotingParameters)"
+      justification: "Intentional break, needed for running experiments / tagged metrics"
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter <T> java.util.List<T> com.palantir.atlasdb.factory.Leaders::createProxyAndLocalList(===com.codahale.metrics.MetricRegistry===,\
+        \ T, java.util.Set<java.lang.String>, java.util.Optional<com.palantir.conjure.java.config.ssl.TrustContext>,\
+        \ java.lang.Class<T>, com.palantir.conjure.java.api.config.service.UserAgent)"
+      new: "parameter <T> java.util.List<T> com.palantir.atlasdb.factory.Leaders::createProxyAndLocalList(===com.palantir.atlasdb.util.MetricsManager===,\
+        \ T, java.util.Set<java.lang.String>, java.util.Optional<com.palantir.conjure.java.config.ssl.TrustContext>,\
+        \ java.lang.Class<T>, com.palantir.conjure.java.api.config.service.UserAgent)"
+      justification: "Intentional break, needed for running experiments / tagged metrics"
   0.161.0:
     com.palantir.atlasdb:atlasdb-config:
     - code: "java.method.removed"

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -64,12 +64,6 @@ acceptedBreaks:
         \ com.palantir.atlasdb.factory.ImmutableLocalPaxosServices.Builder::isCurrentSuspectedLeader(java.util.function.Supplier<java.lang.Boolean>)"
       new: null
       justification: "this is internal code"
-  0.158.6:
-    com.palantir.atlasdb:atlasdb-config:
-    - code: "java.field.removed"
-      old: "field com.palantir.atlasdb.http.AtlasDbHttpClients.DEFAULT_TARGET_FACTORY"
-      new: null
-      justification: "Clean slate"
   0.162.5:
     com.palantir.atlasdb:atlasdb-config:
     - code: "java.method.parameterTypeChanged"
@@ -92,6 +86,32 @@ acceptedBreaks:
         \ com.palantir.atlasdb.factory.Leaders.RemotePaxosServerSpec, com.palantir.conjure.java.api.config.service.UserAgent,\
         \ ===com.palantir.leader.LeadershipObserver===)"
       justification: "this is internal code"
+  0.168.0:
+    com.palantir.atlasdb:atlasdb-config:
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter <T> T com.palantir.atlasdb.http.AtlasDbHttpClients::createProxy(===com.codahale.metrics.MetricRegistry===,\
+        \ java.util.Optional<com.palantir.conjure.java.config.ssl.TrustContext>, java.lang.String,\
+        \ java.lang.Class<T>, com.palantir.atlasdb.config.AuxiliaryRemotingParameters)"
+      new: "parameter <T> T com.palantir.atlasdb.http.AtlasDbHttpClients::createProxy(===com.palantir.atlasdb.util.MetricsManager===,\
+        \ java.util.Optional<com.palantir.conjure.java.config.ssl.TrustContext>, java.lang.String,\
+        \ java.lang.Class<T>, com.palantir.atlasdb.config.AuxiliaryRemotingParameters)"
+      justification: "Change to require tagged metrics registries is an intended break\
+        \ and mostly internal API"
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter <T> java.util.List<T> com.palantir.atlasdb.factory.Leaders::createProxyAndLocalList(===com.codahale.metrics.MetricRegistry===,\
+        \ T, java.util.Set<java.lang.String>, java.util.Optional<com.palantir.conjure.java.config.ssl.TrustContext>,\
+        \ java.lang.Class<T>, com.palantir.conjure.java.api.config.service.UserAgent)"
+      new: "parameter <T> java.util.List<T> com.palantir.atlasdb.factory.Leaders::createProxyAndLocalList(===com.palantir.atlasdb.util.MetricsManager===,\
+        \ T, java.util.Set<java.lang.String>, java.util.Optional<com.palantir.conjure.java.config.ssl.TrustContext>,\
+        \ java.lang.Class<T>, com.palantir.conjure.java.api.config.service.UserAgent)"
+      justification: "Change to require tagged metrics registries is an intended break\
+        \ and mostly internal API"
+  0.158.6:
+    com.palantir.atlasdb:atlasdb-config:
+    - code: "java.field.removed"
+      old: "field com.palantir.atlasdb.http.AtlasDbHttpClients.DEFAULT_TARGET_FACTORY"
+      new: null
+      justification: "Clean slate"
   0.161.0:
     com.palantir.atlasdb:atlasdb-config:
     - code: "java.method.removed"

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
@@ -142,8 +142,12 @@ public final class Leaders {
                 ServiceCreator.createTrustContext(config.sslConfiguration());
 
         List<PaxosLearner> learners = createProxyAndLocalList(
-                metricsManager.getRegistry(), ourLearner, remotePaxosServerSpec.remoteLearnerUris(),
-                trustContext, PaxosLearner.class, userAgent);
+                metricsManager,
+                ourLearner,
+                remotePaxosServerSpec.remoteLearnerUris(),
+                trustContext,
+                PaxosLearner.class,
+                userAgent);
         List<PaxosLearner> remoteLearners = learners.stream()
                 .filter(learner -> !learner.equals(ourLearner))
                 .collect(ImmutableList.toImmutableList());
@@ -154,7 +158,7 @@ public final class Leaders {
                 createExecutorsForService(metricsManager, learners, "knowledge-update"));
 
         List<PaxosAcceptor> acceptors = createProxyAndLocalList(
-                metricsManager.getRegistry(),
+                metricsManager,
                 ourAcceptor,
                 remotePaxosServerSpec.remoteAcceptorUris(),
                 trustContext,
@@ -238,7 +242,7 @@ public final class Leaders {
     }
 
     public static <T> List<T> createProxyAndLocalList(
-            MetricRegistry metrics,
+            MetricsManager metricsManager,
             T localObject,
             Set<String> remoteUris,
             Optional<TrustContext> trustContext,
@@ -248,7 +252,7 @@ public final class Leaders {
         // TODO (jkong): Enable runtime config for leader election services.
         List<T> remotes = remoteUris.stream()
                 .map(uri -> AtlasDbHttpClients.createProxy(
-                        metrics,
+                        metricsManager,
                         trustContext,
                         uri,
                         clazz,
@@ -271,7 +275,7 @@ public final class Leaders {
             UserAgent userAgent) {
         return remoteEndpoints.stream()
                 .map(endpoint -> AtlasDbHttpClients.createProxy(
-                        metricsManager.getRegistry(),
+                        metricsManager,
                         trustContext,
                         endpoint,
                         PingableLeader.class,

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
@@ -42,16 +42,17 @@ public final class AtlasDbHttpClients {
     }
 
     public static <T> T createProxy(
-            MetricRegistry metricRegistry,
+            MetricsManager metricsManager,
             Optional<TrustContext> trustContext,
             String uri,
             Class<T> type,
             AuxiliaryRemotingParameters parameters) {
-        return AtlasDbMetrics.instrument(
-                metricRegistry,
+        return createExperimentallyWithFallback(
+                metricsManager,
+                () -> ConjureJavaRuntimeTargetFactory.DEFAULT.createProxy(trustContext, uri, type, parameters),
+                () -> AtlasDbFeignTargetFactory.DEFAULT.createProxy(trustContext, uri, type, parameters),
                 type,
-                LEGACY_FEIGN_TARGET_FACTORY.createProxy(trustContext, uri, type, parameters).instance(),
-                MetricRegistry.name(type));
+                parameters);
     }
 
     /**

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/LeadersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/LeadersTest.java
@@ -31,10 +31,10 @@ import java.util.Set;
 import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 
-import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.palantir.atlasdb.http.AtlasDbRemotingConstants;
+import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.paxos.PaxosAcceptor;
 import com.palantir.paxos.PaxosLearner;
 import com.palantir.paxos.PaxosValue;
@@ -50,7 +50,7 @@ public class LeadersTest {
         when(localLearner.getGreatestLearnedValue()).thenReturn(presentPaxosValue);
 
         List<PaxosLearner> paxosLearners = Leaders.createProxyAndLocalList(
-                new MetricRegistry(),
+                MetricsManagers.createForTests(),
                 localLearner,
                 REMOTE_SERVICE_ADDRESSES,
                 Optional.empty(),
@@ -70,7 +70,7 @@ public class LeadersTest {
         when(localAcceptor.getLatestSequencePreparedOrAccepted()).thenReturn(1L);
 
         List<PaxosAcceptor> paxosAcceptors = Leaders.createProxyAndLocalList(
-                new MetricRegistry(),
+                MetricsManagers.createForTests(),
                 localAcceptor,
                 REMOTE_SERVICE_ADDRESSES,
                 Optional.empty(),
@@ -91,7 +91,7 @@ public class LeadersTest {
         when(localAcceptor.getLatestSequencePreparedOrAccepted()).thenReturn(1L);
 
         List<PaxosAcceptor> paxosAcceptors = Leaders.createProxyAndLocalList(
-                new MetricRegistry(),
+                MetricsManagers.createForTests(),
                 localAcceptor,
                 ImmutableSet.of(),
                 Optional.empty(),
@@ -110,7 +110,7 @@ public class LeadersTest {
         BigInteger localBigInteger = new BigInteger("0");
 
         Leaders.createProxyAndLocalList(
-                new MetricRegistry(),
+                MetricsManagers.createForTests(),
                 localBigInteger,
                 REMOTE_SERVICE_ADDRESSES,
                 Optional.empty(),
@@ -123,7 +123,7 @@ public class LeadersTest {
         PaxosAcceptor localAcceptor = mock(PaxosAcceptor.class);
 
         Leaders.createProxyAndLocalList(
-                new MetricRegistry(),
+                MetricsManagers.createForTests(),
                 localAcceptor,
                 REMOTE_SERVICE_ADDRESSES,
                 Optional.empty(),

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/AtlasDbHttpClientsTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/AtlasDbHttpClientsTest.java
@@ -153,7 +153,7 @@ public class AtlasDbHttpClientsTest {
     @Test
     public void payloadLimitingClientThrowsOnRequestThatIsTooLarge() {
         TestResource client = AtlasDbHttpClients.createProxy(
-                new MetricRegistry(),
+                MetricsManagers.createForTests(),
                 NO_SSL,
                 getUriForPort(availablePort1),
                 TestResource.class,
@@ -171,7 +171,7 @@ public class AtlasDbHttpClientsTest {
     public void regularClientDoesNotThrowOnRequestThatIsTooLarge() {
         TestResource client
                 = AtlasDbHttpClients.createProxy(
-                new MetricRegistry(),
+                MetricsManagers.createForTests(),
                 NO_SSL,
                 getUriForPort(availablePort1),
                 TestResource.class,
@@ -199,7 +199,7 @@ public class AtlasDbHttpClientsTest {
     @Test
     public void userAgentIsPresentOnClientRequests() {
         TestResource client = AtlasDbHttpClients.createProxy(
-                new MetricRegistry(),
+                MetricsManagers.createForTests(),
                 NO_SSL,
                 getUriForPort(availablePort1),
                 TestResource.class,

--- a/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/ConjureJavaRuntimeTargetFactory.java
+++ b/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/ConjureJavaRuntimeTargetFactory.java
@@ -58,11 +58,13 @@ public final class ConjureJavaRuntimeTargetFactory implements TargetFactory {
                 ImmutableList.of(uri),
                 Optional.empty(),
                 trustContext.orElseThrow(() -> new IllegalStateException("CJR requires a trust context")));
-        return wrapWithVersion(JaxRsClient.create(
+        T client = JaxRsClient.create(
                 type,
                 addAtlasDbRemotingAgent(parameters.userAgent()),
                 HOST_METRICS_REGISTRY,
-                clientConfiguration));
+                clientConfiguration);
+        client = FastFailoverProxy.newProxyInstance(type, client);
+        return wrapWithVersion(client);
     }
 
     @Override

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/EteSetup.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/EteSetup.java
@@ -37,6 +37,7 @@ import com.palantir.atlasdb.config.ImmutableServerListConfig;
 import com.palantir.atlasdb.http.AtlasDbHttpClients;
 import com.palantir.atlasdb.http.TestProxyUtils;
 import com.palantir.atlasdb.todo.TodoResource;
+import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
 import com.palantir.conjure.java.config.ssl.SslSocketFactories;
 import com.palantir.conjure.java.config.ssl.TrustContext;
@@ -203,7 +204,7 @@ public abstract class EteSetup {
     private static <T> T createClientFor(Class<T> clazz, String host, short port) {
         String uri = String.format("http://%s:%s", host, port);
         return AtlasDbHttpClients.createProxy(
-                new MetricRegistry(),
+                MetricsManagers.createForTests(),
                 Optional.of(TRUST_CONTEXT),
                 uri,
                 clazz,

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/LockWithTimelockEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/LockWithTimelockEteTest.java
@@ -17,7 +17,6 @@
 package com.palantir.atlasdb.ete;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Test;
 
@@ -27,7 +26,7 @@ public class LockWithTimelockEteTest {
     private LockResource lockResource = EteSetup.createClientToSingleNode(LockResource.class);
 
     @Test
-    public void smallV1LockSucceeds() throws InterruptedException {
+    public void smallV1LockSucceeds() {
         assertThat(lockResource.lockUsingLegacyLockApi(1, 100)).isTrue();
     }
 
@@ -37,7 +36,7 @@ public class LockWithTimelockEteTest {
     }
 
     @Test
-    public void largeV1LockSucceeds() throws InterruptedException {
+    public void largeV1LockSucceeds() {
         assertThat(lockResource.lockUsingLegacyLockApi(50, 100_000)).isTrue();
 
     }
@@ -45,19 +44,5 @@ public class LockWithTimelockEteTest {
     @Test
     public void largeV2LockSucceeds() {
         assertThat(lockResource.lockUsingTimelockApi(50, 100_000)).isTrue();
-    }
-
-    @Test
-    public void hugeV1LockThrowsOnClientSide() throws InterruptedException {
-        assertThatThrownBy(() -> lockResource.lockUsingLegacyLockApi(100, 500_000))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("INVALID_ARGUMENT");
-    }
-
-    @Test
-    public void hugeV2ThrowsOnClientSide() {
-        assertThatThrownBy(() -> lockResource.lockUsingTimelockApi(100, 500_000))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("INVALID_ARGUMENT");
     }
 }

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TimeLockMigrationEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TimeLockMigrationEteTest.java
@@ -31,13 +31,13 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
 
-import com.codahale.metrics.MetricRegistry;
 import com.palantir.atlasdb.http.AtlasDbHttpClients;
 import com.palantir.atlasdb.http.TestProxyUtils;
 import com.palantir.atlasdb.http.errors.AtlasDbRemoteException;
 import com.palantir.atlasdb.todo.ImmutableTodo;
 import com.palantir.atlasdb.todo.Todo;
 import com.palantir.atlasdb.todo.TodoResource;
+import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.timestamp.TimestampService;
 
 // We don't use EteSetup because we need much finer-grained control of the orchestration here, compared to the other
@@ -183,7 +183,7 @@ public class TimeLockMigrationEteTest {
     private static <T> T createEteClientFor(Class<T> clazz) {
         String uri = String.format("http://%s:%s", ETE_CONTAINER, ETE_PORT);
         return AtlasDbHttpClients.createProxy(
-                new MetricRegistry(),
+                MetricsManagers.createForTests(),
                 Optional.empty(),
                 uri,
                 clazz,
@@ -193,7 +193,7 @@ public class TimeLockMigrationEteTest {
     private static TimestampService createTimeLockTimestampClient() {
         String uri = String.format("http://%s:%s/%s", TIMELOCK_CONTAINER, TIMELOCK_PORT, TEST_CLIENT);
         return AtlasDbHttpClients.createProxy(
-                new MetricRegistry(),
+                MetricsManagers.createForTests(),
                 Optional.empty(),
                 uri,
                 TimestampService.class,

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/http/TestProxyUtils.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/http/TestProxyUtils.java
@@ -17,13 +17,21 @@
 package com.palantir.atlasdb.http;
 
 import com.palantir.atlasdb.config.AuxiliaryRemotingParameters;
+import com.palantir.atlasdb.config.ImmutableRemotingClientConfig;
+import com.palantir.atlasdb.config.RemotingClientConfig;
 import com.palantir.conjure.java.api.config.service.UserAgent;
 
 public final class TestProxyUtils {
+    public static final RemotingClientConfig REMOTING_CLIENT_CONFIG = ImmutableRemotingClientConfig.builder()
+            .enableLegacyClientFallback(false)
+            .maximumConjureRemotingProbability(1.0)
+            .build();
+
     public static final AuxiliaryRemotingParameters AUXILIARY_REMOTING_PARAMETERS
             = AuxiliaryRemotingParameters.builder()
                     .shouldLimitPayload(false)
                     .userAgent(UserAgent.of(UserAgent.Agent.of("bla", "0.1.2")))
+                    .remotingClientConfig(() -> REMOTING_CLIENT_CONFIG)
                     .shouldRetry(true)
                     .build();
 

--- a/changelog/@unreleased/pr-4366.v2.yml
+++ b/changelog/@unreleased/pr-4366.v2.yml
@@ -1,0 +1,8 @@
+type: break
+break:
+  description: '`AtlasDbHttpClients#createProxy` now expects a `MetricsManager` rather
+    than a plain `MetricsRegistry`. This is to enable deployment of experiments for
+    these clients, which are used e.g. internally within timelock or for service nodes
+    performing leader election.'
+  links:
+  - https://github.com/palantir/atlasdb/pull/4366

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/IsolatedPaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/IsolatedPaxosTimeLockServerIntegrationTest.java
@@ -23,12 +23,12 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 
-import com.codahale.metrics.MetricRegistry;
 import com.palantir.atlasdb.http.AtlasDbHttpClients;
 import com.palantir.atlasdb.http.TestProxyUtils;
 import com.palantir.atlasdb.timelock.paxos.PaxosTimeLockConstants;
 import com.palantir.atlasdb.timelock.util.ExceptionMatchers;
 import com.palantir.atlasdb.timelock.util.TestProxies;
+import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.paxos.PaxosAcceptor;
 import com.palantir.paxos.PaxosLearner;
 
@@ -86,7 +86,7 @@ public class IsolatedPaxosTimeLockServerIntegrationTest {
 
     private static <T> T createProxyForInternalNamespacedTestService(Class<T> clazz) {
         return AtlasDbHttpClients.createProxy(
-                new MetricRegistry(),
+                MetricsManagers.createForTests(),
                 Optional.of(TestProxies.TRUST_CONTEXT),
                 String.format("https://localhost:%d/%s/%s/%s",
                         SERVER.serverHolder().getTimelockPort(),

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TimeLockTestUtils.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TimeLockTestUtils.java
@@ -17,15 +17,19 @@ package com.palantir.atlasdb.timelock;
 
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
 import com.codahale.metrics.MetricRegistry;
 import com.palantir.atlasdb.config.AtlasDbConfig;
+import com.palantir.atlasdb.config.AtlasDbRuntimeConfig;
 import com.palantir.atlasdb.config.ImmutableAtlasDbConfig;
+import com.palantir.atlasdb.config.ImmutableAtlasDbRuntimeConfig;
 import com.palantir.atlasdb.config.ImmutableServerListConfig;
 import com.palantir.atlasdb.config.ImmutableTimeLockClientConfig;
 import com.palantir.atlasdb.factory.TransactionManagers;
+import com.palantir.atlasdb.http.TestProxyUtils;
 import com.palantir.atlasdb.memory.InMemoryAtlasDbConfig;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.conjure.java.api.config.service.UserAgent;
@@ -55,11 +59,15 @@ public final class TimeLockTestUtils {
                                 .build())
                         .build())
                 .build();
+        AtlasDbRuntimeConfig runtimeConfig = ImmutableAtlasDbRuntimeConfig.builder()
+                .remotingClient(TestProxyUtils.REMOTING_CLIENT_CONFIG)
+                .build();
         return TransactionManagers.builder()
                 .config(config)
                 .userAgent(UserAgent.of(UserAgent.Agent.of("u" + agent, "0.0.0")))
                 .globalMetricsRegistry(new MetricRegistry())
                 .globalTaggedMetricRegistry(DefaultTaggedMetricRegistry.getDefault())
+                .runtimeConfigSupplier(() -> Optional.of(runtimeConfig))
                 .build()
                 .serializable();
     }

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/util/ExceptionMatchers.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/util/ExceptionMatchers.java
@@ -17,16 +17,15 @@ package com.palantir.atlasdb.timelock.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import feign.RetryableException;
+
 public final class ExceptionMatchers {
 
     private ExceptionMatchers() { }
 
     public static void isRetryableExceptionWhereLeaderCannotBeFound(Throwable throwable) {
         assertThat(throwable)
-                .hasMessageContaining("method invoked on a non-leader");
-
-        // We shade Feign, so we can't rely on our client's RetryableException exactly matching ours.
-        assertThat(throwable.getClass().getName())
-                .contains("RetryableException");
+                .hasMessageContaining("receiving QosException.RetryOther")
+                .isInstanceOf(RetryableException.class);
     }
 }

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/util/ExceptionMatchers.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/util/ExceptionMatchers.java
@@ -17,6 +17,8 @@ package com.palantir.atlasdb.timelock.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.palantir.conjure.java.api.errors.QosException;
+
 import feign.RetryableException;
 
 public final class ExceptionMatchers {
@@ -26,6 +28,7 @@ public final class ExceptionMatchers {
     public static void isRetryableExceptionWhereLeaderCannotBeFound(Throwable throwable) {
         assertThat(throwable)
                 .hasMessageContaining("receiving QosException.RetryOther")
-                .isInstanceOf(RetryableException.class);
+                .isInstanceOf(RetryableException.class)
+                .hasRootCauseInstanceOf(QosException.RetryOther.class);
     }
 }

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/util/TestProxies.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/util/TestProxies.java
@@ -29,6 +29,7 @@ import com.palantir.atlasdb.http.AtlasDbHttpClients;
 import com.palantir.atlasdb.http.TestProxyUtils;
 import com.palantir.atlasdb.timelock.TestableTimelockServer;
 import com.palantir.atlasdb.timelock.TimeLockServerHolder;
+import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
 import com.palantir.conjure.java.config.ssl.SslSocketFactories;
 import com.palantir.conjure.java.config.ssl.TrustContext;
@@ -61,7 +62,7 @@ public class TestProxies {
     public <T> T singleNode(Class<T> serviceInterface, String uri) {
         List<Object> key = ImmutableList.of(serviceInterface, uri, "single");
         return (T) proxies.computeIfAbsent(key, ignored -> AtlasDbHttpClients.createProxy(
-                new MetricRegistry(),
+                MetricsManagers.createForTests(),
                 Optional.of(TRUST_CONTEXT),
                 uri,
                 serviceInterface,


### PR DESCRIPTION
**NOTE TO REVIEWERS: CI may fail until #4361 merges, since CJR will scream at the Nullable things it sees. This PR should nonetheless be reviewable.**

**Goals (and why)**:
- Clear another blocker to TimeLock nodes using CJR to talk to one another.
- Run tests with CJR.

**Implementation Description (bullets)**:
- Switch single node clients to use CJR with provided probability.
- Run tests with CJR (that use `TestProxyUtils`). This includes integration and ETE tests with TimeLock. This does _not_ include running internode communication with CJR just yet, that will be in a follow-up PR.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Updated existing tests, all integration tests passing should be sufficient

**Concerns (what feedback would you like?)**: 
- Removed two old tests for ThreadPooledLockService because exceptions are now handled internally in the CJR client as opposed to being bubbled up - please check this is fine.
- Some tests for payload limiting were removed because CJR seems to work fine with them!

**Where should we start reviewing?**: AtlasDbHttpClients

**Priority (whenever / two weeks / yesterday)**: this week please
