### PR TITLE
Increase default buffer size to 2048

### DIFF
--- a/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/Autobatchers.java
+++ b/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/Autobatchers.java
@@ -31,7 +31,7 @@ import com.palantir.logsafe.Preconditions;
 
 public final class Autobatchers {
 
-    private static final int DEFAULT_BUFFER_SIZE = 1024;
+    private static final int DEFAULT_BUFFER_SIZE = 2048;
 
     /**
      * When invoking an {@link DisruptorAutobatcher autobatcher}, an argument needs to be supplied. In the case of

--- a/changelog/@unreleased/pr-4535.v2.yml
+++ b/changelog/@unreleased/pr-4535.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Increase default autobatcher buffer size to 2048
+  links:
+  - https://github.com/palantir/atlasdb/pull/4535


### PR DESCRIPTION
We see issues internally when the buffer fills up - we think there's a bug in the Disruptor when it fills up where it spinloops on LockSupport.park(1 nanosecond) and death spirals. Thankfully, the amount of stuff in the queue is proportional to the number of threads that block on it and so this is typically at most in the low thousands. I therefore think that while my other PR will work fine, this is much less churn, will not significantly bloat memory, and will take us out of the woods.