### PR TITLE
Shorter Nonblocking Calls, Part 3: Breaking the TimeLock Logjam

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/BlockingSensitiveTimelockRpcClient.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/BlockingSensitiveTimelockRpcClient.java
@@ -1,0 +1,128 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.factory;
+
+import java.util.OptionalLong;
+import java.util.Set;
+
+import com.palantir.lock.client.IdentifiedLockRequest;
+import com.palantir.lock.v2.IdentifiedTimeLockRequest;
+import com.palantir.lock.v2.LeaderTime;
+import com.palantir.lock.v2.LockImmutableTimestampResponse;
+import com.palantir.lock.v2.LockResponseV2;
+import com.palantir.lock.v2.LockToken;
+import com.palantir.lock.v2.RefreshLockResponseV2;
+import com.palantir.lock.v2.StartAtlasDbTransactionResponseV3;
+import com.palantir.lock.v2.StartIdentifiedAtlasDbTransactionRequest;
+import com.palantir.lock.v2.StartTransactionRequestV4;
+import com.palantir.lock.v2.StartTransactionRequestV5;
+import com.palantir.lock.v2.StartTransactionResponseV4;
+import com.palantir.lock.v2.StartTransactionResponseV5;
+import com.palantir.lock.v2.TimelockRpcClient;
+import com.palantir.lock.v2.WaitForLocksRequest;
+import com.palantir.lock.v2.WaitForLocksResponse;
+import com.palantir.lock.watch.TimestampWithWatches;
+import com.palantir.timestamp.TimestampRange;
+
+/**
+ * Given two proxies to the same set of underlying TimeLock servers, one configured to expect longer-running operations
+ * on the server and one configured not to, routes calls appropriately.
+ */
+class BlockingSensitiveTimelockRpcClient implements TimelockRpcClient {
+    private final TimelockRpcClient blockingClient;
+    private final TimelockRpcClient nonBlockingClient;
+
+    public BlockingSensitiveTimelockRpcClient(
+            TimelockRpcClient blockingClient,
+            TimelockRpcClient nonBlockingClient) {
+        this.blockingClient = blockingClient;
+        this.nonBlockingClient = nonBlockingClient;
+    }
+
+    @Override
+    public long getFreshTimestamp(String namespace) {
+        return nonBlockingClient.getFreshTimestamp(namespace);
+    }
+
+    @Override
+    public TimestampRange getFreshTimestamps(String namespace, int numTimestampsRequested) {
+        return nonBlockingClient.getFreshTimestamps(namespace, numTimestampsRequested);
+    }
+
+    @Override
+    public TimestampWithWatches getCommitTimestampWithWatches(String namespace, OptionalLong lastVersion) {
+        return nonBlockingClient.getCommitTimestampWithWatches(namespace, lastVersion);
+    }
+
+    @Override
+    public LockImmutableTimestampResponse lockImmutableTimestamp(String namespace, IdentifiedTimeLockRequest request) {
+        // Despite the name, these locks are not exclusive so we do not expect blocking.
+        return nonBlockingClient.lockImmutableTimestamp(namespace, request);
+    }
+
+    @Override
+    public StartAtlasDbTransactionResponseV3 deprecatedStartTransaction(String namespace,
+            StartIdentifiedAtlasDbTransactionRequest request) {
+        return nonBlockingClient.deprecatedStartTransaction(namespace, request);
+    }
+
+    @Override
+    public StartTransactionResponseV4 startTransactions(String namespace, StartTransactionRequestV4 request) {
+        return nonBlockingClient.startTransactions(namespace, request);
+    }
+
+    @Override
+    public StartTransactionResponseV5 startTransactionsWithWatches(String namespace,
+            StartTransactionRequestV5 request) {
+        return nonBlockingClient.startTransactionsWithWatches(namespace, request);
+    }
+
+    @Override
+    public long getImmutableTimestamp(String namespace) {
+        return nonBlockingClient.getImmutableTimestamp(namespace);
+    }
+
+    @Override
+    public LockResponseV2 lock(String namespace, IdentifiedLockRequest request) {
+        return blockingClient.lock(namespace, request);
+    }
+
+    @Override
+    public WaitForLocksResponse waitForLocks(String namespace, WaitForLocksRequest request) {
+        return blockingClient.waitForLocks(namespace, request);
+    }
+
+    @Override
+    public RefreshLockResponseV2 refreshLockLeases(String namespace, Set<LockToken> tokens) {
+        return nonBlockingClient.refreshLockLeases(namespace, tokens);
+    }
+
+    @Override
+    public LeaderTime getLeaderTime(String namespace) {
+        return nonBlockingClient.getLeaderTime(namespace);
+    }
+
+    @Override
+    public Set<LockToken> unlock(String namespace, Set<LockToken> tokens) {
+        return nonBlockingClient.unlock(namespace, tokens);
+    }
+
+    @Override
+    public long currentTimeMillis(String namespace) {
+        return nonBlockingClient.currentTimeMillis(namespace);
+    }
+}

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/ServiceCreator.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/ServiceCreator.java
@@ -18,8 +18,11 @@ package com.palantir.atlasdb.factory;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import org.immutables.value.Value;
+
 import com.codahale.metrics.MetricRegistry;
 import com.palantir.atlasdb.config.AuxiliaryRemotingParameters;
+import com.palantir.atlasdb.config.ImmutableAuxiliaryRemotingParameters;
 import com.palantir.atlasdb.config.RemotingClientConfig;
 import com.palantir.atlasdb.config.ServerListConfig;
 import com.palantir.atlasdb.http.AtlasDbHttpClients;
@@ -73,6 +76,12 @@ public final class ServiceCreator {
         return create(metricsManager, servers, serviceClass, parameters);
     }
 
+    public <T> T createServiceWithoutBlockingOperations(Class<T> serviceClass) {
+        AuxiliaryRemotingParameters blockingUnsupportedParameters
+                = ImmutableAuxiliaryRemotingParameters.copyOf(parameters).withShouldSupportBlockingOperations(false);
+        return create(metricsManager, servers, serviceClass, blockingUnsupportedParameters);
+    }
+
     /**
      * Utility method for transforming an optional {@link SslConfiguration} into an optional {@link TrustContext}.
      */
@@ -109,6 +118,7 @@ public final class ServiceCreator {
                 .remotingClientConfig(remotingClientConfigSupplier)
                 .userAgent(userAgent)
                 .shouldLimitPayload(shouldLimitPayload)
+                .shouldSupportBlockingOperations(true) // TODO (jkong): Figure out when to migrate safely
                 .shouldRetry(true)
                 .build();
     }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/ServiceCreator.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/ServiceCreator.java
@@ -18,8 +18,6 @@ package com.palantir.atlasdb.factory;
 import java.util.Optional;
 import java.util.function.Supplier;
 
-import org.immutables.value.Value;
-
 import com.codahale.metrics.MetricRegistry;
 import com.palantir.atlasdb.config.AuxiliaryRemotingParameters;
 import com.palantir.atlasdb.config.ImmutableAuxiliaryRemotingParameters;

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -80,6 +80,7 @@ import com.palantir.atlasdb.debug.LockDiagnosticTimelockRpcClient;
 import com.palantir.atlasdb.factory.Leaders.LocalPaxosServices;
 import com.palantir.atlasdb.factory.startup.ConsistencyCheckRunner;
 import com.palantir.atlasdb.factory.startup.TimeLockMigrator;
+import com.palantir.atlasdb.factory.timelock.BlockingSensitiveTimelockRpcClient;
 import com.palantir.atlasdb.factory.timelock.TimestampCorroboratingTimelockService;
 import com.palantir.atlasdb.factory.timestamp.FreshTimestampSupplierAdapter;
 import com.palantir.atlasdb.http.AtlasDbFeignTargetFactory;

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -1039,7 +1039,9 @@ public abstract class TransactionManagers {
                 LockService.class,
                 RemoteLockServiceAdapter.create(creator.createService(LockRpcClient.class), timelockNamespace));
 
-        TimelockRpcClient timelockClient = creator.createService(TimelockRpcClient.class);
+        TimelockRpcClient timelockClient = new BlockingSensitiveTimelockRpcClient(
+                creator.createService(TimelockRpcClient.class),
+                creator.createServiceWithoutBlockingOperations(TimelockRpcClient.class));
 
         // TODO(fdesouza): Remove this once PDS-95791 is resolved.
         TimelockRpcClient withDiagnosticsTimelockClient = lockDiagnosticCollector
@@ -1052,7 +1054,7 @@ public abstract class TransactionManagers {
         RemoteTimelockServiceAdapter remoteTimelockServiceAdapter
                 = RemoteTimelockServiceAdapter.create(namespacedTimelockRpcClient);
         TimestampManagementService timestampManagementService = new RemoteTimestampManagementAdapter(
-                creator.createService(TimestampManagementRpcClient.class), timelockNamespace);
+                creator.createServiceWithoutBlockingOperations(TimestampManagementRpcClient.class), timelockNamespace);
 
         return ImmutableLockAndTimestampServices.builder()
                 .lock(lockService)

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/BlockingSensitiveLockRpcClient.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/BlockingSensitiveLockRpcClient.java
@@ -1,0 +1,161 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.factory.timelock;
+
+import java.math.BigInteger;
+import java.util.Optional;
+import java.util.Set;
+
+import com.palantir.lock.HeldLocksGrant;
+import com.palantir.lock.HeldLocksToken;
+import com.palantir.lock.LockClient;
+import com.palantir.lock.LockRefreshToken;
+import com.palantir.lock.LockRequest;
+import com.palantir.lock.LockResponse;
+import com.palantir.lock.LockRpcClient;
+import com.palantir.lock.LockServerOptions;
+import com.palantir.lock.SimpleHeldLocksToken;
+
+/**
+ * Given two proxies to the same set of underlying remote lock servers, one configured to expect longer-running
+ * operations on the server and one not to, routes calls appropriately.
+ */
+public class BlockingSensitiveLockRpcClient implements LockRpcClient {
+    private final LockRpcClient blockingClient;
+    private final LockRpcClient nonBlockingClient;
+
+    public BlockingSensitiveLockRpcClient(
+            LockRpcClient blockingClient,
+            LockRpcClient nonBlockingClient) {
+        this.blockingClient = blockingClient;
+        this.nonBlockingClient = nonBlockingClient;
+    }
+
+    @Override
+    public Optional<LockResponse> lockWithFullLockResponse(String namespace, LockClient client, LockRequest request)
+            throws InterruptedException {
+        return blockingClient.lockWithFullLockResponse(namespace, client, request);
+    }
+
+    @Override
+    public boolean unlock(String namespace, HeldLocksToken token) {
+        return nonBlockingClient.unlock(namespace, token);
+    }
+
+    @Override
+    public boolean unlock(String namespace, LockRefreshToken token) {
+        return nonBlockingClient.unlock(namespace, token);
+    }
+
+    @Override
+    public boolean unlockSimple(String namespace, SimpleHeldLocksToken token) {
+        return nonBlockingClient.unlockSimple(namespace, token);
+    }
+
+    @Override
+    public boolean unlockAndFreeze(String namespace, HeldLocksToken token) {
+        // TODO (jkong): It feels like this could be non-blocking but not 100% sure so going for the safe option.
+        return blockingClient.unlockAndFreeze(namespace, token);
+    }
+
+    @Override
+    public Set<HeldLocksToken> getTokens(String namespace, LockClient client) {
+        return nonBlockingClient.getTokens(namespace, client);
+    }
+
+    @Override
+    public Set<HeldLocksToken> refreshTokens(String namespace, Iterable<HeldLocksToken> tokens) {
+        return nonBlockingClient.refreshTokens(namespace, tokens);
+    }
+
+    @Override
+    public Optional<HeldLocksGrant> refreshGrant(String namespace, HeldLocksGrant grant) {
+        return nonBlockingClient.refreshGrant(namespace, grant);
+    }
+
+    @Override
+    public Optional<HeldLocksGrant> refreshGrant(String namespace, BigInteger grantId) {
+        return nonBlockingClient.refreshGrant(namespace, grantId);
+    }
+
+    @Override
+    public HeldLocksGrant convertToGrant(String namespace, HeldLocksToken token) {
+        // TODO (jkong): It feels like this could be non-blocking but not 100% sure so going for the safe option.
+        return blockingClient.convertToGrant(namespace, token);
+    }
+
+    @Override
+    public HeldLocksToken useGrant(String namespace, LockClient client, HeldLocksGrant grant) {
+        // TODO (jkong): It feels like this could be non-blocking but not 100% sure so going for the safe option.
+        return blockingClient.useGrant(namespace, client, grant);
+    }
+
+    @Override
+    public HeldLocksToken useGrant(String namespace, LockClient client, BigInteger grantId) {
+        // TODO (jkong): It feels like this could be non-blocking but not 100% sure so going for the safe option.
+        return blockingClient.useGrant(namespace, client, grantId);
+    }
+
+    @Override
+    public Optional<Long> getMinLockedInVersionId(String namespace) {
+        return nonBlockingClient.getMinLockedInVersionId(namespace);
+    }
+
+    @Override
+    public Optional<Long> getMinLockedInVersionId(String namespace, LockClient client) {
+        return nonBlockingClient.getMinLockedInVersionId(namespace, client);
+    }
+
+    @Override
+    public Optional<Long> getMinLockedInVersionId(String namespace, String client) {
+        return nonBlockingClient.getMinLockedInVersionId(namespace, client);
+    }
+
+    @Override
+    public LockServerOptions getLockServerOptions(String namespace) {
+        return nonBlockingClient.getLockServerOptions(namespace);
+    }
+
+    @Override
+    public Optional<LockRefreshToken> lock(String namespace, String client, LockRequest request)
+            throws InterruptedException {
+        return blockingClient.lock(namespace, client, request);
+    }
+
+    @Override
+    public Optional<HeldLocksToken> lockAndGetHeldLocks(String namespace, String client, LockRequest request)
+            throws InterruptedException {
+        return blockingClient.lockAndGetHeldLocks(namespace, client, request);
+    }
+
+    @Override
+    public Set<LockRefreshToken> refreshLockRefreshTokens(String namespace, Iterable<LockRefreshToken> tokens) {
+        return nonBlockingClient.refreshLockRefreshTokens(namespace, tokens);
+    }
+
+    @Override
+    public long currentTimeMillis(String namespace) {
+        return nonBlockingClient.currentTimeMillis(namespace);
+    }
+
+    @Override
+    public void logCurrentState(String namespace) {
+        // Even if this does take more than the non-blocking timeout, the request will fail while the server will
+        // dump its logs out.
+        nonBlockingClient.logCurrentState(namespace);
+    }
+}

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/BlockingSensitiveTimelockRpcClient.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/BlockingSensitiveTimelockRpcClient.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.atlasdb.factory;
+package com.palantir.atlasdb.factory.timelock;
 
 import java.util.OptionalLong;
 import java.util.Set;
@@ -42,7 +42,7 @@ import com.palantir.timestamp.TimestampRange;
  * Given two proxies to the same set of underlying TimeLock servers, one configured to expect longer-running operations
  * on the server and one configured not to, routes calls appropriately.
  */
-class BlockingSensitiveTimelockRpcClient implements TimelockRpcClient {
+public class BlockingSensitiveTimelockRpcClient implements TimelockRpcClient {
     private final TimelockRpcClient blockingClient;
     private final TimelockRpcClient nonBlockingClient;
 

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/timelock/BlockingSensitiveLockRpcClientTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/timelock/BlockingSensitiveLockRpcClientTest.java
@@ -1,0 +1,76 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.factory.timelock;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableSortedMap;
+import com.palantir.lock.LockClient;
+import com.palantir.lock.LockMode;
+import com.palantir.lock.LockRequest;
+import com.palantir.lock.LockRpcClient;
+import com.palantir.lock.StringLockDescriptor;
+
+public class BlockingSensitiveLockRpcClientTest {
+    private static final String NAMESPACE = "namespace";
+    private static final String LOCK_CLIENT_STRING = "client";
+    private static final LockClient LOCK_CLIENT = LockClient.of(LOCK_CLIENT_STRING);
+    private static final LockRequest LOCK_REQUEST = LockRequest.builder(
+            ImmutableSortedMap.of(StringLockDescriptor.of("lock"), LockMode.WRITE))
+            .build();
+
+    private final LockRpcClient blocking = mock(LockRpcClient.class);
+    private final LockRpcClient nonBlocking = mock(LockRpcClient.class);
+    private final LockRpcClient sensitiveClient = new BlockingSensitiveLockRpcClient(blocking, nonBlocking);
+
+    @Test
+    public void lockUsesBlockingClient() throws InterruptedException {
+        sensitiveClient.lock(NAMESPACE, LOCK_CLIENT_STRING, LOCK_REQUEST);
+
+        verify(blocking).lock(NAMESPACE, LOCK_CLIENT_STRING, LOCK_REQUEST);
+        verify(nonBlocking, never()).lock(NAMESPACE, LOCK_CLIENT_STRING, LOCK_REQUEST);
+    }
+
+    @Test
+    public void lockWithFullLockResponseUsesBlockingClient() throws InterruptedException {
+        sensitiveClient.lockWithFullLockResponse(NAMESPACE, LOCK_CLIENT, LOCK_REQUEST);
+
+        verify(blocking).lockWithFullLockResponse(NAMESPACE, LOCK_CLIENT, LOCK_REQUEST);
+        verify(nonBlocking, never()).lockWithFullLockResponse(NAMESPACE, LOCK_CLIENT, LOCK_REQUEST);
+    }
+
+    @Test
+    public void lockAndGetHeldLocksUsesBlockingClient() throws InterruptedException {
+        sensitiveClient.lockAndGetHeldLocks(NAMESPACE, LOCK_CLIENT_STRING, LOCK_REQUEST);
+
+        verify(blocking).lockAndGetHeldLocks(NAMESPACE, LOCK_CLIENT_STRING, LOCK_REQUEST);
+        verify(nonBlocking, never()).lockAndGetHeldLocks(NAMESPACE, LOCK_CLIENT_STRING, LOCK_REQUEST);
+    }
+
+    @Test
+    public void currentTimeMillisUsesNonBlockingClient() {
+        sensitiveClient.currentTimeMillis(NAMESPACE);
+
+        verify(nonBlocking).currentTimeMillis(NAMESPACE);
+        verify(blocking, never()).currentTimeMillis(NAMESPACE);
+
+    }
+}

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/timelock/BlockingSensitiveTimelockRpcClientTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/timelock/BlockingSensitiveTimelockRpcClientTest.java
@@ -1,0 +1,78 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.factory.timelock;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.UUID;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableSet;
+import com.palantir.lock.StringLockDescriptor;
+import com.palantir.lock.client.IdentifiedLockRequest;
+import com.palantir.lock.v2.ImmutableStartTransactionRequestV5;
+import com.palantir.lock.v2.StartTransactionRequestV5;
+import com.palantir.lock.v2.TimelockRpcClient;
+import com.palantir.lock.v2.WaitForLocksRequest;
+
+public class BlockingSensitiveTimelockRpcClientTest {
+    private static final String NAMESPACE = "namespace";
+    private static final IdentifiedLockRequest LOCK_REQUEST = IdentifiedLockRequest.of(
+            ImmutableSet.of(StringLockDescriptor.of("lock")),
+            60_000);
+    private static final WaitForLocksRequest WAIT_FOR_LOCKS_REQUEST = WaitForLocksRequest.of(
+            ImmutableSet.of(StringLockDescriptor.of("waiting-lock")),
+            60_000);
+    private static final StartTransactionRequestV5 START_TRANSACTION_REQUEST
+            = ImmutableStartTransactionRequestV5.builder()
+            .lastKnownLockLogVersion(88)
+            .numTransactions(66)
+            .requestId(UUID.randomUUID())
+            .requestorId(UUID.randomUUID())
+            .build();
+
+    private final TimelockRpcClient blocking = mock(TimelockRpcClient.class);
+    private final TimelockRpcClient nonBlocking = mock(TimelockRpcClient.class);
+    private final TimelockRpcClient sensitiveClient = new BlockingSensitiveTimelockRpcClient(blocking, nonBlocking);
+
+    @Test
+    public void lockUsesBlockingClient() {
+        sensitiveClient.lock(NAMESPACE, LOCK_REQUEST);
+
+        verify(blocking).lock(NAMESPACE, LOCK_REQUEST);
+        verify(nonBlocking, never()).lock(NAMESPACE, LOCK_REQUEST);
+    }
+
+    @Test
+    public void waitForLocksUsesBlockingClient() {
+        sensitiveClient.waitForLocks(NAMESPACE, WAIT_FOR_LOCKS_REQUEST);
+
+        verify(blocking).waitForLocks(NAMESPACE, WAIT_FOR_LOCKS_REQUEST);
+        verify(nonBlocking, never()).waitForLocks(NAMESPACE, WAIT_FOR_LOCKS_REQUEST);
+    }
+
+    @Test
+    public void startTransactionUsesNonBlockingClient() {
+        sensitiveClient.startTransactionsWithWatches(NAMESPACE, START_TRANSACTION_REQUEST);
+
+        verify(nonBlocking).startTransactionsWithWatches(NAMESPACE, START_TRANSACTION_REQUEST);
+        verify(blocking, never()).startTransactionsWithWatches(NAMESPACE, START_TRANSACTION_REQUEST);
+    }
+}

--- a/changelog/@unreleased/pr-4519.v2.yml
+++ b/changelog/@unreleased/pr-4519.v2.yml
@@ -3,6 +3,6 @@ improvement:
   description: |-
     Users can now specify when creating HTTP clients whether the client is expected to support endpoints that may block for extended periods on the server (by default, this is supported as in previous versions).
 
-    Client use-cases where endpoints are expected to return relatively quickly will benefit from having `shouldSupportBlockingOperations` be specified as false. In the event of connection failures or irregularities, the connection should be retried after 10 seconds (as opposed to 65).
+    Client use-cases where endpoints are expected to return relatively quickly will benefit from having `shouldSupportBlockingOperations` being specified as false. In the event of connection failures or irregularities, the connection should be retried after approximately 12.6 seconds (as opposed to 65).
   links:
   - https://github.com/palantir/atlasdb/pull/4519

--- a/changelog/@unreleased/pr-4520.v2.yml
+++ b/changelog/@unreleased/pr-4520.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: |-
+    Read timeouts for the majority of TimeLock calls have been reduced from 65 to approximately 12.6 seconds. This allows for faster client-side recovery in the presence of unresponsive TimeLock hosts.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4520


### PR DESCRIPTION
**Goals (and why)**:
- Reduce read timeouts for the majority of calls. See #4416, though this accounts for the endpoints that are legitimately allowed to take closer to 65 seconds.

**Implementation Description (bullets)**:
- Allow ServiceCreators to create whitelisted things as having the lower read timeout.
- Implement BlockingSensitiveTimelockRpcClient, which delegates between two TimelockRpcClients to the same cluster - one for the time-sensitive endpoints (lock, waitForLocks) and one for everything else.
- For (V1) LockService I just made everything use the old timeouts.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added a test for the delegating timelock rpc client.

**Concerns (what feedback would you like?)**:
_Most of these concerns are around using two separate proxies that operate disjoint sets of endpoints._
- Metrics: will these work correctly? I believe so: they are backed by the same metrics registry, and furthermore the metrics that each of these report will be disjoint.
- ExperimentRunningProxy / Fallback Mechanism for legacy users: This may behave a bit funkily, but if it's bad both services will fallback, and we aren't monitoring the performance numbers for anyone right now.
- HTTP client internals may behave weirdly e.g. sticking to the leader found via 308s: This is a concern, but it's not obvious how we can configure these timeouts at the request level - and if so, we will likely need to have two proxies anyway.

**Where should we start reviewing?**: ServiceCreators or TransactionManagers

**Priority (whenever / two weeks / yesterday)**: early next week? Until this merges #4519 has no value for a majority of our consumers.
