### PR TITLE
[Conjure Java Runtime] Part 21: Global Conjuration

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
@@ -112,7 +112,7 @@ public final class Leaders {
                 metricsManager,
                 config,
                 remotePaxosServerSpec,
-                () -> RemotingClientConfigs.ALWAYS_USE_LEGACY, // TODO (jkong): Wire this up or change it to Conjure
+                () -> RemotingClientConfigs.ALWAYS_USE_CONJURE,
                 userAgent,
                 LeadershipObserver.NO_OP);
     }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -1042,7 +1042,7 @@ public abstract class TransactionManagers {
                 .sslConfiguration(leaderConfig.sslConfiguration())
                 .build();
         ServiceCreator creator = ServiceCreator.noPayloadLimiter(
-                metricsManager, () -> serverListConfig, userAgent, () -> RemotingClientConfigs.ALWAYS_USE_LEGACY);
+                metricsManager, () -> serverListConfig, userAgent, () -> RemotingClientConfigs.ALWAYS_USE_CONJURE);
         LockService remoteLock = creator.createService(LockService.class);
         TimestampService remoteTime = creator.createService(TimestampService.class);
         TimestampManagementService remoteManagement = creator.createService(TimestampManagementService.class);

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -152,6 +152,7 @@ import com.palantir.lock.LockRequest;
 import com.palantir.lock.LockRpcClient;
 import com.palantir.lock.LockServerOptions;
 import com.palantir.lock.LockService;
+import com.palantir.lock.NamespaceAgnosticLockRpcClient;
 import com.palantir.lock.SimpleTimeDuration;
 import com.palantir.lock.client.LockRefreshingLockService;
 import com.palantir.lock.client.ProfilingTimelockService;
@@ -1043,7 +1044,8 @@ public abstract class TransactionManagers {
                 .build();
         ServiceCreator creator = ServiceCreator.noPayloadLimiter(
                 metricsManager, () -> serverListConfig, userAgent, () -> RemotingClientConfigs.ALWAYS_USE_CONJURE);
-        LockService remoteLock = creator.createService(LockService.class);
+        LockService remoteLock = new RemoteLockServiceAdapter(
+                creator.createService(NamespaceAgnosticLockRpcClient.class));
         TimestampService remoteTime = creator.createService(TimestampService.class);
         TimestampManagementService remoteManagement = creator.createService(TimestampManagementService.class);
 
@@ -1119,7 +1121,8 @@ public abstract class TransactionManagers {
                 () -> config.lock().get(),
                 userAgent,
                 () -> runtimeConfigSupplier.get().remotingClient());
-        LockService lockService = creator.createService(LockService.class);
+        LockService lockService = new RemoteLockServiceAdapter(
+                creator.createService(NamespaceAgnosticLockRpcClient.class));
         TimestampService timeService = creator.createService(TimestampService.class);
         TimestampManagementService timestampManagementService = creator.createService(TimestampManagementService.class);
 

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -974,9 +974,7 @@ public abstract class TransactionManagers {
         ServiceCreator creator = ServiceCreator.withPayloadLimiter(
                 metricsManager, timelockServerListConfig, userAgent, remotingConfigSupplier);
 
-        // I'd use instrumentTimed(), but the timed annotations are not visible in LockService. Also, most practical
-        // uses of this code path are in environments where the cost of metrics is not critical.
-        LockService lockService = AtlasDbMetrics.instrument(
+        LockService lockService = AtlasDbMetrics.instrumentTimed(
                 metricsManager.getRegistry(),
                 LockService.class,
                 RemoteLockServiceAdapter.create(creator.createService(LockRpcClient.class), timelockNamespace));

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
@@ -107,6 +107,7 @@ import com.palantir.leader.PingableLeader;
 import com.palantir.lock.LockMode;
 import com.palantir.lock.LockRequest;
 import com.palantir.lock.LockService;
+import com.palantir.lock.NamespaceAgnosticLockRpcClient;
 import com.palantir.lock.SimpleTimeDuration;
 import com.palantir.lock.StringLockDescriptor;
 import com.palantir.lock.TimeDuration;
@@ -132,10 +133,13 @@ public class TransactionManagersTest {
 
     private static final String TIMELOCK_SERVICE_FRESH_TIMESTAMP_METRIC =
             MetricRegistry.name(TimelockRpcClient.class, "getFreshTimestamp");
+    private static final String CURRENT_TIME_MILLIS = "currentTimeMillis";
     private static final String TIMELOCK_SERVICE_CURRENT_TIME_METRIC =
-            MetricRegistry.name(TimelockRpcClient.class, "currentTimeMillis");
+            MetricRegistry.name(TimelockRpcClient.class, CURRENT_TIME_MILLIS);
     private static final String LOCK_SERVICE_CURRENT_TIME_METRIC =
-            MetricRegistry.name(LockService.class, "currentTimeMillis");
+            MetricRegistry.name(LockService.class, CURRENT_TIME_MILLIS);
+    private static final String NAMESPACE_AGNOSTIC_LOCK_RPC_CLIENT_CURRENT_TIME_METRIC =
+            MetricRegistry.name(NamespaceAgnosticLockRpcClient.class, CURRENT_TIME_MILLIS);
     private static final String TIMESTAMP_SERVICE_FRESH_TIMESTAMP_METRIC =
             MetricRegistry.name(TimestampService.class, "getFreshTimestamp");
     private static final Map<String, String> CLIENT_TAGS = ImmutableMap.of("clientVersion", "Conjure-Java-Runtime");
@@ -470,7 +474,7 @@ public class TransactionManagersTest {
 
         assertThatTimeAndLockMetricsWithTagsAreRecorded(
                 TIMESTAMP_SERVICE_FRESH_TIMESTAMP_METRIC,
-                LOCK_SERVICE_CURRENT_TIME_METRIC,
+                NAMESPACE_AGNOSTIC_LOCK_RPC_CLIENT_CURRENT_TIME_METRIC,
                 CLIENT_TAGS);
     }
 

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
@@ -138,7 +138,6 @@ public class TransactionManagersTest {
             MetricRegistry.name(LockService.class, "currentTimeMillis");
     private static final String TIMESTAMP_SERVICE_FRESH_TIMESTAMP_METRIC =
             MetricRegistry.name(TimestampService.class, "getFreshTimestamp");
-    private static final Map<String, String> LEGACY_CLIENT_TAGS = ImmutableMap.of("clientVersion", "AtlasDB-Feign");
     private static final Map<String, String> CLIENT_TAGS = ImmutableMap.of("clientVersion", "Conjure-Java-Runtime");
 
     private static final String LEADER_UUID_PATH = "/leader/uuid";
@@ -472,7 +471,7 @@ public class TransactionManagersTest {
         assertThatTimeAndLockMetricsWithTagsAreRecorded(
                 TIMESTAMP_SERVICE_FRESH_TIMESTAMP_METRIC,
                 LOCK_SERVICE_CURRENT_TIME_METRIC,
-                LEGACY_CLIENT_TAGS);
+                CLIENT_TAGS);
     }
 
     @Test

--- a/atlasdb-remoting-api/src/main/java/com/palantir/atlasdb/config/AuxiliaryRemotingParameters.java
+++ b/atlasdb-remoting-api/src/main/java/com/palantir/atlasdb/config/AuxiliaryRemotingParameters.java
@@ -39,7 +39,7 @@ public interface AuxiliaryRemotingParameters {
 
     @Value.Default
     default Supplier<RemotingClientConfig> remotingClientConfig() {
-        return () -> RemotingClientConfigs.ALWAYS_USE_LEGACY;
+        return () -> RemotingClientConfigs.ALWAYS_USE_CONJURE;
     }
 
     static ImmutableAuxiliaryRemotingParameters.Builder builder() {

--- a/atlasdb-remoting-api/src/main/java/com/palantir/atlasdb/config/RemotingClientConfigs.java
+++ b/atlasdb-remoting-api/src/main/java/com/palantir/atlasdb/config/RemotingClientConfigs.java
@@ -21,11 +21,6 @@ public final class RemotingClientConfigs {
         // Constants
     }
 
-    public static final RemotingClientConfig ALWAYS_USE_LEGACY = ImmutableRemotingClientConfig.builder()
-            .maximumConjureRemotingProbability(0.0)
-            .enableLegacyClientFallback(true)
-            .build();
-
     public static final RemotingClientConfig ALWAYS_USE_CONJURE = ImmutableRemotingClientConfig.builder()
             .maximumConjureRemotingProbability(1.0)
             .enableLegacyClientFallback(false)

--- a/changelog/@unreleased/pr-4403.v2.yml
+++ b/changelog/@unreleased/pr-4403.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Services configured to use leader blocks now use CJR by default.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4403


### PR DESCRIPTION
**Goals (and why)**:
- Switch services using leader blocks to use CJR by default. 
- After this PR, all usage of AtlasDB, apart from tests or where explicitly configured, should go through CJR.

**Implementation Description (bullets)**:
- Use CJR automatically if you are using a leader block.
- Change leader block codepaths to go through `RemoteLockServiceAdapter` where needed, as we cannot accept `null`s.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- We have many existing tests that run with leader blocks.

**Concerns (what feedback would you like?)**:
- Are the existing tests sufficient?

**Where should we start reviewing?**: TransactionManagers

**Priority (whenever / two weeks / yesterday)**: this week would be nice
