### PR TITLE
reduce sleep between scrub runs

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -127,7 +127,7 @@ public final class AtlasDbConstants {
     public static final boolean DEFAULT_BACKGROUND_SCRUB_AGGRESSIVELY = true;
     public static final int DEFAULT_BACKGROUND_SCRUB_THREADS = 8;
     public static final int DEFAULT_BACKGROUND_SCRUB_READ_THREADS = 8;
-    public static final long DEFAULT_BACKGROUND_SCRUB_FREQUENCY_MILLIS = 3600000L;
+    public static final long DEFAULT_BACKGROUND_SCRUB_FREQUENCY_MILLIS = 5 * 60 * 1000; // 5 minutes
     public static final int DEFAULT_BACKGROUND_SCRUB_BATCH_SIZE = 2000;
     public static final long SCRUBBER_RETRY_DELAY_MILLIS = 500L;
     public static final char OLD_SCRUB_TABLE_SEPARATOR_CHAR = '\0';

--- a/changelog/@unreleased/pr-4441.v2.yml
+++ b/changelog/@unreleased/pr-4441.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Reduced the time between periods of background scrubber activity to
+    account for services with short lifetimes.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4441


### PR DESCRIPTION
This will cause extra work to be performed in some cases, especially on initial startup.
This change is intended to fix issues where the scrub queue can easily become permanently behind.

This currently happens on our dev stack for a service that rolls every time a commit is made to a part of the codebase (that happens to need scrub for it to function, at least currently)

It is anticipated that [future deployments that are in the cloud and have cloud-y constant upgrades / upgrade management ] instead of the current user of this product [fairly restrictive on-prem sites that can only occasionally take upgrades] also might run into the same problem as the dev stack, where constant rolling of services can be at odds with this setting.