### PR TITLE
[Transaction Async get] Part 6: Catch unintentional switches between blocking and non-blocking calls during tests.

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -35,6 +35,7 @@ import com.palantir.atlasdb.transaction.TransactionConfig;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.api.AutoDelegate_TransactionManager;
 import com.palantir.atlasdb.transaction.api.PreCommitCondition;
+import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
 import com.palantir.atlasdb.transaction.service.TransactionService;
@@ -473,7 +474,7 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
     }
 
     @Override
-    protected SnapshotTransaction createTransaction(long immutableTimestamp,
+    protected Transaction createTransaction(long immutableTimestamp,
             Supplier<Long> startTimestampSupplier,
             LockToken immutableTsLock,
             PreCommitCondition preCommitCondition) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -2157,7 +2157,6 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         }
 
         log.trace("Getting commit timestamps.", SafeArg.of("numTimestamps", gets.size()));
-
     }
 
     private void logLargeNumberOfTransactions(@Nullable TableReference tableRef, Set<Long> gets) {

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/GetAsyncDelegate.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/GetAsyncDelegate.java
@@ -27,14 +27,14 @@ import com.palantir.atlasdb.transaction.api.Transaction;
 public class GetAsyncDelegate extends ForwardingTransaction {
 
     private final Transaction delegate;
-    private final SynchronousTracker tracker;
+    private final PathTypeTracker tracker;
 
     public GetAsyncDelegate(Transaction transaction) {
         this.delegate = transaction;
-        this.tracker = SynchronousTracker.NO_OP;
+        this.tracker = PathTypeTracker.NO_OP;
     }
 
-    public GetAsyncDelegate(Transaction transaction, SynchronousTracker tracker) {
+    public GetAsyncDelegate(Transaction transaction, PathTypeTracker tracker) {
         this.delegate = transaction;
         this.tracker = tracker;
     }
@@ -46,7 +46,7 @@ public class GetAsyncDelegate extends ForwardingTransaction {
 
     @Override
     public Map<Cell, byte[]> get(TableReference tableRef, Set<Cell> cells) {
-        try (SynchronousTracker resource = tracker.enterAsyncCall()) {
+        try (PathTypeTracker resource = tracker.enterAsyncPath()) {
             return AtlasFutures.getUnchecked(delegate().getAsync(tableRef, cells));
         }
     }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/GetAsyncDelegate.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/GetAsyncDelegate.java
@@ -25,13 +25,12 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.transaction.api.Transaction;
 
 public class GetAsyncDelegate extends ForwardingTransaction {
-
     private final Transaction delegate;
     private final PathTypeTracker tracker;
 
     public GetAsyncDelegate(Transaction transaction) {
         this.delegate = transaction;
-        this.tracker = PathTypeTracker.NO_OP;
+        this.tracker = PathTypeTrackers.NO_OP;
     }
 
     public GetAsyncDelegate(Transaction transaction, PathTypeTracker tracker) {

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/PathTypeTracker.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/PathTypeTracker.java
@@ -16,66 +16,14 @@
 
 package com.palantir.atlasdb.transaction.impl;
 
-import com.google.common.base.Preconditions;
-
 interface PathTypeTracker extends AutoCloseable {
-    PathTypeTracker NO_OP = new PathTypeTracker() {
-        @Override
-        public PathTypeTracker enterAsyncPath() {
-            return this;
-        }
-
-        @Override
-        public PathTypeTracker exitAsyncPath() {
-            return this;
-        }
-
-        @Override
-        public void checkInAsync() {
-
-        }
-
-        @Override
-        public void checkInSync() {
-
-        }
-    };
-
-    static PathTypeTracker constructSynchronousTracker() {
-        return new PathTypeTracker() {
-            volatile boolean inAsyncBoolean;
-
-            @Override
-            public PathTypeTracker enterAsyncPath() {
-                inAsyncBoolean = true;
-                return this;
-            }
-
-            @Override
-            public PathTypeTracker exitAsyncPath() {
-                inAsyncBoolean = false;
-                return this;
-            }
-
-            @Override
-            public void checkInAsync() {
-                Preconditions.checkState(inAsyncBoolean, "Not expected to be in sync path");
-            }
-
-            @Override
-            public void checkInSync() {
-                Preconditions.checkState(!inAsyncBoolean, "Not expected to be in async path");
-            }
-        };
-    }
-
     PathTypeTracker enterAsyncPath();
 
     PathTypeTracker exitAsyncPath();
 
-    void checkInAsync();
+    void expectedToBeInAsync();
 
-    void checkInSync();
+    void checkNotInAsync();
 
     @Override
     default void close() {

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/PathTypeTracker.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/PathTypeTracker.java
@@ -18,15 +18,15 @@ package com.palantir.atlasdb.transaction.impl;
 
 import com.google.common.base.Preconditions;
 
-interface SynchronousTracker extends AutoCloseable {
-    SynchronousTracker NO_OP = new SynchronousTracker() {
+interface PathTypeTracker extends AutoCloseable {
+    PathTypeTracker NO_OP = new PathTypeTracker() {
         @Override
-        public SynchronousTracker enterAsyncCall() {
+        public PathTypeTracker enterAsyncPath() {
             return this;
         }
 
         @Override
-        public SynchronousTracker exitAsyncCall() {
+        public PathTypeTracker exitAsyncPath() {
             return this;
         }
 
@@ -41,18 +41,18 @@ interface SynchronousTracker extends AutoCloseable {
         }
     };
 
-    static SynchronousTracker constructSynchronousTracker() {
-        return new SynchronousTracker() {
+    static PathTypeTracker constructSynchronousTracker() {
+        return new PathTypeTracker() {
             volatile boolean inAsyncBoolean;
 
             @Override
-            public SynchronousTracker enterAsyncCall() {
+            public PathTypeTracker enterAsyncPath() {
                 inAsyncBoolean = true;
                 return this;
             }
 
             @Override
-            public SynchronousTracker exitAsyncCall() {
+            public PathTypeTracker exitAsyncPath() {
                 inAsyncBoolean = false;
                 return this;
             }
@@ -69,9 +69,9 @@ interface SynchronousTracker extends AutoCloseable {
         };
     }
 
-    SynchronousTracker enterAsyncCall();
+    PathTypeTracker enterAsyncPath();
 
-    SynchronousTracker exitAsyncCall();
+    PathTypeTracker exitAsyncPath();
 
     void checkInAsync();
 
@@ -79,6 +79,6 @@ interface SynchronousTracker extends AutoCloseable {
 
     @Override
     default void close() {
-        exitAsyncCall();
+        exitAsyncPath();
     }
 }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/PathTypeTrackers.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/PathTypeTrackers.java
@@ -1,0 +1,75 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl;
+
+import com.google.common.base.Preconditions;
+
+public final class PathTypeTrackers {
+    private PathTypeTrackers() {
+        // static utility class
+    }
+
+    public static final PathTypeTracker NO_OP = new PathTypeTracker() {
+        @Override
+        public PathTypeTracker enterAsyncPath() {
+            return this;
+        }
+
+        @Override
+        public PathTypeTracker exitAsyncPath() {
+            return this;
+        }
+
+        @Override
+        public void expectedToBeInAsync() {
+
+        }
+
+        @Override
+        public void checkNotInAsync() {
+
+        }
+    };
+
+    public static PathTypeTracker constructSynchronousTracker() {
+        return new PathTypeTracker() {
+            volatile boolean inAsyncBoolean;
+
+            @Override
+            public PathTypeTracker enterAsyncPath() {
+                inAsyncBoolean = true;
+                return this;
+            }
+
+            @Override
+            public PathTypeTracker exitAsyncPath() {
+                inAsyncBoolean = false;
+                return this;
+            }
+
+            @Override
+            public void expectedToBeInAsync() {
+                Preconditions.checkState(inAsyncBoolean, "Not expected to be in sync path");
+            }
+
+            @Override
+            public void checkNotInAsync() {
+                Preconditions.checkState(!inAsyncBoolean, "Not expected to be in async path");
+            }
+        };
+    }
+}

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SynchronousTracker.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SynchronousTracker.java
@@ -64,7 +64,7 @@ interface SynchronousTracker extends AutoCloseable {
 
             @Override
             public void checkInSync() {
-                Preconditions.checkState(inAsyncBoolean, "Not expected to be in async path");
+                Preconditions.checkState(!inAsyncBoolean, "Not expected to be in async path");
             }
         };
     }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SynchronousTracker.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SynchronousTracker.java
@@ -1,0 +1,84 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl;
+
+import com.google.common.base.Preconditions;
+
+interface SynchronousTracker extends AutoCloseable {
+    SynchronousTracker NO_OP = new SynchronousTracker() {
+        @Override
+        public SynchronousTracker enterAsyncCall() {
+            return this;
+        }
+
+        @Override
+        public SynchronousTracker exitAsyncCall() {
+            return this;
+        }
+
+        @Override
+        public void checkInAsync() {
+
+        }
+
+        @Override
+        public void checkInSync() {
+
+        }
+    };
+
+    static SynchronousTracker constructSynchronousTracker() {
+        return new SynchronousTracker() {
+            volatile boolean inAsyncBoolean;
+
+            @Override
+            public SynchronousTracker enterAsyncCall() {
+                inAsyncBoolean = true;
+                return this;
+            }
+
+            @Override
+            public SynchronousTracker exitAsyncCall() {
+                inAsyncBoolean = false;
+                return this;
+            }
+
+            @Override
+            public void checkInAsync() {
+                Preconditions.checkState(inAsyncBoolean, "Not expected to be in sync path");
+            }
+
+            @Override
+            public void checkInSync() {
+                Preconditions.checkState(inAsyncBoolean, "Not expected to be in async path");
+            }
+        };
+    }
+
+    SynchronousTracker enterAsyncCall();
+
+    SynchronousTracker exitAsyncCall();
+
+    void checkInAsync();
+
+    void checkInSync();
+
+    @Override
+    default void close() {
+        exitAsyncCall();
+    }
+}

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -169,7 +169,7 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
     @Override
     public Transaction createNewTransaction() {
         long startTimestamp = timelockService.getFreshTimestamp();
-        PathTypeTracker pathTypeTracker = PathTypeTracker.constructSynchronousTracker();
+        PathTypeTracker pathTypeTracker = PathTypeTrackers.constructSynchronousTracker();
         return transactionWrapper.apply(
                 new SnapshotTransaction(metricsManager,
                         keyValueServiceWrapper.apply(keyValueService, pathTypeTracker),
@@ -202,7 +202,7 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
             Supplier<Long> startTimestampSupplier,
             LockToken immutableTsLock,
             PreCommitCondition preCommitCondition) {
-        PathTypeTracker pathTypeTracker = PathTypeTracker.constructSynchronousTracker();
+        PathTypeTracker pathTypeTracker = PathTypeTrackers.constructSynchronousTracker();
         return transactionWrapper.apply(
                 new SerializableTransaction(
                         metricsManager,

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -90,7 +90,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
             LockService lockService,
             TransactionService transactionService,
             AtlasDbConstraintCheckingMode constraintCheckingMode) {
-        super(metricsManager,
+        super(
+                metricsManager,
                 createAssertKeyValue(keyValueService, lockService),
                 new LegacyTimelockService(timestampService, lockService, lockClient),
                 timestampManagementService,
@@ -126,7 +127,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
             ExecutorService deleteExecutor,
             WrapperWithTracker<Transaction> transactionWrapper,
             WrapperWithTracker<KeyValueService> keyValueServiceWrapper) {
-        super(metricsManager,
+        super(
+                metricsManager,
                 createAssertKeyValue(keyValueService, lockService),
                 new LegacyTimelockService(timestampService, lockService, lockClient),
                 timestampManagementService,

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -113,6 +113,7 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
         this.keyValueServiceWrapper = WrapperWithTracker.KEY_VALUE_SERVICE_NO_OP;
     }
 
+    @SuppressWarnings("Indentation") // Checkstyle complains about lambda in constructor.
     public TestTransactionManagerImpl(
             MetricsManager metricsManager,
             KeyValueService keyValueService,

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
 
 import com.google.common.base.Suppliers;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -32,6 +33,7 @@ import com.palantir.atlasdb.transaction.ImmutableTransactionConfig;
 import com.palantir.atlasdb.transaction.TransactionConfig;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
+import com.palantir.atlasdb.transaction.api.PreCommitCondition;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
 import com.palantir.atlasdb.transaction.service.TransactionService;
@@ -39,13 +41,16 @@ import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.lock.LockClient;
 import com.palantir.lock.LockService;
 import com.palantir.lock.impl.LegacyTimelockService;
+import com.palantir.lock.v2.LockToken;
 import com.palantir.timestamp.TimestampManagementService;
 import com.palantir.timestamp.TimestampService;
 
 public class TestTransactionManagerImpl extends SerializableTransactionManager implements TestTransactionManager {
-    private static final TransactionConfig TRANSACTION_CONFIG = ImmutableTransactionConfig.builder().build();
+    static final TransactionConfig TRANSACTION_CONFIG = ImmutableTransactionConfig.builder().build();
 
     private final Map<TableReference, ConflictHandler> conflictHandlerOverrides = new HashMap<>();
+    private final WrapperWithTracker<Transaction> transactionWrapper;
+    private final WrapperWithTracker<KeyValueService> keyValueServiceWrapper;
     private Optional<Long> unreadableTs = Optional.empty();
 
     @SuppressWarnings("Indentation") // Checkstyle complains about lambda in constructor.
@@ -60,24 +65,20 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
             SweepStrategyManager sweepStrategyManager,
             MultiTableSweepQueueWriter sweepQueue,
             ExecutorService deleteExecutor) {
-        super(metricsManager,
-                createAssertKeyValue(keyValueService, lockService),
-                new LegacyTimelockService(timestampService, lockService, lockClient),
+        this(
+                metricsManager,
+                keyValueService,
+                timestampService,
                 timestampManagementService,
+                lockClient,
                 lockService,
                 transactionService,
-                Suppliers.ofInstance(AtlasDbConstraintCheckingMode.FULL_CONSTRAINT_CHECKING_THROWS_EXCEPTIONS),
                 conflictDetectionManager,
                 sweepStrategyManager,
-                NoOpCleaner.INSTANCE,
-                DefaultTimestampCache.createForTests(),
-                false,
-                AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
-                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
                 sweepQueue,
                 deleteExecutor,
-                true,
-                () -> TRANSACTION_CONFIG);
+                WrapperWithTracker.TRANSACTION_NO_OP,
+                WrapperWithTracker.KEY_VALUE_SERVICE_NO_OP);
     }
 
     @SuppressWarnings("Indentation") // Checkstyle complains about lambda in constructor.
@@ -107,6 +108,44 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 MoreExecutors.newDirectExecutorService(),
                 true,
                 () -> TRANSACTION_CONFIG);
+        this.transactionWrapper =  WrapperWithTracker.TRANSACTION_NO_OP;
+        this.keyValueServiceWrapper = WrapperWithTracker.KEY_VALUE_SERVICE_NO_OP;
+    }
+
+    public TestTransactionManagerImpl(
+            MetricsManager metricsManager,
+            KeyValueService keyValueService,
+            TimestampService timestampService,
+            TimestampManagementService timestampManagementService,
+            LockClient lockClient,
+            LockService lockService,
+            TransactionService transactionService,
+            ConflictDetectionManager conflictDetectionManager,
+            SweepStrategyManager sweepStrategyManager,
+            MultiTableSweepQueueWriter sweepQueue,
+            ExecutorService deleteExecutor,
+            WrapperWithTracker<Transaction> transactionWrapper,
+            WrapperWithTracker<KeyValueService> keyValueServiceWrapper) {
+        super(metricsManager,
+                createAssertKeyValue(keyValueService, lockService),
+                new LegacyTimelockService(timestampService, lockService, lockClient),
+                timestampManagementService,
+                lockService,
+                transactionService,
+                Suppliers.ofInstance(AtlasDbConstraintCheckingMode.FULL_CONSTRAINT_CHECKING_THROWS_EXCEPTIONS),
+                conflictDetectionManager,
+                sweepStrategyManager,
+                NoOpCleaner.INSTANCE,
+                DefaultTimestampCache.createForTests(),
+                false,
+                AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
+                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
+                sweepQueue,
+                deleteExecutor,
+                true,
+                () -> TRANSACTION_CONFIG);
+        this.transactionWrapper = transactionWrapper;
+        this.keyValueServiceWrapper = keyValueServiceWrapper;
     }
 
     @Override
@@ -127,28 +166,65 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
     @Override
     public Transaction createNewTransaction() {
         long startTimestamp = timelockService.getFreshTimestamp();
-        return new SnapshotTransaction(metricsManager,
-                keyValueService,
-                timelockService,
-                transactionService,
-                NoOpCleaner.INSTANCE,
-                () -> startTimestamp,
-                getConflictDetectionManager(),
-                SweepStrategyManagers.createDefault(keyValueService),
-                startTimestamp,
-                Optional.empty(),
-                PreCommitConditions.NO_OP,
-                AtlasDbConstraintCheckingMode.NO_CONSTRAINT_CHECKING,
-                null,
-                TransactionReadSentinelBehavior.THROW_EXCEPTION,
-                false,
-                timestampValidationReadCache,
-                getRangesExecutor,
-                defaultGetRangesConcurrency,
-                sweepQueueWriter,
-                deleteExecutor,
-                validateLocksOnReads,
-                () -> TRANSACTION_CONFIG);
+        SynchronousTracker synchronousTracker = SynchronousTracker.constructSynchronousTracker();
+        return transactionWrapper.apply(
+                new SnapshotTransaction(metricsManager,
+                        keyValueServiceWrapper.apply(keyValueService, synchronousTracker),
+                        timelockService,
+                        transactionService,
+                        NoOpCleaner.INSTANCE,
+                        () -> startTimestamp,
+                        getConflictDetectionManager(),
+                        SweepStrategyManagers.createDefault(keyValueService),
+                        startTimestamp,
+                        Optional.empty(),
+                        PreCommitConditions.NO_OP,
+                        AtlasDbConstraintCheckingMode.NO_CONSTRAINT_CHECKING,
+                        null,
+                        TransactionReadSentinelBehavior.THROW_EXCEPTION,
+                        false,
+                        timestampValidationReadCache,
+                        getRangesExecutor,
+                        defaultGetRangesConcurrency,
+                        sweepQueueWriter,
+                        deleteExecutor,
+                        validateLocksOnReads,
+                        () -> TRANSACTION_CONFIG),
+                synchronousTracker);
+    }
+
+    @Override
+    protected Transaction createTransaction(
+            long immutableTimestamp,
+            Supplier<Long> startTimestampSupplier,
+            LockToken immutableTsLock,
+            PreCommitCondition preCommitCondition) {
+        SynchronousTracker synchronousTracker = SynchronousTracker.constructSynchronousTracker();
+        return transactionWrapper.apply(
+                new SerializableTransaction(
+                        metricsManager,
+                        keyValueServiceWrapper.apply(keyValueService, synchronousTracker),
+                        timelockService,
+                        transactionService,
+                        cleaner,
+                        startTimestampSupplier,
+                        getConflictDetectionManager(),
+                        sweepStrategyManager,
+                        immutableTimestamp,
+                        Optional.of(immutableTsLock),
+                        preCommitCondition,
+                        constraintModeSupplier.get(),
+                        cleaner.getTransactionReadTimeoutMillis(),
+                        TransactionReadSentinelBehavior.THROW_EXCEPTION,
+                        allowHiddenTableAccess,
+                        timestampValidationReadCache,
+                        getRangesExecutor,
+                        defaultGetRangesConcurrency,
+                        sweepQueueWriter,
+                        deleteExecutor,
+                        validateLocksOnReads,
+                        transactionConfig),
+                synchronousTracker);
     }
 
     @Override

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -166,10 +166,10 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
     @Override
     public Transaction createNewTransaction() {
         long startTimestamp = timelockService.getFreshTimestamp();
-        SynchronousTracker synchronousTracker = SynchronousTracker.constructSynchronousTracker();
+        PathTypeTracker pathTypeTracker = PathTypeTracker.constructSynchronousTracker();
         return transactionWrapper.apply(
                 new SnapshotTransaction(metricsManager,
-                        keyValueServiceWrapper.apply(keyValueService, synchronousTracker),
+                        keyValueServiceWrapper.apply(keyValueService, pathTypeTracker),
                         timelockService,
                         transactionService,
                         NoOpCleaner.INSTANCE,
@@ -190,7 +190,7 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                         deleteExecutor,
                         validateLocksOnReads,
                         () -> TRANSACTION_CONFIG),
-                synchronousTracker);
+                pathTypeTracker);
     }
 
     @Override
@@ -199,11 +199,11 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
             Supplier<Long> startTimestampSupplier,
             LockToken immutableTsLock,
             PreCommitCondition preCommitCondition) {
-        SynchronousTracker synchronousTracker = SynchronousTracker.constructSynchronousTracker();
+        PathTypeTracker pathTypeTracker = PathTypeTracker.constructSynchronousTracker();
         return transactionWrapper.apply(
                 new SerializableTransaction(
                         metricsManager,
-                        keyValueServiceWrapper.apply(keyValueService, synchronousTracker),
+                        keyValueServiceWrapper.apply(keyValueService, pathTypeTracker),
                         timelockService,
                         transactionService,
                         cleaner,
@@ -224,7 +224,7 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                         deleteExecutor,
                         validateLocksOnReads,
                         transactionConfig),
-                synchronousTracker);
+                pathTypeTracker);
     }
 
     @Override

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/WrapperWithTracker.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/WrapperWithTracker.java
@@ -24,5 +24,5 @@ interface WrapperWithTracker<T> {
 
     WrapperWithTracker<KeyValueService> KEY_VALUE_SERVICE_NO_OP = (delegate, synchronousTracker) -> delegate;
 
-    T apply(T delegate, SynchronousTracker synchronousTracker);
+    T apply(T delegate, PathTypeTracker pathTypeTracker);
 }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/WrapperWithTracker.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/WrapperWithTracker.java
@@ -1,0 +1,28 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl;
+
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.transaction.api.Transaction;
+
+interface WrapperWithTracker<T> {
+    WrapperWithTracker<Transaction> TRANSACTION_NO_OP = (delegate, synchronousTracker) -> delegate;
+
+    WrapperWithTracker<KeyValueService> KEY_VALUE_SERVICE_NO_OP = (delegate, synchronousTracker) -> delegate;
+
+    T apply(T delegate, SynchronousTracker synchronousTracker);
+}

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
@@ -94,8 +94,8 @@ public class AtlasDbTestCase {
         txManager = new CachingTestTransactionManager(serializableTxManager);
     }
 
-    private TrackingKeyValueService trackingKeyValueService(KeyValueService keyValueService) {
-        return spy(new TrackingKeyValueService(new StatsTrackingKeyValueService(keyValueService)));
+    private TrackingKeyValueService trackingKeyValueService(KeyValueService originalKeyValueService) {
+        return spy(new TrackingKeyValueService(new StatsTrackingKeyValueService(originalKeyValueService)));
     }
 
     protected TestTransactionManager constructTestTransactionManager() {

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
@@ -59,7 +59,6 @@ public class AtlasDbTestCase {
     protected LockService lockService;
 
     protected final MetricsManager metricsManager = MetricsManagers.createForTests();
-    protected StatsTrackingKeyValueService keyValueServiceWithStats;
     protected TrackingKeyValueService keyValueService;
     protected InMemoryTimestampService timestampService;
     protected ConflictDetectionManager conflictDetectionManager;
@@ -76,10 +75,8 @@ public class AtlasDbTestCase {
         lockClient = LockClient.of("fake lock client");
         lockService = LockServiceImpl.create(LockServerOptions.builder().isStandaloneServer(false).build());
         timestampService = new InMemoryTimestampService();
-        KeyValueService kvs = getBaseKeyValueService();
-        keyValueServiceWithStats = new StatsTrackingKeyValueService(kvs);
-        keyValueService = spy(new TrackingKeyValueService(keyValueServiceWithStats));
-        TransactionTables.createTables(kvs);
+        keyValueService = trackingKeyValueService(getBaseKeyValueService());
+        TransactionTables.createTables(keyValueService);
         transactionService = TransactionServices.createRaw(keyValueService, timestampService, false);
         conflictDetectionManager = ConflictDetectionManagers.createWithoutWarmingCache(keyValueService);
         sweepStrategyManager = SweepStrategyManagers.createDefault(keyValueService);
@@ -92,7 +89,17 @@ public class AtlasDbTestCase {
     }
 
     private void setUpTransactionManagers() {
-        serializableTxManager = wrapTestTransactionManager(new TestTransactionManagerImpl(
+        serializableTxManager = constructTestTransactionManager();
+
+        txManager = new CachingTestTransactionManager(serializableTxManager);
+    }
+
+    private TrackingKeyValueService trackingKeyValueService(KeyValueService keyValueService) {
+        return spy(new TrackingKeyValueService(new StatsTrackingKeyValueService(keyValueService)));
+    }
+
+    protected TestTransactionManager constructTestTransactionManager() {
+        return new TestTransactionManagerImpl(
                 metricsManager,
                 keyValueService,
                 timestampService,
@@ -103,13 +110,7 @@ public class AtlasDbTestCase {
                 conflictDetectionManager,
                 sweepStrategyManager,
                 sweepQueue,
-                MoreExecutors.newDirectExecutorService()));
-
-        txManager = new CachingTestTransactionManager(serializableTxManager);
-    }
-
-    protected TestTransactionManager wrapTestTransactionManager(TestTransactionManager testTransactionManager) {
-        return testTransactionManager;
+                MoreExecutors.newDirectExecutorService());
     }
 
     protected KeyValueService getBaseKeyValueService() {

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -384,7 +384,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
             never(lockMock).lockWithFullLockResponse(with(LockClient.ANONYMOUS), with(any(LockRequest.class)));
         }});
 
-        PathTypeTracker pathTypeTracker = PathTypeTracker.constructSynchronousTracker();
+        PathTypeTracker pathTypeTracker = PathTypeTrackers.constructSynchronousTracker();
         Transaction snapshot = transactionWrapper.apply(
                 new SnapshotTransaction(
                         metricsManager,
@@ -454,7 +454,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
             inSequence(seq);
         }});
 
-        PathTypeTracker pathTypeTracker = PathTypeTracker.constructSynchronousTracker();
+        PathTypeTracker pathTypeTracker = PathTypeTrackers.constructSynchronousTracker();
         Transaction snapshot = transactionWrapper.apply(
                 new SnapshotTransaction(
                         metricsManager,
@@ -496,7 +496,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
         Random random = new Random(1);
 
         final UnstableKeyValueService unstableKvs = new UnstableKeyValueService(keyValueService, random);
-        PathTypeTracker pathTypeTracker = PathTypeTracker.constructSynchronousTracker();
+        PathTypeTracker pathTypeTracker = PathTypeTrackers.constructSynchronousTracker();
         final TestTransactionManager unstableTransactionManager = new TestTransactionManagerImpl(
                 metricsManager,
                 unstableKvs,
@@ -1390,7 +1390,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
             LockImmutableTimestampResponse lockImmutableTimestampResponse,
             PreCommitCondition preCommitCondition,
             boolean validateLocksOnReads) {
-        PathTypeTracker pathTypeTracker = PathTypeTracker.constructSynchronousTracker();
+        PathTypeTracker pathTypeTracker = PathTypeTrackers.constructSynchronousTracker();
         return transactionWrapper.apply(
                 new SnapshotTransaction(
                         metricsManager,
@@ -1509,13 +1509,13 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
 
         @Override
         public Map<Cell, Value> get(TableReference tableRef, Map<Cell, Long> timestampByCell) {
-            pathTypeTracker.checkInSync();
+            pathTypeTracker.checkNotInAsync();
             return AtlasFutures.getUnchecked(delegate.getAsync(tableRef, timestampByCell));
         }
 
         @Override
         public ListenableFuture<Map<Cell, Value>> getAsync(TableReference tableRef, Map<Cell, Long> timestampByCell) {
-            pathTypeTracker.checkInAsync();
+            pathTypeTracker.expectedToBeInAsync();
             return delegate.getAsync(tableRef, timestampByCell);
         }
     }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -55,9 +55,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.mutable.MutableInt;
@@ -78,7 +76,6 @@ import org.junit.runners.Parameterized;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Suppliers;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -88,6 +85,7 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimaps;
 import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.AtlasDbTestCase;
@@ -95,6 +93,7 @@ import com.palantir.atlasdb.cache.DefaultTimestampCache;
 import com.palantir.atlasdb.cache.TimestampCache;
 import com.palantir.atlasdb.cleaner.NoOpCleaner;
 import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.futures.AtlasFutures;
 import com.palantir.atlasdb.keyvalue.api.AutoDelegate_KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.Cell;
@@ -104,6 +103,8 @@ import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.keyvalue.impl.ForwardingKeyValueService;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence.SweepStrategy;
 import com.palantir.atlasdb.ptobject.EncodingUtils;
 import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
@@ -128,6 +129,7 @@ import com.palantir.common.base.AbortingVisitor;
 import com.palantir.common.base.AbortingVisitors;
 import com.palantir.common.base.BatchingVisitable;
 import com.palantir.common.base.BatchingVisitableView;
+import com.palantir.common.base.Throwables;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.common.proxy.MultiDelegateProxy;
 import com.palantir.lock.AtlasRowLockDescriptor;
@@ -154,14 +156,23 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
     @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> data() {
         Object[][] data = new Object[][] {
-                {SYNC, UnaryOperator.identity()},
-                {ASYNC, (UnaryOperator<Transaction>) GetAsyncDelegate::new}
+                {
+                    SYNC,
+                    WrapperWithTracker.TRANSACTION_NO_OP,
+                    WrapperWithTracker.KEY_VALUE_SERVICE_NO_OP
+                },
+                {
+                    ASYNC,
+                    (WrapperWithTracker<Transaction>) GetAsyncDelegate::new,
+                    (WrapperWithTracker<KeyValueService>) VerifyingKeyValueServiceDelegate::new
+                }
         };
         return Arrays.asList(data);
     }
 
     private final String name;
-    private final UnaryOperator<Transaction> transactionWrapper;
+    private final WrapperWithTracker<Transaction> transactionWrapper;
+    private final WrapperWithTracker<KeyValueService> keyValueServiceWrapper;
     private final Map<String, ExpectationFactory>
             expectationsMapping =
             ImmutableMap.<String, ExpectationFactory>builder()
@@ -209,9 +220,13 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
         }};
     }
 
-    public SnapshotTransactionTest(String name, UnaryOperator<Transaction> transactionWrapper) {
+    public SnapshotTransactionTest(
+            String name,
+            WrapperWithTracker<Transaction> transactionWrapper,
+            WrapperWithTracker<KeyValueService> keyValueServiceWrapper) {
         this.name = name;
         this.transactionWrapper = transactionWrapper;
+        this.keyValueServiceWrapper = keyValueServiceWrapper;
     }
     private class UnstableKeyValueService implements AutoDelegate_KeyValueService {
 
@@ -295,8 +310,21 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
     }
 
     @Override
-    protected TestTransactionManager wrapTestTransactionManager(TestTransactionManager testTransactionManager) {
-        return new WrappingTestTransactionManagerImpl(testTransactionManager, transactionWrapper);
+    protected TestTransactionManager constructTestTransactionManager() {
+        return new TestTransactionManagerImpl(
+                metricsManager,
+                keyValueService,
+                timestampService,
+                timestampService,
+                lockClient,
+                lockService,
+                transactionService,
+                conflictDetectionManager,
+                sweepStrategyManager,
+                sweepQueue,
+                MoreExecutors.newDirectExecutorService(),
+                transactionWrapper, 
+                keyValueServiceWrapper);
     }
 
     @Test
@@ -356,28 +384,32 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
             never(lockMock).lockWithFullLockResponse(with(LockClient.ANONYMOUS), with(any(LockRequest.class)));
         }});
 
-        Transaction snapshot = transactionWrapper.apply(new SnapshotTransaction(metricsManager,
-                kvMock,
-                new LegacyTimelockService(timestampService, lock, lockClient),
-                transactionService,
-                NoOpCleaner.INSTANCE,
-                () -> transactionTs,
-                ConflictDetectionManagers.create(keyValueService),
-                SweepStrategyManagers.createDefault(keyValueService),
-                transactionTs,
-                Optional.empty(),
-                PreCommitConditions.NO_OP,
-                AtlasDbConstraintCheckingMode.NO_CONSTRAINT_CHECKING,
-                null,
-                TransactionReadSentinelBehavior.THROW_EXCEPTION,
-                false,
-                timestampCache,
-                getRangesExecutor,
-                defaultGetRangesConcurrency,
-                MultiTableSweepQueueWriter.NO_OP,
-                MoreExecutors.newDirectExecutorService(),
-                true,
-                () -> transactionConfig));
+        SynchronousTracker synchronousTracker = SynchronousTracker.constructSynchronousTracker();
+        Transaction snapshot = transactionWrapper.apply(
+                new SnapshotTransaction(
+                        metricsManager,
+                        keyValueServiceWrapper.apply(kvMock, synchronousTracker),
+                        new LegacyTimelockService(timestampService, lock, lockClient),
+                        transactionService,
+                        NoOpCleaner.INSTANCE,
+                        () -> transactionTs,
+                        ConflictDetectionManagers.create(keyValueService),
+                        SweepStrategyManagers.createDefault(keyValueService),
+                        transactionTs,
+                        Optional.empty(),
+                        PreCommitConditions.NO_OP,
+                        AtlasDbConstraintCheckingMode.NO_CONSTRAINT_CHECKING,
+                        null,
+                        TransactionReadSentinelBehavior.THROW_EXCEPTION,
+                        false,
+                        timestampCache,
+                        getRangesExecutor,
+                        defaultGetRangesConcurrency,
+                        MultiTableSweepQueueWriter.NO_OP,
+                        MoreExecutors.newDirectExecutorService(),
+                        true,
+                        () -> transactionConfig),
+                synchronousTracker);
         try {
             snapshot.get(TABLE, ImmutableSet.of(cell));
             fail();
@@ -422,28 +454,32 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
             inSequence(seq);
         }});
 
-        Transaction snapshot = transactionWrapper.apply(new SnapshotTransaction(metricsManager,
-                keyValueService,
-                null,
-                transactionService,
-                NoOpCleaner.INSTANCE,
-                () -> transactionTs,
-                ConflictDetectionManagers.create(keyValueService),
-                SweepStrategyManagers.createDefault(keyValueService),
-                transactionTs,
-                Optional.empty(),
-                PreCommitConditions.NO_OP,
-                AtlasDbConstraintCheckingMode.NO_CONSTRAINT_CHECKING,
-                null,
-                TransactionReadSentinelBehavior.THROW_EXCEPTION,
-                false,
-                timestampCache,
-                getRangesExecutor,
-                defaultGetRangesConcurrency,
-                MultiTableSweepQueueWriter.NO_OP,
-                MoreExecutors.newDirectExecutorService(),
-                true,
-                () -> transactionConfig));
+        SynchronousTracker synchronousTracker = SynchronousTracker.constructSynchronousTracker();
+        Transaction snapshot = transactionWrapper.apply(
+                new SnapshotTransaction(
+                        metricsManager,
+                        keyValueServiceWrapper.apply(keyValueService, synchronousTracker),
+                        null,
+                        transactionService,
+                        NoOpCleaner.INSTANCE,
+                        () -> transactionTs,
+                        ConflictDetectionManagers.create(keyValueService),
+                        SweepStrategyManagers.createDefault(keyValueService),
+                        transactionTs,
+                        Optional.empty(),
+                        PreCommitConditions.NO_OP,
+                        AtlasDbConstraintCheckingMode.NO_CONSTRAINT_CHECKING,
+                        null,
+                        TransactionReadSentinelBehavior.THROW_EXCEPTION,
+                        false,
+                        timestampCache,
+                        getRangesExecutor,
+                        defaultGetRangesConcurrency,
+                        MultiTableSweepQueueWriter.NO_OP,
+                        MoreExecutors.newDirectExecutorService(),
+                        true,
+                        () -> transactionConfig),
+                synchronousTracker);
         snapshot.delete(TABLE, ImmutableSet.of(cell));
         snapshot.commit();
 
@@ -460,20 +496,21 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
         Random random = new Random(1);
 
         final UnstableKeyValueService unstableKvs = new UnstableKeyValueService(keyValueService, random);
-        final TestTransactionManager unstableTransactionManager = new WrappingTestTransactionManagerImpl(
-                new TestTransactionManagerImpl(
-                        metricsManager,
-                        unstableKvs,
-                        timestampService,
-                        timestampService,
-                        lockClient,
-                        lockService,
-                        transactionService,
-                        conflictDetectionManager,
-                        sweepStrategyManager,
-                        sweepQueue,
-                        MoreExecutors.newDirectExecutorService()),
-                transactionWrapper);
+        SynchronousTracker synchronousTracker = SynchronousTracker.constructSynchronousTracker();
+        final TestTransactionManager unstableTransactionManager = new TestTransactionManagerImpl(
+                metricsManager,
+                unstableKvs,
+                timestampService,
+                timestampService,
+                lockClient,
+                lockService,
+                transactionService,
+                conflictDetectionManager,
+                sweepStrategyManager,
+                sweepQueue,
+                MoreExecutors.newDirectExecutorService(),
+                transactionWrapper,
+                keyValueServiceWrapper);
 
         ScheduledExecutorService service = PTExecutors.newScheduledThreadPool(20);
 
@@ -703,7 +740,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
         } catch (TransactionFailedNonRetriableException expected) {
             return Optional.empty();
         } catch (Exception e) {
-            throw Throwables.propagate(e);
+            throw Throwables.rewrapAndThrowUncheckedException(e);
         }
     }
 
@@ -945,7 +982,9 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 conflictDetectionManager,
                 sweepStrategyManager,
                 sweepQueue,
-                executor);
+                executor,
+                transactionWrapper,
+                keyValueServiceWrapper);
 
         Supplier<PreCommitCondition> conditionSupplier = mock(Supplier.class);
         when(conditionSupplier.get()).thenReturn(ALWAYS_FAILS_CONDITION)
@@ -1122,7 +1161,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 timelockService.lockImmutableTimestamp();
         long transactionTs = timelockService.getFreshTimestamp();
 
-        SnapshotTransaction snapshot = getSnapshotTransactionWith(
+        Transaction snapshot = getSnapshotTransactionWith(
                 timelockService,
                 () -> transactionTs,
                 res,
@@ -1151,7 +1190,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 timelockService.lockImmutableTimestamp();
         long transactionTs = timelockService.getFreshTimestamp();
 
-        SnapshotTransaction snapshot = getSnapshotTransactionWith(
+        Transaction snapshot = getSnapshotTransactionWith(
                 timelockService,
                 () -> transactionTs,
                 res,
@@ -1177,7 +1216,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
         LockImmutableTimestampResponse res =
                 timelockService.lockImmutableTimestamp();
 
-        SnapshotTransaction snapshot = getSnapshotTransactionWith(
+        Transaction snapshot = getSnapshotTransactionWith(
                 timelockService,
                 () -> transactionTs,
                 res,
@@ -1201,7 +1240,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
         LockImmutableTimestampResponse res =
                 timelockService.lockImmutableTimestamp();
 
-        SnapshotTransaction transaction = getSnapshotTransactionWith(
+        Transaction transaction = getSnapshotTransactionWith(
                 timelockService,
                 () -> transactionTs,
                 res,
@@ -1221,7 +1260,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
         LockImmutableTimestampResponse res =
                 timelockService.lockImmutableTimestamp();
 
-        SnapshotTransaction transaction = getSnapshotTransactionWith(
+        Transaction transaction = getSnapshotTransactionWith(
                 timelockService,
                 () -> transactionTs,
                 res,
@@ -1241,7 +1280,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
         LockImmutableTimestampResponse res =
                 timelockService.lockImmutableTimestamp();
 
-        SnapshotTransaction transaction = getSnapshotTransactionWith(
+        Transaction transaction = getSnapshotTransactionWith(
                 timelockService,
                 () -> transactionTs,
                 res,
@@ -1262,7 +1301,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
         LockImmutableTimestampResponse res =
                 timelockService.lockImmutableTimestamp();
 
-        SnapshotTransaction transaction = getSnapshotTransactionWith(
+        Transaction transaction = getSnapshotTransactionWith(
                 timelockService,
                 () -> transactionTs,
                 res,
@@ -1313,7 +1352,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 .lockImmutableTsOnReadOnlyTransactions(true)
                 .build());
 
-        SnapshotTransaction transaction = getSnapshotTransactionWith(
+        Transaction transaction = getSnapshotTransactionWith(
                 timelockService,
                 () -> transactionTs,
                 res,
@@ -1332,7 +1371,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
         transactionConfig = config;
     }
 
-    private SnapshotTransaction getSnapshotTransactionWith(
+    private Transaction getSnapshotTransactionWith(
             TimelockService timelockService,
             Supplier<Long> startTs,
             LockImmutableTimestampResponse lockImmutableTimestampResponse,
@@ -1345,36 +1384,39 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 true);
     }
 
-    private SnapshotTransaction getSnapshotTransactionWith(
+    private Transaction getSnapshotTransactionWith(
             TimelockService timelockService,
             Supplier<Long> startTs,
             LockImmutableTimestampResponse lockImmutableTimestampResponse,
             PreCommitCondition preCommitCondition,
             boolean validateLocksOnReads) {
-        return new SnapshotTransaction(
-                metricsManager,
-                keyValueService,
-                timelockService,
-                transactionService,
-                NoOpCleaner.INSTANCE,
-                startTs,
-                TestConflictDetectionManagers.createWithStaticConflictDetection(
-                        ImmutableMap.of(TABLE, ConflictHandler.RETRY_ON_WRITE_WRITE)),
-                SweepStrategyManagers.createDefault(keyValueService),
-                lockImmutableTimestampResponse.getImmutableTimestamp(),
-                Optional.of(lockImmutableTimestampResponse.getLock()),
-                preCommitCondition,
-                AtlasDbConstraintCheckingMode.NO_CONSTRAINT_CHECKING,
-                null,
-                TransactionReadSentinelBehavior.THROW_EXCEPTION,
-                false,
-                timestampCache,
-                getRangesExecutor,
-                defaultGetRangesConcurrency,
-                MultiTableSweepQueueWriter.NO_OP,
-                MoreExecutors.newDirectExecutorService(),
-                validateLocksOnReads,
-                () -> transactionConfig);
+        SynchronousTracker synchronousTracker = SynchronousTracker.constructSynchronousTracker();
+        return transactionWrapper.apply(
+                new SnapshotTransaction(
+                        metricsManager,
+                        keyValueServiceWrapper.apply(keyValueService, synchronousTracker),
+                        timelockService,
+                        transactionService,
+                        NoOpCleaner.INSTANCE,
+                        startTs,
+                        TestConflictDetectionManagers.createWithStaticConflictDetection(
+                                ImmutableMap.of(TABLE, ConflictHandler.RETRY_ON_WRITE_WRITE)),
+                        SweepStrategyManagers.createDefault(keyValueService),
+                        lockImmutableTimestampResponse.getImmutableTimestamp(),
+                        Optional.of(lockImmutableTimestampResponse.getLock()),
+                        preCommitCondition,
+                        AtlasDbConstraintCheckingMode.NO_CONSTRAINT_CHECKING,
+                        null,
+                        TransactionReadSentinelBehavior.THROW_EXCEPTION,
+                        false,
+                        timestampCache,
+                        getRangesExecutor,
+                        defaultGetRangesConcurrency,
+                        MultiTableSweepQueueWriter.NO_OP,
+                        MoreExecutors.newDirectExecutorService(),
+                        validateLocksOnReads,
+                        () -> transactionConfig),
+                synchronousTracker);
     }
 
     private void writeCells(TableReference table, ImmutableMap<Cell, byte[]> cellsToWrite) {
@@ -1451,19 +1493,30 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
         return (SnapshotTransaction) transaction;
     }
 
-    private static class WrappingTestTransactionManagerImpl extends WrappingTestTransactionManager {
-        private final Function<Transaction, Transaction> transactionWrapper;
+    private static class VerifyingKeyValueServiceDelegate extends ForwardingKeyValueService {
+        private final KeyValueService delegate;
+        private final SynchronousTracker synchronousTracker;
 
-        WrappingTestTransactionManagerImpl(
-                TestTransactionManager testTransactionManager,
-                Function<Transaction, Transaction> transactionWrapper) {
-            super(testTransactionManager);
-            this.transactionWrapper = transactionWrapper;
+        VerifyingKeyValueServiceDelegate(KeyValueService keyValueService, SynchronousTracker synchronousTracker) {
+            this.delegate = keyValueService;
+            this.synchronousTracker = synchronousTracker;
         }
 
         @Override
-        protected Transaction wrap(Transaction transaction) {
-            return transactionWrapper.apply(transaction);
+        public KeyValueService delegate() {
+            return delegate;
+        }
+
+        @Override
+        public Map<Cell, Value> get(TableReference tableRef, Map<Cell, Long> timestampByCell) {
+            synchronousTracker.checkInSync();
+            return AtlasFutures.getUnchecked(delegate.getAsync(tableRef, timestampByCell));
+        }
+
+        @Override
+        public ListenableFuture<Map<Cell, Value>> getAsync(TableReference tableRef, Map<Cell, Long> timestampByCell) {
+            synchronousTracker.checkInAsync();
+            return delegate.getAsync(tableRef, timestampByCell);
         }
     }
 }


### PR DESCRIPTION
**Goals (and why)**:
Adds tests to prevent unintentional switching from blocking to non-blocking paths. Previously some paths were missed.

**Implementation Description (bullets)**:
- `Transaction` and `KeyValueService` are wrapped such that we keep track of the path we are on. 

**Testing (What was existing testing like?  What have you done to improve it?)**:
- these tests should make it harder for further additions to break the intended behaviour
- should give a template how to add more async paths

**Concerns (what feedback would you like?)**:
- have I covered everything
- are the changes to `SnapshotTransactionManager` allowed
- should I use something 

**Where should we start reviewing?**:
- `SnapshotTransactionTest`

**Priority (whenever / two weeks / yesterday)**:
- this week
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
