### PR TITLE
Fix immutable timestamps from not being cleaned up

### DIFF
--- a/changelog/@unreleased/pr-4452.v2.yml
+++ b/changelog/@unreleased/pr-4452.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: |
+    Prevent immutable timestamp locks from being leaked
+  links:
+  - https://github.com/palantir/atlasdb/pull/4452
+  - https://github.com/palantir/atlasdb/issues/4449

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LegacyTimelockService.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LegacyTimelockService.java
@@ -119,7 +119,7 @@ public class LegacyTimelockService implements TimelockService {
             } catch (Throwable unlockThrowable) {
                 throwable.addSuppressed(unlockThrowable);
             }
-            throw Throwables.rewrapAndThrowUncheckedException(throwable);
+            throw throwable;
         }
     }
 


### PR DESCRIPTION
**Goals (and why)**:
If LegacyTimestampService.startIdentifiedAtlasDbTransaction was interrupted
during the call to getFreshTimestamp, then the immutable timestamp lock
would not be cleaned up.

Decompiling the code indicates that `lockImmutableTimestamp()` is called before `getFreshTimestamp()`.  It's unclear to me whether we need to call `getFreshTimestamp()` because `lockImmutableTimestamp()` itself just got a new fresh timestamp.

Fixes https://github.com/palantir/atlasdb/issues/4449

**Implementation Description (bullets)**:
* added try/catch around the call to `lockImmutableTimestamp()`.

**Testing (What was existing testing like?  What have you done to improve it?)**:
* No manual testing has occurred.

**Concerns (what feedback would you like?)**:
* is it necessary to actually call `getFreshTimestamp()` or can the timestamp of the immutable timestamp lock be re-used?

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

This is causing lost immutable timestamp locks, however this doesn't appear to be causing any user-visible problems currently.