### PR TITLE
[Timelock Partitioning] Part 44g: Use client scoped metrics registries.

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
@@ -130,7 +130,6 @@ public final class Leaders {
                 metricsManager.getTaggedRegistry(),
                 leaderUuid.toString(),
                 leadershipObserver,
-                ImmutableList.of(),
                 ImmutableList.of());
 
         PaxosAcceptor ourAcceptor = AtlasDbMetrics.instrumentTimed(metricsManager.getRegistry(),

--- a/leader-election-impl/src/main/java/com/palantir/leader/LeadershipEvents.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/LeadershipEvents.java
@@ -16,14 +16,12 @@
 package com.palantir.leader;
 
 import java.util.List;
-import java.util.Map;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.Meter;
-import com.palantir.common.streams.KeyedStream;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.paxos.PaxosRoundFailureException;
 import com.palantir.paxos.PaxosValue;
@@ -48,19 +46,15 @@ class LeadershipEvents {
     private final Meter leaderPingReturnedFalse;
     private final Object[] contextArgs;
 
-    LeadershipEvents(
-            TaggedMetricRegistry metrics,
-            List<SafeArg<String>> safeLoggingArgs,
-            List<SafeArg<String>> safeMetricArgs) {
-        Map<String, String> safeTags = safeTags(safeMetricArgs);
-        gainedLeadership = metrics.meter(withName("leadership.gained", safeTags));
-        lostLeadership = metrics.meter(withName("leadership.lost", safeTags));
-        noQuorum = metrics.meter(withName("leadership.no-quorum", safeTags));
-        proposedLeadership = metrics.meter(withName("leadership.proposed", safeTags));
-        proposalFailure = metrics.meter(withName("leadership.proposed.failure", safeTags));
-        leaderPingFailure = metrics.meter(withName("leadership.ping-leader.failure", safeTags));
-        leaderPingTimeout = metrics.meter(withName("leadership.ping-leader.timeout", safeTags));
-        leaderPingReturnedFalse = metrics.meter(withName("leadership.ping-leader.returned-false", safeTags));
+    LeadershipEvents(TaggedMetricRegistry metrics, List<SafeArg<String>> safeLoggingArgs) {
+        gainedLeadership = metrics.meter(withName("leadership.gained"));
+        lostLeadership = metrics.meter(withName("leadership.lost"));
+        noQuorum = metrics.meter(withName("leadership.no-quorum"));
+        proposedLeadership = metrics.meter(withName("leadership.proposed"));
+        proposalFailure = metrics.meter(withName("leadership.proposed.failure"));
+        leaderPingFailure = metrics.meter(withName("leadership.ping-leader.failure"));
+        leaderPingTimeout = metrics.meter(withName("leadership.ping-leader.timeout"));
+        leaderPingReturnedFalse = metrics.meter(withName("leadership.ping-leader.returned-false"));
         this.contextArgs = safeLoggingArgs.toArray(new Object[0]);
     }
 
@@ -118,17 +112,8 @@ class LeadershipEvents {
         }
     }
 
-    private static MetricName withName(String name, Map<String, String> safeTags) {
-        return MetricName.builder()
-                .safeName(name)
-                .safeTags(safeTags)
-                .build();
+    private static MetricName withName(String name) {
+        return MetricName.builder().safeName(name).build();
     }
 
-    private static Map<String, String> safeTags(List<SafeArg<String>> contextArgs) {
-        return KeyedStream.of(contextArgs)
-                .mapKeys(SafeArg::getName)
-                .map(SafeArg::getValue)
-                .collectToMap();
-    }
 }

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeadershipEventRecorder.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeadershipEventRecorder.java
@@ -38,17 +38,16 @@ public class PaxosLeadershipEventRecorder implements PaxosKnowledgeEventRecorder
     @GuardedBy("this") private boolean isLeading = false;
 
     public static PaxosLeadershipEventRecorder create(TaggedMetricRegistry metrics, String leaderUuid) {
-        return create(metrics, leaderUuid, null, ImmutableList.of(), ImmutableList.of());
+        return create(metrics, leaderUuid, null, ImmutableList.of());
     }
 
     public static PaxosLeadershipEventRecorder create(
             TaggedMetricRegistry metrics,
             String leaderUuid,
             @Nullable LeadershipObserver observer,
-            List<SafeArg<String>> safeLoggingArgs,
-            List<SafeArg<String>> safeMetricArgs) {
+            List<SafeArg<String>> safeLoggingArgs) {
         return new PaxosLeadershipEventRecorder(
-                new LeadershipEvents(metrics, safeLoggingArgs, safeMetricArgs),
+                new LeadershipEvents(metrics, safeLoggingArgs),
                 leaderUuid,
                 Optional.ofNullable(observer));
     }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/ClientScopedMetrics.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/ClientScopedMetrics.java
@@ -1,0 +1,59 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.Maps;
+import com.palantir.atlasdb.AtlasDbMetricNames;
+import com.palantir.atlasdb.util.MetricsManager;
+import com.palantir.atlasdb.util.MetricsManagers;
+import com.palantir.tritium.metrics.registry.MetricName;
+import com.palantir.tritium.metrics.registry.SlidingWindowTaggedMetricRegistry;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+
+public class ClientScopedMetrics {
+
+    private final TaggedMetricRegistry parentRegistry;
+    private final Map<Client, MetricsManager> clientScopedMetricRegistry = Maps.newConcurrentMap();
+
+    ClientScopedMetrics(TaggedMetricRegistry parentRegistry) {
+        this.parentRegistry = parentRegistry;
+    }
+
+    public TaggedMetricRegistry metricRegistryForClient(Client client) {
+        return getOrCreateMetricsManager(client).getTaggedRegistry();
+    }
+
+    public void deregisterMetric(Client client, Predicate<MetricName> metricNamePredicate) {
+        getOrCreateMetricsManager(client).deregisterTaggedMetrics(metricNamePredicate);
+    }
+
+    private MetricsManager getOrCreateMetricsManager(Client client) {
+        return clientScopedMetricRegistry.computeIfAbsent(client, this::createScopedMetricsManager);
+    }
+
+    private MetricsManager createScopedMetricsManager(Client client) {
+        TaggedMetricRegistry childRegistry = new SlidingWindowTaggedMetricRegistry(35, TimeUnit.SECONDS);
+        parentRegistry.addMetrics(AtlasDbMetricNames.TAG_CLIENT, client.value(), childRegistry);
+        return MetricsManagers.of(new MetricRegistry(), childRegistry);
+    }
+
+}


### PR DESCRIPTION
**Goals (and why)**:
Go one level deeper for `TaggedMetricRegistries`. Reverts most of the new code in #4494. 

**Implementation Description (bullets)**:
* Have a `ClientScopedMetrics` class that when given a "parent" registry, creates new registries keyed by the `Client` - or more aptly named "namespace" - in the parent registry. 

**Testing (What was existing testing like?  What have you done to improve it?)**:
Existing metrics test should pass.

**Where should we start reviewing?**:
Anywhere.

**Priority (whenever / two weeks / yesterday)**:
Whenever, what's in develop is correct, this just tidies things up.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
