### PR TITLE
Explicit do delegate annotation

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -28,6 +28,7 @@ import com.palantir.common.annotation.NonIdempotent;
 import com.palantir.common.base.ClosableIterator;
 import com.palantir.common.exception.AtlasDbDependencyException;
 import com.palantir.processors.AutoDelegate;
+import com.palantir.processors.DoDelegate;
 import com.palantir.util.paging.BasicResultsPage;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
 
@@ -262,6 +263,7 @@ public interface KeyValueService extends AutoCloseable, AsyncKeyValueService {
      *
      * @return true iff checkAndSet is supported (for all delegates/tables, if applicable)
      */
+    @DoDelegate
     default boolean supportsCheckAndSet() {
         return getCheckAndSetCompatibility() != CheckAndSetCompatibility.NOT_SUPPORTED;
     }
@@ -608,6 +610,7 @@ public interface KeyValueService extends AutoCloseable, AsyncKeyValueService {
      * Some compaction operations might block reads and writes.
      * These operations will trigger only if inMaintenanceMode is set to true.
      */
+    @DoDelegate
     @Timed
     default void compactInternally(TableReference tableRef, boolean inMaintenanceMode) {
         compactInternally(tableRef);
@@ -638,6 +641,7 @@ public interface KeyValueService extends AutoCloseable, AsyncKeyValueService {
      *         Note that this check ignores the cluster's availability - use {@link #getClusterAvailabilityStatus()} if
      *         you wish to verify that we can talk to the backing store.
      */
+    @DoDelegate
     default boolean isInitialized() {
         return true;
     }
@@ -646,6 +650,7 @@ public interface KeyValueService extends AutoCloseable, AsyncKeyValueService {
      * Whether or not read performance degrades significantly when many deleted cells are in the requested range.
      * This is used by sweep to determine if it should wait a while between runs after deleting a large number of cells.
      */
+    @DoDelegate
     default boolean performanceIsSensitiveToTombstones() {
         return false;
     }
@@ -653,6 +658,7 @@ public interface KeyValueService extends AutoCloseable, AsyncKeyValueService {
     /**
      * Whether {@link #compactInternally(TableReference)} should be called to free disk space.
      */
+    @DoDelegate
     default boolean shouldTriggerCompactions() {
         return false;
     }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
@@ -29,6 +29,7 @@ import com.palantir.lock.LockRequest;
 import com.palantir.lock.LockService;
 import com.palantir.lock.v2.TimelockService;
 import com.palantir.processors.AutoDelegate;
+import com.palantir.processors.DoDelegate;
 import com.palantir.processors.DoNotDelegate;
 import com.palantir.timestamp.TimestampManagementService;
 import com.palantir.timestamp.TimestampService;
@@ -48,6 +49,7 @@ public interface TransactionManager extends AutoCloseable {
      *
      * @return true if and only if the TransactionManager has been fully initialized
      */
+    @DoDelegate
     default boolean isInitialized() {
         return true;
     }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -38,7 +38,6 @@ import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
-import com.palantir.processors.AutoDelegate;
 
 @AutoService(KeyValueServiceConfig.class)
 @JsonDeserialize(as = ImmutableCassandraKeyValueServiceConfig.class)

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -44,7 +44,6 @@ import com.palantir.processors.AutoDelegate;
 @JsonDeserialize(as = ImmutableCassandraKeyValueServiceConfig.class)
 @JsonSerialize(as = ImmutableCassandraKeyValueServiceConfig.class)
 @JsonTypeName(CassandraKeyValueServiceConfig.TYPE)
-@AutoDelegate
 @Value.Immutable
 public interface CassandraKeyValueServiceConfig extends KeyValueServiceConfig {
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraReloadableKvsConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraReloadableKvsConfig.java
@@ -15,14 +15,19 @@
  */
 package com.palantir.atlasdb.cassandra;
 
+import java.net.InetSocketAddress;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
 import com.google.common.base.MoreObjects;
+import com.palantir.atlasdb.keyvalue.cassandra.async.CassandraAsyncKeyValueServiceFactory;
+import com.palantir.atlasdb.keyvalue.cassandra.pool.HostLocation;
 import com.palantir.atlasdb.spi.KeyValueServiceRuntimeConfig;
+import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
 
-public class CassandraReloadableKvsConfig implements AutoDelegate_CassandraKeyValueServiceConfig {
+public class CassandraReloadableKvsConfig implements CassandraKeyValueServiceConfig {
     private final CassandraKeyValueServiceConfig config;
     private final Supplier<Optional<KeyValueServiceRuntimeConfig>> runtimeConfigSupplier;
 
@@ -33,14 +38,104 @@ public class CassandraReloadableKvsConfig implements AutoDelegate_CassandraKeyVa
     }
 
     @Override
-    public CassandraKeyValueServiceConfig delegate() {
-        return config;
+    public CassandraServersConfigs.CassandraServersConfig servers() {
+        return config.servers();
+    }
+
+    @Override
+    public Map<String, InetSocketAddress> addressTranslation() {
+        return config.addressTranslation();
+    }
+
+    @Override
+    public Optional<String> namespace() {
+        return config.namespace();
+    }
+
+    @Override
+    public int poolSize() {
+        return config.poolSize();
+    }
+
+    @Override
+    public int maxConnectionBurstSize() {
+        return config.maxConnectionBurstSize();
+    }
+
+    @Override
+    public double proportionConnectionsToCheckPerEvictionRun() {
+        return config.proportionConnectionsToCheckPerEvictionRun();
+    }
+
+    @Override
+    public int idleConnectionTimeoutSeconds() {
+        return config.idleConnectionTimeoutSeconds();
+    }
+
+    @Override
+    public int timeBetweenConnectionEvictionRunsSeconds() {
+        return config.timeBetweenConnectionEvictionRunsSeconds();
+    }
+
+    @Override
+    public int poolRefreshIntervalSeconds() {
+        return config.poolRefreshIntervalSeconds();
     }
 
     @Override
     public int unresponsiveHostBackoffTimeSeconds() {
         return chooseConfig(CassandraKeyValueServiceRuntimeConfig::unresponsiveHostBackoffTimeSeconds,
                 config.unresponsiveHostBackoffTimeSeconds());
+    }
+
+    @Override
+    public int gcGraceSeconds() {
+        return config.gcGraceSeconds();
+    }
+
+    @Override
+    public double localHostWeighting() {
+        return config.localHostWeighting();
+    }
+
+    @Override
+    public Optional<HostLocation> overrideHostLocation() {
+        return config.overrideHostLocation();
+    }
+
+    @Override
+    public String getKeyspaceOrThrow() {
+        return config.getKeyspaceOrThrow();
+    }
+
+    @Override
+    public Optional<String> keyspace() {
+        return config.keyspace();
+    }
+
+    @Override
+    public CassandraCredentialsConfig credentials() {
+        return config.credentials();
+    }
+
+    @Override
+    public Optional<Boolean> ssl() {
+        return config.ssl();
+    }
+
+    @Override
+    public Optional<SslConfiguration> sslConfiguration() {
+        return config.sslConfiguration();
+    }
+
+    @Override
+    public CassandraAsyncKeyValueServiceFactory asyncKeyValueServiceFactory() {
+        return config.asyncKeyValueServiceFactory();
+    }
+
+    @Override
+    public int replicationFactor() {
+        return config.replicationFactor();
     }
 
 
@@ -63,9 +158,99 @@ public class CassandraReloadableKvsConfig implements AutoDelegate_CassandraKeyVa
     }
 
     @Override
+    public boolean ignoreNodeTopologyChecks() {
+        return config.ignoreNodeTopologyChecks();
+    }
+
+    @Override
+    public boolean ignoreInconsistentRingChecks() {
+        return config.ignoreInconsistentRingChecks();
+    }
+
+    @Override
+    public boolean ignoreDatacenterConfigurationChecks() {
+        return config.ignoreDatacenterConfigurationChecks();
+    }
+
+    @Override
+    public boolean ignorePartitionerChecks() {
+        return config.ignorePartitionerChecks();
+    }
+
+    @Override
+    public boolean autoRefreshNodes() {
+        return config.autoRefreshNodes();
+    }
+
+    @Override
+    public boolean clusterMeetsNormalConsistencyGuarantees() {
+        return config.clusterMeetsNormalConsistencyGuarantees();
+    }
+
+    @Override
+    public int socketTimeoutMillis() {
+        return config.socketTimeoutMillis();
+    }
+
+    @Override
+    public int socketQueryTimeoutMillis() {
+        return config.socketQueryTimeoutMillis();
+    }
+
+    @Override
+    public int cqlPoolTimeoutMillis() {
+        return config.cqlPoolTimeoutMillis();
+    }
+
+    @Override
+    public int schemaMutationTimeoutMillis() {
+        return config.schemaMutationTimeoutMillis();
+    }
+
+    @Override
+    public int rangesConcurrency() {
+        return config.rangesConcurrency();
+    }
+
+    @Override
+    public Integer timestampsGetterBatchSize() {
+        return config.timestampsGetterBatchSize();
+    }
+
+    @Override
     public Integer sweepReadThreads() {
         return chooseConfig(CassandraKeyValueServiceRuntimeConfig::sweepReadThreads,
                 config.sweepReadThreads());
+    }
+
+    @Override
+    public Optional<CassandraJmxCompactionConfig> jmx() {
+        return config.jmx();
+    }
+
+    @Override
+    public String type() {
+        return config.type();
+    }
+
+    @Override
+    public int concurrentGetRangesThreadPoolSize() {
+        return config.concurrentGetRangesThreadPoolSize();
+    }
+
+    @Override
+    public int defaultGetRangesConcurrency() {
+        return config.defaultGetRangesConcurrency();
+    }
+
+    @Override
+    public boolean usingSsl() {
+        return config.usingSsl();
+    }
+
+    @Override
+    public void check() {
+
     }
 
     private <T> T chooseConfig(Function<CassandraKeyValueServiceRuntimeConfig, T> runtimeConfig, T installConfig) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraReloadableKvsConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraReloadableKvsConfig.java
@@ -250,7 +250,7 @@ public class CassandraReloadableKvsConfig implements CassandraKeyValueServiceCon
 
     @Override
     public void check() {
-        config.check();
+
     }
 
     private <T> T chooseConfig(Function<CassandraKeyValueServiceRuntimeConfig, T> runtimeConfig, T installConfig) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraReloadableKvsConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraReloadableKvsConfig.java
@@ -250,7 +250,7 @@ public class CassandraReloadableKvsConfig implements CassandraKeyValueServiceCon
 
     @Override
     public void check() {
-
+        config.check();
     }
 
     private <T> T chooseConfig(Function<CassandraKeyValueServiceRuntimeConfig, T> runtimeConfig, T installConfig) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraReloadableKvsConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraReloadableKvsConfig.java
@@ -250,7 +250,8 @@ public class CassandraReloadableKvsConfig implements CassandraKeyValueServiceCon
 
     @Override
     public void check() {
-
+//         The config instance passed here gets checked at the time its of construction
+//         (default implementation in the parent class). Hence, it is okay to do no operation here.
     }
 
     private <T> T chooseConfig(Function<CassandraKeyValueServiceRuntimeConfig, T> runtimeConfig, T installConfig) {

--- a/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/CoordinationStore.java
+++ b/atlasdb-coordination-impl/src/main/java/com/palantir/atlasdb/coordination/CoordinationStore.java
@@ -21,6 +21,7 @@ import java.util.function.Function;
 
 import com.palantir.atlasdb.keyvalue.impl.CheckAndSetResult;
 import com.palantir.processors.AutoDelegate;
+import com.palantir.processors.DoDelegate;
 
 /**
  * A {@link CoordinationStore} stores data that a {@link CoordinationService} may use.
@@ -32,6 +33,8 @@ public interface CoordinationStore<T> {
      *
      * @return true iff the coordination store is ready to service requests
      */
+
+    @DoDelegate
     default boolean isInitialized() {
         return true;
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/PuncherStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/PuncherStore.java
@@ -16,6 +16,7 @@
 package com.palantir.atlasdb.cleaner;
 
 import com.palantir.processors.AutoDelegate;
+import com.palantir.processors.DoDelegate;
 
 /**
  * This is the underlying store used by the puncher for keeping track in a persistent way of the
@@ -32,6 +33,7 @@ public interface PuncherStore {
 
      * @return true if and only if the PuncherStore has been initialized
      */
+    @DoDelegate
     default boolean isInitialized() {
         return true;
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/ScrubberStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/ScrubberStore.java
@@ -23,6 +23,7 @@ import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.common.base.BatchingVisitable;
 import com.palantir.processors.AutoDelegate;
+import com.palantir.processors.DoDelegate;
 
 /**
  * This is the underlying store used by the scrubber for keeping track in a persistent way of the
@@ -32,6 +33,7 @@ import com.palantir.processors.AutoDelegate;
  */
 @AutoDelegate
 public interface ScrubberStore {
+    @DoDelegate
     default boolean isInitialized() {
         return true;
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/priority/SweepPriorityStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/priority/SweepPriorityStore.java
@@ -21,6 +21,7 @@ import java.util.List;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.processors.AutoDelegate;
+import com.palantir.processors.DoDelegate;
 
 @AutoDelegate
 public interface SweepPriorityStore {
@@ -29,6 +30,7 @@ public interface SweepPriorityStore {
     List<SweepPriority> loadNewPriorities(Transaction tx);
     List<SweepPriority> loadOldPriorities(Transaction tx, long sweepTimestamp);
 
+    @DoDelegate
     default boolean isInitialized() {
         return true;
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/progress/SweepProgressStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/progress/SweepProgressStore.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.processors.AutoDelegate;
+import com.palantir.processors.DoDelegate;
 
 @AutoDelegate
 public interface SweepProgressStore {
@@ -28,6 +29,7 @@ public interface SweepProgressStore {
 
     Optional<SweepProgress> loadProgress(TableReference tableRef);
 
+    @DoDelegate
     default boolean isInitialized() {
         return true;
     }

--- a/atlasdb-processors-tests/src/main/java/com/palantir/processors/GenericsTester.java
+++ b/atlasdb-processors-tests/src/main/java/com/palantir/processors/GenericsTester.java
@@ -25,6 +25,7 @@ public interface GenericsTester<A, B extends List<C>, C> {
 
     List<B> getListOfLists(A comparison);
 
+    @DoDelegate
     default Set<C> hello() {
         throw new UnsupportedOperationException("This class doesn't know how to say hello.");
     }

--- a/atlasdb-processors-tests/src/main/java/com/palantir/processors/TestInterface.java
+++ b/atlasdb-processors-tests/src/main/java/com/palantir/processors/TestInterface.java
@@ -34,6 +34,7 @@ public interface TestInterface {
     void overloadedMethod(int p1);
     void overloadedMethod(Integer p1, Integer p2);
 
+    @DoDelegate
     default void defaultMethod() {}
 
     void overriddenMethod(Integer p1, Integer p2, Integer p3);

--- a/atlasdb-processors/src/main/java/com/palantir/processors/AutoDelegateProcessor.java
+++ b/atlasdb-processors/src/main/java/com/palantir/processors/AutoDelegateProcessor.java
@@ -147,6 +147,9 @@ public final class AutoDelegateProcessor extends AbstractProcessor {
         Set<ExecutableElement> methodsToBeDelegated = typeToExtend.getMethods();
 
         for (ExecutableElement methodElement : methodsToBeDelegated) {
+
+            // methods annotated with DoNotDelegate have already been filtered out | TypeToExtend::interfaceMethodFilter
+
             if (methodElement.getModifiers().contains(Modifier.DEFAULT)
                     && methodElement.getAnnotation(DoDelegate.class) == null) {
                 throw new ProcessingException(annotatedElement, "Default methods must be annotated with "

--- a/atlasdb-processors/src/main/java/com/palantir/processors/AutoDelegateProcessor.java
+++ b/atlasdb-processors/src/main/java/com/palantir/processors/AutoDelegateProcessor.java
@@ -110,11 +110,12 @@ public final class AutoDelegateProcessor extends AbstractProcessor {
                 TypeElement typeElement = validateAnnotatedElement(annotatedElement);
                 TypeToExtend typeToExtend = createTypeToExtend(typeElement);
 
-                validateMethodsToBeAutoDelegated(typeElement, typeToExtend);
-
                 if (generatedTypes.contains(typeToExtend.getCanonicalName())) {
                     continue;
                 }
+
+                validateMethodsToBeAutoDelegated(typeElement, typeToExtend);
+
                 generatedTypes.add(typeToExtend.getCanonicalName());
 
                 generateCode(typeToExtend);

--- a/atlasdb-processors/src/main/java/com/palantir/processors/AutoDelegateProcessor.java
+++ b/atlasdb-processors/src/main/java/com/palantir/processors/AutoDelegateProcessor.java
@@ -148,10 +148,9 @@ public final class AutoDelegateProcessor extends AbstractProcessor {
 
         for (ExecutableElement methodElement : methodsToBeDelegated) {
             if (methodElement.getModifiers().contains(Modifier.DEFAULT)
-                && methodElement.getAnnotation(DoDelegate.class) == null
-            ) {
-                throw new ProcessingException(annotatedElement, "Default methods must be annotated with " +
-                        "either @DoNotDelegate or @DoDelegate");
+                    && methodElement.getAnnotation(DoDelegate.class) == null) {
+                throw new ProcessingException(annotatedElement, "Default methods must be annotated with "
+                        + "either @DoNotDelegate or @DoDelegate");
             }
         }
     }

--- a/atlasdb-processors/src/main/java/com/palantir/processors/AutoDelegateProcessor.java
+++ b/atlasdb-processors/src/main/java/com/palantir/processors/AutoDelegateProcessor.java
@@ -110,6 +110,8 @@ public final class AutoDelegateProcessor extends AbstractProcessor {
                 TypeElement typeElement = validateAnnotatedElement(annotatedElement);
                 TypeToExtend typeToExtend = createTypeToExtend(typeElement);
 
+                validateMethodsToBeAutoDelegated(typeElement, typeToExtend);
+
                 if (generatedTypes.contains(typeToExtend.getCanonicalName())) {
                     continue;
                 }
@@ -137,6 +139,20 @@ public final class AutoDelegateProcessor extends AbstractProcessor {
         }
 
         return (TypeElement) annotatedElement;
+    }
+
+    private static void validateMethodsToBeAutoDelegated(Element annotatedElement, TypeToExtend typeToExtend)
+            throws ProcessingException {
+        Set<ExecutableElement> methodsToBeDelegated = typeToExtend.getMethods();
+
+        for (ExecutableElement methodElement : methodsToBeDelegated) {
+            if (methodElement.getModifiers().contains(Modifier.DEFAULT)
+                && methodElement.getAnnotation(DoDelegate.class) == null
+            ) {
+                throw new ProcessingException(annotatedElement, "Default methods must be annotated with " +
+                        "either @DoNotDelegate or @DoDelegate");
+            }
+        }
     }
 
     private TypeToExtend createTypeToExtend(TypeElement annotatedElement) throws ProcessingException {

--- a/atlasdb-processors/src/main/java/com/palantir/processors/DoDelegate.java
+++ b/atlasdb-processors/src/main/java/com/palantir/processors/DoDelegate.java
@@ -1,0 +1,4 @@
+package com.palantir.processors;
+
+public @interface DoDelegate {
+}

--- a/atlasdb-processors/src/main/java/com/palantir/processors/DoDelegate.java
+++ b/atlasdb-processors/src/main/java/com/palantir/processors/DoDelegate.java
@@ -1,3 +1,18 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.palantir.processors;
 
 public @interface DoDelegate {

--- a/changelog/@unreleased/pr-4462.v2.yml
+++ b/changelog/@unreleased/pr-4462.v2.yml
@@ -1,5 +1,5 @@
-type: improvement
-improvement:
+type: break
+break:
   description: |-
     Fail on generating an AutoDelegate implementation if there are any default methods that have not been annotated with either @DoNotDelegate or @DoDelegate.
 

--- a/changelog/@unreleased/pr-4462.v2.yml
+++ b/changelog/@unreleased/pr-4462.v2.yml
@@ -1,0 +1,29 @@
+type: improvement
+improvement:
+  description: |-
+    Explicit do delegate annotation
+
+    [Reference Issue](https://github.com/palantir/atlasdb/issues/4411)
+
+    **Goals**:
+    - Fail on generating an AutoDelegate implementation if there are any default methods that have not been annotated with either @DoNotDelegate or @DoDelegate
+    - Do not autoDelegate CassandraKeyValueServiceConfig
+
+    **Implementation Description (bullets)**:
+    - Validation check is added (validateMethodsToBeAutoDelegated) in the AutoDelegateProcessor.
+    - It enforces decision on whether a default method should be autoDelegated or not.
+    - In case where a default method is not explicitly annotated, autoDelegation for the interface fails.
+
+    **Testing (What was existing testing like?  What have you done to improve it?)**:
+    Work in progress.
+
+    **Where should we start reviewing?**:
+    AutoDelegateProcessor
+
+    <!---
+    Please remember to:
+    - Add any necessary release notes (including breaking changes)
+    - Make sure the documentation is up to date for your change
+    --->
+  links:
+  - https://github.com/palantir/atlasdb/pull/4462

--- a/changelog/@unreleased/pr-4462.v2.yml
+++ b/changelog/@unreleased/pr-4462.v2.yml
@@ -1,29 +1,8 @@
 type: improvement
 improvement:
   description: |-
-    Explicit do delegate annotation
+    Fail on generating an AutoDelegate implementation if there are any default methods that have not been annotated with either @DoNotDelegate or @DoDelegate.
 
-    [Reference Issue](https://github.com/palantir/atlasdb/issues/4411)
-
-    **Goals**:
-    - Fail on generating an AutoDelegate implementation if there are any default methods that have not been annotated with either @DoNotDelegate or @DoDelegate
-    - Do not autoDelegate CassandraKeyValueServiceConfig
-
-    **Implementation Description (bullets)**:
-    - Validation check is added (validateMethodsToBeAutoDelegated) in the AutoDelegateProcessor.
-    - It enforces decision on whether a default method should be autoDelegated or not.
-    - In case where a default method is not explicitly annotated, autoDelegation for the interface fails.
-
-    **Testing (What was existing testing like?  What have you done to improve it?)**:
-    Work in progress.
-
-    **Where should we start reviewing?**:
-    AutoDelegateProcessor
-
-    <!---
-    Please remember to:
-    - Add any necessary release notes (including breaking changes)
-    - Make sure the documentation is up to date for your change
-    --->
+    We now enforce decisions on whether default methods should be autoDelegated or not. This ensures that developers are considering this decision.
   links:
   - https://github.com/palantir/atlasdb/pull/4462

--- a/timestamp-api/src/main/java/com/palantir/timestamp/TimestampService.java
+++ b/timestamp-api/src/main/java/com/palantir/timestamp/TimestampService.java
@@ -23,6 +23,7 @@ import javax.ws.rs.core.MediaType;
 
 import com.palantir.logsafe.Safe;
 import com.palantir.processors.AutoDelegate;
+import com.palantir.processors.DoDelegate;
 
 /**
  * A {@link TimestampService} serves a sequence of timestamps. Requests to {@link TimestampService#getFreshTimestamp()}
@@ -42,6 +43,7 @@ public interface TimestampService {
      *
      * @return true iff the TimestampService has been fully initialized and is ready to use
      */
+    @DoDelegate
     default boolean isInitialized() {
         return true;
     }


### PR DESCRIPTION
[Reference Issue](https://github.com/palantir/atlasdb/issues/4411)

**Goals**:
- Fail on generating an AutoDelegate implementation if there are any default methods that have not been annotated with either @DoNotDelegate or @DoDelegate
- Do not autoDelegate CassandraKeyValueServiceConfig

**Implementation Description (bullets)**:
- Validation check is added (validateMethodsToBeAutoDelegated) in the AutoDelegateProcessor.
- It enforces decision on whether a default method should be autoDelegated or not.
- In case where a default method is not explicitly annotated, autoDelegation for the interface fails.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Work in progress.

**Where should we start reviewing?**:
AutoDelegateProcessor

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
