### PR TITLE
update postgres jdbc [ 42.2.1 --> 42.2.8 ]

### DIFF
--- a/changelog/@unreleased/pr-4371.v2.yml
+++ b/changelog/@unreleased/pr-4371.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: |-
+    Postgres JDBC driver was updated from 42.2.1 to 42.2.8
+    (relevant: minor perf and upsert fixes)
+  links:
+  - https://github.com/palantir/atlasdb/pull/4371

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -31,6 +31,6 @@ ext.libVersions =
     checkstyle: '6.18',
     findbugsAnnotations: '2.0.3',
     ant: '1.9.4',
-    postgresql: '42.2.1',
+    postgresql: '42.2.8',
     c3p0: '0.9.5.1'
 ]


### PR DESCRIPTION
Changelog is here:
https://jdbc.postgresql.org/documentation/changelog.html

changes relevant to us:
- notably want this new version because upserts are a little buggy in 42.2.1 and downstream project wants to use them now that we have 9.6+ postgres version guarantees as of this week
- some random perf fixes

@mswintermeyer FYSA