### PR TITLE
[PDS-10{3841,4895}] Part 1: Revert Automated Stream Store Cleanup

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
@@ -694,25 +694,10 @@ public class StreamStoreRenderer {
                     line("for (Cell cell : cells) {"); {
                         line("rows.add(", StreamMetadataRow, ".BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));");
                     } line("}");
-                    line(StreamIndexTable, " indexTable = tables.get", StreamIndexTable, "(t);");
-                    line("Set<", StreamIndexRow, "> indexRows = rows.stream()");
-                    line("        .map(", StreamMetadataRow, "::getId)");
-                    line("        .map(", StreamIndexRow, "::of)");
-                    line("        .collect(Collectors.toSet());");
-                    line("Map<", StreamIndexRow, ", Iterator<", StreamIndexColumnValue, ">> referenceIteratorByStream");
-                    line("        = indexTable.getRowsColumnRangeIterator(indexRows,");
-                    line("                BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 1));");
-                    line("Set<", StreamMetadataRow, "> streamsWithNoReferences");
-                    line("        = KeyedStream.stream(referenceIteratorByStream)");
-                    line("        .filter(valueIterator -> !valueIterator.hasNext())");
-                    line("        .keys() // (authorized)"); // required for large internal product
-                    line("        .map(", StreamIndexRow, "::getId)");
-                    line("        .map(", StreamMetadataRow, "::of)");
-                    line("        .collect(Collectors.toSet());");
                     line("Map<", StreamMetadataRow, ", StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);");
                     line("Set<", StreamId, "> toDelete = Sets.newHashSet();");
                     line("for (Map.Entry<", StreamMetadataRow, ", StreamMetadata> e : currentMetadata.entrySet()) {"); {
-                        line("if (e.getValue().getStatus() != Status.STORED || streamsWithNoReferences.contains(e.getKey())) {"); {
+                        line("if (e.getValue().getStatus() != Status.STORED) {"); {
                             line("toDelete.add(e.getKey().getId());");
                         } line("}");
                     } line("}");

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsMetadataCleanupTask.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsMetadataCleanupTask.java
@@ -32,25 +32,10 @@ public class SnapshotsMetadataCleanupTask implements OnCleanupTask {
         for (Cell cell : cells) {
             rows.add(SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));
         }
-        SnapshotsStreamIdxTable indexTable = tables.getSnapshotsStreamIdxTable(t);
-        Set<SnapshotsStreamIdxTable.SnapshotsStreamIdxRow> indexRows = rows.stream()
-                .map(SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow::getId)
-                .map(SnapshotsStreamIdxTable.SnapshotsStreamIdxRow::of)
-                .collect(Collectors.toSet());
-        Map<SnapshotsStreamIdxTable.SnapshotsStreamIdxRow, Iterator<SnapshotsStreamIdxTable.SnapshotsStreamIdxColumnValue>> referenceIteratorByStream
-                = indexTable.getRowsColumnRangeIterator(indexRows,
-                        BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 1));
-        Set<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> streamsWithNoReferences
-                = KeyedStream.stream(referenceIteratorByStream)
-                .filter(valueIterator -> !valueIterator.hasNext())
-                .keys() // (authorized)
-                .map(SnapshotsStreamIdxTable.SnapshotsStreamIdxRow::getId)
-                .map(SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow::of)
-                .collect(Collectors.toSet());
         Map<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
         Set<Long> toDelete = Sets.newHashSet();
         for (Map.Entry<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
-            if (e.getValue().getStatus() != Status.STORED || streamsWithNoReferences.contains(e.getKey())) {
+            if (e.getValue().getStatus() != Status.STORED) {
                 toDelete.add(e.getKey().getId());
             }
         }

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TargetedSweepEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TargetedSweepEteTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.palantir.atlasdb.keyvalue.api.Namespace;
@@ -94,8 +95,18 @@ public class TargetedSweepEteTest {
     }
 
     @Test
-    // TODO (jkong): This is obviously not the desired behaviour, but we are doing this in the interest of safety.
-    public void targetedSweepDoesNotCleanupUnmarkedStreamsTest() {
+    @Ignore // TODO (jkong): This is obviously not the desired behaviour, but we are doing this for safety.
+    public void targetedSweepCleansUpUnmarkedStreamsTest() {
+        todoClient.storeUnmarkedSnapshot("snap");
+        todoClient.storeUnmarkedSnapshot("crackle");
+        todoClient.storeUnmarkedSnapshot("pop");
+        todoClient.runIterationOfTargetedSweep();
+
+        assertDeleted(0, 3, 3, 3);
+    }
+
+    @Test
+    public void targetedSweepCurrentlyDoesNotCleanupUnmarkedStreamsTest() {
         todoClient.storeUnmarkedSnapshot("snap");
         todoClient.storeUnmarkedSnapshot("crackle");
         todoClient.storeUnmarkedSnapshot("pop");

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TargetedSweepEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TargetedSweepEteTest.java
@@ -94,15 +94,14 @@ public class TargetedSweepEteTest {
     }
 
     @Test
-    public void targetedSweepCleanupUnmarkedStreamsTest() {
+    // TODO (jkong): This is obviously not the desired behaviour, but we are doing this in the interest of safety.
+    public void targetedSweepDoesNotCleanupUnmarkedStreamsTest() {
         todoClient.storeUnmarkedSnapshot("snap");
         todoClient.storeUnmarkedSnapshot("crackle");
         todoClient.storeUnmarkedSnapshot("pop");
         todoClient.runIterationOfTargetedSweep();
 
-        // Nothing can be deleted from Index because it wasn't written. There should be 3 entries in the other tables
-        // (hash, metadata and value), one per stream, all of which should be cleaned up.
-        assertDeleted(0, 3, 3, 3);
+        assertDeleted(0, 0, 0, 0);
     }
 
     private void assertDeleted(long idx, long hash, long meta, long val) {

--- a/changelog/@unreleased/pr-4434.v2.yml
+++ b/changelog/@unreleased/pr-4434.v2.yml
@@ -1,0 +1,8 @@
+type: manualTask
+manualTask:
+  description: |-
+    Stream stores now no longer automatically clean up streams that were stored but never marked as used. We have noticed an increasing incidence of said cleaning being more aggressive than we anticipated.
+
+    Users that use stream stores *must* regenerate their schemas as part of upgrading to this version.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4434

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamStore.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamStore.java
@@ -60,7 +60,6 @@ import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.atlasdb.transaction.api.TransactionTask;
 import com.palantir.atlasdb.transaction.impl.TxTask;
 import com.palantir.common.base.Throwables;
-import com.palantir.common.compression.LZ4CompressingInputStream;
 import com.palantir.common.compression.StreamCompression;
 import com.palantir.common.io.ConcatenatedInputStream;
 import com.palantir.util.AssertUtils;
@@ -69,8 +68,6 @@ import com.palantir.util.Pair;
 import com.palantir.util.crypto.Sha256Hash;
 import com.palantir.util.file.DeleteOnCloseFileInputStream;
 import com.palantir.util.file.TempFileUtils;
-
-import net.jpountz.lz4.LZ4BlockInputStream;
 
 @Generated("com.palantir.atlasdb.table.description.render.StreamStoreRenderer")
 @SuppressWarnings("all")
@@ -412,8 +409,6 @@ public final class UserPhotosStreamStore extends AbstractPersistentStreamStore {
      * {@link ImmutableSet}
      * {@link InputStream}
      * {@link Ints}
-     * {@link LZ4BlockInputStream}
-     * {@link LZ4CompressingInputStream}
      * {@link List}
      * {@link Lists}
      * {@link Logger}
@@ -434,6 +429,7 @@ public final class UserPhotosStreamStore extends AbstractPersistentStreamStore {
      * {@link Sha256Hash}
      * {@link Status}
      * {@link StreamCleanedException}
+     * {@link StreamCompression}
      * {@link StreamMetadata}
      * {@link StreamStorePersistenceConfiguration}
      * {@link Supplier}


### PR DESCRIPTION
**Goals (and why)**:
- Revert #4201: we have not been able to pin down why #4201 was problematic, and to be clear we aren't necessarily sure that it _is_ broken in the first place. However, it correlates too well with the issues in this ticket's header, so reverting as part of safety.

**Implementation Description (bullets)**:
- Update generated code

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Updated stream test to verify that these streams are *not* cleaned up.

**Concerns (what feedback would you like?)**:
- Is the revert safe?
- Are there edge cases in the stream store code I might have missed out on?

**Where should we start reviewing?**: StreamStoreRenderer

**Priority (whenever / two weeks / yesterday)**: yesterday 🔥 
