### PR TITLE
Increase the timeout on CQL queries.

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/client/creation/DefaultCqlClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/client/creation/DefaultCqlClientFactory.java
@@ -32,6 +32,7 @@ import com.datastax.driver.core.ProtocolOptions;
 import com.datastax.driver.core.ProtocolVersion;
 import com.datastax.driver.core.QueryOptions;
 import com.datastax.driver.core.RemoteEndpointAwareJdkSSLOptions;
+import com.datastax.driver.core.SocketOptions;
 import com.datastax.driver.core.ThreadingOptions;
 import com.datastax.driver.core.policies.DefaultRetryPolicy;
 import com.datastax.driver.core.policies.LatencyAwarePolicy;
@@ -94,6 +95,7 @@ public class DefaultCqlClientFactory implements CqlClientFactory {
                 clusterBuilder = withPoolingOptions(clusterBuilder, config);
                 clusterBuilder = withQueryOptions(clusterBuilder, config);
                 clusterBuilder = withLoadBalancingPolicy(clusterBuilder, config, servers);
+                clusterBuilder = withSocketOptions(clusterBuilder, config);
 
                 return CqlClientImpl.create(
                         taggedMetricRegistry,
@@ -102,6 +104,12 @@ public class DefaultCqlClientFactory implements CqlClientFactory {
                         initializeAsync);
             }
         });
+    }
+
+    private Cluster.Builder withSocketOptions(Cluster.Builder clusterBuilder, CassandraKeyValueServiceConfig config) {
+        return clusterBuilder.withSocketOptions(
+                new SocketOptions()
+                        .setReadTimeoutMillis(config.socketQueryTimeoutMillis()));
     }
 
     private static Cluster.Builder withSslOptions(Cluster.Builder builder, CassandraKeyValueServiceConfig config) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/client/creation/DefaultCqlClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/client/creation/DefaultCqlClientFactory.java
@@ -108,8 +108,7 @@ public class DefaultCqlClientFactory implements CqlClientFactory {
 
     private Cluster.Builder withSocketOptions(Cluster.Builder clusterBuilder, CassandraKeyValueServiceConfig config) {
         return clusterBuilder.withSocketOptions(
-                new SocketOptions()
-                        .setReadTimeoutMillis(config.socketQueryTimeoutMillis()));
+                new SocketOptions().setReadTimeoutMillis(config.socketQueryTimeoutMillis()));
     }
 
     private static Cluster.Builder withSslOptions(Cluster.Builder builder, CassandraKeyValueServiceConfig config) {

--- a/changelog/@unreleased/pr-4447.v2.yml
+++ b/changelog/@unreleased/pr-4447.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Set the timeout on CQL queries from the default 12 seconds to the `socketQueryTimeoutMillis`
+    specified in `CasssandraKeyValueServiceConfig`.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4447


### PR DESCRIPTION
**Goals (and why)**:
Increase timeout for queries such that it is the same as the Thrift path.

**Implementation Description (bullets)**:
 - set `SocketOptions`

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:
today

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
