### PR TITLE
Fixed logging in AsyncTimeLockUnlocker.

### DIFF
--- a/changelog/@unreleased/pr-4480.v2.yml
+++ b/changelog/@unreleased/pr-4480.v2.yml
@@ -1,5 +1,5 @@
 type: improvement
 improvement:
-  description: Fixed logging in AsyncTimeLockUnlocker.
+  description: Fixed logging in `AsyncTimeLockUnlocker`.
   links:
   - https://github.com/palantir/atlasdb/pull/4480

--- a/changelog/@unreleased/pr-4480.v2.yml
+++ b/changelog/@unreleased/pr-4480.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Fixed logging in AsyncTimeLockUnlocker.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4480

--- a/lock-api/src/main/java/com/palantir/lock/client/AsyncTimeLockUnlocker.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/AsyncTimeLockUnlocker.java
@@ -58,9 +58,6 @@ public final class AsyncTimeLockUnlocker implements TimeLockUnlocker, AutoClosea
                         log.info("Failed to unlock lock tokens {} from timelock. They will eventually expire on their "
                                         + "own, but if this message recurs frequently, it may be worth investigation.",
                                 SafeArg.of("numFailed", allTokensToUnlock.size()),
-                                SafeArg.of("firstFailures",
-                                        Iterables.transform(Iterables.limit(allTokensToUnlock, 20),
-                                                LockToken::getRequestId)),
                                 t);
                     }
                     batch.stream().map(BatchElement::result).forEach(f -> f.set(null));

--- a/lock-api/src/main/java/com/palantir/lock/client/AsyncTimeLockUnlocker.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/AsyncTimeLockUnlocker.java
@@ -22,7 +22,6 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.Iterables;
 import com.palantir.atlasdb.autobatch.Autobatchers;
 import com.palantir.atlasdb.autobatch.BatchElement;
 import com.palantir.atlasdb.autobatch.DisruptorAutobatcher;

--- a/lock-api/src/main/java/com/palantir/lock/client/AsyncTimeLockUnlocker.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/AsyncTimeLockUnlocker.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.Iterables;
 import com.palantir.atlasdb.autobatch.Autobatchers;
 import com.palantir.atlasdb.autobatch.BatchElement;
 import com.palantir.atlasdb.autobatch.DisruptorAutobatcher;
@@ -56,7 +57,10 @@ public final class AsyncTimeLockUnlocker implements TimeLockUnlocker, AutoClosea
                     } catch (Throwable t) {
                         log.info("Failed to unlock lock tokens {} from timelock. They will eventually expire on their "
                                         + "own, but if this message recurs frequently, it may be worth investigation.",
-                                SafeArg.of("lockTokens", allTokensToUnlock),
+                                SafeArg.of("numFailed", allTokensToUnlock.size()),
+                                SafeArg.of("firstFailures",
+                                        Iterables.transform(Iterables.limit(allTokensToUnlock, 20),
+                                                LockToken::getRequestId)),
                                 t);
                     }
                     batch.stream().map(BatchElement::result).forEach(f -> f.set(null));


### PR DESCRIPTION
**Goals (and why)**:

Getting serialization errors for this codepath:

```
com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Invalid type definition for type `com.palantir.lock.client.LockTokenShare`: Cannot refine serialization type [simple type, class com.palantir.lock.client.LockTokenShare] into com.palantir.lock.v2.ImmutableLockToken; types not related (through reference chain: java.util.HashSet[0])
	at com.fasterxml.jackson.databind.exc.InvalidDefinitionException.from(InvalidDefinitionException.java:72)
	at com.fasterxml.jackson.databind.SerializerProvider.reportBadTypeDefinition(SerializerProvider.java:1163)
	at com.fasterxml.jackson.databind.ser.BeanSerializerFactory.createSerializer(BeanSerializerFactory.java:151)
	at com.palantir.sls.logging.jackson.DefaultToStringSerializerProvider$SerializerFactoryWrapper.createSerializer(DefaultToStringSerializerProvider.java:94)
	at com.fasterxml.jackson.databind.SerializerProvider._createUntypedSerializer(SerializerProvider.java:1388)
	at com.fasterxml.jackson.databind.SerializerProvider._createAndCacheUntypedSerializer(SerializerProvider.java:1336)
	at com.fasterxml.jackson.databind.SerializerProvider.findValueSerializer(SerializerProvider.java:510)
	at com.fasterxml.jackson.databind.ser.impl.PropertySerializerMap.findAndAddSecondarySerializer(PropertySerializerMap.java:90)
	at com.fasterxml.jackson.databind.ser.std.AsArraySerializerBase._findAndAddDynamic(AsArraySerializerBase.java:304)
	at com.fasterxml.jackson.databind.ser.std.CollectionSerializer.serializeContents(CollectionSerializer.java:140)
	at com.fasterxml.jackson.databind.ser.std.CollectionSerializer.serialize(CollectionSerializer.java:107)
	at com.fasterxml.jackson.databind.ser.std.CollectionSerializer.serialize(CollectionSerializer.java:25)
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider._serialize(DefaultSerializerProvider.java:480)
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:319)
	at com.fasterxml.jackson.databind.ObjectWriter$Prefetch.serialize(ObjectWriter.java:1433)
	at com.fasterxml.jackson.databind.ObjectWriter._configAndWriteValue(ObjectWriter.java:1135)
	at com.fasterxml.jackson.databind.ObjectWriter.writeValue(ObjectWriter.java:977)
```

Whilst we could try to figure out why the serialization fails, I think we should not be logging all of them anyway.

**Implementation Description (bullets)**:

Same trick as LockRefresher#refreshLocks.

**Testing (What was existing testing like?  What have you done to improve it?)**:

I have duplicated that logline in an internal product and saw the logging serialization errors dissapear.

**Concerns (what feedback would you like?)**:

I am not actually sure how useful logging the tokens actually is, since they're random? So I would be up for removing this logging altogether.

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:


