### PR TITLE
Increase number of retries in ClientOptions to 13

### DIFF
--- a/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/ClientOptions.java
+++ b/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/ClientOptions.java
@@ -40,7 +40,7 @@ public abstract class ClientOptions {
             .readTimeout(Duration.ofSeconds(65))
             .backoffSlotSize(Duration.ofMillis(10))
             .failedUrlCooldown(Duration.ofMillis(100))
-            .maxNumRetries(11)
+            .maxNumRetries(13)
             .clientQoS(ClientConfiguration.ClientQoS.DANGEROUS_DISABLE_SYMPATHETIC_CLIENT_QOS)
             .build();
 

--- a/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/ClientOptions.java
+++ b/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/ClientOptions.java
@@ -34,7 +34,7 @@ import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 @Value.Immutable
 public abstract class ClientOptions {
     // TODO (jkong): Re-enable client QoS after response body leaks are handled correctly.
-    // Throws after expected outages of 1/2 * 0.01 * (2^11 - 1) = 10.24 s
+    // Throws after expected outages of 1/2 * 0.01 * (2^13 - 1) = 40.96 s
     public static final ClientOptions DEFAULT_RETRYING = ImmutableClientOptions.builder()
             .connectTimeout(Duration.ofSeconds(10))
             .readTimeout(Duration.ofSeconds(65))

--- a/changelog/@unreleased/pr-4472.v2.yml
+++ b/changelog/@unreleased/pr-4472.v2.yml
@@ -2,8 +2,6 @@ type: improvement
 improvement:
   description: |-
     Increase number of retries in `ClientOptions` to 13.
-
-    **Goals (and why)**:
-    https://github.com/palantir/atlasdb/issues/4470
   links:
   - https://github.com/palantir/atlasdb/pull/4472
+  - https://github.com/palantir/atlasdb/issues/4470

--- a/changelog/@unreleased/pr-4472.v2.yml
+++ b/changelog/@unreleased/pr-4472.v2.yml
@@ -1,0 +1,9 @@
+type: improvement
+improvement:
+  description: |-
+    Increase number of retries in ClientOptions to 13
+
+    **Goals (and why)**:
+    https://github.com/palantir/atlasdb/issues/4470
+  links:
+  - https://github.com/palantir/atlasdb/pull/4472

--- a/changelog/@unreleased/pr-4472.v2.yml
+++ b/changelog/@unreleased/pr-4472.v2.yml
@@ -1,7 +1,7 @@
 type: improvement
 improvement:
   description: |-
-    Increase number of retries in ClientOptions to 13
+    Increase number of retries in `ClientOptions` to 13.
 
     **Goals (and why)**:
     https://github.com/palantir/atlasdb/issues/4470


### PR DESCRIPTION
**Goals (and why)**:
https://github.com/palantir/atlasdb/issues/4470
