### PR TITLE
[Timelock Partitioning] Part 49: Granular health checks.

### DIFF
--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/Dependencies.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/Dependencies.java
@@ -74,7 +74,7 @@ public interface Dependencies {
         com.palantir.atlasdb.timelock.paxos.NetworkClientFactories networkClientFactories();
     }
 
-    interface LeaderPingHealthCheck {
+    interface HealthCheckPinger {
         LocalPaxosComponents components();
         PaxosRemoteClients remoteClients();
     }

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipContextFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipContextFactory.java
@@ -17,6 +17,7 @@
 package com.palantir.atlasdb.timelock.paxos;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.UUID;
 
 import org.immutables.value.Value;
@@ -28,7 +29,6 @@ import com.palantir.leader.PaxosLeadershipEventRecorder;
 import com.palantir.leader.PingableLeader;
 import com.palantir.paxos.LeaderPinger;
 import com.palantir.paxos.PaxosLearner;
-import com.palantir.timelock.paxos.LeaderPingHealthCheck;
 
 @Value.Immutable
 public abstract class LeadershipContextFactory implements
@@ -36,11 +36,11 @@ public abstract class LeadershipContextFactory implements
         Dependencies.NetworkClientFactories,
         Dependencies.LeaderPinger,
         Dependencies.ClientAwareComponents,
-        Dependencies.LeaderPingHealthCheck {
+        Dependencies.HealthCheckPinger {
 
     abstract PaxosResourcesFactory.TimelockPaxosInstallationContext install();
     abstract Factories.LeaderPingerFactory leaderPingerFactory();
-    abstract Factories.LeaderPingHealthCheckFactory leaderPingHealthCheckFactory();
+    abstract Factories.LeaderPingHealthCheckFactory healthCheckPingersFactory();
     abstract NetworkClientFactories.Builder networkClientFactoryBuilder();
 
     @Value.Derived
@@ -78,8 +78,8 @@ public abstract class LeadershipContextFactory implements
     }
 
     @Value.Derived
-    LeaderPingHealthCheck leaderPingHealthCheck() {
-        return leaderPingHealthCheckFactory().create(this);
+    List<com.palantir.timelock.paxos.HealthCheckPinger> healthCheckPingers() {
+        return healthCheckPingersFactory().create(this);
     }
 
     @Value.Derived

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResources.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResources.java
@@ -50,7 +50,7 @@ public abstract class PaxosResources {
 
     @Value.Derived
     public LeadershipComponents leadershipComponents() {
-        return new LeadershipComponents(leadershipContextFactory(), leadershipContextFactory().leaderPingHealthCheck());
+        return new LeadershipComponents(leadershipContextFactory(), leadershipContextFactory().healthCheckPingers());
     }
 
     private static BatchPaxosResources batchResourcesForUseCase(

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/SingleLeaderHealthCheckPinger.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/SingleLeaderHealthCheckPinger.java
@@ -1,0 +1,40 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.Maps;
+import com.palantir.leader.PingableLeader;
+import com.palantir.timelock.paxos.HealthCheckPinger;
+import com.palantir.timelock.paxos.HealthCheckResponse;
+
+public class SingleLeaderHealthCheckPinger implements HealthCheckPinger {
+
+    private final PingableLeader pingableLeader;
+
+    public SingleLeaderHealthCheckPinger(PingableLeader pingableLeader) {
+        this.pingableLeader = pingableLeader;
+    }
+
+    @Override
+    public Map<Client, HealthCheckResponse> apply(Set<Client> request) {
+        boolean isLeader = pingableLeader.ping();
+        return Maps.toMap(request, _client -> new HealthCheckResponse(isLeader));
+    }
+}

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/HealthCheckDigest.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/HealthCheckDigest.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,16 @@
  * limitations under the License.
  */
 
-package com.palantir.atlasdb.timelock.paxos;
+package com.palantir.timelock.paxos;
 
-import java.util.List;
+import org.immutables.value.Value;
 
-import com.palantir.paxos.LeaderPinger;
-import com.palantir.timelock.paxos.HealthCheckPinger;
+import com.google.common.collect.SetMultimap;
+import com.palantir.atlasdb.timelock.paxos.Client;
+import com.palantir.timelock.TimeLockStatus;
 
-public interface Factories {
-    interface LeaderPingerFactory {
-        LeaderPinger create(Dependencies.LeaderPinger dependencies);
-    }
-
-    interface LeaderPingHealthCheckFactory {
-        List<HealthCheckPinger> create(Dependencies.HealthCheckPinger dependencies);
-    }
+@Value.Immutable
+public interface HealthCheckDigest {
+    @Value.Parameter
+    SetMultimap<TimeLockStatus, Client> statusesToClient();
 }

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/HealthCheckPinger.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/HealthCheckPinger.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,9 @@
  * limitations under the License.
  */
 
-package com.palantir.atlasdb.timelock.paxos;
+package com.palantir.timelock.paxos;
 
-import java.util.List;
+import com.palantir.atlasdb.autobatch.CoalescingRequestFunction;
+import com.palantir.atlasdb.timelock.paxos.Client;
 
-import com.palantir.paxos.LeaderPinger;
-import com.palantir.timelock.paxos.HealthCheckPinger;
-
-public interface Factories {
-    interface LeaderPingerFactory {
-        LeaderPinger create(Dependencies.LeaderPinger dependencies);
-    }
-
-    interface LeaderPingHealthCheckFactory {
-        List<HealthCheckPinger> create(Dependencies.HealthCheckPinger dependencies);
-    }
-}
+public interface HealthCheckPinger extends CoalescingRequestFunction<Client, HealthCheckResponse> { }

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/HealthCheckResponse.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/HealthCheckResponse.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,24 @@
  * limitations under the License.
  */
 
-package com.palantir.atlasdb.timelock.paxos;
+package com.palantir.timelock.paxos;
 
-import java.util.List;
+import com.palantir.paxos.PaxosResponse;
 
-import com.palantir.paxos.LeaderPinger;
-import com.palantir.timelock.paxos.HealthCheckPinger;
+public final class HealthCheckResponse implements PaxosResponse {
 
-public interface Factories {
-    interface LeaderPingerFactory {
-        LeaderPinger create(Dependencies.LeaderPinger dependencies);
+    private final boolean isLeader;
+
+    public HealthCheckResponse(boolean isLeader) {
+        this.isLeader = isLeader;
     }
 
-    interface LeaderPingHealthCheckFactory {
-        List<HealthCheckPinger> create(Dependencies.HealthCheckPinger dependencies);
+    @Override
+    public boolean isSuccessful() {
+        return true;
+    }
+
+    public boolean isLeader() {
+        return isLeader;
     }
 }

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/NamespaceTracker.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/NamespaceTracker.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,12 @@
  * limitations under the License.
  */
 
-package com.palantir.atlasdb.timelock.paxos;
+package com.palantir.timelock.paxos;
 
-import java.util.List;
+import java.util.Set;
 
-import com.palantir.paxos.LeaderPinger;
-import com.palantir.timelock.paxos.HealthCheckPinger;
+import com.palantir.atlasdb.timelock.paxos.Client;
 
-public interface Factories {
-    interface LeaderPingerFactory {
-        LeaderPinger create(Dependencies.LeaderPinger dependencies);
-    }
-
-    interface LeaderPingHealthCheckFactory {
-        List<HealthCheckPinger> create(Dependencies.HealthCheckPinger dependencies);
-    }
+public interface NamespaceTracker {
+    Set<Client> trackedNamespaces();
 }

--- a/timelock-agent/src/test/java/com/palantir/timelock/paxos/LeaderPingHealthCheckTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/paxos/LeaderPingHealthCheckTest.java
@@ -19,94 +19,176 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.Maps;
+import com.google.common.collect.SetMultimap;
 import com.palantir.atlasdb.http.errors.AtlasDbRemoteException;
-import com.palantir.leader.PingableLeader;
+import com.palantir.atlasdb.timelock.paxos.Client;
 import com.palantir.timelock.TimeLockStatus;
 
 public class LeaderPingHealthCheckTest {
 
+    private static final Client CLIENT1 = Client.of("client-1");
+    private static final Client CLIENT2 = Client.of("client-2");
+    private static final Client CLIENT3 = Client.of("client-3");
+    private static final Set<Client> ALL_CLIENTS = ImmutableSet.of(CLIENT1, CLIENT2, CLIENT3);
+    private static final NamespaceTracker TRACKER = () -> ALL_CLIENTS;
+
     @Test
     public void shouldBeUnhealthyIfAllNodesPingedSuccessfully() {
-        ImmutableSet<PingableLeader> leaders = getPingableLeaders(true, true, true);
-        assertThat(new LeaderPingHealthCheck(leaders).getStatus()).isEqualTo(TimeLockStatus.MULTIPLE_LEADERS);
+        List<HealthCheckPinger> leaders = getHealthCheckPingers(ALL_CLIENTS, ALL_CLIENTS, ALL_CLIENTS);
+
+        SetMultimap<TimeLockStatus, Client> expected = ImmutableSetMultimap.<TimeLockStatus, Client>builder()
+                .putAll(TimeLockStatus.MULTIPLE_LEADERS, ALL_CLIENTS)
+                .build();
+
+        assertThat(new LeaderPingHealthCheck(TRACKER, leaders).getStatus().statusesToClient())
+                .isEqualTo(expected);
     }
 
     @Test
     public void shouldBeUnhealthyIfMultipleNodesPingedSuccessfully() {
-        ImmutableSet<PingableLeader> leaders = getPingableLeaders(true, true, false);
-        assertThat(new LeaderPingHealthCheck(leaders).getStatus()).isEqualTo(TimeLockStatus.MULTIPLE_LEADERS);
+        List<HealthCheckPinger> leaders = getHealthCheckPingers(ALL_CLIENTS, ALL_CLIENTS, ImmutableSet.of());
+
+        SetMultimap<TimeLockStatus, Client> expected = ImmutableSetMultimap.<TimeLockStatus, Client>builder()
+                .putAll(TimeLockStatus.MULTIPLE_LEADERS, ALL_CLIENTS)
+                .build();
+
+        assertThat(new LeaderPingHealthCheck(TRACKER, leaders).getStatus().statusesToClient())
+                .isEqualTo(expected);
     }
 
     @Test
     public void shouldBeHealthyIfExactlyOneNodePingedSuccessfully() {
-        ImmutableSet<PingableLeader> leaders = getPingableLeaders(true, false, false);
-        assertThat(new LeaderPingHealthCheck(leaders).getStatus()).isEqualTo(TimeLockStatus.ONE_LEADER);
+        List<HealthCheckPinger> leaders = getHealthCheckPingers(ALL_CLIENTS, ImmutableSet.of(), ImmutableSet.of());
+
+        SetMultimap<TimeLockStatus, Client> expected = ImmutableSetMultimap.<TimeLockStatus, Client>builder()
+                .putAll(TimeLockStatus.ONE_LEADER, ALL_CLIENTS)
+                .build();
+
+        assertThat(new LeaderPingHealthCheck(TRACKER, leaders).getStatus().statusesToClient())
+                .isEqualTo(expected);
     }
 
     @Test
     public void shouldBeUnhealthyIfNoNodesPingedSuccessfully() {
-        ImmutableSet<PingableLeader> leaders = getPingableLeaders(false, false, false);
-        assertThat(new LeaderPingHealthCheck(leaders).getStatus()).isEqualTo(TimeLockStatus.NO_LEADER);
+        List<HealthCheckPinger> leaders =
+                getHealthCheckPingers(ImmutableSet.of(), ImmutableSet.of(), ImmutableSet.of());
+
+        SetMultimap<TimeLockStatus, Client> expected = ImmutableSetMultimap.<TimeLockStatus, Client>builder()
+                .putAll(TimeLockStatus.NO_LEADER, ALL_CLIENTS)
+                .build();
+
+        assertThat(new LeaderPingHealthCheck(TRACKER, leaders).getStatus().statusesToClient())
+                .isEqualTo(expected);
     }
 
     @Test
     public void shouldBeHealthyIfQuorumNodesUpAndOnePingedSuccessfully() {
-        PingableLeader leader1 = getMockOfPingableLeaderWherePingReturns(true);
-        PingableLeader leader2 = getMockOfPingableLeaderWherePingReturns(false);
-        PingableLeader leader3 = getMockOfPingableLeaderWherePingThrows();
-        ImmutableSet<PingableLeader> leaders = ImmutableSet.of(leader1, leader2, leader3);
-        assertThat(new LeaderPingHealthCheck(leaders).getStatus()).isEqualTo(TimeLockStatus.ONE_LEADER);
+        HealthCheckPinger leader1 = getMockOfPingableLeaderWherePingReturns(ALL_CLIENTS);
+        HealthCheckPinger leader2 = getMockOfPingableLeaderWherePingReturns(ImmutableSet.of());
+        HealthCheckPinger leader3 = getMockOfPingableLeaderWherePingThrows();
+        List<HealthCheckPinger> leaders = ImmutableList.of(leader1, leader2, leader3);
+
+        SetMultimap<TimeLockStatus, Client> expected = ImmutableSetMultimap.<TimeLockStatus, Client>builder()
+                .putAll(TimeLockStatus.ONE_LEADER, ALL_CLIENTS)
+                .build();
+
+        assertThat(new LeaderPingHealthCheck(TRACKER, leaders).getStatus().statusesToClient())
+                .isEqualTo(expected);
     }
 
     @Test
     public void shouldBeUnhealthyIfQuorumNodesAreUpAndNoNodePingedSuccessfully() {
-        PingableLeader leader1 = getMockOfPingableLeaderWherePingReturns(false);
-        PingableLeader leader2 = getMockOfPingableLeaderWherePingReturns(false);
-        PingableLeader leader3 = getMockOfPingableLeaderWherePingThrows();
-        ImmutableSet<PingableLeader> leaders = ImmutableSet.of(leader1, leader2, leader3);
-        assertThat(new LeaderPingHealthCheck(leaders).getStatus()).isEqualTo(TimeLockStatus.NO_LEADER);
+        HealthCheckPinger leader1 = getMockOfPingableLeaderWherePingReturns(ImmutableSet.of());
+        HealthCheckPinger leader2 = getMockOfPingableLeaderWherePingReturns(ImmutableSet.of());
+        HealthCheckPinger leader3 = getMockOfPingableLeaderWherePingThrows();
+        List<HealthCheckPinger> leaders = ImmutableList.of(leader1, leader2, leader3);
+
+        SetMultimap<TimeLockStatus, Client> expected = ImmutableSetMultimap.<TimeLockStatus, Client>builder()
+                .putAll(TimeLockStatus.NO_LEADER, ALL_CLIENTS)
+                .build();
+
+        assertThat(new LeaderPingHealthCheck(TRACKER, leaders).getStatus().statusesToClient())
+                .isEqualTo(expected);
     }
 
     @Test
     public void shouldBeUnhealthyIfQuorumNodesAreNotUpAndOnePingedSuccessfully() {
-        PingableLeader leader1 = getMockOfPingableLeaderWherePingReturns(true);
-        PingableLeader leader2 = getMockOfPingableLeaderWherePingThrows();
-        PingableLeader leader3 = getMockOfPingableLeaderWherePingThrows();
-        ImmutableSet<PingableLeader> leaders = ImmutableSet.of(leader1, leader2, leader3);
-        assertThat(new LeaderPingHealthCheck(leaders).getStatus()).isEqualTo(TimeLockStatus.NO_QUORUM);
+        HealthCheckPinger leader1 = getMockOfPingableLeaderWherePingReturns(ALL_CLIENTS);
+        HealthCheckPinger leader2 = getMockOfPingableLeaderWherePingThrows();
+        HealthCheckPinger leader3 = getMockOfPingableLeaderWherePingThrows();
+        List<HealthCheckPinger> leaders = ImmutableList.of(leader1, leader2, leader3);
+
+        SetMultimap<TimeLockStatus, Client> expected = ImmutableSetMultimap.<TimeLockStatus, Client>builder()
+                .putAll(TimeLockStatus.NO_QUORUM, ALL_CLIENTS)
+                .build();
+
+        assertThat(new LeaderPingHealthCheck(TRACKER, leaders).getStatus().statusesToClient())
+                .isEqualTo(expected);
     }
 
     @Test
     public void shouldBeUnhealthyIfQuorumNodesAreNotUpAndNoNodePingedSuccessfully() {
-        PingableLeader leader1 = getMockOfPingableLeaderWherePingReturns(false);
-        PingableLeader leader2 = getMockOfPingableLeaderWherePingThrows();
-        PingableLeader leader3 = getMockOfPingableLeaderWherePingThrows();
-        ImmutableSet<PingableLeader> leaders = ImmutableSet.of(leader1, leader2, leader3);
-        assertThat(new LeaderPingHealthCheck(leaders).getStatus()).isEqualTo(TimeLockStatus.NO_QUORUM);
+        HealthCheckPinger leader1 = getMockOfPingableLeaderWherePingReturns(ImmutableSet.of());
+        HealthCheckPinger leader2 = getMockOfPingableLeaderWherePingThrows();
+        HealthCheckPinger leader3 = getMockOfPingableLeaderWherePingThrows();
+        List<HealthCheckPinger> leaders = ImmutableList.of(leader1, leader2, leader3);
+
+        SetMultimap<TimeLockStatus, Client> expected = ImmutableSetMultimap.<TimeLockStatus, Client>builder()
+                .putAll(TimeLockStatus.NO_QUORUM, ALL_CLIENTS)
+                .build();
+
+        assertThat(new LeaderPingHealthCheck(TRACKER, leaders).getStatus().statusesToClient())
+                .isEqualTo(expected);
     }
 
-    private static ImmutableSet<PingableLeader> getPingableLeaders(
-            boolean pingResultForLeader1,
-            boolean pingResultForLeader2,
-            boolean pingResultForLeader3) {
-        PingableLeader leader1 = getMockOfPingableLeaderWherePingReturns(pingResultForLeader1);
-        PingableLeader leader2 = getMockOfPingableLeaderWherePingReturns(pingResultForLeader2);
-        PingableLeader leader3 = getMockOfPingableLeaderWherePingReturns(pingResultForLeader3);
-        return ImmutableSet.of(leader1, leader2, leader3);
+    @Test
+    public void canHandleIndividualClientsSeperately() {
+        List<HealthCheckPinger> leaders = getHealthCheckPingers(
+                ImmutableSet.of(CLIENT1),
+                ImmutableSet.of(CLIENT3),
+                ImmutableSet.of(CLIENT3));
+
+        SetMultimap<TimeLockStatus, Client> expected = ImmutableSetMultimap.<TimeLockStatus, Client>builder()
+                .put(TimeLockStatus.ONE_LEADER, CLIENT1)
+                .put(TimeLockStatus.NO_LEADER, CLIENT2)
+                .put(TimeLockStatus.MULTIPLE_LEADERS, CLIENT3)
+                .build();
+
+        assertThat(new LeaderPingHealthCheck(TRACKER, leaders).getStatus().statusesToClient())
+                .isEqualTo(expected);
     }
 
-    private static PingableLeader getMockOfPingableLeaderWherePingReturns(boolean pingResult) {
-        PingableLeader mockLeader = mock(PingableLeader.class);
-        when(mockLeader.ping()).thenReturn(pingResult);
+    private static List<HealthCheckPinger> getHealthCheckPingers(
+            Set<Client> pingResultForLeader1,
+            Set<Client> pingResultForLeader2,
+            Set<Client> pingResultForLeader3) {
+        HealthCheckPinger leader1 = getMockOfPingableLeaderWherePingReturns(pingResultForLeader1);
+        HealthCheckPinger leader2 = getMockOfPingableLeaderWherePingReturns(pingResultForLeader2);
+        HealthCheckPinger leader3 = getMockOfPingableLeaderWherePingReturns(pingResultForLeader3);
+        return ImmutableList.of(leader1, leader2, leader3);
+    }
+
+    private static HealthCheckPinger getMockOfPingableLeaderWherePingReturns(Set<Client> pingResult) {
+        HealthCheckPinger mockLeader = mock(HealthCheckPinger.class);
+        Map<Client, HealthCheckResponse> response =
+                Maps.toMap(ALL_CLIENTS, client -> new HealthCheckResponse(pingResult.contains(client)));
+        when(mockLeader.apply(ALL_CLIENTS)).thenReturn(response);
         return mockLeader;
     }
 
-    private static PingableLeader getMockOfPingableLeaderWherePingThrows() {
-        PingableLeader mockLeader = mock(PingableLeader.class);
-        when(mockLeader.ping()).thenThrow(mock(AtlasDbRemoteException.class));
+    private static HealthCheckPinger getMockOfPingableLeaderWherePingThrows() {
+        HealthCheckPinger mockLeader = mock(HealthCheckPinger.class);
+        when(mockLeader.apply(ALL_CLIENTS)).thenThrow(mock(AtlasDbRemoteException.class));
         return mockLeader;
     }
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimeLockResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimeLockResource.java
@@ -15,9 +15,11 @@
  */
 package com.palantir.atlasdb.timelock;
 
+import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -29,6 +31,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.palantir.atlasdb.timelock.lock.watch.LockWatchingResource;
+import com.palantir.atlasdb.timelock.paxos.Client;
 import com.palantir.atlasdb.timelock.paxos.PaxosTimeLockConstants;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.lock.LockService;
@@ -102,6 +105,10 @@ public class TimeLockResource {
 
     public int getMaxNumberOfClients() {
         return maxNumberOfClients.get();
+    }
+
+    public Set<Client> getActiveClients() {
+        return servicesByNamespace.keySet().stream().map(Client::of).collect(Collectors.toSet());
     }
 
     private TimeLockServices createNewClient(String namespace) {


### PR DESCRIPTION
**Goals (and why)**:
The current health checks don't really make any sense with multiple leaders for different clients. 

There are two ways to think about it:
* Are a quorum of nodes up?
* Of the clients that I'm aware of (active nodes) is there a node who believes that they are the leader for it?

**Implementation Description (bullets)**:
* I've gone with the second route.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Modified existing tests to do be in terms of clients. Added another test to see different clients tracked separately.

**Concerns (what feedback would you like?)**:
A bit of a break for internal timelock, but should be addressed later. Is there any reason why we don't just 

**Where should we start reviewing?**:
* `LeaderPingHealthCheck(Test)`
* `NamespaceTracker`

**Priority (whenever / two weeks / yesterday)**:
ASAP, since this is blocking/conflicting with merging the other stuff in.
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
