### PR TITLE
[Conjure Java Runtime] Part 20: The Beginning of the End / Force CJR for Inter-Node Communications

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -130,6 +130,52 @@ acceptedBreaks:
         \ T, java.util.Set<java.lang.String>, java.util.Optional<com.palantir.conjure.java.config.ssl.TrustContext>,\
         \ java.lang.Class<T>, com.palantir.conjure.java.api.config.service.UserAgent)"
       justification: "Intentional break, needed for running experiments / tagged metrics"
+  0.171.0:
+    com.palantir.atlasdb:atlasdb-config:
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter com.palantir.atlasdb.factory.Leaders.LocalPaxosServices com.palantir.atlasdb.factory.Leaders::createInstrumentedLocalServices(com.palantir.atlasdb.util.MetricsManager,\
+        \ com.palantir.atlasdb.config.LeaderConfig, ===java.util.function.Supplier<com.palantir.atlasdb.config.LeaderRuntimeConfig>===,\
+        \ com.palantir.atlasdb.factory.Leaders.RemotePaxosServerSpec, com.palantir.conjure.java.api.config.service.UserAgent,\
+        \ com.palantir.leader.LeadershipObserver)"
+      new: "parameter com.palantir.atlasdb.factory.Leaders.LocalPaxosServices com.palantir.atlasdb.factory.Leaders::createInstrumentedLocalServices(com.palantir.atlasdb.util.MetricsManager,\
+        \ com.palantir.atlasdb.config.LeaderConfig, ===com.palantir.atlasdb.factory.Leaders.RemotePaxosServerSpec===,\
+        \ java.util.function.Supplier<com.palantir.atlasdb.config.RemotingClientConfig>,\
+        \ com.palantir.conjure.java.api.config.service.UserAgent, com.palantir.leader.LeadershipObserver)"
+      justification: "Actually internal API"
+    - code: "java.method.numberOfParametersChanged"
+      old: "method com.palantir.atlasdb.factory.Leaders.LocalPaxosServices com.palantir.atlasdb.factory.Leaders::createInstrumentedLocalServices(com.palantir.atlasdb.util.MetricsManager,\
+        \ com.palantir.atlasdb.config.LeaderConfig, java.util.function.Supplier<com.palantir.atlasdb.config.LeaderRuntimeConfig>,\
+        \ com.palantir.conjure.java.api.config.service.UserAgent)"
+      new: "method com.palantir.atlasdb.factory.Leaders.LocalPaxosServices com.palantir.atlasdb.factory.Leaders::createInstrumentedLocalServices(com.palantir.atlasdb.util.MetricsManager,\
+        \ com.palantir.atlasdb.config.LeaderConfig, com.palantir.conjure.java.api.config.service.UserAgent)"
+      justification: "Actually internal API"
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter com.palantir.atlasdb.factory.Leaders.LocalPaxosServices com.palantir.atlasdb.factory.Leaders::createInstrumentedLocalServices(com.palantir.atlasdb.util.MetricsManager,\
+        \ com.palantir.atlasdb.config.LeaderConfig, java.util.function.Supplier<com.palantir.atlasdb.config.LeaderRuntimeConfig>,\
+        \ ===com.palantir.atlasdb.factory.Leaders.RemotePaxosServerSpec===, com.palantir.conjure.java.api.config.service.UserAgent,\
+        \ com.palantir.leader.LeadershipObserver)"
+      new: "parameter com.palantir.atlasdb.factory.Leaders.LocalPaxosServices com.palantir.atlasdb.factory.Leaders::createInstrumentedLocalServices(com.palantir.atlasdb.util.MetricsManager,\
+        \ com.palantir.atlasdb.config.LeaderConfig, com.palantir.atlasdb.factory.Leaders.RemotePaxosServerSpec,\
+        \ ===java.util.function.Supplier<com.palantir.atlasdb.config.RemotingClientConfig>===,\
+        \ com.palantir.conjure.java.api.config.service.UserAgent, com.palantir.leader.LeadershipObserver)"
+      justification: "Actually internal API"
+    - code: "java.method.numberOfParametersChanged"
+      old: "method <T> java.util.List<T> com.palantir.atlasdb.factory.Leaders::createProxyAndLocalList(com.palantir.atlasdb.util.MetricsManager,\
+        \ T, java.util.Set<java.lang.String>, java.util.Optional<com.palantir.conjure.java.config.ssl.TrustContext>,\
+        \ java.lang.Class<T>, com.palantir.conjure.java.api.config.service.UserAgent)"
+      new: "method <T> java.util.List<T> com.palantir.atlasdb.factory.Leaders::createProxyAndLocalList(com.palantir.atlasdb.util.MetricsManager,\
+        \ T, java.util.Set<java.lang.String>, java.util.function.Supplier<com.palantir.atlasdb.config.RemotingClientConfig>,\
+        \ java.util.Optional<com.palantir.conjure.java.config.ssl.TrustContext>, java.lang.Class<T>,\
+        \ com.palantir.conjure.java.api.config.service.UserAgent)"
+      justification: "Actually internal API"
+    - code: "java.method.numberOfParametersChanged"
+      old: "method java.util.List<com.palantir.leader.PingableLeader> com.palantir.atlasdb.factory.Leaders::generatePingables(com.palantir.atlasdb.util.MetricsManager,\
+        \ java.util.Collection<java.lang.String>, java.util.Optional<com.palantir.conjure.java.config.ssl.TrustContext>,\
+        \ com.palantir.conjure.java.api.config.service.UserAgent)"
+      new: "method java.util.List<com.palantir.leader.PingableLeader> com.palantir.atlasdb.factory.Leaders::generatePingables(com.palantir.atlasdb.util.MetricsManager,\
+        \ java.util.Collection<java.lang.String>, java.util.function.Supplier<com.palantir.atlasdb.config.RemotingClientConfig>,\
+        \ java.util.Optional<com.palantir.conjure.java.config.ssl.TrustContext>, com.palantir.conjure.java.api.config.service.UserAgent)"
+      justification: "Actually internal API"
   0.161.0:
     com.palantir.atlasdb:atlasdb-config:
     - code: "java.method.removed"

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/BlacklistTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/BlacklistTest.java
@@ -60,7 +60,7 @@ public class BlacklistTest {
 
     @Before
     @SuppressWarnings("unchecked") // Mock type is correct
-    public void setUp() throws Exception {
+    public void setUp() {
         when(clock.millis()).thenAnswer(invocation -> time.addAndGet(ONE_SECOND.toMillis() + 1));
         when(badContainer.runWithPooledResource(any(FunctionCheckedException.class))).thenThrow(new RuntimeException());
         when(badContainer.getHost()).thenReturn(ADDRESS_1);

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/BlacklistTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/BlacklistTest.java
@@ -60,7 +60,7 @@ public class BlacklistTest {
 
     @Before
     @SuppressWarnings("unchecked") // Mock type is correct
-    public void setUp() {
+    public void setUp() throws Exception {
         when(clock.millis()).thenAnswer(invocation -> time.addAndGet(ONE_SECOND.toMillis() + 1));
         when(badContainer.runWithPooledResource(any(FunctionCheckedException.class))).thenThrow(new RuntimeException());
         when(badContainer.getHost()).thenReturn(ADDRESS_1);

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
@@ -43,6 +43,7 @@ import com.palantir.atlasdb.config.AuxiliaryRemotingParameters;
 import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.config.LeaderRuntimeConfig;
 import com.palantir.atlasdb.config.RemotingClientConfig;
+import com.palantir.atlasdb.config.RemotingClientConfigs;
 import com.palantir.atlasdb.http.AtlasDbHttpClients;
 import com.palantir.atlasdb.http.NotCurrentLeaderExceptionMapper;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
@@ -111,7 +112,7 @@ public final class Leaders {
                 metricsManager,
                 config,
                 remotePaxosServerSpec,
-                () -> RemotingClientConfig.ALWAYS_USE_LEGACY, // TODO (jkong): Wire this up or change it to Conjure
+                () -> RemotingClientConfigs.ALWAYS_USE_LEGACY, // TODO (jkong): Wire this up or change it to Conjure
                 userAgent,
                 LeadershipObserver.NO_OP);
     }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
@@ -111,7 +111,7 @@ public final class Leaders {
                 metricsManager,
                 config,
                 remotePaxosServerSpec,
-                () -> RemotingClientConfig.DEFAULT, // TODO (jkong): Wire this up or change it to Conjure
+                () -> RemotingClientConfig.ALWAYS_USE_LEGACY, // TODO (jkong): Wire this up or change it to Conjure
                 userAgent,
                 LeadershipObserver.NO_OP);
     }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -1008,7 +1008,7 @@ public abstract class TransactionManagers {
                 .sslConfiguration(leaderConfig.sslConfiguration())
                 .build();
         ServiceCreator creator = ServiceCreator.noPayloadLimiter(
-                metricsManager, () -> serverListConfig, userAgent, () -> RemotingClientConfig.DEFAULT);
+                metricsManager, () -> serverListConfig, userAgent, () -> RemotingClientConfig.ALWAYS_USE_LEGACY);
         LockService remoteLock = creator.createService(LockService.class);
         TimestampService remoteTime = creator.createService(TimestampService.class);
         TimestampManagementService remoteManagement = creator.createService(TimestampManagementService.class);

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -63,6 +63,7 @@ import com.palantir.atlasdb.config.ImmutableTimeLockClientConfig;
 import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.config.LeaderRuntimeConfig;
 import com.palantir.atlasdb.config.RemotingClientConfig;
+import com.palantir.atlasdb.config.RemotingClientConfigs;
 import com.palantir.atlasdb.config.ServerListConfig;
 import com.palantir.atlasdb.config.ServerListConfigs;
 import com.palantir.atlasdb.config.ShouldRunBackgroundSweepSupplier;
@@ -1008,7 +1009,7 @@ public abstract class TransactionManagers {
                 .sslConfiguration(leaderConfig.sslConfiguration())
                 .build();
         ServiceCreator creator = ServiceCreator.noPayloadLimiter(
-                metricsManager, () -> serverListConfig, userAgent, () -> RemotingClientConfig.ALWAYS_USE_LEGACY);
+                metricsManager, () -> serverListConfig, userAgent, () -> RemotingClientConfigs.ALWAYS_USE_LEGACY);
         LockService remoteLock = creator.createService(LockService.class);
         TimestampService remoteTime = creator.createService(TimestampService.class);
         TimestampManagementService remoteManagement = creator.createService(TimestampManagementService.class);

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/LeadersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/LeadersTest.java
@@ -35,6 +35,7 @@ import org.junit.Test;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.palantir.atlasdb.config.RemotingClientConfig;
+import com.palantir.atlasdb.config.RemotingClientConfigs;
 import com.palantir.atlasdb.http.AtlasDbRemotingConstants;
 import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.paxos.PaxosAcceptor;
@@ -44,7 +45,8 @@ import com.palantir.paxos.PaxosValue;
 public class LeadersTest {
 
     private static final Set<String> REMOTE_SERVICE_ADDRESSES = ImmutableSet.of("foo:1234", "bar:5678");
-    private static final Supplier<RemotingClientConfig> REMOTING_CLIENT_CONFIG = () -> RemotingClientConfig.ALWAYS_USE_LEGACY;
+    private static final Supplier<RemotingClientConfig> REMOTING_CLIENT_CONFIG
+            = () -> RemotingClientConfigs.ALWAYS_USE_CONJURE;
 
     @Test
     public void canCreateProxyAndLocalListOfPaxosLearners() {

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/LeadersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/LeadersTest.java
@@ -44,7 +44,7 @@ import com.palantir.paxos.PaxosValue;
 public class LeadersTest {
 
     private static final Set<String> REMOTE_SERVICE_ADDRESSES = ImmutableSet.of("foo:1234", "bar:5678");
-    private static final Supplier<RemotingClientConfig> REMOTING_CLIENT_CONFIG = () -> RemotingClientConfig.DEFAULT;
+    private static final Supplier<RemotingClientConfig> REMOTING_CLIENT_CONFIG = () -> RemotingClientConfig.ALWAYS_USE_LEGACY;
 
     @Test
     public void canCreateProxyAndLocalListOfPaxosLearners() {

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/LeadersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/LeadersTest.java
@@ -27,12 +27,14 @@ import java.math.BigInteger;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.palantir.atlasdb.config.RemotingClientConfig;
 import com.palantir.atlasdb.http.AtlasDbRemotingConstants;
 import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.paxos.PaxosAcceptor;
@@ -41,7 +43,8 @@ import com.palantir.paxos.PaxosValue;
 
 public class LeadersTest {
 
-    public static final Set<String> REMOTE_SERVICE_ADDRESSES = ImmutableSet.of("foo:1234", "bar:5678");
+    private static final Set<String> REMOTE_SERVICE_ADDRESSES = ImmutableSet.of("foo:1234", "bar:5678");
+    private static final Supplier<RemotingClientConfig> REMOTING_CLIENT_CONFIG = () -> RemotingClientConfig.DEFAULT;
 
     @Test
     public void canCreateProxyAndLocalListOfPaxosLearners() {
@@ -53,6 +56,7 @@ public class LeadersTest {
                 MetricsManagers.createForTests(),
                 localLearner,
                 REMOTE_SERVICE_ADDRESSES,
+                REMOTING_CLIENT_CONFIG,
                 Optional.empty(),
                 PaxosLearner.class,
                 AtlasDbRemotingConstants.DEFAULT_USER_AGENT);
@@ -73,6 +77,7 @@ public class LeadersTest {
                 MetricsManagers.createForTests(),
                 localAcceptor,
                 REMOTE_SERVICE_ADDRESSES,
+                REMOTING_CLIENT_CONFIG,
                 Optional.empty(),
                 PaxosAcceptor.class,
                 AtlasDbRemotingConstants.DEFAULT_USER_AGENT);
@@ -94,6 +99,7 @@ public class LeadersTest {
                 MetricsManagers.createForTests(),
                 localAcceptor,
                 ImmutableSet.of(),
+                REMOTING_CLIENT_CONFIG,
                 Optional.empty(),
                 PaxosAcceptor.class,
                 AtlasDbRemotingConstants.DEFAULT_USER_AGENT);
@@ -113,6 +119,7 @@ public class LeadersTest {
                 MetricsManagers.createForTests(),
                 localBigInteger,
                 REMOTE_SERVICE_ADDRESSES,
+                REMOTING_CLIENT_CONFIG,
                 Optional.empty(),
                 BigInteger.class,
                 AtlasDbRemotingConstants.DEFAULT_USER_AGENT);
@@ -126,6 +133,7 @@ public class LeadersTest {
                 MetricsManagers.createForTests(),
                 localAcceptor,
                 REMOTE_SERVICE_ADDRESSES,
+                REMOTING_CLIENT_CONFIG,
                 Optional.empty(),
                 null,
                 AtlasDbRemotingConstants.DEFAULT_USER_AGENT);

--- a/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/ConjureJavaRuntimeTargetFactory.java
+++ b/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/ConjureJavaRuntimeTargetFactory.java
@@ -63,7 +63,6 @@ public final class ConjureJavaRuntimeTargetFactory implements TargetFactory {
                 addAtlasDbRemotingAgent(parameters.userAgent()),
                 HOST_METRICS_REGISTRY,
                 clientConfiguration);
-        client = FastFailoverProxy.newProxyInstance(type, client);
         return wrapWithVersion(client);
     }
 

--- a/atlasdb-remoting-api/src/main/java/com/palantir/atlasdb/config/AuxiliaryRemotingParameters.java
+++ b/atlasdb-remoting-api/src/main/java/com/palantir/atlasdb/config/AuxiliaryRemotingParameters.java
@@ -39,7 +39,7 @@ public interface AuxiliaryRemotingParameters {
 
     @Value.Default
     default Supplier<RemotingClientConfig> remotingClientConfig() {
-        return () -> RemotingClientConfig.DEFAULT;
+        return () -> RemotingClientConfig.ALWAYS_USE_LEGACY;
     }
 
     static ImmutableAuxiliaryRemotingParameters.Builder builder() {

--- a/atlasdb-remoting-api/src/main/java/com/palantir/atlasdb/config/AuxiliaryRemotingParameters.java
+++ b/atlasdb-remoting-api/src/main/java/com/palantir/atlasdb/config/AuxiliaryRemotingParameters.java
@@ -39,7 +39,7 @@ public interface AuxiliaryRemotingParameters {
 
     @Value.Default
     default Supplier<RemotingClientConfig> remotingClientConfig() {
-        return () -> RemotingClientConfig.ALWAYS_USE_LEGACY;
+        return () -> RemotingClientConfigs.ALWAYS_USE_LEGACY;
     }
 
     static ImmutableAuxiliaryRemotingParameters.Builder builder() {

--- a/atlasdb-remoting-api/src/main/java/com/palantir/atlasdb/config/RemotingClientConfig.java
+++ b/atlasdb-remoting-api/src/main/java/com/palantir/atlasdb/config/RemotingClientConfig.java
@@ -27,7 +27,10 @@ import com.palantir.logsafe.SafeArg;
 @JsonDeserialize(as = ImmutableRemotingClientConfig.class)
 @Value.Immutable
 public interface RemotingClientConfig {
-    RemotingClientConfig DEFAULT = ImmutableRemotingClientConfig.builder().build();
+    RemotingClientConfig ALWAYS_USE_LEGACY = ImmutableRemotingClientConfig.builder()
+            .maximumConjureRemotingProbability(0.0)
+            .enableLegacyClientFallback(true)
+            .build();
     RemotingClientConfig ALWAYS_USE_CONJURE = ImmutableRemotingClientConfig.builder()
             .maximumConjureRemotingProbability(1.0)
             .enableLegacyClientFallback(false)

--- a/atlasdb-remoting-api/src/main/java/com/palantir/atlasdb/config/RemotingClientConfig.java
+++ b/atlasdb-remoting-api/src/main/java/com/palantir/atlasdb/config/RemotingClientConfig.java
@@ -28,6 +28,10 @@ import com.palantir.logsafe.SafeArg;
 @Value.Immutable
 public interface RemotingClientConfig {
     RemotingClientConfig DEFAULT = ImmutableRemotingClientConfig.builder().build();
+    RemotingClientConfig ALWAYS_USE_CONJURE = ImmutableRemotingClientConfig.builder()
+            .maximumConjureRemotingProbability(1.0)
+            .enableLegacyClientFallback(false)
+            .build();
 
     @Value.Default
     default double maximumConjureRemotingProbability() {

--- a/atlasdb-remoting-api/src/main/java/com/palantir/atlasdb/config/RemotingClientConfig.java
+++ b/atlasdb-remoting-api/src/main/java/com/palantir/atlasdb/config/RemotingClientConfig.java
@@ -27,15 +27,6 @@ import com.palantir.logsafe.SafeArg;
 @JsonDeserialize(as = ImmutableRemotingClientConfig.class)
 @Value.Immutable
 public interface RemotingClientConfig {
-    RemotingClientConfig ALWAYS_USE_LEGACY = ImmutableRemotingClientConfig.builder()
-            .maximumConjureRemotingProbability(0.0)
-            .enableLegacyClientFallback(true)
-            .build();
-    RemotingClientConfig ALWAYS_USE_CONJURE = ImmutableRemotingClientConfig.builder()
-            .maximumConjureRemotingProbability(1.0)
-            .enableLegacyClientFallback(false)
-            .build();
-
     @Value.Default
     default double maximumConjureRemotingProbability() {
         return 0.0;

--- a/atlasdb-remoting-api/src/main/java/com/palantir/atlasdb/config/RemotingClientConfigs.java
+++ b/atlasdb-remoting-api/src/main/java/com/palantir/atlasdb/config/RemotingClientConfigs.java
@@ -21,12 +21,12 @@ public final class RemotingClientConfigs {
         // Constants
     }
 
-    public static RemotingClientConfig ALWAYS_USE_LEGACY = ImmutableRemotingClientConfig.builder()
+    public static final RemotingClientConfig ALWAYS_USE_LEGACY = ImmutableRemotingClientConfig.builder()
             .maximumConjureRemotingProbability(0.0)
             .enableLegacyClientFallback(true)
             .build();
 
-    public static RemotingClientConfig ALWAYS_USE_CONJURE = ImmutableRemotingClientConfig.builder()
+    public static final RemotingClientConfig ALWAYS_USE_CONJURE = ImmutableRemotingClientConfig.builder()
             .maximumConjureRemotingProbability(1.0)
             .enableLegacyClientFallback(false)
             .build();

--- a/atlasdb-remoting-api/src/main/java/com/palantir/atlasdb/config/RemotingClientConfigs.java
+++ b/atlasdb-remoting-api/src/main/java/com/palantir/atlasdb/config/RemotingClientConfigs.java
@@ -1,0 +1,33 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.config;
+
+public final class RemotingClientConfigs {
+    private RemotingClientConfigs() {
+        // Constants
+    }
+
+    public static RemotingClientConfig ALWAYS_USE_LEGACY = ImmutableRemotingClientConfig.builder()
+            .maximumConjureRemotingProbability(0.0)
+            .enableLegacyClientFallback(true)
+            .build();
+
+    public static RemotingClientConfig ALWAYS_USE_CONJURE = ImmutableRemotingClientConfig.builder()
+            .maximumConjureRemotingProbability(1.0)
+            .enableLegacyClientFallback(false)
+            .build();
+}

--- a/changelog/@unreleased/pr-4372.v2.yml
+++ b/changelog/@unreleased/pr-4372.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: AtlasDB now uses Conjure Java Runtime for inter-node communications.
+    In particular, this affects TimeLock Servers using this version of AtlasDB.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4372

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClients.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClients.java
@@ -26,7 +26,7 @@ import org.immutables.value.Value;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.atlasdb.config.AuxiliaryRemotingParameters;
-import com.palantir.atlasdb.config.RemotingClientConfig;
+import com.palantir.atlasdb.config.RemotingClientConfigs;
 import com.palantir.atlasdb.http.AtlasDbHttpClients;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
 import com.palantir.atlasdb.util.MetricsManagers;
@@ -105,7 +105,7 @@ public abstract class PaxosRemoteClients {
                                 .userAgent(UserAgents.tryParse(name))
                                 .shouldLimitPayload(false)
                                 .shouldRetry(shouldRetry)
-                                .remotingClientConfig(() -> RemotingClientConfig.ALWAYS_USE_CONJURE)
+                                .remotingClientConfig(() -> RemotingClientConfigs.ALWAYS_USE_CONJURE)
                                 .build()))
                 .map(proxy -> AtlasDbMetrics.instrumentWithTaggedMetrics(
                         metrics(),

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClients.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClients.java
@@ -23,10 +23,13 @@ import javax.ws.rs.Path;
 
 import org.immutables.value.Value;
 
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.atlasdb.config.AuxiliaryRemotingParameters;
+import com.palantir.atlasdb.config.RemotingClientConfig;
 import com.palantir.atlasdb.http.AtlasDbHttpClients;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
+import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.conjure.java.api.config.service.UserAgents;
 import com.palantir.leader.PingableLeader;
 import com.palantir.paxos.PaxosAcceptor;
@@ -93,8 +96,8 @@ public abstract class PaxosRemoteClients {
 
     private <T> List<T> createInstrumentedRemoteProxies(Class<T> clazz, String name, boolean shouldRetry) {
         return context().remoteUris().stream()
-                // TODO(fdesouza): wire up the configurable cutover to CJR
-                .map(uri -> AtlasDbHttpClients.LEGACY_FEIGN_TARGET_FACTORY.createProxy(
+                .map(uri -> AtlasDbHttpClients.createProxy(
+                        MetricsManagers.of(new MetricRegistry(), metrics()),
                         context().trustContext(),
                         uri,
                         clazz,
@@ -102,7 +105,8 @@ public abstract class PaxosRemoteClients {
                                 .userAgent(UserAgents.tryParse(name))
                                 .shouldLimitPayload(false)
                                 .shouldRetry(shouldRetry)
-                                .build()).instance())
+                                .remotingClientConfig(() -> RemotingClientConfig.ALWAYS_USE_CONJURE)
+                                .build()))
                 .map(proxy -> AtlasDbMetrics.instrumentWithTaggedMetrics(
                         metrics(),
                         clazz,

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/PaxosLeadershipCreator.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/PaxosLeadershipCreator.java
@@ -32,7 +32,7 @@ import com.palantir.atlasdb.config.ImmutableLeaderConfig;
 import com.palantir.atlasdb.config.ImmutableLeaderRuntimeConfig;
 import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.config.LeaderRuntimeConfig;
-import com.palantir.atlasdb.config.RemotingClientConfig;
+import com.palantir.atlasdb.config.RemotingClientConfigs;
 import com.palantir.atlasdb.factory.ImmutableRemotePaxosServerSpec;
 import com.palantir.atlasdb.factory.Leaders;
 import com.palantir.atlasdb.timelock.paxos.AutobatchingLeadershipObserverFactory;
@@ -96,7 +96,7 @@ class PaxosLeadershipCreator {
                         .remoteAcceptorUris(paxosSubresourceUris)
                         .remoteLearnerUris(paxosSubresourceUris)
                         .build(),
-                () -> RemotingClientConfig.ALWAYS_USE_CONJURE,
+                () -> RemotingClientConfigs.ALWAYS_USE_CONJURE,
                 UserAgent.of(UserAgent.Agent.of("leader-election-service", UserAgent.Agent.DEFAULT_VERSION)),
                 leadershipObserver);
         leaderElectionService = localPaxosServices.leaderElectionService();

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/PaxosLeadershipCreator.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/PaxosLeadershipCreator.java
@@ -32,6 +32,7 @@ import com.palantir.atlasdb.config.ImmutableLeaderConfig;
 import com.palantir.atlasdb.config.ImmutableLeaderRuntimeConfig;
 import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.config.LeaderRuntimeConfig;
+import com.palantir.atlasdb.config.RemotingClientConfig;
 import com.palantir.atlasdb.factory.ImmutableRemotePaxosServerSpec;
 import com.palantir.atlasdb.factory.Leaders;
 import com.palantir.atlasdb.timelock.paxos.AutobatchingLeadershipObserverFactory;
@@ -90,12 +91,12 @@ class PaxosLeadershipCreator {
         Leaders.LocalPaxosServices localPaxosServices = Leaders.createInstrumentedLocalServices(
                 metricsManager,
                 leaderConfig,
-                Suppliers.compose(getLeaderRuntimeConfig::apply, runtime::get),
                 ImmutableRemotePaxosServerSpec.builder()
                         .remoteLeaderUris(remoteServers)
                         .remoteAcceptorUris(paxosSubresourceUris)
                         .remoteLearnerUris(paxosSubresourceUris)
                         .build(),
+                () -> RemotingClientConfig.ALWAYS_USE_CONJURE,
                 UserAgent.of(UserAgent.Agent.of("leader-election-service", UserAgent.Agent.DEFAULT_VERSION)),
                 leadershipObserver);
         leaderElectionService = localPaxosServices.leaderElectionService();

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -65,7 +65,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
 
     @ClassRule
     public static ParameterInjector<TestableTimelockCluster> injector =
-            ParameterInjector.withFallBackConfiguration(() -> PaxosSuite.NON_BATCHED_PAXOS);
+            ParameterInjector.withFallBackConfiguration(() -> PaxosSuite.BATCHED_PAXOS);
 
     @Parameterized.Parameter
     public TestableTimelockCluster cluster;

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -65,7 +65,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
 
     @ClassRule
     public static ParameterInjector<TestableTimelockCluster> injector =
-            ParameterInjector.withFallBackConfiguration(() -> PaxosSuite.BATCHED_PAXOS);
+            ParameterInjector.withFallBackConfiguration(() -> PaxosSuite.NON_BATCHED_PAXOS);
 
     @Parameterized.Parameter
     public TestableTimelockCluster cluster;


### PR DESCRIPTION
**Goals (and why)**:
- Roll out our work on CJR!

**Implementation Description (bullets)**:
- Switch `PaxosRemoteClients` to pass through configuration that always enables Conjure with probability 1.0, and disables the fallback mode.
- Include just enough wiring so that leader blocks still use Feign mode.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Existing tests should suffice. There are currently failing tests at time of writing, but I would like to seek opinion on whether these tests should be retained / if retaining these tests should block rollout. There was an opinion that was changed from AtlasDB-Feign to CJR that we may not have realised initially.

**Concerns (what feedback would you like?)**:
- Am I taking too much risk? I believe not: we have tested both the correctness and performance of AtlasDB clients to TimeLock. Also, this change can be rolled back/forward **much** more cheaply than a similar failure on AtlasDB clients.
- Four existing tests fail - I have root caused this to a change in behaviour from AtlasDB-Feign to CJR. Specifically, AtlasDB-Feign would throw out socket exceptions while CJR attempts to retry them. This causes the tests in question to take much longer and eventually time out. I'm not sure how best to proceed; I'd claim that CJR's choice is reasonable and probably better, and fixing the tests will require plumbing configurable logic through TimeLock Server that will only be used for the tests, so I'm not so keen on that.

**Where should we start reviewing?**: PaxosRemoteClients

**Priority (whenever / two weeks / yesterday)**: this week would be great

Specific notes for each reviewer:
@felixdesouza Regarding leadership creation, is there any path I missed out? 
@gmaretic In general you know CJR the best, so I'm putting you generally on this!