### PR TITLE
[Conjure Java Runtime] Part 24: Removing Feign From Jepsen, TM Test and ADHC Test

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/NotCurrentLeaderExceptionMapper.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/NotCurrentLeaderExceptionMapper.java
@@ -49,7 +49,8 @@ public class NotCurrentLeaderExceptionMapper extends ProtocolAwareExceptionMappe
 
     @Override
     QosException handleConjureJavaRuntime(NotCurrentLeaderException exception) {
-        return redirectRetryTargeter.<QosException>map(targeter -> QosException.retryOther(targeter.redirectRequest()))
+        return redirectRetryTargeter.flatMap(RedirectRetryTargeter::redirectRequest)
+                .<QosException>map(QosException::retryOther)
                 .orElseGet(QosException::unavailable);
     }
 }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/RedirectRetryTargeter.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/RedirectRetryTargeter.java
@@ -19,9 +19,11 @@ package com.palantir.atlasdb.http;
 import java.net.URL;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableList;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 
@@ -39,7 +41,7 @@ public final class RedirectRetryTargeter {
                 SafeArg.of("clusterUrls", clusterUrls));
 
         if (clusterUrls.size() == 1) {
-            return new RedirectRetryTargeter(clusterUrls);
+            return new RedirectRetryTargeter(ImmutableList.of());
         }
         List<URL> otherServers = clusterUrls.stream()
                 .filter(url -> !Objects.equals(localServer, url))
@@ -48,7 +50,10 @@ public final class RedirectRetryTargeter {
         return new RedirectRetryTargeter(otherServers);
     }
 
-    URL redirectRequest() {
-        return otherServers.get(ThreadLocalRandom.current().nextInt(otherServers.size()));
+    Optional<URL> redirectRequest() {
+        if (otherServers.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(otherServers.get(ThreadLocalRandom.current().nextInt(otherServers.size())));
     }
 }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/VersionSelectingClients.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/VersionSelectingClients.java
@@ -68,7 +68,7 @@ final class VersionSelectingClients {
                 errorMetric::increment);
     }
 
-    private static <T> T instrumentWithClientVersionTag(
+    static <T> T instrumentWithClientVersionTag(
             TaggedMetricRegistry taggedMetricRegistry,
             TargetFactory.InstanceAndVersion<T> client,
             Class<T> clazz) {

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/AtlasDbHttpClientsTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/AtlasDbHttpClientsTest.java
@@ -45,7 +45,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import com.codahale.metrics.MetricRegistry;
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
@@ -186,7 +185,7 @@ public class AtlasDbHttpClientsTest {
         unavailableServer.stubFor(GET_MAPPING.willReturn(aResponse().withStatus(503)));
 
         TestResource client = AtlasDbHttpClients.createProxyWithFailover(
-                new MetricRegistry(),
+                MetricsManagers.createForTests(),
                 ImmutableServerListConfig.builder().addAllServers(bothUris).build(),
                 TestResource.class,
                 AUXILIARY_REMOTING_PARAMETERS_NO_PAYLOAD_LIMIT);
@@ -213,7 +212,7 @@ public class AtlasDbHttpClientsTest {
     @Test
     public void directProxyIsConfigurableOnClientRequests() {
         TestResource clientWithDirectCall = AtlasDbHttpClients.createProxyWithFailover(
-                new MetricRegistry(),
+                MetricsManagers.createForTests(),
                 ImmutableServerListConfig.builder()
                         .addServers(getUriForPort(availablePort1))
                         .proxyConfiguration(ProxyConfiguration.DIRECT)
@@ -229,7 +228,7 @@ public class AtlasDbHttpClientsTest {
     @Test
     public void httpProxyIsConfigurableOnClientRequests() {
         TestResource clientWithHttpProxy = AtlasDbHttpClients.createProxyWithFailover(
-                new MetricRegistry(),
+                MetricsManagers.createForTests(),
                 ImmutableServerListConfig.builder()
                         .addServers(getUriForPort(availablePort1))
                         .proxyConfiguration(ProxyConfiguration.of(getHostAndPort(proxyPort)))

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/AtlasDbHttpClientsTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/AtlasDbHttpClientsTest.java
@@ -169,7 +169,10 @@ public class AtlasDbHttpClientsTest {
 
         TestResource client = AtlasDbHttpClients.createProxyWithFailover(
                 MetricsManagers.createForTests(),
-                ImmutableServerListConfig.builder().addAllServers(bothUris).build(),
+                ImmutableServerListConfig.builder()
+                        .addAllServers(bothUris)
+                        .sslConfiguration(SSL_CONFIG)
+                        .build(),
                 TestResource.class,
                 AUXILIARY_REMOTING_PARAMETERS);
         int response = client.getTestNumber();

--- a/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/ConjureJavaRuntimeTargetFactory.java
+++ b/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/ConjureJavaRuntimeTargetFactory.java
@@ -96,7 +96,6 @@ public final class ConjureJavaRuntimeTargetFactory implements TargetFactory {
         return wrapWithVersion(client);
     }
 
-    @Override
     public <T> InstanceAndVersion<T> createProxyWithQuickFailoverForTesting(
             ServerListConfig serverListConfig,
             Class<T> type,

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/EteSetup.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/EteSetup.java
@@ -29,7 +29,6 @@ import org.awaitility.Duration;
 import org.junit.rules.ExternalResource;
 import org.junit.rules.RuleChain;
 
-import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
@@ -192,7 +191,7 @@ public abstract class EteSetup {
                 .collect(Collectors.toList());
 
         return AtlasDbHttpClients.createProxyWithFailover(
-                new MetricRegistry(),
+                MetricsManagers.createForTests(),
                 ImmutableServerListConfig.builder()
                         .addAllServers(uris)
                         .sslConfiguration(SSL_CONFIGURATION)

--- a/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
+++ b/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
@@ -8,11 +8,11 @@
             [jepsen.os.debian :as debian]
             [jepsen.util :refer [timeout]]
             [knossos.history :as history])
-  (:import com.codahale.metrics.MetricRegistry)
   (:import com.palantir.atlasdb.jepsen.JepsenHistoryCheckers)
   (:import com.palantir.atlasdb.http.JepsenLockClient)
   (:import com.palantir.atlasdb.http.SynchronousLockClient)
   (:import com.palantir.atlasdb.http.AsyncLockClient))
+  (:import com.palantir.atlasdb.util.MetricsManagers)
 
 (def lock-names ["alpha" "bravo" "charlie" "delta"])
 
@@ -142,8 +142,8 @@
 
 (defn sync-lock-test
   [nem]
-    (lock-test nem (fn [] (SynchronousLockClient/create (MetricRegistry.) '("n1" "n2" "n3" "n4" "n5")))))
+    (lock-test nem (fn [] (SynchronousLockClient/create (MetricsManagers/createForTests) '("n1" "n2" "n3" "n4" "n5")))))
 
 (defn async-lock-test
   [nem]
-    (lock-test nem (fn [] (AsyncLockClient/create (MetricRegistry.) '("n1" "n2" "n3" "n4" "n5")))))
+    (lock-test nem (fn [] (AsyncLockClient/create (MetricsManagers/createForTests) '("n1" "n2" "n3" "n4" "n5")))))

--- a/atlasdb-jepsen-tests/src/jepsen/atlasdb/timestamp.clj
+++ b/atlasdb-jepsen-tests/src/jepsen/atlasdb/timestamp.clj
@@ -9,9 +9,9 @@
             [jepsen.util :refer [timeout]]
             [knossos.history :as history])
   ;; We can import any Java objects, since Clojure runs on the JVM
-  (:import com.codahale.metrics.MetricRegistry)
   (:import com.palantir.atlasdb.http.TimestampClient)
   (:import com.palantir.atlasdb.jepsen.JepsenHistoryCheckers))
+  (:import com.palantir.atlasdb.util.MetricsManagers)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Defining the set of of operations that you can do with a client
@@ -31,7 +31,7 @@
     (setup!
       [this test node]
       "Factory that returns an object implementing client/Client"
-      (create-client (TimestampClient/create (MetricRegistry.) '("n1" "n2" "n3" "n4" "n5"))))
+      (create-client (TimestampClient/create (MetricsManagers/createForTests) '("n1" "n2" "n3" "n4" "n5"))))
 
     (invoke!
       [this test op]

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/AsyncLockClient.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/AsyncLockClient.java
@@ -18,8 +18,8 @@ package com.palantir.atlasdb.http;
 import java.util.List;
 import java.util.Set;
 
-import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableSet;
+import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.lock.StringLockDescriptor;
 import com.palantir.lock.client.RemoteTimelockServiceAdapter;
 import com.palantir.lock.v2.LockRequest;
@@ -36,9 +36,9 @@ public final class AsyncLockClient implements JepsenLockClient<LockToken> {
         this.timelockService = RemoteTimelockServiceAdapter.create(timelockService);
     }
 
-    public static AsyncLockClient create(MetricRegistry metricRegistry, List<String> hosts) {
-        return new AsyncLockClient(TimelockUtils.createClient(metricRegistry, hosts,
-                NamespacedTimelockRpcClient.class));
+    public static AsyncLockClient create(MetricsManager metricsManager, List<String> hosts) {
+        return new AsyncLockClient(
+                TimelockUtils.createClient(metricsManager, hosts, NamespacedTimelockRpcClient.class));
     }
 
     @Override

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/SynchronousLockClient.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/SynchronousLockClient.java
@@ -18,10 +18,10 @@ package com.palantir.atlasdb.http;
 import java.util.List;
 import java.util.Set;
 
-import com.codahale.metrics.MetricRegistry;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Sets;
+import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.LockMode;
 import com.palantir.lock.LockRefreshToken;
@@ -37,8 +37,8 @@ public class SynchronousLockClient implements JepsenLockClient<LockRefreshToken>
         this.lockService = lockService;
     }
 
-    public static JepsenLockClient<LockRefreshToken> create(MetricRegistry metricRegistry, List<String> hosts) {
-        return new SynchronousLockClient(TimelockUtils.createClient(metricRegistry, hosts, LockService.class));
+    public static JepsenLockClient<LockRefreshToken> create(MetricsManager metricsManager, List<String> hosts) {
+        return new SynchronousLockClient(TimelockUtils.createClient(metricsManager, hosts, LockService.class));
     }
 
     @Override

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/TimelockUtils.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/TimelockUtils.java
@@ -17,10 +17,10 @@ package com.palantir.atlasdb.http;
 
 import java.util.List;
 
-import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.Lists;
 import com.palantir.atlasdb.config.AuxiliaryRemotingParameters;
 import com.palantir.atlasdb.config.ImmutableServerListConfig;
+import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.conjure.java.api.config.service.UserAgent;
 
 public final class TimelockUtils {
@@ -30,18 +30,18 @@ public final class TimelockUtils {
     private TimelockUtils() {
     }
 
-    public static <T> T createClient(MetricRegistry metricRegistry, List<String> hosts, Class<T> type) {
+    public static <T> T createClient(MetricsManager metricsManager, List<String> hosts, Class<T> type) {
         List<String> endpointUris = hostnamesToEndpointUris(hosts);
-        return createFromUris(metricRegistry, endpointUris, type);
+        return createFromUris(metricsManager, endpointUris, type);
     }
 
     private static List<String> hostnamesToEndpointUris(List<String> hosts) {
         return Lists.transform(hosts, host -> String.format("http://%s:%d/%s", host, PORT, NAMESPACE));
     }
 
-    private static <T> T createFromUris(MetricRegistry metricRegistry, List<String> endpointUris, Class<T> type) {
+    private static <T> T createFromUris(MetricsManager metricsManager, List<String> endpointUris, Class<T> type) {
         return AtlasDbHttpClients.createProxyWithQuickFailoverForTesting(
-                metricRegistry,
+                metricsManager,
                 ImmutableServerListConfig.builder().addAllServers(endpointUris).build(),
                 type,
                 AuxiliaryRemotingParameters.builder()

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/TimestampClient.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/TimestampClient.java
@@ -17,14 +17,14 @@ package com.palantir.atlasdb.http;
 
 import java.util.List;
 
-import com.codahale.metrics.MetricRegistry;
+import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.timestamp.TimestampService;
 
 public final class TimestampClient {
     private TimestampClient() {
     }
 
-    public static TimestampService create(MetricRegistry metricRegistry, List<String> hosts) {
-        return TimelockUtils.createClient(metricRegistry, hosts, TimestampService.class);
+    public static TimestampService create(MetricsManager metricsManager, List<String> hosts) {
+        return TimelockUtils.createClient(metricsManager, hosts, TimestampService.class);
     }
 }

--- a/atlasdb-remoting-api/src/main/java/com/palantir/atlasdb/http/TargetFactory.java
+++ b/atlasdb-remoting-api/src/main/java/com/palantir/atlasdb/http/TargetFactory.java
@@ -44,8 +44,23 @@ public interface TargetFactory {
             Class<T> type,
             AuxiliaryRemotingParameters parameters);
 
+    /**
+     * Creates a live reloading proxy that performs failover.
+     *
+     * Proxies created by this method are able to detect changes to the serverListConfigSupplier at runtime. However,
+     * there are no guarantees beyond eventual consistency here.
+     *
+     * This method should not be used if the {@link ServerListConfig} is not expected to change, as it may incur
+     * unnecessary resource load from attempting to establish consistency. Please use
+     * {@link #createProxyWithFailover(ServerListConfig, Class, AuxiliaryRemotingParameters)} in that case.
+     */
     <T> InstanceAndVersion<T> createLiveReloadingProxyWithFailover(
             Supplier<ServerListConfig> serverListConfigSupplier,
+            Class<T> type,
+            AuxiliaryRemotingParameters parameters);
+
+    <T> InstanceAndVersion<T> createProxyWithQuickFailoverForTesting(
+            ServerListConfig serverListConfig,
             Class<T> type,
             AuxiliaryRemotingParameters parameters);
 

--- a/atlasdb-remoting-api/src/main/java/com/palantir/atlasdb/http/TargetFactory.java
+++ b/atlasdb-remoting-api/src/main/java/com/palantir/atlasdb/http/TargetFactory.java
@@ -47,8 +47,8 @@ public interface TargetFactory {
     /**
      * Creates a live reloading proxy that performs failover.
      *
-     * Proxies created by this method are able to detect changes to the serverListConfigSupplier at runtime. However,
-     * there are no guarantees beyond eventual consistency here.
+     * Proxies created by this method are able to detect changes to the {@code serverListConfigSupplier} at runtime.
+     * However, there are no guarantees beyond eventual consistency here.
      *
      * This method should not be used if the {@link ServerListConfig} is not expected to change, as it may incur
      * unnecessary resource load from attempting to establish consistency. Please use
@@ -56,11 +56,6 @@ public interface TargetFactory {
      */
     <T> InstanceAndVersion<T> createLiveReloadingProxyWithFailover(
             Supplier<ServerListConfig> serverListConfigSupplier,
-            Class<T> type,
-            AuxiliaryRemotingParameters parameters);
-
-    <T> InstanceAndVersion<T> createProxyWithQuickFailoverForTesting(
-            ServerListConfig serverListConfig,
             Class<T> type,
             AuxiliaryRemotingParameters parameters);
 

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/http/TestProxyUtils.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/http/TestProxyUtils.java
@@ -17,21 +17,15 @@
 package com.palantir.atlasdb.http;
 
 import com.palantir.atlasdb.config.AuxiliaryRemotingParameters;
-import com.palantir.atlasdb.config.ImmutableRemotingClientConfig;
-import com.palantir.atlasdb.config.RemotingClientConfig;
+import com.palantir.atlasdb.config.RemotingClientConfigs;
 import com.palantir.conjure.java.api.config.service.UserAgent;
 
 public final class TestProxyUtils {
-    public static final RemotingClientConfig REMOTING_CLIENT_CONFIG = ImmutableRemotingClientConfig.builder()
-            .enableLegacyClientFallback(false)
-            .maximumConjureRemotingProbability(1.0)
-            .build();
-
     public static final AuxiliaryRemotingParameters AUXILIARY_REMOTING_PARAMETERS_RETRYING
             = AuxiliaryRemotingParameters.builder()
                     .shouldLimitPayload(false)
                     .userAgent(UserAgent.of(UserAgent.Agent.of("bla", "0.1.2")))
-                    .remotingClientConfig(() -> REMOTING_CLIENT_CONFIG)
+                    .remotingClientConfig(() -> RemotingClientConfigs.ALWAYS_USE_CONJURE)
                     .shouldRetry(true)
                     .build();
 

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceIntegrationTest.java
@@ -244,8 +244,8 @@ public class AsyncTimelockServiceIntegrationTest extends AbstractAsyncTimelockSe
     public void unlockAndFreezeDoesNotAllowRefreshes() throws InterruptedException {
         HeldLocksToken token = lockWithFullResponse(requestForWriteLock(LOCK_A), TEST_CLIENT);
         cluster.lockService().unlockAndFreeze(token);
-        Set<LockRefreshToken> lockRefreshTokens = cluster.lockService().refreshLockRefreshTokens(
-                ImmutableList.of(token.getLockRefreshToken()));
+        Set<LockRefreshToken> lockRefreshTokens = cluster.lockService()
+                .refreshLockRefreshTokens(ImmutableList.of(token.getLockRefreshToken()));
         assertThat(lockRefreshTokens).isEmpty();
     }
 

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
@@ -188,7 +188,7 @@ public class TestableTimelockCluster implements TestRule {
     }
 
     long getFreshTimestamp() {
-        return timestampService().getFreshTimestamp();
+        return timelockService().getFreshTimestamp();
     }
 
     TimestampRange getFreshTimestamps(int number) {

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TimeLockTestUtils.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TimeLockTestUtils.java
@@ -31,9 +31,9 @@ import com.palantir.atlasdb.config.ImmutableAtlasDbConfig;
 import com.palantir.atlasdb.config.ImmutableAtlasDbRuntimeConfig;
 import com.palantir.atlasdb.config.ImmutableServerListConfig;
 import com.palantir.atlasdb.config.ImmutableTimeLockClientConfig;
+import com.palantir.atlasdb.config.RemotingClientConfigs;
 import com.palantir.atlasdb.debug.ClientLockDiagnosticCollector;
 import com.palantir.atlasdb.factory.TransactionManagers;
-import com.palantir.atlasdb.http.TestProxyUtils;
 import com.palantir.atlasdb.memory.InMemoryAtlasDbConfig;
 import com.palantir.atlasdb.table.description.Schema;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
@@ -82,7 +82,7 @@ public final class TimeLockTestUtils {
 
         AtlasDbRuntimeConfig runtimeConfig = ImmutableAtlasDbRuntimeConfig
                 .copyOf(runtimeConfigTemplate)
-                .withRemotingClient(TestProxyUtils.REMOTING_CLIENT_CONFIG);
+                .withRemotingClient(RemotingClientConfigs.ALWAYS_USE_CONJURE);
 
         TransactionManager transactionManager = TransactionManagers.builder()
                 .config(config)

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/util/TestProxies.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/util/TestProxies.java
@@ -21,7 +21,6 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 
-import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.palantir.atlasdb.config.ImmutableServerListConfig;
@@ -76,7 +75,7 @@ public class TestProxies {
     public <T> T failover(Class<T> serviceInterface, List<String> uris) {
         List<Object> key = ImmutableList.of(serviceInterface, uris, "failover");
         return (T) proxies.computeIfAbsent(key, ignored -> AtlasDbHttpClients.createProxyWithFailover(
-                new MetricRegistry(),
+                MetricsManagers.createForTests(),
                 ImmutableServerListConfig.builder().addAllServers(uris).sslConfiguration(SSL_CONFIGURATION).build(),
                 serviceInterface,
                 TestProxyUtils.AUXILIARY_REMOTING_PARAMETERS_RETRYING));


### PR DESCRIPTION
**Goals (and why)**:
- Switch all remaining test-only paths (plus a usage in the large internal product) away from Feign.
- After this PR merges, all uses of AtlasDB on develop should use Conjure Java Runtime.

**Implementation Description (bullets)**:
- Switch the last two methods in `AtlasDbHttpClients` to use CJR.
- Clean up necessary tests.

**Testing (What was existing testing like?  What have you done to improve it?)**:
For the most part we can rely on what's already there. Though see the Concerns section

**Concerns (what feedback would you like?)**:
- `TransactionManagersTest`: I removed the test for the Payload Limiter (because CJR does not use them). I also removed the test for canUseCJR since the tests now use that, and I don't think it's necessary to maintain a canUseFeign codepath. 
- (possibly more contentious) I also removed the test for the ProxyConfiguration since we just pass this through to CJR, and I had a lot of difficulty getting WireMock to work nicely.
- Jepsen: Please sanity check my Clojure syntax, it's been a long while...

**Where should we start reviewing?**: `AtlasDbHttpClients`

**Priority (whenever / two weeks / yesterday)**: this week would be nice
