### PR TITLE
Number of hosts in C* config fix.

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -325,7 +325,7 @@ public interface CassandraKeyValueServiceConfig extends KeyValueServiceConfig {
     @Override
     @Value.Default
     default int concurrentGetRangesThreadPoolSize() {
-        return poolSize() * servers().numberOfHosts();
+        return poolSize() * servers().numberOfThriftHosts();
     }
 
     @JsonIgnore

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraServersConfigs.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraServersConfigs.java
@@ -81,7 +81,7 @@ public final class CassandraServersConfigs {
 
         <T> T accept(Visitor<T> visitor);
 
-        int numberOfHosts();
+        int numberOfThriftHosts();
     }
 
     @Value.Immutable
@@ -96,7 +96,7 @@ public final class CassandraServersConfigs {
 
         @Override
         @Value.Derived
-        public int numberOfHosts() {
+        public int numberOfThriftHosts() {
             return thriftHosts().size();
         }
 
@@ -129,8 +129,8 @@ public final class CassandraServersConfigs {
 
         @Override
         @Value.Derived
-        public int numberOfHosts() {
-            return Math.max(thriftHosts().size(), cqlHosts().size());
+        public int numberOfThriftHosts() {
+            return thriftHosts().size();
         }
 
         @Value.Check

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -412,7 +412,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             CassandraClientPool clientPool,
             CassandraMutationTimestampProvider mutationTimestampProvider) {
         super(createInstrumentedFixedThreadPool(
-                config.poolSize() * config.servers().numberOfHosts(),
+                config.poolSize() * config.servers().numberOfThriftHosts(),
                 metricsManager.getRegistry()
         ));
         this.log = log;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
@@ -145,7 +145,7 @@ public final class CassandraKeyValueServices {
             return false;
         }
 
-        int numberOfServers = config.servers().numberOfHosts();
+        int numberOfServers = config.servers().numberOfThriftHosts();
         int numberOfVisibleNodes = getNumberOfReachableNodes(versions);
 
         return numberOfVisibleNodes >= ((numberOfServers / 2) + 1);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/DefaultCassandraAsyncKeyValueServiceFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/DefaultCassandraAsyncKeyValueServiceFactory.java
@@ -23,6 +23,9 @@ import java.util.concurrent.TimeUnit;
 import com.codahale.metrics.InstrumentedExecutorService;
 import com.codahale.metrics.MetricRegistry;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
+import com.palantir.atlasdb.cassandra.CassandraServersConfigs.CqlCapableConfig;
+import com.palantir.atlasdb.cassandra.CassandraServersConfigs.DefaultConfig;
+import com.palantir.atlasdb.cassandra.CassandraServersConfigs.Visitor;
 import com.palantir.atlasdb.futures.AtlasFutures;
 import com.palantir.atlasdb.keyvalue.api.AsyncKeyValueService;
 import com.palantir.atlasdb.keyvalue.cassandra.async.client.creation.CqlClientFactory;
@@ -52,9 +55,21 @@ public final class DefaultCassandraAsyncKeyValueServiceFactory implements Cassan
                 config,
                 initializeAsync);
 
+        int numberOfHosts = config.servers().accept(new Visitor<Integer>() {
+            @Override
+            public Integer visit(DefaultConfig defaultConfig) {
+                return 0;
+            }
+
+            @Override
+            public Integer visit(CqlCapableConfig cqlCapableConfig) {
+                return cqlCapableConfig.cqlHosts().size();
+            }
+        });
+
         ExecutorService executorService = tracingExecutorService(
                 instrumentExecutorService(
-                        createThreadPool(config.servers().numberOfHosts() * config.poolSize()),
+                        createThreadPool(numberOfHosts * config.poolSize()),
                         metricsManager));
 
         return CassandraAsyncKeyValueService.create(

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/DefaultCassandraAsyncKeyValueServiceFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/DefaultCassandraAsyncKeyValueServiceFactory.java
@@ -55,21 +55,21 @@ public final class DefaultCassandraAsyncKeyValueServiceFactory implements Cassan
                 config,
                 initializeAsync);
 
-        int numberOfHosts = config.servers().accept(new Visitor<Integer>() {
+        int threadPoolSize = config.servers().accept(new Visitor<Integer>() {
             @Override
             public Integer visit(DefaultConfig defaultConfig) {
-                return 0;
+                return 1;
             }
 
             @Override
             public Integer visit(CqlCapableConfig cqlCapableConfig) {
-                return cqlCapableConfig.cqlHosts().size();
+                return cqlCapableConfig.cqlHosts().size() * config.poolSize();
             }
         });
 
         ExecutorService executorService = tracingExecutorService(
                 instrumentExecutorService(
-                        createThreadPool(numberOfHosts * config.poolSize()),
+                        createThreadPool(threadPoolSize),
                         metricsManager));
 
         return CassandraAsyncKeyValueService.create(

--- a/changelog/@unreleased/pr-4439.v2.yml
+++ b/changelog/@unreleased/pr-4439.v2.yml
@@ -1,5 +1,5 @@
-type: improvement
-improvement:
+type: fix
+fix:
   description: Fixes the problem for configurations which have different number of
     CQL and Thrift C* hosts.
   links:

--- a/changelog/@unreleased/pr-4439.v2.yml
+++ b/changelog/@unreleased/pr-4439.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Fixes the problem for configurations which have different number of
+    CQL and Thrift C* hosts.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4439


### PR DESCRIPTION
**Goals (and why)**:
Internal deployments have different requirements for number of host.

**Implementation Description (bullets)**:
- renamed the method to reflect the semantic content
- for CQL hosts used a visitor where needed

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:
- `CassandraServersConfigs`

**Priority (whenever / two weeks / yesterday)**:
ASAP

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
