### PR TITLE
improve postgres and oracle range-read perf

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
@@ -210,9 +210,13 @@ public final class DbKvs extends AbstractKeyValueService {
         OracleTableNameGetter tableNameGetter = new OracleTableNameGetter(oracleDdlConfig);
         OraclePrefixedTableNames prefixedTableNames = new OraclePrefixedTableNames(tableNameGetter);
         TableValueStyleCache valueStyleCache = new TableValueStyleCache();
+        DbTableFactory tableFactory = new OracleDbTableFactory(
+                oracleDdlConfig, tableNameGetter, prefixedTableNames, valueStyleCache, executor);
+        TableMetadataCache tableMetadataCache = new TableMetadataCache(tableFactory);
         OverflowValueLoader overflowValueLoader = new OracleOverflowValueLoader(oracleDdlConfig, tableNameGetter);
         DbKvsGetRange getRange = new OracleGetRange(
-                connections, overflowValueLoader, tableNameGetter, valueStyleCache, oracleDdlConfig);
+                connections, overflowValueLoader, tableNameGetter,
+                valueStyleCache, tableMetadataCache, oracleDdlConfig);
         CellTsPairLoader cellTsPageLoader = new OracleCellTsPageLoader(
                 connections, tableNameGetter, valueStyleCache, oracleDdlConfig);
         return new DbKvs(

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresGetRange.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresGetRange.java
@@ -268,8 +268,8 @@ public class PostgresGetRange implements DbKvsGetRange {
 
         private ClosableIterator<AgnosticLightResultRow> selectNextPage(ConnectionSupplier conns) {
             FullQuery query = getRangeQuery();
-            AgnosticLightResultSet rs = conns.get().selectLightResultSetUnregisteredQuery(
-                    query.getQuery(), query.getArgs());
+            AgnosticLightResultSet rs = conns.get().selectLightResultSetUnregisteredQueryWithFetchSize(
+                    query.getQuery(), maxCellsPerPage, query.getArgs());
             return ClosableIterators.wrap(rs.iterator(), rs);
         }
 

--- a/changelog/@unreleased/pr-4367.v2.yml
+++ b/changelog/@unreleased/pr-4367.v2.yml
@@ -1,5 +1,5 @@
 type: improvement
 improvement:
-  description: Improved postgres range-read perf.
+  description: Improved Oracle and Postgres range-read perf.
   links:
   - https://github.com/palantir/atlasdb/pull/4367

--- a/changelog/@unreleased/pr-4367.v2.yml
+++ b/changelog/@unreleased/pr-4367.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Improved postgres range-read perf.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4367


### PR DESCRIPTION
Reduce round-trips by piping batch hints all the way down to the JDBC driver layer fetchSize.

- The postgres driver wasn't pushing down the batch hint into the JDBC layer at all
- The oracle driver was pushing an incorrect hint to the JDBC layer; I think someone confused rows per page (atlas rows) and rows per page (actual oracle rows) which is actually atlas' cells-per-page.