### PR TITLE
Reset the Cassandra cluster after runs of Single/DoubleNodeDown ETE Test

### DIFF
--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/MultiCassandraDoubleNodeDownEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/MultiCassandraDoubleNodeDownEteTest.java
@@ -16,6 +16,7 @@
 package com.palantir.atlasdb.ete;
 
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import org.junit.AfterClass;
@@ -23,11 +24,13 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.todo.ImmutableTodo;
 import com.palantir.atlasdb.todo.Todo;
 import com.palantir.atlasdb.todo.TodoResource;
 
 public class MultiCassandraDoubleNodeDownEteTest {
+    private static final Set<String> ALL_CASSANDRA_NODES = ImmutableSet.of("cassandra1", "cassandra2", "cassandra3");
     private static final List<String> CASSANDRA_NODES_TO_KILL = ImmutableList.of("cassandra1", "cassandra2");
 
     @BeforeClass
@@ -36,8 +39,8 @@ public class MultiCassandraDoubleNodeDownEteTest {
     }
 
     @AfterClass
-    public static void startupCassandraNode() {
-        CASSANDRA_NODES_TO_KILL.forEach(MultiCassandraUtils::startCassandraContainer);
+    public static void resetCassandraNode() {
+        MultiCassandraUtils.resetCassandraCluster(ALL_CASSANDRA_NODES);
     }
 
     @Test(expected = RuntimeException.class)

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/MultiCassandraSingleNodeDownEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/MultiCassandraSingleNodeDownEteTest.java
@@ -17,6 +17,7 @@ package com.palantir.atlasdb.ete;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Set;
 import java.util.UUID;
 
 import org.junit.AfterClass;
@@ -25,6 +26,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
 
+import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.todo.ImmutableTodo;
 import com.palantir.atlasdb.todo.Todo;
 import com.palantir.atlasdb.todo.TodoResource;
@@ -33,6 +35,7 @@ import com.palantir.flake.ShouldRetry;
 
 @ShouldRetry // In some cases we obtain a TTransportException from Cassandra, probably because we don't wait enough?
 public class MultiCassandraSingleNodeDownEteTest {
+    private static final Set<String> ALL_CASSANDRA_NODES = ImmutableSet.of("cassandra1", "cassandra2", "cassandra3");
     private static final String CASSANDRA_NODE_TO_KILL = "cassandra1";
 
     @Rule
@@ -44,8 +47,8 @@ public class MultiCassandraSingleNodeDownEteTest {
     }
 
     @AfterClass
-    public static void startupCassandraNode() {
-        MultiCassandraUtils.startCassandraContainer(CASSANDRA_NODE_TO_KILL);
+    public static void resetCassandraNodes() {
+        MultiCassandraUtils.resetCassandraCluster(ALL_CASSANDRA_NODES);
     }
 
     @Test

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/MultiCassandraUtils.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/MultiCassandraUtils.java
@@ -31,7 +31,7 @@ public final class MultiCassandraUtils {
         // utility
     }
 
-    /** Kill all of the Cassandra containers and start them again.  This wipes all data on the nodes. */
+    /* Kill all of the Cassandra containers and start them again.  This wipes all data on the nodes. */
     public static void resetCassandraCluster(Set<String> containerNames) {
         containerNames.forEach(MultiCassandraUtils::killCassandraContainer);
         containerNames.forEach(MultiCassandraUtils::startCassandraContainer);

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/MultiCassandraUtils.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/MultiCassandraUtils.java
@@ -16,6 +16,7 @@
 package com.palantir.atlasdb.ete;
 
 import java.io.IOException;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.awaitility.Awaitility;
@@ -28,6 +29,12 @@ public final class MultiCassandraUtils {
 
     private MultiCassandraUtils() {
         // utility
+    }
+
+    /** Kill all of the Cassandra containers and start them again.  This wipes all data on the nodes. */
+    public static void resetCassandraCluster(Set<String> containerNames) {
+        containerNames.forEach(MultiCassandraUtils::killCassandraContainer);
+        containerNames.forEach(MultiCassandraUtils::startCassandraContainer);
     }
 
     public static void killCassandraContainer(String containerName) {

--- a/changelog/@unreleased/pr-4529.v2.yml
+++ b/changelog/@unreleased/pr-4529.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Reset the Cassandra cluster after runs of Single/DoubleNodeDown ETE
+    Test.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4529


### PR DESCRIPTION
**Goals (and why)**:
Starting in [Cassandra 3.6](https://issues.apache.org/jira/browse/CASSANDRA-10134), Cassandra detects and fails to start if a different node previously existed at the same IP address.

The Multi Cassandra tests kill the docker container and then start it up again with the same IP, which is not valid since the node is technically no longer the same node (killing the docker container wipes the data).

**Implementation Description (bullets)**:

At the end of each Multi Cassandra test, reset the state of the Cassandra cluster by killing _all_ of the nodes and starting them back up again.

**Testing (What was existing testing like?  What have you done to improve it?)**:

I tested this fix on top of the Cassandra 3 development branch to prove that it worked in both Cassandra 2 and 3.  This is just a test fix, so no impact to production systems.

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
