### PR TITLE
Bump gradle-rev-api to deal with semantic merge conflicts.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
         classpath 'com.netflix.nebula:nebula-publishing-plugin:14.0.0'
         classpath 'gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:0.15.0'
         classpath 'gradle.plugin.org.inferred:gradle-processors:3.1.0'
-        classpath 'com.palantir.gradle.revapi:gradle-revapi:1.0.3'
+        classpath 'com.palantir.gradle.revapi:gradle-revapi:1.0.8'
     }
 }
 


### PR DESCRIPTION
**Goals (and why)**:
An alternative proposal to #4383, the disruption of not being able to quickly release due to breaks, is mainly solved by 1.0.8 of gradle-rev-api. Acknowledging breaks is still useful despite the noise when you're breaking internal apis. We should iterate with them for things that don't work well for us.

**Priority (whenever / two weeks / yesterday)**:
Whenever.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
