### PR TITLE
Throwables.rewrap does not attempt to replace stack frames

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/common/base/Throwables.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/base/Throwables.java
@@ -212,7 +212,6 @@ public final class Throwables {
                     return chain(rv, throwable);
                 }
             }
-            addCurrentStackIfRewrapFails(throwable);
             return throwable;
 
         } catch (Exception e) {
@@ -258,17 +257,6 @@ public final class Throwables {
                 printwriter.println((new StringBuilder()).append("\tat ").append(elements[i]).toString());
             }
 
-        }
-    }
-
-    private static void addCurrentStackIfRewrapFails(Throwable ex) {
-        if (ex != null) {
-            StackTraceElement[] thisThreadStack = new Throwable().getStackTrace();
-            StackTraceElement[] exisitingStack = ex.getStackTrace();
-            StackTraceElement[] combinedStack = new StackTraceElement[exisitingStack.length + thisThreadStack.length];
-            System.arraycopy(exisitingStack, 0, combinedStack, 0, exisitingStack.length);
-            System.arraycopy(thisThreadStack, 0, combinedStack, exisitingStack.length, thisThreadStack.length);
-            ex.setStackTrace(combinedStack);
         }
     }
 }

--- a/atlasdb-commons/src/test/java/com/palantir/common/base/ThrowablesTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/common/base/ThrowablesTest.java
@@ -17,7 +17,6 @@ package com.palantir.common.base;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -61,7 +60,7 @@ public class ThrowablesTest {
             NoUsefulConstructorException wrapped = Throwables.rewrap(e);
             assertSame(e, wrapped);
             int sizeAfter = e.getStackTrace().length;
-            assertTrue(sizeAfter + " should be > " + sizeBefore, sizeAfter > sizeBefore);
+            assertEquals(sizeAfter, sizeBefore);
         }
     }
 


### PR DESCRIPTION
The old behaviuor lead to unreadable stack traces that are not
helpful for debugging. For an example, add a dependency on
`slf4j-simple` in `leader-election-impl/build.gradle` and run
PaxosConsensusFastTest. It takes a very long time to run, and
the stack trace doesn't make sense.