### PR TITLE
Improve TimeLock Client Recovery From Network Partitions

### DIFF
--- a/changelog/@unreleased/pr-4517.v2.yml
+++ b/changelog/@unreleased/pr-4517.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: TimeLock now recovers more quickly when a node is partitioned off from
+    the network. Previously, if a leader node was partitioned off, talking to it as
+    a client would take about 50 seconds before the leader realised it was no longer
+    the leader. This should now be about 7 seconds.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4517

--- a/changelog/@unreleased/pr-4517.v2.yml
+++ b/changelog/@unreleased/pr-4517.v2.yml
@@ -2,7 +2,7 @@ type: improvement
 improvement:
   description: TimeLock now recovers more quickly when a node is partitioned off from
     the network. Previously, if a leader node was partitioned off, talking to it as
-    a client would take about 50 seconds before the leader realised it was no longer
-    the leader. This should now be about 7 seconds.
+    a client would take about 50 seconds before that leader realised it was no longer
+    the leader and redirect you (via 503 or 308). This should now be about 7 seconds.
   links:
   - https://github.com/palantir/atlasdb/pull/4517

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
@@ -198,7 +198,7 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
         Object delegate = delegateRef.get();
         StillLeadingStatus leading = null;
 
-        // Wait for at most 6.7 seconds in case of a momentary network partition
+        // Wait for at most 6.3 seconds in case of a momentary network partition
         for (int i = 0; i < MAX_NO_QUORUM_RETRIES; i++) {
             // TODO(nziebart): check if leadershipTokenRef has been nulled out between iterations?
             leading = leaderElectionService.isStillLeading(leadershipToken);
@@ -206,7 +206,7 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
                 break;
             }
             if (i != MAX_NO_QUORUM_RETRIES - 1) {
-                Uninterruptibles.sleepUninterruptibly(670, TimeUnit.MILLISECONDS);
+                Uninterruptibles.sleepUninterruptibly(700, TimeUnit.MILLISECONDS);
             }
         }
 

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
@@ -24,6 +24,7 @@ import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
@@ -35,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.reflect.AbstractInvocationHandler;
+import com.google.common.util.concurrent.Uninterruptibles;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.common.remoting.ServiceNotAvailableException;
 import com.palantir.leader.LeaderElectionService;
@@ -195,11 +197,16 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
 
         Object delegate = delegateRef.get();
         StillLeadingStatus leading = null;
+
+        // Wait for at most 6.7 seconds in case of a momentary network partition
         for (int i = 0; i < MAX_NO_QUORUM_RETRIES; i++) {
             // TODO(nziebart): check if leadershipTokenRef has been nulled out between iterations?
             leading = leaderElectionService.isStillLeading(leadershipToken);
             if (leading != StillLeadingStatus.NO_QUORUM) {
                 break;
+            }
+            if (i != MAX_NO_QUORUM_RETRIES - 1) {
+                Uninterruptibles.sleepUninterruptibly(670, TimeUnit.MILLISECONDS);
             }
         }
 

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClients.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClients.java
@@ -53,32 +53,33 @@ public abstract class PaxosRemoteClients {
 
     @Value.Derived
     public List<TimelockPaxosAcceptorRpcClient> nonBatchTimestampAcceptor() {
-        return createInstrumentedRemoteProxies(TimelockPaxosAcceptorRpcClient.class);
+        return createInstrumentedRemoteProxyList(TimelockPaxosAcceptorRpcClient.class, true);
     }
 
     @Value.Derived
     public List<TimelockPaxosLearnerRpcClient> nonBatchTimestampLearner() {
-        return createInstrumentedRemoteProxies(TimelockPaxosLearnerRpcClient.class);
-    }
-
-    @Value.Derived
-    public List<TimelockSingleLeaderPaxosLearnerRpcClient> singleLeaderLearner() {
-        return createInstrumentedRemoteProxies(TimelockSingleLeaderPaxosLearnerRpcClient.class);
+        return createInstrumentedRemoteProxyList(TimelockPaxosLearnerRpcClient.class, true);
     }
 
     @Value.Derived
     public List<TimelockSingleLeaderPaxosAcceptorRpcClient> singleLeaderAcceptor() {
-        return createInstrumentedRemoteProxies(TimelockSingleLeaderPaxosAcceptorRpcClient.class);
+        // Retries should be performed at a higher level, in AwaitingLeadershipProxy.
+        return createInstrumentedRemoteProxyList(TimelockSingleLeaderPaxosAcceptorRpcClient.class, false);
+    }
+
+    @Value.Derived
+    public List<TimelockSingleLeaderPaxosLearnerRpcClient> singleLeaderLearner() {
+        return createInstrumentedRemoteProxyList(TimelockSingleLeaderPaxosLearnerRpcClient.class, true);
     }
 
     @Value.Derived
     public List<BatchPaxosAcceptorRpcClient> batchAcceptor() {
-        return createInstrumentedRemoteProxies(BatchPaxosAcceptorRpcClient.class);
+        return createInstrumentedRemoteProxyList(BatchPaxosAcceptorRpcClient.class, true);
     }
 
     @Value.Derived
     public List<BatchPaxosLearnerRpcClient> batchLearner() {
-        return createInstrumentedRemoteProxies(BatchPaxosLearnerRpcClient.class);
+        return createInstrumentedRemoteProxyList(BatchPaxosLearnerRpcClient.class, true);
     }
 
     @Value.Derived
@@ -96,8 +97,8 @@ public abstract class PaxosRemoteClients {
                 .collect(Collectors.toList());
     }
 
-    private <T> List<T> createInstrumentedRemoteProxies(Class<T> clazz) {
-        return createInstrumentedRemoteProxies(clazz, true).values().collect(Collectors.toList());
+    private <T> List<T> createInstrumentedRemoteProxyList(Class<T> clazz, boolean shouldRetry) {
+        return createInstrumentedRemoteProxies(clazz, shouldRetry).values().collect(Collectors.toList());
     }
 
     private <T> KeyedStream<HostAndPort, T> createInstrumentedRemoteProxies(Class<T> clazz, boolean shouldRetry) {


### PR DESCRIPTION
**Goals (and why)**:
- Improve recovery times when a node is partitioned off from the network. Previously, if a leader was partitioned off, talking to it as a client would take about 50 seconds before the leader realised it was no longer the leader.
- Fail faster when a quorum of nodes is unavailable.

**Implementation Description (bullets)**:
- Don't retry for the single-leader `PaxosAcceptor`, because this is handled at a higher level in `AwaitingLeadershipProxy`. Previously, we had multiple levels of retries meaning recovery time was often 50 seconds.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Run `MultiNodePaxosTimeLockServerIntegrationTest#leaderLosesLeadershipIfQuorumIsNotAlive`. Previously 55 seconds, now about 8. Sadly nothing automated and I'm not so keen on putting a time limit on the test.

**Concerns (what feedback would you like?)**:
- Is there a cleaner way to test this?

**Where should we start reviewing?**: PaxosRemoteClients.java

**Priority (whenever / two weeks / yesterday)**: this week
