### PR TITLE
Ensure that `NotCurrentLeaderExceptionMapper` can leverage the leader hint.

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/config/LeaderConfig.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/config/LeaderConfig.java
@@ -32,7 +32,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Preconditions;
-import com.palantir.conjure.java.api.config.service.HumanReadableDuration;
 import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
 import com.palantir.logsafe.SafeArg;
 
@@ -100,8 +99,8 @@ public abstract class LeaderConfig {
     }
 
     @Value.Default
-    public HumanReadableDuration leaderAddressCacheTtl() {
-        return HumanReadableDuration.seconds(15);
+    public Duration leaderAddressCacheTtl() {
+        return Duration.ofSeconds(15);
     }
 
     @Value.Check

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/config/LeaderConfig.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/config/LeaderConfig.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Preconditions;
+import com.palantir.conjure.java.api.config.service.HumanReadableDuration;
 import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
 import com.palantir.logsafe.SafeArg;
 
@@ -96,6 +97,11 @@ public abstract class LeaderConfig {
     @Value.Auxiliary
     public Duration leaderPingResponseWait() {
         return Duration.ofMillis(leaderPingResponseWaitMs());
+    }
+
+    @Value.Default
+    public HumanReadableDuration leaderAddressCacheTtl() {
+        return HumanReadableDuration.seconds(15);
     }
 
     @Value.Check

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/config/LeaderConfig.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/config/LeaderConfig.java
@@ -98,6 +98,7 @@ public abstract class LeaderConfig {
         return Duration.ofMillis(leaderPingResponseWaitMs());
     }
 
+    @JsonIgnore
     @Value.Default
     public Duration leaderAddressCacheTtl() {
         return Duration.ofSeconds(15);

--- a/atlasdb-commons/src/main/java/com/palantir/common/remoting/ServiceNotAvailableException.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/remoting/ServiceNotAvailableException.java
@@ -48,26 +48,23 @@ public class ServiceNotAvailableException extends RuntimeException {
         super(message, cause);
         this.serviceHint = Optional.empty();
         this.serviceHintUrl = Optional.empty();
-
     }
 
     public ServiceNotAvailableException(String message) {
         super(message);
         this.serviceHint = Optional.empty();
         this.serviceHintUrl = Optional.empty();
-
     }
 
     public ServiceNotAvailableException(Throwable cause) {
         super(cause);
         this.serviceHint = Optional.empty();
         this.serviceHintUrl = Optional.empty();
-
     }
 
     public ServiceNotAvailableException(String message, Throwable cause, URL leaderHint) {
         super(message, cause);
-        this.serviceHint = Optional.empty();
+        this.serviceHint = Optional.of(HostAndPort.fromParts(leaderHint.getHost(), leaderHint.getPort()));
         this.serviceHintUrl = Optional.of(leaderHint);
     }
 

--- a/atlasdb-commons/src/main/java/com/palantir/common/remoting/ServiceNotAvailableException.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/remoting/ServiceNotAvailableException.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.common.remoting;
 
+import java.net.URL;
 import java.util.Optional;
 
 import com.google.common.net.HostAndPort;
@@ -29,33 +30,52 @@ public class ServiceNotAvailableException extends RuntimeException {
     private static final long serialVersionUID = 2L;
 
     private final Optional<HostAndPort> serviceHint;
+    private final Optional<URL> serviceHintUrl;
 
     public ServiceNotAvailableException(String message, Throwable cause, HostAndPort serviceHint) {
         super(message, cause);
         this.serviceHint = Optional.of(serviceHint);
+        this.serviceHintUrl = Optional.empty();
     }
 
     public ServiceNotAvailableException(String message, HostAndPort serviceHint) {
         super(message);
         this.serviceHint = Optional.of(serviceHint);
+        this.serviceHintUrl = Optional.empty();
     }
 
     public ServiceNotAvailableException(String message, Throwable cause) {
         super(message, cause);
         this.serviceHint = Optional.empty();
+        this.serviceHintUrl = Optional.empty();
+
     }
 
     public ServiceNotAvailableException(String message) {
         super(message);
         this.serviceHint = Optional.empty();
+        this.serviceHintUrl = Optional.empty();
+
     }
 
     public ServiceNotAvailableException(Throwable cause) {
         super(cause);
         this.serviceHint = Optional.empty();
+        this.serviceHintUrl = Optional.empty();
+
+    }
+
+    public ServiceNotAvailableException(String message, Throwable cause, URL leaderHint) {
+        super(message, cause);
+        this.serviceHint = Optional.empty();
+        this.serviceHintUrl = Optional.of(leaderHint);
     }
 
     public Optional<HostAndPort> getServiceHint() {
         return serviceHint;
+    }
+
+    public Optional<URL> getServiceHintAsUrl() {
+        return serviceHintUrl;
     }
 }

--- a/atlasdb-commons/src/main/java/com/palantir/common/remoting/ServiceNotAvailableException.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/remoting/ServiceNotAvailableException.java
@@ -15,7 +15,6 @@
  */
 package com.palantir.common.remoting;
 
-import java.net.URL;
 import java.util.Optional;
 
 import com.google.common.net.HostAndPort;
@@ -30,49 +29,33 @@ public class ServiceNotAvailableException extends RuntimeException {
     private static final long serialVersionUID = 2L;
 
     private final Optional<HostAndPort> serviceHint;
-    private final Optional<URL> serviceHintUrl;
 
     public ServiceNotAvailableException(String message, Throwable cause, HostAndPort serviceHint) {
         super(message, cause);
         this.serviceHint = Optional.of(serviceHint);
-        this.serviceHintUrl = Optional.empty();
     }
 
     public ServiceNotAvailableException(String message, HostAndPort serviceHint) {
         super(message);
         this.serviceHint = Optional.of(serviceHint);
-        this.serviceHintUrl = Optional.empty();
     }
 
     public ServiceNotAvailableException(String message, Throwable cause) {
         super(message, cause);
         this.serviceHint = Optional.empty();
-        this.serviceHintUrl = Optional.empty();
     }
 
     public ServiceNotAvailableException(String message) {
         super(message);
         this.serviceHint = Optional.empty();
-        this.serviceHintUrl = Optional.empty();
     }
 
     public ServiceNotAvailableException(Throwable cause) {
         super(cause);
         this.serviceHint = Optional.empty();
-        this.serviceHintUrl = Optional.empty();
-    }
-
-    public ServiceNotAvailableException(String message, Throwable cause, URL leaderHint) {
-        super(message, cause);
-        this.serviceHint = Optional.of(HostAndPort.fromParts(leaderHint.getHost(), leaderHint.getPort()));
-        this.serviceHintUrl = Optional.of(leaderHint);
     }
 
     public Optional<HostAndPort> getServiceHint() {
         return serviceHint;
-    }
-
-    public Optional<URL> getServiceHintAsUrl() {
-        return serviceHintUrl;
     }
 }

--- a/atlasdb-commons/src/main/java/com/palantir/leader/NotCurrentLeaderException.java
+++ b/atlasdb-commons/src/main/java/com/palantir/leader/NotCurrentLeaderException.java
@@ -15,6 +15,8 @@
  */
 package com.palantir.leader;
 
+import java.net.URL;
+
 import com.google.common.net.HostAndPort;
 import com.palantir.common.remoting.ServiceNotAvailableException;
 
@@ -27,7 +29,7 @@ import com.palantir.common.remoting.ServiceNotAvailableException;
 public class NotCurrentLeaderException extends ServiceNotAvailableException {
     private static final long serialVersionUID = 1L;
 
-    public NotCurrentLeaderException(String message, Throwable cause, HostAndPort leaderHint) {
+    public NotCurrentLeaderException(String message, Throwable cause, URL leaderHint) {
         super(message, cause, leaderHint);
     }
 

--- a/atlasdb-commons/src/main/java/com/palantir/leader/NotCurrentLeaderException.java
+++ b/atlasdb-commons/src/main/java/com/palantir/leader/NotCurrentLeaderException.java
@@ -15,8 +15,6 @@
  */
 package com.palantir.leader;
 
-import java.net.URL;
-
 import com.google.common.net.HostAndPort;
 import com.palantir.common.remoting.ServiceNotAvailableException;
 
@@ -29,7 +27,7 @@ import com.palantir.common.remoting.ServiceNotAvailableException;
 public class NotCurrentLeaderException extends ServiceNotAvailableException {
     private static final long serialVersionUID = 1L;
 
-    public NotCurrentLeaderException(String message, Throwable cause, URL leaderHint) {
+    public NotCurrentLeaderException(String message, Throwable cause, HostAndPort leaderHint) {
         super(message, cause, leaderHint);
     }
 

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
@@ -16,6 +16,7 @@
 package com.palantir.atlasdb.factory;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.Collection;
 import java.util.List;
@@ -30,8 +31,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-
-import javax.ws.rs.core.UriBuilder;
 
 import org.immutables.value.Value;
 
@@ -308,16 +307,15 @@ public final class Leaders {
                                 .shouldLimitPayload(true)
                                 .remotingClientConfig(remotingClientConfig)
                                 .build()))
-                .map(url -> convertAddressToUrl(trustContext, url))
+                .map(Leaders::convertAddressToUrl)
                 .map(ImmutableLeaderPingerContext::of)
                 .values()
                 .collect(Collectors.toList());
     }
 
-    private static URL convertAddressToUrl(Optional<TrustContext> install, String addressHostAndPort) {
-        String protocolPrefix = install.isPresent() ? "https://" : "http://";
+    private static URL convertAddressToUrl(String addressHostAndPort) {
         try {
-            return UriBuilder.fromPath(protocolPrefix + addressHostAndPort).build().toURL();
+            return URI.create(addressHostAndPort).toURL();
         } catch (MalformedURLException e) {
             throw new RuntimeException(e);
         }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
@@ -212,12 +212,15 @@ public final class Leaders {
                 PingableLeader.class,
                 new LocalPingableLeader(ourLearner, leaderUuid));
 
+        List<PingableLeader> remotePingableLeaders = otherLeaders.stream()
+                .map(LeaderPingerContext::pinger)
+                .collect(toList());
         return ImmutableLocalPaxosServices.builder()
                 .ourAcceptor(ourAcceptor)
                 .ourLearner(ourLearner)
                 .leaderElectionService(new BatchingLeaderElectionService(leaderElectionService))
                 .localPingableLeader(pingableLeader)
-                .remotePingableLeaders(otherLeaders.stream().map(LeaderPingerContext::pinger).collect(toList()))
+                .remotePingableLeaders(remotePingableLeaders)
                 .build();
     }
 

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
@@ -201,6 +201,7 @@ public final class Leaders {
                 .learnerClient(learnerNetworkClient)
                 .decorateProposer(proposer ->
                         AtlasDbMetrics.instrumentTimed(metricsManager.getRegistry(), PaxosProposer.class, proposer))
+                .leaderAddressCacheTtl(config.leaderAddressCacheTtl())
                 .build();
 
         LeaderElectionService leaderElectionService = AtlasDbMetrics.instrumentTimed(

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
@@ -15,9 +15,7 @@
  */
 package com.palantir.atlasdb.factory;
 
-import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URL;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -41,6 +39,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.common.net.HostAndPort;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.palantir.atlasdb.config.AuxiliaryRemotingParameters;
 import com.palantir.atlasdb.config.LeaderConfig;
@@ -307,18 +306,15 @@ public final class Leaders {
                                 .shouldLimitPayload(true)
                                 .remotingClientConfig(remotingClientConfig)
                                 .build()))
-                .map(Leaders::convertAddressToUrl)
+                .map(Leaders::convertAddressToHostAndPort)
                 .map(ImmutableLeaderPingerContext::of)
                 .values()
                 .collect(Collectors.toList());
     }
 
-    private static URL convertAddressToUrl(String addressHostAndPort) {
-        try {
-            return URI.create(addressHostAndPort).toURL();
-        } catch (MalformedURLException e) {
-            throw new RuntimeException(e);
-        }
+    private static HostAndPort convertAddressToHostAndPort(String url) {
+        URI uri = URI.create(url);
+        return HostAndPort.fromParts(uri.getHost(), uri.getPort());
     }
 
     @Value.Immutable

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
@@ -15,8 +15,6 @@
  */
 package com.palantir.atlasdb.factory;
 
-import static java.util.stream.Collectors.toList;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +27,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import org.immutables.value.Value;
 
@@ -214,7 +213,7 @@ public final class Leaders {
 
         List<PingableLeader> remotePingableLeaders = otherLeaders.stream()
                 .map(LeaderPingerContext::pinger)
-                .collect(toList());
+                .collect(Collectors.toList());
         return ImmutableLocalPaxosServices.builder()
                 .ourAcceptor(ourAcceptor)
                 .ourLearner(ourLearner)
@@ -280,7 +279,7 @@ public final class Leaders {
                                 .shouldRetry(true)
                                 .remotingClientConfig(remotingClientConfig)
                                 .build()))
-                .collect(toList());
+                .collect(Collectors.toList());
 
         return ImmutableList.copyOf(Iterables.concat(
                 remotes,
@@ -309,7 +308,7 @@ public final class Leaders {
                 .map(HostAndPort::fromString)
                 .map(ImmutableLeaderPingerContext::of)
                 .values()
-                .collect(toList());
+                .collect(Collectors.toList());
     }
 
     @Value.Immutable

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/NotCurrentLeaderExceptionMapper.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/NotCurrentLeaderExceptionMapper.java
@@ -28,8 +28,6 @@ import com.palantir.leader.NotCurrentLeaderException;
  * is no need to wait before retrying as there is no indication that clients should do so.
  *
  * This is a 503 response in {@link AtlasDbHttpProtocolVersion#LEGACY_OR_UNKNOWN}.
- *
- * @author carrino
  */
 public class NotCurrentLeaderExceptionMapper extends ProtocolAwareExceptionMapper<NotCurrentLeaderException> {
     private final Optional<RedirectRetryTargeter> redirectRetryTargeter;
@@ -49,7 +47,8 @@ public class NotCurrentLeaderExceptionMapper extends ProtocolAwareExceptionMappe
 
     @Override
     QosException handleConjureJavaRuntime(NotCurrentLeaderException exception) {
-        return redirectRetryTargeter.flatMap(RedirectRetryTargeter::redirectRequest)
+        return redirectRetryTargeter.flatMap(redirectTargeter ->
+                redirectTargeter.redirectRequest(exception.getServiceHint()))
                 .<QosException>map(QosException::retryOther)
                 .orElseGet(QosException::unavailable);
     }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/NotCurrentLeaderExceptionMapper.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/NotCurrentLeaderExceptionMapper.java
@@ -48,7 +48,7 @@ public class NotCurrentLeaderExceptionMapper extends ProtocolAwareExceptionMappe
     @Override
     QosException handleConjureJavaRuntime(NotCurrentLeaderException exception) {
         return redirectRetryTargeter.flatMap(redirectTargeter ->
-                redirectTargeter.redirectRequest(exception.getServiceHintAsUrl()))
+                redirectTargeter.redirectRequest(exception.getServiceHint()))
                 .<QosException>map(QosException::retryOther)
                 .orElseGet(QosException::unavailable);
     }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/NotCurrentLeaderExceptionMapper.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/NotCurrentLeaderExceptionMapper.java
@@ -48,7 +48,7 @@ public class NotCurrentLeaderExceptionMapper extends ProtocolAwareExceptionMappe
     @Override
     QosException handleConjureJavaRuntime(NotCurrentLeaderException exception) {
         return redirectRetryTargeter.flatMap(redirectTargeter ->
-                redirectTargeter.redirectRequest(exception.getServiceHint()))
+                redirectTargeter.redirectRequest(exception.getServiceHintAsUrl()))
                 .<QosException>map(QosException::retryOther)
                 .orElseGet(QosException::unavailable);
     }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/RedirectRetryTargeter.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/RedirectRetryTargeter.java
@@ -23,23 +23,16 @@ import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
-import com.google.common.collect.BiMap;
-import com.google.common.collect.HashBiMap;
 import com.google.common.collect.ImmutableList;
-import com.google.common.net.HostAndPort;
-import com.palantir.common.streams.KeyedStream;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 
 public final class RedirectRetryTargeter {
+
     private final List<URL> otherServers;
-    private final BiMap<HostAndPort, URL> urlsToHostAndPort;
 
     private RedirectRetryTargeter(List<URL> otherServers) {
         this.otherServers = otherServers;
-        this.urlsToHostAndPort = KeyedStream.of(otherServers)
-                .mapKeys(url -> HostAndPort.fromParts(url.getHost(), url.getPort()))
-                .collectTo(HashBiMap::create);
     }
 
     public static RedirectRetryTargeter create(URL localServer, List<URL> clusterUrls) {
@@ -58,14 +51,13 @@ public final class RedirectRetryTargeter {
         return new RedirectRetryTargeter(otherServers);
     }
 
-    Optional<URL> redirectRequest(Optional<HostAndPort> leaderHint) {
+    Optional<URL> redirectRequest(Optional<URL> leaderHint) {
         if (otherServers.isEmpty()) {
             return Optional.empty();
         }
 
         if (leaderHint.isPresent()) {
-            HostAndPort leader = leaderHint.get();
-            return Optional.ofNullable(urlsToHostAndPort.get(leader));
+            return leaderHint;
         }
         return Optional.of(otherServers.get(ThreadLocalRandom.current().nextInt(otherServers.size())));
     }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/RedirectRetryTargeter.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/RedirectRetryTargeter.java
@@ -59,13 +59,13 @@ public final class RedirectRetryTargeter {
     }
 
     Optional<URL> redirectRequest(Optional<HostAndPort> leaderHint) {
+        if (otherServers.isEmpty()) {
+            return Optional.empty();
+        }
+
         if (leaderHint.isPresent()) {
             HostAndPort leader = leaderHint.get();
             return Optional.ofNullable(urlsToHostAndPort.get(leader));
-        }
-
-        if (otherServers.isEmpty()) {
-            return Optional.empty();
         }
         return Optional.of(otherServers.get(ThreadLocalRandom.current().nextInt(otherServers.size())));
     }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/RedirectRetryTargeter.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/RedirectRetryTargeter.java
@@ -23,16 +23,23 @@ import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
 import com.google.common.collect.ImmutableList;
+import com.google.common.net.HostAndPort;
+import com.palantir.common.streams.KeyedStream;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 
 public final class RedirectRetryTargeter {
-
     private final List<URL> otherServers;
+    private final BiMap<HostAndPort, URL> urlsToHostAndPort;
 
     private RedirectRetryTargeter(List<URL> otherServers) {
         this.otherServers = otherServers;
+        this.urlsToHostAndPort = KeyedStream.of(otherServers)
+                .mapKeys(url -> HostAndPort.fromParts(url.getHost(), url.getPort()))
+                .collectTo(HashBiMap::create);
     }
 
     public static RedirectRetryTargeter create(URL localServer, List<URL> clusterUrls) {
@@ -51,13 +58,14 @@ public final class RedirectRetryTargeter {
         return new RedirectRetryTargeter(otherServers);
     }
 
-    Optional<URL> redirectRequest(Optional<URL> leaderHint) {
+    Optional<URL> redirectRequest(Optional<HostAndPort> leaderHint) {
         if (otherServers.isEmpty()) {
             return Optional.empty();
         }
 
         if (leaderHint.isPresent()) {
-            return leaderHint;
+            HostAndPort leader = leaderHint.get();
+            return Optional.ofNullable(urlsToHostAndPort.get(leader));
         }
         return Optional.of(otherServers.get(ThreadLocalRandom.current().nextInt(otherServers.size())));
     }

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/RedirectRetryTargeterTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/RedirectRetryTargeterTest.java
@@ -31,7 +31,6 @@ import java.util.stream.IntStream;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.net.HostAndPort;
 
 public class RedirectRetryTargeterTest {
     private static final URL URL_1 = createUrlUnchecked("https", "hostage", 42, "/request/hourai-branch");
@@ -59,7 +58,7 @@ public class RedirectRetryTargeterTest {
         RedirectRetryTargeter targeter = RedirectRetryTargeter.create(URL_2, ImmutableList.of(URL_1, URL_2, URL_3));
         Map<URL, List<URL>> results = IntStream.range(0, 10000)
                 .boxed()
-                .map($ -> targeter.redirectRequest(Optional.of(hostAndPort(URL_1))).get())
+                .map($ -> targeter.redirectRequest(Optional.of(URL_1)).get())
                 .collect(Collectors.groupingBy(Function.identity()));
         assertThat(results.keySet()).containsOnly(URL_1);
     }
@@ -79,7 +78,4 @@ public class RedirectRetryTargeterTest {
         }
     }
 
-    private static HostAndPort hostAndPort(URL url) {
-        return HostAndPort.fromParts(url.getHost(), url.getPort());
-    }
 }

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/RedirectRetryTargeterTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/RedirectRetryTargeterTest.java
@@ -31,6 +31,7 @@ import java.util.stream.IntStream;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.net.HostAndPort;
 
 public class RedirectRetryTargeterTest {
     private static final URL URL_1 = createUrlUnchecked("https", "hostage", 42, "/request/hourai-branch");
@@ -58,7 +59,7 @@ public class RedirectRetryTargeterTest {
         RedirectRetryTargeter targeter = RedirectRetryTargeter.create(URL_2, ImmutableList.of(URL_1, URL_2, URL_3));
         Map<URL, List<URL>> results = IntStream.range(0, 10000)
                 .boxed()
-                .map($ -> targeter.redirectRequest(Optional.of(URL_1)).get())
+                .map($ -> targeter.redirectRequest(Optional.of(hostAndPort(URL_1))).get())
                 .collect(Collectors.groupingBy(Function.identity()));
         assertThat(results.keySet()).containsOnly(URL_1);
     }
@@ -78,4 +79,7 @@ public class RedirectRetryTargeterTest {
         }
     }
 
+    private static HostAndPort hostAndPort(URL url) {
+        return HostAndPort.fromParts(url.getHost(), url.getPort());
+    }
 }

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/RedirectRetryTargeterTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/RedirectRetryTargeterTest.java
@@ -23,6 +23,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -30,6 +31,7 @@ import java.util.stream.IntStream;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.net.HostAndPort;
 
 public class RedirectRetryTargeterTest {
     private static final URL URL_1 = createUrlUnchecked("https", "hostage", 42, "/request/hourai-branch");
@@ -39,17 +41,27 @@ public class RedirectRetryTargeterTest {
     @Test
     public void redirectsToSelfIfOnlyOneNode() {
         RedirectRetryTargeter targeter = RedirectRetryTargeter.create(URL_1, ImmutableList.of(URL_1));
-        assertThat(targeter.redirectRequest()).isEmpty();
+        assertThat(targeter.redirectRequest(Optional.empty())).isEmpty();
     }
 
     @Test
-    public void redirectsToOtherNodes() {
+    public void redirectsToOtherNodesIfLeaderUnknown() {
         RedirectRetryTargeter targeter = RedirectRetryTargeter.create(URL_2, ImmutableList.of(URL_1, URL_2, URL_3));
         Map<URL, List<URL>> results = IntStream.range(0, 10000)
                 .boxed()
-                .map($ -> targeter.redirectRequest().get())
+                .map($ -> targeter.redirectRequest(Optional.empty()).get())
                 .collect(Collectors.groupingBy(Function.identity()));
         assertThat(results.keySet()).containsExactlyInAnyOrder(URL_1, URL_3);
+    }
+
+    @Test
+    public void redirectsToLeaderIfLeaderKnown() {
+        RedirectRetryTargeter targeter = RedirectRetryTargeter.create(URL_2, ImmutableList.of(URL_1, URL_2, URL_3));
+        Map<URL, List<URL>> results = IntStream.range(0, 10000)
+                .boxed()
+                .map($ -> targeter.redirectRequest(Optional.of(hostAndPort(URL_1))).get())
+                .collect(Collectors.groupingBy(Function.identity()));
+        assertThat(results.keySet()).containsOnly(URL_1);
     }
 
     @Test
@@ -65,5 +77,9 @@ public class RedirectRetryTargeterTest {
         } catch (MalformedURLException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private static HostAndPort hostAndPort(URL url) {
+        return HostAndPort.fromParts(url.getHost(), url.getPort());
     }
 }

--- a/changelog/@unreleased/pr-4481.v2.yml
+++ b/changelog/@unreleased/pr-4481.v2.yml
@@ -5,3 +5,4 @@ improvement:
     failures.
   links:
   - https://github.com/palantir/atlasdb/pull/4481
+  - https://github.com/palantir/atlasdb/issues/4471

--- a/changelog/@unreleased/pr-4481.v2.yml
+++ b/changelog/@unreleased/pr-4481.v2.yml
@@ -5,4 +5,3 @@ improvement:
     failures.
   links:
   - https://github.com/palantir/atlasdb/pull/4481
-  - https://github.com/palantir/atlasdb/issues/4471

--- a/changelog/@unreleased/pr-4481.v2.yml
+++ b/changelog/@unreleased/pr-4481.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Fix issue where we could get into a retry loop which when exhausted
+    would manifest in a non-actionable and non-retryable error resulting in visible
+    failures.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4481

--- a/leader-election-api/src/main/java/com/palantir/leader/LeaderElectionService.java
+++ b/leader-election-api/src/main/java/com/palantir/leader/LeaderElectionService.java
@@ -85,9 +85,12 @@ public interface LeaderElectionService {
     boolean stepDown();
 
     /**
-     * If this {@link LeaderElectionService} has successfully pinged the leader recently (up to the implementation),
-     * it returns the {@link HostAndPort} through which the leader can be contacted.
-     *
+     * If this {@link LeaderElectionService} has last successfully pinged node that believed it was the leader recently
+     * (up to the implementation), it returns the {@link HostAndPort} through which the leader can be contacted.
+     * <p>
+     * In practice, there may be a few false positives, but assuming everything is working as intended, they should
+     * quickly resolve.
+     * <p>
      * @return {@link Optional} containing address of suspected leader, otherwise empty if this
      * {@link LeaderElectionService} has not been able to contact the leader recently.
      */

--- a/leader-election-api/src/main/java/com/palantir/leader/LeaderElectionService.java
+++ b/leader-election-api/src/main/java/com/palantir/leader/LeaderElectionService.java
@@ -16,9 +16,9 @@
 package com.palantir.leader;
 
 import java.io.Serializable;
+import java.net.URL;
 import java.util.Optional;
 
-import com.google.common.net.HostAndPort;
 import com.palantir.atlasdb.metrics.Timed;
 
 public interface LeaderElectionService {
@@ -86,10 +86,10 @@ public interface LeaderElectionService {
 
     /**
      * If this {@link LeaderElectionService} has successfully pinged the leader recently (up to the implementation),
-     * it returns the {@link HostAndPort} through which the leader can be contacted.
+     * it returns the {@link URL} through which the leader can be contacted.
      *
      * @return {@link Optional} containing address of suspected leader, otherwise empty if this
      * {@link LeaderElectionService} has not been able to contact the leader recently.
      */
-    Optional<HostAndPort> getRecentlyPingedLeaderHost();
+    Optional<URL> getRecentlyPingedLeader();
 }

--- a/leader-election-api/src/main/java/com/palantir/leader/LeaderElectionService.java
+++ b/leader-election-api/src/main/java/com/palantir/leader/LeaderElectionService.java
@@ -86,10 +86,10 @@ public interface LeaderElectionService {
 
     /**
      * If this {@link LeaderElectionService} has successfully pinged the leader recently (up to the implementation),
-     * it returns the address through which the leader can be contacted.
+     * it returns the {@link HostAndPort} through which the leader can be contacted.
      *
      * @return {@link Optional} containing address of suspected leader, otherwise empty if this
      * {@link LeaderElectionService} has not been able to contact the leader recently.
      */
-    Optional<HostAndPort> getSuspectedLeaderHost();
+    Optional<HostAndPort> getRecentlyPingedLeaderHost();
 }

--- a/leader-election-api/src/main/java/com/palantir/leader/LeaderElectionService.java
+++ b/leader-election-api/src/main/java/com/palantir/leader/LeaderElectionService.java
@@ -18,6 +18,7 @@ package com.palantir.leader;
 import java.io.Serializable;
 import java.util.Optional;
 
+import com.google.common.net.HostAndPort;
 import com.palantir.atlasdb.metrics.Timed;
 
 public interface LeaderElectionService {
@@ -82,4 +83,13 @@ public interface LeaderElectionService {
      * @return true if and only if this node was able to cause itself to lose leadership
      */
     boolean stepDown();
+
+    /**
+     * If this {@link LeaderElectionService} has successfully pinged the leader recently (up to the implementation),
+     * it returns the address through which the leader can be contacted.
+     *
+     * @return {@link Optional} containing address of suspected leader, otherwise empty if this
+     * {@link LeaderElectionService} has not been able to contact the leader recently.
+     */
+    Optional<HostAndPort> getSuspectedLeaderHost();
 }

--- a/leader-election-api/src/main/java/com/palantir/leader/LeaderElectionService.java
+++ b/leader-election-api/src/main/java/com/palantir/leader/LeaderElectionService.java
@@ -16,9 +16,9 @@
 package com.palantir.leader;
 
 import java.io.Serializable;
-import java.net.URL;
 import java.util.Optional;
 
+import com.google.common.net.HostAndPort;
 import com.palantir.atlasdb.metrics.Timed;
 
 public interface LeaderElectionService {
@@ -86,10 +86,10 @@ public interface LeaderElectionService {
 
     /**
      * If this {@link LeaderElectionService} has successfully pinged the leader recently (up to the implementation),
-     * it returns the {@link URL} through which the leader can be contacted.
+     * it returns the {@link HostAndPort} through which the leader can be contacted.
      *
      * @return {@link Optional} containing address of suspected leader, otherwise empty if this
      * {@link LeaderElectionService} has not been able to contact the leader recently.
      */
-    Optional<URL> getRecentlyPingedLeader();
+    Optional<HostAndPort> getRecentlyPingedLeaderHost();
 }

--- a/leader-election-impl/src/main/java/com/palantir/leader/BatchingLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/BatchingLeaderElectionService.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
+import com.google.common.net.HostAndPort;
 import com.palantir.atlasdb.autobatch.Autobatchers;
 import com.palantir.atlasdb.autobatch.BatchElement;
 import com.palantir.atlasdb.autobatch.DisruptorAutobatcher;
@@ -67,6 +68,11 @@ public class BatchingLeaderElectionService implements LeaderElectionService, Clo
     @Override
     public boolean stepDown() {
         return delegate.stepDown();
+    }
+
+    @Override
+    public Optional<HostAndPort> getSuspectedLeaderHost() {
+        return delegate.getSuspectedLeaderHost();
     }
 
     private void processBatch(List<BatchElement<Void, LeadershipToken>> batch) {

--- a/leader-election-impl/src/main/java/com/palantir/leader/BatchingLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/BatchingLeaderElectionService.java
@@ -17,11 +17,11 @@
 package com.palantir.leader;
 
 import java.io.Closeable;
-import java.net.URL;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
+import com.google.common.net.HostAndPort;
 import com.palantir.atlasdb.autobatch.Autobatchers;
 import com.palantir.atlasdb.autobatch.BatchElement;
 import com.palantir.atlasdb.autobatch.DisruptorAutobatcher;
@@ -71,8 +71,8 @@ public class BatchingLeaderElectionService implements LeaderElectionService, Clo
     }
 
     @Override
-    public Optional<URL> getRecentlyPingedLeader() {
-        return delegate.getRecentlyPingedLeader();
+    public Optional<HostAndPort> getRecentlyPingedLeaderHost() {
+        return delegate.getRecentlyPingedLeaderHost();
     }
 
     private void processBatch(List<BatchElement<Void, LeadershipToken>> batch) {

--- a/leader-election-impl/src/main/java/com/palantir/leader/BatchingLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/BatchingLeaderElectionService.java
@@ -17,11 +17,11 @@
 package com.palantir.leader;
 
 import java.io.Closeable;
+import java.net.URL;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
-import com.google.common.net.HostAndPort;
 import com.palantir.atlasdb.autobatch.Autobatchers;
 import com.palantir.atlasdb.autobatch.BatchElement;
 import com.palantir.atlasdb.autobatch.DisruptorAutobatcher;
@@ -71,8 +71,8 @@ public class BatchingLeaderElectionService implements LeaderElectionService, Clo
     }
 
     @Override
-    public Optional<HostAndPort> getRecentlyPingedLeaderHost() {
-        return delegate.getRecentlyPingedLeaderHost();
+    public Optional<URL> getRecentlyPingedLeader() {
+        return delegate.getRecentlyPingedLeader();
     }
 
     private void processBatch(List<BatchElement<Void, LeadershipToken>> batch) {

--- a/leader-election-impl/src/main/java/com/palantir/leader/BatchingLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/BatchingLeaderElectionService.java
@@ -71,8 +71,8 @@ public class BatchingLeaderElectionService implements LeaderElectionService, Clo
     }
 
     @Override
-    public Optional<HostAndPort> getSuspectedLeaderHost() {
-        return delegate.getSuspectedLeaderHost();
+    public Optional<HostAndPort> getRecentlyPingedLeaderHost() {
+        return delegate.getRecentlyPingedLeaderHost();
     }
 
     private void processBatch(List<BatchElement<Void, LeadershipToken>> batch) {

--- a/leader-election-impl/src/main/java/com/palantir/leader/LeaderElectionServiceBuilder.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/LeaderElectionServiceBuilder.java
@@ -40,6 +40,7 @@ public final class LeaderElectionServiceBuilder {
     @Nullable private PaxosLeaderElectionEventRecorder eventRecorder = PaxosLeaderElectionEventRecorder.NO_OP;
     @Nullable private Duration pingRate;
     @Nullable private Duration randomWaitBeforeProposingLeadership;
+    @Nullable private Duration leaderAddressCacheTtl;
     @Nullable private UUID leaderUuid;
     private UnaryOperator<PaxosProposer> proposerDecorator = paxosProposer -> paxosProposer;
 
@@ -86,6 +87,13 @@ public final class LeaderElectionServiceBuilder {
         return this;
     }
 
+    public LeaderElectionServiceBuilder leaderAddressCacheTtl(Duration leaderAddressCacheTtl) {
+        Preconditions.checkNotNull(leaderAddressCacheTtl, "leaderAddressCacheTtl cannot be null");
+        Preconditions.checkArgument(!leaderAddressCacheTtl.isNegative(), "leaderAddressCacheTtl must be positive");
+        this.leaderAddressCacheTtl = leaderAddressCacheTtl;
+        return this;
+    }
+
     public LeaderElectionServiceBuilder leaderUuid(UUID leaderUuid) {
         this.leaderUuid = Preconditions.checkNotNull(leaderUuid, "leaderUuid cannot be null");
         return this;
@@ -103,8 +111,9 @@ public final class LeaderElectionServiceBuilder {
                 leaderPinger(),
                 acceptorClient(),
                 learnerClient(),
-                pingRate().toMillis(),
-                randomWaitBeforeProposingLeadership().toMillis(),
+                pingRate(),
+                randomWaitBeforeProposingLeadership(),
+                leaderAddressCacheTtl(),
                 eventRecorder());
     }
 
@@ -139,6 +148,10 @@ public final class LeaderElectionServiceBuilder {
     private Duration randomWaitBeforeProposingLeadership() {
         return Preconditions.checkNotNull(randomWaitBeforeProposingLeadership,
                 "randomWaitBeforeProposingLeadership not set");
+    }
+
+    private Duration leaderAddressCacheTtl() {
+        return Preconditions.checkNotNull(leaderAddressCacheTtl, "leaderAddressCacheTtl not set");
     }
 
     private UUID leaderUuid() {

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
@@ -154,10 +154,10 @@ public class PaxosLeaderElectionService implements LeaderElectionService {
 
     private boolean isSuccessfulPing(LeaderPingResult leaderPingResult) {
         return LeaderPingResults.caseOf(leaderPingResult)
-                .pingReturnedTrue(((leaderUuid, leader) -> {
+                .pingReturnedTrue((leaderUuid, leader) -> {
                     leaderAddressCache.put(leaderUuid, leader);
                     return true;
-                }))
+                })
                 .otherwise_(false);
     }
 

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
@@ -308,7 +308,7 @@ public class PaxosLeaderElectionService implements LeaderElectionService {
     }
 
     @Override
-    public Optional<HostAndPort> getSuspectedLeaderHost() {
+    public Optional<HostAndPort> getRecentlyPingedLeaderHost() {
         return extractLeaderUuid(knowledge.getGreatestLearnedValue()).map(leaderAddressCache::getIfPresent);
     }
 

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.leader;
 
+import java.net.URL;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.UUID;
@@ -28,7 +29,6 @@ import org.slf4j.LoggerFactory;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.collect.ImmutableCollection;
-import com.google.common.net.HostAndPort;
 import com.google.common.util.concurrent.RateLimiter;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.paxos.CoalescingPaxosLatestRoundVerifier;
@@ -72,7 +72,7 @@ public class PaxosLeaderElectionService implements LeaderElectionService {
     private final AtomicBoolean leaderEligible = new AtomicBoolean(true);
     private final RateLimiter leaderEligibilityLoggingRateLimiter = RateLimiter.create(1);
 
-    private final Cache<UUID, HostAndPort> leaderAddressCache;
+    private final Cache<UUID, URL> leaderAddressCache;
 
     PaxosLeaderElectionService(
             PaxosProposer proposer,
@@ -304,7 +304,7 @@ public class PaxosLeaderElectionService implements LeaderElectionService {
     }
 
     @Override
-    public Optional<HostAndPort> getRecentlyPingedLeaderHost() {
+    public Optional<URL> getRecentlyPingedLeader() {
         return extractLeaderUuid(knowledge.getGreatestLearnedValue()).map(leaderAddressCache::getIfPresent);
     }
 

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
@@ -15,7 +15,6 @@
  */
 package com.palantir.leader;
 
-import java.net.URL;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.UUID;
@@ -29,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.collect.ImmutableCollection;
+import com.google.common.net.HostAndPort;
 import com.google.common.util.concurrent.RateLimiter;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.paxos.CoalescingPaxosLatestRoundVerifier;
@@ -72,7 +72,7 @@ public class PaxosLeaderElectionService implements LeaderElectionService {
     private final AtomicBoolean leaderEligible = new AtomicBoolean(true);
     private final RateLimiter leaderEligibilityLoggingRateLimiter = RateLimiter.create(1);
 
-    private final Cache<UUID, URL> leaderAddressCache;
+    private final Cache<UUID, HostAndPort> leaderAddressCache;
 
     PaxosLeaderElectionService(
             PaxosProposer proposer,
@@ -304,7 +304,7 @@ public class PaxosLeaderElectionService implements LeaderElectionService {
     }
 
     @Override
-    public Optional<URL> getRecentlyPingedLeader() {
+    public Optional<HostAndPort> getRecentlyPingedLeaderHost() {
         return extractLeaderUuid(knowledge.getGreatestLearnedValue()).map(leaderAddressCache::getIfPresent);
     }
 

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.leader;
 
+import java.time.Duration;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -24,7 +25,10 @@ import org.immutables.value.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.collect.ImmutableCollection;
+import com.google.common.net.HostAndPort;
 import com.google.common.util.concurrent.RateLimiter;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.paxos.CoalescingPaxosLatestRoundVerifier;
@@ -60,13 +64,15 @@ public class PaxosLeaderElectionService implements LeaderElectionService {
     private final LeaderPinger leaderPinger;
     private final PaxosLearnerNetworkClient learnerClient;
 
-    private final long updatePollingRateInMs;
-    private final long randomWaitBeforeProposingLeadership;
+    private final Duration updatePollingRate;
+    private final Duration randomWaitBeforeProposingLeadership;
 
     private final PaxosLeaderElectionEventRecorder eventRecorder;
 
     private final AtomicBoolean leaderEligible = new AtomicBoolean(true);
     private final RateLimiter leaderEligibilityLoggingRateLimiter = RateLimiter.create(1);
+
+    private final Cache<UUID, HostAndPort> leaderAddressCache;
 
     PaxosLeaderElectionService(
             PaxosProposer proposer,
@@ -74,18 +80,22 @@ public class PaxosLeaderElectionService implements LeaderElectionService {
             LeaderPinger leaderPinger,
             PaxosAcceptorNetworkClient acceptorClient,
             PaxosLearnerNetworkClient learnerClient,
-            long updatePollingWaitInMs,
-            long randomWaitBeforeProposingLeadership,
+            Duration updatePollingWait,
+            Duration randomWaitBeforeProposingLeadership,
+            Duration leaderAddressCacheTtl,
             PaxosLeaderElectionEventRecorder eventRecorder) {
         this.proposer = proposer;
         this.knowledge = knowledge;
         this.leaderPinger = leaderPinger;
         this.learnerClient = learnerClient;
-        this.updatePollingRateInMs = updatePollingWaitInMs;
+        this.updatePollingRate = updatePollingWait;
         this.randomWaitBeforeProposingLeadership = randomWaitBeforeProposingLeadership;
         this.eventRecorder = eventRecorder;
         this.latestRoundVerifier =
                 new CoalescingPaxosLatestRoundVerifier(new PaxosLatestRoundVerifierImpl(acceptorClient));
+        this.leaderAddressCache = Caffeine.newBuilder()
+                .expireAfterWrite(leaderAddressCacheTtl)
+                .build();
     }
 
     @Override
@@ -125,8 +135,8 @@ public class PaxosLeaderElectionService implements LeaderElectionService {
             throw new InterruptedException("leader no longer eligible");
         }
 
-        if (pingLeader(currentState.greatestLearnedValue()).isSuccessful()) {
-            Thread.sleep(updatePollingRateInMs);
+        if (isSuccessfulPing(pingLeader(currentState.greatestLearnedValue()))) {
+            Thread.sleep(updatePollingRate.toMillis());
             return;
         }
 
@@ -135,11 +145,20 @@ public class PaxosLeaderElectionService implements LeaderElectionService {
             return;
         }
 
-        long backoffTime = (long) (randomWaitBeforeProposingLeadership * Math.random());
+        long backoffTime = (long) (randomWaitBeforeProposingLeadership.toMillis() * Math.random());
         log.debug("Waiting for [{}] ms before proposing leadership", SafeArg.of("waitTimeMs", backoffTime));
         Thread.sleep(backoffTime);
 
         proposeLeadershipAfter(currentState.greatestLearnedValue());
+    }
+
+    private boolean isSuccessfulPing(LeaderPingResult leaderPingResult) {
+        return LeaderPingResults.caseOf(leaderPingResult)
+                .pingReturnedTrue(((leaderUuid, leader) -> {
+                    leaderAddressCache.put(leaderUuid, leader);
+                    return true;
+                }))
+                .otherwise_(false);
     }
 
     @Override
@@ -155,12 +174,16 @@ public class PaxosLeaderElectionService implements LeaderElectionService {
     }
 
     private LeaderPingResult pingLeader(Optional<PaxosValue> maybeGreatestLearnedValue) {
-        Optional<LeaderPingResult> maybeLeaderPingResult = maybeGreatestLearnedValue
-                .map(PaxosValue::getLeaderUUID)
-                .map(UUID::fromString)
+        Optional<LeaderPingResult> maybeLeaderPingResult = extractLeaderUuid(maybeGreatestLearnedValue)
                 .map(leaderPinger::pingLeaderWithUuid);
         maybeLeaderPingResult.ifPresent(leaderPingResult -> leaderPingResult.recordEvent(eventRecorder));
         return maybeLeaderPingResult.orElseGet(LeaderPingResults::pingReturnedFalse);
+    }
+
+    private static Optional<UUID> extractLeaderUuid(Optional<PaxosValue> maybeGreatestLearnedValue) {
+        return maybeGreatestLearnedValue
+                .map(PaxosValue::getLeaderUUID)
+                .map(UUID::fromString);
     }
 
     private void proposeLeadershipAfter(Optional<PaxosValue> value) {
@@ -282,6 +305,11 @@ public class PaxosLeaderElectionService implements LeaderElectionService {
             }
         }
         return false;
+    }
+
+    @Override
+    public Optional<HostAndPort> getSuspectedLeaderHost() {
+        return extractLeaderUuid(knowledge.getGreatestLearnedValue()).map(leaderAddressCache::getIfPresent);
     }
 
     private static long getNextSequenceNumber(Optional<PaxosValue> paxosValue) {

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
@@ -239,7 +239,8 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
             NotCurrentLeaderException notCurrentLeaderException = notCurrentLeaderException(
                     "method invoked on a non-leader");
 
-            if (notCurrentLeaderException.getServiceHint().isPresent()) {
+            if (notCurrentLeaderException.getServiceHintAsUrl().isPresent()
+                    || notCurrentLeaderException.getServiceHint().isPresent()) {
                 // There's a chance that we can gain leadership while generating this exception.
                 // In this case, we should be able to get a leadership token after all
                 leadershipToken = leadershipTokenRef.get();
@@ -259,8 +260,8 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
     }
 
     private NotCurrentLeaderException notCurrentLeaderException(String message, @Nullable Throwable cause) {
-        return leaderElectionService.getRecentlyPingedLeaderHost()
-                .map(hostAndPort -> new NotCurrentLeaderException(message, cause, hostAndPort))
+        return leaderElectionService.getRecentlyPingedLeader()
+                .map(leaderUrl -> new NotCurrentLeaderException(message, cause, leaderUrl))
                 .orElseGet(() -> new NotCurrentLeaderException(message, cause));
     }
 

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
@@ -258,11 +258,13 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
         return leadershipTokenRef.get() == leadershipToken;
     }
 
-    private static NotCurrentLeaderException notCurrentLeaderException(String message, @Nullable Throwable cause) {
-        return new NotCurrentLeaderException(message, cause);
+    private NotCurrentLeaderException notCurrentLeaderException(String message, @Nullable Throwable cause) {
+        return leaderElectionService.getSuspectedLeaderHost()
+                .map(hostAndPort -> new NotCurrentLeaderException(message, cause, hostAndPort))
+                .orElseGet(() -> new NotCurrentLeaderException(message, cause));
     }
 
-    private static NotCurrentLeaderException notCurrentLeaderException(String message) {
+    private NotCurrentLeaderException notCurrentLeaderException(String message) {
         return notCurrentLeaderException(message, null /* cause */);
     }
 

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
@@ -259,7 +259,7 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
     }
 
     private NotCurrentLeaderException notCurrentLeaderException(String message, @Nullable Throwable cause) {
-        return leaderElectionService.getSuspectedLeaderHost()
+        return leaderElectionService.getRecentlyPingedLeaderHost()
                 .map(hostAndPort -> new NotCurrentLeaderException(message, cause, hostAndPort))
                 .orElseGet(() -> new NotCurrentLeaderException(message, cause));
     }

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
@@ -239,8 +239,7 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
             NotCurrentLeaderException notCurrentLeaderException = notCurrentLeaderException(
                     "method invoked on a non-leader");
 
-            if (notCurrentLeaderException.getServiceHintAsUrl().isPresent()
-                    || notCurrentLeaderException.getServiceHint().isPresent()) {
+            if (notCurrentLeaderException.getServiceHint().isPresent()) {
                 // There's a chance that we can gain leadership while generating this exception.
                 // In this case, we should be able to get a leadership token after all
                 leadershipToken = leadershipTokenRef.get();
@@ -260,8 +259,8 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
     }
 
     private NotCurrentLeaderException notCurrentLeaderException(String message, @Nullable Throwable cause) {
-        return leaderElectionService.getRecentlyPingedLeader()
-                .map(leaderUrl -> new NotCurrentLeaderException(message, cause, leaderUrl))
+        return leaderElectionService.getRecentlyPingedLeaderHost()
+                .map(hostAndPort -> new NotCurrentLeaderException(message, cause, hostAndPort))
                 .orElseGet(() -> new NotCurrentLeaderException(message, cause));
     }
 

--- a/leader-election-impl/src/main/java/com/palantir/paxos/LeaderPingResult.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/LeaderPingResult.java
@@ -46,6 +46,12 @@ public abstract class LeaderPingResult {
                 .otherwise_(null);
     }
 
+    public boolean isSuccessful() {
+        return LeaderPingResults.caseOf(this)
+                .pingReturnedTrue_(true)
+                .otherwise_(false);
+    }
+
     private static <R> Supplier<R> wrap(Runnable runnable) {
         return () -> {
             runnable.run();

--- a/leader-election-impl/src/main/java/com/palantir/paxos/LeaderPingResult.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/LeaderPingResult.java
@@ -16,6 +16,7 @@
 
 package com.palantir.paxos;
 
+import java.net.URL;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -23,7 +24,6 @@ import java.util.function.Supplier;
 
 import org.derive4j.Data;
 
-import com.google.common.net.HostAndPort;
 import com.palantir.leader.PaxosLeaderElectionEventRecorder;
 
 @Data
@@ -31,7 +31,7 @@ public abstract class LeaderPingResult {
 
     interface Cases<R> {
         R pingTimedOut();
-        R pingReturnedTrue(UUID leaderUuid, HostAndPort leader);
+        R pingReturnedTrue(UUID leaderUuid, URL leader);
         R pingReturnedFalse();
         R pingCallFailure(Throwable exception);
     }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/LeaderPingResult.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/LeaderPingResult.java
@@ -16,7 +16,6 @@
 
 package com.palantir.paxos;
 
-import java.net.URL;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -24,6 +23,7 @@ import java.util.function.Supplier;
 
 import org.derive4j.Data;
 
+import com.google.common.net.HostAndPort;
 import com.palantir.leader.PaxosLeaderElectionEventRecorder;
 
 @Data
@@ -31,7 +31,7 @@ public abstract class LeaderPingResult {
 
     interface Cases<R> {
         R pingTimedOut();
-        R pingReturnedTrue(UUID leaderUuid, URL leader);
+        R pingReturnedTrue(UUID leaderUuid, HostAndPort leader);
         R pingReturnedFalse();
         R pingCallFailure(Throwable exception);
     }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/LeaderPingerContext.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/LeaderPingerContext.java
@@ -16,13 +16,13 @@
 
 package com.palantir.paxos;
 
-import org.immutables.value.Value;
+import java.net.URL;
 
-import com.google.common.net.HostAndPort;
+import org.immutables.value.Value;
 
 @Value.Immutable
 @Value.Style(allParameters = true)
 public interface LeaderPingerContext<T> {
     T pinger();
-    HostAndPort hostAndPort();
+    URL url();
 }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/LeaderPingerContext.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/LeaderPingerContext.java
@@ -16,13 +16,13 @@
 
 package com.palantir.paxos;
 
-import java.net.URL;
-
 import org.immutables.value.Value;
+
+import com.google.common.net.HostAndPort;
 
 @Value.Immutable
 @Value.Style(allParameters = true)
 public interface LeaderPingerContext<T> {
     T pinger();
-    URL url();
+    HostAndPort hostAndPort();
 }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/LeaderPingerContext.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/LeaderPingerContext.java
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-package com.palantir.atlasdb.timelock.paxos;
+package com.palantir.paxos;
 
-import java.io.Closeable;
-import java.util.UUID;
+import org.immutables.value.Value;
 
-import com.palantir.paxos.LeaderPingResult;
-import com.palantir.paxos.LeaderPingerContext;
+import com.google.common.net.HostAndPort;
 
-interface ClientAwarePingableLeader extends Closeable {
-    LeaderPingResult ping(UUID requestedUuid, Client client);
-    LeaderPingerContext<BatchPingableLeader> underlyingRpcClient();
+@Value.Immutable
+@Value.Style(allParameters = true)
+public interface LeaderPingerContext<T> {
+    T pinger();
+    HostAndPort hostAndPort();
 }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderPinger.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderPinger.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.Futures;
 import com.palantir.common.base.Throwables;
 import com.palantir.common.concurrent.MultiplexingCompletionService;
 import com.palantir.leader.PingableLeader;
@@ -42,13 +43,13 @@ public class SingleLeaderPinger implements LeaderPinger {
 
     private static final Logger log = LoggerFactory.getLogger(SingleLeaderPinger.class);
 
-    private final ConcurrentMap<UUID, PingableLeader> uuidToServiceCache = Maps.newConcurrentMap();
-    private final Map<PingableLeader, ExecutorService> leaderPingExecutors;
+    private final ConcurrentMap<UUID, LeaderPingerContext<PingableLeader>> uuidToServiceCache = Maps.newConcurrentMap();
+    private final Map<LeaderPingerContext<PingableLeader>, ExecutorService> leaderPingExecutors;
     private final Duration leaderPingResponseWait;
     private final UUID localUuid;
 
     public SingleLeaderPinger(
-            Map<PingableLeader, ExecutorService> otherPingableExecutors,
+            Map<LeaderPingerContext<PingableLeader>, ExecutorService> otherPingableExecutors,
             Duration leaderPingResponseWait,
             UUID localUuid) {
         this.leaderPingExecutors = otherPingableExecutors;
@@ -58,44 +59,49 @@ public class SingleLeaderPinger implements LeaderPinger {
 
     @Override
     public LeaderPingResult pingLeaderWithUuid(UUID uuid) {
-        Optional<PingableLeader> suspectedLeader = getSuspectedLeader(uuid);
+        Optional<LeaderPingerContext<PingableLeader>> suspectedLeader = getSuspectedLeader(uuid);
         if (!suspectedLeader.isPresent()) {
             return LeaderPingResults.pingReturnedFalse();
         }
 
-        PingableLeader leader = suspectedLeader.get();
+        LeaderPingerContext<PingableLeader> leader = suspectedLeader.get();
 
-        MultiplexingCompletionService<PingableLeader, Boolean> multiplexingCompletionService
+        MultiplexingCompletionService<LeaderPingerContext<PingableLeader>, Boolean> multiplexingCompletionService
                 = MultiplexingCompletionService.create(leaderPingExecutors);
 
-        multiplexingCompletionService.submit(leader, leader::ping);
+        multiplexingCompletionService.submit(leader, () -> leader.pinger().ping());
 
         try {
-            Future<Map.Entry<PingableLeader, Boolean>> pingFuture = multiplexingCompletionService.poll(
+            Future<Map.Entry<LeaderPingerContext<PingableLeader>, Boolean>> pingFuture = multiplexingCompletionService.poll(
                     leaderPingResponseWait.toMillis(),
                     TimeUnit.MILLISECONDS);
-            return getAndRecordLeaderPingResult(pingFuture);
+            return getLeaderPingResult(uuid, pingFuture);
         } catch (InterruptedException ex) {
             Thread.currentThread().interrupt();
             return LeaderPingResults.pingCallFailure(ex);
         }
     }
 
-    private static LeaderPingResult getAndRecordLeaderPingResult(
-            @Nullable Future<Map.Entry<PingableLeader, Boolean>> pingFuture) throws InterruptedException {
+    private static LeaderPingResult getLeaderPingResult(
+            UUID uuid,
+            @Nullable Future<Map.Entry<LeaderPingerContext<PingableLeader>, Boolean>> pingFuture) {
         if (pingFuture == null) {
             return LeaderPingResults.pingTimedOut();
         }
 
         try {
-            boolean isLeader = pingFuture.get().getValue();
-            return LeaderPingResult.fromBooleanResult(isLeader);
+            boolean isLeader = Futures.getDone(pingFuture).getValue();
+            if (isLeader) {
+                return LeaderPingResults.pingReturnedTrue(uuid, Futures.getDone(pingFuture).getKey().hostAndPort());
+            } else {
+                return LeaderPingResults.pingReturnedFalse();
+            }
         } catch (ExecutionException ex) {
             return LeaderPingResults.pingCallFailure(ex.getCause());
         }
     }
 
-    private Optional<PingableLeader> getSuspectedLeader(UUID uuid) {
+    private Optional<LeaderPingerContext<PingableLeader>> getSuspectedLeader(UUID uuid) {
         if (uuidToServiceCache.containsKey(uuid)) {
             return Optional.of(uuidToServiceCache.get(uuid));
         }
@@ -121,17 +127,17 @@ public class SingleLeaderPinger implements LeaderPinger {
         }
     }
 
-    private Optional<PingableLeader> getSuspectedLeaderOverNetwork(UUID uuid) {
-        PaxosResponsesWithRemote<PingableLeader, PaxosString> responses = PaxosQuorumChecker.collectUntil(
+    private Optional<LeaderPingerContext<PingableLeader>> getSuspectedLeaderOverNetwork(UUID uuid) {
+        PaxosResponsesWithRemote<LeaderPingerContext<PingableLeader>, PaxosString> responses = PaxosQuorumChecker.collectUntil(
                 ImmutableList.copyOf(leaderPingExecutors.keySet()),
-                pingableLeader -> new PaxosString(pingableLeader.getUUID()),
+                pingableLeader -> new PaxosString(pingableLeader.pinger().getUUID()),
                 leaderPingExecutors,
                 leaderPingResponseWait,
                 state -> state.responses().values().stream().map(PaxosString::get).anyMatch(uuid.toString()::equals));
 
-        for (Map.Entry<PingableLeader, PaxosString> cacheEntry : responses.responses().entrySet()) {
+        for (Map.Entry<LeaderPingerContext<PingableLeader>, PaxosString> cacheEntry : responses.responses().entrySet()) {
             UUID uuidFromRequest = UUID.fromString(cacheEntry.getValue().get());
-            PingableLeader service = uuidToServiceCache.putIfAbsent(uuidFromRequest, cacheEntry.getKey());
+            LeaderPingerContext<PingableLeader> service = uuidToServiceCache.putIfAbsent(uuidFromRequest, cacheEntry.getKey());
             throwIfInvalidSetup(service, cacheEntry.getKey(), uuidFromRequest);
 
             // return the leader if it matches
@@ -143,8 +149,8 @@ public class SingleLeaderPinger implements LeaderPinger {
         return Optional.empty();
     }
 
-    private void throwIfInvalidSetup(PingableLeader cachedService,
-            PingableLeader pingedService,
+    private void throwIfInvalidSetup(LeaderPingerContext<PingableLeader> cachedService,
+            LeaderPingerContext<PingableLeader> pingedService,
             UUID pingedServiceUuid) {
         if (cachedService == null) {
             return;

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderPinger.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderPinger.java
@@ -74,7 +74,7 @@ public class SingleLeaderPinger implements LeaderPinger {
         try {
             Future<Map.Entry<LeaderPingerContext<PingableLeader>, Boolean>> pingFuture = multiplexingCompletionService
                     .poll(leaderPingResponseWait.toMillis(), TimeUnit.MILLISECONDS);
-            return getLeaderPingResult(uuid, pingFuture);
+            return getLeaderPingResult(uuid, leader, pingFuture);
         } catch (InterruptedException ex) {
             Thread.currentThread().interrupt();
             return LeaderPingResults.pingCallFailure(ex);
@@ -83,15 +83,15 @@ public class SingleLeaderPinger implements LeaderPinger {
 
     private static LeaderPingResult getLeaderPingResult(
             UUID uuid,
+            LeaderPingerContext<PingableLeader> remote,
             @Nullable Future<Map.Entry<LeaderPingerContext<PingableLeader>, Boolean>> pingFuture) {
         if (pingFuture == null) {
             return LeaderPingResults.pingTimedOut();
         }
 
         try {
-            boolean isLeader = Futures.getDone(pingFuture).getValue();
-            if (isLeader) {
-                return LeaderPingResults.pingReturnedTrue(uuid, Futures.getDone(pingFuture).getKey().hostAndPort());
+            if (Futures.getDone(pingFuture).getValue()) {
+                return LeaderPingResults.pingReturnedTrue(uuid, remote.url());
             } else {
                 return LeaderPingResults.pingReturnedFalse();
             }

--- a/leader-election-impl/src/test/java/com/palantir/leader/PaxosLeaderEventsTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/PaxosLeaderEventsTest.java
@@ -18,6 +18,8 @@ package com.palantir.leader;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
@@ -30,7 +32,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.net.HostAndPort;
 import com.palantir.paxos.ImmutableLeaderPingerContext;
 import com.palantir.paxos.LeaderPingResults;
 import com.palantir.paxos.LeaderPinger;
@@ -42,7 +43,7 @@ public class PaxosLeaderEventsTest {
     private static final UUID LOCAL_UUID = UUID.randomUUID();
     private static final UUID REMOTE_UUID = UUID.randomUUID();
 
-    private static final HostAndPort HOST_AND_PORT = HostAndPort.fromParts("localhost", 8080);
+    private static final URL TIMELOCK_URL = createUrl("https://localhost:8080/timelock/api");
 
     private final ExecutorService executorService = Executors.newSingleThreadExecutor();
 
@@ -95,14 +96,22 @@ public class PaxosLeaderEventsTest {
 
         LeaderPinger pinger = pingerWithTimeout(Duration.ofSeconds(1));
         assertThat(pinger.pingLeaderWithUuid(REMOTE_UUID))
-                .isEqualTo(LeaderPingResults.pingReturnedTrue(REMOTE_UUID, HOST_AND_PORT));
+                .isEqualTo(LeaderPingResults.pingReturnedTrue(REMOTE_UUID, TIMELOCK_URL));
     }
 
     private LeaderPinger pingerWithTimeout(Duration leaderPingResponseWait) {
         return new SingleLeaderPinger(
-                ImmutableMap.of(ImmutableLeaderPingerContext.of(pingableLeader, HOST_AND_PORT), executorService),
+                ImmutableMap.of(ImmutableLeaderPingerContext.of(pingableLeader, TIMELOCK_URL), executorService),
                 leaderPingResponseWait,
                 LOCAL_UUID);
+    }
+
+    private static URL createUrl(String url) {
+        try {
+            return new URL(url);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
     }
 
 }

--- a/leader-election-impl/src/test/java/com/palantir/leader/PaxosLeaderEventsTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/PaxosLeaderEventsTest.java
@@ -30,6 +30,8 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.net.HostAndPort;
+import com.palantir.paxos.ImmutableLeaderPingerContext;
 import com.palantir.paxos.LeaderPingResults;
 import com.palantir.paxos.LeaderPinger;
 import com.palantir.paxos.SingleLeaderPinger;
@@ -39,6 +41,8 @@ public class PaxosLeaderEventsTest {
 
     private static final UUID LOCAL_UUID = UUID.randomUUID();
     private static final UUID REMOTE_UUID = UUID.randomUUID();
+
+    private static final HostAndPort HOST_AND_PORT = HostAndPort.fromParts("localhost", 8080);
 
     private final ExecutorService executorService = Executors.newSingleThreadExecutor();
 
@@ -91,12 +95,12 @@ public class PaxosLeaderEventsTest {
 
         LeaderPinger pinger = pingerWithTimeout(Duration.ofSeconds(1));
         assertThat(pinger.pingLeaderWithUuid(REMOTE_UUID))
-                .isEqualTo(LeaderPingResults.pingReturnedTrue());
+                .isEqualTo(LeaderPingResults.pingReturnedTrue(REMOTE_UUID, HOST_AND_PORT));
     }
 
     private LeaderPinger pingerWithTimeout(Duration leaderPingResponseWait) {
         return new SingleLeaderPinger(
-                ImmutableMap.of(pingableLeader, executorService),
+                ImmutableMap.of(ImmutableLeaderPingerContext.of(pingableLeader, HOST_AND_PORT), executorService),
                 leaderPingResponseWait,
                 LOCAL_UUID);
     }

--- a/leader-election-impl/src/test/java/com/palantir/leader/PaxosLeaderEventsTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/PaxosLeaderEventsTest.java
@@ -18,8 +18,6 @@ package com.palantir.leader;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
@@ -32,6 +30,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.net.HostAndPort;
 import com.palantir.paxos.ImmutableLeaderPingerContext;
 import com.palantir.paxos.LeaderPingResults;
 import com.palantir.paxos.LeaderPinger;
@@ -43,7 +42,7 @@ public class PaxosLeaderEventsTest {
     private static final UUID LOCAL_UUID = UUID.randomUUID();
     private static final UUID REMOTE_UUID = UUID.randomUUID();
 
-    private static final URL TIMELOCK_URL = createUrl("https://localhost:8080/timelock/api");
+    private static final HostAndPort HOST_AND_PORT = HostAndPort.fromParts("localhost", 8080);
 
     private final ExecutorService executorService = Executors.newSingleThreadExecutor();
 
@@ -96,22 +95,14 @@ public class PaxosLeaderEventsTest {
 
         LeaderPinger pinger = pingerWithTimeout(Duration.ofSeconds(1));
         assertThat(pinger.pingLeaderWithUuid(REMOTE_UUID))
-                .isEqualTo(LeaderPingResults.pingReturnedTrue(REMOTE_UUID, TIMELOCK_URL));
+                .isEqualTo(LeaderPingResults.pingReturnedTrue(REMOTE_UUID, HOST_AND_PORT));
     }
 
     private LeaderPinger pingerWithTimeout(Duration leaderPingResponseWait) {
         return new SingleLeaderPinger(
-                ImmutableMap.of(ImmutableLeaderPingerContext.of(pingableLeader, TIMELOCK_URL), executorService),
+                ImmutableMap.of(ImmutableLeaderPingerContext.of(pingableLeader, HOST_AND_PORT), executorService),
                 leaderPingResponseWait,
                 LOCAL_UUID);
-    }
-
-    private static URL createUrl(String url) {
-        try {
-            return new URL(url);
-        } catch (MalformedURLException e) {
-            throw new RuntimeException(e);
-        }
     }
 
 }

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosConsensusTestUtils.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosConsensusTestUtils.java
@@ -91,6 +91,7 @@ public final class PaxosConsensusTestUtils {
                     .leaderUuid(leaderUuid)
                     .pingRate(Duration.ZERO)
                     .randomWaitBeforeProposingLeadership(Duration.ZERO)
+                    .leaderAddressCacheTtl(Duration.ZERO)
                     .knowledge(ourLearner)
                     .acceptorClient(acceptorNetworkClient)
                     .learnerClient(learnerNetworkClient)

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeaderElectionServiceFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeaderElectionServiceFactory.java
@@ -16,6 +16,7 @@
 
 package com.palantir.atlasdb.timelock.paxos;
 
+import java.time.Duration;
 import java.util.Map;
 
 import com.google.common.collect.Maps;
@@ -48,6 +49,7 @@ public class LeaderElectionServiceFactory {
                         dependencies.paxosClient(),
                         dependencies.metrics(),
                         uninstrumentedPaxosProposer))
+                .leaderAddressCacheTtl(Duration.ofSeconds(1))
                 .build());
     }
 

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResourcesFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResourcesFactory.java
@@ -90,7 +90,7 @@ public final class PaxosResourcesFactory {
 
         Factories.LeaderPingerFactory leaderPingerFactory = dependencies -> new SingleLeaderPinger(
                 Maps.toMap(
-                        dependencies.remoteClients().nonBatchPingableLeaders(),
+                        dependencies.remoteClients().nonBatchPingableLeadersWithContext(),
                         _pingableLeader -> dependencies.sharedExecutor()),
                 dependencies.leaderPingResponseWait(),
                 dependencies.leaderUuid());

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosRuntimeConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosRuntimeConfiguration.java
@@ -68,11 +68,6 @@ public interface PaxosRuntimeConfiguration {
         return Duration.ofMillis(leaderPingResponseWaitMs());
     }
 
-    @JsonProperty("leader-address-cache-ttl")
-    default Duration leaderAddressCacheTtl() {
-        return Duration.ofSeconds(1);
-    }
-
     @JsonProperty("only-log-on-quorum-failure")
     @Value.Default
     default boolean onlyLogOnQuorumFailure() {

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosRuntimeConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosRuntimeConfiguration.java
@@ -68,6 +68,11 @@ public interface PaxosRuntimeConfiguration {
         return Duration.ofMillis(leaderPingResponseWaitMs());
     }
 
+    @JsonProperty("leader-address-cache-ttl")
+    default Duration leaderAddressCacheTtl() {
+        return Duration.ofSeconds(1);
+    }
+
     @JsonProperty("only-log-on-quorum-failure")
     @Value.Default
     default boolean onlyLogOnQuorumFailure() {

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AutobatchingPingableLeaderFactory.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AutobatchingPingableLeaderFactory.java
@@ -156,7 +156,8 @@ public class AutobatchingPingableLeaderFactory implements Closeable {
                 }
 
                 ClientAwarePingableLeader pingableLeaderWithUuid = maybePingableLeader.get();
-                return executors.get(pingableLeaderWithUuid).submit(() -> pingableLeaderWithUuid.ping(uuid, client))
+                return executors.get(pingableLeaderWithUuid.underlyingRpcClient())
+                        .submit(() -> pingableLeaderWithUuid.ping(uuid, client))
                         .get(leaderPingResponseWait.toMillis(), TimeUnit.MILLISECONDS);
             } catch (InterruptedException e) {
                 log.warn("received interrupt whilst trying to ping leader",

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PingCoalescingFunction.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PingCoalescingFunction.java
@@ -46,7 +46,7 @@ final class PingCoalescingFunction implements CoalescingRequestFunction<PingRequ
         if (pingResults.contains(currentRequest.client())) {
             return LeaderPingResults.pingReturnedTrue(
                     currentRequest.requestedLeaderId(),
-                    batchPingableLeader.hostAndPort());
+                    batchPingableLeader.url());
         } else {
             return LeaderPingResults.pingReturnedFalse();
         }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PingCoalescingFunction.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PingCoalescingFunction.java
@@ -18,22 +18,37 @@ package com.palantir.atlasdb.timelock.paxos;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.google.common.collect.Maps;
 import com.palantir.atlasdb.autobatch.CoalescingRequestFunction;
+import com.palantir.atlasdb.timelock.paxos.AutobatchingPingableLeaderFactory.PingRequest;
 import com.palantir.paxos.LeaderPingResult;
+import com.palantir.paxos.LeaderPingResults;
+import com.palantir.paxos.LeaderPingerContext;
 
-final class PingCoalescingFunction implements CoalescingRequestFunction<Client, LeaderPingResult> {
+final class PingCoalescingFunction implements CoalescingRequestFunction<PingRequest, LeaderPingResult> {
 
-    private final BatchPingableLeader batchPingableLeader;
+    private final LeaderPingerContext<BatchPingableLeader> batchPingableLeader;
 
-    PingCoalescingFunction(BatchPingableLeader batchPingableLeader) {
+    PingCoalescingFunction(LeaderPingerContext<BatchPingableLeader> batchPingableLeader) {
         this.batchPingableLeader = batchPingableLeader;
     }
 
     @Override
-    public Map<Client, LeaderPingResult> apply(Set<Client> request) {
-        Set<Client> pingResults = batchPingableLeader.ping(request);
-        return Maps.toMap(request, client -> LeaderPingResult.fromBooleanResult(pingResults.contains(client)));
+    public Map<PingRequest, LeaderPingResult> apply(Set<PingRequest> requests) {
+        Set<Client> clientRequests = requests.stream().map(PingRequest::client).collect(Collectors.toSet());
+        Set<Client> pingResults = batchPingableLeader.pinger().ping(clientRequests);
+        return Maps.toMap(requests, client -> getLeaderPingResult(pingResults, client));
+    }
+
+    private LeaderPingResult getLeaderPingResult(Set<Client> pingResults, PingRequest currentRequest) {
+        if (pingResults.contains(currentRequest.client())) {
+            return LeaderPingResults.pingReturnedTrue(
+                    currentRequest.requestedLeaderId(),
+                    batchPingableLeader.hostAndPort());
+        } else {
+            return LeaderPingResults.pingReturnedFalse();
+        }
     }
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PingCoalescingFunction.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PingCoalescingFunction.java
@@ -46,7 +46,7 @@ final class PingCoalescingFunction implements CoalescingRequestFunction<PingRequ
         if (pingResults.contains(currentRequest.client())) {
             return LeaderPingResults.pingReturnedTrue(
                     currentRequest.requestedLeaderId(),
-                    batchPingableLeader.url());
+                    batchPingableLeader.hostAndPort());
         } else {
             return LeaderPingResults.pingReturnedFalse();
         }

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/AutobatchingPingableLeaderFactoryTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/AutobatchingPingableLeaderFactoryTests.java
@@ -23,8 +23,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.time.Duration;
 import java.util.Set;
 import java.util.UUID;
@@ -38,6 +36,7 @@ import org.mockito.Answers;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.common.net.HostAndPort;
 import com.palantir.paxos.ImmutableLeaderPingerContext;
 import com.palantir.paxos.LeaderPingResults;
 import com.palantir.paxos.LeaderPinger;
@@ -47,7 +46,7 @@ public class AutobatchingPingableLeaderFactoryTests {
 
     private static final Client CLIENT_1 = Client.of("client-1");
     private static final Client CLIENT_2 = Client.of("client-2");
-    private static final URL TIMELOCK_URL = createUrl("https://localhost:8080/timelock/api");
+    private static final HostAndPort HOST_AND_PORT = HostAndPort.fromParts("localhost", 8080);
 
     private final ExecutorService executorService = Executors.newCachedThreadPool();
 
@@ -58,14 +57,14 @@ public class AutobatchingPingableLeaderFactoryTests {
 
     @Test
     public void canPingLeaderMatchingUuidAndClient() {
-        LeaderPingerContext<BatchPingableLeader> rpc = batchPingableLeader(TIMELOCK_URL, CLIENT_1);
+        LeaderPingerContext<BatchPingableLeader> rpc = batchPingableLeader(HOST_AND_PORT, CLIENT_1);
         AutobatchingPingableLeaderFactory factory = factoryForPingables(rpc);
 
         LeaderPinger client1Pinger = factory.leaderPingerFor(CLIENT_1);
         LeaderPinger client2Pinger = factory.leaderPingerFor(CLIENT_2);
 
         assertThat(client1Pinger.pingLeaderWithUuid(rpc.pinger().uuid()))
-                .isEqualTo(LeaderPingResults.pingReturnedTrue(rpc.pinger().uuid(), TIMELOCK_URL));
+                .isEqualTo(LeaderPingResults.pingReturnedTrue(rpc.pinger().uuid(), HOST_AND_PORT));
 
         assertThat(client2Pinger.pingLeaderWithUuid(rpc.pinger().uuid()))
                 .isEqualTo(LeaderPingResults.pingReturnedFalse());
@@ -73,7 +72,7 @@ public class AutobatchingPingableLeaderFactoryTests {
 
     @Test
     public void unknownUuidReturnsFalse() {
-        LeaderPingerContext<BatchPingableLeader> rpc = batchPingableLeader(TIMELOCK_URL, CLIENT_1, CLIENT_2);
+        LeaderPingerContext<BatchPingableLeader> rpc = batchPingableLeader(HOST_AND_PORT, CLIENT_1, CLIENT_2);
         AutobatchingPingableLeaderFactory factory = factoryForPingables(rpc);
 
         LeaderPinger client1Pinger = factory.leaderPingerFor(CLIENT_1);
@@ -88,8 +87,8 @@ public class AutobatchingPingableLeaderFactoryTests {
 
     @Test
     public void twoDifferentLeaders() {
-        URL leader1 = createUrl("https://timelock-1:8080/timelock/api");
-        URL leader2 = createUrl("https://timelock-2:8080/timelock/api");
+        HostAndPort leader1 = HostAndPort.fromParts("timelock-1", 8080);
+        HostAndPort leader2 = HostAndPort.fromParts("timelock-2", 8080);
         LeaderPingerContext<BatchPingableLeader> client1Leader =
                 batchPingableLeader(leader1, CLIENT_1);
         LeaderPingerContext<BatchPingableLeader> client2Leader =
@@ -115,7 +114,7 @@ public class AutobatchingPingableLeaderFactoryTests {
         when(rpc.ping(anySet())).thenThrow(error);
 
         AutobatchingPingableLeaderFactory factory =
-                factoryForPingables(ImmutableLeaderPingerContext.of(rpc, TIMELOCK_URL));
+                factoryForPingables(ImmutableLeaderPingerContext.of(rpc, HOST_AND_PORT));
 
         assertThat(factory.leaderPingerFor(CLIENT_1).pingLeaderWithUuid(uuid))
                 .isEqualTo(LeaderPingResults.pingCallFailure(error));
@@ -135,10 +134,10 @@ public class AutobatchingPingableLeaderFactoryTests {
     }
 
     private static LeaderPingerContext<BatchPingableLeader> batchPingableLeader(
-            URL url,
+            HostAndPort hostAndPort,
             Client... clientsWhichWeAreLeaderFor) {
         FakeBatchPingableLeader fakeBatchPingableLeader = new FakeBatchPingableLeader(clientsWhichWeAreLeaderFor);
-        return ImmutableLeaderPingerContext.of(fakeBatchPingableLeader, url);
+        return ImmutableLeaderPingerContext.of(fakeBatchPingableLeader, hostAndPort);
     }
 
     private static final class FakeBatchPingableLeader implements BatchPingableLeader {
@@ -158,14 +157,6 @@ public class AutobatchingPingableLeaderFactoryTests {
         @Override
         public UUID uuid() {
             return uuid;
-        }
-    }
-
-    private static URL createUrl(String url) {
-        try {
-            return new URL(url);
-        } catch (MalformedURLException e) {
-            throw new RuntimeException(e);
         }
     }
 }

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/GetSuspectedLeaderWithUuidTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/GetSuspectedLeaderWithUuidTests.java
@@ -27,21 +27,26 @@ import static org.mockito.Mockito.when;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 
 import org.immutables.value.Value;
 import org.junit.After;
 import org.junit.Test;
+import org.mockito.Answers;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.SettableFuture;
 import com.palantir.atlasdb.autobatch.BatchElement;
+import com.palantir.paxos.LeaderPingerContext;
 
 public class GetSuspectedLeaderWithUuidTests {
 
@@ -62,7 +67,7 @@ public class GetSuspectedLeaderWithUuidTests {
 
         GetSuspectedLeaderWithUuid function = functionForRemotes(remote1, remote2);
 
-        TestBatchElement element1 = TestBatchElement.of(remote1.uuid());
+        TestBatchElement element1 = TestBatchElement.of(remote1.underlyingRpcClient().pinger().uuid());
         TestBatchElement element2 = TestBatchElement.random();
 
         function.accept(ImmutableList.of(element1, element2));
@@ -97,7 +102,7 @@ public class GetSuspectedLeaderWithUuidTests {
         assertThat(element.get())
                 .as("we're using the same instance for the same requests")
                 .isSameAs(elementWithSameUuid.get());
-        verify(remote, only()).uuid();
+        verify(remote.underlyingRpcClient().pinger(), only()).uuid();
     }
 
     @Test
@@ -110,7 +115,7 @@ public class GetSuspectedLeaderWithUuidTests {
         function.accept(ImmutableList.of(firstRequest));
 
         assertThat(firstRequest.get()).contains(remote);
-        verify(remote, times(1)).uuid();
+        verify(remote.underlyingRpcClient().pinger(), times(1)).uuid();
 
         TestBatchElement secondRequest = TestBatchElement.of(uuid);
         function.accept(ImmutableList.of(secondRequest));
@@ -120,8 +125,8 @@ public class GetSuspectedLeaderWithUuidTests {
     }
 
     private static ClientAwarePingableLeader remoteWithUuid(UUID uuid) {
-        ClientAwarePingableLeader mock = mock(ClientAwarePingableLeader.class);
-        return when(mock.uuid()).thenReturn(uuid).getMock();
+        ClientAwarePingableLeader mock = mock(ClientAwarePingableLeader.class, Answers.RETURNS_DEEP_STUBS);
+        return when(mock.underlyingRpcClient().pinger().uuid()).thenReturn(uuid).getMock();
     }
 
     private static ClientAwarePingableLeader remoteWithRandomUuid() {
@@ -129,10 +134,16 @@ public class GetSuspectedLeaderWithUuidTests {
     }
 
     private GetSuspectedLeaderWithUuid functionForRemotes(ClientAwarePingableLeader... remotes) {
-        Map<ClientAwarePingableLeader, ExecutorService> executors =
-                Maps.toMap(ImmutableList.copyOf(remotes), $ -> executorService);
+        Set<ClientAwarePingableLeader> clientAwareLeaders = ImmutableSet.copyOf(remotes);
 
-        return new GetSuspectedLeaderWithUuid(executors, LOCAL_UUID, Duration.ofSeconds(1));
+        Set<LeaderPingerContext<BatchPingableLeader>> rpcClients = clientAwareLeaders.stream()
+                .map(ClientAwarePingableLeader::underlyingRpcClient)
+                .collect(Collectors.toSet());
+
+        Map<LeaderPingerContext<BatchPingableLeader>, ExecutorService> executors =
+                Maps.toMap(ImmutableList.copyOf(rpcClients), $ -> executorService);
+
+        return new GetSuspectedLeaderWithUuid(executors, clientAwareLeaders, LOCAL_UUID, Duration.ofSeconds(1));
     }
 
     @Value.Immutable

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/GetSuspectedLeaderWithUuidTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/GetSuspectedLeaderWithUuidTests.java
@@ -121,12 +121,13 @@ public class GetSuspectedLeaderWithUuidTests {
         function.accept(ImmutableList.of(secondRequest));
 
         assertThat(secondRequest.get()).contains(remote);
-        verifyNoMoreInteractions(remote);
+        verifyNoMoreInteractions(remote.underlyingRpcClient().pinger());
     }
 
     private static ClientAwarePingableLeader remoteWithUuid(UUID uuid) {
         ClientAwarePingableLeader mock = mock(ClientAwarePingableLeader.class, Answers.RETURNS_DEEP_STUBS);
-        return when(mock.underlyingRpcClient().pinger().uuid()).thenReturn(uuid).getMock();
+        when(mock.underlyingRpcClient().pinger().uuid()).thenReturn(uuid);
+        return mock;
     }
 
     private static ClientAwarePingableLeader remoteWithRandomUuid() {

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PingCoalescingFunctionTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PingCoalescingFunctionTests.java
@@ -19,7 +19,11 @@ package com.palantir.atlasdb.timelock.paxos;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+import static com.palantir.paxos.LeaderPingResults.pingReturnedFalse;
+import static com.palantir.paxos.LeaderPingResults.pingReturnedTrue;
+
 import java.util.Set;
+import java.util.UUID;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,7 +31,9 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.collect.ImmutableSet;
-import com.palantir.paxos.LeaderPingResults;
+import com.google.common.net.HostAndPort;
+import com.palantir.atlasdb.timelock.paxos.AutobatchingPingableLeaderFactory.PingRequest;
+import com.palantir.paxos.ImmutableLeaderPingerContext;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PingCoalescingFunctionTests {
@@ -35,6 +41,11 @@ public class PingCoalescingFunctionTests {
     private static final Client CLIENT_1 = Client.of("client1");
     private static final Client CLIENT_2 = Client.of("client2");
     private static final Client CLIENT_3 = Client.of("client3");
+
+    private static final UUID LEADER_UUID_1 = UUID.randomUUID();
+    private static final UUID LEADER_UUID_2 = UUID.randomUUID();
+
+    private static final HostAndPort HOST_AND_PORT = HostAndPort.fromParts("localhost", 8080);
 
     @Mock private BatchPingableLeader remote;
 
@@ -44,11 +55,22 @@ public class PingCoalescingFunctionTests {
         when(remote.ping(clients))
                 .thenReturn(ImmutableSet.of(CLIENT_1, CLIENT_3));
 
-        PingCoalescingFunction function = new PingCoalescingFunction(remote);
-        assertThat(function.apply(clients))
-                .containsEntry(CLIENT_1, LeaderPingResults.pingReturnedTrue())
-                .containsEntry(CLIENT_3, LeaderPingResults.pingReturnedTrue())
-                .doesNotContainEntry(CLIENT_2, LeaderPingResults.pingReturnedTrue())
-                .containsEntry(CLIENT_2, LeaderPingResults.pingReturnedFalse());
+        Set<PingRequest> requests = ImmutableSet.of(
+                pingRequest(CLIENT_1, LEADER_UUID_1),
+                pingRequest(CLIENT_2, LEADER_UUID_2),
+                pingRequest(CLIENT_3, LEADER_UUID_1));
+
+        PingCoalescingFunction function =
+                new PingCoalescingFunction(ImmutableLeaderPingerContext.of(remote, HOST_AND_PORT));
+        assertThat(function.apply(requests))
+                .containsEntry(pingRequest(CLIENT_1, LEADER_UUID_1), pingReturnedTrue(LEADER_UUID_1, HOST_AND_PORT))
+                .containsEntry(pingRequest(CLIENT_3, LEADER_UUID_1), pingReturnedTrue(LEADER_UUID_1, HOST_AND_PORT))
+                .doesNotContainEntry(
+                        pingRequest(CLIENT_2, LEADER_UUID_2), pingReturnedTrue(LEADER_UUID_2, HOST_AND_PORT))
+                .containsEntry(pingRequest(CLIENT_2, LEADER_UUID_2), pingReturnedFalse());
+    }
+
+    private static PingRequest pingRequest(Client client, UUID leaderUuid) {
+        return ImmutablePingRequest.of(client, leaderUuid);
     }
 }

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PingCoalescingFunctionTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PingCoalescingFunctionTests.java
@@ -22,6 +22,8 @@ import static org.mockito.Mockito.when;
 import static com.palantir.paxos.LeaderPingResults.pingReturnedFalse;
 import static com.palantir.paxos.LeaderPingResults.pingReturnedTrue;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Set;
 import java.util.UUID;
 
@@ -31,7 +33,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.net.HostAndPort;
 import com.palantir.atlasdb.timelock.paxos.AutobatchingPingableLeaderFactory.PingRequest;
 import com.palantir.paxos.ImmutableLeaderPingerContext;
 
@@ -45,7 +46,7 @@ public class PingCoalescingFunctionTests {
     private static final UUID LEADER_UUID_1 = UUID.randomUUID();
     private static final UUID LEADER_UUID_2 = UUID.randomUUID();
 
-    private static final HostAndPort HOST_AND_PORT = HostAndPort.fromParts("localhost", 8080);
+    private static final URL TIMELOCK_URL = createUrl("https://localhost:8080/timelock/api");
 
     @Mock private BatchPingableLeader remote;
 
@@ -61,16 +62,24 @@ public class PingCoalescingFunctionTests {
                 pingRequest(CLIENT_3, LEADER_UUID_1));
 
         PingCoalescingFunction function =
-                new PingCoalescingFunction(ImmutableLeaderPingerContext.of(remote, HOST_AND_PORT));
+                new PingCoalescingFunction(ImmutableLeaderPingerContext.of(remote, TIMELOCK_URL));
         assertThat(function.apply(requests))
-                .containsEntry(pingRequest(CLIENT_1, LEADER_UUID_1), pingReturnedTrue(LEADER_UUID_1, HOST_AND_PORT))
-                .containsEntry(pingRequest(CLIENT_3, LEADER_UUID_1), pingReturnedTrue(LEADER_UUID_1, HOST_AND_PORT))
+                .containsEntry(pingRequest(CLIENT_1, LEADER_UUID_1), pingReturnedTrue(LEADER_UUID_1, TIMELOCK_URL))
+                .containsEntry(pingRequest(CLIENT_3, LEADER_UUID_1), pingReturnedTrue(LEADER_UUID_1, TIMELOCK_URL))
                 .doesNotContainEntry(
-                        pingRequest(CLIENT_2, LEADER_UUID_2), pingReturnedTrue(LEADER_UUID_2, HOST_AND_PORT))
+                        pingRequest(CLIENT_2, LEADER_UUID_2), pingReturnedTrue(LEADER_UUID_2, TIMELOCK_URL))
                 .containsEntry(pingRequest(CLIENT_2, LEADER_UUID_2), pingReturnedFalse());
     }
 
     private static PingRequest pingRequest(Client client, UUID leaderUuid) {
         return ImmutablePingRequest.of(client, leaderUuid);
+    }
+
+    private static URL createUrl(String url) {
+        try {
+            return new URL(url);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
**Goals (and why)**:
Fixes #4471. Instead of just randomly redirecting when we *do* know the leader, we use the leader hint that's gathered in the background whilst pinging the leader. When we don't know the leader, we still bias towards fast redirects by picking a random leader vs a 503 which will invoke backoff (we don't want this).

**Implementation Description (bullets)**:
Idea here is that we ping the leader and we know who that leader is every 50 milliseconds. We just need to associate a `HostAndPort`/`URL` when we *do* ping. We also want to encode recency since it's not necessarily the case that the logs are up to date, so we only return the `HostAndPort` if we've successfully pinged the leader within some time frame.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Amended current tests to be aware of host and port etc.

**Concerns (what feedback would you like?)**:
Is remembering for 1 second too much? should it be 500ms? Bear in mind that we ping 20 times a second by default in timelock. I have made it 15 seconds in leader-block mode.

**Where should we start reviewing?**:
* `NotCurrentLeaderExceptionMapper`
* `LeaderElectionService`, `PaxosLeaderElectionService`
* `RetryRedirectTargeter`
* `SingleLeaderPinger`
* `AutobatchingPingableLeaderPingerFactory` if you're interested :P
* `PaxosRuntimeConfiguration` for the cache ttl defaults.

**Priority (whenever / two weeks / yesterday)**:
At some point this week, if not then over the christmas break.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
