### PR TITLE
[PDS-10{3841,4895}] Disable Cleanup Of Unmarked Streams

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
@@ -651,6 +651,8 @@ public class StreamStoreRenderer {
                 line();
                 line("public class ", MetadataCleanupTask, " implements OnCleanupTask {"); {
                     line();
+                    line("private static final Logger log = LoggerFactory.getLogger(", MetadataCleanupTask, ".class);");
+                    line();
                     line("private final ", TableFactory, " tables;");
                     line();
                     line("public ", MetadataCleanupTask, "(Namespace namespace) {"); {
@@ -658,6 +660,8 @@ public class StreamStoreRenderer {
                     } line("}");
                     line();
                     cellsCleanedUp();
+                    line();
+                    streamDiagnostics();
                 } line("}");
             }
 
@@ -669,6 +673,10 @@ public class StreamStoreRenderer {
                 line("import java.util.Set;");
                 line("import java.util.stream.Collectors;");
                 line();
+                line("import org.slf4j.Logger;");
+                line("import org.slf4j.LoggerFactory;");
+                line();
+                line("import com.google.common.collect.Multimap;");
                 line("import com.google.common.collect.Sets;");
                 line("import com.palantir.atlasdb.cleaner.api.OnCleanupTask;");
                 line("import com.palantir.atlasdb.encoding.PtBytes;");
@@ -680,6 +688,7 @@ public class StreamStoreRenderer {
                 line("import com.palantir.atlasdb.table.description.ValueType;");
                 line("import com.palantir.atlasdb.transaction.api.Transaction;");
                 line("import com.palantir.common.streams.KeyedStream;");
+                line("import com.palantir.logsafe.SafeArg;");
 
                 if (streamIdType == ValueType.SHA256HASH) {
                     line("import com.palantir.util.crypto.Sha256Hash;");
@@ -695,29 +704,92 @@ public class StreamStoreRenderer {
                         line("rows.add(", StreamMetadataRow, ".BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));");
                     } line("}");
                     line(StreamIndexTable, " indexTable = tables.get", StreamIndexTable, "(t);");
-                    line("Set<", StreamIndexRow, "> indexRows = rows.stream()");
+                    line("executeUnreferencedStreamDiagnostics(indexTable, rows);");
+                    line("Map<", StreamMetadataRow, ", StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);");
+                    line("Set<", StreamId, "> toDelete = Sets.newHashSet();");
+                    line("for (Map.Entry<", StreamMetadataRow, ", StreamMetadata> e : currentMetadata.entrySet()) {"); {
+                        line("if (e.getValue().getStatus() != Status.STORED) {"); {
+                            line("toDelete.add(e.getKey().getId());");
+                        } line("}");
+                    } line("}");
+                    line(StreamStore, ".of(tables).deleteStreams(t, toDelete);");
+                    line("return false;");
+                } line("}");
+            }
+
+            private void streamDiagnostics() {
+                conversionHelpers();
+                line();
+                diagnosticsByMultimap();
+                line();
+                diagnosticsByIterator();
+                line();
+                evaluation();
+            }
+
+            private void evaluation() {
+                line("private static void executeUnreferencedStreamDiagnostics(", StreamIndexTable, " indexTable, Set<", StreamMetadataRow, "> metadataRows) {"); {
+                    line("Set<", StreamIndexRow, "> indexRows = metadataRows.stream()");
                     line("        .map(", StreamMetadataRow, "::getId)");
                     line("        .map(", StreamIndexRow, "::of)");
                     line("        .collect(Collectors.toSet());");
+
+                    line("Set<", StreamMetadataRow, "> unreferencedStreamsByIterator = getUnreferencedStreamsByIterator(indexTable, indexRows);");
+                    line("Set<", StreamMetadataRow, "> unreferencedStreamsByMultimap = getUnreferencedStreamsByMultimap(indexTable, indexRows);");
+
+                    line("if (!unreferencedStreamsByIterator.equals(unreferencedStreamsByMultimap)) {"); {
+                        line("log.info(\"We searched for unreferenced streams with methodological inconsistency: iterators claimed we could delete {}, but multimaps {}.\",");
+                        line("        SafeArg.of(\"unreferencedByIterator\", convertToIdsForLogging(unreferencedStreamsByIterator)),");
+                        line("        SafeArg.of(\"unreferencedByMultimap\", convertToIdsForLogging(unreferencedStreamsByMultimap)));");
+                    } line("} else {"); {
+                        line("log.info(\"We searched for unreferenced streams and consistently found {}.\",");
+                        line("        SafeArg.of(\"unreferencedStreamIds\", convertToIdsForLogging(unreferencedStreamsByIterator)));");
+                    } line("}");
+                } line("}");
+            }
+
+            private void conversionHelpers() {
+                line("private static ", StreamMetadataRow, " convertFromIndexRow(", StreamIndexRow, " idxRow) {"); {
+                    line("return ", StreamMetadataRow, ".of(idxRow.getId());");
+                } line("}");
+
+                line("private static Set<Long> convertToIdsForLogging(Set<", StreamMetadataRow, "> iteratorExcess) {"); {
+                    line("return iteratorExcess.stream()");
+                    line("        .map(", StreamMetadataRow, "::getId)");
+                    line("        .collect(Collectors.toSet());");
+                } line("}");
+            }
+
+            private void diagnosticsByMultimap() {
+                line("private static Set<", StreamMetadataRow, "> getUnreferencedStreamsByMultimap(", StreamIndexTable, " indexTable, Set<", StreamIndexRow, "> indexRows) {"); {
+                    line("Multimap<", StreamIndexRow, ", ", StreamIndexColumnValue, "> indexValues = indexTable.getRowsMultimap(indexRows);");
+                    line("Set<", StreamMetadataRow, "> presentMetadataRows");
+                    line("        = indexValues.keySet().stream()");
+                    line("        .map(", MetadataCleanupTask, "::convertFromIndexRow)");
+                    line("        .collect(Collectors.toSet());");
+
+                    line("Set<", StreamMetadataRow, "> queriedMetadataRows");
+                    line("        = indexRows.stream()");
+                    line("        .map(", MetadataCleanupTask, "::convertFromIndexRow)");
+                    line("        .collect(Collectors.toSet());");
+
+                    line("return Sets.difference(queriedMetadataRows, presentMetadataRows);");
+                } line("}");
+            }
+
+            private void diagnosticsByIterator() {
+                line("private static Set<", StreamMetadataRow, "> getUnreferencedStreamsByIterator(", StreamIndexTable, " indexTable, Set<", StreamIndexRow, "> indexRows) {"); {
                     line("Map<", StreamIndexRow, ", Iterator<", StreamIndexColumnValue, ">> referenceIteratorByStream");
                     line("        = indexTable.getRowsColumnRangeIterator(indexRows,");
                     line("                BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 1));");
-                    line("Set<", StreamMetadataRow, "> streamsWithNoReferences");
+                    line("Set<", StreamMetadataRow, "> unreferencedStreamMetadata");
                     line("        = KeyedStream.stream(referenceIteratorByStream)");
                     line("        .filter(valueIterator -> !valueIterator.hasNext())");
                     line("        .keys() // (authorized)"); // required for large internal product
                     line("        .map(", StreamIndexRow, "::getId)");
                     line("        .map(", StreamMetadataRow, "::of)");
                     line("        .collect(Collectors.toSet());");
-                    line("Map<", StreamMetadataRow, ", StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);");
-                    line("Set<", StreamId, "> toDelete = Sets.newHashSet();");
-                    line("for (Map.Entry<", StreamMetadataRow, ", StreamMetadata> e : currentMetadata.entrySet()) {"); {
-                        line("if (e.getValue().getStatus() != Status.STORED || streamsWithNoReferences.contains(e.getKey())) {"); {
-                            line("toDelete.add(e.getKey().getId());");
-                        } line("}");
-                    } line("}");
-                    line(StreamStore, ".of(tables).deleteStreams(t, toDelete);");
-                    line("return false;");
+                    line("return unreferencedStreamMetadata;");
                 } line("}");
             }
         }.render();

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsMetadataCleanupTask.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsMetadataCleanupTask.java
@@ -5,6 +5,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
 import com.palantir.atlasdb.encoding.PtBytes;
@@ -16,8 +20,11 @@ import com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.common.streams.KeyedStream;
+import com.palantir.logsafe.SafeArg;
 
 public class SnapshotsMetadataCleanupTask implements OnCleanupTask {
+
+    private static final Logger log = LoggerFactory.getLogger(SnapshotsMetadataCleanupTask.class);
 
     private final TodoSchemaTableFactory tables;
 
@@ -33,28 +40,68 @@ public class SnapshotsMetadataCleanupTask implements OnCleanupTask {
             rows.add(SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));
         }
         SnapshotsStreamIdxTable indexTable = tables.getSnapshotsStreamIdxTable(t);
-        Set<SnapshotsStreamIdxTable.SnapshotsStreamIdxRow> indexRows = rows.stream()
+        executeUnreferencedStreamDiagnostics(indexTable, rows);
+        Map<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
+        Set<Long> toDelete = Sets.newHashSet();
+        for (Map.Entry<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
+            if (e.getValue().getStatus() != Status.STORED) {
+                toDelete.add(e.getKey().getId());
+            }
+        }
+        SnapshotsStreamStore.of(tables).deleteStreams(t, toDelete);
+        return false;
+    }
+
+    private static SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow convertFromIndexRow(SnapshotsStreamIdxTable.SnapshotsStreamIdxRow idxRow) {
+        return SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow.of(idxRow.getId());
+    }
+    private static Set<Long> convertToIdsForLogging(Set<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> iteratorExcess) {
+        return iteratorExcess.stream()
                 .map(SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow::getId)
-                .map(SnapshotsStreamIdxTable.SnapshotsStreamIdxRow::of)
                 .collect(Collectors.toSet());
+    }
+
+    private static Set<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> getUnreferencedStreamsByMultimap(SnapshotsStreamIdxTable indexTable, Set<SnapshotsStreamIdxTable.SnapshotsStreamIdxRow> indexRows) {
+        Multimap<SnapshotsStreamIdxTable.SnapshotsStreamIdxRow, SnapshotsStreamIdxTable.SnapshotsStreamIdxColumnValue> indexValues = indexTable.getRowsMultimap(indexRows);
+        Set<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> presentMetadataRows
+                = indexValues.keySet().stream()
+                .map(SnapshotsMetadataCleanupTask::convertFromIndexRow)
+                .collect(Collectors.toSet());
+        Set<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> queriedMetadataRows
+                = indexRows.stream()
+                .map(SnapshotsMetadataCleanupTask::convertFromIndexRow)
+                .collect(Collectors.toSet());
+        return Sets.difference(queriedMetadataRows, presentMetadataRows);
+    }
+
+    private static Set<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> getUnreferencedStreamsByIterator(SnapshotsStreamIdxTable indexTable, Set<SnapshotsStreamIdxTable.SnapshotsStreamIdxRow> indexRows) {
         Map<SnapshotsStreamIdxTable.SnapshotsStreamIdxRow, Iterator<SnapshotsStreamIdxTable.SnapshotsStreamIdxColumnValue>> referenceIteratorByStream
                 = indexTable.getRowsColumnRangeIterator(indexRows,
                         BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 1));
-        Set<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> streamsWithNoReferences
+        Set<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> unreferencedStreamMetadata
                 = KeyedStream.stream(referenceIteratorByStream)
                 .filter(valueIterator -> !valueIterator.hasNext())
                 .keys() // (authorized)
                 .map(SnapshotsStreamIdxTable.SnapshotsStreamIdxRow::getId)
                 .map(SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow::of)
                 .collect(Collectors.toSet());
-        Map<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
-        Set<Long> toDelete = Sets.newHashSet();
-        for (Map.Entry<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
-            if (e.getValue().getStatus() != Status.STORED || streamsWithNoReferences.contains(e.getKey())) {
-                toDelete.add(e.getKey().getId());
-            }
+        return unreferencedStreamMetadata;
+    }
+
+    private static void executeUnreferencedStreamDiagnostics(SnapshotsStreamIdxTable indexTable, Set<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> metadataRows) {
+        Set<SnapshotsStreamIdxTable.SnapshotsStreamIdxRow> indexRows = metadataRows.stream()
+                .map(SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow::getId)
+                .map(SnapshotsStreamIdxTable.SnapshotsStreamIdxRow::of)
+                .collect(Collectors.toSet());
+        Set<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> unreferencedStreamsByIterator = getUnreferencedStreamsByIterator(indexTable, indexRows);
+        Set<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> unreferencedStreamsByMultimap = getUnreferencedStreamsByMultimap(indexTable, indexRows);
+        if (!unreferencedStreamsByIterator.equals(unreferencedStreamsByMultimap)) {
+            log.info("We searched for unreferenced streams with methodological inconsistency: iterators claimed we could delete {}, but multimaps {}.",
+                    SafeArg.of("unreferencedByIterator", convertToIdsForLogging(unreferencedStreamsByIterator)),
+                    SafeArg.of("unreferencedByMultimap", convertToIdsForLogging(unreferencedStreamsByMultimap)));
+        } else {
+            log.info("We searched for unreferenced streams and consistently found {}.",
+                    SafeArg.of("unreferencedStreamIds", convertToIdsForLogging(unreferencedStreamsByIterator)));
         }
-        SnapshotsStreamStore.of(tables).deleteStreams(t, toDelete);
-        return false;
     }
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataMetadataCleanupTask.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataMetadataCleanupTask.java
@@ -5,6 +5,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
 import com.palantir.atlasdb.encoding.PtBytes;
@@ -16,8 +20,11 @@ import com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.common.streams.KeyedStream;
+import com.palantir.logsafe.SafeArg;
 
 public class DataMetadataCleanupTask implements OnCleanupTask {
+
+    private static final Logger log = LoggerFactory.getLogger(DataMetadataCleanupTask.class);
 
     private final BlobSchemaTableFactory tables;
 
@@ -33,28 +40,68 @@ public class DataMetadataCleanupTask implements OnCleanupTask {
             rows.add(DataStreamMetadataTable.DataStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));
         }
         DataStreamIdxTable indexTable = tables.getDataStreamIdxTable(t);
-        Set<DataStreamIdxTable.DataStreamIdxRow> indexRows = rows.stream()
+        executeUnreferencedStreamDiagnostics(indexTable, rows);
+        Map<DataStreamMetadataTable.DataStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
+        Set<Long> toDelete = Sets.newHashSet();
+        for (Map.Entry<DataStreamMetadataTable.DataStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
+            if (e.getValue().getStatus() != Status.STORED) {
+                toDelete.add(e.getKey().getId());
+            }
+        }
+        DataStreamStore.of(tables).deleteStreams(t, toDelete);
+        return false;
+    }
+
+    private static DataStreamMetadataTable.DataStreamMetadataRow convertFromIndexRow(DataStreamIdxTable.DataStreamIdxRow idxRow) {
+        return DataStreamMetadataTable.DataStreamMetadataRow.of(idxRow.getId());
+    }
+    private static Set<Long> convertToIdsForLogging(Set<DataStreamMetadataTable.DataStreamMetadataRow> iteratorExcess) {
+        return iteratorExcess.stream()
                 .map(DataStreamMetadataTable.DataStreamMetadataRow::getId)
-                .map(DataStreamIdxTable.DataStreamIdxRow::of)
                 .collect(Collectors.toSet());
+    }
+
+    private static Set<DataStreamMetadataTable.DataStreamMetadataRow> getUnreferencedStreamsByMultimap(DataStreamIdxTable indexTable, Set<DataStreamIdxTable.DataStreamIdxRow> indexRows) {
+        Multimap<DataStreamIdxTable.DataStreamIdxRow, DataStreamIdxTable.DataStreamIdxColumnValue> indexValues = indexTable.getRowsMultimap(indexRows);
+        Set<DataStreamMetadataTable.DataStreamMetadataRow> presentMetadataRows
+                = indexValues.keySet().stream()
+                .map(DataMetadataCleanupTask::convertFromIndexRow)
+                .collect(Collectors.toSet());
+        Set<DataStreamMetadataTable.DataStreamMetadataRow> queriedMetadataRows
+                = indexRows.stream()
+                .map(DataMetadataCleanupTask::convertFromIndexRow)
+                .collect(Collectors.toSet());
+        return Sets.difference(queriedMetadataRows, presentMetadataRows);
+    }
+
+    private static Set<DataStreamMetadataTable.DataStreamMetadataRow> getUnreferencedStreamsByIterator(DataStreamIdxTable indexTable, Set<DataStreamIdxTable.DataStreamIdxRow> indexRows) {
         Map<DataStreamIdxTable.DataStreamIdxRow, Iterator<DataStreamIdxTable.DataStreamIdxColumnValue>> referenceIteratorByStream
                 = indexTable.getRowsColumnRangeIterator(indexRows,
                         BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 1));
-        Set<DataStreamMetadataTable.DataStreamMetadataRow> streamsWithNoReferences
+        Set<DataStreamMetadataTable.DataStreamMetadataRow> unreferencedStreamMetadata
                 = KeyedStream.stream(referenceIteratorByStream)
                 .filter(valueIterator -> !valueIterator.hasNext())
                 .keys() // (authorized)
                 .map(DataStreamIdxTable.DataStreamIdxRow::getId)
                 .map(DataStreamMetadataTable.DataStreamMetadataRow::of)
                 .collect(Collectors.toSet());
-        Map<DataStreamMetadataTable.DataStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
-        Set<Long> toDelete = Sets.newHashSet();
-        for (Map.Entry<DataStreamMetadataTable.DataStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
-            if (e.getValue().getStatus() != Status.STORED || streamsWithNoReferences.contains(e.getKey())) {
-                toDelete.add(e.getKey().getId());
-            }
+        return unreferencedStreamMetadata;
+    }
+
+    private static void executeUnreferencedStreamDiagnostics(DataStreamIdxTable indexTable, Set<DataStreamMetadataTable.DataStreamMetadataRow> metadataRows) {
+        Set<DataStreamIdxTable.DataStreamIdxRow> indexRows = metadataRows.stream()
+                .map(DataStreamMetadataTable.DataStreamMetadataRow::getId)
+                .map(DataStreamIdxTable.DataStreamIdxRow::of)
+                .collect(Collectors.toSet());
+        Set<DataStreamMetadataTable.DataStreamMetadataRow> unreferencedStreamsByIterator = getUnreferencedStreamsByIterator(indexTable, indexRows);
+        Set<DataStreamMetadataTable.DataStreamMetadataRow> unreferencedStreamsByMultimap = getUnreferencedStreamsByMultimap(indexTable, indexRows);
+        if (!unreferencedStreamsByIterator.equals(unreferencedStreamsByMultimap)) {
+            log.info("We searched for unreferenced streams with methodological inconsistency: iterators claimed we could delete {}, but multimaps {}.",
+                    SafeArg.of("unreferencedByIterator", convertToIdsForLogging(unreferencedStreamsByIterator)),
+                    SafeArg.of("unreferencedByMultimap", convertToIdsForLogging(unreferencedStreamsByMultimap)));
+        } else {
+            log.info("We searched for unreferenced streams and consistently found {}.",
+                    SafeArg.of("unreferencedStreamIds", convertToIdsForLogging(unreferencedStreamsByIterator)));
         }
-        DataStreamStore.of(tables).deleteStreams(t, toDelete);
-        return false;
     }
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataMetadataCleanupTask.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataMetadataCleanupTask.java
@@ -5,6 +5,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
 import com.palantir.atlasdb.encoding.PtBytes;
@@ -16,8 +20,11 @@ import com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.common.streams.KeyedStream;
+import com.palantir.logsafe.SafeArg;
 
 public class HotspottyDataMetadataCleanupTask implements OnCleanupTask {
+
+    private static final Logger log = LoggerFactory.getLogger(HotspottyDataMetadataCleanupTask.class);
 
     private final BlobSchemaTableFactory tables;
 
@@ -33,28 +40,68 @@ public class HotspottyDataMetadataCleanupTask implements OnCleanupTask {
             rows.add(HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));
         }
         HotspottyDataStreamIdxTable indexTable = tables.getHotspottyDataStreamIdxTable(t);
-        Set<HotspottyDataStreamIdxTable.HotspottyDataStreamIdxRow> indexRows = rows.stream()
+        executeUnreferencedStreamDiagnostics(indexTable, rows);
+        Map<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
+        Set<Long> toDelete = Sets.newHashSet();
+        for (Map.Entry<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
+            if (e.getValue().getStatus() != Status.STORED) {
+                toDelete.add(e.getKey().getId());
+            }
+        }
+        HotspottyDataStreamStore.of(tables).deleteStreams(t, toDelete);
+        return false;
+    }
+
+    private static HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow convertFromIndexRow(HotspottyDataStreamIdxTable.HotspottyDataStreamIdxRow idxRow) {
+        return HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow.of(idxRow.getId());
+    }
+    private static Set<Long> convertToIdsForLogging(Set<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow> iteratorExcess) {
+        return iteratorExcess.stream()
                 .map(HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow::getId)
-                .map(HotspottyDataStreamIdxTable.HotspottyDataStreamIdxRow::of)
                 .collect(Collectors.toSet());
+    }
+
+    private static Set<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow> getUnreferencedStreamsByMultimap(HotspottyDataStreamIdxTable indexTable, Set<HotspottyDataStreamIdxTable.HotspottyDataStreamIdxRow> indexRows) {
+        Multimap<HotspottyDataStreamIdxTable.HotspottyDataStreamIdxRow, HotspottyDataStreamIdxTable.HotspottyDataStreamIdxColumnValue> indexValues = indexTable.getRowsMultimap(indexRows);
+        Set<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow> presentMetadataRows
+                = indexValues.keySet().stream()
+                .map(HotspottyDataMetadataCleanupTask::convertFromIndexRow)
+                .collect(Collectors.toSet());
+        Set<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow> queriedMetadataRows
+                = indexRows.stream()
+                .map(HotspottyDataMetadataCleanupTask::convertFromIndexRow)
+                .collect(Collectors.toSet());
+        return Sets.difference(queriedMetadataRows, presentMetadataRows);
+    }
+
+    private static Set<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow> getUnreferencedStreamsByIterator(HotspottyDataStreamIdxTable indexTable, Set<HotspottyDataStreamIdxTable.HotspottyDataStreamIdxRow> indexRows) {
         Map<HotspottyDataStreamIdxTable.HotspottyDataStreamIdxRow, Iterator<HotspottyDataStreamIdxTable.HotspottyDataStreamIdxColumnValue>> referenceIteratorByStream
                 = indexTable.getRowsColumnRangeIterator(indexRows,
                         BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 1));
-        Set<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow> streamsWithNoReferences
+        Set<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow> unreferencedStreamMetadata
                 = KeyedStream.stream(referenceIteratorByStream)
                 .filter(valueIterator -> !valueIterator.hasNext())
                 .keys() // (authorized)
                 .map(HotspottyDataStreamIdxTable.HotspottyDataStreamIdxRow::getId)
                 .map(HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow::of)
                 .collect(Collectors.toSet());
-        Map<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
-        Set<Long> toDelete = Sets.newHashSet();
-        for (Map.Entry<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
-            if (e.getValue().getStatus() != Status.STORED || streamsWithNoReferences.contains(e.getKey())) {
-                toDelete.add(e.getKey().getId());
-            }
+        return unreferencedStreamMetadata;
+    }
+
+    private static void executeUnreferencedStreamDiagnostics(HotspottyDataStreamIdxTable indexTable, Set<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow> metadataRows) {
+        Set<HotspottyDataStreamIdxTable.HotspottyDataStreamIdxRow> indexRows = metadataRows.stream()
+                .map(HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow::getId)
+                .map(HotspottyDataStreamIdxTable.HotspottyDataStreamIdxRow::of)
+                .collect(Collectors.toSet());
+        Set<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow> unreferencedStreamsByIterator = getUnreferencedStreamsByIterator(indexTable, indexRows);
+        Set<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow> unreferencedStreamsByMultimap = getUnreferencedStreamsByMultimap(indexTable, indexRows);
+        if (!unreferencedStreamsByIterator.equals(unreferencedStreamsByMultimap)) {
+            log.info("We searched for unreferenced streams with methodological inconsistency: iterators claimed we could delete {}, but multimaps {}.",
+                    SafeArg.of("unreferencedByIterator", convertToIdsForLogging(unreferencedStreamsByIterator)),
+                    SafeArg.of("unreferencedByMultimap", convertToIdsForLogging(unreferencedStreamsByMultimap)));
+        } else {
+            log.info("We searched for unreferenced streams and consistently found {}.",
+                    SafeArg.of("unreferencedStreamIds", convertToIdsForLogging(unreferencedStreamsByIterator)));
         }
-        HotspottyDataStreamStore.of(tables).deleteStreams(t, toDelete);
-        return false;
     }
 }

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TargetedSweepEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TargetedSweepEteTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.palantir.atlasdb.keyvalue.api.Namespace;
@@ -94,6 +95,7 @@ public class TargetedSweepEteTest {
     }
 
     @Test
+    @Ignore // This is desired behaviour, but is disabled as part of safety investigations on PDS-104895
     public void targetedSweepCleanupUnmarkedStreamsTest() {
         todoClient.storeUnmarkedSnapshot("snap");
         todoClient.storeUnmarkedSnapshot("crackle");

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueMetadataCleanupTask.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueMetadataCleanupTask.java
@@ -5,6 +5,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
 import com.palantir.atlasdb.encoding.PtBytes;
@@ -16,8 +20,11 @@ import com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.common.streams.KeyedStream;
+import com.palantir.logsafe.SafeArg;
 
 public class ValueMetadataCleanupTask implements OnCleanupTask {
+
+    private static final Logger log = LoggerFactory.getLogger(ValueMetadataCleanupTask.class);
 
     private final StreamTestTableFactory tables;
 
@@ -33,28 +40,68 @@ public class ValueMetadataCleanupTask implements OnCleanupTask {
             rows.add(ValueStreamMetadataTable.ValueStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));
         }
         ValueStreamIdxTable indexTable = tables.getValueStreamIdxTable(t);
-        Set<ValueStreamIdxTable.ValueStreamIdxRow> indexRows = rows.stream()
+        executeUnreferencedStreamDiagnostics(indexTable, rows);
+        Map<ValueStreamMetadataTable.ValueStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
+        Set<Long> toDelete = Sets.newHashSet();
+        for (Map.Entry<ValueStreamMetadataTable.ValueStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
+            if (e.getValue().getStatus() != Status.STORED) {
+                toDelete.add(e.getKey().getId());
+            }
+        }
+        ValueStreamStore.of(tables).deleteStreams(t, toDelete);
+        return false;
+    }
+
+    private static ValueStreamMetadataTable.ValueStreamMetadataRow convertFromIndexRow(ValueStreamIdxTable.ValueStreamIdxRow idxRow) {
+        return ValueStreamMetadataTable.ValueStreamMetadataRow.of(idxRow.getId());
+    }
+    private static Set<Long> convertToIdsForLogging(Set<ValueStreamMetadataTable.ValueStreamMetadataRow> iteratorExcess) {
+        return iteratorExcess.stream()
                 .map(ValueStreamMetadataTable.ValueStreamMetadataRow::getId)
-                .map(ValueStreamIdxTable.ValueStreamIdxRow::of)
                 .collect(Collectors.toSet());
+    }
+
+    private static Set<ValueStreamMetadataTable.ValueStreamMetadataRow> getUnreferencedStreamsByMultimap(ValueStreamIdxTable indexTable, Set<ValueStreamIdxTable.ValueStreamIdxRow> indexRows) {
+        Multimap<ValueStreamIdxTable.ValueStreamIdxRow, ValueStreamIdxTable.ValueStreamIdxColumnValue> indexValues = indexTable.getRowsMultimap(indexRows);
+        Set<ValueStreamMetadataTable.ValueStreamMetadataRow> presentMetadataRows
+                = indexValues.keySet().stream()
+                .map(ValueMetadataCleanupTask::convertFromIndexRow)
+                .collect(Collectors.toSet());
+        Set<ValueStreamMetadataTable.ValueStreamMetadataRow> queriedMetadataRows
+                = indexRows.stream()
+                .map(ValueMetadataCleanupTask::convertFromIndexRow)
+                .collect(Collectors.toSet());
+        return Sets.difference(queriedMetadataRows, presentMetadataRows);
+    }
+
+    private static Set<ValueStreamMetadataTable.ValueStreamMetadataRow> getUnreferencedStreamsByIterator(ValueStreamIdxTable indexTable, Set<ValueStreamIdxTable.ValueStreamIdxRow> indexRows) {
         Map<ValueStreamIdxTable.ValueStreamIdxRow, Iterator<ValueStreamIdxTable.ValueStreamIdxColumnValue>> referenceIteratorByStream
                 = indexTable.getRowsColumnRangeIterator(indexRows,
                         BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 1));
-        Set<ValueStreamMetadataTable.ValueStreamMetadataRow> streamsWithNoReferences
+        Set<ValueStreamMetadataTable.ValueStreamMetadataRow> unreferencedStreamMetadata
                 = KeyedStream.stream(referenceIteratorByStream)
                 .filter(valueIterator -> !valueIterator.hasNext())
                 .keys() // (authorized)
                 .map(ValueStreamIdxTable.ValueStreamIdxRow::getId)
                 .map(ValueStreamMetadataTable.ValueStreamMetadataRow::of)
                 .collect(Collectors.toSet());
-        Map<ValueStreamMetadataTable.ValueStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
-        Set<Long> toDelete = Sets.newHashSet();
-        for (Map.Entry<ValueStreamMetadataTable.ValueStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
-            if (e.getValue().getStatus() != Status.STORED || streamsWithNoReferences.contains(e.getKey())) {
-                toDelete.add(e.getKey().getId());
-            }
+        return unreferencedStreamMetadata;
+    }
+
+    private static void executeUnreferencedStreamDiagnostics(ValueStreamIdxTable indexTable, Set<ValueStreamMetadataTable.ValueStreamMetadataRow> metadataRows) {
+        Set<ValueStreamIdxTable.ValueStreamIdxRow> indexRows = metadataRows.stream()
+                .map(ValueStreamMetadataTable.ValueStreamMetadataRow::getId)
+                .map(ValueStreamIdxTable.ValueStreamIdxRow::of)
+                .collect(Collectors.toSet());
+        Set<ValueStreamMetadataTable.ValueStreamMetadataRow> unreferencedStreamsByIterator = getUnreferencedStreamsByIterator(indexTable, indexRows);
+        Set<ValueStreamMetadataTable.ValueStreamMetadataRow> unreferencedStreamsByMultimap = getUnreferencedStreamsByMultimap(indexTable, indexRows);
+        if (!unreferencedStreamsByIterator.equals(unreferencedStreamsByMultimap)) {
+            log.info("We searched for unreferenced streams with methodological inconsistency: iterators claimed we could delete {}, but multimaps {}.",
+                    SafeArg.of("unreferencedByIterator", convertToIdsForLogging(unreferencedStreamsByIterator)),
+                    SafeArg.of("unreferencedByMultimap", convertToIdsForLogging(unreferencedStreamsByMultimap)));
+        } else {
+            log.info("We searched for unreferenced streams and consistently found {}.",
+                    SafeArg.of("unreferencedStreamIds", convertToIdsForLogging(unreferencedStreamsByIterator)));
         }
-        ValueStreamStore.of(tables).deleteStreams(t, toDelete);
-        return false;
     }
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamStore.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamStore.java
@@ -60,7 +60,6 @@ import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.atlasdb.transaction.api.TransactionTask;
 import com.palantir.atlasdb.transaction.impl.TxTask;
 import com.palantir.common.base.Throwables;
-import com.palantir.common.compression.LZ4CompressingInputStream;
 import com.palantir.common.compression.StreamCompression;
 import com.palantir.common.io.ConcatenatedInputStream;
 import com.palantir.util.AssertUtils;
@@ -69,8 +68,6 @@ import com.palantir.util.Pair;
 import com.palantir.util.crypto.Sha256Hash;
 import com.palantir.util.file.DeleteOnCloseFileInputStream;
 import com.palantir.util.file.TempFileUtils;
-
-import net.jpountz.lz4.LZ4BlockInputStream;
 
 @Generated("com.palantir.atlasdb.table.description.render.StreamStoreRenderer")
 @SuppressWarnings("all")
@@ -412,8 +409,6 @@ public final class UserPhotosStreamStore extends AbstractPersistentStreamStore {
      * {@link ImmutableSet}
      * {@link InputStream}
      * {@link Ints}
-     * {@link LZ4BlockInputStream}
-     * {@link LZ4CompressingInputStream}
      * {@link List}
      * {@link Lists}
      * {@link Logger}
@@ -434,6 +429,7 @@ public final class UserPhotosStreamStore extends AbstractPersistentStreamStore {
      * {@link Sha256Hash}
      * {@link Status}
      * {@link StreamCleanedException}
+     * {@link StreamCompression}
      * {@link StreamMetadata}
      * {@link StreamStorePersistenceConfiguration}
      * {@link Supplier}


### PR DESCRIPTION
**Goals (and why)**:
- Although we have not identified a specific bug in the cleaning of unmarked streams (introduced in #4201), it has correlated with internal issues. In the interest of risk mitigation, we should disable this.
- We have a hypothesis for what might be going wrong, and have written some code to evaluate that as we go.

**Implementation Description (bullets)**:
- Only clean streams that weren't stored, as per legacy behaviour before #4201 
- Implement both the method of cleanup used in large internal product and in #4201 but purely for diagnostic purposes. Add logging comparing their results.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Existing tests should suffice, I added an ignore on the test that actually checks this behaviour

**Concerns (what feedback would you like?)**:
- The feature being effectively reverted is still needed for internal shopping product, so it needs to come back in some form; though shopping product is able to mitigate it safely.

**Where should we start reviewing?**: StreamStoreRenderer

**Priority (whenever / two weeks / yesterday)**: yesterday 🔥 
