### PR TITLE
[Timelock Partitioning] Part 44c: Restore batching behaviour.

### DIFF
--- a/changelog/@unreleased/pr-4450.v2.yml
+++ b/changelog/@unreleased/pr-4450.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Restore batching behaviour across all clients that use the same `LeaderElectionService`.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4450

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeaderElectionServiceFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeaderElectionServiceFactory.java
@@ -19,22 +19,22 @@ package com.palantir.atlasdb.timelock.paxos;
 import java.util.Map;
 
 import com.google.common.collect.Maps;
-import com.palantir.leader.LeaderElectionService;
+import com.palantir.leader.BatchingLeaderElectionService;
 import com.palantir.leader.LeaderElectionServiceBuilder;
 import com.palantir.paxos.PaxosProposer;
 
 public class LeaderElectionServiceFactory {
 
-    private final Map<Client, LeaderElectionService> leaderElectionServicesByClient = Maps.newConcurrentMap();
+    private final Map<Client, BatchingLeaderElectionService> leaderElectionServicesByClient = Maps.newConcurrentMap();
 
-    public LeaderElectionService create(Dependencies.LeaderElectionService dependencies) {
+    public BatchingLeaderElectionService create(Dependencies.LeaderElectionService dependencies) {
         return leaderElectionServicesByClient.computeIfAbsent(
                 dependencies.paxosClient(),
                 _client -> createNewInstance(dependencies));
     }
 
-    private static LeaderElectionService createNewInstance(Dependencies.LeaderElectionService dependencies) {
-        return new LeaderElectionServiceBuilder()
+    private static BatchingLeaderElectionService createNewInstance(Dependencies.LeaderElectionService dependencies) {
+        return new BatchingLeaderElectionService(new LeaderElectionServiceBuilder()
                 .leaderPinger(dependencies.leaderPinger())
                 .leaderUuid(dependencies.leaderUuid())
                 .pingRate(dependencies.runtime().get().pingRate())
@@ -48,7 +48,7 @@ public class LeaderElectionServiceFactory {
                         dependencies.paxosClient(),
                         dependencies.metrics(),
                         uninstrumentedPaxosProposer))
-                .build();
+                .build());
     }
 
     private static PaxosProposer instrumentProposer(

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipContextFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipContextFactory.java
@@ -23,6 +23,7 @@ import org.immutables.value.Value;
 
 import com.palantir.atlasdb.timelock.paxos.LeadershipComponents.LeadershipContext;
 import com.palantir.atlasdb.timelock.paxos.NetworkClientFactories.Factory;
+import com.palantir.leader.BatchingLeaderElectionService;
 import com.palantir.leader.PaxosLeadershipEventRecorder;
 import com.palantir.leader.PingableLeader;
 import com.palantir.paxos.LeaderPinger;
@@ -93,9 +94,12 @@ public abstract class LeadershipContextFactory implements
                 .proxyClient(client)
                 .build();
 
+        BatchingLeaderElectionService leaderElectionService =
+                leaderElectionServiceFactory().create(clientAwareComponents);
         return ImmutableLeadershipContext.builder()
                 .leadershipMetrics(clientAwareComponents.leadershipMetrics())
-                .leaderElectionService(leaderElectionServiceFactory().create(clientAwareComponents))
+                .leaderElectionService(leaderElectionService)
+                .addCloseables(leaderElectionService)
                 .build();
     }
 

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResources.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResources.java
@@ -50,10 +50,7 @@ public abstract class PaxosResources {
 
     @Value.Derived
     public LeadershipComponents leadershipComponents() {
-        return new LeadershipComponents(
-                leadershipContextFactory().metrics(),
-                leadershipContextFactory(),
-                leadershipContextFactory().leaderPingHealthCheck());
+        return new LeadershipComponents(leadershipContextFactory(), leadershipContextFactory().leaderPingHealthCheck());
     }
 
     private static BatchPaxosResources batchResourcesForUseCase(


### PR DESCRIPTION
**Goals (and why)**:
As a consequence of #4340, we put a `BatchingLeaderElectionService` at the wrong level, meaning that - despite #4448 where we share the underlying `LeaderElectionService` - we're no longer batching `blockOnBecomingLeader` across all clients from the follower perpsective. This would mean an increase of ping calls per client to the leader from each follower that aren't coalesced together.

NB each follower that knows about a particular client. I.e. if a client guessed the leader directly after a leader election, then the followers don't "know" about that client. Similarly if it takes `n` hops to find the leader, all `n-1` followers will know about the client, and thus will start pinging the leader in order to gain leadership.

**Implementation Description (bullets)**:
Factory in #4448 returns a `BatchingLeaderElectionService`, and then that is shared everywhere.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Observations from prod. It would be nice to be able to categorise timelock perf characteristics in some sort of bi-daily test or something.

**Concerns (what feedback would you like?)**:
None really.

**Where should we start reviewing?**:
Everywhere.

**Priority (whenever / two weeks / yesterday)**:
ASAP.
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
