### PR TITLE
Do not delegate for new API with default implementations

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
@@ -316,6 +316,7 @@ public interface TransactionManager extends AutoCloseable {
     TimelockService getTimelockService();
 
     // todo(gmaretic): implement
+    @DoNotDelegate
     default KvsLockWatchingService getLockWatchingService() {
         return NoOpKvsLockWatchingService.INSTANCE;
     }

--- a/lock-api/src/main/java/com/palantir/lock/v2/TimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/v2/TimelockService.java
@@ -24,6 +24,7 @@ import com.palantir.lock.watch.LockWatchState;
 import com.palantir.lock.watch.TimestampedLockResponse;
 import com.palantir.logsafe.Safe;
 import com.palantir.processors.AutoDelegate;
+import com.palantir.processors.DoNotDelegate;
 import com.palantir.timestamp.TimestampRange;
 
 @AutoDelegate
@@ -82,12 +83,14 @@ public interface TimelockService {
     long currentTimeMillis();
 
     // todo(gmaretic): implement
+    @DoNotDelegate
     default StartTransactionWithWatchesResponse startTransactionWithWatches() {
         return StartTransactionWithWatchesResponse.of(
                 startIdentifiedAtlasDbTransaction(), LockWatchState.of(ImmutableMap.of()));
     }
 
     // todo(gmaretic): implement
+    @DoNotDelegate
     default TimestampedLockResponse acquireLocksForWrites(LockRequest lockRequest) {
         return TimestampedLockResponse.of(null, lock(lockRequest));
     }


### PR DESCRIPTION
**Goals (and why)**:
This was broken, as the generated code will call the default method of the delegate instead of the enclosing class
