### PR TITLE
[PDS-10{3841,4895}] Part 5: Don't Reuse Streams In The Stream Store

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/AbstractPersistentStreamStore.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/AbstractPersistentStreamStore.java
@@ -42,6 +42,7 @@ import com.palantir.atlasdb.transaction.api.TransactionTask;
 import com.palantir.atlasdb.transaction.impl.TxTask;
 import com.palantir.common.base.Throwables;
 import com.palantir.common.compression.StreamCompression;
+import com.palantir.common.streams.KeyedStream;
 import com.palantir.util.Pair;
 import com.palantir.util.crypto.Sha256Hash;
 
@@ -134,16 +135,19 @@ public abstract class AbstractPersistentStreamStore extends AbstractGenericStrea
             return ImmutableMap.of();
         }
 
-        Map<Long, StreamMetadata> idsToEmptyMetadata = Maps.transformValues(streams,
-                Functions.constant(getEmptyMetadata()));
+        Map<Long, StreamMetadata> idsToEmptyMetadata = KeyedStream.stream(streams)
+                .map($ -> getEmptyMetadata())
+                .collectToMap();
         putMetadataAndHashIndexTask(tx, idsToEmptyMetadata);
 
-        Map<Long, StreamMetadata> idsToMetadata = Maps.transformEntries(streams,
-                (id, stream) -> storeBlocksAndGetFinalMetadata(tx, id, stream));
+        Map<Long, StreamMetadata> idsToMetadata = KeyedStream.stream(streams)
+                .map((id, stream) -> storeBlocksAndGetFinalMetadata(tx, id, stream))
+                .collectToMap();
         putMetadataAndHashIndexTask(tx, idsToMetadata);
 
-        Map<Long, Sha256Hash> hashes = Maps.transformValues(idsToMetadata,
-                metadata -> new Sha256Hash(metadata.getHash().toByteArray()));
+        Map<Long, Sha256Hash> hashes = KeyedStream.stream(idsToMetadata)
+                .map(metadata -> new Sha256Hash(metadata.getHash().toByteArray()))
+                .collectToMap();
         return hashes;
     }
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/AbstractPersistentStreamStore.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/AbstractPersistentStreamStore.java
@@ -145,10 +145,9 @@ public abstract class AbstractPersistentStreamStore extends AbstractGenericStrea
                 .collectToMap();
         putMetadataAndHashIndexTask(tx, idsToMetadata);
 
-        Map<Long, Sha256Hash> hashes = KeyedStream.stream(idsToMetadata)
+        return KeyedStream.stream(idsToMetadata)
                 .map(metadata -> new Sha256Hash(metadata.getHash().toByteArray()))
                 .collectToMap();
-        return hashes;
     }
 
     // This method is overridden in generated code. Changes to this method may have unintended consequences.

--- a/atlasdb-tests-shared/build.gradle
+++ b/atlasdb-tests-shared/build.gradle
@@ -9,6 +9,8 @@ dependencies {
   compile project(":atlasdb-config")
   testCompile project(":atlasdb-config")
 
+  testCompile project(":commons-api")
+
   compile project(path: ":atlasdb-feign", configuration: "shadow")
 
   compile group: 'com.palantir.tracing', name: 'tracing'

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/StreamTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/StreamTest.java
@@ -797,7 +797,7 @@ public class StreamTest extends AtlasDbTestCase {
         return data;
     }
 
-    private static class CloseEnforcingInputStream extends ForwardingInputStream {
+    private static final class CloseEnforcingInputStream extends ForwardingInputStream {
         private final InputStream delegate;
         private final AtomicBoolean closed = new AtomicBoolean(false);
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/StreamTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/StreamTest.java
@@ -814,8 +814,8 @@ public class StreamTest extends AtlasDbTestCase {
 
         @Override
         public void close() throws IOException {
+            delegate.close();
             closed.set(true);
-            delegate().close();
         }
     }
 }

--- a/changelog/@unreleased/pr-4444.v2.yml
+++ b/changelog/@unreleased/pr-4444.v2.yml
@@ -1,9 +1,13 @@
 type: fix
 fix:
-  description: We no longer read and physically store streams lazily in the Atlas
-    stream store when `storeStreams()` is called. This fixes a bug where users who
-    stored and marked streams in a single transaction and subsequently referenced
-    the returned `Sha256Hash` may throw when storing streams, and/or suffer from data
-    corruption.
+  description: "We no longer read and physically store streams lazily in the AtlasDB
+    store when transactionally storing a stream (via `storeStreams()`). \n\nPreviously,
+    users who stored and marked streams in a single transaction and subsequently referenced
+    the returned `Sha256Hash` may fail in the following ways:\n\n- if the provided
+    `InputStream`s throw when they are read after being closed, these exceptions would
+    be thrown out to the user.\n- if the provided `InputStream`s do not throw when
+    they are read after being closed, AtlasDB would erroneously write an empty block
+    as the first block of the stream, and incorrect metadata of the stream being a
+    1-block empty stream."
   links:
   - https://github.com/palantir/atlasdb/pull/4444

--- a/changelog/@unreleased/pr-4444.v2.yml
+++ b/changelog/@unreleased/pr-4444.v2.yml
@@ -7,7 +7,7 @@ fix:
     `InputStream`s throw when they are read after being closed, these exceptions would
     be thrown out to the user.\n- if the provided `InputStream`s do not throw when
     they are read after being closed, AtlasDB would erroneously write an empty block
-    as the first block of the stream, and incorrect metadata of the stream being a
-    1-block empty stream."
+    as the first block of the stream, and incorrect metadata of the stream being an
+    empty stream."
   links:
   - https://github.com/palantir/atlasdb/pull/4444


### PR DESCRIPTION
**Thanks to @jackwickham and @j-baker for helping to puzzle through this issue!**

**Goals (and why)**:
- Don't break users who use `storeStreams` plural, and read the `Sha256Hash` data from the stream for whatever reason. Previously, this would invoke `storeBlocksAndGetHashlessMetadata` multiple times. But since the input stream was already consumed, it either returns nothing (e.g. if using `ByteArrayInputStream`), or throws.

**Implementation Description (bullets)**:
- Store streams and generate metadata eagerly.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added two new tests validating
- streams are not used once closed
- that reading the metadata is allowed and won't cause **SEVERE DATA CORRUPTION**™️. 

**Concerns (what feedback would you like?)**:
- General correctness. Nothing too special.

**Where should we start reviewing?**: `StreamTest`

**Priority (whenever / two weeks / yesterday)**: yesterday
