### PR TITLE
Refactor HostLocation discovery

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
@@ -95,7 +95,7 @@ public class CassandraService implements AutoCloseable {
         this.blacklist = blacklist;
         this.myLocationSupplier = new CombiningHostLocationSupplier(
                 config::overrideHostLocation,
-                Ec2AwareHostLocationSupplier.createMemoized(this::getSnitch));
+                new MemoizedHostLocationSupplier(Ec2AwareHostLocationSupplier.create(this::getSnitch)));
     }
 
     @VisibleForTesting

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
@@ -95,7 +95,7 @@ public class CassandraService implements AutoCloseable {
         this.blacklist = blacklist;
         this.myLocationSupplier = new CombiningHostLocationSupplier(
                 config::overrideHostLocation,
-                Ec2AwareHostLocationSupplier.create(this::getSnitch));
+                Ec2AwareHostLocationSupplier.createMemoized(this::getSnitch));
     }
 
     @VisibleForTesting

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CombiningHostLocationSupplier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CombiningHostLocationSupplier.java
@@ -17,14 +17,25 @@
 package com.palantir.atlasdb.keyvalue.cassandra.pool;
 
 import java.util.Optional;
-import java.util.function.Supplier;
 
-public interface HostLocationSupplier extends Supplier<Optional<HostLocation>> {
+final class CombiningHostLocationSupplier implements HostLocationSupplier {
+    private final HostLocationSupplier locationSupplier;
+    private final HostLocationSupplier overrideLocation;
 
-    static HostLocationSupplier createForTests() {
-        return Optional::empty;
+    public CombiningHostLocationSupplier(
+            HostLocationSupplier overrideLocationSupplier,
+            HostLocationSupplier locationSupplier) {
+        this.overrideLocation = overrideLocationSupplier;
+        this.locationSupplier = locationSupplier;
     }
 
     @Override
-    Optional<HostLocation> get();
+    public Optional<HostLocation> get() {
+        Optional<HostLocation> location = overrideLocation.get();
+        if (location.isPresent()) {
+            return location;
+        }
+
+        return locationSupplier.get();
+    }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CombiningHostLocationSupplier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CombiningHostLocationSupplier.java
@@ -19,19 +19,19 @@ package com.palantir.atlasdb.keyvalue.cassandra.pool;
 import java.util.Optional;
 
 final class CombiningHostLocationSupplier implements HostLocationSupplier {
-    private final HostLocationSupplier overrideLocation;
+    private final HostLocationSupplier overrideLocationSupplier;
     private final HostLocationSupplier locationSupplier;
 
     CombiningHostLocationSupplier(
             HostLocationSupplier overrideLocationSupplier,
             HostLocationSupplier locationSupplier) {
-        this.overrideLocation = overrideLocationSupplier;
+        this.overrideLocationSupplier = overrideLocationSupplier;
         this.locationSupplier = locationSupplier;
     }
 
     @Override
     public Optional<HostLocation> get() {
-        Optional<HostLocation> location = overrideLocation.get();
+        Optional<HostLocation> location = overrideLocationSupplier.get();
         if (location.isPresent()) {
             return location;
         }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CombiningHostLocationSupplier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CombiningHostLocationSupplier.java
@@ -19,10 +19,10 @@ package com.palantir.atlasdb.keyvalue.cassandra.pool;
 import java.util.Optional;
 
 final class CombiningHostLocationSupplier implements HostLocationSupplier {
-    private final HostLocationSupplier locationSupplier;
     private final HostLocationSupplier overrideLocation;
+    private final HostLocationSupplier locationSupplier;
 
-    public CombiningHostLocationSupplier(
+    CombiningHostLocationSupplier(
             HostLocationSupplier overrideLocationSupplier,
             HostLocationSupplier locationSupplier) {
         this.overrideLocation = overrideLocationSupplier;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/Ec2AwareHostLocationSupplier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/Ec2AwareHostLocationSupplier.java
@@ -32,8 +32,19 @@ final class Ec2AwareHostLocationSupplier implements HostLocationSupplier {
     private final Supplier<String> snitchSupplier;
     private final Supplier<HostLocation> ec2Supplier;
 
-    public static HostLocationSupplier create(Supplier<String> snitchSupplier) {
-        return new Ec2AwareHostLocationSupplier(snitchSupplier, new Ec2HostLocationSupplier());
+    public static HostLocationSupplier createMemoized(Supplier<String> snitchSupplier) {
+        HostLocationSupplier delegate = new Ec2AwareHostLocationSupplier(
+                snitchSupplier,
+                new Ec2HostLocationSupplier());
+
+        return new HostLocationSupplier() {
+            private final Supplier<Optional<HostLocation>> memoized = Suppliers.memoize(delegate::get);
+
+            @Override
+            public Optional<HostLocation> get() {
+                return memoized.get();
+            }
+        };
     }
 
     @VisibleForTesting

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/Ec2AwareHostLocationSupplier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/Ec2AwareHostLocationSupplier.java
@@ -1,0 +1,60 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra.pool;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Suppliers;
+import com.palantir.logsafe.SafeArg;
+
+final class Ec2AwareHostLocationSupplier implements HostLocationSupplier {
+    private static final Logger log = LoggerFactory.getLogger(Ec2AwareHostLocationSupplier.class);
+
+    private final Supplier<String> snitchSupplier;
+    private final Supplier<HostLocation> ec2Supplier;
+
+    public static HostLocationSupplier create(Supplier<String> snitchSupplier) {
+        return new Ec2AwareHostLocationSupplier(snitchSupplier, new Ec2HostLocationSupplier());
+    }
+
+    @VisibleForTesting
+    Ec2AwareHostLocationSupplier(Supplier<String> snitchSupplier, Supplier<HostLocation> ec2Supplier) {
+        this.snitchSupplier = Suppliers.memoize(snitchSupplier::get);
+        this.ec2Supplier = Suppliers.memoize(ec2Supplier::get);
+    }
+
+    @Override
+    public Optional<HostLocation> get() {
+        try {
+            String snitch = snitchSupplier.get();
+            log.debug("Snitch successfully detected", SafeArg.of("snitch", snitch));
+
+            if ("org.apache.cassandra.locator.Ec2Snitch".equals(snitch)) {
+                return Optional.of(ec2Supplier.get());
+            }
+            return Optional.empty();
+        } catch (RuntimeException e) {
+            log.warn("Host location supplier failed to retrieve the host location", e);
+            return Optional.empty();
+        }
+    }
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/Ec2AwareHostLocationSupplier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/Ec2AwareHostLocationSupplier.java
@@ -23,7 +23,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Suppliers;
 import com.palantir.logsafe.SafeArg;
 
 final class Ec2AwareHostLocationSupplier implements HostLocationSupplier {
@@ -32,25 +31,16 @@ final class Ec2AwareHostLocationSupplier implements HostLocationSupplier {
     private final Supplier<String> snitchSupplier;
     private final Supplier<HostLocation> ec2Supplier;
 
-    public static HostLocationSupplier createMemoized(Supplier<String> snitchSupplier) {
-        HostLocationSupplier delegate = new Ec2AwareHostLocationSupplier(
+    public static HostLocationSupplier create(Supplier<String> snitchSupplier) {
+        return new Ec2AwareHostLocationSupplier(
                 snitchSupplier,
                 new Ec2HostLocationSupplier());
-
-        return new HostLocationSupplier() {
-            private final Supplier<Optional<HostLocation>> memoized = Suppliers.memoize(delegate::get);
-
-            @Override
-            public Optional<HostLocation> get() {
-                return memoized.get();
-            }
-        };
     }
 
     @VisibleForTesting
     Ec2AwareHostLocationSupplier(Supplier<String> snitchSupplier, Supplier<HostLocation> ec2Supplier) {
-        this.snitchSupplier = Suppliers.memoize(snitchSupplier::get);
-        this.ec2Supplier = Suppliers.memoize(ec2Supplier::get);
+        this.snitchSupplier = snitchSupplier;
+        this.ec2Supplier = ec2Supplier;
     }
 
     @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/Ec2HostLocationSupplier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/Ec2HostLocationSupplier.java
@@ -55,7 +55,7 @@ import okhttp3.Response;
  * AWS has an endpoint that returns the datacenter and rack (in Cassandra terms) - this request will fail if not on AWS.
  * The reply comes in the form "datacenter"+"rack", e.g. "us-east-1a", where datacenter is "us-east-1" and rack is "a".
  */
-public final class Ec2HostLocationSupplier implements Supplier<HostLocation> {
+final class Ec2HostLocationSupplier implements Supplier<HostLocation> {
 
     /*
         This is a supplier to avoid class loading races breaking downstream internal products.

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostLocationSupplier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostLocationSupplier.java
@@ -21,10 +21,6 @@ import java.util.function.Supplier;
 
 public interface HostLocationSupplier extends Supplier<Optional<HostLocation>> {
 
-    static HostLocationSupplier createForTests() {
-        return Optional::empty;
-    }
-
     @Override
     Optional<HostLocation> get();
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/MemoizedHostLocationSupplier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/MemoizedHostLocationSupplier.java
@@ -17,7 +17,19 @@
 package com.palantir.atlasdb.keyvalue.cassandra.pool;
 
 import java.util.Optional;
+import java.util.function.Supplier;
 
-public interface HostLocationSupplier {
-    Optional<HostLocation> get();
+import com.google.common.base.Suppliers;
+
+final class MemoizedHostLocationSupplier implements HostLocationSupplier {
+    private final Supplier<Optional<HostLocation>> delegate;
+
+    MemoizedHostLocationSupplier(HostLocationSupplier hostLocationSupplier) {
+        this.delegate = Suppliers.memoize(hostLocationSupplier::get);
+    }
+
+    @Override
+    public Optional<HostLocation> get() {
+        return delegate.get();
+    }
 }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
@@ -187,7 +187,7 @@ public class CassandraServiceTest {
                 MetricsManagers.createForTests(),
                 config,
                 blacklist,
-                HostLocationSupplier.createForTests());
+                Optional::empty);
 
         service.cacheInitialCassandraHosts();
         serversInPool.forEach(service::addPool);

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
@@ -183,7 +183,11 @@ public class CassandraServiceTest {
 
         blacklist = new Blacklist(config);
 
-        CassandraService service = new CassandraService(MetricsManagers.createForTests(), config, blacklist);
+        CassandraService service = new CassandraService(
+                MetricsManagers.createForTests(),
+                config,
+                blacklist,
+                HostLocationSupplier.createForTests());
 
         service.cacheInitialCassandraHosts();
         serversInPool.forEach(service::addPool);

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CombiningAwareHostLocationSupplierTests.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CombiningAwareHostLocationSupplierTests.java
@@ -1,0 +1,45 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra.pool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+import org.junit.Test;
+
+public class CombiningAwareHostLocationSupplierTests {
+    private static final Optional<HostLocation> US_1 = Optional.of(HostLocation.of("dc", "us1"));
+
+    @Test
+    public void testShouldOverrideHostLocation() {
+        HostLocationSupplier hostLocationSupplier = new CombiningHostLocationSupplier(
+                () -> US_1,
+                () -> {
+                    throw new RuntimeException("Should never reach this");
+                });
+
+        assertThat(hostLocationSupplier.get()).isEqualTo(US_1);
+    }
+
+    @Test
+    public void testNoOverride() {
+        HostLocationSupplier hostLocationSupplier = new CombiningHostLocationSupplier(Optional::empty, () -> US_1);
+
+        assertThat(hostLocationSupplier.get()).isEqualTo(US_1);
+    }
+}

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CombiningHostLocationSupplierTests.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CombiningHostLocationSupplierTests.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 
 import org.junit.Test;
 
-public class CombiningAwareHostLocationSupplierTests {
+public class CombiningHostLocationSupplierTests {
     private static final Optional<HostLocation> US_1 = Optional.of(HostLocation.of("dc", "us1"));
 
     @Test

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/Ec2AwareHostLocationSupplierTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/Ec2AwareHostLocationSupplierTest.java
@@ -18,30 +18,20 @@ package com.palantir.atlasdb.keyvalue.cassandra.pool;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Optional;
 import java.util.function.Supplier;
 
 import org.junit.Test;
 
-public class HostLocationSupplierTest {
-
+public final class Ec2AwareHostLocationSupplierTest {
     private static final Supplier<String> ec2SnitchSupplier = () -> "org.apache.cassandra.locator.Ec2Snitch";
     private static final Supplier<HostLocation> ec2LocationSupplier = () -> HostLocation.of("dc2", "rack2");
 
-    @Test
-    public void shouldReturnOverrideLocation() {
-        Optional<HostLocation> overrideLocation = Optional.of(HostLocation.of("dc1", "rack1"));
-
-        Supplier<Optional<HostLocation>> hostLocationSupplier = new HostLocationSupplier(ec2SnitchSupplier,
-                ec2LocationSupplier, overrideLocation);
-
-        assertThat(hostLocationSupplier.get()).isEqualTo(overrideLocation);
-    }
 
     @Test
     public void shouldReturnEc2Location() {
-        Supplier<Optional<HostLocation>> hostLocationSupplier = new HostLocationSupplier(ec2SnitchSupplier,
-                ec2LocationSupplier, Optional.empty());
+        HostLocationSupplier hostLocationSupplier = new Ec2AwareHostLocationSupplier(
+                ec2SnitchSupplier,
+                ec2LocationSupplier);
 
         assertThat(hostLocationSupplier.get()).isPresent();
         assertThat(hostLocationSupplier.get().get()).isEqualTo(ec2LocationSupplier.get());
@@ -51,8 +41,9 @@ public class HostLocationSupplierTest {
     public void shouldReturnEmptyLocationFromUnexpectedSnitch() {
         Supplier<String> unexpectedSnitchSupplier = () -> "unexpected snitch";
 
-        Supplier<Optional<HostLocation>> hostLocationSupplier = new HostLocationSupplier(unexpectedSnitchSupplier,
-                ec2LocationSupplier, Optional.empty());
+        HostLocationSupplier hostLocationSupplier = new Ec2AwareHostLocationSupplier(
+                unexpectedSnitchSupplier,
+                ec2LocationSupplier);
 
         assertThat(hostLocationSupplier.get()).isNotPresent();
     }
@@ -63,8 +54,9 @@ public class HostLocationSupplierTest {
             throw new RuntimeException();
         };
 
-        Supplier<Optional<HostLocation>> hostLocationSupplier = new HostLocationSupplier(badSnitchSupplier,
-                ec2LocationSupplier, Optional.empty());
+        HostLocationSupplier hostLocationSupplier = new Ec2AwareHostLocationSupplier(
+                badSnitchSupplier,
+                ec2LocationSupplier);
 
         assertThat(hostLocationSupplier.get()).isNotPresent();
     }
@@ -75,8 +67,9 @@ public class HostLocationSupplierTest {
             throw new RuntimeException();
         };
 
-        Supplier<Optional<HostLocation>> hostLocationSupplier = new HostLocationSupplier(ec2SnitchSupplier,
-                ec2BadLocationSupplier, Optional.empty());
+        HostLocationSupplier hostLocationSupplier = new Ec2AwareHostLocationSupplier(
+                ec2SnitchSupplier,
+                ec2BadLocationSupplier);
 
         assertThat(hostLocationSupplier.get()).isNotPresent();
     }
@@ -86,5 +79,4 @@ public class HostLocationSupplierTest {
         HostLocation awsLocation = HostLocation.of("us-east", "1a");
         assertThat(Ec2HostLocationSupplier.parseHostLocation("us-east-1a")).isEqualTo(awsLocation);
     }
-
 }


### PR DESCRIPTION
**Goals (and why)**:
Make the host location discovery easier to propagate and split the logic.

**Implementation Description (bullets)**:
- `HostLocationSupplier` is an interface
- `CombiningHostLocationSupplier` deals with location override
- `Ec2AwareHostLocationSupplier` does the dc aware logic

**Testing (What was existing testing like?  What have you done to improve it?)**:
- tests are mostly the same but are split based on the tested class

**Concerns (what feedback would you like?)**:
- standard coding style

**Where should we start reviewing?**:
- `HostLocationSupplier`

**Priority (whenever / two weeks / yesterday)**:
- tomorrow
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
