### PR TITLE
[Conjure Java Runtime] Part 25: Fast Failover Proxy Needs To Be Used On Non-Live-Reloadable Paths

### DIFF
--- a/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/ConjureJavaRuntimeTargetFactory.java
+++ b/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/ConjureJavaRuntimeTargetFactory.java
@@ -92,8 +92,7 @@ public final class ConjureJavaRuntimeTargetFactory implements TargetFactory {
                 addAtlasDbRemotingAgent(parameters.userAgent()),
                 HOST_METRICS_REGISTRY,
                 refreshableConfig);
-        client = FastFailoverProxy.newProxyInstance(type, client);
-        return wrapWithVersion(client);
+        return decorateFailoverProxy(type, client);
     }
 
     public <T> InstanceAndVersion<T> createProxyWithQuickFailoverForTesting(
@@ -115,8 +114,11 @@ public final class ConjureJavaRuntimeTargetFactory implements TargetFactory {
                 addAtlasDbRemotingAgent(parameters.userAgent()),
                 HOST_METRICS_REGISTRY,
                 clientConfiguration);
-        client = FastFailoverProxy.newProxyInstance(type, client);
-        return wrapWithVersion(client);
+        return decorateFailoverProxy(type, client);
+    }
+
+    private static <T> InstanceAndVersion<T> decorateFailoverProxy(Class<T> type, T client) {
+        return wrapWithVersion(FastFailoverProxy.newProxyInstance(type, client));
     }
 
     private static UserAgent addAtlasDbRemotingAgent(UserAgent agent) {

--- a/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/ConjureJavaRuntimeTargetFactory.java
+++ b/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/ConjureJavaRuntimeTargetFactory.java
@@ -110,11 +110,13 @@ public final class ConjureJavaRuntimeTargetFactory implements TargetFactory {
             ClientOptions clientOptions) {
         ClientConfiguration clientConfiguration = clientOptions.serverListToClient(serverListConfig);
 
-        return wrapWithVersion(JaxRsClient.create(
+        T client = JaxRsClient.create(
                 type,
                 addAtlasDbRemotingAgent(parameters.userAgent()),
                 HOST_METRICS_REGISTRY,
-                clientConfiguration));
+                clientConfiguration);
+        client = FastFailoverProxy.newProxyInstance(type, client);
+        return wrapWithVersion(client);
     }
 
     private static UserAgent addAtlasDbRemotingAgent(UserAgent agent) {

--- a/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/FastFailoverProxy.java
+++ b/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/FastFailoverProxy.java
@@ -30,7 +30,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.reflect.AbstractInvocationHandler;
 import com.palantir.common.base.Throwables;
-import com.palantir.common.exception.AtlasDbDependencyException;
 import com.palantir.conjure.java.api.errors.QosException;
 
 import feign.RetryableException;
@@ -81,7 +80,7 @@ public final class FastFailoverProxy<T> extends AbstractInvocationHandler {
         if (attempt.isSuccessful()) {
             return attempt.result().orElse(null);
         }
-        throw new AtlasDbDependencyException(Throwables.unwrapIfPossible(attempt.throwable().get()));
+        throw Throwables.unwrapIfPossible(attempt.throwable().get());
     }
 
     private ResultOrThrowable singleInvocation(Method method, Object[] args) {

--- a/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/FastFailoverProxy.java
+++ b/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/FastFailoverProxy.java
@@ -30,6 +30,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.reflect.AbstractInvocationHandler;
 import com.palantir.common.base.Throwables;
+import com.palantir.common.exception.AtlasDbDependencyException;
 import com.palantir.conjure.java.api.errors.QosException;
 
 import feign.RetryableException;
@@ -80,7 +81,7 @@ public final class FastFailoverProxy<T> extends AbstractInvocationHandler {
         if (attempt.isSuccessful()) {
             return attempt.result().orElse(null);
         }
-        throw Throwables.unwrapIfPossible(attempt.throwable().get());
+        throw new AtlasDbDependencyException(Throwables.unwrapIfPossible(attempt.throwable().get()));
     }
 
     private ResultOrThrowable singleInvocation(Method method, Object[] args) {

--- a/changelog/@unreleased/pr-4413.v2.yml
+++ b/changelog/@unreleased/pr-4413.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: Non-live reloading proxies created via `AtlasDbHttpClients` now correctly
+    perform fast failover. Previously, they would throw relatively quickly when encountering
+    308s, which may occur when TimeLock Server (or services running embedded leader
+    blocks) have a leader election.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4413


### PR DESCRIPTION
**Goals (and why)**:
- Stop build flakes
- Ensure large internal product usage on non-live-reloadable paths.

**Implementation Description (bullets)**:
- Wrap proxies with failover.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Should reduce number of flakes. I can run a few builds to test this.

**Concerns (what feedback would you like?)**:
- Nothing in particular.

**Where should we start reviewing?**: the one file

**Priority (whenever / two weeks / yesterday)**: yesterday 🔥 
