### PR TITLE
AsyncPuncherTest shuts down AsyncPuncher instances

### DIFF
--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/cleaner/AsyncPuncherTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/cleaner/AsyncPuncherTest.java
@@ -66,13 +66,17 @@ public class AsyncPuncherTest {
     public void delegatesInitializationCheck() {
         Puncher delegate = mock(Puncher.class);
         Puncher puncher = AsyncPuncher.create(delegate, ASYNC_PUNCHER_INTERVAL, THROWING_BACKUP_TIMESTAMP_SUPPLIER);
+        try {
 
-        when(delegate.isInitialized())
-                .thenReturn(false)
-                .thenReturn(true);
+            when(delegate.isInitialized())
+                    .thenReturn(false)
+                    .thenReturn(true);
 
-        assertThat(puncher.isInitialized()).isFalse();
-        assertThat(puncher.isInitialized()).isTrue();
+            assertThat(puncher.isInitialized()).isFalse();
+            assertThat(puncher.isInitialized()).isTrue();
+        } finally {
+            puncher.shutdown();
+        }
     }
 
     @Test


### PR DESCRIPTION
This way we can avoid writing 600mb of `IllegalStateException: bla`
in large test suites.

**Goals (and why)**:

600mb of console logs in large a large test suite.
