### PR TITLE
Docs: Rolling Migrations Into TimeLock Are Dangerous

### DIFF
--- a/docs/source/services/timelock_service/migration.rst
+++ b/docs/source/services/timelock_service/migration.rst
@@ -14,6 +14,10 @@ Otherwise, this can lead to serious data corruption.
 Automated Migration
 -------------------
 
+.. danger::
+    If your service is highly available, you MUST shut down ALL nodes of your service after step 2 before bringing up any
+    nodes in step 4. Otherwise, there is a risk of **SEVERE DATA CORRUPTION** as timestamps may be given out of order.
+
 .. warning::
     Automated migrations are only implemented for Cassandra. If you are using any other KVS, please follow the
     instructions at :ref:`manual-timelock-migration`.


### PR DESCRIPTION
**Goals (and why)**:
- Have clear guidance for users switching from embedded services to timelock.

**Implementation Description (bullets)**:
- Add specific caveat that a rolling bounce is unacceptable in the docs, which was missing

**Testing (What was existing testing like?  What have you done to improve it?)**: NA

**Concerns (what feedback would you like?)**: NA

**Where should we start reviewing?**: NA

**Priority (whenever / two weeks / yesterday)**: ASAP