### PR TITLE
Remove PollingRefreshable from CJR codepath.

### DIFF
--- a/atlasdb-conjure/src/test/java/com/palantir/atlasdb/http/v2/FastFailoverProxyTest.java
+++ b/atlasdb-conjure/src/test/java/com/palantir/atlasdb/http/v2/FastFailoverProxyTest.java
@@ -103,7 +103,7 @@ public class FastFailoverProxyTest {
         RetryableException retryableException = createRetryableException(QosException.retryOther(createUrl()));
         doThrow(retryableException).doNothing().when(longConsumer).accept(42L);
 
-        LongConsumer proxyConsumer = FastFailoverProxy.newProxyInstance(LongConsumer.class, longConsumer, clock);
+        LongConsumer proxyConsumer = FastFailoverProxy.newProxyInstance(LongConsumer.class, () -> longConsumer, clock);
         assertThatCode(() -> proxyConsumer.accept(42L)).doesNotThrowAnyException();
         verify(longConsumer, times(2)).accept(42L);
     }
@@ -148,7 +148,7 @@ public class FastFailoverProxyTest {
     }
 
     private void createProxy() {
-        proxy = FastFailoverProxy.newProxyInstance(BinaryOperator.class, binaryOperator, clock);
+        proxy = FastFailoverProxy.newProxyInstance(BinaryOperator.class, () -> binaryOperator, clock);
     }
 
 

--- a/changelog/@unreleased/pr-4486.v2.yml
+++ b/changelog/@unreleased/pr-4486.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Remediate a thread leak when the we reload the http clients every 30
+    minutes.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4486


### PR DESCRIPTION
**Goals (and why)**:

Remediate a leak when the we reload the http clients every 30 minutes.

**Implementation Description (bullets)**:

Removed the use of PollingRefreshable and instead just use CachedTransformingSupplier. Every request will have to enter a synchronized block to do a reference check on the old set of URLs. I think this should not contend enough to cause issues.

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
