### PR TITLE
Actually disable concurrency limiting.

### DIFF
--- a/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/ClientOptions.java
+++ b/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/ClientOptions.java
@@ -94,6 +94,7 @@ public abstract class ClientOptions {
                 .failedUrlCooldown(failedUrlCooldown())
                 .enableGcmCipherSuites(true)
                 .fallbackToCommonNameVerification(true)
+                .clientQoS(clientQoS())
                 .build();
     }
 

--- a/changelog/@unreleased/pr-4500.v2.yml
+++ b/changelog/@unreleased/pr-4500.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Actually disable concurrency limiting.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4500

--- a/changelog/@unreleased/pr-4500.v2.yml
+++ b/changelog/@unreleased/pr-4500.v2.yml
@@ -1,5 +1,5 @@
 type: improvement
 improvement:
-  description: Actually disable concurrency limiting.
+  description: Actually disable concurrency limiting for connections to Timelock.
   links:
   - https://github.com/palantir/atlasdb/pull/4500


### PR DESCRIPTION
**Goals (and why)**:

*ClientOptions* currently has a field for clientQos to disable it. But the factory method #serverListToClient used by AtlasDB clients (so clients of timelock) did not actually propagate that setting to com.palantir.conjure.java.client.config.ClientConfiguration. Meaning that since this codepath became the default, concurrency limiting has been enabled. Timelock itself does not send 429s, but concurrency limiters also have an adaptive mechanism, where they slowly release new permits: effectively slowing us down, where we know we don't want this for timelock.

Therefore, the code was simply incomplete.

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
