### PR TITLE
Coalescing Suppliers: Explicit Round Ordering and Max Accumulation

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/common/concurrent/CoalescingSupplier.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/concurrent/CoalescingSupplier.java
@@ -82,8 +82,9 @@ public class CoalescingSupplier<T> implements Supplier<T> {
                 future.complete(delegate.get());
             } catch (Throwable t) {
                 future.completeExceptionally(t);
+            } finally {
+                round.accumulateAndGet(next, (r1, r2) -> r1.roundNumber > r2.roundNumber ? r1 : r2);
             }
-            round.accumulateAndGet(next, (r1, r2) -> r1.roundNumber > r2.roundNumber ? r1 : r2);
         }
 
         T getResult() {

--- a/changelog/@unreleased/pr-4540.v2.yml
+++ b/changelog/@unreleased/pr-4540.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fixed a race condition in `CoalescingSupplier` that could cause the
+    supplier to be stuck in returning the results of old rounds indefinitely.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4540


### PR DESCRIPTION
**Goals (and why)**:
- Fix what I think is an issue with our `CoalescingSupplier` implementation. If I'm not mistaken, multiple executions of `execute()` on different rounds _can_ concurrently happen, and there is a particularly nasty way in which they can interact. 

![coalescing-supplier](https://user-images.githubusercontent.com/5955510/73213134-923a5000-4147-11ea-8519-86654b781d35.png)

- Basically, future completion and `round` getting updated are non-atomic, so a bad GC at the wrong time can cause us to be stuck in an old round, if two new rounds happened during the GC. Thanks to @gmaretic and @felixdesouza who helped a lot in isolating this.
- See PDS-109071 for more details: this explains our metrics woes, among other concerns.

**Implementation Description (bullets)**:
- Add a numeric counter to rounds. The idea is to achieve an ordering.
- Have the next round be the _highest claimed next round_ in terms of sequence, and not just a volatile assignment.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- None, other than that the existing tests still pass. Happy to take suggestions/ideas on how to test this better.

**Concerns (what feedback would you like?)**:
- Am I mistaken in thinking the interaction is bad?
- Is it more prudent to just revert to the old implementation?
- Are there other categories of issues that tracking rounds won't fix?

**Where should we start reviewing?**: `CoalescingSupplier.java`

**Priority (whenever / two weeks / yesterday)**: yesterday 🔥 