### PR TITLE
Improve Metrics Logging To Indicate Sources

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/AtlasDbMetrics.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/AtlasDbMetrics.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 import com.codahale.metrics.MetricRegistry;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.tritium.api.event.InstrumentationFilter;
 import com.palantir.tritium.event.InstrumentationFilters;
 import com.palantir.tritium.event.InvocationContext;
@@ -118,10 +119,12 @@ public final class AtlasDbMetrics {
     }
 
     private static <T, U extends T> void logMetricsRegistration(Class<T> serviceInterface, U service, String name) {
-        log.info("Registering metrics for an instance of {} (implementation type believed to be {}) with name {}.",
+        log.info("Registering metrics for an instance of {} (implementation type believed to be {}) with name {}."
+                        + " Also logging an exception for purposes of discovering the current stack trace.",
                 SafeArg.of("serviceInterface", serviceInterface),
                 SafeArg.of("serviceClass", service.getClass()),
-                SafeArg.of("name", name));
+                SafeArg.of("name", name),
+                new SafeRuntimeException("I exist to show you the stack trace"));
     }
 
     private static InstrumentationFilter instrumentTimedOnly() {

--- a/changelog/@unreleased/pr-4537.v2.yml
+++ b/changelog/@unreleased/pr-4537.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Indicate the source of instrumentation (stack trace) when logging that
+    something was instrumented. Internal reference PDS-109071.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4537


### PR DESCRIPTION
**Goals (and why)**:
- Indicate the source of instrumentation in metrics logging. See PDS-109071 - we believe that something is going wrong with the metrics being produced (even though the server is fine).

**Implementation Description (bullets)**:
- Create a safe exception - the purpose is to show the stack trace.

**Testing (What was existing testing like?  What have you done to improve it?)**: none

**Concerns (what feedback would you like?)**: none in particular

**Where should we start reviewing?**: the little bit

**Priority (whenever / two weeks / yesterday)**: today? 🔥 
