### PR TITLE
Introduce NanoClock

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/common/time/NanoClock.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/time/NanoClock.java
@@ -1,0 +1,46 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.common.time;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+public enum NanoClock implements Supplier<NanoTime> {
+    INSTANCE;
+
+    private final AtomicReference<NanoTime> maxSeen = new AtomicReference<>();
+
+    @Override
+    public NanoTime get() {
+        NanoTime currentMax = maxSeen.get();
+        NanoTime now = NanoTime.now();
+        checkState(!now.isBefore(currentMax), "Clock reversal detected");
+        maybeSetNewMax(now);
+        return now;
+    }
+
+    private void maybeSetNewMax(NanoTime time) {
+        while (true) {
+            NanoTime current = maxSeen.get();
+            if (time.isBefore(current) || maxSeen.compareAndSet(current, time)) {
+                return;
+            }
+        }
+    }
+}

--- a/atlasdb-commons/src/main/java/com/palantir/common/time/NanoClock.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/time/NanoClock.java
@@ -16,7 +16,7 @@
 
 package com.palantir.common.time;
 
-import static com.google.common.base.Preconditions.checkState;
+import static com.palantir.logsafe.Preconditions.checkState;
 
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Supplier;

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LeaderClock.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LeaderClock.java
@@ -19,11 +19,12 @@ package com.palantir.atlasdb.timelock.lock;
 import java.util.function.Supplier;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.palantir.common.time.NanoClock;
 import com.palantir.common.time.NanoTime;
 import com.palantir.lock.v2.LeaderTime;
 import com.palantir.lock.v2.LeadershipId;
 
-public class LeaderClock {
+public final class LeaderClock {
     private final LeadershipId leadershipId;
     private final Supplier<NanoTime> clock;
 
@@ -34,7 +35,7 @@ public class LeaderClock {
     }
 
     public static LeaderClock create() {
-        return new LeaderClock(LeadershipId.random(), NanoTime::now);
+        return new LeaderClock(LeadershipId.random(), NanoClock.INSTANCE);
     }
 
     public LeaderTime time() {

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LeaderClock.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LeaderClock.java
@@ -24,7 +24,7 @@ import com.palantir.common.time.NanoTime;
 import com.palantir.lock.v2.LeaderTime;
 import com.palantir.lock.v2.LeadershipId;
 
-public final class LeaderClock {
+public class LeaderClock {
     private final LeadershipId leadershipId;
     private final Supplier<NanoTime> clock;
 


### PR DESCRIPTION
NanoClock represents a safety mechanism around NanoTime - it throws if
we ever spot NanoTime.now() go down (which we should never see, but
would lead to weird locking behaviour).