### PR TITLE
[Timelock Partitioning] Part 44b: Ensure same instance of `LeaderElectionService` is reused

### DIFF
--- a/changelog/@unreleased/pr-4448.v2.yml
+++ b/changelog/@unreleased/pr-4448.v2.yml
@@ -1,7 +1,7 @@
 type: fix
 fix:
   description: 'Ensure we use the same instance of `LeaderElectionService` when in
-    `leader-for-all clients` mode, this brings request rates back to the same rate
+    `leader-for-all-clients` mode, this brings request rates back to the same rate
     before PR 4340 merged. This addresses internal issue PDS-105806.'
   links:
   - https://github.com/palantir/atlasdb/pull/4448

--- a/changelog/@unreleased/pr-4448.v2.yml
+++ b/changelog/@unreleased/pr-4448.v2.yml
@@ -2,6 +2,7 @@ type: fix
 fix:
   description: 'Ensure we use the same instance of `LeaderElectionService` when in
     `leader-for-all clients` mode, this brings request rates back to the same rate
-    before #4340 merged. This addresses internal issue PDS-105806.'
+    before PR 4340 merged. This addresses internal issue PDS-105806.'
   links:
   - https://github.com/palantir/atlasdb/pull/4448
+  - https://github.com/palantir/atlasdb/pull/4340  

--- a/changelog/@unreleased/pr-4448.v2.yml
+++ b/changelog/@unreleased/pr-4448.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: 'Ensure we use the same instance of `LeaderElectionService` when in
+    `leader-for-all clients` mode, this brings request rates back to the same rate
+    before #4340 merged. This addresses internal issue PDS-105806.'
+  links:
+  - https://github.com/palantir/atlasdb/pull/4448

--- a/changelog/@unreleased/pr-4448.v2.yml
+++ b/changelog/@unreleased/pr-4448.v2.yml
@@ -5,4 +5,4 @@ fix:
     before PR 4340 merged. This addresses internal issue PDS-105806.'
   links:
   - https://github.com/palantir/atlasdb/pull/4448
-  - https://github.com/palantir/atlasdb/pull/4340  
+  - https://github.com/palantir/atlasdb/pull/4340

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/Dependencies.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/Dependencies.java
@@ -21,7 +21,9 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
 
+import com.palantir.leader.PaxosLeadershipEventRecorder;
 import com.palantir.leader.PingableLeader;
+import com.palantir.paxos.PaxosLearner;
 import com.palantir.timelock.config.PaxosRuntimeConfiguration;
 
 public interface Dependencies {
@@ -59,6 +61,17 @@ public interface Dependencies {
         com.palantir.atlasdb.timelock.paxos.NetworkClientFactories networkClientFactories();
         Supplier<PaxosRuntimeConfiguration> runtime();
         AutobatchingLeadershipObserverFactory leadershipObserverFactory();
+    }
+
+    interface LeaderElectionService {
+        Client paxosClient();
+        UUID leaderUuid();
+        TimelockPaxosMetrics metrics();
+        com.palantir.paxos.LeaderPinger leaderPinger();
+        Supplier<PaxosRuntimeConfiguration> runtime();
+        PaxosLeadershipEventRecorder eventRecorder();
+        PaxosLearner localLearner();
+        com.palantir.atlasdb.timelock.paxos.NetworkClientFactories networkClientFactories();
     }
 
     interface LeaderPingHealthCheck {

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeaderElectionServiceFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeaderElectionServiceFactory.java
@@ -1,0 +1,61 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import java.util.Map;
+
+import com.google.common.collect.Maps;
+import com.palantir.leader.LeaderElectionService;
+import com.palantir.leader.LeaderElectionServiceBuilder;
+import com.palantir.paxos.PaxosProposer;
+
+public class LeaderElectionServiceFactory {
+
+    private final Map<Client, LeaderElectionService> leaderElectionServicesByClient = Maps.newConcurrentMap();
+
+    public LeaderElectionService create(Dependencies.LeaderElectionService dependencies) {
+        return leaderElectionServicesByClient.computeIfAbsent(
+                dependencies.paxosClient(),
+                _client -> createNewInstance(dependencies));
+    }
+
+    private static LeaderElectionService createNewInstance(Dependencies.LeaderElectionService dependencies) {
+        return new LeaderElectionServiceBuilder()
+                .leaderPinger(dependencies.leaderPinger())
+                .leaderUuid(dependencies.leaderUuid())
+                .pingRate(dependencies.runtime().get().pingRate())
+                .randomWaitBeforeProposingLeadership(
+                        dependencies.runtime().get().maximumWaitBeforeProposingLeadership())
+                .eventRecorder(dependencies.eventRecorder())
+                .knowledge(dependencies.localLearner())
+                .acceptorClient(dependencies.networkClientFactories().acceptor().create(dependencies.paxosClient()))
+                .learnerClient(dependencies.networkClientFactories().learner().create(dependencies.paxosClient()))
+                .decorateProposer(uninstrumentedPaxosProposer -> instrumentProposer(
+                        dependencies.paxosClient(),
+                        dependencies.metrics(),
+                        uninstrumentedPaxosProposer))
+                .build();
+    }
+
+    private static PaxosProposer instrumentProposer(
+            Client paxosClient,
+            TimelockPaxosMetrics metrics,
+            PaxosProposer uninstrumentedPaxosProposer) {
+        return metrics.instrument(PaxosProposer.class, uninstrumentedPaxosProposer, "paxos-proposer", paxosClient);
+    }
+
+}

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipContextFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipContextFactory.java
@@ -23,13 +23,10 @@ import org.immutables.value.Value;
 
 import com.palantir.atlasdb.timelock.paxos.LeadershipComponents.LeadershipContext;
 import com.palantir.atlasdb.timelock.paxos.NetworkClientFactories.Factory;
-import com.palantir.leader.LeaderElectionService;
-import com.palantir.leader.LeaderElectionServiceBuilder;
 import com.palantir.leader.PaxosLeadershipEventRecorder;
 import com.palantir.leader.PingableLeader;
 import com.palantir.paxos.LeaderPinger;
 import com.palantir.paxos.PaxosLearner;
-import com.palantir.paxos.PaxosProposer;
 import com.palantir.timelock.paxos.LeaderPingHealthCheck;
 
 @Value.Immutable
@@ -84,13 +81,22 @@ public abstract class LeadershipContextFactory implements
         return leaderPingHealthCheckFactory().create(this);
     }
 
+    @Value.Derived
+    LeaderElectionServiceFactory leaderElectionServiceFactory() {
+        return new LeaderElectionServiceFactory();
+    }
+
     @Override
     public LeadershipContext create(Client client) {
-        return ImmutableClientAwareComponents.builder()
+        ClientAwareComponents clientAwareComponents = ImmutableClientAwareComponents.builder()
                 .from(this)
                 .proxyClient(client)
-                .build()
-                .leadershipContext();
+                .build();
+
+        return ImmutableLeadershipContext.builder()
+                .leadershipMetrics(clientAwareComponents.leadershipMetrics())
+                .leaderElectionService(leaderElectionServiceFactory().create(clientAwareComponents))
+                .build();
     }
 
     @Value.Derived
@@ -101,17 +107,18 @@ public abstract class LeadershipContextFactory implements
     @Value.Immutable
     abstract static class ClientAwareComponents implements
             Dependencies.ClientAwareComponents,
+            Dependencies.LeaderElectionService,
             Dependencies.LeadershipMetrics {
 
         public abstract Client proxyClient();
 
         @Value.Derived
-        Client paxosClient() {
+        public Client paxosClient() {
             return useCase().resolveClient(proxyClient());
         }
 
         @Value.Derived
-        PaxosLearner localLearner() {
+        public PaxosLearner localLearner() {
             return components().learner(paxosClient());
         }
 
@@ -128,37 +135,6 @@ public abstract class LeadershipContextFactory implements
         @Value.Derived
         public PaxosLeadershipEventRecorder eventRecorder() {
             return leadershipMetrics().eventRecorder();
-        }
-
-        @Value.Derived
-        LeaderElectionService leaderElectionService() {
-            return new LeaderElectionServiceBuilder()
-                    .leaderPinger(leaderPinger())
-                    .leaderUuid(leaderUuid())
-                    .pingRate(runtime().get().pingRate())
-                    .randomWaitBeforeProposingLeadership(runtime().get().maximumWaitBeforeProposingLeadership())
-                    .eventRecorder(eventRecorder())
-                    .knowledge(localLearner())
-                    .acceptorClient(networkClientFactories().acceptor().create(paxosClient()))
-                    .learnerClient(networkClientFactories().learner().create(paxosClient()))
-                    .decorateProposer(this::instrumentProposer)
-                    .build();
-        }
-
-        @Value.Derived
-        LeadershipContext leadershipContext() {
-            return ImmutableLeadershipContext.builder()
-                    .leadershipMetrics(leadershipMetrics())
-                    .leaderElectionService(leaderElectionService())
-                    .build();
-        }
-
-        private PaxosProposer instrumentProposer(PaxosProposer uninstrumentedPaxosProposer) {
-            return metrics().instrument(
-                    PaxosProposer.class,
-                    uninstrumentedPaxosProposer,
-                    "paxos-proposer",
-                    paxosClient());
         }
 
     }


### PR DESCRIPTION
**Goals (and why)**:
As part of #4340, I switched over the wiring logic for timelock and how it does paxos in preparation for "leader for each namespace" timelock.

However, a new instance of a `LeaderElectionService` was being made for each client, despite the cluster only having *one* leader. As such, in this mode, we'd have `n` `LeaderElectionService`, and each would have a corresponding `AwaitingLeadershipProxy`. We're not running with any batching, so it's disastrous.

**Implementation Description (bullets)**:
Similar to `LocalPaxosComponents`, we want to have a class that we store instances of a `LeaderElectionService` keyed on its `Client`.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Local testing to ensure we haven't blown up number of threads. 

**Where should we start reviewing?**:
Anywhere.

**Priority (whenever / two weeks / yesterday)**:
ASAP, unblocks atlasdb upgrades on internal timelock repo.
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
