### PR TITLE
[CJR] Refresh experimental clients every 30 minutes

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/common/proxy/ExperimentRunningProxy.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/proxy/ExperimentRunningProxy.java
@@ -110,10 +110,11 @@ public final class ExperimentRunningProxy<T> extends AbstractInvocationHandler {
         }
     }
 
-    private synchronized void possiblyRefreshClient() {
-        if (Instant.now(clock).compareTo(lastClientRefresh.get().plus(CLIENT_REFRESH_INTERVAL)) > 0) {
+    private void possiblyRefreshClient() {
+        Instant currentLastRefresh = lastClientRefresh.get();
+        if (Instant.now(clock).compareTo(currentLastRefresh.plus(CLIENT_REFRESH_INTERVAL)) > 0 &&
+        lastClientRefresh.compareAndSet(currentLastRefresh, currentLastRefresh.plus(CLIENT_REFRESH_INTERVAL))) {
             experimentalService.set(experimentalServiceSupplier.get());
-            lastClientRefresh.set(Instant.now(clock));
         }
     }
 

--- a/atlasdb-commons/src/test/java/com/palantir/common/proxy/ExperimentRunningProxyTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/common/proxy/ExperimentRunningProxyTest.java
@@ -149,6 +149,9 @@ public class ExperimentRunningProxyTest {
         enableExperiment();
         assertThat(proxyInstance.getAsInt()).isEqualTo(EXPERIMENTAL_RESULT);
 
+        setTimeTo(Instant.ofEpochSecond(ExperimentRunningProxy.CLIENT_REFRESH_INTERVAL.getSeconds() - 1));
+        assertThat(proxyInstance.getAsInt()).isEqualTo(EXPERIMENTAL_RESULT);
+
         setTimeTo(Instant.ofEpochSecond(ExperimentRunningProxy.CLIENT_REFRESH_INTERVAL.getSeconds() + 1));
         assertThat(proxyInstance.getAsInt()).isEqualTo(OTHER_EXPERIMENTAL_RESULT);
     }

--- a/atlasdb-commons/src/test/java/com/palantir/common/proxy/ExperimentRunningProxyTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/common/proxy/ExperimentRunningProxyTest.java
@@ -35,12 +35,10 @@ import org.junit.Test;
 
 public class ExperimentRunningProxyTest {
     private static final int EXPERIMENTAL_RESULT = 123;
-    private static final int OTHER_EXPERIMENTAL_RESULT = 2123;
     private static final int FALLBACK_RESULT = 1;
     private static final RuntimeException RUNTIME_EXCEPTION = new RuntimeException("foo");
 
     private final IntSupplier experimentalIntSupplier = mock(IntSupplier.class);
-    private final IntSupplier secondExperimentalSupplier = mock(IntSupplier.class);
     private final Supplier<IntSupplier> experimentSupplier = mock(Supplier.class);
     private final IntSupplier fallbackIntSupplier = () -> FALLBACK_RESULT;
     private final BooleanSupplier useExperimental = mock(BooleanSupplier.class);
@@ -48,16 +46,15 @@ public class ExperimentRunningProxyTest {
     private final Clock clock = mock(Clock.class);
     private final AtomicLong errorCounter = new AtomicLong();
 
-    private IntSupplier proxyInstance;
+    private final IntSupplier proxyInstance = intSupplierForProxy(new ExperimentRunningProxy<>(experimentSupplier,
+            fallbackIntSupplier, useExperimental, enableFallback, clock, errorCounter::incrementAndGet));
 
     @Before
     public void setup() {
-        when(experimentSupplier.get()).thenReturn(experimentalIntSupplier).thenReturn(secondExperimentalSupplier);
+        when(experimentSupplier.get()).thenReturn(experimentalIntSupplier);
         returnValueOnExperiment();
         enableFallback();
         setTimeTo(Instant.ofEpochSecond(0));
-        proxyInstance = intSupplierForProxy(new ExperimentRunningProxy<>(experimentSupplier,
-                fallbackIntSupplier, useExperimental, enableFallback, clock, errorCounter::incrementAndGet));
     }
 
     @Test
@@ -144,18 +141,6 @@ public class ExperimentRunningProxyTest {
         assertErrors(3L);
     }
 
-    @Test
-    public void refreshesExperimentalClientAfterEnoughTimeHasPassed() {
-        enableExperiment();
-        assertThat(proxyInstance.getAsInt()).isEqualTo(EXPERIMENTAL_RESULT);
-
-        setTimeTo(Instant.ofEpochSecond(ExperimentRunningProxy.CLIENT_REFRESH_INTERVAL.getSeconds() - 1));
-        assertThat(proxyInstance.getAsInt()).isEqualTo(EXPERIMENTAL_RESULT);
-
-        setTimeTo(Instant.ofEpochSecond(ExperimentRunningProxy.CLIENT_REFRESH_INTERVAL.getSeconds() + 1));
-        assertThat(proxyInstance.getAsInt()).isEqualTo(OTHER_EXPERIMENTAL_RESULT);
-    }
-
     private static IntSupplier intSupplierForProxy(ExperimentRunningProxy<IntSupplier> proxy) {
         return (IntSupplier) Proxy.newProxyInstance(IntSupplier.class.getClassLoader(),
                 new Class[] { IntSupplier.class },
@@ -164,7 +149,6 @@ public class ExperimentRunningProxyTest {
 
     private void returnValueOnExperiment() {
         doReturn(EXPERIMENTAL_RESULT).when(experimentalIntSupplier).getAsInt();
-        doReturn(OTHER_EXPERIMENTAL_RESULT).when(secondExperimentalSupplier).getAsInt();
     }
 
     private void throwOnExperiment() {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
@@ -98,9 +98,9 @@ public final class AtlasDbHttpClients {
             AuxiliaryRemotingParameters clientParameters) {
         TargetFactory.InstanceAndVersion<T> fallbackProxy = fallbackProxySupplier.get();
         try {
-            return VersionSelectingClients.createVersionSelectingClient(
+            return VersionSelectingClients.createVersionSelectingClientWithRefreshingNewClient(
                     metricsManager,
-                    experimentalProxySupplier.get(),
+                    experimentalProxySupplier,
                     fallbackProxy,
                     VersionSelectingConfig.fromRemotingConfigSupplier(clientParameters.remotingClientConfig()),
                     type);

--- a/changelog/@unreleased/pr-4485.v2.yml
+++ b/changelog/@unreleased/pr-4485.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: AtlasDB CJR clients now get recreated every 30 minutes to alleviate
+    an infrequent issue where clients could get locked up.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4485


### PR DESCRIPTION
**Goals (and why)**:
Sometimes CJR clients end up in a bad state, and given that now is a rough time to root cause and fix, this is a stop gap measure to alleviate the issue by recreating CJR clients every 30 minutes.

**Implementation Description (bullets)**:
Pretty straightforward

**Testing (What was existing testing like?  What have you done to improve it?)**:
Unit test that verifies the recreation happens in ERP

**Concerns (what feedback would you like?)**:
Is this enough, and is it correct -- or did I miss something obvious?

**Where should we start reviewing?**:
Anywhere

**Priority (whenever / two weeks / yesterday)**:
ASAP