### PR TITLE
Batched off-heap timestamp cache implementation

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/cache/OffHeapTimestampCache.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/cache/OffHeapTimestampCache.java
@@ -1,0 +1,147 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.cache;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+
+import org.immutables.value.Value;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.Futures;
+import com.palantir.atlasdb.autobatch.Autobatchers;
+import com.palantir.atlasdb.autobatch.CoalescingRequestFunction;
+import com.palantir.atlasdb.autobatch.DisruptorAutobatcher;
+import com.palantir.atlasdb.offheap.PersistentTimestampStore;
+import com.palantir.atlasdb.offheap.PersistentTimestampStore.StoreNamespace;
+import com.palantir.common.streams.KeyedStream;
+
+public final class OffHeapTimestampCache implements TimestampCache {
+    private static final String TIMESTAMP_CACHE_NAMESPACE = "timestamp_cache";
+    public static final String BATCHER_PURPOSE = "off-heap-timestamp-cache";
+
+    private final PersistentTimestampStore persistentTimestampStore;
+    private final int maxSize;
+    private final AtomicReference<CacheDescriptor> cacheDescriptor = new AtomicReference<>();
+    private final ConcurrentMap<Long, Long> concurrentHashMap = new ConcurrentHashMap<>();
+    private final DisruptorAutobatcher<Map.Entry<Long, Long>, Map.Entry<Long, Long>> autobatcher;
+
+    public static TimestampCache create(PersistentTimestampStore persistentTimestampStore, int maxSize) {
+        StoreNamespace storeNamespace = persistentTimestampStore.createNamespace(TIMESTAMP_CACHE_NAMESPACE);
+
+        CacheDescriptor cacheDescriptor = ImmutableCacheDescriptor.builder()
+                .currentSize(new AtomicInteger())
+                .storeNamespace(storeNamespace)
+                .build();
+
+        return new OffHeapTimestampCache(persistentTimestampStore, cacheDescriptor, maxSize);
+    }
+
+    private OffHeapTimestampCache(
+            PersistentTimestampStore persistentTimestampStore,
+            CacheDescriptor cacheDescriptor,
+            int maxSize) {
+        this.persistentTimestampStore = persistentTimestampStore;
+        this.cacheDescriptor.set(cacheDescriptor);
+        this.maxSize = maxSize;
+        this.autobatcher = Autobatchers.coalescing(new WriteBatcher(this))
+                .safeLoggablePurpose(BATCHER_PURPOSE)
+                .build();
+    }
+
+    @Override
+    public void clear() {
+        CacheDescriptor proposedCacheDescriptor = constructCacheProposal(persistentTimestampStore);
+
+        CacheDescriptor previous = cacheDescriptor.getAndUpdate(prev -> proposedCacheDescriptor);
+        if (previous != null) {
+            persistentTimestampStore.dropNamespace(previous.storeNamespace());
+        }
+    }
+
+
+    @Override
+    public void putAlreadyCommittedTransaction(Long startTimestamp, Long commitTimestamp) {
+        if (concurrentHashMap.putIfAbsent(startTimestamp, commitTimestamp) != null) {
+            return;
+        }
+        Futures.getUnchecked(autobatcher.apply(Maps.immutableEntry(startTimestamp, commitTimestamp)));
+    }
+
+    @Nullable
+    @Override
+    public Long getCommitTimestampIfPresent(Long startTimestamp) {
+        Long value = concurrentHashMap.get(startTimestamp);
+        if (value != null) {
+            return value;
+        }
+
+        return persistentTimestampStore.get(cacheDescriptor.get().storeNamespace(), startTimestamp);
+    }
+
+    private static class WriteBatcher
+            implements CoalescingRequestFunction<Map.Entry<Long, Long>, Map.Entry<Long, Long>> {
+        OffHeapTimestampCache offHeapTimestampCache;
+
+        WriteBatcher(OffHeapTimestampCache offHeapTimestampCache) {
+            this.offHeapTimestampCache = offHeapTimestampCache;
+        }
+
+        @Override
+        public Map<Map.Entry<Long, Long>, Map.Entry<Long, Long>> apply(Set<Map.Entry<Long, Long>> request) {
+            if (offHeapTimestampCache.cacheDescriptor.get().currentSize().get() >= offHeapTimestampCache.maxSize) {
+                offHeapTimestampCache.clear();
+            }
+
+            Set<Map.Entry<Long, Long>> response = offHeapTimestampCache.persistentTimestampStore.multiGet(
+                    offHeapTimestampCache.cacheDescriptor.get().storeNamespace(),
+                    request.stream().map(Map.Entry::getKey).collect(Collectors.toList()));
+
+            Set<Map.Entry<Long, Long>> toWrite = Sets.difference(request, response);
+            offHeapTimestampCache.persistentTimestampStore.multiPut(
+                    offHeapTimestampCache.cacheDescriptor.get().storeNamespace(),
+                    toWrite);
+
+            offHeapTimestampCache.cacheDescriptor.get().currentSize().addAndGet(toWrite.size());
+            offHeapTimestampCache.concurrentHashMap.clear();
+            return KeyedStream.of(request.stream()).collectToMap();
+        }
+    }
+
+    private static CacheDescriptor constructCacheProposal(PersistentTimestampStore persistentTimestampStore) {
+        StoreNamespace proposal = persistentTimestampStore.createNamespace(TIMESTAMP_CACHE_NAMESPACE);
+        return ImmutableCacheDescriptor.builder()
+                .currentSize(new AtomicInteger())
+                .storeNamespace(proposal)
+                .build();
+    }
+
+    @Value.Immutable
+    @Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+    public interface CacheDescriptor {
+        AtomicInteger currentSize();
+        StoreNamespace storeNamespace();
+    }
+}

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/cache/OffHeapTimestampCache.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/cache/OffHeapTimestampCache.java
@@ -128,11 +128,11 @@ public final class OffHeapTimestampCache implements TimestampCache {
             }
             CacheDescriptor cacheDescriptor = offHeapTimestampCache.cacheDescriptor.get();
             try {
-                Set<Map.Entry<Long, Long>> response = offHeapTimestampCache.persistentTimestampStore.multiGet(
+                Map<Long, Long> response = offHeapTimestampCache.persistentTimestampStore.multiGet(
                         cacheDescriptor.storeNamespace(),
                         request.stream().map(Map.Entry::getKey).collect(Collectors.toList()));
 
-                Set<Map.Entry<Long, Long>> toWrite = Sets.difference(request, response);
+                Set<Map.Entry<Long, Long>> toWrite = Sets.difference(request, response.entrySet());
                 offHeapTimestampCache.persistentTimestampStore.multiPut(
                         cacheDescriptor.storeNamespace(),
                         toWrite);

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/cache/OffHeapTimestampCache.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/cache/OffHeapTimestampCache.java
@@ -138,9 +138,10 @@ public final class OffHeapTimestampCache implements TimestampCache {
                         toWrite);
 
                 cacheDescriptor.currentSize().addAndGet(toWrite.size());
-                offHeapTimestampCache.concurrentHashMap.clear();
             } catch (SafeIllegalArgumentException exception) {
                 log.warn("Clear called concurrently, writing failed");
+            } finally {
+                offHeapTimestampCache.concurrentHashMap.clear();
             }
             return KeyedStream.of(request.stream()).collectToMap();
         }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/offheap/PersistentTimestampStore.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/offheap/PersistentTimestampStore.java
@@ -52,9 +52,9 @@ public interface PersistentTimestampStore extends AutoCloseable {
      *
      * @param storeNamespace handle to the namespace from which we want to retrieve the commit timestamp
      * @param keys representing start timestamps for which to retrieve commit timestamps
-     * @return a map for start to commit timestamp of null if the commit timestamp is not present in cache
+     * @return a map for start to commit timestamp
      */
-    Set<Map.Entry<Long, Long>> multiGet(StoreNamespace storeNamespace, List<Long> keys);
+    Map<Long, Long> multiGet(StoreNamespace storeNamespace, List<Long> keys);
 
     /**
      * Stores the {@code commitTs} for the associated {@code startTs} while overwriting the existing value in the

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/offheap/PersistentTimestampStore.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/offheap/PersistentTimestampStore.java
@@ -18,7 +18,6 @@ package com.palantir.atlasdb.offheap;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 
 import javax.annotation.Nonnull;
@@ -73,11 +72,11 @@ public interface PersistentTimestampStore extends AutoCloseable {
      * Stores the start to commit timestamp pairs given in {@code toWrite}, overwriting the existing values.
      *
      * @param storeNamespace of the store to which we should store the entry
-     * @param toWrite pairs of entries to write
+     * @param toWrite timestamp pairs to write
      * @throws com.palantir.logsafe.exceptions.SafeIllegalArgumentException when {@code storeNamespace} is a
      * handle to a non existing namespace
      */
-    void multiPut(StoreNamespace storeNamespace, Set<Map.Entry<Long, Long>> toWrite);
+    void multiPut(StoreNamespace storeNamespace, Map<Long, Long> toWrite);
 
     /**
      * Creates a handle of type {@link StoreNamespace} with a {@link StoreNamespace#humanReadableName()} equals to

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/offheap/PersistentTimestampStore.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/offheap/PersistentTimestampStore.java
@@ -16,6 +16,9 @@
 
 package com.palantir.atlasdb.offheap;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import javax.annotation.Nonnull;
@@ -44,6 +47,8 @@ public interface PersistentTimestampStore extends AutoCloseable {
     @Nullable
     Long get(StoreNamespace storeNamespace, @Nonnull Long startTs) throws SafeIllegalArgumentException;
 
+    Set<Map.Entry<Long, Long>> multiGet(StoreNamespace storeNamespace, List<Long> keys);
+
     /**
      * Stores the {@code commitTs} for the associated {@code startTs} while overwriting the existing value in the
      * specified {@code storeNamespace}.
@@ -56,6 +61,8 @@ public interface PersistentTimestampStore extends AutoCloseable {
      */
     void put(StoreNamespace storeNamespace, @Nonnull Long startTs, @Nonnull Long commitTs)
             throws SafeIllegalArgumentException;
+
+    void multiPut(StoreNamespace storeNamespace, Set<Map.Entry<Long, Long>> toWrite);
 
     /**
      * Creates a handle of type {@link StoreNamespace} with a {@link StoreNamespace#humanReadableName()} equals to

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/offheap/PersistentTimestampStore.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/offheap/PersistentTimestampStore.java
@@ -47,6 +47,13 @@ public interface PersistentTimestampStore extends AutoCloseable {
     @Nullable
     Long get(StoreNamespace storeNamespace, @Nonnull Long startTs) throws SafeIllegalArgumentException;
 
+    /**
+     * Gets the commit timestamps associated with the entries specified by {@code keys}.
+     *
+     * @param storeNamespace handle to the namespace from which we want to retrieve the commit timestamp
+     * @param keys representing start timestamps for which to retrieve commit timestamps
+     * @return a map for start to commit timestamp of null if the commit timestamp is not present in cache
+     */
     Set<Map.Entry<Long, Long>> multiGet(StoreNamespace storeNamespace, List<Long> keys);
 
     /**
@@ -62,6 +69,14 @@ public interface PersistentTimestampStore extends AutoCloseable {
     void put(StoreNamespace storeNamespace, @Nonnull Long startTs, @Nonnull Long commitTs)
             throws SafeIllegalArgumentException;
 
+    /**
+     * Stores the start to commit timestamp pairs given in {@code toWrite}, overwriting the existing values.
+     *
+     * @param storeNamespace of the store to which we should store the entry
+     * @param toWrite pairs of entries to write
+     * @throws com.palantir.logsafe.exceptions.SafeIllegalArgumentException when {@code storeNamespace} is a
+     * handle to a non existing namespace
+     */
     void multiPut(StoreNamespace storeNamespace, Set<Map.Entry<Long, Long>> toWrite);
 
     /**

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/offheap/rocksdb/RocksDbPersistentTimestampStore.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/offheap/rocksdb/RocksDbPersistentTimestampStore.java
@@ -35,6 +35,8 @@ import org.rocksdb.RocksDBException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Streams;
 import com.palantir.atlasdb.offheap.ImmutableStoreNamespace;
@@ -89,6 +91,10 @@ public final class RocksDbPersistentTimestampStore implements PersistentTimestam
         List<byte[]> byteValues = multiGetValueBytes(
                 availableColumnFamilies.get(storeNamespace.uniqueName()),
                 byteKeys);
+
+        if (byteValues.isEmpty()) {
+            return ImmutableSet.of();
+        }
 
         return KeyedStream.ofEntries(
                 Streams.zip(
@@ -177,7 +183,7 @@ public final class RocksDbPersistentTimestampStore implements PersistentTimestam
             return rocksDB.multiGetAsList(Collections.nCopies(keys.size(), columnFamilyHandle), keys);
         } catch (RocksDBException exception) {
             log.warn("Rocks db raised an exception", exception);
-            return null;
+            return ImmutableList.of();
         }
     }
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/offheap/rocksdb/RocksDbPersistentTimestampStore.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/offheap/rocksdb/RocksDbPersistentTimestampStore.java
@@ -82,13 +82,13 @@ public final class RocksDbPersistentTimestampStore implements PersistentTimestam
                 availableColumnFamilies.containsKey(storeNamespace.uniqueName()),
                 "Store namespace does not exist");
 
-        List<byte[]> byteKeyValues = keys.stream()
+        List<byte[]> byteKeys = keys.stream()
                 .map(ValueType.VAR_LONG::convertFromJava)
                 .collect(Collectors.toList());
 
         List<byte[]> byteValues = multiGetValueBytes(
                 availableColumnFamilies.get(storeNamespace.uniqueName()),
-                byteKeyValues);
+                byteKeys);
 
         return KeyedStream.ofEntries(
                 Streams.zip(
@@ -96,7 +96,7 @@ public final class RocksDbPersistentTimestampStore implements PersistentTimestam
                         byteValues.stream(),
                         (key, value) -> {
                             if (value == null) {
-                                return null;
+                                return Maps.immutableEntry(key, null);
                             }
                             return Maps.immutableEntry(
                                     key, key + (Long) ValueType.VAR_LONG.convertToJava(value, 0));

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/cache/OffHeapTimestampCacheIntegrationTests.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/cache/OffHeapTimestampCacheIntegrationTests.java
@@ -66,7 +66,7 @@ public final class OffHeapTimestampCacheIntegrationTests {
     }
 
     @Test
-    public void cacheNuked() {
+    public void cacheNukedWhenSizeLimitExceeded() {
         offHeapTimestampCache.putAlreadyCommittedTransaction(1L, 3L);
         offHeapTimestampCache.putAlreadyCommittedTransaction(2L, 4L);
         offHeapTimestampCache.putAlreadyCommittedTransaction(5L, 6L);

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/cache/OffHeapTimestampCacheIntegrationTests.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/cache/OffHeapTimestampCacheIntegrationTests.java
@@ -1,0 +1,87 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+
+import com.palantir.atlasdb.offheap.PersistentTimestampStore;
+import com.palantir.atlasdb.offheap.rocksdb.RocksDbPersistentTimestampStore;
+
+public final class OffHeapTimestampCacheIntegrationTests {
+    @ClassRule
+    public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+    private static final int CACHE_SIZE = 2;
+
+    private TimestampCache offHeapTimestampCache;
+    private PersistentTimestampStore persistentTimestampStore;
+
+    @Before
+    public void before() throws RocksDBException, IOException {
+        RocksDB rocksDb = RocksDB.open(TEMPORARY_FOLDER.newFolder().getAbsolutePath());
+
+        persistentTimestampStore = new RocksDbPersistentTimestampStore(rocksDb);
+
+        offHeapTimestampCache = OffHeapTimestampCache.create(persistentTimestampStore, CACHE_SIZE);
+    }
+
+    @After
+    public void after() throws Exception {
+        persistentTimestampStore.close();
+    }
+
+    @Test
+    public void cachedEntry() {
+        offHeapTimestampCache.putAlreadyCommittedTransaction(1L, 3L);
+
+        assertThat(offHeapTimestampCache.getCommitTimestampIfPresent(1L)).isEqualTo(3L);
+    }
+
+    @Test
+    public void nonCachedEntry() {
+        assertThat(offHeapTimestampCache.getCommitTimestampIfPresent(1L)).isNull();
+    }
+
+    @Test
+    public void cacheNuked() {
+        offHeapTimestampCache.putAlreadyCommittedTransaction(1L, 3L);
+        offHeapTimestampCache.putAlreadyCommittedTransaction(2L, 4L);
+        offHeapTimestampCache.putAlreadyCommittedTransaction(5L, 6L);
+
+        assertThat(offHeapTimestampCache.getCommitTimestampIfPresent(1L)).isNull();
+        assertThat(offHeapTimestampCache.getCommitTimestampIfPresent(2L)).isNull();
+        assertThat(offHeapTimestampCache.getCommitTimestampIfPresent(5L)).isEqualTo(6L);
+    }
+
+    @Test
+    public void clearCache() {
+        offHeapTimestampCache.putAlreadyCommittedTransaction(1L, 3L);
+        assertThat(offHeapTimestampCache.getCommitTimestampIfPresent(1L)).isEqualTo(3L);
+
+        offHeapTimestampCache.clear();
+        assertThat(offHeapTimestampCache.getCommitTimestampIfPresent(1L)).isNull();
+    }
+}

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/offheap/rocksdb/RocksDbPersistentTimestampStoreTests.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/offheap/rocksdb/RocksDbPersistentTimestampStoreTests.java
@@ -30,6 +30,7 @@ import org.junit.rules.TemporaryFolder;
 import org.rocksdb.RocksDB;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.offheap.ImmutableStoreNamespace;
 import com.palantir.atlasdb.offheap.PersistentTimestampStore;
@@ -126,10 +127,9 @@ public final class RocksDbPersistentTimestampStoreTests {
         timestampMappingStore.put(defaultNamespace, 3L, 4L);
 
         assertThat(timestampMappingStore.multiGet(defaultNamespace, ImmutableList.of(1L, 2L, 3L)))
-                .containsExactlyInAnyOrder(
-                        entry(1L, 2L),
-                        entry(3L, 4L),
-                        entry(2L, null)
+                .containsExactlyInAnyOrderEntriesOf(ImmutableMap.of(
+                        1L, 2L,
+                        3L, 4L)
                 );
     }
 }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/offheap/rocksdb/RocksDbPersistentTimestampStoreTests.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/offheap/rocksdb/RocksDbPersistentTimestampStoreTests.java
@@ -18,7 +18,6 @@ package com.palantir.atlasdb.offheap.rocksdb;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.entry;
 
 import java.util.UUID;
 
@@ -31,7 +30,6 @@ import org.rocksdb.RocksDB;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.offheap.ImmutableStoreNamespace;
 import com.palantir.atlasdb.offheap.PersistentTimestampStore;
 import com.palantir.atlasdb.offheap.PersistentTimestampStore.StoreNamespace;
@@ -115,7 +113,7 @@ public final class RocksDbPersistentTimestampStoreTests {
     public void testMultiPut() {
         timestampMappingStore.multiPut(
                 defaultNamespace,
-                ImmutableSet.of(entry(1L, 2L), entry(3L, 4L)));
+                ImmutableMap.of(1L, 2L, 3L, 4L));
 
         assertThat(timestampMappingStore.get(defaultNamespace, 1L)).isEqualTo(2L);
         assertThat(timestampMappingStore.get(defaultNamespace, 3L)).isEqualTo(4L);


### PR DESCRIPTION
**Goals (and why)**:
Implementation of an off heap cache with write buffering
**Implementation Description (bullets)**:
- using batching to simplify the concurrency model

**Testing (What was existing testing like?  What have you done to improve it?)**:
- added simple integration tests

**Concerns (what feedback would you like?)**:
- somebody calling clear during a write

**Where should we start reviewing?**:
- `OffHeapTimestampCache`

**Priority (whenever / two weeks / yesterday)**:
- by Wednesday
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
