### PR TITLE
[Timelock Partitioning] Part 44f: More metrics fixes

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
@@ -130,6 +130,7 @@ public final class Leaders {
                 metricsManager.getTaggedRegistry(),
                 leaderUuid.toString(),
                 leadershipObserver,
+                ImmutableList.of(),
                 ImmutableList.of());
 
         PaxosAcceptor ourAcceptor = AtlasDbMetrics.instrumentTimed(metricsManager.getRegistry(),

--- a/changelog/@unreleased/pr-4494.v2.yml
+++ b/changelog/@unreleased/pr-4494.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Metrics should now be produced with the new Timelock Partitioning code
+    path.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4494

--- a/leader-election-impl/src/main/java/com/palantir/leader/LeadershipEvents.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/LeadershipEvents.java
@@ -48,8 +48,11 @@ class LeadershipEvents {
     private final Meter leaderPingReturnedFalse;
     private final Object[] contextArgs;
 
-    LeadershipEvents(TaggedMetricRegistry metrics, List<SafeArg<String>> contextArgs) {
-        Map<String, String> safeTags = safeTags(contextArgs);
+    LeadershipEvents(
+            TaggedMetricRegistry metrics,
+            List<SafeArg<String>> safeLoggingArgs,
+            List<SafeArg<String>> safeMetricArgs) {
+        Map<String, String> safeTags = safeTags(safeMetricArgs);
         gainedLeadership = metrics.meter(withName("leadership.gained", safeTags));
         lostLeadership = metrics.meter(withName("leadership.lost", safeTags));
         noQuorum = metrics.meter(withName("leadership.no-quorum", safeTags));
@@ -58,7 +61,7 @@ class LeadershipEvents {
         leaderPingFailure = metrics.meter(withName("leadership.ping-leader.failure", safeTags));
         leaderPingTimeout = metrics.meter(withName("leadership.ping-leader.timeout", safeTags));
         leaderPingReturnedFalse = metrics.meter(withName("leadership.ping-leader.returned-false", safeTags));
-        this.contextArgs = contextArgs.toArray(new Object[0]);
+        this.contextArgs = safeLoggingArgs.toArray(new Object[0]);
     }
 
     void proposedLeadershipFor(long round) {

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeadershipEventRecorder.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeadershipEventRecorder.java
@@ -38,16 +38,17 @@ public class PaxosLeadershipEventRecorder implements PaxosKnowledgeEventRecorder
     @GuardedBy("this") private boolean isLeading = false;
 
     public static PaxosLeadershipEventRecorder create(TaggedMetricRegistry metrics, String leaderUuid) {
-        return create(metrics, leaderUuid, null, ImmutableList.of());
+        return create(metrics, leaderUuid, null, ImmutableList.of(), ImmutableList.of());
     }
 
     public static PaxosLeadershipEventRecorder create(
             TaggedMetricRegistry metrics,
             String leaderUuid,
             @Nullable LeadershipObserver observer,
-            List<SafeArg<String>> safeArgs) {
+            List<SafeArg<String>> safeLoggingArgs,
+            List<SafeArg<String>> safeMetricArgs) {
         return new PaxosLeadershipEventRecorder(
-                new LeadershipEvents(metrics, safeArgs),
+                new LeadershipEvents(metrics, safeLoggingArgs, safeMetricArgs),
                 leaderUuid,
                 Optional.ofNullable(observer));
     }

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
@@ -34,6 +34,7 @@ import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.server.jersey.ConjureJerseyFeature;
 import com.palantir.timelock.paxos.TimeLockAgent;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 
 import io.dropwizard.Application;
 import io.dropwizard.jersey.optional.EmptyOptionalException;
@@ -53,6 +54,8 @@ public class TimeLockServerLauncher extends Application<CombinedTimeLockServerCo
         new TimeLockServerLauncher().run(args);
     }
 
+    private final TaggedMetricRegistry taggedMetricRegistry = new DefaultTaggedMetricRegistry();
+
     @Override
     public void initialize(Bootstrap<CombinedTimeLockServerConfiguration> bootstrap) {
         MetricRegistry metricRegistry = SharedMetricRegistries
@@ -71,7 +74,7 @@ public class TimeLockServerLauncher extends Application<CombinedTimeLockServerCo
         environment.jersey().register(ConjureJerseyFeature.INSTANCE);
         environment.jersey().register(new EmptyOptionalTo204ExceptionMapper());
 
-        MetricsManager metricsManager = MetricsManagers.of(environment.metrics(), new DefaultTaggedMetricRegistry());
+        MetricsManager metricsManager = MetricsManagers.of(environment.metrics(), taggedMetricRegistry);
         Consumer<Object> registrar = component -> environment.jersey().register(component);
 
         TimeLockAgent timeLockAgent = TimeLockAgent.create(
@@ -94,6 +97,10 @@ public class TimeLockServerLauncher extends Application<CombinedTimeLockServerCo
                 timeLockAgent.shutdown();
             }
         });
+    }
+
+    public TaggedMetricRegistry taggedMetricRegistry() {
+        return taggedMetricRegistry;
     }
 
     @Provider

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Maps;
 import com.palantir.atlasdb.timelock.NamespacedClients.ProxyFactory;
 import com.palantir.atlasdb.timelock.util.TestProxies;
 import com.palantir.leader.PingableLeader;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 
 public class TestableTimelockServer {
 
@@ -55,6 +56,10 @@ public class TestableTimelockServer {
 
     NamespacedClients client(String namespace) {
         return clientsByNamespace.computeIfAbsent(namespace, key -> NamespacedClients.from(namespace, proxyFactory));
+    }
+
+    public TaggedMetricRegistry taggedMetricRegistry() {
+        return serverHolder.getTaggedMetricsRegistry();
     }
 
     private static final class SingleNodeProxyFactory implements ProxyFactory {

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TimeLockServerHolder.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TimeLockServerHolder.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.palantir.atlasdb.timelock.config.CombinedTimeLockServerConfiguration;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 
 import io.dropwizard.testing.DropwizardTestSupport;
 
@@ -75,6 +76,10 @@ public class TimeLockServerHolder extends ExternalResource {
         checkTimelockPortInitialised();
         // TODO(nziebart): hack
         return "https://localhost:" + timelockPort;
+    }
+
+    public TaggedMetricRegistry getTaggedMetricsRegistry() {
+        return ((TimeLockServerLauncher) timelockServer.getApplication()).taggedMetricRegistry();
     }
 
     private void checkTimelockPortInitialised() {


### PR DESCRIPTION
**Goals (and why)**:
So, introduction of the new code path for partitioning makes use of hierarchical metric registries. `LeadershipEvents`, is a class that just logs/tracks metrics of events pertaining to leadership. 

The issue here is that loggers are not hierarchical, and it would be nice to know the context we're in + the client we're talking for. Hence we pass both the `paxosUseCase` and the `client` as `namespaceArgs`. However, the metric registry that is passed in *is* a child registry keyed by `paxosUseCase`, so including the `paxosUseCase` as a safe tag to a metric that will be inserted into its parent with keyed by that is an error and we get the following exception:

```
c.p.logsafe.e.SIAE: Base must not contain the extra key that is to be added
	at com.palantir.logsafe.Preconditions.checkArgument(Preconditions.java:52)
	at com.palantir.tritium.metrics.registry.ExtraEntrySortedMap.<init>(ExtraEntrySortedMap.java:53)
	at com.palantir.tritium.metrics.registry.RealMetricName.create(RealMetricName.java:81)
	at com.palantir.tritium.metrics.registry.AbstractTaggedMetricRegistry.lambda$getMetrics$3(AbstractTaggedMetricRegistry.java:156)
	at com.google.common.collect.RegularImmutableMap.forEach(RegularImmutableMap.java:154)
	at com.palantir.tritium.metrics.registry.AbstractTaggedMetricRegistry.lambda$getMetrics$4(AbstractTaggedMetricRegistry.java:155)
	at java.util.concurrent.ConcurrentHashMap.forEach(ConcurrentHashMap.java:1597)
	at com.palantir.tritium.metrics.registry.AbstractTaggedMetricRegistry.getMetrics(AbstractTaggedMetricRegistry.java:154)
	...
```

**Implementation Description (bullets)**:
* Leadership events now takes in a logging safe args and a metrics safe args. A bit janky, but don't want to leak timelock implementation details into `leader-election-impl`.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added the ability to get the `TaggedMetricRegistry` from Dropwizard. Added a smoke test/sanity check that we're able to iterate through the tagged metric registry. This was failing before I added the fix.

**Priority (whenever / two weeks / yesterday)**:
ASAP

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
