### PR TITLE
[LW] Part 8: Limit LWEL window size wrt number of Lock Descriptors

### DIFF
--- a/lock-api/src/main/java/com/palantir/lock/watch/LockEvent.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/LockEvent.java
@@ -38,6 +38,11 @@ public abstract class LockEvent implements LockWatchEvent {
     public abstract LockToken lockToken();
 
     @Override
+    public int size() {
+        return lockDescriptors().size();
+    }
+
+    @Override
     public <T> T accept(Visitor<T> visitor) {
         return visitor.visit(this);
     }

--- a/lock-api/src/main/java/com/palantir/lock/watch/LockWatchCreatedEvent.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/LockWatchCreatedEvent.java
@@ -36,6 +36,11 @@ public abstract class LockWatchCreatedEvent implements LockWatchEvent {
     public abstract LockWatchRequest request();
 
     @Override
+    public int size() {
+        return request().references().size();
+    }
+
+    @Override
     public <T> T accept(Visitor<T> visitor) {
         return visitor.visit(this);
     }

--- a/lock-api/src/main/java/com/palantir/lock/watch/LockWatchEvent.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/LockWatchEvent.java
@@ -16,6 +16,7 @@
 
 package com.palantir.lock.watch;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
@@ -27,6 +28,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
         @JsonSubTypes.Type(value = ImmutableLockWatchCreatedEvent.class, name = LockWatchCreatedEvent.TYPE)})
 public interface LockWatchEvent {
     long sequence();
+    int size();
     <T> T accept(Visitor<T> visitor);
 
     interface Builder {

--- a/lock-api/src/main/java/com/palantir/lock/watch/LockWatchEvent.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/LockWatchEvent.java
@@ -16,7 +16,6 @@
 
 package com.palantir.lock.watch;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 

--- a/lock-api/src/main/java/com/palantir/lock/watch/LockWatchOpenLocksEvent.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/LockWatchOpenLocksEvent.java
@@ -38,6 +38,11 @@ public abstract class LockWatchOpenLocksEvent implements LockWatchEvent {
     public abstract Set<LockDescriptor> lockDescriptors();
 
     @Override
+    public int size() {
+        return lockDescriptors().size();
+    }
+
+    @Override
     public <T> T accept(LockWatchEvent.Visitor<T> visitor) {
         return visitor.visit(this);
     }

--- a/lock-api/src/main/java/com/palantir/lock/watch/LockWatchStateUpdate.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/LockWatchStateUpdate.java
@@ -49,7 +49,8 @@ public interface LockWatchStateUpdate {
         if (!events().isEmpty()) {
             Preconditions.checkState(lastKnownVersion().isPresent(),
                     "If events are present, last known version must be present as well.");
-            Preconditions.checkState(events().get(events().size() - 1).sequence() == lastKnownVersion().getAsLong(),
+            LockWatchEvent lastEvent = events().get(events().size() - 1);
+            Preconditions.checkState(lastEvent.sequence() + lastEvent.size() - 1 == lastKnownVersion().getAsLong(),
                     "The sequence of the last event and the last known version must match");
         }
     }

--- a/lock-api/src/main/java/com/palantir/lock/watch/LockWatchStateUpdate.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/LockWatchStateUpdate.java
@@ -40,17 +40,12 @@ public interface LockWatchStateUpdate {
     List<LockWatchEvent> events();
 
     @Value.Check
-    default void successHasLastKnownVersion() {
-        Preconditions.checkState(!success() || lastKnownVersion().isPresent(), "Success must have a version.");
-    }
-
-    @Value.Check
     default void lastEventSequenceMatchesLastKnownVersion() {
         if (!events().isEmpty()) {
             Preconditions.checkState(lastKnownVersion().isPresent(),
                     "If events are present, last known version must be present as well.");
             LockWatchEvent lastEvent = events().get(events().size() - 1);
-            Preconditions.checkState(lastEvent.sequence() + lastEvent.size() - 1 == lastKnownVersion().getAsLong(),
+            Preconditions.checkState(lastEvent.sequence() == lastKnownVersion().getAsLong(),
                     "The sequence of the last event and the last known version must match");
         }
     }

--- a/lock-api/src/main/java/com/palantir/lock/watch/UnlockEvent.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/UnlockEvent.java
@@ -36,6 +36,11 @@ public abstract class UnlockEvent implements LockWatchEvent {
     public abstract Set<LockDescriptor> lockDescriptors();
 
     @Override
+    public int size() {
+        return lockDescriptors().size();
+    }
+
+    @Override
     public <T> T accept(Visitor<T> visitor) {
         return visitor.visit(this);
     }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/ArrayLockEventSlidingWindow.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/ArrayLockEventSlidingWindow.java
@@ -136,8 +136,8 @@ public class ArrayLockEventSlidingWindow {
     }
 
     private Optional<List<LockWatchEvent>> validateConsistencyOrReturnEmpty(long version, List<LockWatchEvent> events) {
-        for (int i = 1; i <= events.size(); i++) {
-            if (events.get(i).sequence() != version + i) {
+        for (int i = 0; i < events.size(); i++) {
+            if (events.get(i).sequence() != version + i + 1) {
                 return Optional.empty();
             }
         }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/ArrayLockEventSlidingWindow.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/ArrayLockEventSlidingWindow.java
@@ -51,11 +51,11 @@ public class ArrayLockEventSlidingWindow {
      */
     public synchronized void add(LockWatchEvent.Builder eventBuilder) {
         LockWatchEvent event = eventBuilder.build(nextSequence);
-        Preconditions.checkArgument(event.size() <= maxSize);
         int index = LongMath.mod(nextSequence, maxSize);
         buffer[index] = event;
         nextSequence = nextSequence + event.size();
-        for (int i = 1; i < event.size(); i++) {
+        int lastIndex = Math.min(event.size(), maxSize);
+        for (int i = 1; i < lastIndex; i++) {
             index = incrementAndMod(index);
             buffer[index] = PlaceholderLockWatchEvent.INSTANCE;
         }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockEventLogImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockEventLogImpl.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.v2.LockToken;
@@ -46,8 +47,10 @@ public class LockEventLogImpl implements LockEventLog {
             return LockWatchStateUpdate.failure(leaderId, slidingWindow.getVersion());
         }
         List<LockWatchEvent> events = maybeEvents.get();
-        return LockWatchStateUpdate
-                .of(leaderId, true, OptionalLong.of(fromVersion.getAsLong() + events.size()), events);
+        return LockWatchStateUpdate.of(leaderId,true, OptionalLong.of(fromVersion.getAsLong() + events.size()),
+                events.stream()
+                        .filter(event -> event != PlaceholderLockWatchEvent.INSTANCE)
+                        .collect(Collectors.toList()));
     }
 
     @Override

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockEventLogImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockEventLogImpl.java
@@ -34,8 +34,9 @@ import com.palantir.lock.watch.LockWatchStateUpdate;
 import com.palantir.lock.watch.UnlockEvent;
 
 public class LockEventLogImpl implements LockEventLog {
+    final static int WINDOW_SIZE = 1000;
     private final UUID leaderId = UUID.randomUUID();
-    private final ArrayLockEventSlidingWindow slidingWindow = new ArrayLockEventSlidingWindow(1000);
+    private final ArrayLockEventSlidingWindow slidingWindow = new ArrayLockEventSlidingWindow(WINDOW_SIZE);
 
     @Override
     public LockWatchStateUpdate getLogDiff(OptionalLong fromVersion) {

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockEventLogImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockEventLogImpl.java
@@ -16,18 +16,14 @@
 
 package com.palantir.atlasdb.timelock.lock.watch;
 
-import java.util.List;
-import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.watch.LockEvent;
 import com.palantir.lock.watch.LockWatchCreatedEvent;
-import com.palantir.lock.watch.LockWatchEvent;
 import com.palantir.lock.watch.LockWatchOpenLocksEvent;
 import com.palantir.lock.watch.LockWatchRequest;
 import com.palantir.lock.watch.LockWatchStateUpdate;

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/PlaceholderLockWatchEvent.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/PlaceholderLockWatchEvent.java
@@ -1,0 +1,42 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.lock.watch;
+
+import com.palantir.lock.watch.LockWatchEvent;
+
+public final class PlaceholderLockWatchEvent implements LockWatchEvent {
+    public static final LockWatchEvent INSTANCE = new PlaceholderLockWatchEvent();
+
+    private PlaceholderLockWatchEvent() {
+        // hidden
+    }
+
+    @Override
+    public long sequence() {
+        return 0;
+    }
+
+    @Override
+    public int size() {
+        return 0;
+    }
+
+    @Override
+    public <T> T accept(Visitor<T> visitor) {
+        return null;
+    }
+}

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/PlaceholderLockWatchEvent.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/PlaceholderLockWatchEvent.java
@@ -19,7 +19,8 @@ package com.palantir.atlasdb.timelock.lock.watch;
 import com.palantir.lock.watch.LockWatchEvent;
 
 public final class PlaceholderLockWatchEvent implements LockWatchEvent {
-    public static final LockWatchEvent INSTANCE = new PlaceholderLockWatchEvent();
+    // This is effectively a LockWatchEvent tombstone
+    static final LockWatchEvent INSTANCE = new PlaceholderLockWatchEvent();
 
     private PlaceholderLockWatchEvent() {
         // hidden
@@ -27,7 +28,7 @@ public final class PlaceholderLockWatchEvent implements LockWatchEvent {
 
     @Override
     public long sequence() {
-        return 0;
+        return -1;
     }
 
     @Override

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/lock/watch/LockEventLogImplTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/lock/watch/LockEventLogImplTest.java
@@ -1,0 +1,21 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.lock.watch;
+
+public class LockEventLogImplTest {
+
+}

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/lock/watch/LockEventLogImplTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/lock/watch/LockEventLogImplTest.java
@@ -16,6 +16,148 @@
 
 package com.palantir.atlasdb.timelock.lock.watch;
 
-public class LockEventLogImplTest {
+import static org.assertj.core.api.Assertions.assertThat;
 
+import static com.palantir.atlasdb.timelock.lock.watch.LockEventLogImpl.WINDOW_SIZE;
+
+import java.util.OptionalLong;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.Test;
+
+import com.palantir.lock.LockDescriptor;
+import com.palantir.lock.StringLockDescriptor;
+import com.palantir.lock.v2.LockToken;
+import com.palantir.lock.watch.LockEvent;
+import com.palantir.lock.watch.LockWatchEvent;
+import com.palantir.lock.watch.LockWatchStateUpdate;
+
+public class LockEventLogImplTest {
+    private long nextSequence = 0;
+    private final LockEventLog log = new LockEventLogImpl();
+
+    @Test
+    public void test() {
+        LockWatchEvent loggedEvent = logLocks(100);
+
+        LockWatchStateUpdate updateWithNoFromVersion = log.getLogDiff(OptionalLong.empty());
+        assertThat(updateWithNoFromVersion.success()).isFalse();
+        assertThat(updateWithNoFromVersion.events()).isEmpty();
+        assertThat(updateWithNoFromVersion.lastKnownVersion()).isEqualTo(OptionalLong.of(loggedEvent.size() - 1));
+    }
+
+    @Test
+    public void getFromBeginningSingleEvent() {
+        LockWatchEvent loggedEvent = logLocks(100);
+
+        LockWatchStateUpdate updateWithNoFromVersion = log.getLogDiff(OptionalLong.of(-1));
+        assertThat(updateWithNoFromVersion.success()).isTrue();
+        assertThat(updateWithNoFromVersion.events()).containsExactly(loggedEvent);
+        assertThat(updateWithNoFromVersion.lastKnownVersion()).isEqualTo(OptionalLong.of(loggedEvent.size() - 1));
+    }
+
+    @Test
+    public void getFromMiddleOfSingleEvent() {
+        LockWatchEvent loggedEvent = logLocks(100);
+
+        LockWatchStateUpdate updateWithNoFromVersion = log.getLogDiff(OptionalLong.of(loggedEvent.size() - 10));
+        assertThat(updateWithNoFromVersion.success()).isTrue();
+        assertThat(updateWithNoFromVersion.events()).isEmpty();
+        assertThat(updateWithNoFromVersion.lastKnownVersion()).isEqualTo(OptionalLong.of(loggedEvent.size() - 1));
+    }
+
+    @Test
+    public void getFromAfterSingleEvent() {
+        LockWatchEvent loggedEvent = logLocks(100);
+
+        LockWatchStateUpdate updateWithNoFromVersion = log.getLogDiff(OptionalLong.of(loggedEvent.size() + 10));
+        assertThat(updateWithNoFromVersion.success()).isFalse();
+        assertThat(updateWithNoFromVersion.events()).isEmpty();
+        assertThat(updateWithNoFromVersion.lastKnownVersion()).isEqualTo(OptionalLong.of(loggedEvent.size() - 1));
+    }
+
+    @Test
+    public void getFromBeginningMultipleEvents() {
+        LockWatchEvent firstEvent = logLocks(200);
+        LockWatchEvent secondEvent = logLocks(100);
+        LockWatchEvent thirdEvent = logLocks(300);
+
+        LockWatchStateUpdate updateWithNoFromVersion = log.getLogDiff(OptionalLong.of(-1));
+        assertThat(updateWithNoFromVersion.success()).isTrue();
+        assertThat(updateWithNoFromVersion.events()).containsExactly(firstEvent, secondEvent, thirdEvent);
+        assertThat(updateWithNoFromVersion.lastKnownVersion())
+                .isEqualTo(OptionalLong.of(firstEvent.size() + secondEvent.size() + thirdEvent.size() - 1));
+    }
+
+    @Test
+    public void getFromEndOfFirstEvent() {
+        LockWatchEvent firstEvent = logLocks(200);
+        LockWatchEvent secondEvent = logLocks(100);
+        LockWatchEvent thirdEvent = logLocks(300);
+
+        LockWatchStateUpdate updateWithNoFromVersion = log.getLogDiff(OptionalLong.of(firstEvent.size() - 1));
+        assertThat(updateWithNoFromVersion.success()).isTrue();
+        assertThat(updateWithNoFromVersion.events()).containsExactly(secondEvent, thirdEvent);
+        assertThat(updateWithNoFromVersion.lastKnownVersion())
+                .isEqualTo(OptionalLong.of(firstEvent.size() + secondEvent.size() + thirdEvent.size() - 1));
+    }
+
+    @Test
+    public void getFromMiddleOfFirstEvent() {
+        LockWatchEvent firstEvent = logLocks(200);
+        LockWatchEvent secondEvent = logLocks(100);
+        LockWatchEvent thirdEvent = logLocks(300);
+
+        LockWatchStateUpdate updateWithNoFromVersion = log.getLogDiff(OptionalLong.of(firstEvent.size() - 100));
+        assertThat(updateWithNoFromVersion.success()).isTrue();
+        assertThat(updateWithNoFromVersion.events()).containsExactly(secondEvent, thirdEvent);
+        assertThat(updateWithNoFromVersion.lastKnownVersion())
+                .isEqualTo(OptionalLong.of(firstEvent.size() + secondEvent.size() + thirdEvent.size() - 1));
+    }
+
+    @Test
+    public void fillUpBuffer() {
+        LockWatchEvent firstEvent = logLocks(500);
+        LockWatchEvent secondEvent = logLocks(400);
+        LockWatchEvent thirdEvent = logLocks(500);
+        LockWatchEvent fourthEvent = logLocks(100);
+        int numDescriptors = firstEvent.size() + secondEvent.size() + thirdEvent.size() + fourthEvent.size();
+
+        LockWatchStateUpdate updateWithNoFromVersion = log.getLogDiff(OptionalLong.of(numDescriptors - 950));
+        assertThat(updateWithNoFromVersion.success()).isTrue();
+        assertThat(updateWithNoFromVersion.events()).containsExactly(thirdEvent, fourthEvent);
+        assertThat(updateWithNoFromVersion.lastKnownVersion()).isEqualTo(OptionalLong.of(numDescriptors - 1));
+    }
+
+    @Test
+    public void hugeEvent() {
+        LockWatchEvent event = logLocks(WINDOW_SIZE * 2);
+
+        LockWatchStateUpdate update = log.getLogDiff(OptionalLong.of(-1));
+        assertThat(update.success()).isTrue();
+        assertThat(update.events()).containsExactly(event);
+        assertThat(update.lastKnownVersion()).isEqualTo(OptionalLong.of(event.size() - 1));
+    }
+
+    private LockWatchEvent logLocks(int numDescriptors) {
+        Set<LockDescriptor> descriptors = generateDescriptors(numDescriptors);
+        LockToken token = generateToken();
+        log.logLock(descriptors, token);
+        LockWatchEvent event = LockEvent.builder(descriptors, token).build(nextSequence);
+        nextSequence = nextSequence + numDescriptors;
+        return event;
+    }
+
+    private static Set<LockDescriptor> generateDescriptors(int num) {
+        return IntStream.range(0, num)
+                .mapToObj(ignore -> StringLockDescriptor.of(UUID.randomUUID().toString()))
+                .collect(Collectors.toSet());
+    }
+
+    private static LockToken generateToken() {
+        return LockToken.of(UUID.randomUUID());
+    }
 }


### PR DESCRIPTION
**Goals (and why)**:
Limit the size of lock watch event log window in terms of the number of lock descriptors and lock watch requests that are tracked.

**Implementation Description (bullets)**:
We maintain the size of all events in the window, when a new event is added that makes us go over the limit, we evict old events until we are under the limit again.
 
**Testing (What was existing testing like?  What have you done to improve it?)**:
Added more tests for both the log and the sliding window classes.

**Concerns (what feedback would you like?)**:
The concurrency is now slightly more complex than before, is it still understandable?

Do we want to do something along the lines of always maintaining a few events in the window, regardless of large events? Currently, a single large event evicts everything else, and then gets evicted itself on the first new event added, almost certainly causing clients to miss out on the updates.

The maximum size of 1000 is a random choice, we should actually figure out what is a reasonable value for this constant.

**Where should we start reviewing?**:

Either dig directly into `ArrayLockEventSlidingWindow.java` or read through the tests first

**Priority (whenever / two weeks / yesterday)**:
After the previous links in the chain
