### PR TITLE
Remove references to populate_io_cache_on_flush

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ColumnFamilyDefinitions.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ColumnFamilyDefinitions.java
@@ -30,9 +30,7 @@ import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.impl.AbstractKeyValueService;
 import com.palantir.atlasdb.logging.LoggingArgs;
-import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
 import com.palantir.atlasdb.table.description.TableMetadata;
-import com.palantir.common.exception.PalantirRuntimeException;
 import com.palantir.logsafe.SafeArg;
 
 final class ColumnFamilyDefinitions {
@@ -62,24 +60,6 @@ final class ColumnFamilyDefinitions {
         if (appendHeavyAndReadLight) {
             cf.setCompaction_strategy(CassandraConstants.SIZE_TIERED_COMPACTION_STRATEGY);
             cf.setCompaction_strategy_optionsIsSet(false);
-        }
-
-        TableMetadataPersistence.CachePriority cachePriority = tableMetadata.map(TableMetadata::getCachePriority)
-                .orElse(TableMetadataPersistence.CachePriority.WARM);
-        switch (cachePriority) {
-            case COLDEST:
-                break;
-            case COLD:
-                break;
-            case WARM:
-                break;
-            case HOT:
-                break;
-            case HOTTEST:
-                cf.setPopulate_io_cache_on_flushIsSet(true);
-                break;
-            default:
-                throw new PalantirRuntimeException("Unknown cache priority: " + cachePriority);
         }
 
         cf.setGc_grace_seconds(gcGraceSeconds);
@@ -196,13 +176,6 @@ final class ColumnFamilyDefinitions {
                         clusterSide.compaction_strategy);
                 return false;
             }
-        }
-        if (clientSide.isSetPopulate_io_cache_on_flush() != clusterSide.isSetPopulate_io_cache_on_flush()) {
-            logMismatch("populate_io_cache_on_flush",
-                    tableName,
-                    clientSide.isSetPopulate_io_cache_on_flush(),
-                    clusterSide.isSetPopulate_io_cache_on_flush());
-            return false;
         }
         if (clientSide.min_index_interval != clusterSide.min_index_interval) {
             logMismatch("min index interval",

--- a/changelog/@unreleased/pr-4396.v2.yml
+++ b/changelog/@unreleased/pr-4396.v2.yml
@@ -1,0 +1,11 @@
+type: improvement
+improvement:
+  description: |-
+    Remove all references to the Cassandra table property `populate_io_cache_on_flush`, which is supported or used in Cassandra.
+    <!---
+    Please remember to:
+    - Add any necessary release notes (including breaking changes)
+    - Make sure the documentation is up to date for your change
+    --->
+  links:
+  - https://github.com/palantir/atlasdb/pull/4396

--- a/changelog/@unreleased/pr-4396.v2.yml
+++ b/changelog/@unreleased/pr-4396.v2.yml
@@ -1,11 +1,6 @@
 type: improvement
 improvement:
-  description: |-
-    Remove all references to the Cassandra table property `populate_io_cache_on_flush`, which is supported or used in Cassandra.
-    <!---
-    Please remember to:
-    - Add any necessary release notes (including breaking changes)
-    - Make sure the documentation is up to date for your change
-    --->
+  description: Remove all references to the Cassandra table property `populate_io_cache_on_flush`,
+    which is supported or used in Cassandra.
   links:
   - https://github.com/palantir/atlasdb/pull/4396


### PR DESCRIPTION
**Goals (and why)**:

The property "populate_io_cache_on_flush" had no functionality started in Cassandra 2.1 (see https://issues.apache.org/jira/browse/CASSANDRA-7493), and Cassandra 3 now throws a SyntaxException if a query has this property.

**Implementation Description (bullets)**:

Removes any use of "populate_io_cache_on_flush".

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

Should `cachePriority` be removed also, or left as a no-op field (maybe deprecated)?  It doesn't seem to be used anywhere anymore, but it might be a breaking change to remove it.

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
