### PR TITLE
Force native protocol v3 for CqlClient

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/CqlClientFactoryImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/CqlClientFactoryImpl.java
@@ -31,6 +31,7 @@ import com.datastax.driver.core.HostDistance;
 import com.datastax.driver.core.NettyOptions;
 import com.datastax.driver.core.PoolingOptions;
 import com.datastax.driver.core.ProtocolOptions;
+import com.datastax.driver.core.ProtocolVersion;
 import com.datastax.driver.core.QueryOptions;
 import com.datastax.driver.core.RemoteEndpointAwareJdkSSLOptions;
 import com.datastax.driver.core.SSLOptions;
@@ -115,6 +116,7 @@ public final class CqlClientFactoryImpl implements CqlClientFactory {
                 .withQueryOptions(queryOptions)
                 .withRetryPolicy(DefaultRetryPolicy.INSTANCE)
                 .withoutJMXReporting()
+                .withProtocolVersion(ProtocolVersion.V3)
                 .withThreadingOptions(new ThreadingOptions());
 
         nettyOptions.ifPresent(clusterBuilder::withNettyOptions);

--- a/changelog/@unreleased/pr-4397.v2.yml
+++ b/changelog/@unreleased/pr-4397.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Force native protocol v3 for CqlClient
+  links:
+  - https://github.com/palantir/atlasdb/pull/4397


### PR DESCRIPTION
**Goals (and why)**:
In preparation for supporting Cassandra 3, and specifically to support clusters with mixed node versions (2.x and 3.x concurrently) we need to force native protocol v3.

See https://www.mail-archive.com/user@cassandra.apache.org/msg45381.html for full discussion

**Implementation Description (bullets)**:

We were using Protocol Version 4 by default before, now we are dropping down to Version 3.

```
Changelog
- the use of the recently added CQL type `date`, `time`, `tinyint` and
  `smallint` involves sending slightly bigger metadata in v3 that in v4. The
  resulting performance difference is unlikely to be noticeable.
- schema changes related to User Defined Functions are notified to clients as a "keyspace change" in v3 which, being imprecise, might require a client driver to request more schema metadata to update its own copy of said metadata This is again a very minor inefficiently.
- The protocol v4 has a feature that allows the server to send warnings to the clients. This is as of yet little used by the server and in which case where it is, the warning is also logged server side.
```
**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
