### PR TITLE
Table creation metadata tests

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
@@ -96,9 +96,6 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
     private static final String SYNC = "sync";
     private static final String CASSANDRA_DEFAULT_TABLE_NAME = "ns__default_table";
     private static final String ATLAS_DEFAULT_TABLE_NAME = "ns.default_table";
-    private static final byte[] DEFAULT_TABLE_METADATA = {10, 18, 10, 14, 10, 4, 110, 97, 109, 101, 16, 4, 24, 1, 32, 1,
-            48, 1, 24, 0, 18, 30, 18, 28, 10, 18, 10, 14, 10, 4, 110, 97, 109, 101, 16, 4, 24, 1, 32, 1, 48, 1, 24, 0,
-            18, 6, 8, 4, 24, 1, 32, 3, 24, 2, 32, 64, 48, 0, 64, 0, 72, 1, 88, 0, 96, 0};
 
     @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> data() {
@@ -147,17 +144,6 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
         Preconditions.checkArgument(allTables.contains(table1));
         Preconditions.checkArgument(!allTables.contains(table2));
         Preconditions.checkArgument(!allTables.contains(table3));
-    }
-
-    @Test
-    public void testCreateTableDefaultAtlasDbMetadata() {
-        TableReference tableReference = TableReference.createFromFullyQualifiedName(ATLAS_DEFAULT_TABLE_NAME);
-        keyValueService.createTable(tableReference, AtlasDbConstants.GENERIC_TABLE_METADATA);
-        TableMetadata tableMetadata = TableMetadata.BYTES_HYDRATOR.hydrateFromBytes(
-                keyValueService.getMetadataForTable(tableReference));
-
-        assertThat(tableMetadata)
-                .isEqualTo(TableMetadata.BYTES_HYDRATOR.hydrateFromBytes(DEFAULT_TABLE_METADATA));
     }
 
     @Test

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
@@ -98,8 +98,8 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
     private static final String ATLAS_DEFAULT_TABLE_NAME = "ns.default_table";
     private final String name;
     private static final byte[] DEFAULT_TABLE_METADATA = {10, 18, 10, 14, 10, 4, 110, 97, 109, 101, 16, 4, 24, 1, 32, 1,
-        48, 1, 24, 0, 18, 30, 18, 28, 10, 18, 10, 14, 10, 4, 110, 97, 109, 101, 16, 4, 24, 1, 32, 1, 48, 1, 24, 0, 18,
-        6, 8, 4, 24, 1, 32, 3, 24, 2, 32, 64, 48, 0, 64, 0, 72, 1, 88, 0, 96, 0};
+            48, 1, 24, 0, 18, 30, 18, 28, 10, 18, 10, 14, 10, 4, 110, 97, 109, 101, 16, 4, 24, 1, 32, 1, 48, 1, 24, 0,
+            18, 6, 8, 4, 24, 1, 32, 3, 24, 2, 32, 64, 48, 0, 64, 0, 72, 1, 88, 0, 96, 0};
 
     @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> data() {

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
@@ -89,6 +89,16 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
     private static final MetricsManager metricsManager = MetricsManagers.createForTests();
     private static final int FOUR_DAYS_IN_SECONDS = 4 * 24 * 60 * 60;
     private static final long STARTING_ATLAS_TIMESTAMP = 10_000_000;
+    private static final int ONE_HOUR_IN_SECONDS = 60 * 60;
+    private static final TableReference NEVER_SEEN = TableReference.createFromFullyQualifiedName("ns.never_seen");
+    private static final Cell CELL = Cell.create(PtBytes.toBytes("row"), PtBytes.toBytes("column"));
+    private static final String ASYNC = "async";
+    private static final String SYNC = "sync";
+    private static final String CASSANDRA_DEFAULT_TABLE_NAME = "ns__default_table";
+    private static final String ATLAS_DEFAULT_TABLE_NAME = "ns.default_table";
+    private static final byte[] DEFAULT_TABLE_METADATA = {10, 18, 10, 14, 10, 4, 110, 97, 109, 101, 16, 4, 24, 1, 32, 1,
+            48, 1, 24, 0, 18, 30, 18, 28, 10, 18, 10, 14, 10, 4, 110, 97, 109, 101, 16, 4, 24, 1, 32, 1, 48, 1, 24, 0,
+            18, 6, 8, 4, 24, 1, 32, 3, 24, 2, 32, 64, 48, 0, 64, 0, 72, 1, 88, 0, 96, 0};
 
     @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> data() {
@@ -98,25 +108,12 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
         };
         return Arrays.asList(data);
     }
-
     @ClassRule
     public static final CassandraResource CASSANDRA = new CassandraResource(() -> CassandraKeyValueServiceImpl.create(
             MetricsManagers.createForTests(),
             getConfigWithGcGraceSeconds(FOUR_DAYS_IN_SECONDS),
             CassandraTestTools.getMutationProviderWithStartingTimestamp(STARTING_ATLAS_TIMESTAMP),
             logger));
-
-    private static final int ONE_HOUR_IN_SECONDS = 60 * 60;
-    private static final TableReference NEVER_SEEN = TableReference.createFromFullyQualifiedName("ns.never_seen");
-    private static final Cell CELL = Cell.create(PtBytes.toBytes("row"), PtBytes.toBytes("column"));
-    private static final String ASYNC = "async";
-    private static final String SYNC = "sync";
-    private static final String CASSANDRA_DEFAULT_TABLE_NAME = "ns__default_table";
-    private static final String ATLAS_DEFAULT_TABLE_NAME = "ns.default_table";
-
-    private static final byte[] DEFAULT_TABLE_METADATA = {10, 18, 10, 14, 10, 4, 110, 97, 109, 101, 16, 4, 24, 1, 32, 1,
-            48, 1, 24, 0, 18, 30, 18, 28, 10, 18, 10, 14, 10, 4, 110, 97, 109, 101, 16, 4, 24, 1, 32, 1, 48, 1, 24, 0,
-            18, 6, 8, 4, 24, 1, 32, 3, 24, 2, 32, 64, 48, 0, 64, 0, 72, 1, 88, 0, 96, 0};
 
     private final String name;
 

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
@@ -70,6 +70,7 @@ import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.TimestampRangeDelete;
 import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.keyvalue.impl.AbstractKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.AbstractKeyValueServiceTest;
 import com.palantir.atlasdb.keyvalue.impl.TableSplittingKeyValueService;
 import com.palantir.atlasdb.logging.LoggingArgs;
@@ -94,8 +95,10 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
     private static final Cell CELL = Cell.create(PtBytes.toBytes("row"), PtBytes.toBytes("column"));
     private static final String ASYNC = "async";
     private static final String SYNC = "sync";
-    private static final String CASSANDRA_DEFAULT_TABLE_NAME = "ns__default_table";
-    private static final String ATLAS_DEFAULT_TABLE_NAME = "ns.default_table";
+    private static final TableReference ATLAS_DEFAULT_TABLE_REFERENCE =
+            TableReference.createFromFullyQualifiedName("ns.default_table");
+    private static final String CASSANDRA_DEFAULT_TABLE_NAME =
+            AbstractKeyValueService.internalTableName(ATLAS_DEFAULT_TABLE_REFERENCE);
 
     @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> data() {
@@ -151,8 +154,7 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
         String keyspace = CASSANDRA.getConfig().getKeyspaceOrThrow();
         CfDef expectedCfDef = createDefaultCfDef(keyspace, CASSANDRA_DEFAULT_TABLE_NAME);
 
-        TableReference tableReference = TableReference.createFromFullyQualifiedName(ATLAS_DEFAULT_TABLE_NAME);
-        keyValueService.createTable(tableReference, AtlasDbConstants.GENERIC_TABLE_METADATA);
+        keyValueService.createTable(ATLAS_DEFAULT_TABLE_REFERENCE, AtlasDbConstants.GENERIC_TABLE_METADATA);
 
         List<CfDef> cfDefs = ((CassandraKeyValueService) keyValueService).getClientPool()
                 .run(client -> client.describe_keyspace(keyspace).getCf_defs());

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
@@ -197,8 +197,7 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
                 .filter(cf -> cf.getName().equals(getInternalTestTableName()))
                 .collect(Collectors.toList()));
 
-        assertThat(clusterSideCf.gc_grace_seconds)
-                .isEqualTo(gcGraceSeconds);
+        assertThat(clusterSideCf.gc_grace_seconds).isEqualTo(gcGraceSeconds);
     }
 
     @Test
@@ -208,7 +207,8 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
             kvs = getUnderlyingKvs(keyValueService);
         } else if (keyValueService instanceof TableSplittingKeyValueService) { // scylla tests
             KeyValueService delegate = ((TableSplittingKeyValueService) keyValueService).getDelegate(NEVER_SEEN);
-            assertThat(delegate).as("The nesting of Key Value Services has apparently changed")
+            assertThat(delegate)
+                    .as("The nesting of Key Value Services has apparently changed")
                     .isInstanceOf(CassandraKeyValueService.class);
 
             kvs = (CassandraKeyValueServiceImpl) delegate;
@@ -259,8 +259,7 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
 
         int garbageAfterTest = getAmountOfGarbageInMetadataTable(keyValueService, NEVER_SEEN);
 
-        assertThat(garbageAfterTest)
-                .isLessThanOrEqualTo(preExistingGarbageBeforeTest);
+        assertThat(garbageAfterTest).isLessThanOrEqualTo(preExistingGarbageBeforeTest);
     }
 
     @Test
@@ -280,8 +279,7 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
         Map<Cell, Value> results = keyValueService.get(tableReference, ImmutableMap.of(CELL, 1L));
         byte[] contents = results.get(CELL).getContents();
 
-        assertThat(contents)
-                .isEqualTo(PtBytes.EMPTY_BYTE_ARRAY);
+        assertThat(contents).isEqualTo(PtBytes.EMPTY_BYTE_ARRAY);
     }
 
     @Test
@@ -299,8 +297,7 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
         putDummyValueAtCellAndTimestamp(tableReference, CELL, 8L, STARTING_ATLAS_TIMESTAMP - 1);
         Map<Cell, Value> results = keyValueService.get(tableReference, ImmutableMap.of(CELL, 8L + 1));
 
-        assertThat(results)
-                .doesNotContainKey(CELL);
+        assertThat(results).doesNotContainKey(CELL);
     }
 
     @Test
@@ -321,8 +318,7 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
         Map<Cell, Value> resultExpectedCoveredByRangeTombstone =
                 keyValueService.get(tableReference, ImmutableMap.of(CELL, 1337L + 1));
 
-        assertThat(resultExpectedCoveredByRangeTombstone)
-                .doesNotContainKey(CELL);
+        assertThat(resultExpectedCoveredByRangeTombstone).doesNotContainKey(CELL);
     }
 
     @Test
@@ -346,8 +342,7 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
         Map<Cell, Value> resultsOutsideRangeTombstone =
                 keyValueService.get(tableReference, ImmutableMap.of(CELL, Long.MAX_VALUE));
 
-        assertThat(resultsOutsideRangeTombstone)
-                .containsKey(CELL);
+        assertThat(resultsOutsideRangeTombstone).containsKey(CELL);
     }
 
     @Test
@@ -357,8 +352,7 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
         clearOutMetadataTable(keyValueService);
         insertGenericMetadataIntoLegacyCell(keyValueService, userTable, ORIGINAL_METADATA);
 
-        assertThat(keyValueService.getMetadataForTable(userTable))
-                .isEqualTo(ORIGINAL_METADATA);
+        assertThat(keyValueService.getMetadataForTable(userTable)).isEqualTo(ORIGINAL_METADATA);
     }
 
     @Test
@@ -367,8 +361,7 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
 
         keyValueService.createTable(userTable, ORIGINAL_METADATA);
 
-        assertThat(keyValueService.getMetadataForTables().keySet())
-                .contains(userTable);
+        assertThat(keyValueService.getMetadataForTables().keySet()).contains(userTable);
     }
 
     @Test
@@ -389,8 +382,7 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
 
         keyValueService.createTable(userTable, tableMetadataUpdate);
 
-        assertThat(keyValueService.getMetadataForTable(userTable))
-                .isEqualTo(tableMetadataUpdate);
+        assertThat(keyValueService.getMetadataForTable(userTable)).isEqualTo(tableMetadataUpdate);
     }
 
     @Test
@@ -515,7 +507,7 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
                         + "(org.apache.cassandra.db.marshal.BytesType,org.apache.cassandra.db.marshal.LongType)")
                 .setCompaction_strategy_options(new HashMap<>())
                 .setRead_repair_chance(0.0)
-                .setGc_grace_seconds(345600)
+                .setGc_grace_seconds(FOUR_DAYS_IN_SECONDS)
                 .setDefault_validation_class("org.apache.cassandra.db.marshal.BytesType")
                 .setMin_compaction_threshold(4)
                 .setMax_compaction_threshold(32)


### PR DESCRIPTION
**Goals (and why)**:
Add tests for verifying created table metadata. Future driver bumps which change the API might result in different table metadata, this should catch the unwanted changes. 

**Implementation Description (bullets)**:
- manually extracted the metadata we want to compare
- test both Atlas internal metadata and Cassandra 

**Testing (What was existing testing like?  What have you done to improve it?)**:
- more complete tests

**Concerns (what feedback would you like?)**:
- have I covered all important metadata
- should the constants be extracted? I intentionally did not do that since they are not reused anywhere else

**Where should we start reviewing?**:
- `CassandraKeyValueServiceIntegrationTest`

**Priority (whenever / two weeks / yesterday)**:
- tomorrow

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
