### PR TITLE
[Timelock Partitioning] Part 50: Wire up multi leader paxos

### DIFF
--- a/scripts/circle-ci/run-circle-tests.sh
+++ b/scripts/circle-ci/run-circle-tests.sh
@@ -16,13 +16,13 @@ CONTAINER_1=(':atlasdb-cassandra-integration-tests:check')
 
 CONTAINER_2=(':atlasdb-ete-tests:check')
 
-CONTAINER_3=(':atlasdb-dbkvs:check' ':atlasdb-cassandra:check')
+CONTAINER_3=(':atlasdb-dbkvs:check' ':atlasdb-cassandra:check' ':timelock-server:integTest')
 
-CONTAINER_4=(':atlasdb-cassandra-multinode-tests:check' ':atlasdb-impl-shared:check' ':atlasdb-tests-shared:check' ':atlasdb-perf:check')
+CONTAINER_4=(':atlasdb-cassandra-multinode-tests:check' ':atlasdb-impl-shared:check' ':atlasdb-tests-shared:check' ':atlasdb-perf:check' ':atlasdb-ete-tests:dbkvsTest')
 
 CONTAINER_5=(':lock-impl:check' ':atlasdb-dbkvs-tests:check' ':atlasdb-ete-test-utils:check' ':atlasdb-ete-tests:longTest')
 
-CONTAINER_6=(':atlasdb-ete-tests:dbkvsTest' ':timelock-server:integTest' ':timelock-server:suiteTest')
+CONTAINER_6=(':timelock-server:suiteTest')
 
 CONTAINER_7=('compileJava' 'compileTestJava' ':atlasdb-refactorings:test')
 

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/Dependencies.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/Dependencies.java
@@ -57,7 +57,7 @@ public interface Dependencies {
         PaxosUseCase useCase();
         TimelockPaxosMetrics metrics();
         UUID leaderUuid();
-        com.palantir.paxos.LeaderPinger leaderPinger();
+        Factories.LeaderPingerFactory leaderPingerFactory();
         com.palantir.atlasdb.timelock.paxos.NetworkClientFactories networkClientFactories();
         Supplier<PaxosRuntimeConfiguration> runtime();
         AutobatchingLeadershipObserverFactory leadershipObserverFactory();

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/Dependencies.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/Dependencies.java
@@ -57,7 +57,7 @@ public interface Dependencies {
         PaxosUseCase useCase();
         TimelockPaxosMetrics metrics();
         UUID leaderUuid();
-        Factories.LeaderPingerFactory leaderPingerFactory();
+        Factories.LeaderPingerFactoryContainer leaderPingerFactory();
         com.palantir.atlasdb.timelock.paxos.NetworkClientFactories networkClientFactories();
         Supplier<PaxosRuntimeConfiguration> runtime();
         AutobatchingLeadershipObserverFactory leadershipObserverFactory();

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/Factories.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/Factories.java
@@ -16,17 +16,48 @@
 
 package com.palantir.atlasdb.timelock.paxos;
 
+import java.io.Closeable;
 import java.util.List;
 
+import org.immutables.value.Value;
+
+import com.google.common.collect.Maps;
+import com.palantir.atlasdb.timelock.paxos.NetworkClientFactories.Factory;
 import com.palantir.paxos.LeaderPinger;
+import com.palantir.paxos.SingleLeaderPinger;
 import com.palantir.timelock.paxos.HealthCheckPinger;
 
 public interface Factories {
     interface LeaderPingerFactory {
-        LeaderPinger create(Dependencies.LeaderPinger dependencies);
+        Factory<LeaderPinger> get();
+        List<Closeable> closeables();
+
+        interface Builder {
+            Builder from(Dependencies.LeaderPinger dependencies);
+            LeaderPingerFactory build();
+        }
     }
 
     interface LeaderPingHealthCheckFactory {
         List<HealthCheckPinger> create(Dependencies.HealthCheckPinger dependencies);
+    }
+
+    @Value.Immutable
+    abstract class SingleLeaderPingerFactory implements LeaderPingerFactory, Dependencies.LeaderPinger {
+
+        @Value.Derived
+        SingleLeaderPinger pinger() {
+            return new SingleLeaderPinger(
+                    Maps.toMap(remoteClients().nonBatchPingableLeadersWithContext(), _pingable -> sharedExecutor()),
+                    leaderPingResponseWait(),
+                    leaderUuid());
+        }
+
+        @Override
+        public Factory<LeaderPinger> get() {
+            return _client -> pinger();
+        }
+
+        public abstract static class Builder implements LeaderPingerFactory.Builder {}
     }
 }

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/Factories.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/Factories.java
@@ -29,13 +29,13 @@ import com.palantir.paxos.SingleLeaderPinger;
 import com.palantir.timelock.paxos.HealthCheckPinger;
 
 public interface Factories {
-    interface LeaderPingerFactory {
+    interface LeaderPingerFactoryContainer {
         Factory<LeaderPinger> get();
         List<Closeable> closeables();
 
         interface Builder {
             Builder from(Dependencies.LeaderPinger dependencies);
-            LeaderPingerFactory build();
+            LeaderPingerFactoryContainer build();
         }
     }
 
@@ -44,7 +44,7 @@ public interface Factories {
     }
 
     @Value.Immutable
-    abstract class BatchingLeaderPingerFactory implements LeaderPingerFactory, Dependencies.LeaderPinger {
+    abstract class BatchingLeaderPingerFactory implements LeaderPingerFactoryContainer, Dependencies.LeaderPinger {
 
         @Value.Derived
         AutobatchingPingableLeaderFactory pingableLeaderFactory() {
@@ -65,11 +65,11 @@ public interface Factories {
             return ImmutableList.of(pingableLeaderFactory());
         }
 
-        public abstract static class Builder implements LeaderPingerFactory.Builder {}
+        public abstract static class Builder implements LeaderPingerFactoryContainer.Builder {}
     }
 
     @Value.Immutable
-    abstract class SingleLeaderPingerFactory implements LeaderPingerFactory, Dependencies.LeaderPinger {
+    abstract class SingleLeaderPingerFactory implements LeaderPingerFactoryContainer, Dependencies.LeaderPinger {
 
         @Value.Derived
         SingleLeaderPinger pinger() {
@@ -84,6 +84,6 @@ public interface Factories {
             return _client -> pinger();
         }
 
-        public abstract static class Builder implements LeaderPingerFactory.Builder {}
+        public abstract static class Builder implements LeaderPingerFactoryContainer.Builder {}
     }
 }

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipContextFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipContextFactory.java
@@ -27,7 +27,6 @@ import com.palantir.atlasdb.timelock.paxos.NetworkClientFactories.Factory;
 import com.palantir.leader.BatchingLeaderElectionService;
 import com.palantir.leader.PaxosLeadershipEventRecorder;
 import com.palantir.leader.PingableLeader;
-import com.palantir.paxos.LeaderPinger;
 import com.palantir.paxos.PaxosLearner;
 
 @Value.Immutable
@@ -39,9 +38,9 @@ public abstract class LeadershipContextFactory implements
         Dependencies.HealthCheckPinger {
 
     abstract PaxosResourcesFactory.TimelockPaxosInstallationContext install();
-    abstract Factories.LeaderPingerFactory leaderPingerFactory();
     abstract Factories.LeaderPingHealthCheckFactory healthCheckPingersFactory();
     abstract NetworkClientFactories.Builder networkClientFactoryBuilder();
+    abstract Factories.LeaderPingerFactory.Builder leaderPingerFactoryBuilder();
 
     @Value.Derived
     @Override
@@ -68,13 +67,13 @@ public abstract class LeadershipContextFactory implements
     }
 
     @Value.Derived
-    public Duration leaderPingResponseWait() {
-        return runtime().get().leaderPingResponseWait();
+    public Factories.LeaderPingerFactory leaderPingerFactory() {
+        return leaderPingerFactoryBuilder().from(this).build();
     }
 
     @Value.Derived
-    public LeaderPinger leaderPinger() {
-        return leaderPingerFactory().create(this);
+    public Duration leaderPingResponseWait() {
+        return runtime().get().leaderPingResponseWait();
     }
 
     @Value.Derived

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipContextFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipContextFactory.java
@@ -41,7 +41,7 @@ public abstract class LeadershipContextFactory implements
     abstract PaxosResourcesFactory.TimelockPaxosInstallationContext install();
     abstract Factories.LeaderPingHealthCheckFactory healthCheckPingersFactory();
     abstract NetworkClientFactories.Builder networkClientFactoryBuilder();
-    abstract Factories.LeaderPingerFactory.Builder leaderPingerFactoryBuilder();
+    abstract Factories.LeaderPingerFactoryContainer.Builder leaderPingerFactoryBuilder();
 
     @Value.Derived
     @Override
@@ -68,7 +68,7 @@ public abstract class LeadershipContextFactory implements
     }
 
     @Value.Derived
-    public Factories.LeaderPingerFactory leaderPingerFactory() {
+    public Factories.LeaderPingerFactoryContainer leaderPingerFactory() {
         return leaderPingerFactoryBuilder().from(this).build();
     }
 

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipContextFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipContextFactory.java
@@ -27,6 +27,7 @@ import com.palantir.atlasdb.timelock.paxos.NetworkClientFactories.Factory;
 import com.palantir.leader.BatchingLeaderElectionService;
 import com.palantir.leader.PaxosLeadershipEventRecorder;
 import com.palantir.leader.PingableLeader;
+import com.palantir.paxos.LeaderPinger;
 import com.palantir.paxos.PaxosLearner;
 
 @Value.Immutable
@@ -99,6 +100,7 @@ public abstract class LeadershipContextFactory implements
                 .leadershipMetrics(clientAwareComponents.leadershipMetrics())
                 .leaderElectionService(leaderElectionService)
                 .addCloseables(leaderElectionService)
+                .addAllCloseables(leaderPingerFactory().closeables())
                 .build();
     }
 
@@ -128,6 +130,11 @@ public abstract class LeadershipContextFactory implements
         @Value.Derived
         public PingableLeader localPingableLeader() {
             return components().pingableLeader(paxosClient());
+        }
+
+        @Value.Derived
+        public LeaderPinger leaderPinger() {
+            return leaderPingerFactory().get().create(paxosClient());
         }
 
         @Value.Derived

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/MultiLeaderHealthCheckPinger.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/MultiLeaderHealthCheckPinger.java
@@ -23,7 +23,7 @@ import com.google.common.collect.Maps;
 import com.palantir.timelock.paxos.HealthCheckPinger;
 import com.palantir.timelock.paxos.HealthCheckResponse;
 
-public class MultiLeaderHealthCheckPinger implements HealthCheckPinger {
+public final class MultiLeaderHealthCheckPinger implements HealthCheckPinger {
 
     private final BatchPingableLeader batchPingableLeader;
 

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/MultiLeaderHealthCheckPinger.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/MultiLeaderHealthCheckPinger.java
@@ -1,0 +1,40 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.Maps;
+import com.palantir.timelock.paxos.HealthCheckPinger;
+import com.palantir.timelock.paxos.HealthCheckResponse;
+
+public class MultiLeaderHealthCheckPinger implements HealthCheckPinger {
+
+    private final BatchPingableLeader batchPingableLeader;
+
+    public MultiLeaderHealthCheckPinger(BatchPingableLeader batchPingableLeader) {
+        this.batchPingableLeader = batchPingableLeader;
+    }
+
+    @Override
+    public Map<Client, HealthCheckResponse> apply(Set<Client> request) {
+        Set<Client> results = batchPingableLeader.ping(request);
+        return Maps.toMap(request, client -> new HealthCheckResponse(results.contains(client)));
+    }
+
+}

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClients.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClients.java
@@ -89,10 +89,25 @@ public abstract class PaxosRemoteClients {
     }
 
     @Value.Derived
+    public List<BatchPingableLeader> batchPingableLeaders() {
+        return batchPingableLeadersWithContext().stream()
+                .map(LeaderPingerContext::pinger)
+                .collect(Collectors.toList());
+    }
+
+    @Value.Derived
     public List<LeaderPingerContext<PingableLeader>> nonBatchPingableLeadersWithContext() {
-        return createInstrumentedRemoteProxies(PingableLeader.class, false).entries()
-                .<LeaderPingerContext<PingableLeader>>map(entry ->
-                        ImmutableLeaderPingerContext.of(entry.getValue(), entry.getKey()))
+        return leaderPingerContext(PingableLeader.class);
+    }
+
+    @Value.Derived
+    public List<LeaderPingerContext<BatchPingableLeader>> batchPingableLeadersWithContext() {
+        return leaderPingerContext(BatchPingableLeader.class);
+    }
+
+    private <T> List<LeaderPingerContext<T>> leaderPingerContext(Class<T> clazz) {
+        return createInstrumentedRemoteProxies(clazz, false).entries()
+                .<LeaderPingerContext<T>>map(entry -> ImmutableLeaderPingerContext.of(entry.getValue(), entry.getKey()))
                 .collect(Collectors.toList());
     }
 

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResources.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResources.java
@@ -24,20 +24,29 @@ import org.immutables.value.Value;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.palantir.common.streams.KeyedStream;
 
 @Value.Immutable
 public abstract class PaxosResources {
     public abstract PaxosResourcesFactory.PaxosUseCaseContext timestamp();
     abstract List<Object> adhocResources();
-
+    abstract Map<PaxosUseCase, LocalPaxosComponents> leadershipBatchComponents();
     abstract LeadershipContextFactory leadershipContextFactory();
+
+    @Value.Derived
+    Map<PaxosUseCase, BatchPaxosResources> leadershipBatchResources() {
+        return KeyedStream.stream(leadershipBatchComponents())
+                .map(PaxosResources::batchResourcesFromComponents)
+                .collectToMap();
+    }
 
     @Value.Derived
     public List<Object> resourcesForRegistration() {
         Map<PaxosUseCase, BatchPaxosResources> batchPaxosResourcesByUseCase =
                 ImmutableMap.<PaxosUseCase, BatchPaxosResources>builder()
-                .put(PaxosUseCase.TIMESTAMP, batchResourcesForUseCase(timestamp()))
-                .build();
+                        .put(PaxosUseCase.TIMESTAMP, batchResourcesFromComponents(timestamp().components()))
+                        .putAll(leadershipBatchResources())
+                        .build();
 
         UseCaseAwareBatchPaxosResource combinedBatchResource =
                 new UseCaseAwareBatchPaxosResource(new EnumMap<>(batchPaxosResourcesByUseCase));
@@ -53,9 +62,7 @@ public abstract class PaxosResources {
         return new LeadershipComponents(leadershipContextFactory(), leadershipContextFactory().healthCheckPingers());
     }
 
-    private static BatchPaxosResources batchResourcesForUseCase(
-            PaxosResourcesFactory.PaxosUseCaseContext useCaseContext) {
-        LocalPaxosComponents components = useCaseContext.components();
+    private static BatchPaxosResources batchResourcesFromComponents(LocalPaxosComponents components) {
         BatchPaxosAcceptorResource acceptorResource = new BatchPaxosAcceptorResource(components.batchAcceptor());
         BatchPaxosLearnerResource learnerResource = new BatchPaxosLearnerResource(components.batchLearner());
         return ImmutableBatchPaxosResources.of(acceptorResource, learnerResource);

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResourcesFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResourcesFactory.java
@@ -40,6 +40,7 @@ import com.palantir.paxos.PaxosAcceptorNetworkClient;
 import com.palantir.paxos.PaxosLearnerNetworkClient;
 import com.palantir.paxos.PaxosProposer;
 import com.palantir.paxos.PaxosProposerImpl;
+import com.palantir.timelock.config.PaxosInstallConfiguration.PaxosLeaderMode;
 import com.palantir.timelock.config.PaxosRuntimeConfiguration;
 import com.palantir.timelock.config.TimeLockInstallConfiguration;
 import com.palantir.timelock.paxos.PaxosRemotingUtils;
@@ -258,7 +259,7 @@ public final class PaxosResourcesFactory {
 
         @Value.Derived
         default boolean useLeaderForEachClient() {
-            return false;
+            return install().paxos().leaderMode() == PaxosLeaderMode.LEADER_PER_CLIENT;
         }
 
     }

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/SingleLeaderHealthCheckPinger.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/SingleLeaderHealthCheckPinger.java
@@ -24,7 +24,7 @@ import com.palantir.leader.PingableLeader;
 import com.palantir.timelock.paxos.HealthCheckPinger;
 import com.palantir.timelock.paxos.HealthCheckResponse;
 
-public class SingleLeaderHealthCheckPinger implements HealthCheckPinger {
+public final class SingleLeaderHealthCheckPinger implements HealthCheckPinger {
 
     private final PingableLeader pingableLeader;
 

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosInstallConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosInstallConfiguration.java
@@ -59,7 +59,8 @@ public interface PaxosInstallConfiguration {
 
     @Value.Check
     default void checkLeaderModeIsNotInAutoMigrationMode() {
-        Preconditions.checkState(leaderMode() != PaxosLeaderMode.AUTO_MIGRATION_MODE,
+        Preconditions.checkState(
+                leaderMode() != PaxosLeaderMode.AUTO_MIGRATION_MODE,
                 "Auto migration mode is not supported just yet");
     }
 

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosInstallConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosInstallConfiguration.java
@@ -22,6 +22,7 @@ import org.immutables.value.Value;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 
 @JsonDeserialize(as = ImmutablePaxosInstallConfiguration.class)
@@ -43,6 +44,24 @@ public interface PaxosInstallConfiguration {
      */
     @JsonProperty("is-new-service")
     boolean isNewService();
+
+    enum PaxosLeaderMode {
+        SINGLE_LEADER,
+        LEADER_PER_CLIENT,
+        AUTO_MIGRATION_MODE
+    }
+
+    @JsonProperty("leader-mode")
+    @Value.Default
+    default PaxosLeaderMode leaderMode() {
+        return PaxosLeaderMode.SINGLE_LEADER;
+    }
+
+    @Value.Check
+    default void checkLeaderModeIsNotInAutoMigrationMode() {
+        Preconditions.checkState(leaderMode() != PaxosLeaderMode.AUTO_MIGRATION_MODE,
+                "Auto migration mode is not supported just yet");
+    }
 
     @Value.Check
     default void check() {

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPingableLeader.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPingableLeader.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
@@ -42,7 +43,7 @@ public interface BatchPingableLeader {
      * @param clients set of clients to check remote servers leadership on
      * @return clients for which the remote server believes that it is the leader for
      */
-    @GET
+    @POST
     @Path("ping")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponents.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponents.java
@@ -40,6 +40,7 @@ public class LocalPaxosComponents {
     private final Map<Client, Components> componentsByClient = Maps.newConcurrentMap();
     private final Supplier<BatchPaxosAcceptor> memoizedBatchAcceptor;
     private final Supplier<BatchPaxosLearner> memoizedBatchLearner;
+    private final Supplier<BatchPingableLeader> memoizedBatchPingableLeader;
 
     LocalPaxosComponents(TimelockPaxosMetrics metrics, Path logDirectory, UUID leaderUuid) {
         this.metrics = metrics;
@@ -47,6 +48,7 @@ public class LocalPaxosComponents {
         this.leaderUuid = leaderUuid;
         this.memoizedBatchAcceptor = Suppliers.memoize(this::createBatchAcceptor);
         this.memoizedBatchLearner = Suppliers.memoize(this::createBatchLearner);
+        this.memoizedBatchPingableLeader = Suppliers.memoize(this::createBatchPingableLeader);
     }
 
     public PaxosAcceptor acceptor(Client client) {
@@ -67,6 +69,10 @@ public class LocalPaxosComponents {
 
     public BatchPaxosLearner batchLearner() {
         return memoizedBatchLearner.get();
+    }
+
+    public BatchPingableLeader batchPingableLeader() {
+        return memoizedBatchPingableLeader.get();
     }
 
     private Components getOrCreateComponents(Client client) {
@@ -112,6 +118,12 @@ public class LocalPaxosComponents {
         return metrics.instrument(
                 BatchPaxosLearner.class,
                 new LocalBatchPaxosLearner(this));
+    }
+
+    private BatchPingableLeader createBatchPingableLeader() {
+        return metrics.instrument(
+                BatchPingableLeader.class,
+                new BatchPingableLeaderResource(leaderUuid, this));
     }
 
     @Value.Immutable

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/AbstractAsyncTimelockServiceIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/AbstractAsyncTimelockServiceIntegrationTest.java
@@ -19,6 +19,7 @@ import org.junit.ClassRule;
 import org.junit.rules.RuleChain;
 
 import com.palantir.atlasdb.timelock.ImmutableTemplateVariables.TimestampPaxos;
+import com.palantir.timelock.config.PaxosInstallConfiguration.PaxosLeaderMode;
 
 public abstract class AbstractAsyncTimelockServiceIntegrationTest {
 
@@ -26,6 +27,7 @@ public abstract class AbstractAsyncTimelockServiceIntegrationTest {
             .localServerPort(9050)
             .addServerPorts()
             .clientPaxos(TimestampPaxos.builder().isUseBatchPaxos(true).build())
+            .leaderMode(PaxosLeaderMode.SINGLE_LEADER)
             .build();
 
     protected static final TestableTimelockCluster CLUSTER_WITH_ASYNC =

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/IsolatedPaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/IsolatedPaxosTimeLockServerIntegrationTest.java
@@ -35,6 +35,7 @@ import com.palantir.atlasdb.timelock.util.TestProxies;
 import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.paxos.PaxosAcceptor;
 import com.palantir.paxos.PaxosLearner;
+import com.palantir.timelock.config.PaxosInstallConfiguration.PaxosLeaderMode;
 
 /**
  * This test creates a single TimeLock server that is configured in a three node configuration.
@@ -46,6 +47,7 @@ public class IsolatedPaxosTimeLockServerIntegrationTest {
     private static final TemplateVariables SINGLE_NODE = ImmutableTemplateVariables.builder()
             .localServerPort(9060)
             .clientPaxos(TimestampPaxos.builder().isUseBatchPaxos(false).build())
+            .leaderMode(PaxosLeaderMode.SINGLE_LEADER)
             .build();
 
     private static final TestableTimelockCluster CLUSTER = new TestableTimelockCluster(

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
@@ -22,8 +22,12 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.SharedMetricRegistries;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.palantir.atlasdb.timelock.config.CombinedTimeLockServerConfiguration;
@@ -47,6 +51,8 @@ import io.dropwizard.setup.Environment;
  */
 public class TimeLockServerLauncher extends Application<CombinedTimeLockServerConfiguration> {
 
+    private static final Logger log = LoggerFactory.getLogger(TimeLockServerLauncher.class);
+
     private static final UserAgent USER_AGENT =
             UserAgent.of(UserAgent.Agent.of("TimeLockServerLauncher", "0.0.0"));
 
@@ -67,7 +73,8 @@ public class TimeLockServerLauncher extends Application<CombinedTimeLockServerCo
     }
 
     @Override
-    public void run(CombinedTimeLockServerConfiguration configuration, Environment environment) {
+    public void run(CombinedTimeLockServerConfiguration configuration, Environment environment)
+            throws JsonProcessingException {
         environment.getObjectMapper()
                 .registerModule(new Jdk8Module())
                 .registerModule(new JavaTimeModule());
@@ -76,6 +83,8 @@ public class TimeLockServerLauncher extends Application<CombinedTimeLockServerCo
 
         MetricsManager metricsManager = MetricsManagers.of(environment.metrics(), taggedMetricRegistry);
         Consumer<Object> registrar = component -> environment.jersey().register(component);
+
+        log.error("Paxos configuration\n{}", environment.getObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(configuration.install().paxos()));
 
         TimeLockAgent timeLockAgent = TimeLockAgent.create(
                 metricsManager,

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
@@ -84,7 +84,7 @@ public class TimeLockServerLauncher extends Application<CombinedTimeLockServerCo
         MetricsManager metricsManager = MetricsManagers.of(environment.metrics(), taggedMetricRegistry);
         Consumer<Object> registrar = component -> environment.jersey().register(component);
 
-        log.error("Paxos configuration\n{}", environment.getObjectMapper()
+        log.info("Paxos configuration\n{}", environment.getObjectMapper()
                 .writerWithDefaultPrettyPrinter()
                 .writeValueAsString(configuration.install().paxos()));
 

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
@@ -84,7 +84,9 @@ public class TimeLockServerLauncher extends Application<CombinedTimeLockServerCo
         MetricsManager metricsManager = MetricsManagers.of(environment.metrics(), taggedMetricRegistry);
         Consumer<Object> registrar = component -> environment.jersey().register(component);
 
-        log.error("Paxos configuration\n{}", environment.getObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(configuration.install().paxos()));
+        log.error("Paxos configuration\n{}", environment.getObjectMapper()
+                .writerWithDefaultPrettyPrinter()
+                .writeValueAsString(configuration.install().paxos()));
 
         TimeLockAgent timeLockAgent = TimeLockAgent.create(
                 metricsManager,

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -30,7 +30,7 @@ import org.junit.runners.Parameterized;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.palantir.atlasdb.timelock.suite.PaxosSuite;
+import com.palantir.atlasdb.timelock.suite.MultiLeaderPaxosSuite;
 import com.palantir.atlasdb.timelock.util.ExceptionMatchers;
 import com.palantir.atlasdb.timelock.util.ParameterInjector;
 import com.palantir.lock.LockDescriptor;
@@ -44,7 +44,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
 
     @ClassRule
     public static ParameterInjector<TestableTimelockCluster> injector =
-            ParameterInjector.withFallBackConfiguration(() -> PaxosSuite.BATCHED_TIMESTAMP_PAXOS);
+            ParameterInjector.withFallBackConfiguration(() -> MultiLeaderPaxosSuite.MULTI_LEADER_PAXOS);
 
     @Parameterized.Parameter
     public TestableTimelockCluster cluster;

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/SingleLeaderMultiNodePaxosTimeLockIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/SingleLeaderMultiNodePaxosTimeLockIntegrationTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import com.palantir.atlasdb.timelock.suite.PaxosSuite;
+import com.palantir.atlasdb.timelock.suite.SingleLeaderPaxosSuite;
 import com.palantir.atlasdb.timelock.util.ExceptionMatchers;
 import com.palantir.atlasdb.timelock.util.ParameterInjector;
 
@@ -35,7 +35,7 @@ public class SingleLeaderMultiNodePaxosTimeLockIntegrationTest {
 
     @ClassRule
     public static ParameterInjector<TestableTimelockCluster> injector =
-            ParameterInjector.withFallBackConfiguration(() -> PaxosSuite.BATCHED_TIMESTAMP_PAXOS);
+            ParameterInjector.withFallBackConfiguration(() -> SingleLeaderPaxosSuite.BATCHED_TIMESTAMP_PAXOS);
 
     @Parameterized.Parameter
     public TestableTimelockCluster cluster;

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/suite/MultiLeaderPaxosSuite.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/suite/MultiLeaderPaxosSuite.java
@@ -33,7 +33,7 @@ import com.palantir.timelock.config.PaxosInstallConfiguration.PaxosLeaderMode;
 
 @RunWith(ParameterizedSuite.class)
 @Suite.SuiteClasses(MultiNodePaxosTimeLockServerIntegrationTest.class)
-public class MultiLeaderPaxosSuite {
+public final class MultiLeaderPaxosSuite {
 
     public static final TestableTimelockCluster MULTI_LEADER_PAXOS = new TestableTimelockCluster(
             "batched paxos multi leader",

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/suite/MultiLeaderPaxosSuite.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/suite/MultiLeaderPaxosSuite.java
@@ -1,0 +1,54 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.suite;
+
+import static com.palantir.atlasdb.timelock.TemplateVariables.generateThreeNodeTimelockCluster;
+
+import java.util.Collection;
+
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Suite;
+
+import com.github.peterwippermann.junit4.parameterizedsuite.ParameterizedSuite;
+import com.google.common.collect.ImmutableSet;
+import com.palantir.atlasdb.timelock.MultiNodePaxosTimeLockServerIntegrationTest;
+import com.palantir.atlasdb.timelock.TestableTimelockCluster;
+import com.palantir.timelock.config.PaxosInstallConfiguration.PaxosLeaderMode;
+
+@RunWith(ParameterizedSuite.class)
+@Suite.SuiteClasses(MultiNodePaxosTimeLockServerIntegrationTest.class)
+public class MultiLeaderPaxosSuite {
+
+    public static final TestableTimelockCluster MULTI_LEADER_PAXOS = new TestableTimelockCluster(
+            "batched paxos multi leader",
+            "paxosMultiServer.ftl",
+            generateThreeNodeTimelockCluster(9086, builder ->
+                    builder.clientPaxosBuilder(builder.clientPaxosBuilder().isUseBatchPaxos(true))
+                            .leaderMode(PaxosLeaderMode.LEADER_PER_CLIENT)));
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<TestableTimelockCluster> params() {
+        return ImmutableSet.of(MULTI_LEADER_PAXOS);
+    }
+
+    @Rule
+    @Parameterized.Parameter
+    public TestableTimelockCluster cluster;
+
+}

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/suite/SingleLeaderPaxosSuite.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/suite/SingleLeaderPaxosSuite.java
@@ -37,7 +37,7 @@ import com.palantir.timelock.config.PaxosInstallConfiguration.PaxosLeaderMode;
         MultiNodePaxosTimeLockServerIntegrationTest.class,
         SingleLeaderMultiNodePaxosTimeLockIntegrationTest.class
         })
-public class SingleLeaderPaxosSuite {
+public final class SingleLeaderPaxosSuite {
 
     public static final TestableTimelockCluster NON_BATCHED_TIMESTAMP_PAXOS = new TestableTimelockCluster(
             "non-batched paxos single leader",

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/suite/SingleLeaderPaxosSuite.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/suite/SingleLeaderPaxosSuite.java
@@ -36,7 +36,7 @@ import com.palantir.timelock.config.PaxosInstallConfiguration.PaxosLeaderMode;
 @Suite.SuiteClasses({
         MultiNodePaxosTimeLockServerIntegrationTest.class,
         SingleLeaderMultiNodePaxosTimeLockIntegrationTest.class
-})
+        })
 public class SingleLeaderPaxosSuite {
 
     public static final TestableTimelockCluster NON_BATCHED_TIMESTAMP_PAXOS = new TestableTimelockCluster(

--- a/timelock-server/src/testCommon/resources/paxosMultiServer.ftl
+++ b/timelock-server/src/testCommon/resources/paxosMultiServer.ftl
@@ -2,6 +2,7 @@ install:
   paxos:
     data-directory: "${dataDirectory}"
     is-new-service: false
+    leader-mode: ${leaderMode}
   cluster:
     cluster:
       security:


### PR DESCRIPTION
**Goals (and why)**:
Big step! This grants capability to run multi leader paxos. We run subset of tests (things that test leadership and change of leadership heavily) under this configuration to see whether we're still behaving to our spec.

What's next: Have some tailored tests that basically force certain nodes to be leaders for certain namespaces. This should be the test or not we're actually having separate leaders simultaneously.

**Implementation Description (bullets)**:
* Wire up in a similar manner inside `PaxosResourcesFactory`. 
* a few fixes found when integration testing
* test infrastructure evolution to support the new leader-mode

**Testing (What was existing testing like?  What have you done to improve it?)**:
* Have a new configuration that uses multi leader mode and runs a subset of existing tests with it. 

**Concerns (what feedback would you like?)**:
None, it's disabled right now. We still can't rolling bounce to this, but that's okay.

**Where should we start reviewing?**:
* `PaxosResourcesFactory`
* `PaxosResources`
* `PaxosInstallConfiguration`
* `MultiLeaderPaxosSuite`
* `SingleLeaderPaxosSuite`

**Priority (whenever / two weeks / yesterday)**:
ASAP, need to get on to other work.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
