### PR TITLE
Fix potential flake in CassandraTimestampsEteTest

### DIFF
--- a/changelog/@unreleased/pr-4513.v2.yml
+++ b/changelog/@unreleased/pr-4513.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix a potential flake in CassandraTimestampsEteTest.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4513


### PR DESCRIPTION
**Goals (and why)**:
This ETE test uses the estimated droppable tombstones ratio from the sstablesmetadata output to determine if tombstones exist in a table.  This is not a very precise method, and a not-yet-identified change in Cassandra 3 makes this metric significantly less reliable and causes the test to flake.

To illustrate the problem, consider this output of sstablesmetadata from a run of the ETE test:
```
WARN  19:02:16,885 Only 51.302GiB free across all data volumes. Consider adding more capacity to your cluster or removing obsolete snapshots
SSTable: /var/lib/cassandra/data/atlasete/default__namespacedTodo-41e1e4da596b32afb88934ae3310ccf4/md-1-big
Estimated droppable tombstones: 0.0
Estimated tombstone drop times:
1579114980:         2
```

This table has 2 tombstones, which are estimated to drop at 1579114980, which is 01/15/2020 @ 7:03:00pm (UTC).  However, the metadata was requested at 19:02:16,885, which is 44 seconds before the drop time.  Assuming gc_grace = 0 (which is the default for sstablemetadata), the estimated droppable tombstones would be reported as zero.

On disk, the tombstones have a local delete time of 2020-01-15T19:02:08Z.  So my theory is that this is an artifact of the imprecision of the histogram that calculates the drop times.

**Implementation Description (bullets)**:

The test is actually trying to determine if tombstones exist at all.  Rather than use estimated droppable tombstone ratio, we can use a different metric, "estimated tombstone drop times", which is a listing of all tombstones and their drop times.  This metric is not dependent on various timing artifacts, and gives us a result closer to the spirit of what we want.

**Testing (What was existing testing like?  What have you done to improve it?)**:

This is a test :).  I've validated that this improvement works in Cassandra 2 and eliminates flakes in Cassandra 3.

**Concerns (what feedback would you like?)**:

There is a slight change to Cassandra 4 sstablemetadata output that will require a change to the parsing.  But we'll cross that bridge when we get there :)

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
