### PR TITLE
[PDS-10{3841,4895}] Part 3: Framework For Runtime-Configurable Cleanup Tasks

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/cleaner/api/CleanupFollowerConfig.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/cleaner/api/CleanupFollowerConfig.java
@@ -1,0 +1,47 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.cleaner.api;
+
+import org.immutables.value.Value;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * Contains information that may be useful for the execution of cleanup tasks.
+ */
+@JsonSerialize(as = ImmutableCleanupFollowerConfig.class)
+@JsonDeserialize(as = ImmutableCleanupFollowerConfig.class)
+@Value.Immutable
+public interface CleanupFollowerConfig {
+    /**
+     * Enables cleanup of unreferenced streams in stream store cleanup tasks.
+     *
+     * This codepath has historically experienced bugs which the AtlasDB team has had difficulty debugging, even though
+     * on a conceptual level it is permissible to clean up unreferenced streams from stream stores, and the AtlasDB team
+     * is not aware of any concrete bugs in their implementation. This option must ONLY be used if your usage of streams
+     * is not strictly required for correctness; that is, in the event of a stream going missing, there will be no data
+     * loss, and your application will handle the situation correctly.
+     *
+     * To repeat: if your use case is unable to handle a stream going missing when you don't expect it, DO NOT ENABLE
+     * THIS OPTION. There is a risk of SEVERE DATA CORRUPTION(TM) if you do so.
+     */
+    @Value.Default
+    default boolean dangerousRiskOfDataCorruptionEnableCleanupOfUnreferencedStreamsInStreamStoreCleanupTasks() {
+        return false;
+    }
+}

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/cleaner/api/OnCleanupTask.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/cleaner/api/OnCleanupTask.java
@@ -49,7 +49,7 @@ public interface OnCleanupTask {
      * Similar to {@link #cellsCleanedUp(Transaction, Set)}, but admits a configuration object that allows for
      * user-configurable behaviour at runtime. Not all cleanup tasks may be responsive to configuration.
      */
-    default boolean cellsCleanedUp(Transaction transaction, Set<Cell> cells, CleanupFollowerConfig _config) {
+    default boolean cellsCleanedUp(Transaction transaction, Set<Cell> cells, CleanupFollowerConfig config) {
         return cellsCleanedUp(transaction, cells);
     }
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/cleaner/api/OnCleanupTask.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/cleaner/api/OnCleanupTask.java
@@ -36,7 +36,7 @@ public interface OnCleanupTask {
      * an opportunity to use the fresh transaction to make decisions about what else needs
      * to be cleaned up.
      * <p>
-     * This method may be called for uncommited cells or old cells with new values.
+     * This method may be called for uncommitted cells or old cells with new values.
      * <p>
      * If the current transaction fills up this method should return true and it will be called
      * again with a fresh transaction.  This is useful if a large cleanup is needed.

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/cleaner/api/OnCleanupTask.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/cleaner/api/OnCleanupTask.java
@@ -44,4 +44,12 @@ public interface OnCleanupTask {
      * @return true if this method should be called again with a fresh transaction
      */
     boolean cellsCleanedUp(Transaction transaction, Set<Cell> cells);
+
+    /**
+     * Similar to {@link #cellsCleanedUp(Transaction, Set)}, but admits a configuration object that allows for
+     * user-configurable behaviour at runtime. Not all cleanup tasks may be responsive to configuration.
+     */
+    default boolean cellsCleanedUp(Transaction transaction, Set<Cell> cells, CleanupFollowerConfig _config) {
+        return cellsCleanedUp(transaction, cells);
+    }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
@@ -694,25 +694,10 @@ public class StreamStoreRenderer {
                     line("for (Cell cell : cells) {"); {
                         line("rows.add(", StreamMetadataRow, ".BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));");
                     } line("}");
-                    line(StreamIndexTable, " indexTable = tables.get", StreamIndexTable, "(t);");
-                    line("Set<", StreamIndexRow, "> indexRows = rows.stream()");
-                    line("        .map(", StreamMetadataRow, "::getId)");
-                    line("        .map(", StreamIndexRow, "::of)");
-                    line("        .collect(Collectors.toSet());");
-                    line("Map<", StreamIndexRow, ", Iterator<", StreamIndexColumnValue, ">> referenceIteratorByStream");
-                    line("        = indexTable.getRowsColumnRangeIterator(indexRows,");
-                    line("                BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 1));");
-                    line("Set<", StreamMetadataRow, "> streamsWithNoReferences");
-                    line("        = KeyedStream.stream(referenceIteratorByStream)");
-                    line("        .filter(valueIterator -> !valueIterator.hasNext())");
-                    line("        .keys() // (authorized)"); // required for large internal product
-                    line("        .map(", StreamIndexRow, "::getId)");
-                    line("        .map(", StreamMetadataRow, "::of)");
-                    line("        .collect(Collectors.toSet());");
                     line("Map<", StreamMetadataRow, ", StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);");
                     line("Set<", StreamId, "> toDelete = Sets.newHashSet();");
                     line("for (Map.Entry<", StreamMetadataRow, ", StreamMetadata> e : currentMetadata.entrySet()) {"); {
-                        line("if (e.getValue().getStatus() != Status.STORED || streamsWithNoReferences.contains(e.getKey())) {"); {
+                        line("if (e.getValue().getStatus() != Status.STORED) {"); {
                             line("toDelete.add(e.getKey().getId());");
                         } line("}");
                     } line("}");

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfig.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cleaner.api.CleanupFollowerConfig;
+import com.palantir.atlasdb.cleaner.api.ImmutableCleanupFollowerConfig;
 import com.palantir.atlasdb.compact.CompactorConfig;
 import com.palantir.atlasdb.internalschema.ImmutableInternalSchemaConfig;
 import com.palantir.atlasdb.internalschema.InternalSchemaConfig;

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfig.java
@@ -22,6 +22,7 @@ import org.immutables.value.Value;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.cleaner.api.CleanupFollowerConfig;
 import com.palantir.atlasdb.compact.CompactorConfig;
 import com.palantir.atlasdb.internalschema.ImmutableInternalSchemaConfig;
 import com.palantir.atlasdb.internalschema.InternalSchemaConfig;
@@ -106,6 +107,11 @@ public abstract class AtlasDbRuntimeConfig {
     @Value.Default
     public RemotingClientConfig remotingClient() {
         return ImmutableRemotingClientConfig.builder().build();
+    }
+
+    @Value.Default
+    public CleanupFollowerConfig cleanupFollower() {
+        return ImmutableCleanupFollowerConfig.builder().build();
     }
 
     public static ImmutableAtlasDbRuntimeConfig defaultRuntimeConfig() {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -392,7 +392,8 @@ public abstract class TransactionManagers {
         ConflictDetectionManager conflictManager = ConflictDetectionManagers.create(keyValueService);
         SweepStrategyManager sweepStrategyManager = SweepStrategyManagers.createDefault(keyValueService);
 
-        CleanupFollower follower = CleanupFollower.create(schemas());
+        CleanupFollower follower = CleanupFollower.create(
+                schemas(), () -> runtimeConfigSupplier.get().cleanupFollower());
 
         Cleaner cleaner = initializeCloseable(() ->
                         new DefaultCleanerBuilder(keyValueService, lockAndTimestampServices.timelock(),

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfigDeserializationTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfigDeserializationTest.java
@@ -59,6 +59,9 @@ public class AtlasDbRuntimeConfigDeserializationTest {
                 });
 
         assertThat(runtimeConfig.internalSchema().targetTransactionsSchemaVersion()).contains(1);
+        assertThat(runtimeConfig.cleanupFollower()
+                .dangerousRiskOfDataCorruptionEnableCleanupOfUnreferencedStreamsInStreamStoreCleanupTasks())
+                .isTrue();
     }
 
     private void assertSslConfigDeserializedCorrectly(SslConfiguration sslConfiguration) {
@@ -76,5 +79,9 @@ public class AtlasDbRuntimeConfigDeserializationTest {
         assertThat(runtimeConfig.timelockRuntime()).isPresent();
         assertThat(runtimeConfig.timelockRuntime().get().serversList().servers()).isEmpty();
         assertThat(runtimeConfig.timelockRuntime().get().serversList().sslConfiguration()).isEmpty();
+
+        assertThat(runtimeConfig.cleanupFollower()
+                .dangerousRiskOfDataCorruptionEnableCleanupOfUnreferencedStreamsInStreamStoreCleanupTasks())
+                .isFalse();
     }
 }

--- a/atlasdb-config/src/test/resources/runtime-config-block.yml
+++ b/atlasdb-config/src/test/resources/runtime-config-block.yml
@@ -26,3 +26,6 @@ sweep:
 
 internalSchema:
   targetTransactionsSchemaVersion: 1
+
+cleanupFollower:
+  dangerousRiskOfDataCorruptionEnableCleanupOfUnreferencedStreamsInStreamStoreCleanupTasks: true

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
@@ -27,6 +27,8 @@ import com.palantir.atlasdb.cleaner.CleanupFollower;
 import com.palantir.atlasdb.cleaner.DefaultCleanerBuilder;
 import com.palantir.atlasdb.cleaner.Follower;
 import com.palantir.atlasdb.cleaner.api.Cleaner;
+import com.palantir.atlasdb.cleaner.api.CleanupFollowerConfig;
+import com.palantir.atlasdb.cleaner.api.ImmutableCleanupFollowerConfig;
 import com.palantir.atlasdb.config.AtlasDbConfig;
 import com.palantir.atlasdb.debug.ConflictTracer;
 import com.palantir.atlasdb.factory.TransactionManagers;
@@ -57,7 +59,7 @@ public class TransactionManagerModule {
     @Provides
     @Singleton
     public Follower provideCleanupFollower(ServicesConfig atlasDbConfig) {
-        return CleanupFollower.create(atlasDbConfig.schemas());
+        return CleanupFollower.create(atlasDbConfig.schemas(), () -> ImmutableCleanupFollowerConfig.builder().build());
     }
 
     @Provides

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
@@ -27,7 +27,6 @@ import com.palantir.atlasdb.cleaner.CleanupFollower;
 import com.palantir.atlasdb.cleaner.DefaultCleanerBuilder;
 import com.palantir.atlasdb.cleaner.Follower;
 import com.palantir.atlasdb.cleaner.api.Cleaner;
-import com.palantir.atlasdb.cleaner.api.CleanupFollowerConfig;
 import com.palantir.atlasdb.cleaner.api.ImmutableCleanupFollowerConfig;
 import com.palantir.atlasdb.config.AtlasDbConfig;
 import com.palantir.atlasdb.debug.ConflictTracer;

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
@@ -25,6 +25,7 @@ import com.palantir.atlasdb.cleaner.CleanupFollower;
 import com.palantir.atlasdb.cleaner.DefaultCleanerBuilder;
 import com.palantir.atlasdb.cleaner.Follower;
 import com.palantir.atlasdb.cleaner.api.Cleaner;
+import com.palantir.atlasdb.cleaner.api.ImmutableCleanupFollowerConfig;
 import com.palantir.atlasdb.config.AtlasDbConfig;
 import com.palantir.atlasdb.debug.ConflictTracer;
 import com.palantir.atlasdb.factory.TransactionManagers;
@@ -58,7 +59,7 @@ public class TestTransactionManagerModule {
     @Provides
     @Singleton
     public Follower provideCleanupFollower(ServicesConfig atlasDbConfig) {
-        return CleanupFollower.create(atlasDbConfig.schemas());
+        return CleanupFollower.create(atlasDbConfig.schemas(), () -> ImmutableCleanupFollowerConfig.builder().build());
     }
 
     @Provides

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsMetadataCleanupTask.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsMetadataCleanupTask.java
@@ -32,25 +32,10 @@ public class SnapshotsMetadataCleanupTask implements OnCleanupTask {
         for (Cell cell : cells) {
             rows.add(SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));
         }
-        SnapshotsStreamIdxTable indexTable = tables.getSnapshotsStreamIdxTable(t);
-        Set<SnapshotsStreamIdxTable.SnapshotsStreamIdxRow> indexRows = rows.stream()
-                .map(SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow::getId)
-                .map(SnapshotsStreamIdxTable.SnapshotsStreamIdxRow::of)
-                .collect(Collectors.toSet());
-        Map<SnapshotsStreamIdxTable.SnapshotsStreamIdxRow, Iterator<SnapshotsStreamIdxTable.SnapshotsStreamIdxColumnValue>> referenceIteratorByStream
-                = indexTable.getRowsColumnRangeIterator(indexRows,
-                        BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 1));
-        Set<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> streamsWithNoReferences
-                = KeyedStream.stream(referenceIteratorByStream)
-                .filter(valueIterator -> !valueIterator.hasNext())
-                .keys() // (authorized)
-                .map(SnapshotsStreamIdxTable.SnapshotsStreamIdxRow::getId)
-                .map(SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow::of)
-                .collect(Collectors.toSet());
         Map<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
         Set<Long> toDelete = Sets.newHashSet();
         for (Map.Entry<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
-            if (e.getValue().getStatus() != Status.STORED || streamsWithNoReferences.contains(e.getKey())) {
+            if (e.getValue().getStatus() != Status.STORED) {
                 toDelete.add(e.getKey().getId());
             }
         }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
@@ -34,6 +34,7 @@ import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.blob.BlobSchema;
 import com.palantir.atlasdb.cleaner.CleanupFollower;
 import com.palantir.atlasdb.cleaner.Follower;
+import com.palantir.atlasdb.cleaner.api.ImmutableCleanupFollowerConfig;
 import com.palantir.atlasdb.config.AtlasDbConfig;
 import com.palantir.atlasdb.config.AtlasDbRuntimeConfig;
 import com.palantir.atlasdb.coordination.SimpleCoordinationResource;
@@ -78,7 +79,8 @@ public class AtlasDbEteServer extends Application<AtlasDbEteConfiguration> {
     private static final Set<Schema> ETE_SCHEMAS = ImmutableSet.of(
             TodoSchema.getSchema(),
             BlobSchema.getSchema());
-    private static final Follower FOLLOWER = CleanupFollower.create(ETE_SCHEMAS);
+    private static final Follower FOLLOWER = CleanupFollower.create(ETE_SCHEMAS,
+            () -> ImmutableCleanupFollowerConfig.builder().build());
 
 
     public static void main(String[] args) throws Exception {
@@ -136,7 +138,8 @@ public class AtlasDbEteServer extends Application<AtlasDbEteConfiguration> {
                 MetricsManagers.of(metricRegistry, taggedMetricRegistry),
                 new NoOpPersistentLockService(),
                 AtlasDbConstants.DEFAULT_SWEEP_PERSISTENT_LOCK_WAIT_MILLIS);
-        CleanupFollower follower = CleanupFollower.create(ETE_SCHEMAS);
+        CleanupFollower follower = CleanupFollower.create(ETE_SCHEMAS,
+                () -> ImmutableCleanupFollowerConfig.builder().build());
         CellsSweeper cellsSweeper = new CellsSweeper(transactionManager, kvs, noLocks, ImmutableList.of(follower));
         return new SweepTaskRunner(kvs, ts, ts, txnService, ssm, cellsSweeper);
     }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataMetadataCleanupTask.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataMetadataCleanupTask.java
@@ -5,6 +5,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
 import com.palantir.atlasdb.encoding.PtBytes;
@@ -16,8 +20,11 @@ import com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.common.streams.KeyedStream;
+import com.palantir.logsafe.SafeArg;
 
 public class DataMetadataCleanupTask implements OnCleanupTask {
+
+    private static final Logger log = LoggerFactory.getLogger(DataMetadataCleanupTask.class);
 
     private final BlobSchemaTableFactory tables;
 
@@ -32,6 +39,8 @@ public class DataMetadataCleanupTask implements OnCleanupTask {
         for (Cell cell : cells) {
             rows.add(DataStreamMetadataTable.DataStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));
         }
+        DataStreamIdxTable indexTable = tables.getDataStreamIdxTable(t);
+        executeUnreferencedStreamDiagnostics(indexTable, rows);
         Map<DataStreamMetadataTable.DataStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
         Set<Long> toDelete = Sets.newHashSet();
         for (Map.Entry<DataStreamMetadataTable.DataStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
@@ -41,5 +50,58 @@ public class DataMetadataCleanupTask implements OnCleanupTask {
         }
         DataStreamStore.of(tables).deleteStreams(t, toDelete);
         return false;
+    }
+
+    private static DataStreamMetadataTable.DataStreamMetadataRow convertFromIndexRow(DataStreamIdxTable.DataStreamIdxRow idxRow) {
+        return DataStreamMetadataTable.DataStreamMetadataRow.of(idxRow.getId());
+    }
+    private static Set<Long> convertToIdsForLogging(Set<DataStreamMetadataTable.DataStreamMetadataRow> iteratorExcess) {
+        return iteratorExcess.stream()
+                .map(DataStreamMetadataTable.DataStreamMetadataRow::getId)
+                .collect(Collectors.toSet());
+    }
+
+    private static Set<DataStreamMetadataTable.DataStreamMetadataRow> getUnreferencedStreamsByMultimap(DataStreamIdxTable indexTable, Set<DataStreamIdxTable.DataStreamIdxRow> indexRows) {
+        Multimap<DataStreamIdxTable.DataStreamIdxRow, DataStreamIdxTable.DataStreamIdxColumnValue> indexValues = indexTable.getRowsMultimap(indexRows);
+        Set<DataStreamMetadataTable.DataStreamMetadataRow> presentMetadataRows
+                = indexValues.keySet().stream()
+                .map(DataMetadataCleanupTask::convertFromIndexRow)
+                .collect(Collectors.toSet());
+        Set<DataStreamMetadataTable.DataStreamMetadataRow> queriedMetadataRows
+                = indexRows.stream()
+                .map(DataMetadataCleanupTask::convertFromIndexRow)
+                .collect(Collectors.toSet());
+        return Sets.difference(queriedMetadataRows, presentMetadataRows);
+    }
+
+    private static Set<DataStreamMetadataTable.DataStreamMetadataRow> getUnreferencedStreamsByIterator(DataStreamIdxTable indexTable, Set<DataStreamIdxTable.DataStreamIdxRow> indexRows) {
+        Map<DataStreamIdxTable.DataStreamIdxRow, Iterator<DataStreamIdxTable.DataStreamIdxColumnValue>> referenceIteratorByStream
+                = indexTable.getRowsColumnRangeIterator(indexRows,
+                        BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 1));
+        Set<DataStreamMetadataTable.DataStreamMetadataRow> unreferencedStreamMetadata
+                = KeyedStream.stream(referenceIteratorByStream)
+                .filter(valueIterator -> !valueIterator.hasNext())
+                .keys() // (authorized)
+                .map(DataStreamIdxTable.DataStreamIdxRow::getId)
+                .map(DataStreamMetadataTable.DataStreamMetadataRow::of)
+                .collect(Collectors.toSet());
+        return unreferencedStreamMetadata;
+    }
+
+    private static void executeUnreferencedStreamDiagnostics(DataStreamIdxTable indexTable, Set<DataStreamMetadataTable.DataStreamMetadataRow> metadataRows) {
+        Set<DataStreamIdxTable.DataStreamIdxRow> indexRows = metadataRows.stream()
+                .map(DataStreamMetadataTable.DataStreamMetadataRow::getId)
+                .map(DataStreamIdxTable.DataStreamIdxRow::of)
+                .collect(Collectors.toSet());
+        Set<DataStreamMetadataTable.DataStreamMetadataRow> unreferencedStreamsByIterator = getUnreferencedStreamsByIterator(indexTable, indexRows);
+        Set<DataStreamMetadataTable.DataStreamMetadataRow> unreferencedStreamsByMultimap = getUnreferencedStreamsByMultimap(indexTable, indexRows);
+        if (!unreferencedStreamsByIterator.equals(unreferencedStreamsByMultimap)) {
+            log.info("We searched for unreferenced streams with methodological inconsistency: iterators claimed we could delete {}, but multimaps {}.",
+                    SafeArg.of("unreferencedByIterator", convertToIdsForLogging(unreferencedStreamsByIterator)),
+                    SafeArg.of("unreferencedByMultimap", convertToIdsForLogging(unreferencedStreamsByMultimap)));
+        } else {
+            log.info("We searched for unreferenced streams and consistently found {}.",
+                    SafeArg.of("unreferencedStreamIds", convertToIdsForLogging(unreferencedStreamsByIterator)));
+        }
     }
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataMetadataCleanupTask.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataMetadataCleanupTask.java
@@ -5,6 +5,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
 import com.palantir.atlasdb.encoding.PtBytes;
@@ -16,8 +20,11 @@ import com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.common.streams.KeyedStream;
+import com.palantir.logsafe.SafeArg;
 
 public class HotspottyDataMetadataCleanupTask implements OnCleanupTask {
+
+    private static final Logger log = LoggerFactory.getLogger(HotspottyDataMetadataCleanupTask.class);
 
     private final BlobSchemaTableFactory tables;
 
@@ -32,6 +39,8 @@ public class HotspottyDataMetadataCleanupTask implements OnCleanupTask {
         for (Cell cell : cells) {
             rows.add(HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));
         }
+        HotspottyDataStreamIdxTable indexTable = tables.getHotspottyDataStreamIdxTable(t);
+        executeUnreferencedStreamDiagnostics(indexTable, rows);
         Map<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
         Set<Long> toDelete = Sets.newHashSet();
         for (Map.Entry<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
@@ -41,5 +50,58 @@ public class HotspottyDataMetadataCleanupTask implements OnCleanupTask {
         }
         HotspottyDataStreamStore.of(tables).deleteStreams(t, toDelete);
         return false;
+    }
+
+    private static HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow convertFromIndexRow(HotspottyDataStreamIdxTable.HotspottyDataStreamIdxRow idxRow) {
+        return HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow.of(idxRow.getId());
+    }
+    private static Set<Long> convertToIdsForLogging(Set<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow> iteratorExcess) {
+        return iteratorExcess.stream()
+                .map(HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow::getId)
+                .collect(Collectors.toSet());
+    }
+
+    private static Set<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow> getUnreferencedStreamsByMultimap(HotspottyDataStreamIdxTable indexTable, Set<HotspottyDataStreamIdxTable.HotspottyDataStreamIdxRow> indexRows) {
+        Multimap<HotspottyDataStreamIdxTable.HotspottyDataStreamIdxRow, HotspottyDataStreamIdxTable.HotspottyDataStreamIdxColumnValue> indexValues = indexTable.getRowsMultimap(indexRows);
+        Set<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow> presentMetadataRows
+                = indexValues.keySet().stream()
+                .map(HotspottyDataMetadataCleanupTask::convertFromIndexRow)
+                .collect(Collectors.toSet());
+        Set<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow> queriedMetadataRows
+                = indexRows.stream()
+                .map(HotspottyDataMetadataCleanupTask::convertFromIndexRow)
+                .collect(Collectors.toSet());
+        return Sets.difference(queriedMetadataRows, presentMetadataRows);
+    }
+
+    private static Set<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow> getUnreferencedStreamsByIterator(HotspottyDataStreamIdxTable indexTable, Set<HotspottyDataStreamIdxTable.HotspottyDataStreamIdxRow> indexRows) {
+        Map<HotspottyDataStreamIdxTable.HotspottyDataStreamIdxRow, Iterator<HotspottyDataStreamIdxTable.HotspottyDataStreamIdxColumnValue>> referenceIteratorByStream
+                = indexTable.getRowsColumnRangeIterator(indexRows,
+                        BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 1));
+        Set<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow> unreferencedStreamMetadata
+                = KeyedStream.stream(referenceIteratorByStream)
+                .filter(valueIterator -> !valueIterator.hasNext())
+                .keys() // (authorized)
+                .map(HotspottyDataStreamIdxTable.HotspottyDataStreamIdxRow::getId)
+                .map(HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow::of)
+                .collect(Collectors.toSet());
+        return unreferencedStreamMetadata;
+    }
+
+    private static void executeUnreferencedStreamDiagnostics(HotspottyDataStreamIdxTable indexTable, Set<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow> metadataRows) {
+        Set<HotspottyDataStreamIdxTable.HotspottyDataStreamIdxRow> indexRows = metadataRows.stream()
+                .map(HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow::getId)
+                .map(HotspottyDataStreamIdxTable.HotspottyDataStreamIdxRow::of)
+                .collect(Collectors.toSet());
+        Set<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow> unreferencedStreamsByIterator = getUnreferencedStreamsByIterator(indexTable, indexRows);
+        Set<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow> unreferencedStreamsByMultimap = getUnreferencedStreamsByMultimap(indexTable, indexRows);
+        if (!unreferencedStreamsByIterator.equals(unreferencedStreamsByMultimap)) {
+            log.info("We searched for unreferenced streams with methodological inconsistency: iterators claimed we could delete {}, but multimaps {}.",
+                    SafeArg.of("unreferencedByIterator", convertToIdsForLogging(unreferencedStreamsByIterator)),
+                    SafeArg.of("unreferencedByMultimap", convertToIdsForLogging(unreferencedStreamsByMultimap)));
+        } else {
+            log.info("We searched for unreferenced streams and consistently found {}.",
+                    SafeArg.of("unreferencedStreamIds", convertToIdsForLogging(unreferencedStreamsByIterator)));
+        }
     }
 }

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TargetedSweepEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TargetedSweepEteTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.palantir.atlasdb.keyvalue.api.Namespace;

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TargetedSweepEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TargetedSweepEteTest.java
@@ -23,7 +23,6 @@ import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.palantir.atlasdb.keyvalue.api.Namespace;

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TargetedSweepEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TargetedSweepEteTest.java
@@ -94,15 +94,14 @@ public class TargetedSweepEteTest {
     }
 
     @Test
-    public void targetedSweepCleanupUnmarkedStreamsTest() {
+    // TODO (jkong): This is obviously not the desired behaviour, but we are doing this in the interest of safety.
+    public void targetedSweepDoesNotCleanupUnmarkedStreamsTest() {
         todoClient.storeUnmarkedSnapshot("snap");
         todoClient.storeUnmarkedSnapshot("crackle");
         todoClient.storeUnmarkedSnapshot("pop");
         todoClient.runIterationOfTargetedSweep();
 
-        // Nothing can be deleted from Index because it wasn't written. There should be 3 entries in the other tables
-        // (hash, metadata and value), one per stream, all of which should be cleaned up.
-        assertDeleted(0, 3, 3, 3);
+        assertDeleted(0, 0, 0, 0);
     }
 
     private void assertDeleted(long idx, long hash, long meta, long val) {

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueMetadataCleanupTask.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueMetadataCleanupTask.java
@@ -5,6 +5,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
 import com.palantir.atlasdb.encoding.PtBytes;
@@ -16,8 +20,11 @@ import com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.common.streams.KeyedStream;
+import com.palantir.logsafe.SafeArg;
 
 public class ValueMetadataCleanupTask implements OnCleanupTask {
+
+    private static final Logger log = LoggerFactory.getLogger(ValueMetadataCleanupTask.class);
 
     private final StreamTestTableFactory tables;
 
@@ -33,28 +40,68 @@ public class ValueMetadataCleanupTask implements OnCleanupTask {
             rows.add(ValueStreamMetadataTable.ValueStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));
         }
         ValueStreamIdxTable indexTable = tables.getValueStreamIdxTable(t);
-        Set<ValueStreamIdxTable.ValueStreamIdxRow> indexRows = rows.stream()
+        executeUnreferencedStreamDiagnostics(indexTable, rows);
+        Map<ValueStreamMetadataTable.ValueStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
+        Set<Long> toDelete = Sets.newHashSet();
+        for (Map.Entry<ValueStreamMetadataTable.ValueStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
+            if (e.getValue().getStatus() != Status.STORED) {
+                toDelete.add(e.getKey().getId());
+            }
+        }
+        ValueStreamStore.of(tables).deleteStreams(t, toDelete);
+        return false;
+    }
+
+    private static ValueStreamMetadataTable.ValueStreamMetadataRow convertFromIndexRow(ValueStreamIdxTable.ValueStreamIdxRow idxRow) {
+        return ValueStreamMetadataTable.ValueStreamMetadataRow.of(idxRow.getId());
+    }
+    private static Set<Long> convertToIdsForLogging(Set<ValueStreamMetadataTable.ValueStreamMetadataRow> iteratorExcess) {
+        return iteratorExcess.stream()
                 .map(ValueStreamMetadataTable.ValueStreamMetadataRow::getId)
-                .map(ValueStreamIdxTable.ValueStreamIdxRow::of)
                 .collect(Collectors.toSet());
+    }
+
+    private static Set<ValueStreamMetadataTable.ValueStreamMetadataRow> getUnreferencedStreamsByMultimap(ValueStreamIdxTable indexTable, Set<ValueStreamIdxTable.ValueStreamIdxRow> indexRows) {
+        Multimap<ValueStreamIdxTable.ValueStreamIdxRow, ValueStreamIdxTable.ValueStreamIdxColumnValue> indexValues = indexTable.getRowsMultimap(indexRows);
+        Set<ValueStreamMetadataTable.ValueStreamMetadataRow> presentMetadataRows
+                = indexValues.keySet().stream()
+                .map(ValueMetadataCleanupTask::convertFromIndexRow)
+                .collect(Collectors.toSet());
+        Set<ValueStreamMetadataTable.ValueStreamMetadataRow> queriedMetadataRows
+                = indexRows.stream()
+                .map(ValueMetadataCleanupTask::convertFromIndexRow)
+                .collect(Collectors.toSet());
+        return Sets.difference(queriedMetadataRows, presentMetadataRows);
+    }
+
+    private static Set<ValueStreamMetadataTable.ValueStreamMetadataRow> getUnreferencedStreamsByIterator(ValueStreamIdxTable indexTable, Set<ValueStreamIdxTable.ValueStreamIdxRow> indexRows) {
         Map<ValueStreamIdxTable.ValueStreamIdxRow, Iterator<ValueStreamIdxTable.ValueStreamIdxColumnValue>> referenceIteratorByStream
                 = indexTable.getRowsColumnRangeIterator(indexRows,
                         BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 1));
-        Set<ValueStreamMetadataTable.ValueStreamMetadataRow> streamsWithNoReferences
+        Set<ValueStreamMetadataTable.ValueStreamMetadataRow> unreferencedStreamMetadata
                 = KeyedStream.stream(referenceIteratorByStream)
                 .filter(valueIterator -> !valueIterator.hasNext())
                 .keys() // (authorized)
                 .map(ValueStreamIdxTable.ValueStreamIdxRow::getId)
                 .map(ValueStreamMetadataTable.ValueStreamMetadataRow::of)
                 .collect(Collectors.toSet());
-        Map<ValueStreamMetadataTable.ValueStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
-        Set<Long> toDelete = Sets.newHashSet();
-        for (Map.Entry<ValueStreamMetadataTable.ValueStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
-            if (e.getValue().getStatus() != Status.STORED || streamsWithNoReferences.contains(e.getKey())) {
-                toDelete.add(e.getKey().getId());
-            }
+        return unreferencedStreamMetadata;
+    }
+
+    private static void executeUnreferencedStreamDiagnostics(ValueStreamIdxTable indexTable, Set<ValueStreamMetadataTable.ValueStreamMetadataRow> metadataRows) {
+        Set<ValueStreamIdxTable.ValueStreamIdxRow> indexRows = metadataRows.stream()
+                .map(ValueStreamMetadataTable.ValueStreamMetadataRow::getId)
+                .map(ValueStreamIdxTable.ValueStreamIdxRow::of)
+                .collect(Collectors.toSet());
+        Set<ValueStreamMetadataTable.ValueStreamMetadataRow> unreferencedStreamsByIterator = getUnreferencedStreamsByIterator(indexTable, indexRows);
+        Set<ValueStreamMetadataTable.ValueStreamMetadataRow> unreferencedStreamsByMultimap = getUnreferencedStreamsByMultimap(indexTable, indexRows);
+        if (!unreferencedStreamsByIterator.equals(unreferencedStreamsByMultimap)) {
+            log.info("We searched for unreferenced streams with methodological inconsistency: iterators claimed we could delete {}, but multimaps {}.",
+                    SafeArg.of("unreferencedByIterator", convertToIdsForLogging(unreferencedStreamsByIterator)),
+                    SafeArg.of("unreferencedByMultimap", convertToIdsForLogging(unreferencedStreamsByMultimap)));
+        } else {
+            log.info("We searched for unreferenced streams and consistently found {}.",
+                    SafeArg.of("unreferencedStreamIds", convertToIdsForLogging(unreferencedStreamsByIterator)));
         }
-        ValueStreamStore.of(tables).deleteStreams(t, toDelete);
-        return false;
     }
 }

--- a/changelog/@unreleased/pr-4435.v2.yml
+++ b/changelog/@unreleased/pr-4435.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: AtlasDB clients using Stream Stores now log diagnostic information concerning unreferenced streams
+    when a stream is cleaned up (via one of its cleanup tasks).
+  links:
+    - https://github.com/palantir/atlasdb/pull/4235
+

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosMetadataCleanupTask.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosMetadataCleanupTask.java
@@ -5,6 +5,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
 import com.palantir.atlasdb.encoding.PtBytes;
@@ -16,8 +20,11 @@ import com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.common.streams.KeyedStream;
+import com.palantir.logsafe.SafeArg;
 
 public class UserPhotosMetadataCleanupTask implements OnCleanupTask {
+
+    private static final Logger log = LoggerFactory.getLogger(UserPhotosMetadataCleanupTask.class);
 
     private final ProfileTableFactory tables;
 
@@ -32,6 +39,8 @@ public class UserPhotosMetadataCleanupTask implements OnCleanupTask {
         for (Cell cell : cells) {
             rows.add(UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));
         }
+        UserPhotosStreamIdxTable indexTable = tables.getUserPhotosStreamIdxTable(t);
+        executeUnreferencedStreamDiagnostics(indexTable, rows);
         Map<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
         Set<Long> toDelete = Sets.newHashSet();
         for (Map.Entry<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
@@ -41,5 +50,58 @@ public class UserPhotosMetadataCleanupTask implements OnCleanupTask {
         }
         UserPhotosStreamStore.of(tables).deleteStreams(t, toDelete);
         return false;
+    }
+
+    private static UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow convertFromIndexRow(UserPhotosStreamIdxTable.UserPhotosStreamIdxRow idxRow) {
+        return UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow.of(idxRow.getId());
+    }
+    private static Set<Long> convertToIdsForLogging(Set<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow> iteratorExcess) {
+        return iteratorExcess.stream()
+                .map(UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow::getId)
+                .collect(Collectors.toSet());
+    }
+
+    private static Set<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow> getUnreferencedStreamsByMultimap(UserPhotosStreamIdxTable indexTable, Set<UserPhotosStreamIdxTable.UserPhotosStreamIdxRow> indexRows) {
+        Multimap<UserPhotosStreamIdxTable.UserPhotosStreamIdxRow, UserPhotosStreamIdxTable.UserPhotosStreamIdxColumnValue> indexValues = indexTable.getRowsMultimap(indexRows);
+        Set<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow> presentMetadataRows
+                = indexValues.keySet().stream()
+                .map(UserPhotosMetadataCleanupTask::convertFromIndexRow)
+                .collect(Collectors.toSet());
+        Set<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow> queriedMetadataRows
+                = indexRows.stream()
+                .map(UserPhotosMetadataCleanupTask::convertFromIndexRow)
+                .collect(Collectors.toSet());
+        return Sets.difference(queriedMetadataRows, presentMetadataRows);
+    }
+
+    private static Set<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow> getUnreferencedStreamsByIterator(UserPhotosStreamIdxTable indexTable, Set<UserPhotosStreamIdxTable.UserPhotosStreamIdxRow> indexRows) {
+        Map<UserPhotosStreamIdxTable.UserPhotosStreamIdxRow, Iterator<UserPhotosStreamIdxTable.UserPhotosStreamIdxColumnValue>> referenceIteratorByStream
+                = indexTable.getRowsColumnRangeIterator(indexRows,
+                        BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 1));
+        Set<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow> unreferencedStreamMetadata
+                = KeyedStream.stream(referenceIteratorByStream)
+                .filter(valueIterator -> !valueIterator.hasNext())
+                .keys() // (authorized)
+                .map(UserPhotosStreamIdxTable.UserPhotosStreamIdxRow::getId)
+                .map(UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow::of)
+                .collect(Collectors.toSet());
+        return unreferencedStreamMetadata;
+    }
+
+    private static void executeUnreferencedStreamDiagnostics(UserPhotosStreamIdxTable indexTable, Set<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow> metadataRows) {
+        Set<UserPhotosStreamIdxTable.UserPhotosStreamIdxRow> indexRows = metadataRows.stream()
+                .map(UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow::getId)
+                .map(UserPhotosStreamIdxTable.UserPhotosStreamIdxRow::of)
+                .collect(Collectors.toSet());
+        Set<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow> unreferencedStreamsByIterator = getUnreferencedStreamsByIterator(indexTable, indexRows);
+        Set<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow> unreferencedStreamsByMultimap = getUnreferencedStreamsByMultimap(indexTable, indexRows);
+        if (!unreferencedStreamsByIterator.equals(unreferencedStreamsByMultimap)) {
+            log.info("We searched for unreferenced streams with methodological inconsistency: iterators claimed we could delete {}, but multimaps {}.",
+                    SafeArg.of("unreferencedByIterator", convertToIdsForLogging(unreferencedStreamsByIterator)),
+                    SafeArg.of("unreferencedByMultimap", convertToIdsForLogging(unreferencedStreamsByMultimap)));
+        } else {
+            log.info("We searched for unreferenced streams and consistently found {}.",
+                    SafeArg.of("unreferencedStreamIds", convertToIdsForLogging(unreferencedStreamsByIterator)));
+        }
     }
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamStore.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamStore.java
@@ -60,7 +60,6 @@ import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.atlasdb.transaction.api.TransactionTask;
 import com.palantir.atlasdb.transaction.impl.TxTask;
 import com.palantir.common.base.Throwables;
-import com.palantir.common.compression.LZ4CompressingInputStream;
 import com.palantir.common.compression.StreamCompression;
 import com.palantir.common.io.ConcatenatedInputStream;
 import com.palantir.util.AssertUtils;
@@ -69,8 +68,6 @@ import com.palantir.util.Pair;
 import com.palantir.util.crypto.Sha256Hash;
 import com.palantir.util.file.DeleteOnCloseFileInputStream;
 import com.palantir.util.file.TempFileUtils;
-
-import net.jpountz.lz4.LZ4BlockInputStream;
 
 @Generated("com.palantir.atlasdb.table.description.render.StreamStoreRenderer")
 @SuppressWarnings("all")
@@ -412,8 +409,6 @@ public final class UserPhotosStreamStore extends AbstractPersistentStreamStore {
      * {@link ImmutableSet}
      * {@link InputStream}
      * {@link Ints}
-     * {@link LZ4BlockInputStream}
-     * {@link LZ4CompressingInputStream}
      * {@link List}
      * {@link Lists}
      * {@link Logger}
@@ -434,6 +429,7 @@ public final class UserPhotosStreamStore extends AbstractPersistentStreamStore {
      * {@link Sha256Hash}
      * {@link Status}
      * {@link StreamCleanedException}
+     * {@link StreamCompression}
      * {@link StreamMetadata}
      * {@link StreamStorePersistenceConfiguration}
      * {@link Supplier}


### PR DESCRIPTION
**Goals (and why)**:
- Provide a mechanism for cleanup tasks to admit runtime configuration.
- This is required as part of internal shopping product's use case for stream stores.
- Outline precisely what configuration would be required.

**Implementation Description (bullets)**:
- Pass config into executions of a cleanup task.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Added a test for how the config should look like.

**Concerns (what feedback would you like?)**:
- The abstraction is kind of poor. Not entirely keen on `CleanupFollowerConfig` living in `atlasdb-api`, but unfortunately it's needed as it may be passed to the cleanup tasks.

**Where should we start reviewing?**: `CleanupFollowerConfig`

**Priority (whenever / two weeks / yesterday)**: this week would be great, if not early next week. **While this is outstanding, shopping product cannot take AtlasDB upgrades.**
