### PR TITLE
Fix deadlock in static class initialization

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/api/WriteReference.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/api/WriteReference.java
@@ -38,10 +38,6 @@ public abstract class WriteReference {
         return ImmutableCellReference.builder().tableRef(tableRef()).cell(cell()).build();
     }
 
-    public static final WriteReference DUMMY = WriteReference.of(
-            TableReference.createFromFullyQualifiedName("dum.my"),
-            Cell.create(new byte[] {0}, new byte[] {0}), false);
-
     public static WriteReference tombstone(TableReference tableRef, Cell cell) {
         return WriteReference.of(tableRef, cell, true);
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableCells.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableCells.java
@@ -68,6 +68,10 @@ public class SweepableCells extends SweepQueueTable {
     private final CommitTsCache commitTsCache;
     private final WriteReferencePersister writeReferencePersister;
 
+    private static final WriteReference DUMMY = WriteReference.of(
+            TableReference.createFromFullyQualifiedName("dum.my"),
+            Cell.create(new byte[] {0}, new byte[] {0}), false);
+
     public SweepableCells(
             KeyValueService kvs,
             WriteInfoPartitioner partitioner,
@@ -102,7 +106,7 @@ public class SweepableCells extends SweepQueueTable {
     }
 
     private Map<Cell, byte[]> addReferenceToDedicatedRows(PartitionInfo info, List<WriteInfo> writes) {
-        return addCell(info, WriteReference.DUMMY, false, 0, entryIndicatingNumberOfRequiredRows(writes));
+        return addCell(info, DUMMY, false, 0, entryIndicatingNumberOfRequiredRows(writes));
     }
 
     private long entryIndicatingNumberOfRequiredRows(List<WriteInfo> writes) {

--- a/changelog/@unreleased/pr-4374.v2.yml
+++ b/changelog/@unreleased/pr-4374.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: |
+    Fix deadlock in static class initialization
+  links:
+  - https://github.com/palantir/atlasdb/pull/4374


### PR DESCRIPTION
**Goals (and why)**:
We have a static class initialisation deadlock in WriterReference.

Initialising ImmutableWriterReference causes WriterReference to get initialised. But because of the static `DUMMY` variable, initialising WriterReference also causes ImmutableWriterReference to get initialised. The JVM appears to take out locks on the respective Class objects when initialising them. Because of the cyclical dependency here, we can end up with a deadlock when two threads try using ImmutableWriterReference and WriterReference at the same time.

**Implementation Description (bullets)**:
We move the `DUMMY` variable to the one place it is used.

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:
ASAP, this has caused multiple internal clients to deadlock.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
