### PR TITLE
Disable legacy sweep while sweep queue writes are on

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -134,7 +134,6 @@ public final class AtlasDbConstants {
 
     public static final boolean DEFAULT_INITIALIZE_ASYNC = AtlasDbFactory.DEFAULT_INITIALIZE_ASYNC;
 
-    public static final boolean DEFAULT_ENABLE_SWEEP = true;
     public static final long DEFAULT_SWEEP_PAUSE_MILLIS = 5 * 1000;
     public static final long DEFAULT_SWEEP_PERSISTENT_LOCK_WAIT_MILLIS = 30_000L;
     public static final int DEFAULT_SWEEP_DELETE_BATCH_HINT = 128;

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -660,10 +660,13 @@ public abstract class TransactionManagers {
                 config.initializeAsync(),
                 sweepBatchConfigSource);
 
+        boolean sweepQueueWritesEnabled = config.targetedSweep().enableSweepQueueWrites();
         BackgroundSweeperImpl backgroundSweeper = BackgroundSweeperImpl.create(
                 metricsManager,
                 sweepBatchConfigSource,
-                new ShouldRunBackgroundSweepSupplier(config.targetedSweep(), runtimeConfigSupplier)::getAsBoolean,
+                new ShouldRunBackgroundSweepSupplier(
+                        () -> runtimeConfigSupplier.get().sweep(),
+                        sweepQueueWritesEnabled)::getAsBoolean,
                 () -> runtimeConfigSupplier.get().sweep().sweepThreads(),
                 () -> runtimeConfigSupplier.get().sweep().pauseMillis(),
                 () -> runtimeConfigSupplier.get().sweep().sweepPriorityOverrides(),

--- a/changelog/@unreleased/pr-4394.v2.yml
+++ b/changelog/@unreleased/pr-4394.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: 'If legacy sweep is not explicitly enabled, it will now be disabled
+    as long as targeted sweep queue writes are enabled. Previously, legacy sweep would
+    be disabled only if targeted sweep was also enabled. '
+  links:
+  - https://github.com/palantir/atlasdb/pull/4394


### PR DESCRIPTION
**Goals (and why)**:
Pausing targeted sweep can be done as a way to prevent sweeping temporarily. The last thing you want to happen is legacy sweep helpfully kicking in when that is the case.
