### PR TITLE
add metrics to scrubber

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbMetricNames.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbMetricNames.java
@@ -63,6 +63,11 @@ public final class AtlasDbMetricNames {
     public static final String SWEEP_OUTCOME = "outcome";
     public static final String TAG_OUTCOME = "status";
 
+    public static final String ENQUEUED_CELLS = "enqueuedCells";
+    public static final String DELETED_CELLS = "deletedCells";
+    public static final String SCRUBBED_CELLS = "scrubbedCells";
+    public static final String SCRUB_RETRIES = "retriedBatches";
+
     public static final String TAG_CURRENT_SUSPECTED_LEADER = "isCurrentSuspectedLeader";
     public static final String TAG_CLIENT = "client";
     public static final String TAG_PAXOS_USE_CASE = "paxosUseCase";

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -380,7 +380,7 @@ public abstract class TransactionManagers {
 
         Cleaner cleaner = initializeCloseable(() ->
                         new DefaultCleanerBuilder(keyValueService, lockAndTimestampServices.timelock(),
-                                        ImmutableList.of(follower), transactionService)
+                                        ImmutableList.of(follower), transactionService, metricsManager)
                                 .setBackgroundScrubAggressively(config().backgroundScrubAggressively())
                                 .setBackgroundScrubBatchSize(config().getBackgroundScrubBatchSize())
                                 .setBackgroundScrubFrequencyMillis(config().getBackgroundScrubFrequencyMillis())

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
@@ -65,13 +65,15 @@ public class TransactionManagerModule {
                                   @Named("kvs") KeyValueService kvs,
                                   TimelockService timelock,
                                   Follower follower,
-                                  TransactionService transactionService) {
+                                  TransactionService transactionService,
+                                  MetricsManager metricsManager) {
         AtlasDbConfig atlasDbConfig = config.atlasDbConfig();
         return new DefaultCleanerBuilder(
                 kvs,
                 timelock,
                 ImmutableList.of(follower),
-                transactionService)
+                transactionService,
+                metricsManager)
                 .setBackgroundScrubAggressively(atlasDbConfig.backgroundScrubAggressively())
                 .setBackgroundScrubBatchSize(atlasDbConfig.getBackgroundScrubBatchSize())
                 .setBackgroundScrubFrequencyMillis(atlasDbConfig.getBackgroundScrubFrequencyMillis())

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
@@ -36,6 +36,7 @@ import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager;
 import com.palantir.atlasdb.transaction.impl.SweepStrategyManager;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.util.MetricsManager;
+import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.lock.LockClient;
 import com.palantir.lock.LockService;
@@ -75,7 +76,8 @@ public class TestTransactionManagerModule {
                 tss,
                 lockClient,
                 ImmutableList.of(follower),
-                transactionService)
+                transactionService,
+                MetricsManagers.createForTests())
                 .setBackgroundScrubAggressively(atlasDbConfig.backgroundScrubAggressively())
                 .setBackgroundScrubBatchSize(atlasDbConfig.getBackgroundScrubBatchSize())
                 .setBackgroundScrubFrequencyMillis(atlasDbConfig.getBackgroundScrubFrequencyMillis())

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/DefaultCleanerBuilder.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/DefaultCleanerBuilder.java
@@ -28,6 +28,7 @@ import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cleaner.api.Cleaner;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.transaction.service.TransactionService;
+import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.common.time.Clock;
 import com.palantir.lock.LockClient;
 import com.palantir.lock.LockService;
@@ -42,6 +43,7 @@ public class DefaultCleanerBuilder {
     private final TimelockService timelockService;
     private final List<Follower> followerList;
     private final TransactionService transactionService;
+    private final MetricsManager metricsManager;
 
     private long transactionReadTimeout = AtlasDbConstants.DEFAULT_TRANSACTION_READ_TIMEOUT;
     private long punchIntervalMillis = AtlasDbConstants.DEFAULT_PUNCH_INTERVAL_MILLIS;
@@ -57,19 +59,22 @@ public class DefaultCleanerBuilder {
             TimestampService timestampService,
             LockClient lockClient,
             List<? extends Follower> followerList,
-            TransactionService transactionService) {
+            TransactionService transactionService,
+            MetricsManager metricsManager) {
         this(keyValueService, new LegacyTimelockService(timestampService, lockService, lockClient), followerList,
-                transactionService);
+                transactionService, metricsManager);
     }
 
     public DefaultCleanerBuilder(KeyValueService keyValueService,
             TimelockService timelockService,
             List<? extends Follower> followerList,
-            TransactionService transactionService) {
+            TransactionService transactionService,
+            MetricsManager metricsManager) {
         this.keyValueService = keyValueService;
         this.timelockService = timelockService;
         this.followerList = ImmutableList.copyOf(followerList);
         this.transactionService = transactionService;
+        this.metricsManager = metricsManager;
     }
 
     public DefaultCleanerBuilder setTransactionReadTimeout(long transactionReadTimeout) {
@@ -140,7 +145,8 @@ public class DefaultCleanerBuilder {
                 Suppliers.ofInstance(backgroundScrubBatchSize),
                 backgroundScrubThreads,
                 backgroundScrubReadThreads,
-                followerList);
+                followerList,
+                metricsManager);
     }
 
     public Cleaner buildCleaner() {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/cleaner/ScrubberTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/cleaner/ScrubberTest.java
@@ -44,6 +44,7 @@ import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
 import com.palantir.atlasdb.transaction.impl.TransactionTables;
 import com.palantir.atlasdb.transaction.service.SimpleTransactionService;
 import com.palantir.atlasdb.transaction.service.TransactionService;
+import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.common.base.BatchingVisitables;
 
 @RunWith(Parameterized.class)
@@ -156,6 +157,7 @@ public class ScrubberTest {
                 () -> 100, //  batch size
                 1, // thread count
                 1, // read thread count
-                ImmutableList.of()); // followers
+                ImmutableList.of(), // followers
+                MetricsManagers.createForTests());
     }
 }

--- a/changelog/@unreleased/pr-4398.v2.yml
+++ b/changelog/@unreleased/pr-4398.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: The scrubber has been instrumented with metrics.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4398


### PR DESCRIPTION
Add metrics to scrubbing, for the purposes of debugging a stack that may not be keeping up with its own scrub queue.

(Aside) I believe the eventual goal is to get rid of 90% of scrubbing and trust in targeted sweep, but in the interim this needs metrics.