### PR TITLE
[PDS-10{3841,4895}] Part 4: Delete Unreferenced Streams, But Only If Authorized

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
@@ -722,6 +722,8 @@ public class StreamStoreRenderer {
                     line(StreamIndexTable, " indexTable = tables.get", StreamIndexTable, "(t);");
                     line("Set<", StreamId, "> unreferencedStreamIds = findUnreferencedStreams(indexTable, rows);");
                     line("if (cleanupFollowerConfig.dangerousRiskOfDataCorruptionEnableCleanupOfUnreferencedStreamsInStreamStoreCleanupTasks()) {"); {
+                        line("log.info(\"Deleting streams {}, which are stored, but we believe to be unreferenced.\",");
+                        line("        SafeArg.of(\"additionalStreamIds\", Sets.difference(unreferencedStreamIds, toDelete)));");
                         line("toDelete.addAll(unreferencedStreamIds);");
                     } line("}");
                     line(StreamStore, ".of(tables).deleteStreams(t, toDelete);");

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsMetadataCleanupTask.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsMetadataCleanupTask.java
@@ -55,6 +55,8 @@ public class SnapshotsMetadataCleanupTask implements OnCleanupTask {
         SnapshotsStreamIdxTable indexTable = tables.getSnapshotsStreamIdxTable(t);
         Set<Long> unreferencedStreamIds = findUnreferencedStreams(indexTable, rows);
         if (cleanupFollowerConfig.dangerousRiskOfDataCorruptionEnableCleanupOfUnreferencedStreamsInStreamStoreCleanupTasks()) {
+            log.info("Deleting streams {}, which are stored, but we believe to be unreferenced.",
+                    SafeArg.of("additionalStreamIds", Sets.difference(unreferencedStreamIds, toDelete)));
             toDelete.addAll(unreferencedStreamIds);
         }
         SnapshotsStreamStore.of(tables).deleteStreams(t, toDelete);

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataMetadataCleanupTask.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataMetadataCleanupTask.java
@@ -10,6 +10,8 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
+import com.palantir.atlasdb.cleaner.api.CleanupFollowerConfig;
+import com.palantir.atlasdb.cleaner.api.ImmutableCleanupFollowerConfig;
 import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
@@ -34,13 +36,15 @@ public class DataMetadataCleanupTask implements OnCleanupTask {
 
     @Override
     public boolean cellsCleanedUp(Transaction t, Set<Cell> cells) {
+        return cellsCleanedUp(t, cells, ImmutableCleanupFollowerConfig.builder().build());
+    }
+    @Override
+    public boolean cellsCleanedUp(Transaction t, Set<Cell> cells, CleanupFollowerConfig cleanupFollowerConfig) {
         DataStreamMetadataTable metaTable = tables.getDataStreamMetadataTable(t);
         Set<DataStreamMetadataTable.DataStreamMetadataRow> rows = Sets.newHashSetWithExpectedSize(cells.size());
         for (Cell cell : cells) {
             rows.add(DataStreamMetadataTable.DataStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));
         }
-        DataStreamIdxTable indexTable = tables.getDataStreamIdxTable(t);
-        executeUnreferencedStreamDiagnostics(indexTable, rows);
         Map<DataStreamMetadataTable.DataStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
         Set<Long> toDelete = Sets.newHashSet();
         for (Map.Entry<DataStreamMetadataTable.DataStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
@@ -48,17 +52,32 @@ public class DataMetadataCleanupTask implements OnCleanupTask {
                 toDelete.add(e.getKey().getId());
             }
         }
+        DataStreamIdxTable indexTable = tables.getDataStreamIdxTable(t);
+        Set<Long> unreferencedStreamIds = findUnreferencedStreams(indexTable, rows);
+        if (cleanupFollowerConfig.dangerousRiskOfDataCorruptionEnableCleanupOfUnreferencedStreamsInStreamStoreCleanupTasks()) {
+            toDelete.addAll(unreferencedStreamIds);
+        }
         DataStreamStore.of(tables).deleteStreams(t, toDelete);
         return false;
     }
 
-    private static DataStreamMetadataTable.DataStreamMetadataRow convertFromIndexRow(DataStreamIdxTable.DataStreamIdxRow idxRow) {
-        return DataStreamMetadataTable.DataStreamMetadataRow.of(idxRow.getId());
-    }
-    private static Set<Long> convertToIdsForLogging(Set<DataStreamMetadataTable.DataStreamMetadataRow> iteratorExcess) {
-        return iteratorExcess.stream()
+    private static Set<Long> findUnreferencedStreams(DataStreamIdxTable indexTable, Set<DataStreamMetadataTable.DataStreamMetadataRow> metadataRows) {
+        Set<DataStreamIdxTable.DataStreamIdxRow> indexRows = metadataRows.stream()
                 .map(DataStreamMetadataTable.DataStreamMetadataRow::getId)
+                .map(DataStreamIdxTable.DataStreamIdxRow::of)
                 .collect(Collectors.toSet());
+        Set<Long> unreferencedStreamsByIterator = convertToIds(getUnreferencedStreamsByIterator(indexTable, indexRows));
+        Set<Long> unreferencedStreamsByMultimap = convertToIds(getUnreferencedStreamsByMultimap(indexTable, indexRows));
+        if (!unreferencedStreamsByIterator.equals(unreferencedStreamsByMultimap)) {
+            log.info("We searched for unreferenced streams with methodological inconsistency: iterators claimed we could delete {}, but multimaps {}.",
+                    SafeArg.of("unreferencedByIterator", unreferencedStreamsByIterator),
+                    SafeArg.of("unreferencedByMultimap", unreferencedStreamsByMultimap));
+            return Sets.intersection(unreferencedStreamsByIterator, unreferencedStreamsByMultimap);
+        } else {
+            log.info("We searched for unreferenced streams and consistently found {}.",
+                    SafeArg.of("unreferencedStreamIds", unreferencedStreamsByIterator));
+            return unreferencedStreamsByIterator;
+        }
     }
 
     private static Set<DataStreamMetadataTable.DataStreamMetadataRow> getUnreferencedStreamsByMultimap(DataStreamIdxTable indexTable, Set<DataStreamIdxTable.DataStreamIdxRow> indexRows) {
@@ -88,20 +107,12 @@ public class DataMetadataCleanupTask implements OnCleanupTask {
         return unreferencedStreamMetadata;
     }
 
-    private static void executeUnreferencedStreamDiagnostics(DataStreamIdxTable indexTable, Set<DataStreamMetadataTable.DataStreamMetadataRow> metadataRows) {
-        Set<DataStreamIdxTable.DataStreamIdxRow> indexRows = metadataRows.stream()
+    private static DataStreamMetadataTable.DataStreamMetadataRow convertFromIndexRow(DataStreamIdxTable.DataStreamIdxRow idxRow) {
+        return DataStreamMetadataTable.DataStreamMetadataRow.of(idxRow.getId());
+    }
+    private static Set<Long> convertToIds(Set<DataStreamMetadataTable.DataStreamMetadataRow> iteratorExcess) {
+        return iteratorExcess.stream()
                 .map(DataStreamMetadataTable.DataStreamMetadataRow::getId)
-                .map(DataStreamIdxTable.DataStreamIdxRow::of)
                 .collect(Collectors.toSet());
-        Set<DataStreamMetadataTable.DataStreamMetadataRow> unreferencedStreamsByIterator = getUnreferencedStreamsByIterator(indexTable, indexRows);
-        Set<DataStreamMetadataTable.DataStreamMetadataRow> unreferencedStreamsByMultimap = getUnreferencedStreamsByMultimap(indexTable, indexRows);
-        if (!unreferencedStreamsByIterator.equals(unreferencedStreamsByMultimap)) {
-            log.info("We searched for unreferenced streams with methodological inconsistency: iterators claimed we could delete {}, but multimaps {}.",
-                    SafeArg.of("unreferencedByIterator", convertToIdsForLogging(unreferencedStreamsByIterator)),
-                    SafeArg.of("unreferencedByMultimap", convertToIdsForLogging(unreferencedStreamsByMultimap)));
-        } else {
-            log.info("We searched for unreferenced streams and consistently found {}.",
-                    SafeArg.of("unreferencedStreamIds", convertToIdsForLogging(unreferencedStreamsByIterator)));
-        }
     }
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataMetadataCleanupTask.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataMetadataCleanupTask.java
@@ -55,6 +55,8 @@ public class DataMetadataCleanupTask implements OnCleanupTask {
         DataStreamIdxTable indexTable = tables.getDataStreamIdxTable(t);
         Set<Long> unreferencedStreamIds = findUnreferencedStreams(indexTable, rows);
         if (cleanupFollowerConfig.dangerousRiskOfDataCorruptionEnableCleanupOfUnreferencedStreamsInStreamStoreCleanupTasks()) {
+            log.info("Deleting streams {}, which are stored, but we believe to be unreferenced.",
+                    SafeArg.of("additionalStreamIds", Sets.difference(unreferencedStreamIds, toDelete)));
             toDelete.addAll(unreferencedStreamIds);
         }
         DataStreamStore.of(tables).deleteStreams(t, toDelete);

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataMetadataCleanupTask.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataMetadataCleanupTask.java
@@ -55,6 +55,8 @@ public class HotspottyDataMetadataCleanupTask implements OnCleanupTask {
         HotspottyDataStreamIdxTable indexTable = tables.getHotspottyDataStreamIdxTable(t);
         Set<Long> unreferencedStreamIds = findUnreferencedStreams(indexTable, rows);
         if (cleanupFollowerConfig.dangerousRiskOfDataCorruptionEnableCleanupOfUnreferencedStreamsInStreamStoreCleanupTasks()) {
+            log.info("Deleting streams {}, which are stored, but we believe to be unreferenced.",
+                    SafeArg.of("additionalStreamIds", Sets.difference(unreferencedStreamIds, toDelete)));
             toDelete.addAll(unreferencedStreamIds);
         }
         HotspottyDataStreamStore.of(tables).deleteStreams(t, toDelete);

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataMetadataCleanupTask.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataMetadataCleanupTask.java
@@ -10,6 +10,8 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
+import com.palantir.atlasdb.cleaner.api.CleanupFollowerConfig;
+import com.palantir.atlasdb.cleaner.api.ImmutableCleanupFollowerConfig;
 import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
@@ -34,13 +36,15 @@ public class HotspottyDataMetadataCleanupTask implements OnCleanupTask {
 
     @Override
     public boolean cellsCleanedUp(Transaction t, Set<Cell> cells) {
+        return cellsCleanedUp(t, cells, ImmutableCleanupFollowerConfig.builder().build());
+    }
+    @Override
+    public boolean cellsCleanedUp(Transaction t, Set<Cell> cells, CleanupFollowerConfig cleanupFollowerConfig) {
         HotspottyDataStreamMetadataTable metaTable = tables.getHotspottyDataStreamMetadataTable(t);
         Set<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow> rows = Sets.newHashSetWithExpectedSize(cells.size());
         for (Cell cell : cells) {
             rows.add(HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));
         }
-        HotspottyDataStreamIdxTable indexTable = tables.getHotspottyDataStreamIdxTable(t);
-        executeUnreferencedStreamDiagnostics(indexTable, rows);
         Map<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
         Set<Long> toDelete = Sets.newHashSet();
         for (Map.Entry<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
@@ -48,17 +52,32 @@ public class HotspottyDataMetadataCleanupTask implements OnCleanupTask {
                 toDelete.add(e.getKey().getId());
             }
         }
+        HotspottyDataStreamIdxTable indexTable = tables.getHotspottyDataStreamIdxTable(t);
+        Set<Long> unreferencedStreamIds = findUnreferencedStreams(indexTable, rows);
+        if (cleanupFollowerConfig.dangerousRiskOfDataCorruptionEnableCleanupOfUnreferencedStreamsInStreamStoreCleanupTasks()) {
+            toDelete.addAll(unreferencedStreamIds);
+        }
         HotspottyDataStreamStore.of(tables).deleteStreams(t, toDelete);
         return false;
     }
 
-    private static HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow convertFromIndexRow(HotspottyDataStreamIdxTable.HotspottyDataStreamIdxRow idxRow) {
-        return HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow.of(idxRow.getId());
-    }
-    private static Set<Long> convertToIdsForLogging(Set<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow> iteratorExcess) {
-        return iteratorExcess.stream()
+    private static Set<Long> findUnreferencedStreams(HotspottyDataStreamIdxTable indexTable, Set<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow> metadataRows) {
+        Set<HotspottyDataStreamIdxTable.HotspottyDataStreamIdxRow> indexRows = metadataRows.stream()
                 .map(HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow::getId)
+                .map(HotspottyDataStreamIdxTable.HotspottyDataStreamIdxRow::of)
                 .collect(Collectors.toSet());
+        Set<Long> unreferencedStreamsByIterator = convertToIds(getUnreferencedStreamsByIterator(indexTable, indexRows));
+        Set<Long> unreferencedStreamsByMultimap = convertToIds(getUnreferencedStreamsByMultimap(indexTable, indexRows));
+        if (!unreferencedStreamsByIterator.equals(unreferencedStreamsByMultimap)) {
+            log.info("We searched for unreferenced streams with methodological inconsistency: iterators claimed we could delete {}, but multimaps {}.",
+                    SafeArg.of("unreferencedByIterator", unreferencedStreamsByIterator),
+                    SafeArg.of("unreferencedByMultimap", unreferencedStreamsByMultimap));
+            return Sets.intersection(unreferencedStreamsByIterator, unreferencedStreamsByMultimap);
+        } else {
+            log.info("We searched for unreferenced streams and consistently found {}.",
+                    SafeArg.of("unreferencedStreamIds", unreferencedStreamsByIterator));
+            return unreferencedStreamsByIterator;
+        }
     }
 
     private static Set<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow> getUnreferencedStreamsByMultimap(HotspottyDataStreamIdxTable indexTable, Set<HotspottyDataStreamIdxTable.HotspottyDataStreamIdxRow> indexRows) {
@@ -88,20 +107,12 @@ public class HotspottyDataMetadataCleanupTask implements OnCleanupTask {
         return unreferencedStreamMetadata;
     }
 
-    private static void executeUnreferencedStreamDiagnostics(HotspottyDataStreamIdxTable indexTable, Set<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow> metadataRows) {
-        Set<HotspottyDataStreamIdxTable.HotspottyDataStreamIdxRow> indexRows = metadataRows.stream()
+    private static HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow convertFromIndexRow(HotspottyDataStreamIdxTable.HotspottyDataStreamIdxRow idxRow) {
+        return HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow.of(idxRow.getId());
+    }
+    private static Set<Long> convertToIds(Set<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow> iteratorExcess) {
+        return iteratorExcess.stream()
                 .map(HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow::getId)
-                .map(HotspottyDataStreamIdxTable.HotspottyDataStreamIdxRow::of)
                 .collect(Collectors.toSet());
-        Set<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow> unreferencedStreamsByIterator = getUnreferencedStreamsByIterator(indexTable, indexRows);
-        Set<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow> unreferencedStreamsByMultimap = getUnreferencedStreamsByMultimap(indexTable, indexRows);
-        if (!unreferencedStreamsByIterator.equals(unreferencedStreamsByMultimap)) {
-            log.info("We searched for unreferenced streams with methodological inconsistency: iterators claimed we could delete {}, but multimaps {}.",
-                    SafeArg.of("unreferencedByIterator", convertToIdsForLogging(unreferencedStreamsByIterator)),
-                    SafeArg.of("unreferencedByMultimap", convertToIdsForLogging(unreferencedStreamsByMultimap)));
-        } else {
-            log.info("We searched for unreferenced streams and consistently found {}.",
-                    SafeArg.of("unreferencedStreamIds", convertToIdsForLogging(unreferencedStreamsByIterator)));
-        }
     }
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosMetadataCleanupTask.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosMetadataCleanupTask.java
@@ -55,6 +55,8 @@ public class UserPhotosMetadataCleanupTask implements OnCleanupTask {
         UserPhotosStreamIdxTable indexTable = tables.getUserPhotosStreamIdxTable(t);
         Set<Long> unreferencedStreamIds = findUnreferencedStreams(indexTable, rows);
         if (cleanupFollowerConfig.dangerousRiskOfDataCorruptionEnableCleanupOfUnreferencedStreamsInStreamStoreCleanupTasks()) {
+            log.info("Deleting streams {}, which are stored, but we believe to be unreferenced.",
+                    SafeArg.of("additionalStreamIds", Sets.difference(unreferencedStreamIds, toDelete)));
             toDelete.addAll(unreferencedStreamIds);
         }
         UserPhotosStreamStore.of(tables).deleteStreams(t, toDelete);


### PR DESCRIPTION
**Goals (and why)**:
- Allow shopping product to continue its workflows at large deployments where it needs the old cleanup functionality (and it has suitable safety mechanisms)
- While still generally ensuring that products which can't take such hits are protected.

**Implementation Description (bullets)**:
- Wire the configuration option through.

**Testing (What was existing testing like?  What have you done to improve it?)**:
[] TODO jkong add tests
The 'no' version is tested by the `TargetedSweepEteTest`. The `yes` version is untested, @jeremyk-91 to add this. Nonetheless most of the PR should be reviewable in this state.

**Concerns (what feedback would you like?)**:
- Nothing in particular actually. Are we VERY sure this is safe, even assuming that the stream IDs we get back from findUnreferencedStreams may be wrong?

**Where should we start reviewing?**: `StreamStoreRenderer`

**Priority (whenever / two weeks / yesterday)**: this week would be nice, if not early next - this blocks AtlasDB upgrades on shopping product while outstanding
