### PR TITLE
Rewrite disruptorautobatcher to just use a plain blocking queue

### DIFF
--- a/atlasdb-autobatch/build.gradle
+++ b/atlasdb-autobatch/build.gradle
@@ -8,7 +8,6 @@ repositories {
 libsDirName = file('build/artifacts')
 dependencies {
     compile project(":atlasdb-commons")
-    compile group: 'com.lmax', name: 'disruptor'
     compile group: 'com.palantir.safe-logging', name: 'safe-logging'
     compile group: 'com.palantir.tritium', name: 'tritium-registry'
 

--- a/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/EventHandler.java
+++ b/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/EventHandler.java
@@ -1,0 +1,22 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.autobatch;
+
+import java.util.List;
+
+public interface EventHandler<T> {
+    void onEvents(List<T> events) throws Exception;
+}

--- a/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/ProfilingEventHandler.java
+++ b/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/ProfilingEventHandler.java
@@ -16,8 +16,6 @@
 
 package com.palantir.atlasdb.autobatch;
 
-import com.lmax.disruptor.EventHandler;
-
 final class ProfilingEventHandler<T, R> implements EventHandler<BatchElement<T, R>> {
 
     private final EventHandler<BatchElement<T, R>> delegateHandler;
@@ -33,9 +31,9 @@ final class ProfilingEventHandler<T, R> implements EventHandler<BatchElement<T, 
     }
 
     @Override
-    public void onEvent(BatchElement<T, R> event, long sequence, boolean endOfBatch) throws Exception {
+    public void onEvent(BatchElement<T, R> event, boolean endOfBatch) throws Exception {
         elementsSeenSoFar++;
-        delegateHandler.onEvent(event, sequence, endOfBatch);
+        delegateHandler.onEvent(event, endOfBatch);
 
         if (endOfBatch) {
             // Shouldn't affect clients, because futures have already been completed

--- a/versions.props
+++ b/versions.props
@@ -18,7 +18,6 @@ com.google.errorprone:error_prone_core = 2.3.3
 com.google.guava:* = 23.6-jre
 com.google.protobuf:protobuf-java = 3.10.0
 com.googlecode.json-simple:json-simple = 1.1.1
-com.lmax:disruptor = 3.4.2
 com.netflix.feign:* = 8.18.0
 com.palantir.common:streams = 1.9.1
 com.palantir.config.crypto:encrypted-config-value-module = 2.1.0


### PR DESCRIPTION
We've seen bugs internally caused by the autobatcher. In particular, the
code here:
https://github.com/LMAX-Exchange/disruptor/blob/master/src/main/java/com/lmax/disruptor/MultiProducerSequencer.java#L136
is causing a high context switch rate. Since I mostly used this class
because it seemed cute, and not because it seemed necessary, it seems
reasonable to rewrite it. This means that a few of the other classes
also become simpler.