### PR TITLE
[Timelock Partitioning] Part 47: Adapt tests to be in terms of namespaces.

### DIFF
--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceIntegrationTest.java
@@ -177,7 +177,8 @@ public class AsyncTimelockServiceIntegrationTest extends AbstractAsyncTimelockSe
     public void taggedMetricsCanBeIteratedThrough() {
         NamespacedClients randomNamespace = cluster.clientForRandomNamespace();
         randomNamespace.getFreshTimestamp();
-        Map<MetricName, Metric> metrics = cluster.currentLeader().taggedMetricRegistry().getMetrics();
+        Map<MetricName, Metric> metrics = cluster.currentLeaderFor(randomNamespace.namespace())
+                .taggedMetricRegistry().getMetrics();
         assertThat(metrics).hasKeySatisfying(new Condition<MetricName>("contains random namespace") {
             @Override
             public boolean matches(MetricName value) {

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/IsolatedPaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/IsolatedPaxosTimeLockServerIntegrationTest.java
@@ -25,6 +25,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 
+import com.google.common.collect.Iterables;
 import com.palantir.atlasdb.http.AtlasDbHttpClients;
 import com.palantir.atlasdb.http.TestProxyUtils;
 import com.palantir.atlasdb.timelock.paxos.PaxosTimeLockConstants;
@@ -45,7 +46,7 @@ public class IsolatedPaxosTimeLockServerIntegrationTest {
             "https://localhost",
             "paxosThreeServers.yml");
 
-    private static final TestableTimelockServer SERVER = CLUSTER.servers().get(0);
+    private static final TestableTimelockServer SERVER = Iterables.getOnlyElement(CLUSTER.servers());
 
     @ClassRule
     public static final RuleChain ruleChain = CLUSTER.getRuleChain();
@@ -78,7 +79,7 @@ public class IsolatedPaxosTimeLockServerIntegrationTest {
 
     @Test
     public void canPingWithoutQuorum() {
-        assertThatCode(SERVER.pingableLeader()::ping)
+        assertThatCode(() -> SERVER.pinger().ping(namespace.namespace()))
                 .doesNotThrowAnyException();
     }
 

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/NonBlockingAppenderIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/NonBlockingAppenderIntegrationTest.java
@@ -20,6 +20,8 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 
+import com.google.common.collect.ImmutableList;
+
 public class NonBlockingAppenderIntegrationTest {
     private static final TestableTimelockCluster CLUSTER = new TestableTimelockCluster(
             "https://localhost",
@@ -27,15 +29,17 @@ public class NonBlockingAppenderIntegrationTest {
 
     @ClassRule
     public static final RuleChain ruleChain = CLUSTER.getRuleChain();
+    private static NamespacedClients namespace;
 
     @BeforeClass
     public static void setUp() {
-        CLUSTER.waitUntilLeaderIsElected();
+        namespace = CLUSTER.clientForRandomNamespace();
+        CLUSTER.waitUntilLeaderIsElected(ImmutableList.of(namespace.namespace()));
     }
 
     @Test
     public void canDeserializeConfigAndStart() {
-        CLUSTER.clientForRandomNamespace().getFreshTimestamp();
+        namespace.getFreshTimestamp();
     }
 
 }

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
@@ -34,7 +34,6 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
-import com.palantir.leader.PingableLeader;
 import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.LockMode;
 import com.palantir.lock.LockRefreshToken;
@@ -87,7 +86,6 @@ public class PaxosTimeLockServerIntegrationTest {
     public static void waitForClusterToStabilize() {
         namespace1 = TIMELOCK.client(CLIENT_1);
         namespace2 = TIMELOCK.client(CLIENT_2);
-        PingableLeader leader = TIMELOCK.pingableLeader();
         Awaitility.await()
                 .atMost(30, TimeUnit.SECONDS)
                 .pollInterval(1, TimeUnit.SECONDS)
@@ -97,7 +95,7 @@ public class PaxosTimeLockServerIntegrationTest {
                         NAMESPACES.forEach(client -> TIMELOCK.client(client).getFreshTimestamp());
                         NAMESPACES.forEach(client -> TIMELOCK.client(client).timelockService().currentTimeMillis());
                         NAMESPACES.forEach(client -> TIMELOCK.client(client).legacyLockService().currentTimeMillis());
-                        return leader.ping();
+                        return TIMELOCK.pinger().ping(NAMESPACES).containsAll(NAMESPACES);
                     } catch (Throwable t) {
                         LoggerFactory.getLogger(PaxosTimeLockServerIntegrationTest.class).error("erreur!", t);
                         return false;

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -64,7 +64,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
     @Before
     public void bringAllNodesOnline() {
         namespace = cluster.clientForRandomNamespace();
-        cluster.waitUntilAllServersOnlineAndReadyToServeClients(ImmutableList.of(namespace.namespace()));
+        cluster.waitUntilAllServersOnlineAndReadyToServeNamespaces(ImmutableList.of(namespace.namespace()));
     }
 
     @Test
@@ -119,7 +119,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
         bringAllNodesOnline();
         for (TestableTimelockServer server : cluster.servers()) {
             server.kill();
-            cluster.waitUntilAllServersOnlineAndReadyToServeClients(ImmutableList.of(namespace.namespace()));
+            cluster.waitUntilAllServersOnlineAndReadyToServeNamespaces(ImmutableList.of(namespace.namespace()));
             namespace.getFreshTimestamp();
             server.start();
         }

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/SingleLeaderMultiNodePaxosTimeLockIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/SingleLeaderMultiNodePaxosTimeLockIntegrationTest.java
@@ -54,30 +54,32 @@ public class SingleLeaderMultiNodePaxosTimeLockIntegrationTest {
 
     @Test
     public void clientsCreatedDynamicallyOnNonLeadersAreFunctionalAfterFailover() {
-        cluster.nonLeaders().forEach(server ->
-                assertThatThrownBy(() -> server.client(namespace.namespace()).getFreshTimestamp())
+        cluster.nonLeaders(namespace.namespace()).forEach((namespace, server) ->
+                assertThatThrownBy(() -> server.client(namespace).getFreshTimestamp())
                 .satisfies(ExceptionMatchers::isRetryableExceptionWhereLeaderCannotBeFound));
 
-        cluster.failoverToNewLeader();
+        cluster.failoverToNewLeader(namespace.namespace());
 
         namespace.getFreshTimestamp();
     }
 
     @Test
     public void clientsCreatedDynamicallyOnLeaderAreFunctionalImmediately() {
-        assertThatCode(() -> cluster.currentLeader().client(namespace.namespace()).getFreshTimestamp())
+        assertThatCode(() -> cluster.currentLeaderFor(namespace.namespace())
+                .client(namespace.namespace())
+                .getFreshTimestamp())
                 .doesNotThrowAnyException();
     }
 
     @Test
     public void noConflictIfLeaderAndNonLeadersSeparatelyInitializeClient() {
-        cluster.nonLeaders().forEach(server ->
-                assertThatThrownBy(() -> server.client(namespace.namespace()).getFreshTimestamp())
+        cluster.nonLeaders(namespace.namespace()).forEach((namespace, server) ->
+                assertThatThrownBy(() -> server.client(namespace).getFreshTimestamp())
                 .satisfies(ExceptionMatchers::isRetryableExceptionWhereLeaderCannotBeFound));
 
         long ts1 = namespace.getFreshTimestamp();
 
-        cluster.failoverToNewLeader();
+        cluster.failoverToNewLeader(namespace.namespace());
 
         long ts2 = namespace.getFreshTimestamp();
         assertThat(ts1).isLessThan(ts2);

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/SingleLeaderMultiNodePaxosTimeLockIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/SingleLeaderMultiNodePaxosTimeLockIntegrationTest.java
@@ -54,8 +54,8 @@ public class SingleLeaderMultiNodePaxosTimeLockIntegrationTest {
 
     @Test
     public void clientsCreatedDynamicallyOnNonLeadersAreFunctionalAfterFailover() {
-        cluster.nonLeaders(namespace.namespace()).forEach((namespace, server) ->
-                assertThatThrownBy(() -> server.client(namespace).getFreshTimestamp())
+        cluster.nonLeaders(namespace.namespace()).forEach((clientName, server) ->
+                assertThatThrownBy(() -> server.client(clientName).getFreshTimestamp())
                 .satisfies(ExceptionMatchers::isRetryableExceptionWhereLeaderCannotBeFound));
 
         cluster.failoverToNewLeader(namespace.namespace());
@@ -73,8 +73,8 @@ public class SingleLeaderMultiNodePaxosTimeLockIntegrationTest {
 
     @Test
     public void noConflictIfLeaderAndNonLeadersSeparatelyInitializeClient() {
-        cluster.nonLeaders(namespace.namespace()).forEach((namespace, server) ->
-                assertThatThrownBy(() -> server.client(namespace).getFreshTimestamp())
+        cluster.nonLeaders(namespace.namespace()).forEach((clientName, server) ->
+                assertThatThrownBy(() -> server.client(clientName).getFreshTimestamp())
                 .satisfies(ExceptionMatchers::isRetryableExceptionWhereLeaderCannotBeFound));
 
         long ts1 = namespace.getFreshTimestamp();

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableLeaderPinger.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableLeaderPinger.java
@@ -1,0 +1,29 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock;
+
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
+
+public interface TestableLeaderPinger {
+    default Set<String> ping(String... namespaces) {
+        return ping(ImmutableSet.copyOf(namespaces));
+    }
+
+    Set<String> ping(Iterable<String> namespaces);
+}

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
@@ -105,17 +105,17 @@ public class TestableTimelockCluster implements TestRule {
         }
     }
 
-    void waitUntilLeaderIsElected(List<String> clients) {
-        waitUntilReadyToServeClients(clients);
+    void waitUntilLeaderIsElected(List<String> namespaces) {
+        waitUntilReadyToServeNamespaces(namespaces);
     }
 
-    private void waitUntilReadyToServeClients(List<String> clients) {
+    private void waitUntilReadyToServeNamespaces(List<String> namespaces) {
         Awaitility.await()
                 .atMost(60, TimeUnit.SECONDS)
                 .pollInterval(500, TimeUnit.MILLISECONDS)
                 .until(() -> {
                     try {
-                        clients.forEach(name -> client(name).getFreshTimestamp());
+                        namespaces.forEach(name -> client(name).getFreshTimestamp());
                         return true;
                     } catch (Throwable t) {
                         return false;
@@ -123,9 +123,9 @@ public class TestableTimelockCluster implements TestRule {
                 });
     }
 
-    void waitUntilAllServersOnlineAndReadyToServeClients(List<String> additionalClients) {
+    void waitUntilAllServersOnlineAndReadyToServeNamespaces(List<String> namespaces) {
         servers.forEach(TestableTimelockServer::start);
-        waitUntilReadyToServeClients(additionalClients);
+        waitUntilReadyToServeNamespaces(namespaces);
     }
 
     TestableTimelockServer currentLeaderFor(String namespace) {

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
@@ -15,17 +15,22 @@
  */
 package com.palantir.atlasdb.timelock;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
+import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
-
-import javax.annotation.Nullable;
 
 import org.awaitility.Awaitility;
 import org.immutables.value.Value;
@@ -36,9 +41,18 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.SetMultimap;
+import com.google.common.collect.Sets;
 import com.google.common.hash.Hashing;
+import com.palantir.atlasdb.timelock.paxos.PaxosQuorumCheckingCoalescingFunction.PaxosContainer;
 import com.palantir.atlasdb.timelock.util.TestProxies;
+import com.palantir.common.streams.KeyedStream;
+import com.palantir.paxos.InProgressResponseState;
+import com.palantir.paxos.PaxosQuorumChecker;
 
 import io.dropwizard.testing.ResourceHelpers;
 
@@ -48,13 +62,12 @@ public class TestableTimelockCluster implements TestRule {
 
     private final String clusterName;
     private final List<TemporaryConfigurationHolder> configs;
-    private final List<TestableTimelockServer> servers;
+    private final Set<TestableTimelockServer> servers;
+    private final Multimap<TestableTimelockServer, TestableTimelockServer> serverToOtherServers;
     private final FailoverProxyFactory proxyFactory;
+    private final ExecutorService executorService = Executors.newCachedThreadPool();
 
     private final Map<String, NamespacedClients> clientsByNamespace = Maps.newConcurrentMap();
-
-    @Nullable
-    private TestableTimelockServer lastLeader;
 
     public TestableTimelockCluster(String baseUri, String... configFileTemplates) {
         this(ClusterName.random(), baseUri, configFileTemplates);
@@ -68,8 +81,13 @@ public class TestableTimelockCluster implements TestRule {
         this.servers = configs.stream()
                 .map(TestableTimelockCluster::getServerHolder)
                 .map(holder -> new TestableTimelockServer(baseUri, holder))
-                .collect(Collectors.toList());
-        this.proxyFactory = new FailoverProxyFactory(new TestProxies(baseUri, servers));
+                .collect(Collectors.toSet());
+        this.serverToOtherServers = KeyedStream.of(servers)
+                .map(server -> ImmutableSet.of(server))
+                .map(server -> Sets.difference(servers, server))
+                .flatMap(Collection::stream)
+                .collectToSetMultimap();
+        this.proxyFactory = new FailoverProxyFactory(new TestProxies(baseUri, ImmutableList.copyOf(servers)));
     }
 
     @Value.Immutable
@@ -85,10 +103,6 @@ public class TestableTimelockCluster implements TestRule {
         static ClusterName random() {
             return ImmutableClusterName.of(Hashing.murmur3_32().hashLong(new Random().nextLong()).toString());
         }
-    }
-
-    void waitUntilLeaderIsElected() {
-        waitUntilLeaderIsElected(ImmutableList.of(UUID.randomUUID().toString()));
     }
 
     void waitUntilLeaderIsElected(List<String> clients) {
@@ -114,47 +128,55 @@ public class TestableTimelockCluster implements TestRule {
         waitUntilReadyToServeClients(additionalClients);
     }
 
-    TestableTimelockServer currentLeader() {
-        Optional<TestableTimelockServer> maybeCurrentLeader = tryToPingCurrentLeader();
-        if (maybeCurrentLeader.isPresent()) {
-            return maybeCurrentLeader.get();
-        }
-
-        for (TestableTimelockServer server : servers) {
-            try {
-                if (server.pingableLeader().ping()) {
-                    lastLeader = server;
-                    return server;
-                }
-            } catch (Throwable t) {
-                // continue;
-            }
-        }
-        throw new IllegalStateException("no nodes are currently the leader");
+    TestableTimelockServer currentLeaderFor(String namespace) {
+        return Iterables.getOnlyElement(currentLeaders(namespace).get(namespace));
     }
 
-    private Optional<TestableTimelockServer> tryToPingCurrentLeader() {
-        try {
-            if (lastLeader != null && lastLeader.pingableLeader().ping()) {
-                return Optional.of(lastLeader);
-            }
-            return Optional.empty();
-        } catch (Throwable t) {
-            return Optional.empty();
-        }
+    SetMultimap<String, TestableTimelockServer> currentLeaders(String... namespaces) {
+        Set<String> namespacesIterable = ImmutableSet.copyOf(namespaces);
+        KeyedStream<TestableTimelockServer, PaxosContainer<Set<String>>> responses = PaxosQuorumChecker.collectUntil(
+                ImmutableList.copyOf(servers),
+                server -> PaxosContainer.of(server.pinger().ping(namespaces)),
+                Maps.toMap(servers, unused -> executorService),
+                Duration.ofSeconds(2),
+                untilAllNamespacesAreSeen(namespacesIterable))
+                .stream();
+
+        return responses
+                .filter(PaxosContainer::isSuccessful)
+                .map(PaxosContainer::get)
+                .flatMap(Collection::stream)
+                .mapEntries((server, namespace) -> Maps.immutableEntry(namespace, server))
+                .collectToSetMultimap();
     }
 
-    List<TestableTimelockServer> nonLeaders() {
-        TestableTimelockServer leader = currentLeader();
-        return servers.stream()
-                .filter(server -> server != leader)
-                .collect(Collectors.toList());
+    private static Predicate<InProgressResponseState<TestableTimelockServer, PaxosContainer<Set<String>>>>
+    untilAllNamespacesAreSeen(Set<String> namespacesIterable) {
+        return state -> state.responses().values().stream()
+                .filter(PaxosContainer::isSuccessful)
+                .map(PaxosContainer::get)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toSet())
+                .containsAll(namespacesIterable);
     }
 
-    void failoverToNewLeader() {
+
+    SetMultimap<String, TestableTimelockServer> nonLeaders(String... namespaces) {
+        SetMultimap<String, TestableTimelockServer> currentLeaderPerNamespace = currentLeaders(namespaces);
+
+        assertThat(currentLeaderPerNamespace.asMap().values())
+                .as("there should only be one leader per namespace")
+                .allMatch(servers -> servers.size() == 1);
+
+        return KeyedStream.stream(currentLeaderPerNamespace)
+                .flatMap(leader -> serverToOtherServers.get(leader).stream())
+                .collectToSetMultimap();
+    }
+
+    void failoverToNewLeader(String namespace) {
         int maxTries = 5;
         for (int i = 0; i < maxTries; i++) {
-            if (tryFailoverToNewLeader()) {
+            if (tryFailoverToNewLeader(namespace)) {
                 return;
             }
         }
@@ -162,16 +184,16 @@ public class TestableTimelockCluster implements TestRule {
         throw new IllegalStateException("unable to force a failover after " + maxTries + " tries");
     }
 
-    private boolean tryFailoverToNewLeader() {
-        TestableTimelockServer leader = currentLeader();
+    private boolean tryFailoverToNewLeader(String namespace) {
+        TestableTimelockServer leader = currentLeaderFor(namespace);
         leader.kill();
-        waitUntilLeaderIsElected();
+        waitUntilLeaderIsElected(ImmutableList.of(namespace));
         leader.start();
 
-        return !currentLeader().equals(leader);
+        return !currentLeaderFor(namespace).equals(leader);
     }
 
-    List<TestableTimelockServer> servers() {
+    Set<TestableTimelockServer> servers() {
         return servers;
     }
 

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
@@ -151,7 +151,7 @@ public class TestableTimelockCluster implements TestRule {
     }
 
     private static Predicate<InProgressResponseState<TestableTimelockServer, PaxosContainer<Set<String>>>>
-    untilAllNamespacesAreSeen(Set<String> namespacesIterable) {
+            untilAllNamespacesAreSeen(Set<String> namespacesIterable) {
         return state -> state.responses().values().stream()
                 .filter(PaxosContainer::isSuccessful)
                 .map(PaxosContainer::get)
@@ -166,7 +166,7 @@ public class TestableTimelockCluster implements TestRule {
 
         assertThat(currentLeaderPerNamespace.asMap().values())
                 .as("there should only be one leader per namespace")
-                .allMatch(servers -> servers.size() == 1);
+                .allMatch(leadersForNamespace -> leadersForNamespace.size() == 1);
 
         return KeyedStream.stream(currentLeaderPerNamespace)
                 .flatMap(leader -> serverToOtherServers.get(leader).stream())

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.timelock;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.palantir.atlasdb.timelock.NamespacedClients.ProxyFactory;
 import com.palantir.atlasdb.timelock.util.TestProxies;
@@ -50,8 +51,15 @@ public class TestableTimelockServer {
         serverHolder.start();
     }
 
-    PingableLeader pingableLeader() {
-        return proxies.singleNode(serverHolder, PingableLeader.class);
+    TestableLeaderPinger pinger() {
+        PingableLeader pingableLeader = proxies.singleNode(serverHolder, PingableLeader.class);
+        return namespaces -> {
+            if (pingableLeader.ping()) {
+                return ImmutableSet.copyOf(namespaces);
+            } else {
+                return ImmutableSet.of();
+            }
+        };
     }
 
     NamespacedClients client(String namespace) {


### PR DESCRIPTION
**Goals (and why)**:
To be able to verify the new implementation, we want to be able to run all the existing tests on it. However the existing tests assume a single leader in a lot of places (entirely reasonable).

In `TestableTimelockCluster` we have:

| Method | Why it no longer works |
| --- | --- |
| `currentLeader()` | if we can have multiple leaders, this is now ill defined |
| `nonLeaders()` | this is defined in terms of the above, and is also ill defined |
| `failoverToNewLeader` | which leader should be failed over? |
| `waitUntilLeaderIsElected` | impl is picking a random namespace and waiting till a leader gets elected, this can't be used as a preamble anymore without specifying a namespace you want to wait for |

They are now all parameterised by a namespace(s), making the tests more explicit.

**Implementation Description (bullets)**:
Everything inside `TestableTimelockCluster` becomes namespace aware. 

**Testing (What was existing testing like?  What have you done to improve it?)**:
Tests are a bit more explicit, and should read pretty well still, and continue to read well once we add the multi-leader specific tests.

**Concerns (what feedback would you like?)**:
None

**Where should we start reviewing?**:
`TestableTimelockCluster`

**Priority (whenever / two weeks / yesterday)**:
ASAP 🔥 🚒 
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
