### PR TITLE
[Timelock Partitioning] Part 46: Test reorganisation/refactor

### DIFF
--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/http/TestProxyUtils.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/http/TestProxyUtils.java
@@ -21,6 +21,7 @@ import com.palantir.atlasdb.config.RemotingClientConfigs;
 import com.palantir.conjure.java.api.config.service.UserAgent;
 
 public final class TestProxyUtils {
+
     public static final AuxiliaryRemotingParameters AUXILIARY_REMOTING_PARAMETERS_RETRYING
             = AuxiliaryRemotingParameters.builder()
                     .shouldLimitPayload(false)

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceIntegrationTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -31,6 +32,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -38,6 +40,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Iterables;
 import com.palantir.atlasdb.transaction.impl.TransactionConstants;
+import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.lock.HeldLocksGrant;
 import com.palantir.lock.HeldLocksToken;
 import com.palantir.lock.LockClient;
@@ -54,10 +57,10 @@ import com.palantir.lock.v2.LockRequest;
 import com.palantir.lock.v2.LockResponse;
 import com.palantir.lock.v2.LockResponseV2;
 import com.palantir.lock.v2.LockToken;
-import com.palantir.lock.v2.StartIdentifiedAtlasDbTransactionRequest;
 import com.palantir.lock.v2.StartIdentifiedAtlasDbTransactionResponse;
 import com.palantir.lock.v2.StartTransactionRequestV4;
 import com.palantir.lock.v2.StartTransactionResponseV4;
+import com.palantir.lock.v2.TimelockService;
 import com.palantir.lock.v2.WaitForLocksRequest;
 import com.palantir.lock.v2.WaitForLocksResponse;
 import com.palantir.timestamp.TimestampRange;
@@ -73,16 +76,26 @@ public class AsyncTimelockServiceIntegrationTest extends AbstractAsyncTimelockSe
     private static final LockClient TEST_CLIENT_2 = LockClient.of("test2");
     private static final LockClient TEST_CLIENT_3 = LockClient.of("test3");
 
+    private final ExecutorService executor = PTExecutors.newCachedThreadPool();
+
+    private NamespacedClients namespace;
+
+    @Before
+    public void setUp() {
+        namespace = cluster.client("namespace");
+    }
+
     @After
     public void after() {
-        assertThat(cluster.lockService().getTokens(TEST_CLIENT)).isEmpty();
+        assertThat(namespace.legacyLockService().getTokens(TEST_CLIENT)).isEmpty();
+        executor.shutdown();
     }
 
     @Test
     public void canLockRefreshAndUnlock() {
-        LockToken token = cluster.lock(requestFor(LOCK_A)).getToken();
-        boolean wasRefreshed = cluster.refreshLockLease(token);
-        boolean wasUnlocked = cluster.unlock(token);
+        LockToken token = namespace.lock(requestFor(LOCK_A)).getToken();
+        boolean wasRefreshed = namespace.refreshLockLease(token);
+        boolean wasUnlocked = namespace.unlock(token);
 
         assertTrue(wasRefreshed);
         assertTrue(wasUnlocked);
@@ -90,63 +103,70 @@ public class AsyncTimelockServiceIntegrationTest extends AbstractAsyncTimelockSe
 
     @Test
     public void locksAreExclusive() {
-        LockToken token = cluster.lock(requestFor(LOCK_A)).getToken();
-        Future<LockToken> futureToken = cluster.lockAsync(requestFor(LOCK_A))
+        LockToken token = namespace.lock(requestFor(LOCK_A)).getToken();
+        Future<LockToken> futureToken = lockAsync(requestFor(LOCK_A))
                 .thenApply(LockResponse::getToken);
 
         assertNotYetLocked(futureToken);
 
-        cluster.unlock(token);
+        namespace.unlock(token);
 
         assertLockedAndUnlock(futureToken);
     }
 
+    private CompletableFuture<LockResponse> lockAsync(LockRequest requestV2) {
+        return CompletableFuture.supplyAsync(() -> namespace.lock(requestV2), executor);
+    }
+
     @Test
     public void canLockImmutableTimestamp() {
-        LockImmutableTimestampResponse response1 = cluster.timelockService()
+        LockImmutableTimestampResponse response1 = namespace.timelockService()
                 .lockImmutableTimestamp();
-        LockImmutableTimestampResponse response2 = cluster.timelockService()
+        LockImmutableTimestampResponse response2 = namespace.timelockService()
                 .lockImmutableTimestamp();
 
-        long immutableTs = cluster.timelockService().getImmutableTimestamp();
+        long immutableTs = namespace.timelockService().getImmutableTimestamp();
         assertThat(immutableTs).isEqualTo(response1.getImmutableTimestamp());
 
-        cluster.unlock(response1.getLock());
+        namespace.unlock(response1.getLock());
 
         assertThat(immutableTs).isEqualTo(response2.getImmutableTimestamp());
 
-        cluster.unlock(response2.getLock());
+        namespace.unlock(response2.getLock());
     }
 
     @Test
     public void batchedStartTransactionCallShouldLockImmutableTimestamp() {
+        // requestor id corresponds to an instance of the timelock service client
         StartTransactionRequestV4 request = StartTransactionRequestV4.createForRequestor(
                 UUID.randomUUID(),
                 123);
 
-        LockImmutableTimestampResponse response1 = cluster.namespacedClient()
+        LockImmutableTimestampResponse response1 = namespace.namespacedTimelockRpcClient()
                 .startTransactions(request)
                 .immutableTimestamp();
 
-        LockImmutableTimestampResponse response2 = cluster.namespacedClient()
+        LockImmutableTimestampResponse response2 = namespace.namespacedTimelockRpcClient()
                 .startTransactions(request)
                 .immutableTimestamp();
 
-        long immutableTs = cluster.timelockService().getImmutableTimestamp();
+        // above are two *separate* batches
+
+        long immutableTs = namespace.timelockService().getImmutableTimestamp();
         assertThat(immutableTs).isEqualTo(response1.getImmutableTimestamp());
 
-        cluster.namespacedClient().unlock(ImmutableSet.of(response1.getLock()));
+        namespace.unlock(response1.getLock());
 
         assertThat(immutableTs).isEqualTo(response2.getImmutableTimestamp());
 
-        cluster.namespacedClient().unlock(ImmutableSet.of(response2.getLock()));
+        namespace.unlock(response2.getLock());
 
     }
 
     @Test
     public void immutableTimestampIsGreaterThanFreshTimestampWhenNotLocked() {
-        long freshTs = cluster.getFreshTimestamp();
-        long immutableTs = cluster.timelockService().getImmutableTimestamp();
+        long freshTs = namespace.getFreshTimestamp();
+        long immutableTs = namespace.timelockService().getImmutableTimestamp();
 
         assertThat(immutableTs).isGreaterThan(freshTs);
     }
@@ -159,7 +179,7 @@ public class AsyncTimelockServiceIntegrationTest extends AbstractAsyncTimelockSe
         }
         // Catching any exception since this currently is an error deserialization exception
         // until we stop requiring http-remoting2 errors
-        assertThatThrownBy(() -> cluster.lockService().getMinLockedInVersionId("foo"))
+        assertThatThrownBy(() -> namespace.legacyLockService().getMinLockedInVersionId("foo"))
                 .isInstanceOf(Exception.class);
     }
 
@@ -169,82 +189,82 @@ public class AsyncTimelockServiceIntegrationTest extends AbstractAsyncTimelockSe
             // will fail - ensuring this fails is covered by cannotRetrieveImmutableTimestampViaSyncApiForAsyncService
             return;
         }
-        cluster.lockService().getMinLockedInVersionId("foo");
+        namespace.legacyLockService().getMinLockedInVersionId("foo");
     }
 
     @Test
     public void canWaitForLocks() {
-        LockToken token = cluster.lock(requestFor(LOCK_A, LOCK_B)).getToken();
+        LockToken token = namespace.lock(requestFor(LOCK_A, LOCK_B)).getToken();
 
-        CompletableFuture<WaitForLocksResponse> future = cluster.waitForLocksAsync(waitRequestFor(LOCK_A, LOCK_B));
+        CompletableFuture<WaitForLocksResponse> future = waitForLocksAsync(waitRequestFor(LOCK_A, LOCK_B));
         assertNotDone(future);
 
-        cluster.unlock(token);
+        namespace.unlock(token);
 
         assertDone(future);
         assertThat(future.join().wasSuccessful()).isTrue();
     }
 
+    private CompletableFuture<WaitForLocksResponse> waitForLocksAsync(WaitForLocksRequest waitForLocksRequest) {
+        return CompletableFuture.supplyAsync(() -> namespace.waitForLocks(waitForLocksRequest), executor);
+    }
+
     @Test
     public void canGetTimestamps() {
         List<Long> timestamps = ImmutableList.of(
-                cluster.getFreshTimestamp(),
-                cluster.timelockService().getFreshTimestamp(),
-                cluster.getFreshTimestamp(),
-                cluster.timelockService().getFreshTimestamp());
+                namespace.getFreshTimestamp(),
+                namespace.timelockService().getFreshTimestamp(),
+                namespace.getFreshTimestamp(),
+                namespace.timelockService().getFreshTimestamp());
 
-        long lastTs = -1;
-        for (long ts : timestamps) {
-            assertThat(ts).isGreaterThan(lastTs);
-            lastTs = ts;
-        }
+        assertThat(timestamps).isSorted();
     }
 
     @Test
     public void canGetBatchTimestamps() {
-        TimestampRange range1 = cluster.getFreshTimestamps(5);
-        TimestampRange range2 = cluster.timelockService().getFreshTimestamps(5);
+        TimestampRange range1 = namespace.getFreshTimestamps(5);
+        TimestampRange range2 = namespace.getFreshTimestamps(5);
 
         assertThat(range1.getUpperBound()).isLessThan(range2.getLowerBound());
     }
 
     @Test
     public void lockRequestCanTimeOut() {
-        LockToken token = cluster.lock(requestFor(LOCK_A)).getToken();
-        LockResponse token2 = cluster.lock(requestFor(SHORT_TIMEOUT, LOCK_A));
+        LockToken token = namespace.lock(requestFor(LOCK_A)).getToken();
+        LockResponse token2 = namespace.lock(requestFor(SHORT_TIMEOUT, LOCK_A));
 
         assertThat(token2.wasSuccessful()).isFalse();
-        cluster.unlock(token);
+        namespace.unlock(token);
     }
 
     @Test
     public void waitForLocksRequestCanTimeOut() {
-        LockToken token = cluster.lock(requestFor(LOCK_A)).getToken();
-        WaitForLocksResponse response = cluster.waitForLocks(waitRequestFor(SHORT_TIMEOUT, LOCK_A));
+        LockToken token = namespace.lock(requestFor(LOCK_A)).getToken();
+        WaitForLocksResponse response = namespace.waitForLocks(waitRequestFor(SHORT_TIMEOUT, LOCK_A));
 
         assertThat(response.wasSuccessful()).isFalse();
-        cluster.unlock(token);
+        namespace.unlock(token);
     }
 
     @Test
     public void canGetCurrentTimeMillis() {
-        assertThat(cluster.lockService().currentTimeMillis()).isGreaterThan(0L);
-        assertThat(cluster.timelockService().currentTimeMillis()).isGreaterThan(0L);
+        assertThat(namespace.legacyLockService().currentTimeMillis()).isGreaterThan(0L);
+        assertThat(namespace.timelockService().currentTimeMillis()).isGreaterThan(0L);
     }
 
     @Test
     public void canPerformLockAndUnlock() throws InterruptedException {
         HeldLocksToken token1 = lockWithFullResponse(requestForWriteLock(LOCK_A), TEST_CLIENT);
-        cluster.lockService().unlock(token1);
+        namespace.legacyLockService().unlock(token1);
         HeldLocksToken token2 = lockWithFullResponse(requestForWriteLock(LOCK_A), TEST_CLIENT);
-        cluster.lockService().unlockSimple(SimpleHeldLocksToken.fromHeldLocksToken(token2));
+        namespace.legacyLockService().unlockSimple(SimpleHeldLocksToken.fromHeldLocksToken(token2));
     }
 
     @Test
     public void canPerformLockAndRefreshLock() throws InterruptedException {
         HeldLocksToken token1 = lockWithFullResponse(requestForWriteLock(LOCK_A), TEST_CLIENT);
         LockRefreshToken token = token1.getLockRefreshToken();
-        Set<LockRefreshToken> lockRefreshTokens = cluster.lockService().refreshLockRefreshTokens(
+        Set<LockRefreshToken> lockRefreshTokens = namespace.legacyLockService().refreshLockRefreshTokens(
                 ImmutableList.of(token));
         assertThat(lockRefreshTokens).contains(token);
 
@@ -254,8 +274,8 @@ public class AsyncTimelockServiceIntegrationTest extends AbstractAsyncTimelockSe
     @Test
     public void unlockAndFreezeDoesNotAllowRefreshes() throws InterruptedException {
         HeldLocksToken token = lockWithFullResponse(requestForWriteLock(LOCK_A), TEST_CLIENT);
-        cluster.lockService().unlockAndFreeze(token);
-        Set<LockRefreshToken> lockRefreshTokens = cluster.lockService()
+        namespace.legacyLockService().unlockAndFreeze(token);
+        Set<LockRefreshToken> lockRefreshTokens = namespace.legacyLockService()
                 .refreshLockRefreshTokens(ImmutableList.of(token.getLockRefreshToken()));
         assertThat(lockRefreshTokens).isEmpty();
     }
@@ -265,12 +285,12 @@ public class AsyncTimelockServiceIntegrationTest extends AbstractAsyncTimelockSe
         HeldLocksToken token1 = lockWithFullResponse(requestForWriteLock(LOCK_A), TEST_CLIENT);
         HeldLocksToken token2 = lockWithFullResponse(requestForWriteLock(LOCK_B), TEST_CLIENT);
 
-        Set<HeldLocksToken> tokens = cluster.lockService().getTokens(TEST_CLIENT);
+        Set<HeldLocksToken> tokens = namespace.legacyLockService().getTokens(TEST_CLIENT);
         assertThat(tokens.stream()
                 .map(token -> Iterables.getOnlyElement(token.getLocks()).getLockDescriptor())
                 .collect(Collectors.toList())).containsExactlyInAnyOrder(LOCK_A, LOCK_B);
 
-        Set<HeldLocksToken> heldLocksTokens = cluster.lockService().refreshTokens(tokens);
+        Set<HeldLocksToken> heldLocksTokens = namespace.legacyLockService().refreshTokens(tokens);
         assertThat(heldLocksTokens.stream()
                 .map(token -> Iterables.getOnlyElement(token.getLocks()).getLockDescriptor())
                 .collect(Collectors.toList())).containsExactlyInAnyOrder(LOCK_A, LOCK_B);
@@ -281,30 +301,31 @@ public class AsyncTimelockServiceIntegrationTest extends AbstractAsyncTimelockSe
     @Test
     public void lockGrantsCanBeServedAndRefreshed() throws InterruptedException {
         HeldLocksToken heldLocksToken = lockWithFullResponse(requestForReadLock(LOCK_A), TEST_CLIENT);
-        HeldLocksGrant heldLocksGrant = cluster.lockService().convertToGrant(heldLocksToken);
+        HeldLocksGrant heldLocksGrant = namespace.legacyLockService().convertToGrant(heldLocksToken);
 
-        assertThat(cluster.lockService().getTokens(TEST_CLIENT)).isEmpty();
+        assertThat(namespace.legacyLockService().getTokens(TEST_CLIENT)).isEmpty();
 
-        HeldLocksGrant refreshedLockGrant = cluster.lockService().refreshGrant(heldLocksGrant);
+        HeldLocksGrant refreshedLockGrant = namespace.legacyLockService().refreshGrant(heldLocksGrant);
         assertThat(refreshedLockGrant).isEqualTo(heldLocksGrant);
 
-        HeldLocksGrant refreshedLockGrant2 = cluster.lockService().refreshGrant(heldLocksGrant.getGrantId());
+        HeldLocksGrant refreshedLockGrant2 = namespace.legacyLockService().refreshGrant(heldLocksGrant.getGrantId());
         assertThat(refreshedLockGrant2).isEqualTo(heldLocksGrant);
 
-        cluster.lockService().useGrant(TEST_CLIENT_2, heldLocksGrant);
-        assertThat(Iterables.getOnlyElement(cluster.lockService().getTokens(TEST_CLIENT_2)).getLockDescriptors())
+        namespace.legacyLockService().useGrant(TEST_CLIENT_2, heldLocksGrant);
+        assertThat(Iterables.getOnlyElement(namespace.legacyLockService().getTokens(TEST_CLIENT_2)).getLockDescriptors())
                 .contains(LOCK_A);
 
         // Catching any exception since this currently is an error deserialization exception
         // until we stop requiring http-remoting2 errors
-        assertThatThrownBy(() -> cluster.lockService().useGrant(TEST_CLIENT_3, heldLocksGrant.getGrantId()))
+        assertThatThrownBy(
+                () -> namespace.legacyLockService().useGrant(TEST_CLIENT_3, heldLocksGrant.getGrantId()))
                 .isInstanceOf(Exception.class);
     }
 
     @Test
     public void getMinLockedInVersionIdReturnsNullIfNoVersionIdsAreSpecified() throws InterruptedException {
         HeldLocksToken token = lockWithFullResponse(requestForReadLock(LOCK_A), TEST_CLIENT);
-        assertThat(cluster.lockService().getMinLockedInVersionId(TEST_CLIENT)).isNull();
+        assertThat(namespace.legacyLockService().getMinLockedInVersionId(TEST_CLIENT)).isNull();
         unlock(token);
     }
 
@@ -312,7 +333,7 @@ public class AsyncTimelockServiceIntegrationTest extends AbstractAsyncTimelockSe
     public void getMinLockedInVersionIdReturnsValidValues() throws InterruptedException {
         HeldLocksToken token1 = lockWithFullResponse(requestForReadLock(LOCK_A, 10L), TEST_CLIENT);
         HeldLocksToken token2 = lockWithFullResponse(requestForReadLock(LOCK_B, 12L), TEST_CLIENT);
-        assertThat(cluster.lockService().getMinLockedInVersionId(TEST_CLIENT)).isEqualTo(10L);
+        assertThat(namespace.legacyLockService().getMinLockedInVersionId(TEST_CLIENT)).isEqualTo(10L);
         unlock(token1, token2);
     }
 
@@ -320,40 +341,40 @@ public class AsyncTimelockServiceIntegrationTest extends AbstractAsyncTimelockSe
     public void getMinLockedInVersionIdReturnsValidValuesForAnonymousClient() throws InterruptedException {
         HeldLocksToken token1 = lockWithFullResponse(requestForReadLock(LOCK_A, 10L), LockClient.ANONYMOUS);
         HeldLocksToken token2 = lockWithFullResponse(requestForReadLock(LOCK_B, 12L), LockClient.ANONYMOUS);
-        assertThat(cluster.lockService().getMinLockedInVersionId()).isEqualTo(10L);
+        assertThat(namespace.legacyLockService().getMinLockedInVersionId()).isEqualTo(10L);
         unlock(token1, token2);
     }
 
     @Test
     public void testGetLockServerOptions() {
-        assertThat(cluster.lockService().getLockServerOptions())
+        assertThat(namespace.legacyLockService().getLockServerOptions())
                 .isEqualTo(LockServerOptions.builder().randomBitCount(127).build());
     }
 
     @Test
     public void testCurrentTimeMillis() {
-        assertThat(cluster.lockService().currentTimeMillis()).isPositive();
+        assertThat(namespace.legacyLockService().currentTimeMillis()).isPositive();
     }
 
     @Test
     public void lockRequestsToRpcClientAreIdempotent() {
-        IdentifiedLockRequest firstRequest = IdentifiedLockRequest.from(requestFor(LOCK_A));
-
-        LockToken token = getToken(cluster.namespacedClient().lock(firstRequest));
+        LockToken token = namespace.lock(requestFor(LOCK_A)).getToken();
 
         IdentifiedLockRequest secondRequest = IdentifiedLockRequest.from(requestFor(LOCK_A));
-        CompletableFuture<LockResponseV2> responseFuture =
-                cluster.runWithRpcClientAsync(rpcClient -> rpcClient.lock(secondRequest));
-        CompletableFuture<LockResponseV2> duplicateResponseFuture =
-                cluster.runWithRpcClientAsync(rpcClient -> rpcClient.lock(secondRequest));
+        CompletableFuture<LockResponseV2> responseFuture = lockWithRpcClientAsync(secondRequest);
+        CompletableFuture<LockResponseV2> duplicateResponseFuture = lockWithRpcClientAsync(secondRequest);
 
-        cluster.namespacedClient().unlock(ImmutableSet.of(token));
+        namespace.unlock(token);
 
         LockResponseV2 response = responseFuture.join();
         LockResponseV2 duplicateResponse = duplicateResponseFuture.join();
         assertThat(response).isEqualTo(duplicateResponse);
 
-        cluster.namespacedClient().unlock(ImmutableSet.of(getToken(response)));
+        namespace.unlock(getToken(response));
+    }
+
+    private CompletableFuture<LockResponseV2> lockWithRpcClientAsync(IdentifiedLockRequest lockRequest) {
+        return CompletableFuture.supplyAsync(() -> namespace.namespacedTimelockRpcClient().lock(lockRequest), executor);
     }
 
     private static LockToken getToken(LockResponseV2 responseV2) {
@@ -368,33 +389,34 @@ public class AsyncTimelockServiceIntegrationTest extends AbstractAsyncTimelockSe
     public void lockSucceedsOnlyOnce() {
         LockRequest request = requestFor(SHORT_TIMEOUT, LOCK_A);
 
-        LockResponse response = cluster.lock(request);
-        LockResponse duplicateResponse = cluster.lock(request);
+        LockResponse response = namespace.lock(request);
+        LockResponse duplicateResponse = namespace.lock(request);
 
         assertThat(response.wasSuccessful()).isTrue();
         assertThat(duplicateResponse.wasSuccessful()).isFalse();
 
-        cluster.unlock(response.getToken());
+        namespace.unlock(response.getToken());
     }
 
     @Test
     public void waitForLockRequestsAreIdempotent() {
-        LockToken token = cluster.lock(requestFor(LOCK_A)).getToken();
+        LockToken token = namespace.lock(requestFor(LOCK_A)).getToken();
 
         WaitForLocksRequest request = waitRequestFor(LOCK_A);
-        CompletableFuture<WaitForLocksResponse> response = cluster.waitForLocksAsync(request);
-        CompletableFuture<WaitForLocksResponse> duplicateResponse = cluster.waitForLocksAsync(request);
+        CompletableFuture<WaitForLocksResponse> response = waitForLocksAsync(request);
+        CompletableFuture<WaitForLocksResponse> duplicateResponse = waitForLocksAsync(request);
 
-        cluster.unlock(token);
+        namespace.unlock(token);
 
         assertThat(response.join()).isEqualTo(duplicateResponse.join());
     }
 
     @Test
     public void startIdentifiedAtlasDbTransactionGivesUsTimestampsInSequence() {
-        UUID requestorUuid = UUID.randomUUID();
-        StartIdentifiedAtlasDbTransactionResponse firstResponse = startIdentifiedAtlasDbTransaction(requestorUuid);
-        StartIdentifiedAtlasDbTransactionResponse secondResponse = startIdentifiedAtlasDbTransaction(requestorUuid);
+        StartIdentifiedAtlasDbTransactionResponse firstResponse =
+                namespace.timelockService().startIdentifiedAtlasDbTransaction();
+        StartIdentifiedAtlasDbTransactionResponse secondResponse =
+                namespace.timelockService().startIdentifiedAtlasDbTransaction();
 
         // Note that we technically cannot guarantee an ordering between the fresh timestamp on response 1 and the
         // immutable timestamp on response 2. Most of the time, we will have IT on response 2 = IT on response 1
@@ -413,9 +435,10 @@ public class AsyncTimelockServiceIntegrationTest extends AbstractAsyncTimelockSe
 
     @Test
     public void startIdentifiedAtlasDbTransactionGivesUsStartTimestampsInTheSamePartition() {
-        UUID requestorUuid = UUID.randomUUID();
-        StartIdentifiedAtlasDbTransactionResponse firstResponse = startIdentifiedAtlasDbTransaction(requestorUuid);
-        StartIdentifiedAtlasDbTransactionResponse secondResponse = startIdentifiedAtlasDbTransaction(requestorUuid);
+        StartIdentifiedAtlasDbTransactionResponse firstResponse =
+                namespace.timelockService().startIdentifiedAtlasDbTransaction();
+        StartIdentifiedAtlasDbTransactionResponse secondResponse =
+                namespace.timelockService().startIdentifiedAtlasDbTransaction();
 
         assertThat(firstResponse.startTimestampAndPartition().partition())
                 .isEqualTo(secondResponse.startTimestampAndPartition().partition());
@@ -423,30 +446,29 @@ public class AsyncTimelockServiceIntegrationTest extends AbstractAsyncTimelockSe
 
     @Test
     public void temporalOrderingIsPreservedWhenMixingStandardTimestampAndIdentifiedTimestampRequests() {
-        UUID requestorUuid = UUID.randomUUID();
         List<Long> temporalSequence = ImmutableList.of(
-                cluster.getFreshTimestamp(),
-                getStartTimestampFromIdentifiedAtlasDbTransaction(requestorUuid),
-                cluster.getFreshTimestamp(),
-                getStartTimestampFromIdentifiedAtlasDbTransaction(requestorUuid),
-                cluster.getFreshTimestamp());
+                namespace.getFreshTimestamp(),
+                namespace.timelockService().startIdentifiedAtlasDbTransaction().startTimestampAndPartition().timestamp(),
+                namespace.getFreshTimestamp(),
+                namespace.timelockService().startIdentifiedAtlasDbTransaction().startTimestampAndPartition().timestamp(),
+                namespace.getFreshTimestamp());
 
         assertThat(temporalSequence).isSorted();
     }
 
     @Test
-    public void distinctClientsStillShareTheSameSequenceOfTimestamps() {
-        UUID requestor1 = UUID.randomUUID();
-        UUID requestor2 = UUID.randomUUID();
+    public void distinctClientsForTheSameNamespaceStillShareTheSameSequenceOfTimestamps() {
+        TimelockService independentClient1 = cluster.uncachedNamespacedClients(namespace.namespace()).timelockService();
+        TimelockService independentClient2 = cluster.uncachedNamespacedClients(namespace.namespace()).timelockService();
 
         List<Long> temporalSequence = ImmutableList.of(
-                getStartTimestampFromIdentifiedAtlasDbTransaction(requestor1),
-                getStartTimestampFromIdentifiedAtlasDbTransaction(requestor1),
-                getStartTimestampFromIdentifiedAtlasDbTransaction(requestor2),
-                getStartTimestampFromIdentifiedAtlasDbTransaction(requestor2),
-                getStartTimestampFromIdentifiedAtlasDbTransaction(requestor1),
-                getStartTimestampFromIdentifiedAtlasDbTransaction(requestor2),
-                getStartTimestampFromIdentifiedAtlasDbTransaction(requestor1));
+                independentClient1.startIdentifiedAtlasDbTransaction().startTimestampAndPartition().timestamp(),
+                independentClient1.startIdentifiedAtlasDbTransaction().startTimestampAndPartition().timestamp(),
+                independentClient2.startIdentifiedAtlasDbTransaction().startTimestampAndPartition().timestamp(),
+                independentClient2.startIdentifiedAtlasDbTransaction().startTimestampAndPartition().timestamp(),
+                independentClient1.startIdentifiedAtlasDbTransaction().startTimestampAndPartition().timestamp(),
+                independentClient2.startIdentifiedAtlasDbTransaction().startTimestampAndPartition().timestamp(),
+                independentClient1.startIdentifiedAtlasDbTransaction().startTimestampAndPartition().timestamp());
 
         assertThat(temporalSequence).isSorted();
     }
@@ -492,7 +514,7 @@ public class AsyncTimelockServiceIntegrationTest extends AbstractAsyncTimelockSe
 
     private HeldLocksToken lockWithFullResponse(com.palantir.lock.LockRequest request,
             LockClient client) throws InterruptedException {
-        return cluster.lockService()
+        return namespace.legacyLockService()
                 .lockWithFullLockResponse(client, request)
                 .getToken();
     }
@@ -537,7 +559,7 @@ public class AsyncTimelockServiceIntegrationTest extends AbstractAsyncTimelockSe
     }
 
     private void assertLockedAndUnlock(Future<LockToken> futureToken) {
-        cluster.unlock(assertLocked(futureToken));
+        namespace.unlock(assertLocked(futureToken));
     }
 
     private static LockToken assertLocked(Future<LockToken> futureToken) {
@@ -559,7 +581,7 @@ public class AsyncTimelockServiceIntegrationTest extends AbstractAsyncTimelockSe
 
     private void unlock(HeldLocksToken... tokens) {
         for (HeldLocksToken token : tokens) {
-            cluster.lockService().unlock(token);
+            namespace.legacyLockService().unlock(token);
         }
     }
 
@@ -567,18 +589,10 @@ public class AsyncTimelockServiceIntegrationTest extends AbstractAsyncTimelockSe
         StartTransactionRequestV4 request = StartTransactionRequestV4.createForRequestor(
                 requestorUuid,
                 numRequestedTimestamps);
-        StartTransactionResponseV4 response = cluster.namespacedClient().startTransactions(request);
+        StartTransactionResponseV4 response = namespace.namespacedTimelockRpcClient().startTransactions(request);
         return response.timestamps().stream()
                 .boxed()
                 .collect(Collectors.toList());
     }
 
-    private StartIdentifiedAtlasDbTransactionResponse startIdentifiedAtlasDbTransaction(UUID requestorUuid) {
-        return cluster.startIdentifiedAtlasDbTransaction(
-                StartIdentifiedAtlasDbTransactionRequest.createForRequestor(requestorUuid));
-    }
-
-    private long getStartTimestampFromIdentifiedAtlasDbTransaction(UUID requestorUuid) {
-        return startIdentifiedAtlasDbTransaction(requestorUuid).startTimestampAndPartition().timestamp();
-    }
 }

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceIntegrationTest.java
@@ -82,7 +82,7 @@ public class AsyncTimelockServiceIntegrationTest extends AbstractAsyncTimelockSe
 
     @Before
     public void setUp() {
-        namespace = cluster.client("namespace");
+        namespace = cluster.clientForRandomNamespace();
     }
 
     @After
@@ -164,15 +164,10 @@ public class AsyncTimelockServiceIntegrationTest extends AbstractAsyncTimelockSe
 
     @Test
     public void immutableTimestampIsGreaterThanFreshTimestampWhenNotLocked() {
-        String randomNamespace = randomNamespace();
-        long freshTs = cluster.client(randomNamespace).getFreshTimestamp();
-        long immutableTs = cluster.client(randomNamespace).timelockService().getImmutableTimestamp();
+        long freshTs = namespace.getFreshTimestamp();
+        long immutableTs = namespace.timelockService().getImmutableTimestamp();
 
         assertThat(immutableTs).isGreaterThan(freshTs);
-    }
-
-    private static String randomNamespace() {
-        return UUID.randomUUID().toString();
     }
 
     @Test

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceIntegrationTest.java
@@ -50,6 +50,7 @@ import com.palantir.lock.LockRefreshToken;
 import com.palantir.lock.LockServerOptions;
 import com.palantir.lock.SimpleHeldLocksToken;
 import com.palantir.lock.SimpleTimeDuration;
+import com.palantir.lock.SortedLockCollection;
 import com.palantir.lock.StringLockDescriptor;
 import com.palantir.lock.client.IdentifiedLockRequest;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
@@ -312,8 +313,10 @@ public class AsyncTimelockServiceIntegrationTest extends AbstractAsyncTimelockSe
         assertThat(refreshedLockGrant2).isEqualTo(heldLocksGrant);
 
         namespace.legacyLockService().useGrant(TEST_CLIENT_2, heldLocksGrant);
-        assertThat(Iterables.getOnlyElement(namespace.legacyLockService().getTokens(TEST_CLIENT_2)).getLockDescriptors())
-                .contains(LOCK_A);
+
+        SortedLockCollection<LockDescriptor> lockDescriptors =
+                Iterables.getOnlyElement(namespace.legacyLockService().getTokens(TEST_CLIENT_2)).getLockDescriptors();
+        assertThat(lockDescriptors).contains(LOCK_A);
 
         // Catching any exception since this currently is an error deserialization exception
         // until we stop requiring http-remoting2 errors
@@ -448,9 +451,11 @@ public class AsyncTimelockServiceIntegrationTest extends AbstractAsyncTimelockSe
     public void temporalOrderingIsPreservedWhenMixingStandardTimestampAndIdentifiedTimestampRequests() {
         List<Long> temporalSequence = ImmutableList.of(
                 namespace.getFreshTimestamp(),
-                namespace.timelockService().startIdentifiedAtlasDbTransaction().startTimestampAndPartition().timestamp(),
+                namespace.timelockService().startIdentifiedAtlasDbTransaction().startTimestampAndPartition()
+                        .timestamp(),
                 namespace.getFreshTimestamp(),
-                namespace.timelockService().startIdentifiedAtlasDbTransaction().startTimestampAndPartition().timestamp(),
+                namespace.timelockService().startIdentifiedAtlasDbTransaction().startTimestampAndPartition()
+                        .timestamp(),
                 namespace.getFreshTimestamp());
 
         assertThat(temporalSequence).isSorted();

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/IsolatedPaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/IsolatedPaxosTimeLockServerIntegrationTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Optional;
 
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -39,7 +40,6 @@ import com.palantir.paxos.PaxosLearner;
  * However it should still be pingable and should be able to participate in Paxos as well.
  */
 public class IsolatedPaxosTimeLockServerIntegrationTest {
-    private static final String CLIENT = "isolated";
 
     private static final TestableTimelockCluster CLUSTER = new TestableTimelockCluster(
             "https://localhost",
@@ -50,21 +50,29 @@ public class IsolatedPaxosTimeLockServerIntegrationTest {
     @ClassRule
     public static final RuleChain ruleChain = CLUSTER.getRuleChain();
 
+    private NamespacedClients namespace;
+
+    @Before
+    public void setUp() {
+        namespace = CLUSTER.clientForRandomNamespace();
+    }
+
     @Test
     public void cannotIssueTimestampsWithoutQuorum() {
-        assertThatThrownBy(() -> CLUSTER.client(CLIENT).getFreshTimestamp())
+        assertThatThrownBy(() -> CLUSTER.clientForRandomNamespace().getFreshTimestamp())
                 .satisfies(ExceptionMatchers::isRetryableExceptionWhereLeaderCannotBeFound);
     }
 
     @Test
     public void cannotIssueLocksWithoutQuorum() {
-        assertThatThrownBy(() -> CLUSTER.client(CLIENT).timelockService().currentTimeMillis())
+        assertThatThrownBy(() -> CLUSTER.clientForRandomNamespace().timelockService().currentTimeMillis())
                 .satisfies(ExceptionMatchers::isRetryableExceptionWhereLeaderCannotBeFound);
     }
 
     @Test
     public void cannotPerformTimestampManagementWithoutQuorum() {
-        assertThatThrownBy(() -> CLUSTER.client(CLIENT).timestampManagementService().fastForwardTimestamp(1000L))
+        assertThatThrownBy(
+                () -> CLUSTER.clientForRandomNamespace().timestampManagementService().fastForwardTimestamp(1000L))
                 .satisfies(ExceptionMatchers::isRetryableExceptionWhereLeaderCannotBeFound);
     }
 
@@ -86,7 +94,7 @@ public class IsolatedPaxosTimeLockServerIntegrationTest {
         learner.getGreatestLearnedValue();
     }
 
-    private static <T> T createProxyForInternalNamespacedTestService(Class<T> clazz) {
+    private <T> T createProxyForInternalNamespacedTestService(Class<T> clazz) {
         return AtlasDbHttpClients.createProxy(
                 MetricsManagers.createForTests(),
                 Optional.of(TestProxies.TRUST_CONTEXT),
@@ -94,7 +102,7 @@ public class IsolatedPaxosTimeLockServerIntegrationTest {
                         SERVER.serverHolder().getTimelockPort(),
                         PaxosTimeLockConstants.INTERNAL_NAMESPACE,
                         PaxosTimeLockConstants.CLIENT_PAXOS_NAMESPACE,
-                        CLIENT),
+                        namespace.namespace()),
                 clazz,
                 TestProxyUtils.AUXILIARY_REMOTING_PARAMETERS_RETRYING);
     }

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/IsolatedPaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/IsolatedPaxosTimeLockServerIntegrationTest.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.timelock;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Optional;
@@ -51,25 +52,26 @@ public class IsolatedPaxosTimeLockServerIntegrationTest {
 
     @Test
     public void cannotIssueTimestampsWithoutQuorum() {
-        assertThatThrownBy(() -> SERVER.getFreshTimestamp())
+        assertThatThrownBy(() -> CLUSTER.client(CLIENT).getFreshTimestamp())
                 .satisfies(ExceptionMatchers::isRetryableExceptionWhereLeaderCannotBeFound);
     }
 
     @Test
     public void cannotIssueLocksWithoutQuorum() {
-        assertThatThrownBy(() -> SERVER.lockService().currentTimeMillis())
+        assertThatThrownBy(() -> CLUSTER.client(CLIENT).timelockService().currentTimeMillis())
                 .satisfies(ExceptionMatchers::isRetryableExceptionWhereLeaderCannotBeFound);
     }
 
     @Test
     public void cannotPerformTimestampManagementWithoutQuorum() {
-        assertThatThrownBy(() -> SERVER.timestampManagementService().fastForwardTimestamp(1000L))
+        assertThatThrownBy(() -> CLUSTER.client(CLIENT).timestampManagementService().fastForwardTimestamp(1000L))
                 .satisfies(ExceptionMatchers::isRetryableExceptionWhereLeaderCannotBeFound);
     }
 
     @Test
     public void canPingWithoutQuorum() {
-        SERVER.leaderPing(); // should succeed
+        assertThatCode(SERVER.pingableLeader()::ping)
+                .doesNotThrowAnyException();
     }
 
     @Test

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/NonBlockingAppenderIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/NonBlockingAppenderIntegrationTest.java
@@ -35,7 +35,7 @@ public class NonBlockingAppenderIntegrationTest {
 
     @Test
     public void canDeserializeConfigAndStart() {
-        CLUSTER.client("namespace").getFreshTimestamp();
+        CLUSTER.clientForRandomNamespace().getFreshTimestamp();
     }
 
 }

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/NonBlockingAppenderIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/NonBlockingAppenderIntegrationTest.java
@@ -25,8 +25,6 @@ public class NonBlockingAppenderIntegrationTest {
             "https://localhost",
             "paxosSingleServerWithNonBlockingAppender.yml");
 
-    private static final TestableTimelockServer SERVER = CLUSTER.servers().get(0);
-
     @ClassRule
     public static final RuleChain ruleChain = CLUSTER.getRuleChain();
 
@@ -37,7 +35,7 @@ public class NonBlockingAppenderIntegrationTest {
 
     @Test
     public void canDeserializeConfigAndStart() {
-        SERVER.getFreshTimestamp();
+        CLUSTER.client("namespace").getFreshTimestamp();
     }
 
 }

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
@@ -73,12 +73,10 @@ public class PaxosTimeLockServerIntegrationTest {
     private static final TimeLockServerHolder TIMELOCK_SERVER_HOLDER =
             new TimeLockServerHolder(TEMPORARY_CONFIG_HOLDER::getTemporaryConfigFileLocation);
     private static final TestableTimelockServer TIMELOCK =
-            new TestableTimelockServer("https://localhost:", TIMELOCK_SERVER_HOLDER);
+            new TestableTimelockServer("https://localhost", TIMELOCK_SERVER_HOLDER);
 
-    private static final NamespacedClients NAMESPACE_2 = TIMELOCK.client(CLIENT_2);
-    private static final NamespacedClients NAMESPACE_1 = TIMELOCK.client(CLIENT_1);
-
-    private final TimestampManagementService timestampManagementService = NAMESPACE_1.timestampManagementService();
+    private static NamespacedClients NAMESPACE_1;
+    private static NamespacedClients NAMESPACE_2;
 
     @ClassRule
     public static final RuleChain ruleChain = RuleChain.outerRule(TEMPORARY_FOLDER)
@@ -87,6 +85,8 @@ public class PaxosTimeLockServerIntegrationTest {
 
     @BeforeClass
     public static void waitForClusterToStabilize() {
+        NAMESPACE_1 = TIMELOCK.client(CLIENT_1);
+        NAMESPACE_2 = TIMELOCK.client(CLIENT_2);
         PingableLeader leader = TIMELOCK.pingableLeader();
         Awaitility.await()
                 .atMost(30, TimeUnit.SECONDS)
@@ -205,7 +205,7 @@ public class PaxosTimeLockServerIntegrationTest {
     @Test
     public void timestampServiceRespectsTimestampManagementService() {
         long currentTimestampIncrementedByOneMillion = NAMESPACE_1.getFreshTimestamp() + ONE_MILLION;
-        timestampManagementService.fastForwardTimestamp(currentTimestampIncrementedByOneMillion);
+        NAMESPACE_1.timestampManagementService().fastForwardTimestamp(currentTimestampIncrementedByOneMillion);
         assertThat(NAMESPACE_1.getFreshTimestamp())
                 .isGreaterThan(currentTimestampIncrementedByOneMillion);
     }
@@ -213,9 +213,9 @@ public class PaxosTimeLockServerIntegrationTest {
     @Test
     public void timestampManagementServiceRespectsTimestampService() {
         long currentTimestampIncrementedByOneMillion = NAMESPACE_1.getFreshTimestamp() + ONE_MILLION;
-        timestampManagementService.fastForwardTimestamp(currentTimestampIncrementedByOneMillion);
+        NAMESPACE_1.timestampManagementService().fastForwardTimestamp(currentTimestampIncrementedByOneMillion);
         getFortyTwoFreshTimestamps(NAMESPACE_1.timelockService());
-        timestampManagementService.fastForwardTimestamp(currentTimestampIncrementedByOneMillion + 1);
+        NAMESPACE_1.timestampManagementService().fastForwardTimestamp(currentTimestampIncrementedByOneMillion + 1);
         assertThat(NAMESPACE_1.getFreshTimestamp())
                 .isGreaterThan(currentTimestampIncrementedByOneMillion + FORTY_TWO);
     }
@@ -252,8 +252,8 @@ public class PaxosTimeLockServerIntegrationTest {
         long currentTimestampIncrementedByOneMillion = currentTimestamp + ONE_MILLION;
         long currentTimestampIncrementedByTwoMillion = currentTimestamp + TWO_MILLION;
 
-        timestampManagementService.fastForwardTimestamp(currentTimestampIncrementedByTwoMillion);
-        timestampManagementService.fastForwardTimestamp(currentTimestampIncrementedByOneMillion);
+        NAMESPACE_1.timestampManagementService().fastForwardTimestamp(currentTimestampIncrementedByTwoMillion);
+        NAMESPACE_1.timestampManagementService().fastForwardTimestamp(currentTimestampIncrementedByOneMillion);
         assertThat(NAMESPACE_1.getFreshTimestamp()).isGreaterThan(currentTimestampIncrementedByTwoMillion);
     }
 

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
@@ -75,8 +75,8 @@ public class PaxosTimeLockServerIntegrationTest {
     private static final TestableTimelockServer TIMELOCK =
             new TestableTimelockServer("https://localhost", TIMELOCK_SERVER_HOLDER);
 
-    private static NamespacedClients NAMESPACE_1;
-    private static NamespacedClients NAMESPACE_2;
+    private static NamespacedClients namespace1;
+    private static NamespacedClients namespace2;
 
     @ClassRule
     public static final RuleChain ruleChain = RuleChain.outerRule(TEMPORARY_FOLDER)
@@ -85,8 +85,8 @@ public class PaxosTimeLockServerIntegrationTest {
 
     @BeforeClass
     public static void waitForClusterToStabilize() {
-        NAMESPACE_1 = TIMELOCK.client(CLIENT_1);
-        NAMESPACE_2 = TIMELOCK.client(CLIENT_2);
+        namespace1 = TIMELOCK.client(CLIENT_1);
+        namespace2 = TIMELOCK.client(CLIENT_2);
         PingableLeader leader = TIMELOCK.pingableLeader();
         Awaitility.await()
                 .atMost(30, TimeUnit.SECONDS)
@@ -107,7 +107,7 @@ public class PaxosTimeLockServerIntegrationTest {
 
     @Test
     public void lockServiceShouldAllowUsToTakeOutLocks() throws InterruptedException {
-        LockService lockService = NAMESPACE_1.legacyLockService();
+        LockService lockService = namespace1.legacyLockService();
 
         LockRefreshToken token = lockService.lock(LOCK_CLIENT_NAME, com.palantir.lock.LockRequest.builder(LOCK_MAP)
                 .doNotBlock()
@@ -120,8 +120,8 @@ public class PaxosTimeLockServerIntegrationTest {
 
     @Test
     public void lockServiceShouldAllowUsToTakeOutSameLockInDifferentNamespaces() throws InterruptedException {
-        LockService lockService1 = NAMESPACE_1.legacyLockService();
-        LockService lockService2 = NAMESPACE_2.legacyLockService();
+        LockService lockService1 = namespace1.legacyLockService();
+        LockService lockService2 = namespace2.legacyLockService();
 
         LockRefreshToken token1 = lockService1.lock(LOCK_CLIENT_NAME, com.palantir.lock.LockRequest.builder(LOCK_MAP)
                 .doNotBlock()
@@ -139,8 +139,8 @@ public class PaxosTimeLockServerIntegrationTest {
 
     @Test
     public void lockServiceShouldNotAllowUsToRefreshLocksFromDifferentNamespaces() throws InterruptedException {
-        LockService lockService1 = NAMESPACE_1.legacyLockService();
-        LockService lockService2 = NAMESPACE_2.legacyLockService();
+        LockService lockService1 = namespace1.legacyLockService();
+        LockService lockService2 = namespace2.legacyLockService();
 
         com.palantir.lock.LockRequest request = com.palantir.lock.LockRequest.builder(LOCK_MAP)
                 .doNotBlock()
@@ -157,46 +157,46 @@ public class PaxosTimeLockServerIntegrationTest {
 
     @Test
     public void asyncLockServiceShouldAllowUsToTakeOutLocks() {
-        LockToken token = NAMESPACE_1.lock(newLockV2Request(LOCK_1)).getToken();
-        assertThat(NAMESPACE_1.unlock(token)).isTrue();
+        LockToken token = namespace1.lock(newLockV2Request(LOCK_1)).getToken();
+        assertThat(namespace1.unlock(token)).isTrue();
     }
 
     @Test
     public void asyncLockServiceShouldAllowUsToTakeOutSameLockInDifferentNamespaces() {
-        LockToken token1 = NAMESPACE_1.lock(newLockV2Request(LOCK_1)).getToken();
-        LockToken token2 = NAMESPACE_2.lock(newLockV2Request(LOCK_1)).getToken();
+        LockToken token1 = namespace1.lock(newLockV2Request(LOCK_1)).getToken();
+        LockToken token2 = namespace2.lock(newLockV2Request(LOCK_1)).getToken();
 
-        NAMESPACE_1.unlock(token1);
-        NAMESPACE_2.unlock(token2);
+        namespace1.unlock(token1);
+        namespace2.unlock(token2);
     }
 
     @Test
     public void asyncLockServiceShouldNotAllowUsToRefreshLocksFromDifferentNamespaces() {
-        LockToken token = NAMESPACE_1.lock(newLockV2Request(LOCK_1)).getToken();
+        LockToken token = namespace1.lock(newLockV2Request(LOCK_1)).getToken();
 
-        assertThat(NAMESPACE_1.refreshLockLease(token)).isTrue();
-        assertThat(NAMESPACE_2.refreshLockLease(token)).isFalse();
+        assertThat(namespace1.refreshLockLease(token)).isTrue();
+        assertThat(namespace2.refreshLockLease(token)).isFalse();
 
-        NAMESPACE_1.unlock(token);
+        namespace1.unlock(token);
     }
 
     @Test
     public void timestampServiceShouldGiveUsIncrementalTimestamps() {
-        long timestamp1 = NAMESPACE_1.getFreshTimestamp();
-        long timestamp2 = NAMESPACE_1.getFreshTimestamp();
+        long timestamp1 = namespace1.getFreshTimestamp();
+        long timestamp2 = namespace1.getFreshTimestamp();
 
         assertThat(timestamp1).isLessThan(timestamp2);
     }
 
     @Test
     public void timestampServiceShouldRespectDistinctClientsWhenIssuingTimestamps() {
-        long firstServiceFirstTimestamp = NAMESPACE_1.getFreshTimestamp();
-        long secondServiceFirstTimestamp = NAMESPACE_2.getFreshTimestamp();
+        long firstServiceFirstTimestamp = namespace1.getFreshTimestamp();
+        long secondServiceFirstTimestamp = namespace2.getFreshTimestamp();
 
-        getFortyTwoFreshTimestamps(NAMESPACE_1.timelockService());
+        getFortyTwoFreshTimestamps(namespace1.timelockService());
 
-        long firstServiceSecondTimestamp = NAMESPACE_1.getFreshTimestamp();
-        long secondServiceSecondTimestamp = NAMESPACE_2.getFreshTimestamp();
+        long firstServiceSecondTimestamp = namespace1.getFreshTimestamp();
+        long secondServiceSecondTimestamp = namespace2.getFreshTimestamp();
 
         assertThat(firstServiceSecondTimestamp - firstServiceFirstTimestamp).isGreaterThanOrEqualTo(FORTY_TWO);
         assertThat(secondServiceSecondTimestamp - secondServiceFirstTimestamp).isBetween(0L, (long) FORTY_TWO);
@@ -204,25 +204,25 @@ public class PaxosTimeLockServerIntegrationTest {
 
     @Test
     public void timestampServiceRespectsTimestampManagementService() {
-        long currentTimestampIncrementedByOneMillion = NAMESPACE_1.getFreshTimestamp() + ONE_MILLION;
-        NAMESPACE_1.timestampManagementService().fastForwardTimestamp(currentTimestampIncrementedByOneMillion);
-        assertThat(NAMESPACE_1.getFreshTimestamp())
+        long currentTimestampIncrementedByOneMillion = namespace1.getFreshTimestamp() + ONE_MILLION;
+        namespace1.timestampManagementService().fastForwardTimestamp(currentTimestampIncrementedByOneMillion);
+        assertThat(namespace1.getFreshTimestamp())
                 .isGreaterThan(currentTimestampIncrementedByOneMillion);
     }
 
     @Test
     public void timestampManagementServiceRespectsTimestampService() {
-        long currentTimestampIncrementedByOneMillion = NAMESPACE_1.getFreshTimestamp() + ONE_MILLION;
-        NAMESPACE_1.timestampManagementService().fastForwardTimestamp(currentTimestampIncrementedByOneMillion);
-        getFortyTwoFreshTimestamps(NAMESPACE_1.timelockService());
-        NAMESPACE_1.timestampManagementService().fastForwardTimestamp(currentTimestampIncrementedByOneMillion + 1);
-        assertThat(NAMESPACE_1.getFreshTimestamp())
+        long currentTimestampIncrementedByOneMillion = namespace1.getFreshTimestamp() + ONE_MILLION;
+        namespace1.timestampManagementService().fastForwardTimestamp(currentTimestampIncrementedByOneMillion);
+        getFortyTwoFreshTimestamps(namespace1.timelockService());
+        namespace1.timestampManagementService().fastForwardTimestamp(currentTimestampIncrementedByOneMillion + 1);
+        assertThat(namespace1.getFreshTimestamp())
                 .isGreaterThan(currentTimestampIncrementedByOneMillion + FORTY_TWO);
     }
 
     @Test
     public void lockServiceShouldDisallowGettingMinLockedInVersionId() {
-        LockService lockService = NAMESPACE_1.legacyLockService();
+        LockService lockService = namespace1.legacyLockService();
 
         // Catching any exception since this currently is an error deserialization exception
         // until we stop requiring http-remoting2 errors
@@ -238,23 +238,23 @@ public class PaxosTimeLockServerIntegrationTest {
 
     @Test
     public void fastForwardRespectsDistinctClients() {
-        TimestampManagementService anotherClientTimestampManagementService = NAMESPACE_2.timestampManagementService();
+        TimestampManagementService anotherClientTimestampManagementService = namespace2.timestampManagementService();
 
-        long currentTimestamp = NAMESPACE_1.getFreshTimestamp();
+        long currentTimestamp = namespace1.getFreshTimestamp();
         anotherClientTimestampManagementService.fastForwardTimestamp(currentTimestamp + ONE_MILLION);
-        assertThat(NAMESPACE_1.getFreshTimestamp())
+        assertThat(namespace1.getFreshTimestamp())
                 .isBetween(currentTimestamp + 1, currentTimestamp + ONE_MILLION - 1);
     }
 
     @Test
     public void fastForwardToThePastDoesNothing() {
-        long currentTimestamp = NAMESPACE_1.getFreshTimestamp();
+        long currentTimestamp = namespace1.getFreshTimestamp();
         long currentTimestampIncrementedByOneMillion = currentTimestamp + ONE_MILLION;
         long currentTimestampIncrementedByTwoMillion = currentTimestamp + TWO_MILLION;
 
-        NAMESPACE_1.timestampManagementService().fastForwardTimestamp(currentTimestampIncrementedByTwoMillion);
-        NAMESPACE_1.timestampManagementService().fastForwardTimestamp(currentTimestampIncrementedByOneMillion);
-        assertThat(NAMESPACE_1.getFreshTimestamp()).isGreaterThan(currentTimestampIncrementedByTwoMillion);
+        namespace1.timestampManagementService().fastForwardTimestamp(currentTimestampIncrementedByTwoMillion);
+        namespace1.timestampManagementService().fastForwardTimestamp(currentTimestampIncrementedByOneMillion);
+        assertThat(namespace1.getFreshTimestamp()).isGreaterThan(currentTimestampIncrementedByTwoMillion);
     }
 
     @Test

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
@@ -19,15 +19,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
-import java.io.IOException;
-import java.net.URL;
 import java.util.List;
-import java.util.Optional;
 import java.util.SortedMap;
 import java.util.concurrent.TimeUnit;
 
 import org.awaitility.Awaitility;
-import org.eclipse.jetty.http.HttpStatus;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -35,44 +31,21 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
-import com.palantir.atlasdb.config.AuxiliaryRemotingParameters;
-import com.palantir.atlasdb.http.AtlasDbHttpClients;
-import com.palantir.atlasdb.http.FeignOkHttpClients;
-import com.palantir.atlasdb.http.TestProxyUtils;
-import com.palantir.atlasdb.http.errors.AtlasDbRemoteException;
-import com.palantir.atlasdb.timelock.util.TestProxies;
-import com.palantir.atlasdb.util.MetricsManagers;
-import com.palantir.conjure.java.api.config.service.UserAgents;
 import com.palantir.leader.PingableLeader;
 import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.LockMode;
 import com.palantir.lock.LockRefreshToken;
-import com.palantir.lock.LockRpcClient;
 import com.palantir.lock.LockService;
-import com.palantir.lock.SimpleTimeDuration;
 import com.palantir.lock.StringLockDescriptor;
-import com.palantir.lock.client.RemoteLockServiceAdapter;
-import com.palantir.lock.client.RemoteTimelockServiceAdapter;
 import com.palantir.lock.v2.LockRequest;
 import com.palantir.lock.v2.LockToken;
-import com.palantir.lock.v2.NamespacedTimelockRpcClient;
-import com.palantir.lock.v2.TimelockRpcClient;
 import com.palantir.lock.v2.TimelockService;
-import com.palantir.timestamp.RemoteTimestampManagementAdapter;
-import com.palantir.timestamp.TimestampManagementRpcClient;
 import com.palantir.timestamp.TimestampManagementService;
-import com.palantir.timestamp.TimestampService;
 
 import io.dropwizard.testing.ResourceHelpers;
-import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
 
 public class PaxosTimeLockServerIntegrationTest {
     private static final String CLIENT_1 = "test";
@@ -80,7 +53,7 @@ public class PaxosTimeLockServerIntegrationTest {
     private static final String CLIENT_3 = "test3";
     private static final String LEARNER = "learner";
     private static final String ACCEPTOR = "acceptor";
-    private static final List<String> CLIENTS = ImmutableList.of(CLIENT_1, CLIENT_2, CLIENT_3, LEARNER, ACCEPTOR);
+    private static final List<String> NAMESPACES = ImmutableList.of(CLIENT_1, CLIENT_2, CLIENT_3, LEARNER, ACCEPTOR);
     private static final String INVALID_CLIENT = "test2\b";
 
     private static final long ONE_MILLION = 1000000;
@@ -99,15 +72,13 @@ public class PaxosTimeLockServerIntegrationTest {
             new TemporaryConfigurationHolder(TEMPORARY_FOLDER, TIMELOCK_CONFIG_TEMPLATE);
     private static final TimeLockServerHolder TIMELOCK_SERVER_HOLDER =
             new TimeLockServerHolder(TEMPORARY_CONFIG_HOLDER::getTemporaryConfigFileLocation);
+    private static final TestableTimelockServer TIMELOCK =
+            new TestableTimelockServer("https://localhost:", TIMELOCK_SERVER_HOLDER);
 
-    private static final com.palantir.lock.LockRequest REQUEST_LOCK_WITH_LONG_TIMEOUT = com.palantir.lock.LockRequest
-            .builder(ImmutableSortedMap.of(StringLockDescriptor.of("lock"), LockMode.WRITE))
-            .timeoutAfter(SimpleTimeDuration.of(20, TimeUnit.SECONDS))
-            .blockForAtMost(SimpleTimeDuration.of(4, TimeUnit.SECONDS))
-            .build();
+    private static final NamespacedClients NAMESPACE_2 = TIMELOCK.client(CLIENT_2);
+    private static final NamespacedClients NAMESPACE_1 = TIMELOCK.client(CLIENT_1);
 
-    private final TimestampService timestampService = getTimestampService(CLIENT_1);
-    private final TimestampManagementService timestampManagementService = getTimestampManagementService(CLIENT_1);
+    private final TimestampManagementService timestampManagementService = NAMESPACE_1.timestampManagementService();
 
     @ClassRule
     public static final RuleChain ruleChain = RuleChain.outerRule(TEMPORARY_FOLDER)
@@ -116,21 +87,16 @@ public class PaxosTimeLockServerIntegrationTest {
 
     @BeforeClass
     public static void waitForClusterToStabilize() {
-        PingableLeader leader = AtlasDbHttpClients.createProxy(
-                MetricsManagers.createForTests(),
-                Optional.of(TestProxies.TRUST_CONTEXT),
-                "https://localhost:" + TIMELOCK_SERVER_HOLDER.getTimelockPort(),
-                PingableLeader.class,
-                TestProxyUtils.AUXILIARY_REMOTING_PARAMETERS_RETRYING);
+        PingableLeader leader = TIMELOCK.pingableLeader();
         Awaitility.await()
                 .atMost(30, TimeUnit.SECONDS)
                 .pollInterval(1, TimeUnit.SECONDS)
                 .until(() -> {
                     try {
                         // Returns true only if this node is ready to serve timestamps and locks on all clients.
-                        CLIENTS.forEach(client -> getTimelockService(client).getFreshTimestamp());
-                        CLIENTS.forEach(client -> getTimelockService(client).currentTimeMillis());
-                        CLIENTS.forEach(client -> getLockService(client).currentTimeMillis());
+                        NAMESPACES.forEach(client -> TIMELOCK.client(client).getFreshTimestamp());
+                        NAMESPACES.forEach(client -> TIMELOCK.client(client).timelockService().currentTimeMillis());
+                        NAMESPACES.forEach(client -> TIMELOCK.client(client).legacyLockService().currentTimeMillis());
                         return leader.ping();
                     } catch (Throwable t) {
                         LoggerFactory.getLogger(PaxosTimeLockServerIntegrationTest.class).error("erreur!", t);
@@ -141,7 +107,7 @@ public class PaxosTimeLockServerIntegrationTest {
 
     @Test
     public void lockServiceShouldAllowUsToTakeOutLocks() throws InterruptedException {
-        LockService lockService = getLockService(CLIENT_1);
+        LockService lockService = NAMESPACE_1.legacyLockService();
 
         LockRefreshToken token = lockService.lock(LOCK_CLIENT_NAME, com.palantir.lock.LockRequest.builder(LOCK_MAP)
                 .doNotBlock()
@@ -154,8 +120,8 @@ public class PaxosTimeLockServerIntegrationTest {
 
     @Test
     public void lockServiceShouldAllowUsToTakeOutSameLockInDifferentNamespaces() throws InterruptedException {
-        LockService lockService1 = getLockService(CLIENT_1);
-        LockService lockService2 = getLockService(CLIENT_2);
+        LockService lockService1 = NAMESPACE_1.legacyLockService();
+        LockService lockService2 = NAMESPACE_2.legacyLockService();
 
         LockRefreshToken token1 = lockService1.lock(LOCK_CLIENT_NAME, com.palantir.lock.LockRequest.builder(LOCK_MAP)
                 .doNotBlock()
@@ -173,12 +139,14 @@ public class PaxosTimeLockServerIntegrationTest {
 
     @Test
     public void lockServiceShouldNotAllowUsToRefreshLocksFromDifferentNamespaces() throws InterruptedException {
-        LockService lockService1 = getLockService(CLIENT_1);
-        LockService lockService2 = getLockService(CLIENT_2);
+        LockService lockService1 = NAMESPACE_1.legacyLockService();
+        LockService lockService2 = NAMESPACE_2.legacyLockService();
 
-        LockRefreshToken token = lockService1.lock(LOCK_CLIENT_NAME, com.palantir.lock.LockRequest.builder(LOCK_MAP)
+        com.palantir.lock.LockRequest request = com.palantir.lock.LockRequest.builder(LOCK_MAP)
                 .doNotBlock()
-                .build());
+                .build();
+
+        LockRefreshToken token = lockService1.lock(LOCK_CLIENT_NAME, request);
 
         assertThat(token).isNotNull();
         assertThat(lockService1.refreshLockRefreshTokens(ImmutableList.of(token))).isNotEmpty();
@@ -188,59 +156,47 @@ public class PaxosTimeLockServerIntegrationTest {
     }
 
     @Test
-    public void asyncLockServiceShouldAllowUsToTakeOutLocks() throws InterruptedException {
-        TimelockService timelockService = getTimelockService(CLIENT_1);
-
-        LockToken token = timelockService.lock(newLockV2Request(LOCK_1)).getToken();
-
-        assertThat(timelockService.unlock(ImmutableSet.of(token))).contains(token);
+    public void asyncLockServiceShouldAllowUsToTakeOutLocks() {
+        LockToken token = NAMESPACE_1.lock(newLockV2Request(LOCK_1)).getToken();
+        assertThat(NAMESPACE_1.unlock(token)).isTrue();
     }
 
     @Test
-    public void asyncLockServiceShouldAllowUsToTakeOutSameLockInDifferentNamespaces() throws InterruptedException {
-        TimelockService lockService1 = getTimelockService(CLIENT_1);
-        TimelockService lockService2 = getTimelockService(CLIENT_2);
+    public void asyncLockServiceShouldAllowUsToTakeOutSameLockInDifferentNamespaces() {
+        LockToken token1 = NAMESPACE_1.lock(newLockV2Request(LOCK_1)).getToken();
+        LockToken token2 = NAMESPACE_2.lock(newLockV2Request(LOCK_1)).getToken();
 
-        LockToken token1 = lockService1.lock(newLockV2Request(LOCK_1)).getToken();
-        LockToken token2 = lockService2.lock(newLockV2Request(LOCK_1)).getToken();
-
-        lockService1.unlock(ImmutableSet.of(token1));
-        lockService2.unlock(ImmutableSet.of(token2));
+        NAMESPACE_1.unlock(token1);
+        NAMESPACE_2.unlock(token2);
     }
 
     @Test
-    public void asyncLockServiceShouldNotAllowUsToRefreshLocksFromDifferentNamespaces() throws InterruptedException {
-        TimelockService lockService1 = getTimelockService(CLIENT_1);
-        TimelockService lockService2 = getTimelockService(CLIENT_2);
+    public void asyncLockServiceShouldNotAllowUsToRefreshLocksFromDifferentNamespaces() {
+        LockToken token = NAMESPACE_1.lock(newLockV2Request(LOCK_1)).getToken();
 
-        LockToken token = lockService1.lock(newLockV2Request(LOCK_1)).getToken();
+        assertThat(NAMESPACE_1.refreshLockLease(token)).isTrue();
+        assertThat(NAMESPACE_2.refreshLockLease(token)).isFalse();
 
-        assertThat(lockService1.refreshLockLeases(ImmutableSet.of(token))).isNotEmpty();
-        assertThat(lockService2.refreshLockLeases(ImmutableSet.of(token))).isEmpty();
-
-        lockService1.unlock(ImmutableSet.of(token));
+        NAMESPACE_1.unlock(token);
     }
 
     @Test
     public void timestampServiceShouldGiveUsIncrementalTimestamps() {
-        long timestamp1 = timestampService.getFreshTimestamp();
-        long timestamp2 = timestampService.getFreshTimestamp();
+        long timestamp1 = NAMESPACE_1.getFreshTimestamp();
+        long timestamp2 = NAMESPACE_1.getFreshTimestamp();
 
         assertThat(timestamp1).isLessThan(timestamp2);
     }
 
     @Test
     public void timestampServiceShouldRespectDistinctClientsWhenIssuingTimestamps() {
-        TimestampService timestampService1 = getTimestampService(CLIENT_1);
-        TimestampService timestampService2 = getTimestampService(CLIENT_2);
+        long firstServiceFirstTimestamp = NAMESPACE_1.getFreshTimestamp();
+        long secondServiceFirstTimestamp = NAMESPACE_2.getFreshTimestamp();
 
-        long firstServiceFirstTimestamp = timestampService1.getFreshTimestamp();
-        long secondServiceFirstTimestamp = timestampService2.getFreshTimestamp();
+        getFortyTwoFreshTimestamps(NAMESPACE_1.timelockService());
 
-        getFortyTwoFreshTimestamps(timestampService1);
-
-        long firstServiceSecondTimestamp = timestampService1.getFreshTimestamp();
-        long secondServiceSecondTimestamp = timestampService2.getFreshTimestamp();
+        long firstServiceSecondTimestamp = NAMESPACE_1.getFreshTimestamp();
+        long secondServiceSecondTimestamp = NAMESPACE_2.getFreshTimestamp();
 
         assertThat(firstServiceSecondTimestamp - firstServiceFirstTimestamp).isGreaterThanOrEqualTo(FORTY_TWO);
         assertThat(secondServiceSecondTimestamp - secondServiceFirstTimestamp).isBetween(0L, (long) FORTY_TWO);
@@ -248,24 +204,25 @@ public class PaxosTimeLockServerIntegrationTest {
 
     @Test
     public void timestampServiceRespectsTimestampManagementService() {
-        long currentTimestampIncrementedByOneMillion = timestampService.getFreshTimestamp() + ONE_MILLION;
+        long currentTimestampIncrementedByOneMillion = NAMESPACE_1.getFreshTimestamp() + ONE_MILLION;
         timestampManagementService.fastForwardTimestamp(currentTimestampIncrementedByOneMillion);
-        assertThat(timestampService.getFreshTimestamp()).isGreaterThan(currentTimestampIncrementedByOneMillion);
+        assertThat(NAMESPACE_1.getFreshTimestamp())
+                .isGreaterThan(currentTimestampIncrementedByOneMillion);
     }
 
     @Test
     public void timestampManagementServiceRespectsTimestampService() {
-        long currentTimestampIncrementedByOneMillion = timestampService.getFreshTimestamp() + ONE_MILLION;
+        long currentTimestampIncrementedByOneMillion = NAMESPACE_1.getFreshTimestamp() + ONE_MILLION;
         timestampManagementService.fastForwardTimestamp(currentTimestampIncrementedByOneMillion);
-        getFortyTwoFreshTimestamps(timestampService);
+        getFortyTwoFreshTimestamps(NAMESPACE_1.timelockService());
         timestampManagementService.fastForwardTimestamp(currentTimestampIncrementedByOneMillion + 1);
-        assertThat(timestampService.getFreshTimestamp())
+        assertThat(NAMESPACE_1.getFreshTimestamp())
                 .isGreaterThan(currentTimestampIncrementedByOneMillion + FORTY_TWO);
     }
 
     @Test
     public void lockServiceShouldDisallowGettingMinLockedInVersionId() {
-        LockService lockService = getLockService(CLIENT_1);
+        LockService lockService = NAMESPACE_1.legacyLockService();
 
         // Catching any exception since this currently is an error deserialization exception
         // until we stop requiring http-remoting2 errors
@@ -273,143 +230,47 @@ public class PaxosTimeLockServerIntegrationTest {
                 .isInstanceOf(Exception.class);
     }
 
-    private static void getFortyTwoFreshTimestamps(TimestampService timestampService) {
+    private static void getFortyTwoFreshTimestamps(TimelockService timelockService) {
         for (int i = 0; i < FORTY_TWO; i++) {
-            timestampService.getFreshTimestamp();
+            timelockService.getFreshTimestamp();
         }
     }
 
     @Test
     public void fastForwardRespectsDistinctClients() {
-        TimestampManagementService anotherClientTimestampManagementService = getTimestampManagementService(CLIENT_2);
+        TimestampManagementService anotherClientTimestampManagementService = NAMESPACE_2.timestampManagementService();
 
-        long currentTimestamp = timestampService.getFreshTimestamp();
+        long currentTimestamp = NAMESPACE_1.getFreshTimestamp();
         anotherClientTimestampManagementService.fastForwardTimestamp(currentTimestamp + ONE_MILLION);
-        assertThat(timestampService.getFreshTimestamp())
+        assertThat(NAMESPACE_1.getFreshTimestamp())
                 .isBetween(currentTimestamp + 1, currentTimestamp + ONE_MILLION - 1);
     }
 
     @Test
     public void fastForwardToThePastDoesNothing() {
-        long currentTimestamp = timestampService.getFreshTimestamp();
+        long currentTimestamp = NAMESPACE_1.getFreshTimestamp();
         long currentTimestampIncrementedByOneMillion = currentTimestamp + ONE_MILLION;
         long currentTimestampIncrementedByTwoMillion = currentTimestamp + TWO_MILLION;
 
         timestampManagementService.fastForwardTimestamp(currentTimestampIncrementedByTwoMillion);
         timestampManagementService.fastForwardTimestamp(currentTimestampIncrementedByOneMillion);
-        assertThat(timestampService.getFreshTimestamp()).isGreaterThan(currentTimestampIncrementedByTwoMillion);
+        assertThat(NAMESPACE_1.getFreshTimestamp()).isGreaterThan(currentTimestampIncrementedByTwoMillion);
     }
 
     @Test
     public void throwsOnQueryingTimestampWithInvalidClientName() {
-        TimestampService invalidTimestampService = getTimestampService(INVALID_CLIENT);
-        assertThatThrownBy(invalidTimestampService::getFreshTimestamp)
+        TimelockService invalidTimelockService = TIMELOCK.client(INVALID_CLIENT).timelockService();
+        assertThatThrownBy(invalidTimelockService::getFreshTimestamp)
                 .hasMessageContaining("NOT_FOUND");
     }
 
     @Test
-    public void supportsClientNamesMatchingPaxosRoles() throws InterruptedException {
-        getTimestampService(LEARNER).getFreshTimestamp();
-        getTimestampService(ACCEPTOR).getFreshTimestamp();
+    public void supportsClientNamesMatchingPaxosRoles() {
+        TIMELOCK.client(LEARNER).getFreshTimestamp();
+        TIMELOCK.client(ACCEPTOR).getFreshTimestamp();
     }
 
-    @Test
-    public void throwsOnFastForwardWithUnspecifiedParameter() throws IOException {
-        Response response = makeEmptyPostToUri(getFastForwardUriForClientOne());
-        assertThat(response.code()).isEqualTo(HttpStatus.BAD_REQUEST_400);
-    }
-
-    @Test
-    public void throwsOnFastForwardWithIncorrectParameter() throws IOException {
-        String uriWithParam = getFastForwardUriForClientOne() + "?newMinimum=1200";
-        Response response = makeEmptyPostToUri(uriWithParam);
-        assertThat(response.code()).isEqualTo(HttpStatus.BAD_REQUEST_400);
-    }
-
-    private static String getFastForwardUriForClientOne() {
-        return getRootUriForClient(CLIENT_1) + "/timestamp-management/fast-forward";
-    }
-
-    private static Response makeEmptyPostToUri(String uri) throws IOException {
-        OkHttpClient client = new OkHttpClient.Builder()
-                .sslSocketFactory(
-                        TestProxies.TRUST_CONTEXT.sslSocketFactory(),
-                        TestProxies.TRUST_CONTEXT.x509TrustManager())
-                .connectionSpecs(FeignOkHttpClients.CONNECTION_SPEC_WITH_CYPHER_SUITES)
-                .build();
-        return client.newCall(new Request.Builder()
-                .url(uri)
-                .post(RequestBody.create(MediaType.parse("application/json"), ""))
-                .build()).execute();
-    }
-
-    private static MetricsOutput getMetricsOutput() throws IOException {
-        return new MetricsOutput(new ObjectMapper().readTree(
-                new URL("http", "localhost", TIMELOCK_SERVER_HOLDER.getAdminPort(), "/metrics")));
-    }
-
-    private static TimelockService getTimelockService(String client) {
-        return RemoteTimelockServiceAdapter.create(
-                new NamespacedTimelockRpcClient(getProxyForRootService(client, TimelockRpcClient.class), client));
-    }
-
-    private static LockService getLockService(String client) {
-        LockRpcClient lockRpcClient = getProxyForRootService(client, LockRpcClient.class);
-        return RemoteLockServiceAdapter.create(lockRpcClient, client);
-    }
-
-    private static TimestampService getTimestampService(String client) {
-        return getProxyForService(client, TimestampService.class);
-    }
-
-    private static TimestampManagementService getTimestampManagementService(String client) {
-        return new RemoteTimestampManagementAdapter(
-                getProxyForRootService(client, TimestampManagementRpcClient.class),
-                client);
-    }
-
-    private static <T> T getProxyForRootService(String client, Class<T> clazz) {
-        return AtlasDbHttpClients.createProxy(
-                MetricsManagers.createForTests(),
-                Optional.of(TestProxies.TRUST_CONTEXT),
-                getGenericRootUri(),
-                clazz,
-                remotingParametersForClient(client));
-    }
-
-    private static <T> T getProxyForService(String client, Class<T> clazz) {
-        return AtlasDbHttpClients.createProxy(
-                MetricsManagers.createForTests(),
-                Optional.of(TestProxies.TRUST_CONTEXT),
-                getRootUriForClient(client),
-                clazz,
-                remotingParametersForClient(client));
-    }
-
-    private static AuxiliaryRemotingParameters remotingParametersForClient(String client) {
-        return AuxiliaryRemotingParameters.builder()
-                .shouldLimitPayload(true)
-                .userAgent(UserAgents.tryParse(client))
-                .shouldRetry(true)
-                .build();
-    }
-
-    private static String getGenericRootUri() {
-        return String.format("https://localhost:%d", TIMELOCK_SERVER_HOLDER.getTimelockPort());
-    }
-
-    private static String getRootUriForClient(String client) {
-        return String.format("https://localhost:%d/%s", TIMELOCK_SERVER_HOLDER.getTimelockPort(), client);
-    }
-
-    private static void assertRemoteExceptionWithStatus(Throwable throwable, int expectedStatus) {
-        assertThat(throwable).isInstanceOf(AtlasDbRemoteException.class);
-
-        AtlasDbRemoteException remoteException = (AtlasDbRemoteException) throwable;
-        assertThat(remoteException.getStatus()).isEqualTo(expectedStatus);
-    }
-
-    private LockRequest newLockV2Request(LockDescriptor lock) {
+    private static LockRequest newLockV2Request(LockDescriptor lock) {
         return LockRequest.of(ImmutableSet.of(lock), 10_000L);
     }
 }

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/SingleLeaderMultiNodePaxosTimeLockIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/SingleLeaderMultiNodePaxosTimeLockIntegrationTest.java
@@ -48,38 +48,34 @@ public class SingleLeaderMultiNodePaxosTimeLockIntegrationTest {
     @Test
     public void clientsCreatedDynamicallyOnNonLeadersAreFunctionalAfterFailover() {
         String client = UUID.randomUUID().toString();
-        cluster.nonLeaders().forEach(server -> {
-            assertThatThrownBy(() -> server.timelockServiceForClient(client).getFreshTimestamp())
-                    .satisfies(ExceptionMatchers::isRetryableExceptionWhereLeaderCannotBeFound);
-        });
+        cluster.nonLeaders().forEach(server ->
+                assertThatThrownBy(() -> server.client(client).getFreshTimestamp())
+                .satisfies(ExceptionMatchers::isRetryableExceptionWhereLeaderCannotBeFound));
 
         cluster.failoverToNewLeader();
 
-        cluster.getFreshTimestamp();
+        cluster.client(client).getFreshTimestamp();
     }
 
     @Test
     public void clientsCreatedDynamicallyOnLeaderAreFunctionalImmediately() {
         String client = UUID.randomUUID().toString();
 
-        cluster.currentLeader()
-                .timelockServiceForClient(client)
-                .getFreshTimestamp();
+        cluster.currentLeader().client(client).getFreshTimestamp();
     }
 
     @Test
     public void noConflictIfLeaderAndNonLeadersSeparatelyInitializeClient() {
         String client = UUID.randomUUID().toString();
-        cluster.nonLeaders().forEach(server -> {
-            assertThatThrownBy(() -> server.timelockServiceForClient(client).getFreshTimestamp())
-                    .satisfies(ExceptionMatchers::isRetryableExceptionWhereLeaderCannotBeFound);
-        });
+        cluster.nonLeaders().forEach(server ->
+                assertThatThrownBy(() -> server.client(client).getFreshTimestamp())
+                .satisfies(ExceptionMatchers::isRetryableExceptionWhereLeaderCannotBeFound));
 
-        long ts1 = cluster.timelockServiceForClient(client).getFreshTimestamp();
+        long ts1 = cluster.client(client).getFreshTimestamp();
 
         cluster.failoverToNewLeader();
 
-        long ts2 = cluster.getFreshTimestamp();
+        long ts2 = cluster.client(client).getFreshTimestamp();
         assertThat(ts1).isLessThan(ts2);
     }
 }

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/SingleLeaderMultiNodePaxosTimeLockIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/SingleLeaderMultiNodePaxosTimeLockIntegrationTest.java
@@ -1,0 +1,85 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.UUID;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import com.palantir.atlasdb.timelock.suite.PaxosSuite;
+import com.palantir.atlasdb.timelock.util.ExceptionMatchers;
+import com.palantir.atlasdb.timelock.util.ParameterInjector;
+
+@RunWith(Parameterized.class)
+public class SingleLeaderMultiNodePaxosTimeLockIntegrationTest {
+
+    @ClassRule
+    public static ParameterInjector<TestableTimelockCluster> injector =
+            ParameterInjector.withFallBackConfiguration(() -> PaxosSuite.BATCHED_TIMESTAMP_PAXOS);
+
+    @Parameterized.Parameter
+    public TestableTimelockCluster cluster;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Iterable<TestableTimelockCluster> params() {
+        return injector.getParameter();
+    }
+
+    @Test
+    public void clientsCreatedDynamicallyOnNonLeadersAreFunctionalAfterFailover() {
+        String client = UUID.randomUUID().toString();
+        cluster.nonLeaders().forEach(server -> {
+            assertThatThrownBy(() -> server.timelockServiceForClient(client).getFreshTimestamp())
+                    .satisfies(ExceptionMatchers::isRetryableExceptionWhereLeaderCannotBeFound);
+        });
+
+        cluster.failoverToNewLeader();
+
+        cluster.getFreshTimestamp();
+    }
+
+    @Test
+    public void clientsCreatedDynamicallyOnLeaderAreFunctionalImmediately() {
+        String client = UUID.randomUUID().toString();
+
+        cluster.currentLeader()
+                .timelockServiceForClient(client)
+                .getFreshTimestamp();
+    }
+
+    @Test
+    public void noConflictIfLeaderAndNonLeadersSeparatelyInitializeClient() {
+        String client = UUID.randomUUID().toString();
+        cluster.nonLeaders().forEach(server -> {
+            assertThatThrownBy(() -> server.timelockServiceForClient(client).getFreshTimestamp())
+                    .satisfies(ExceptionMatchers::isRetryableExceptionWhereLeaderCannotBeFound);
+        });
+
+        long ts1 = cluster.timelockServiceForClient(client).getFreshTimestamp();
+
+        cluster.failoverToNewLeader();
+
+        long ts2 = cluster.getFreshTimestamp();
+        assertThat(ts1).isLessThan(ts2);
+    }
+}

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/suite/PaxosSuite.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/suite/PaxosSuite.java
@@ -33,14 +33,14 @@ import com.palantir.atlasdb.timelock.TestableTimelockCluster;
 @Suite.SuiteClasses(MultiNodePaxosTimeLockServerIntegrationTest.class)
 public class PaxosSuite {
 
-    public static final TestableTimelockCluster NON_BATCHED_PAXOS = new TestableTimelockCluster(
+    public static final TestableTimelockCluster NON_BATCHED_TIMESTAMP_PAXOS = new TestableTimelockCluster(
             ImmutableClusterName.of("non-batched paxos"),
             "https://localhost",
             "paxosMultiServer0.yml",
             "paxosMultiServer1.yml",
             "paxosMultiServer2.yml");
 
-    public static final TestableTimelockCluster BATCHED_PAXOS = new TestableTimelockCluster(
+    public static final TestableTimelockCluster BATCHED_TIMESTAMP_PAXOS = new TestableTimelockCluster(
             ImmutableClusterName.of("batched paxos"),
             "https://localhost",
             "paxosMultiServerBatch0.yml",
@@ -49,7 +49,7 @@ public class PaxosSuite {
 
     @Parameterized.Parameters(name = "{0}")
     public static Collection<TestableTimelockCluster> params() {
-        return ImmutableSet.of(NON_BATCHED_PAXOS, BATCHED_PAXOS);
+        return ImmutableSet.of(NON_BATCHED_TIMESTAMP_PAXOS, BATCHED_TIMESTAMP_PAXOS);
     }
 
     @Rule

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/NamespacedClients.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/NamespacedClients.java
@@ -1,0 +1,106 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock;
+
+import org.immutables.value.Value;
+
+import com.google.common.collect.ImmutableSet;
+import com.palantir.lock.LockRpcClient;
+import com.palantir.lock.LockService;
+import com.palantir.lock.client.RemoteLockServiceAdapter;
+import com.palantir.lock.client.RemoteTimelockServiceAdapter;
+import com.palantir.lock.v2.LockRequest;
+import com.palantir.lock.v2.LockResponse;
+import com.palantir.lock.v2.LockToken;
+import com.palantir.lock.v2.NamespacedTimelockRpcClient;
+import com.palantir.lock.v2.TimelockRpcClient;
+import com.palantir.lock.v2.TimelockService;
+import com.palantir.lock.v2.WaitForLocksRequest;
+import com.palantir.lock.v2.WaitForLocksResponse;
+import com.palantir.timestamp.RemoteTimestampManagementAdapter;
+import com.palantir.timestamp.TimestampManagementRpcClient;
+import com.palantir.timestamp.TimestampManagementService;
+import com.palantir.timestamp.TimestampRange;
+
+@Value.Immutable
+public interface NamespacedClients {
+
+    interface ProxyFactory {
+        <T> T createProxy(Class<T> clazz);
+    }
+
+    @Value.Parameter
+    String namespace();
+
+    @Value.Parameter
+    ProxyFactory proxyFactory();
+
+    static NamespacedClients from(String namespace, ProxyFactory proxyFactory) {
+        return ImmutableNamespacedClients.of(namespace, proxyFactory);
+    }
+
+    @Value.Derived
+    default TimelockService timelockService() {
+        return RemoteTimelockServiceAdapter.create(namespacedTimelockRpcClient());
+    }
+
+    @Value.Derived
+    default NamespacedTimelockRpcClient namespacedTimelockRpcClient() {
+        return new NamespacedTimelockRpcClient(timelockRpcClient(), namespace());
+    }
+
+    @Value.Derived
+    default TimelockRpcClient timelockRpcClient() {
+        return proxyFactory().createProxy(TimelockRpcClient.class);
+    }
+
+    @Value.Derived
+    default LockService legacyLockService() {
+        return RemoteLockServiceAdapter.create(proxyFactory().createProxy(LockRpcClient.class), namespace());
+    }
+
+    @Value.Derived
+    default TimestampManagementService timestampManagementService() {
+        return new RemoteTimestampManagementAdapter(
+                proxyFactory().createProxy(TimestampManagementRpcClient.class),
+                namespace());
+    }
+
+    default long getFreshTimestamp() {
+        return timelockService().getFreshTimestamp();
+    }
+
+    default TimestampRange getFreshTimestamps(int number) {
+        return timelockService().getFreshTimestamps(number);
+    }
+
+    default LockResponse lock(LockRequest requestV2) {
+        return timelockService().lock(requestV2);
+    }
+
+    default boolean unlock(LockToken token) {
+        return timelockService().unlock(ImmutableSet.of(token)).contains(token);
+    }
+
+    default boolean refreshLockLease(LockToken token) {
+        return timelockService().refreshLockLeases(ImmutableSet.of(token)).contains(token);
+    }
+
+    default WaitForLocksResponse waitForLocks(WaitForLocksRequest request) {
+        return timelockService().waitForLocks(request);
+    }
+}

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TemporaryConfigurationHolder.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TemporaryConfigurationHolder.java
@@ -17,6 +17,7 @@ package com.palantir.atlasdb.timelock;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.rules.ExternalResource;
@@ -35,7 +36,7 @@ public class TemporaryConfigurationHolder extends ExternalResource {
     private File temporaryConfigFile;
     private File temporaryLogDirectory;
 
-    public TemporaryConfigurationHolder(TemporaryFolder temporaryFolder, File configTemplate) {
+    TemporaryConfigurationHolder(TemporaryFolder temporaryFolder, File configTemplate) {
         this.temporaryFolder = temporaryFolder;
         this.configTemplate = configTemplate;
     }
@@ -57,9 +58,9 @@ public class TemporaryConfigurationHolder extends ExternalResource {
         Preconditions.checkArgument(!sourceFile.getCanonicalFile().equals(destinationFile.getCanonicalFile()),
                 "The source and destination files both point to '%s'.", sourceFile.getCanonicalPath());
 
-        String oldConfig = FileUtils.readFileToString(sourceFile);
+        String oldConfig = FileUtils.readFileToString(sourceFile, StandardCharsets.UTF_8);
         String newConfig = replaceTempDataDirPlaceholder(oldConfig, substitution);
-        FileUtils.writeStringToFile(destinationFile, newConfig);
+        FileUtils.writeStringToFile(destinationFile, newConfig, StandardCharsets.UTF_8);
     }
 
     @VisibleForTesting
@@ -67,7 +68,7 @@ public class TemporaryConfigurationHolder extends ExternalResource {
         return config.replace(TEMP_DATA_DIR, substitution);
     }
 
-    public String getTemporaryConfigFileLocation() {
+    String getTemporaryConfigFileLocation() {
         return temporaryConfigFile.getPath();
     }
 }

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
@@ -175,6 +175,10 @@ public class TestableTimelockCluster implements TestRule {
         return servers;
     }
 
+    NamespacedClients clientForRandomNamespace() {
+        return client(UUID.randomUUID().toString());
+    }
+
     NamespacedClients client(String namespace) {
         return clientsByNamespace.computeIfAbsent(namespace, this::uncachedNamespacedClients);
     }

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
@@ -16,17 +16,12 @@
 package com.palantir.atlasdb.timelock;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.Random;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.awaitility.Awaitility;
@@ -38,29 +33,9 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
+import com.google.common.hash.Hashing;
 import com.palantir.atlasdb.timelock.util.TestProxies;
-import com.palantir.common.concurrent.PTExecutors;
-import com.palantir.lock.LockRefreshToken;
-import com.palantir.lock.LockRpcClient;
-import com.palantir.lock.LockService;
-import com.palantir.lock.client.AsyncTimeLockUnlocker;
-import com.palantir.lock.client.RemoteLockServiceAdapter;
-import com.palantir.lock.client.RemoteTimelockServiceAdapter;
-import com.palantir.lock.client.TimeLockUnlocker;
-import com.palantir.lock.v2.LockRequest;
-import com.palantir.lock.v2.LockResponse;
-import com.palantir.lock.v2.LockToken;
-import com.palantir.lock.v2.NamespacedTimelockRpcClient;
-import com.palantir.lock.v2.StartIdentifiedAtlasDbTransactionRequest;
-import com.palantir.lock.v2.StartIdentifiedAtlasDbTransactionResponse;
-import com.palantir.lock.v2.TimelockRpcClient;
-import com.palantir.lock.v2.TimelockService;
-import com.palantir.lock.v2.WaitForLocksRequest;
-import com.palantir.lock.v2.WaitForLocksResponse;
-import com.palantir.timestamp.TimestampRange;
-import com.palantir.timestamp.TimestampService;
 
 import io.dropwizard.testing.ResourceHelpers;
 
@@ -68,39 +43,27 @@ public class TestableTimelockCluster implements TestRule {
 
     private final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-    private final Optional<String> clusterName;
-
-    private final String client = UUID.randomUUID().toString();
+    private final String clusterName;
     private final List<TemporaryConfigurationHolder> configs;
     private final List<TestableTimelockServer> servers;
-    private final Map<String, TimelockService> timelockServicesForClient = Maps.newConcurrentMap();
-    private final Map<String, TimeLockUnlocker> unlockerForClient = Maps.newConcurrentMap();
-    private final TestProxies proxies;
+    private final FailoverProxyFactory proxyFactory;
 
-    private final ExecutorService executor = PTExecutors.newCachedThreadPool();
+    private final Map<String, NamespacedClients> clientsByNamespace = Maps.newConcurrentMap();
 
     public TestableTimelockCluster(String baseUri, String... configFileTemplates) {
-        this.clusterName = Optional.empty();
-        this.configs = Arrays.stream(configFileTemplates)
-                .map(this::getConfigHolder)
-                .collect(Collectors.toList());
-        this.servers = configs.stream()
-                .map(TestableTimelockCluster::getServerHolder)
-                .map(holder -> new TestableTimelockServer(baseUri, client, holder))
-                .collect(Collectors.toList());
-        this.proxies = new TestProxies(baseUri, servers);
+        this(ClusterName.random(), baseUri, configFileTemplates);
     }
 
     public TestableTimelockCluster(ClusterName clusterName, String baseUri, String... configFileTemplates) {
-        this.clusterName = Optional.of(clusterName.get());
+        this.clusterName = clusterName.get();
         this.configs = Arrays.stream(configFileTemplates)
                 .map(this::getConfigHolder)
                 .collect(Collectors.toList());
         this.servers = configs.stream()
                 .map(TestableTimelockCluster::getServerHolder)
-                .map(holder -> new TestableTimelockServer(baseUri, client, holder))
+                .map(holder -> new TestableTimelockServer(baseUri, holder))
                 .collect(Collectors.toList());
-        this.proxies = new TestProxies(baseUri, servers);
+        this.proxyFactory = new FailoverProxyFactory(new TestProxies(baseUri, servers));
     }
 
     @Value.Immutable
@@ -112,15 +75,17 @@ public class TestableTimelockCluster implements TestRule {
         public String toString() {
             return get();
         }
+
+        static ClusterName random() {
+            return ImmutableClusterName.of(Hashing.murmur3_32().hashLong(new Random().nextLong()).toString());
+        }
     }
 
     void waitUntilLeaderIsElected() {
-        waitUntilLeaderIsElected(ImmutableList.of());
+        waitUntilLeaderIsElected(ImmutableList.of(UUID.randomUUID().toString()));
     }
 
-    void waitUntilLeaderIsElected(List<String> additionalClients) {
-        List<String> clients = new ArrayList<>(additionalClients);
-        clients.add(client);
+    void waitUntilLeaderIsElected(List<String> clients) {
         waitUntilReadyToServeClients(clients);
     }
 
@@ -130,7 +95,7 @@ public class TestableTimelockCluster implements TestRule {
                 .pollInterval(500, TimeUnit.MILLISECONDS)
                 .until(() -> {
                     try {
-                        clients.forEach(name -> timelockServiceForClient(name).getFreshTimestamp());
+                        clients.forEach(name -> client(name).getFreshTimestamp());
                         return true;
                     } catch (Throwable t) {
                         return false;
@@ -146,7 +111,7 @@ public class TestableTimelockCluster implements TestRule {
     TestableTimelockServer currentLeader() {
         for (TestableTimelockServer server : servers) {
             try {
-                if (server.leaderPing()) {
+                if (server.pingableLeader().ping()) {
                     return server;
                 }
             } catch (Throwable t) {
@@ -187,92 +152,26 @@ public class TestableTimelockCluster implements TestRule {
         return servers;
     }
 
-    long getFreshTimestamp() {
-        return timelockService().getFreshTimestamp();
+    NamespacedClients client(String namespace) {
+        return clientsByNamespace.computeIfAbsent(namespace, this::uncachedNamespacedClients);
     }
 
-    TimestampRange getFreshTimestamps(int number) {
-        return timestampService().getFreshTimestamps(number);
+    NamespacedClients uncachedNamespacedClients(String namespace) {
+        return NamespacedClients.from(namespace, proxyFactory);
     }
 
-    LockRefreshToken remoteLock(com.palantir.lock.LockRequest lockRequest)
-            throws InterruptedException {
-        return lockService().lock(client, lockRequest);
-    }
+    private static final class FailoverProxyFactory implements NamespacedClients.ProxyFactory {
 
-    public boolean remoteUnlock(LockRefreshToken token) {
-        return lockService().unlock(token);
-    }
+        private final TestProxies proxies;
 
-    public LockResponse lock(LockRequest requestV2) {
-        return timelockService().lock(requestV2);
-    }
+        private FailoverProxyFactory(TestProxies proxies) {
+            this.proxies = proxies;
+        }
 
-    CompletableFuture<LockResponse> lockAsync(LockRequest requestV2) {
-        return CompletableFuture.supplyAsync(() -> lock(requestV2), executor);
-    }
-
-    public boolean unlock(LockToken token) {
-        return timelockService().unlock(ImmutableSet.of(token)).contains(token);
-    }
-
-    private Set<LockToken> refreshLockLeases(Set<LockToken> tokens) {
-        return timelockService().refreshLockLeases(tokens);
-    }
-
-    boolean refreshLockLease(LockToken token) {
-        return refreshLockLeases(ImmutableSet.of(token)).contains(token);
-    }
-
-    WaitForLocksResponse waitForLocks(WaitForLocksRequest request) {
-        return timelockService().waitForLocks(request);
-    }
-
-    CompletableFuture<WaitForLocksResponse> waitForLocksAsync(WaitForLocksRequest request) {
-        return CompletableFuture.supplyAsync(() -> waitForLocks(request), executor);
-    }
-
-    StartIdentifiedAtlasDbTransactionResponse startIdentifiedAtlasDbTransaction(
-            StartIdentifiedAtlasDbTransactionRequest request) {
-        return namespacedClient().deprecatedStartTransaction(request).toStartTransactionResponse();
-    }
-
-    private TimestampService timestampService() {
-        return proxies.failoverForClient(client, TimestampService.class);
-    }
-
-    LockService lockService() {
-        return RemoteLockServiceAdapter.create(proxies.failover(LockRpcClient.class, proxies.getServerUris()), client);
-    }
-
-    TimelockService timelockService() {
-        return timelockServiceForClient(client);
-    }
-
-    TimelockService timelockServiceForClient(String name) {
-        return timelockServicesForClient.computeIfAbsent(
-                name,
-                clientName -> {
-                    TimelockRpcClient rpcClient = proxies.failover(TimelockRpcClient.class, proxies.getServerUris());
-                    return RemoteTimelockServiceAdapter.create(new NamespacedTimelockRpcClient(rpcClient, clientName));
-                });
-    }
-
-    TimeLockUnlocker unlockerForClient(String name) {
-        return unlockerForClient.computeIfAbsent(name,
-                clientName -> AsyncTimeLockUnlocker.create(timelockServiceForClient(clientName)));
-    }
-
-    <T> CompletableFuture<T> runWithRpcClientAsync(Function<NamespacedTimelockRpcClient, T> function) {
-        return CompletableFuture.supplyAsync(() -> function.apply(namespacedClient()));
-    }
-
-    NamespacedTimelockRpcClient namespacedClient() {
-        return new NamespacedTimelockRpcClient(timelockRpcClient(), client);
-    }
-
-    private TimelockRpcClient timelockRpcClient() {
-        return proxies.failover(TimelockRpcClient.class, proxies.getServerUris());
+        @Override
+        public <T> T createProxy(Class<T> clazz) {
+            return proxies.failover(clazz);
+        }
     }
 
     RuleChain getRuleChain() {
@@ -294,8 +193,7 @@ public class TestableTimelockCluster implements TestRule {
     }
 
     private TemporaryConfigurationHolder getConfigHolder(String configFileName) {
-        File configTemplate =
-                new File(ResourceHelpers.resourceFilePath(configFileName));
+        File configTemplate = new File(ResourceHelpers.resourceFilePath(configFileName));
         return new TemporaryConfigurationHolder(temporaryFolder, configTemplate);
     }
 
@@ -306,6 +204,6 @@ public class TestableTimelockCluster implements TestRule {
 
     @Override
     public String toString() {
-        return clusterName.orElseGet(super::toString);
+        return clusterName;
     }
 }

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
@@ -15,97 +15,61 @@
  */
 package com.palantir.atlasdb.timelock;
 
-import java.io.IOException;
-import java.net.URL;
+import java.util.Map;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import com.palantir.atlasdb.timelock.NamespacedClients.ProxyFactory;
 import com.palantir.atlasdb.timelock.util.TestProxies;
 import com.palantir.leader.PingableLeader;
-import com.palantir.lock.LockRefreshToken;
-import com.palantir.lock.LockService;
-import com.palantir.lock.client.RemoteTimelockServiceAdapter;
-import com.palantir.lock.v2.LockRequest;
-import com.palantir.lock.v2.LockResponse;
-import com.palantir.lock.v2.NamespacedTimelockRpcClient;
-import com.palantir.lock.v2.TimelockRpcClient;
-import com.palantir.lock.v2.TimelockService;
-import com.palantir.timestamp.TimestampManagementService;
-import com.palantir.timestamp.TimestampService;
 
 public class TestableTimelockServer {
 
     private final TimeLockServerHolder serverHolder;
-    private final String defaultClient;
     private final TestProxies proxies;
+    private final ProxyFactory proxyFactory;
 
-    public TestableTimelockServer(String baseUri, String defaultClient, TimeLockServerHolder serverHolder) {
-        this.defaultClient = defaultClient;
+    private final Map<String, NamespacedClients> clientsByNamespace = Maps.newConcurrentMap();
+
+    TestableTimelockServer(String baseUri, TimeLockServerHolder serverHolder) {
         this.serverHolder = serverHolder;
         this.proxies = new TestProxies(baseUri, ImmutableList.of());
+        this.proxyFactory = new SingleNodeProxyFactory(proxies, serverHolder);
     }
 
     public TimeLockServerHolder serverHolder() {
         return serverHolder;
     }
 
-    public boolean leaderPing() {
-        return pingableLeader().ping();
-    }
-
-    public long getFreshTimestamp() {
-        return timestampService().getFreshTimestamp();
-    }
-
-    public LockRefreshToken remoteLock(String client, com.palantir.lock.LockRequest lockRequest)
-            throws InterruptedException {
-        return lockService().lock(client, lockRequest);
-    }
-
-    public LockResponse lock(LockRequest lockRequest) {
-        return timelockService().lock(lockRequest);
-    }
-
-    public void kill() {
+    void kill() {
         serverHolder.kill();
     }
 
-    public void start() {
+    void start() {
         serverHolder.start();
     }
 
-    public PingableLeader pingableLeader() {
+    PingableLeader pingableLeader() {
         return proxies.singleNode(serverHolder, PingableLeader.class);
     }
 
-    public TimestampService timestampService() {
-        return proxies.singleNodeForClient(defaultClient, serverHolder, TimestampService.class);
+    NamespacedClients client(String namespace) {
+        return clientsByNamespace.computeIfAbsent(namespace, key -> NamespacedClients.from(namespace, proxyFactory));
     }
 
-    public TimestampManagementService timestampManagementService() {
-        return proxies.singleNodeForClient(defaultClient, serverHolder, TimestampManagementService.class);
-    }
+    private static final class SingleNodeProxyFactory implements ProxyFactory {
 
-    public LockService lockService() {
-        return proxies.singleNodeForClient(defaultClient, serverHolder, LockService.class);
-    }
+        private final TestProxies proxies;
+        private final TimeLockServerHolder serverHolder;
 
-    public TimelockService timelockService() {
-        return timelockServiceForClient(defaultClient);
-    }
+        private SingleNodeProxyFactory(TestProxies proxies, TimeLockServerHolder serverHolder) {
+            this.proxies = proxies;
+            this.serverHolder = serverHolder;
+        }
 
-    public TimelockService timelockServiceForClient(String client) {
-        return RemoteTimelockServiceAdapter.create(
-                new NamespacedTimelockRpcClient(proxies.singleNode(serverHolder, TimelockRpcClient.class), client));
-    }
-
-    public MetricsOutput getMetricsOutput() {
-        try {
-            return new MetricsOutput(
-                    new ObjectMapper().readTree(
-                            new URL("http", "localhost", serverHolder.getAdminPort(), "/metrics")));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+        @Override
+        public <T> T createProxy(Class<T> clazz) {
+            return proxies.singleNode(serverHolder, clazz);
         }
     }
 

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TimeLockServerHolder.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TimeLockServerHolder.java
@@ -37,6 +37,7 @@ public class TimeLockServerHolder extends ExternalResource {
     private Supplier<String> configFilePathSupplier;
     private DropwizardTestSupport<CombinedTimeLockServerConfiguration> timelockServer;
     private boolean isRunning = false;
+    private boolean portInitialised = false;
     private int timelockPort;
 
     TimeLockServerHolder(Supplier<String> configFilePathSupplier) {
@@ -54,6 +55,7 @@ public class TimeLockServerHolder extends ExternalResource {
         timelockServer = new DropwizardTestSupport<>(TimeLockServerLauncher.class, configFilePathSupplier.get());
         timelockServer.before();
         isRunning = true;
+        portInitialised = true;
     }
 
     @Override
@@ -65,18 +67,18 @@ public class TimeLockServerHolder extends ExternalResource {
     }
 
     public int getTimelockPort() {
-        checkTimelockHasStarted();
+        checkTimelockPortInitialised();
         return timelockPort;
     }
 
     public String getTimelockUri() {
-        checkTimelockHasStarted();
+        checkTimelockPortInitialised();
         // TODO(nziebart): hack
         return "https://localhost:" + timelockPort;
     }
 
-    private void checkTimelockHasStarted() {
-        Preconditions.checkState(isRunning, "timelock server isn't running yet, bad initialisation?");
+    private void checkTimelockPortInitialised() {
+        Preconditions.checkState(portInitialised, "timelock server isn't running yet, bad initialisation?");
     }
 
     public synchronized void kill() {

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TimeLockServerHolder.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TimeLockServerHolder.java
@@ -24,6 +24,7 @@ import org.junit.rules.ExternalResource;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.palantir.atlasdb.timelock.config.CombinedTimeLockServerConfiguration;
+import com.palantir.logsafe.Preconditions;
 
 import io.dropwizard.testing.DropwizardTestSupport;
 
@@ -64,12 +65,18 @@ public class TimeLockServerHolder extends ExternalResource {
     }
 
     public int getTimelockPort() {
+        checkTimelockHasStarted();
         return timelockPort;
     }
 
     public String getTimelockUri() {
+        checkTimelockHasStarted();
         // TODO(nziebart): hack
         return "https://localhost:" + timelockPort;
+    }
+
+    private void checkTimelockHasStarted() {
+        Preconditions.checkState(isRunning, "timelock server isn't running yet, bad initialisation?");
     }
 
     public synchronized void kill() {

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/util/TestProxies.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/util/TestProxies.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.palantir.atlasdb.config.ImmutableServerListConfig;
+import com.palantir.atlasdb.config.ServerListConfig;
 import com.palantir.atlasdb.http.AtlasDbHttpClients;
 import com.palantir.atlasdb.http.TestProxyUtils;
 import com.palantir.atlasdb.timelock.TestableTimelockServer;

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/util/TestProxies.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/util/TestProxies.java
@@ -35,7 +35,7 @@ import com.palantir.conjure.java.config.ssl.TrustContext;
 
 public class TestProxies {
 
-    public static final SslConfiguration SSL_CONFIGURATION
+    private static final SslConfiguration SSL_CONFIGURATION
             = SslConfiguration.of(Paths.get("var/security/trustStore.jks"));
     public static final TrustContext TRUST_CONTEXT = SslSocketFactories.createTrustContext(SSL_CONFIGURATION);
 
@@ -50,15 +50,8 @@ public class TestProxies {
                 .collect(Collectors.toList());
     }
 
-    public <T> T singleNodeForClient(String client, TimeLockServerHolder server, Class<T> serviceInterface) {
-        return singleNode(serviceInterface, getServerUriForClient(client, server));
-    }
-
     public <T> T singleNode(TimeLockServerHolder server, Class<T> serviceInterface) {
-        return singleNode(serviceInterface, getServerUri(server));
-    }
-
-    public <T> T singleNode(Class<T> serviceInterface, String uri) {
+        String uri = getServerUri(server);
         List<Object> key = ImmutableList.of(serviceInterface, uri, "single");
         return (T) proxies.computeIfAbsent(key, ignored -> AtlasDbHttpClients.createProxy(
                 MetricsManagers.createForTests(),
@@ -68,11 +61,11 @@ public class TestProxies {
                 TestProxyUtils.AUXILIARY_REMOTING_PARAMETERS_RETRYING));
     }
 
-    public <T> T failoverForClient(String client, Class<T> serviceInterface) {
-        return failover(serviceInterface, getServerUrisForClient(client));
-    }
+    public <T> T failover(Class<T> serviceInterface) {
+        List<String> uris = servers.stream()
+                .map(this::getServerUri)
+                .collect(Collectors.toList());
 
-    public <T> T failover(Class<T> serviceInterface, List<String> uris) {
         List<Object> key = ImmutableList.of(serviceInterface, uris, "failover");
         return (T) proxies.computeIfAbsent(key, ignored -> AtlasDbHttpClients.createProxyWithFailover(
                 MetricsManagers.createForTests(),
@@ -81,28 +74,8 @@ public class TestProxies {
                 TestProxyUtils.AUXILIARY_REMOTING_PARAMETERS_RETRYING));
     }
 
-    public List<String> getServerUris() {
-        return servers.stream()
-                .map(this::getServerUri)
-                .collect(Collectors.toList());
-    }
-
-    public List<String> getServerUrisForClient(String client) {
-        return getServerUris().stream()
-                .map(uri -> uri + "/" + client)
-                .collect(Collectors.toList());
-    }
-
     private String getServerUri(TimeLockServerHolder server) {
         return baseUri + ":" + server.getTimelockPort();
-    }
-
-    private String getServerUriForClient(String client, TimeLockServerHolder server) {
-        return getServerUriForClient(client, getServerUri(server));
-    }
-
-    private String getServerUriForClient(String client, String uri) {
-        return uri + "/" + client;
     }
 
 }

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/util/TestProxies.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/util/TestProxies.java
@@ -24,7 +24,6 @@ import java.util.stream.Collectors;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.palantir.atlasdb.config.ImmutableServerListConfig;
-import com.palantir.atlasdb.config.ServerListConfig;
 import com.palantir.atlasdb.http.AtlasDbHttpClients;
 import com.palantir.atlasdb.http.TestProxyUtils;
 import com.palantir.atlasdb.timelock.TestableTimelockServer;


### PR DESCRIPTION
**Goals (and why)**:
The current tests heavily make use of an implicit default namespace. That namespace is then used to do a lot of things, but more importantly it's as part of some readiness check i.e. check if the cluster is ready by grabbing a fresh timestamp etc.

I would like to reuse as many tests as possible, but run them under different configurations i.e. both single leader and multi leader configurations.

In the multi leader configuration, a default namespace now no longer serves as a viable readiness check. This is paving the way so that we can adapt existing tests/test setup 

They're some minor changes but still pretty close to source in terms of readability, but intent/semantics should be a lot clearer and it'd be harder to screw up etc.

**Implementation Description (bullets)**:
* Move tests that don't really need multi-node configurations into the single node version
* Move tests that are really only applicable to single leader timelock into its own test class. Arguably, we could use `assume`? didn't really dig too deep into this, happy to try a better approach.
* Remove dead code
* Free up test specific cruft from `TestableTimelockCluster` and `TestableTimelockServer` by moving it into the corresponding test class.
* `TestableTimelockServer` and `TestableTimelockCluster` now require a namespace to be specified in order to do things with the cluster/server resp.
* Introduce some shared logic for constructing clients that also offers conveniences.
* Got rid of references to the old timestamp service. Can't really use it under normal operation, so everything just goes through timelock service.
* Also try to the use the upper most client where it makes sense i.e. use `TimelockService` vs `TimelockRpcClient` where possible. 
  * It's closer to how it will actually be used
  * It's no longer susceptible to rpc client "breaks", timelock service is still nice and high level "api" that we try to keep consistent.

**Testing (What was existing testing like?  What have you done to improve it?)**:
This is all test code.

**Concerns (what feedback would you like?)**:
Some tests seemed to be doing weird things i.e. locking a lock with a random namespace, and then appearing to unlock that lock but only with the default namespace, which could explain why some tests take longer than they need to etc.

**Where should we start reviewing?**:
* `TestableTimelockCluster`
* `TestableTimelockServer`
* `TestProxies`
* Everything else, this will require a test by test scan, for the most part it's quite mechanical, but it's worth just double checking the semantics are still good.

**Priority (whenever / two weeks / yesterday)**:
ASAP.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
