### PR TITLE
Fix develop

### DIFF
--- a/changelog/@unreleased/pr-4473.v2.yml
+++ b/changelog/@unreleased/pr-4473.v2.yml
@@ -4,5 +4,5 @@ improvement:
     Change logging level of Rollback Other Transaction Logline
 
     Change the level of logging from info to debug for the message This isn't a bug but it should be very infrequent. Two transactions tried to roll back someone else's request with start: {} from SnapshotTransaction as we already have logging for when that happens.
-    links:
+  links:
   - https://github.com/palantir/atlasdb/pull/4473


### PR DESCRIPTION
**Goals (and why)**:
Correct indentation for changelog. `links` should be the same level as `description`

**Priority (whenever / two weeks / yesterday)**:
ASAP, develop is not releaseable.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
