### PR TITLE
Use supported CachingOptions for Cassandra CQL

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTableCreator.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTableCreator.java
@@ -81,7 +81,7 @@ class CassandraTableCreator {
                 .addColumn(VALUE, DataType.blob())
                 .withOptions()
                 .bloomFilterFPChance(CassandraTableOptions.bloomFilterFpChance(tableMetadata))
-                .caching(SchemaBuilder.Caching.KEYS_ONLY)
+                .caching(SchemaBuilder.KeyCaching.ALL, SchemaBuilder.noRows())
                 .compactionOptions(getCompaction(appendHeavyReadLight))
                 .compactStorage()
                 .compressionOptions(getCompression(tableMetadata.getExplicitCompressionBlockSizeKB()))

--- a/changelog/@unreleased/pr-4399.v2.yml
+++ b/changelog/@unreleased/pr-4399.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Switch the `CassandraTableCreator` to use supported caching options.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4399


### PR DESCRIPTION
**Goals (and why)**:
The `KEYS_ONLY` syntax has been deprecated since Cassandra 2.1, and is no longer supported for new tables starting in Cassandra 3.0 in the CQL client.  It continues to be supported for existing tables / as part of the migration to Cassandra 3, and in the Thrift interface.

**Implementation Description (bullets)**:

Switch use of `KEYS_ONLY` to a map with equivalent options for the CQL interface.
The Thrift interface continues to accept `KEYS_ONLY` as a String, and converts it.

Cassandra 3.x support for legacy syntax in Thrift: https://github.com/apache/cassandra/blob/cassandra-3.11/src/java/org/apache/cassandra/thrift/ThriftConversion.java#L684

Related commit - https://github.com/apache/cassandra/commit/b31845c4a7982358a7c5bfd9bcf572fda6c1bfa9

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
