### PR TITLE
fix infinite loop in LocalOrRemoteProxy

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/LocalOrRemoteProxy.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/LocalOrRemoteProxy.java
@@ -24,7 +24,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import com.google.common.reflect.AbstractInvocationHandler;
-import com.google.common.util.concurrent.Uninterruptibles;
 import com.palantir.leader.NotCurrentLeaderException;
 
 /**
@@ -63,7 +62,7 @@ final class LocalOrRemoteProxy<T> extends AbstractInvocationHandler {
             } catch (InvocationTargetException e) {
                 Throwable targetException = e.getTargetException();
                 if (targetException instanceof NotCurrentLeaderException) {
-                    Uninterruptibles.sleepUninterruptibly(10, TimeUnit.MILLISECONDS);
+                    Thread.sleep(10);
                     continue;
                 }
                 throw targetException;

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
@@ -17,6 +17,7 @@ package com.palantir.atlasdb.factory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -39,12 +40,16 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 
 import java.io.IOException;
+import java.lang.reflect.UndeclaredThrowableException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -77,6 +82,7 @@ import com.palantir.atlasdb.config.AtlasDbRuntimeConfig;
 import com.palantir.atlasdb.config.ImmutableAtlasDbConfig;
 import com.palantir.atlasdb.config.ImmutableAtlasDbRuntimeConfig;
 import com.palantir.atlasdb.config.ImmutableLeaderConfig;
+import com.palantir.atlasdb.config.ImmutableLeaderRuntimeConfig;
 import com.palantir.atlasdb.config.ImmutableRemotingClientConfig;
 import com.palantir.atlasdb.config.ImmutableServerListConfig;
 import com.palantir.atlasdb.config.ImmutableTimeLockClientConfig;
@@ -104,7 +110,9 @@ import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.api.config.service.UserAgents;
 import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
 import com.palantir.exception.NotInitializedException;
+import com.palantir.leader.LeaderElectionService;
 import com.palantir.leader.PingableLeader;
+import com.palantir.leader.proxy.AwaitingLeadershipProxy;
 import com.palantir.lock.AutoDelegate_LockService;
 import com.palantir.lock.LockMode;
 import com.palantir.lock.LockRefreshToken;
@@ -462,6 +470,36 @@ public class TransactionManagersTest {
                 .serializable();
         assertThat(metrics.getNames().stream()
                 .anyMatch(metricName -> metricName.contains(USER_AGENT_NAME)), is(false));
+    }
+
+    @Test
+    public void interruptingLocalLeaderElectionTerminates() throws IOException {
+        Path tempDir = Files.createTempDirectory("foo");
+        Leaders.LocalPaxosServices localPaxosServices = Leaders.createAndRegisterLocalServices(
+                metricsManager,
+                environment,
+                ImmutableLeaderConfig.builder()
+                        .localServer("https://example")
+                        .quorumSize(1)
+                        .addLeaders("https://example")
+                        .acceptorLogDir(tempDir.resolve("acceptor").toFile())
+                        .learnerLogDir(tempDir.resolve("learner").toFile())
+                        .build(),
+                () -> ImmutableLeaderRuntimeConfig.builder().build(),
+                USER_AGENT);
+        LeaderElectionService leader = localPaxosServices.leaderElectionService();
+        LockService lockService = LockServiceImpl.create();
+        LockService leadershipLock = AwaitingLeadershipProxy.newProxyInstance(
+                LockService.class, () -> lockService, leader);
+        LockService localOrRemoteLock = LocalOrRemoteProxy.newProxyInstance(
+                LockService.class, leadershipLock, null, CompletableFuture.completedFuture(true));
+        try {
+            Thread.currentThread().interrupt();
+            localOrRemoteLock.currentTimeMillis();
+            fail("expected InterruptedException");
+        } catch (UndeclaredThrowableException e) {
+            assertThat(e.getCause()).isInstanceOf(InterruptedException.class);
+        }
     }
 
     @Test

--- a/changelog/@unreleased/pr-4469.v2.yml
+++ b/changelog/@unreleased/pr-4469.v2.yml
@@ -1,0 +1,13 @@
+type: fix
+fix:
+  description: |-
+    fix infinite loop in LocalOrRemoteProxy
+
+    previously LocalOrRemoteProxy would infinitely retry its call as long as
+    the delegate was throwing a NotCurrentLeaderException, regardless of
+    whether the thread was interrupted. Calling a local service behind a
+    AwaitingLeadershipProxy on an interrupted thread would trigger a
+    NotCurrentLeaderException without clearing the interrupt, leading to an
+    infinte loop.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4469

--- a/changelog/@unreleased/pr-4469.v2.yml
+++ b/changelog/@unreleased/pr-4469.v2.yml
@@ -1,13 +1,7 @@
 type: fix
 fix:
   description: |-
-    fix infinite loop in LocalOrRemoteProxy
-
-    previously LocalOrRemoteProxy would infinitely retry its call as long as
-    the delegate was throwing a NotCurrentLeaderException, regardless of
-    whether the thread was interrupted. Calling a local service behind a
-    AwaitingLeadershipProxy on an interrupted thread would trigger a
-    NotCurrentLeaderException without clearing the interrupt, leading to an
-    infinte loop.
+    Services running with a leader block no longer get into infinite loops when
+    interrupted and now deal with interrupts correctly.
   links:
   - https://github.com/palantir/atlasdb/pull/4469


### PR DESCRIPTION
previously LocalOrRemoteProxy would infinitely retry its call as long as
the delegate was throwing a NotCurrentLeaderException, regardless of
whether the thread was interrupted. Calling a local service behind a
AwaitingLeadershipProxy on an interrupted thread would trigger a
NotCurrentLeaderException without clearing the interrupt, leading to an
infinte loop.