### PR TITLE
Remove populateIoCacheOnFlush from TableCreator

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTableCreator.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTableCreator.java
@@ -28,7 +28,6 @@ import com.datastax.driver.core.schemabuilder.TableOptions.CompressionOptions;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
-import com.palantir.atlasdb.protos.generated.TableMetadataPersistence.CachePriority;
 import com.palantir.atlasdb.table.description.TableMetadata;
 import com.palantir.common.base.Throwables;
 import com.palantir.logsafe.SafeArg;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTableCreator.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTableCreator.java
@@ -89,7 +89,6 @@ class CassandraTableCreator {
                 .gcGraceSeconds(config.gcGraceSeconds())
                 .minIndexInterval(CassandraTableOptions.minIndexInterval(tableMetadata))
                 .maxIndexInterval(CassandraTableOptions.maxIndexInterval(tableMetadata))
-                .populateIOCacheOnFlush(tableMetadata.getCachePriority() == CachePriority.HOTTEST)
                 .speculativeRetry(SchemaBuilder.noSpeculativeRetry())
                 .clusteringOrder(COLUMN, SchemaBuilder.Direction.ASC)
                 .clusteringOrder(TIMESTAMP, SchemaBuilder.Direction.ASC)

--- a/changelog/@unreleased/pr-4422.v2.yml
+++ b/changelog/@unreleased/pr-4422.v2.yml
@@ -1,5 +1,5 @@
 type: fix
 fix:
-  description: Remove the populateIoCacheOnFlush field from the CassandraTableCreator.
+  description: Remove the `populateIoCacheOnFlush` field from the `CassandraTableCreator`.
   links:
   - https://github.com/palantir/atlasdb/pull/4422

--- a/changelog/@unreleased/pr-4422.v2.yml
+++ b/changelog/@unreleased/pr-4422.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Remove the populateIoCacheOnFlush field from the CassandraTableCreator.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4422


### PR DESCRIPTION
**Goals (and why)**:
I missed this reference in https://github.com/palantir/atlasdb/pull/4396.  

This flag is a no-op in Cassandra 2.1+.

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
