### PR TITLE
[PDS-95791] Stop deserialising!

### DIFF
--- a/changelog/@unreleased/pr-4453.v2.yml
+++ b/changelog/@unreleased/pr-4453.v2.yml
@@ -1,5 +1,5 @@
-type: fix
-fix:
+type: improvement
+improvement:
   description: '[PDS-95791] Shore up `TransactionPostMortemRunner`'
   links:
   - https://github.com/palantir/atlasdb/pull/4453

--- a/changelog/@unreleased/pr-4453.v2.yml
+++ b/changelog/@unreleased/pr-4453.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: '[PDS-95791] Shore up `TransactionPostMortemRunner`'
+  links:
+  - https://github.com/palantir/atlasdb/pull/4453

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TransactionPostMortemIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TransactionPostMortemIntegrationTest.java
@@ -93,11 +93,9 @@ public class TransactionPostMortemIntegrationTest extends AbstractAsyncTimelockS
         runWithRetryVoid(store -> store.putPhotoStreamId(ImmutableMap.of(row, 11L)));
         runWithRetryVoid(store -> store.putPhotoStreamId(ImmutableMap.of(row, 19L)));
         runWithRetryVoid(store -> store.putPhotoStreamId(ImmutableMap.of(row, 23L)));
+        runWithRetryVoid(store -> store.deletePhotoStreamId(row));
 
-        FullDiagnosticDigest<Long> digest = runner.conductPostMortem(
-                row,
-                PhotoStreamId.of(0L).persistColumnName(),
-                value -> PhotoStreamId.BYTES_HYDRATOR.hydrateFromBytes(value.getContents()).getValue());
+        FullDiagnosticDigest<String> digest = runner.conductPostMortem(row, PhotoStreamId.of(0L).persistColumnName());
 
         System.out.println(
                 ObjectMappers.newServerObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(digest));


### PR DESCRIPTION
**Goals (and why)**:
The assumption was that values are able to be read. This isn't always the case, and as a result it becomes a bit more difficult to see the logs since we bail out.

We only base64 encode instead of trying to actually deserialise the value since it's not actually important, just a visual aid.

We also log at each step of the way in the event that something unexpected fails.

**Priority (whenever / two weeks / yesterday)**:
ASAP.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
