### PR TITLE
Writes digest

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/debug/WritesDigest.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/debug/WritesDigest.java
@@ -1,0 +1,42 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.debug;
+
+import java.util.SortedMap;
+import java.util.SortedSet;
+
+import org.immutables.value.Value;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@JsonDeserialize(as = ImmutableWritesDigest.class)
+@JsonSerialize(as = ImmutableWritesDigest.class)
+@Value.Immutable
+public interface WritesDigest<T> {
+    @Value.NaturalOrder
+    SortedSet<Long> allWrittenTimestamps();
+
+    @Value.NaturalOrder
+    SortedMap<Long, Long> completedOrAbortedTransactions();
+
+    @Value.NaturalOrder
+    SortedSet<Long> inProgressTransactions();
+
+    @Value.NaturalOrder
+    SortedMap<Long, T> allWrittenValuesDeserialized();
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/debug/WritesDigestEmitter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/debug/WritesDigestEmitter.java
@@ -1,0 +1,90 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.debug;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.transaction.api.TransactionManager;
+import com.palantir.atlasdb.transaction.service.TransactionService;
+import com.palantir.common.persist.Persistable;
+import com.palantir.common.streams.KeyedStream;
+
+public class WritesDigestEmitter {
+
+    private final TransactionService transactionService;
+    private final TableReference tableReference;
+    private final KeyValueService keyValueService;
+
+    public WritesDigestEmitter(TransactionManager transactionManager, TableReference tableReference) {
+        this.keyValueService = transactionManager.getKeyValueService();
+        this.transactionService = transactionManager.getTransactionService();
+        this.tableReference = tableReference;
+    }
+
+    public <T> WritesDigest<T> getDigest(Persistable row, byte[] columnName, Function<Value, T> deserializer) {
+        Cell asCell = Cell.create(row.persistToBytes(), columnName);
+
+        Multimap<Cell, Long> allWrittenCells =
+                keyValueService.getAllTimestamps(tableReference, ImmutableSet.of(asCell), Long.MAX_VALUE);
+
+        Collection<Long> allWrittenTimestamps = allWrittenCells.get(asCell);
+
+        Map<Long, Long> transactionCommitStatuses = transactionService.get(allWrittenTimestamps);
+        Map<Long, Long> completedOrAbortedTransactions = KeyedStream.stream(transactionCommitStatuses)
+                .filter(Objects::nonNull)
+                .collectToMap();
+
+        Set<Long> inProgressTransactions = Sets.difference(
+                transactionCommitStatuses.keySet(),
+                completedOrAbortedTransactions.keySet());
+
+        Set<Long> boundsForCell = allWrittenTimestamps.stream()
+                .map(existingTimestamp -> existingTimestamp + 1)
+                .collect(Collectors.toSet());
+
+        Map<Long, T> allSeenWrittenValues = boundsForCell.stream()
+                .map(bound -> ImmutableMap.of(asCell, bound))
+                .map(request -> keyValueService.get(tableReference, request))
+                .map(result -> result.get(asCell))
+                .filter(Objects::nonNull)
+                .collect(KeyedStream.toKeyedStream())
+                .mapKeys(Value::getTimestamp)
+                .map(deserializer)
+                .collectToMap();
+
+        return ImmutableWritesDigest.<T>builder()
+                .allWrittenTimestamps(allWrittenTimestamps)
+                .completedOrAbortedTransactions(completedOrAbortedTransactions)
+                .inProgressTransactions(inProgressTransactions)
+                .allWrittenValuesDeserialized(allSeenWrittenValues)
+                .build();
+    }
+
+}

--- a/examples/profile-client/src/test/java/com/palantir/example/profile/WritesDigestTest.java
+++ b/examples/profile-client/src/test/java/com/palantir/example/profile/WritesDigestTest.java
@@ -1,0 +1,105 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.example.profile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableMap;
+import com.palantir.atlasdb.config.AtlasDbConfig;
+import com.palantir.atlasdb.config.AtlasDbRuntimeConfig;
+import com.palantir.atlasdb.config.ImmutableAtlasDbConfig;
+import com.palantir.atlasdb.config.ImmutableAtlasDbRuntimeConfig;
+import com.palantir.atlasdb.debug.WritesDigest;
+import com.palantir.atlasdb.debug.WritesDigestEmitter;
+import com.palantir.atlasdb.factory.TransactionManagers;
+import com.palantir.atlasdb.http.AtlasDbRemotingConstants;
+import com.palantir.atlasdb.memory.InMemoryAtlasDbConfig;
+import com.palantir.atlasdb.transaction.api.TransactionManager;
+import com.palantir.example.profile.schema.ProfileSchema;
+import com.palantir.example.profile.schema.generated.ProfileTableFactory;
+import com.palantir.example.profile.schema.generated.UserProfileTable;
+import com.palantir.example.profile.schema.generated.UserProfileTable.PhotoStreamId;
+import com.palantir.example.profile.schema.generated.UserProfileTable.UserProfileRow;
+import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
+
+public class WritesDigestTest {
+
+    private static final ProfileTableFactory TABLE_FACTORY = ProfileTableFactory.of();
+    private TransactionManager transactionManager;
+    private WritesDigestEmitter emitter;
+
+    @Before
+    public void setUp() {
+        AtlasDbConfig config = ImmutableAtlasDbConfig.builder().keyValueService(new InMemoryAtlasDbConfig()).build();
+        AtlasDbRuntimeConfig runtimeConfig = ImmutableAtlasDbRuntimeConfig.withSweepDisabled();
+        transactionManager = TransactionManagers.builder()
+                .config(config)
+                .userAgent(AtlasDbRemotingConstants.DEFAULT_USER_AGENT)
+                .globalMetricsRegistry(new MetricRegistry())
+                .globalTaggedMetricRegistry(DefaultTaggedMetricRegistry.getDefault())
+                .addSchemas(ProfileSchema.INSTANCE.getLatestSchema())
+                .runtimeConfigSupplier(() -> Optional.of(runtimeConfig))
+                .build()
+                .serializable();
+        emitter = new WritesDigestEmitter(transactionManager, TABLE_FACTORY.getUserProfileTable(null).getTableRef());
+
+    }
+
+    @Test
+    public void canGetAllWritesThatHaventBeenSwept() {
+        UUID uuid = UUID.randomUUID();
+        UserProfileRow row = UserProfileRow.of(uuid);
+        runWithRetryVoid(store -> store.putPhotoStreamId(ImmutableMap.of(row, 5L)));
+        runWithRetryVoid(store -> store.putPhotoStreamId(ImmutableMap.of(row, 11L)));
+        runWithRetryVoid(store -> store.putPhotoStreamId(ImmutableMap.of(row, 19L)));
+        runWithRetryVoid(store -> store.putPhotoStreamId(ImmutableMap.of(row, 23L)));
+
+        WritesDigest<Long> digest = emitter.getDigest(
+                row,
+                PhotoStreamId.of(0L).persistColumnName(),
+                value -> PhotoStreamId.BYTES_HYDRATOR.hydrateFromBytes(value.getContents()).getValue());
+
+        assertThat(digest.allWrittenTimestamps())
+                .as("nothing should be swept, we can see all the timestamps we've written at thus far")
+                .hasSize(4);
+
+        assertThat(digest.allWrittenValuesDeserialized().values())
+                .as("nothing should be swept, we can see all the values we've written thus far")
+                .containsOnly(5L, 11L, 19L, 23L);
+    }
+
+    private <T> T runWithRetry(Function<UserProfileTable, T> task) {
+        return transactionManager.runTaskWithRetry(transaction ->
+                task.apply(TABLE_FACTORY.getUserProfileTable(transaction)));
+    }
+
+    private void runWithRetryVoid(Consumer<UserProfileTable> task) {
+        runWithRetry(store -> {
+            task.accept(store);
+            return null;
+        });
+    }
+}


### PR DESCRIPTION
**Goals (and why)**:
This is a function that can be called during some sort of post-mortem on the key value service for transactions that have seemingly violated the protocol. 

Given a row and a column, we will list all given writes to that in the kvs, and any unswept entries and their corresponding start timestamps.

We will then attempt to get the commit timestamps for all transactions/start timestamps seen. This also includes aborted transactions

If there are any transactions that are ongoing, we will list those start timestamps too.

We also list the written values at that time.

**Priority (whenever / two weeks / yesterday)**:
ASAP.
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
