### PR TITLE
PTExecutors does not propagate state to recurring tasks

### DIFF
--- a/changelog/@unreleased/pr-4436.v2.yml
+++ b/changelog/@unreleased/pr-4436.v2.yml
@@ -1,0 +1,13 @@
+type: improvement
+improvement:
+  description: |-
+    PTExecutors does not propagate state to recurring tasks
+
+    Previously both tracing and ExecutorInheritableThreadLocal state
+    were retained by recurring tasks, which lead to background activity
+    referencing state from when a task is first scheduled. There are
+    several places where we lazily start scheduled background tasks,
+    this inadvertently attributes background work to the first user
+    to exercise the codepath.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4436

--- a/commons-executors/src/main/java/com/palantir/common/concurrent/InternalForwardingScheduledExecutorService.java
+++ b/commons-executors/src/main/java/com/palantir/common/concurrent/InternalForwardingScheduledExecutorService.java
@@ -1,0 +1,93 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.common.concurrent;
+
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Similar to {@link AbstractForwardingScheduledExecutorService} except this implementation allows
+ * implementors to wrap one-shot and recurring tasks differently. Consider tracing, for example,
+ * where we want to propagate trace-id to executors, we generally do not want recurring tasks
+ * to retain information from the originating thread.
+ *
+ * Intentionally package private, not meant for consumption outside of PTExecutors.
+ */
+abstract class InternalForwardingScheduledExecutorService extends AbstractExecutorService
+        implements ScheduledExecutorService {
+
+    protected abstract ScheduledExecutorService delegate();
+
+    protected abstract Runnable wrap(Runnable runnable);
+
+    protected abstract <T> Callable<T> wrap(Callable<T> callable);
+
+    protected abstract Runnable wrapRecurring(Runnable runnable);
+
+    @Override
+    public void shutdown() {
+        delegate().shutdown();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        return delegate().shutdownNow();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return delegate().isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return delegate().isTerminated();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return delegate().awaitTermination(timeout, unit);
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        delegate().execute(wrap(command));
+    }
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+        return delegate().schedule(wrap(command), delay, unit);
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+        return delegate().schedule(wrap(callable), delay, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+        return delegate().scheduleAtFixedRate(wrapRecurring(command), initialDelay, period, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+        return delegate().scheduleWithFixedDelay(wrapRecurring(command), initialDelay, delay, unit);
+    }
+}

--- a/commons-executors/src/main/java/com/palantir/common/concurrent/PTExecutors.java
+++ b/commons-executors/src/main/java/com/palantir/common/concurrent/PTExecutors.java
@@ -509,7 +509,7 @@ public final class PTExecutors {
     public static ScheduledExecutorService wrap(
             final String operationName,
             final ScheduledExecutorService scheduledExecutorService) {
-        return new AbstractForwardingScheduledExecutorService() {
+        return new InternalForwardingScheduledExecutorService() {
             @Override protected ScheduledExecutorService delegate() {
                 return scheduledExecutorService;
             }
@@ -520,6 +520,11 @@ public final class PTExecutors {
 
             @Override protected <T> Callable<T> wrap(Callable<T> callable) {
                 return PTExecutors.wrap(operationName, callable);
+            }
+
+            @Override protected Runnable wrapRecurring(Runnable runnable) {
+                // Intentionally does not retain current thread state.
+                return Tracers.wrapWithNewTrace(operationName, runnable);
             }
         };
     }

--- a/commons-executors/src/test/java/com/palantir/common/concurrent/PTExecutorsTest.java
+++ b/commons-executors/src/test/java/com/palantir/common/concurrent/PTExecutorsTest.java
@@ -18,22 +18,17 @@ package com.palantir.common.concurrent;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import org.junit.Test;
 
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
-import com.google.common.util.concurrent.Uninterruptibles;
 
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName") // Name matches the class we're testing
 public class PTExecutorsTest {

--- a/commons-executors/src/test/java/com/palantir/common/concurrent/PTExecutorsTest.java
+++ b/commons-executors/src/test/java/com/palantir/common/concurrent/PTExecutorsTest.java
@@ -18,10 +18,22 @@ package com.palantir.common.concurrent;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import org.junit.Test;
+
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.SettableFuture;
+import com.google.common.util.concurrent.Uninterruptibles;
 
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName") // Name matches the class we're testing
 public class PTExecutorsTest {
@@ -50,5 +62,87 @@ public class PTExecutorsTest {
             return thread;
         };
         assertThat(PTExecutors.getExecutorName(factory)).isEqualTo("PTExecutor");
+    }
+
+    @Test
+    public void testExecutorThreadLocalState_cachedPool() {
+        withExecutor(PTExecutors::newCachedThreadPool, executor -> {
+            ExecutorInheritableThreadLocal<String> threadLocal = new ExecutorInheritableThreadLocal<>();
+            threadLocal.set("test");
+            String result = executor.submit(threadLocal::get).get();
+            assertThat(result).isEqualTo("test");
+        });
+    }
+
+    @Test
+    public void testExecutorThreadLocalState_scheduledPool_submit() {
+        withExecutor(PTExecutors::newSingleThreadScheduledExecutor, executor -> {
+            ExecutorInheritableThreadLocal<String> threadLocal = new ExecutorInheritableThreadLocal<>();
+            threadLocal.set("test");
+            String result = executor.submit(threadLocal::get).get();
+            assertThat(result).isEqualTo("test");
+        });
+    }
+
+    @Test
+    public void testExecutorThreadLocalState_scheduledPool_scheduleOnce() {
+        withExecutor(PTExecutors::newSingleThreadScheduledExecutor, executor -> {
+            ExecutorInheritableThreadLocal<String> threadLocal = new ExecutorInheritableThreadLocal<>();
+            threadLocal.set("test");
+            String result = executor.schedule(threadLocal::get, 1, TimeUnit.MILLISECONDS).get();
+            assertThat(result).isEqualTo("test");
+        });
+    }
+
+    @Test
+    public void testExecutorThreadLocalState_scheduledPool_scheduleWithFixedDelay() {
+        withExecutor(PTExecutors::newSingleThreadScheduledExecutor, executor -> {
+            SettableFuture<String> result = SettableFuture.create();
+            ExecutorInheritableThreadLocal<String> threadLocal = new ExecutorInheritableThreadLocal<>();
+            threadLocal.set("test");
+            ScheduledFuture<?> scheduledFuture = executor.scheduleWithFixedDelay(() ->
+                    result.set(threadLocal.get()), 0, 1, TimeUnit.MILLISECONDS);
+            String value = result.get();
+            scheduledFuture.cancel(true);
+            assertThat(value)
+                    .describedAs("Executor inheritable state should not be propagated to recurring tasks")
+                    .isNull();
+        });
+    }
+
+    @Test
+    public void testExecutorThreadLocalState_scheduledPool_scheduleAtFixedRate() {
+        withExecutor(PTExecutors::newSingleThreadScheduledExecutor, executor -> {
+            SettableFuture<String> result = SettableFuture.create();
+            ExecutorInheritableThreadLocal<String> threadLocal = new ExecutorInheritableThreadLocal<>();
+            threadLocal.set("test");
+            ScheduledFuture<?> scheduledFuture = executor.scheduleAtFixedRate(() ->
+                    result.set(threadLocal.get()), 0, 1, TimeUnit.MILLISECONDS);
+            String value = result.get();
+            scheduledFuture.cancel(true);
+            assertThat(value)
+                    .describedAs("Executor inheritable state should not be propagated to recurring tasks")
+                    .isNull();
+        });
+    }
+
+    private static <T extends ExecutorService> void withExecutor(Supplier<T> factory, ThrowingConsumer<T> test) {
+        T executor = factory.get();
+        try {
+            test.accept(executor);
+        } catch (RuntimeException | Error e) {
+            throw e;
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        } finally {
+            executor.shutdownNow();
+            assertThat(MoreExecutors.shutdownAndAwaitTermination(executor, 5, TimeUnit.SECONDS))
+                    .describedAs("Executor failed to shutdown within 5 seconds")
+                    .isTrue();
+        }
+    }
+
+    interface ThrowingConsumer<T> {
+        void accept(T executor) throws Exception;
     }
 }


### PR DESCRIPTION
Previously both tracing and ExecutorInheritableThreadLocal state
were retained by recurring tasks, which lead to background activity
referencing state from when a task is first scheduled. There are
several places where we lazily start scheduled background tasks,
this inadvertently attributes background work to the first user
to exercise the codepath.
