### PR TITLE
upgrade HikariCP [2.4.7 -> 3.4.1]

### DIFF
--- a/changelog/@unreleased/pr-4421.v2.yml
+++ b/changelog/@unreleased/pr-4421.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: |-
+    HikariCP was upgraded 2.4.7 -> 3.4.1
+    There are minor API and metrics changes/breaks.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4421

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -27,7 +27,7 @@ ext.libVersions =
     libthrift: '0.9.2',
     protoc: '3.5.1',
     findbugs: '1.3.9',
-    hikariCP: '2.4.7',
+    hikariCP: '3.4.1',
     checkstyle: '6.18',
     findbugsAnnotations: '2.0.3',
     ant: '1.9.4',


### PR DESCRIPTION
Background:
Judging from some of the hikari github issues with similar errors to ours, this might resolve an issue we're seeing around excessive errors when hikari tries to double-close already closed connections (perhaps due to DB-side timeouts / poor customer DB configuration or network)

Issues:
The 2.x --> 3.x bump does remove some API bits that downstream project touches, but the fixes are easy and I can do them.
The metrics hikari produces also got a bunch of changes, mostly additions, but some small changes that may break the dashboards that use them. I own the downstream dashboard and can fix.