### PR TITLE
[Conjure Java Runtime] Part 19: Retrying is Futile... Sometimes.

### DIFF
--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/BlacklistTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/BlacklistTest.java
@@ -60,7 +60,7 @@ public class BlacklistTest {
 
     @Before
     @SuppressWarnings("unchecked") // Mock type is correct
-    public void setUp() {
+    public void setUp() throws Throwable {
         when(clock.millis()).thenAnswer(invocation -> time.addAndGet(ONE_SECOND.toMillis() + 1));
         when(badContainer.runWithPooledResource(any(FunctionCheckedException.class))).thenThrow(new RuntimeException());
         when(badContainer.getHost()).thenReturn(ADDRESS_1);

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/BlacklistTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/BlacklistTest.java
@@ -60,7 +60,7 @@ public class BlacklistTest {
 
     @Before
     @SuppressWarnings("unchecked") // Mock type is correct
-    public void setUp() throws Throwable {
+    public void setUp() {
         when(clock.millis()).thenAnswer(invocation -> time.addAndGet(ONE_SECOND.toMillis() + 1));
         when(badContainer.runWithPooledResource(any(FunctionCheckedException.class))).thenThrow(new RuntimeException());
         when(badContainer.getHost()).thenReturn(ADDRESS_1);

--- a/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/ConjureJavaRuntimeTargetFactory.java
+++ b/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/ConjureJavaRuntimeTargetFactory.java
@@ -63,7 +63,9 @@ public final class ConjureJavaRuntimeTargetFactory implements TargetFactory {
                 addAtlasDbRemotingAgent(parameters.userAgent()),
                 HOST_METRICS_REGISTRY,
                 clientConfiguration);
-        client = FastFailoverProxy.newProxyInstance(type, client);
+        if (parameters.shouldRetry()) {
+            client = FastFailoverProxy.newProxyInstance(type, client);
+        }
         return wrapWithVersion(client);
     }
 
@@ -98,7 +100,9 @@ public final class ConjureJavaRuntimeTargetFactory implements TargetFactory {
                 addAtlasDbRemotingAgent(parameters.userAgent()),
                 HOST_METRICS_REGISTRY,
                 refreshableConfig);
-        client = FastFailoverProxy.newProxyInstance(type, client);
+        if (parameters.shouldRetry()) {
+            client = FastFailoverProxy.newProxyInstance(type, client);
+        }
         return wrapWithVersion(client);
     }
 

--- a/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/ConjureJavaRuntimeTargetFactory.java
+++ b/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/ConjureJavaRuntimeTargetFactory.java
@@ -63,9 +63,6 @@ public final class ConjureJavaRuntimeTargetFactory implements TargetFactory {
                 addAtlasDbRemotingAgent(parameters.userAgent()),
                 HOST_METRICS_REGISTRY,
                 clientConfiguration);
-        if (parameters.shouldRetry()) {
-            client = FastFailoverProxy.newProxyInstance(type, client);
-        }
         return wrapWithVersion(client);
     }
 
@@ -100,9 +97,7 @@ public final class ConjureJavaRuntimeTargetFactory implements TargetFactory {
                 addAtlasDbRemotingAgent(parameters.userAgent()),
                 HOST_METRICS_REGISTRY,
                 refreshableConfig);
-        if (parameters.shouldRetry()) {
-            client = FastFailoverProxy.newProxyInstance(type, client);
-        }
+        client = FastFailoverProxy.newProxyInstance(type, client);
         return wrapWithVersion(client);
     }
 

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/EteSetup.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/EteSetup.java
@@ -198,7 +198,7 @@ public abstract class EteSetup {
                         .sslConfiguration(SSL_CONFIGURATION)
                         .build(),
                 clazz,
-                TestProxyUtils.AUXILIARY_REMOTING_PARAMETERS);
+                TestProxyUtils.AUXILIARY_REMOTING_PARAMETERS_RETRYING);
     }
 
     private static <T> T createClientFor(Class<T> clazz, String host, short port) {
@@ -208,6 +208,6 @@ public abstract class EteSetup {
                 Optional.of(TRUST_CONTEXT),
                 uri,
                 clazz,
-                TestProxyUtils.AUXILIARY_REMOTING_PARAMETERS);
+                TestProxyUtils.AUXILIARY_REMOTING_PARAMETERS_RETRYING);
     }
 }

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TimeLockMigrationEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TimeLockMigrationEteTest.java
@@ -187,7 +187,7 @@ public class TimeLockMigrationEteTest {
                 Optional.empty(),
                 uri,
                 clazz,
-                TestProxyUtils.AUXILIARY_REMOTING_PARAMETERS);
+                TestProxyUtils.AUXILIARY_REMOTING_PARAMETERS_RETRYING);
     }
 
     private static TimestampService createTimeLockTimestampClient() {
@@ -197,6 +197,6 @@ public class TimeLockMigrationEteTest {
                 Optional.empty(),
                 uri,
                 TimestampService.class,
-                TestProxyUtils.AUXILIARY_REMOTING_PARAMETERS);
+                TestProxyUtils.AUXILIARY_REMOTING_PARAMETERS_RETRYING);
     }
 }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/http/TestProxyUtils.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/http/TestProxyUtils.java
@@ -29,11 +29,11 @@ public final class TestProxyUtils {
 
     public static final AuxiliaryRemotingParameters AUXILIARY_REMOTING_PARAMETERS_RETRYING
             = AuxiliaryRemotingParameters.builder()
-            .shouldLimitPayload(false)
-            .userAgent(UserAgent.of(UserAgent.Agent.of("bla", "0.1.2")))
-            .remotingClientConfig(() -> REMOTING_CLIENT_CONFIG)
-            .shouldRetry(true)
-            .build();
+                    .shouldLimitPayload(false)
+                    .userAgent(UserAgent.of(UserAgent.Agent.of("bla", "0.1.2")))
+                    .remotingClientConfig(() -> REMOTING_CLIENT_CONFIG)
+                    .shouldRetry(true)
+                    .build();
 
     private TestProxyUtils() {
         // constants

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/http/TestProxyUtils.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/http/TestProxyUtils.java
@@ -27,13 +27,19 @@ public final class TestProxyUtils {
             .maximumConjureRemotingProbability(1.0)
             .build();
 
-    public static final AuxiliaryRemotingParameters AUXILIARY_REMOTING_PARAMETERS
+    public static final AuxiliaryRemotingParameters AUXILIARY_REMOTING_PARAMETERS_RETRYING
             = AuxiliaryRemotingParameters.builder()
-                    .shouldLimitPayload(false)
-                    .userAgent(UserAgent.of(UserAgent.Agent.of("bla", "0.1.2")))
-                    .remotingClientConfig(() -> REMOTING_CLIENT_CONFIG)
-                    .shouldRetry(true)
-                    .build();
+            .shouldLimitPayload(false)
+            .userAgent(UserAgent.of(UserAgent.Agent.of("bla", "0.1.2")))
+            .remotingClientConfig(() -> REMOTING_CLIENT_CONFIG)
+            .shouldRetry(true)
+            .build();
+
+    public static final AuxiliaryRemotingParameters AUXILIARY_REMOTING_PARAMETERS_NON_RETRYING
+            = AuxiliaryRemotingParameters.builder()
+            .from(AUXILIARY_REMOTING_PARAMETERS_RETRYING)
+            .shouldRetry(false)
+            .build();
 
     private TestProxyUtils() {
         // constants

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/http/TestProxyUtils.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/http/TestProxyUtils.java
@@ -35,12 +35,6 @@ public final class TestProxyUtils {
             .shouldRetry(true)
             .build();
 
-    public static final AuxiliaryRemotingParameters AUXILIARY_REMOTING_PARAMETERS_NON_RETRYING
-            = AuxiliaryRemotingParameters.builder()
-            .from(AUXILIARY_REMOTING_PARAMETERS_RETRYING)
-            .shouldRetry(false)
-            .build();
-
     private TestProxyUtils() {
         // constants
     }

--- a/changelog/@unreleased/pr-4370.v2.yml
+++ b/changelog/@unreleased/pr-4370.v2.yml
@@ -1,9 +1,10 @@
 type: fix
 fix:
-  description: We no longer create a `FastFailoverProxy` should not be created when
-    creating a single node proxy. Previously, if this was created when talking to
-    an individual TimeLock node that was not the leader, we would spin for about 10
-    seconds before returning. Users of failover proxies to TimeLock (e.g. if using
-    the timestamp or lock services from a `TransactionManager`) are unaffected.
+  description: We no longer create a `FastFailoverProxy` when creating a single node
+    proxy. Previously, if this was created when talking to an individual TimeLock
+    node that was not the leader (or a service that would otherwise return `308`s),
+    we would spin for about 10 seconds before returning. Users of failover proxies
+    to TimeLock (e.g. if using the timestamp or lock services from a `TransactionManager`)
+    are unaffected.
   links:
   - https://github.com/palantir/atlasdb/pull/4370

--- a/changelog/@unreleased/pr-4370.v2.yml
+++ b/changelog/@unreleased/pr-4370.v2.yml
@@ -1,0 +1,9 @@
+type: fix
+fix:
+  description: We no longer create a `FastFailoverProxy` should not be created when
+    creating a single node proxy. Previously, if this was created when talking to
+    an individual TimeLock node that was not the leader, we would spin for about 10
+    seconds before returning. Users of failover proxies to TimeLock (e.g. if using
+    the timestamp or lock services from a `TransactionManager`) are unaffected.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4370

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/IsolatedPaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/IsolatedPaxosTimeLockServerIntegrationTest.java
@@ -94,7 +94,7 @@ public class IsolatedPaxosTimeLockServerIntegrationTest {
                         PaxosTimeLockConstants.CLIENT_PAXOS_NAMESPACE,
                         CLIENT),
                 clazz,
-                TestProxyUtils.AUXILIARY_REMOTING_PARAMETERS);
+                TestProxyUtils.AUXILIARY_REMOTING_PARAMETERS_RETRYING);
     }
 
 }

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
@@ -121,7 +121,7 @@ public class PaxosTimeLockServerIntegrationTest {
                 Optional.of(TestProxies.TRUST_CONTEXT),
                 "https://localhost:" + TIMELOCK_SERVER_HOLDER.getTimelockPort(),
                 PingableLeader.class,
-                TestProxyUtils.AUXILIARY_REMOTING_PARAMETERS);
+                TestProxyUtils.AUXILIARY_REMOTING_PARAMETERS_RETRYING);
         Awaitility.await()
                 .atMost(30, TimeUnit.SECONDS)
                 .pollInterval(1, TimeUnit.SECONDS)

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/util/TestProxies.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/util/TestProxies.java
@@ -66,7 +66,7 @@ public class TestProxies {
                 Optional.of(TRUST_CONTEXT),
                 uri,
                 serviceInterface,
-                TestProxyUtils.AUXILIARY_REMOTING_PARAMETERS));
+                TestProxyUtils.AUXILIARY_REMOTING_PARAMETERS_NON_RETRYING));
     }
 
     public <T> T failoverForClient(String client, Class<T> serviceInterface) {
@@ -79,7 +79,7 @@ public class TestProxies {
                 new MetricRegistry(),
                 ImmutableServerListConfig.builder().addAllServers(uris).sslConfiguration(SSL_CONFIGURATION).build(),
                 serviceInterface,
-                TestProxyUtils.AUXILIARY_REMOTING_PARAMETERS));
+                TestProxyUtils.AUXILIARY_REMOTING_PARAMETERS_RETRYING));
     }
 
     public List<String> getServerUris() {

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/util/TestProxies.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/util/TestProxies.java
@@ -66,7 +66,7 @@ public class TestProxies {
                 Optional.of(TRUST_CONTEXT),
                 uri,
                 serviceInterface,
-                TestProxyUtils.AUXILIARY_REMOTING_PARAMETERS_NON_RETRYING));
+                TestProxyUtils.AUXILIARY_REMOTING_PARAMETERS_RETRYING));
     }
 
     public <T> T failoverForClient(String client, Class<T> serviceInterface) {


### PR DESCRIPTION
**Goals (and why)**:
- Fix a bug in #4366: a `FastFailoverProxy` should *not* be created when creating a single node proxy, as that's futile.

**Implementation Description (bullets)**:
- Remove `FastFailoverProxy` creation from the `createProxy` (no failover) codepath.
- Rename semantics of configuration in `TestProxyUtils` to make it obvious that the default params are with retrying enabled.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Existing tests should work, and should be faster.

**Concerns (what feedback would you like?)**:
- In production things shouldn't be affected, as the single node clients created e.g. timelock's PaxosLearner etc. aren't gated behind an AwaitingLeadershipProxy. Does this make sense / do we need to perform more drastic action?

**Where should we start reviewing?**: ConjureJavaRuntimeTargetFactory

**Priority (whenever / two weeks / yesterday)**: yesterday 🔥Until this merges, all builds will probably be ten minutes slower than they should be.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
