### PR TITLE
reduce sweep queue logspam for short-lived write-heavy tables

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueDeleter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueDeleter.java
@@ -74,7 +74,8 @@ public class SweepQueueDeleter {
                         });
             } catch (Exception e) {
                 if (tableWasDropped(entry.getKey())) {
-                    log.info("The table {} has been deleted.", LoggingArgs.tableRef(entry.getKey()), e);
+                    log.debug("Dropping sweeper work for table {}, which has been dropped.",
+                            LoggingArgs.tableRef(entry.getKey()), e);
                 } else {
                     throw e;
                 }

--- a/changelog/@unreleased/pr-4456.v2.yml
+++ b/changelog/@unreleased/pr-4456.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: reduce sweep queue logspam for short-lived, write-heavy tables
+  links:
+  - https://github.com/palantir/atlasdb/pull/4456


### PR DESCRIPTION
The existing code is bad mostly because it emits a log per batch, instead of something
halfway reasonable like emitting the log per deleted table.

Low sweep queue batch sizes along with short-lived, heavily mutated groups of tables is probably the worst case scenario, which we had on our stack. The service creates a decent number of tables (~10-20), does a data import and manipulation into them (performs lots of writes, including to the sweep queue), and then upon completion drops the tables.
Having every batch of the sweep queue afterwards log about these tables proved to be very logspammy.
