### PR TITLE
[Conjure Java Runtime] Part 23 - Guest PR: Random retries

### DIFF
--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/RedirectRetryTargeterTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/RedirectRetryTargeterTest.java
@@ -38,15 +38,10 @@ public class RedirectRetryTargeterTest {
     }
 
     @Test
-    public void redirectsToNextNode() {
+    public void redirectsToRandomNode() {
         RedirectRetryTargeter targeter = RedirectRetryTargeter.create(URL_2, ImmutableList.of(URL_1, URL_2, URL_3));
-        assertThat(targeter.redirectRequest()).isEqualTo(URL_3);
-    }
-
-    @Test
-    public void redirectsAroundLastElement() {
-        RedirectRetryTargeter targeter = RedirectRetryTargeter.create(URL_3, ImmutableList.of(URL_1, URL_2, URL_3));
-        assertThat(targeter.redirectRequest()).isEqualTo(URL_1);
+        assertThat(targeter.redirectRequest())
+                .isIn(URL_1, URL_3);
     }
 
     @Test

--- a/changelog/@unreleased/pr-4407.v2.yml
+++ b/changelog/@unreleased/pr-4407.v2.yml
@@ -1,0 +1,9 @@
+type: improvement
+improvement:
+  description: Under certain circumstances, clients will fail to recognise a new timelock
+    leader until the old leader has rebooted/is available. This would lead to unavailability
+    for the duration of the reboot, or an outage if the old leader stays unreachable.
+    We now randomise the next timelock host for a client to try instead of a fixed
+    host.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4407

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/util/ExceptionMatchers.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/util/ExceptionMatchers.java
@@ -27,8 +27,7 @@ public final class ExceptionMatchers {
 
     public static void isRetryableExceptionWhereLeaderCannotBeFound(Throwable throwable) {
         assertThat(throwable)
-                .hasMessageContaining("receiving QosException.RetryOther")
-                .isInstanceOf(RetryableException.class)
-                .hasRootCauseInstanceOf(QosException.RetryOther.class);
+                .hasRootCauseInstanceOf(QosException.RetryOther.class)
+                .isInstanceOf(RetryableException.class);
     }
 }


### PR DESCRIPTION
**Goals (and why)**:
* If we're no longer eligible to gain leadership there is no point in pinging the leaders since when we discover the leader is down, we can't do anything anyway. Plus we're shutting down.

* We can get into a situation where given A, B, C are "ordered" timelock hosts. C starts off being the leader, and then C is killed and then A becomes the leader. Currently, if we talk to B, we get stuck talking to B because it will always recommend us to try C which is then dead and we may spend a lot of time retrying on connection failures.
  * Conjure by default randomises the hosts every ten minutes give or take 30 secs
  * B will 308 and return C, C will subsequently fail, Conjure will then find the next healthy node based on the current order of the urls. e.g. pathological case, Conjure sees nodes as [C, B, A], [A, C, B] or [B, A, C].
  * You then get into a retry loop that can never resolve until:
    * you wait ten minutes for Conjure to shuffle the nodes 
    * or if for some miracle reason, the list of timelock nodes changes, but at that point you have an outage.
    * if this is as a result of leader election, we wait until the node is back online, which makes us not really available (well conceptually we are if we do the right thing which we're not).
  * Note, the 308 from B will not go through the filtering based on health.

* Message contents isn't super useful for exceptions that arise from failing to redirect, mainly we're concerned with receiving a 308/`QosException.RetryOther` and that the top exception is `Retryable`.

**Implementation Description (bullets)**:
* Instead of selecting the next node, we just take the difference of the nodes presented 
* Stop asserting the contents of the message, the instance types are sufficient.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Existing tests should pass.

**Concerns (what feedback would you like?)**:
Is my reasoning behind the `LeaderElectionService` valid? Can it lead to some bad edge case?

**Where should we start reviewing?**:
Everywhere.

**Priority (whenever / two weeks / yesterday)**:
ASAP.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
