### PR TITLE
Refactor sweep strategy manager

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ReadTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ReadTransaction.java
@@ -126,7 +126,7 @@ public class ReadTransaction extends ForwardingTransaction {
     }
 
     private void checkTableName(TableReference tableRef) {
-        SweepStrategy sweepStrategy = sweepStrategies.get().get(tableRef);
+        SweepStrategy sweepStrategy = sweepStrategies.get(tableRef);
         if (sweepStrategy == SweepStrategy.THOROUGH) {
             throw new SafeIllegalStateException(
                     "Cannot read from a table with a thorough sweep strategy in a read only transaction.");

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/RecomputingSupplier.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/RecomputingSupplier.java
@@ -21,8 +21,8 @@ import java.util.function.Supplier;
 
 public class RecomputingSupplier<T> implements Supplier<T> {
     final Supplier<? extends T> supplier;
-    final AtomicReference<T> cache = new AtomicReference<T>();
-    final AtomicReference<CountDownLatch> latch = new AtomicReference<CountDownLatch>();
+    final AtomicReference<T> cache = new AtomicReference<>();
+    final AtomicReference<CountDownLatch> latch = new AtomicReference<>();
 
     private RecomputingSupplier(Supplier<? extends T> supplier) {
         this.supplier = supplier;
@@ -57,6 +57,6 @@ public class RecomputingSupplier<T> implements Supplier<T> {
     }
 
     public static <T> RecomputingSupplier<T> create(Supplier<? extends T> supplier) {
-        return new RecomputingSupplier<T>(supplier);
+        return new RecomputingSupplier<>(supplier);
     }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/SweepStrategyManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/SweepStrategyManager.java
@@ -15,23 +15,9 @@
  */
 package com.palantir.atlasdb.transaction.impl;
 
-import java.util.Map;
-
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence.SweepStrategy;
 
-public class SweepStrategyManager {
-    private final RecomputingSupplier<Map<TableReference, SweepStrategy>> supplier;
-
-    public SweepStrategyManager(RecomputingSupplier<Map<TableReference, SweepStrategy>> supplier) {
-        this.supplier = supplier;
-    }
-
-    public Map<TableReference, SweepStrategy> get() {
-        return supplier.get();
-    }
-
-    public void recompute() {
-        supplier.recompute();
-    }
+public interface SweepStrategyManager {
+    SweepStrategy get(TableReference tableRef);
 }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/transaction/impl/ReadTransactionShould.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/transaction/impl/ReadTransactionShould.java
@@ -65,14 +65,13 @@ public class ReadTransactionShould {
     private AbstractTransaction delegateTransaction;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         delegateTransaction = Mockito.mock(AbstractTransaction.class);
         SweepStrategyManager sweepStrategies = Mockito.mock(SweepStrategyManager.class);
-        when(sweepStrategies.get()).thenReturn(ImmutableMap.of(
-                DUMMY_CONSERVATIVE_TABLE,
-                TableMetadataPersistence.SweepStrategy.CONSERVATIVE,
-                DUMMY_THOROUGH_TABLE,
-                TableMetadataPersistence.SweepStrategy.THOROUGH));
+        when(sweepStrategies.get(DUMMY_CONSERVATIVE_TABLE))
+                .thenReturn(TableMetadataPersistence.SweepStrategy.CONSERVATIVE);
+        when(sweepStrategies.get(DUMMY_THOROUGH_TABLE))
+                .thenReturn(TableMetadataPersistence.SweepStrategy.THOROUGH);
         readTransaction = new ReadTransaction(delegateTransaction, sweepStrategies);
     }
 
@@ -102,7 +101,7 @@ public class ReadTransactionShould {
     }
 
     @Test
-    public void notAllowSimpleGetsOnThoroughTables() throws IllegalAccessException {
+    public void notAllowSimpleGetsOnThoroughTables() {
         Method[] declaredMethods = ReadTransaction.class.getDeclaredMethods();
 
         for (Method method : declaredMethods) {

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
@@ -131,7 +131,7 @@ public class AtlasDbEteServer extends Application<AtlasDbEteConfiguration> {
         LongSupplier ts = transactionManager.getTimestampService()::getFreshTimestamp;
         TransactionService txnService
                 = TransactionServices.createRaw(kvs, transactionManager.getTimestampService(), false);
-        SweepStrategyManager ssm = SweepStrategyManagers.completelyConservative(kvs); // maybe createDefault
+        SweepStrategyManager ssm = SweepStrategyManagers.completelyConservative(); // maybe createDefault
         PersistentLockManager noLocks = new PersistentLockManager(
                 MetricsManagers.of(metricRegistry, taggedMetricRegistry),
                 new NoOpPersistentLockService(),

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -875,7 +875,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     }
 
     private boolean isThoroughlySwept(TableReference tableRef) {
-        return sweepStrategyManager.get().get(tableRef) == SweepStrategy.THOROUGH;
+        return sweepStrategyManager.get(tableRef) == SweepStrategy.THOROUGH;
     }
 
     private List<Map.Entry<Cell, byte[]>> getPostFilteredWithLocalWrites(final TableReference tableRef,

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/TableMigratorTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/TableMigratorTest.java
@@ -93,7 +93,7 @@ public class TableMigratorTest extends AtlasDbTestCase {
 
         final InMemoryKeyValueService kvs2 = new InMemoryKeyValueService(false);
         final ConflictDetectionManager cdm2 = ConflictDetectionManagers.createWithNoConflictDetection();
-        final SweepStrategyManager ssm2 = SweepStrategyManagers.completelyConservative(kvs2);
+        final SweepStrategyManager ssm2 = SweepStrategyManagers.completelyConservative();
         final MetricsManager metricsManager =
                 MetricsManagers.createForTests();
         final TestTransactionManagerImpl txManager2 = new TestTransactionManagerImpl(
@@ -134,7 +134,7 @@ public class TableMigratorTest extends AtlasDbTestCase {
         checkpointer.deleteCheckpoints();
 
         final ConflictDetectionManager verifyCdm = ConflictDetectionManagers.createWithNoConflictDetection();
-        final SweepStrategyManager verifySsm = SweepStrategyManagers.completelyConservative(kvs2);
+        final SweepStrategyManager verifySsm = SweepStrategyManagers.completelyConservative();
         final TestTransactionManagerImpl verifyTxManager = new TestTransactionManagerImpl(
                 metricsManager,
                 kvs2,

--- a/changelog/@unreleased/pr-4542.v2.yml
+++ b/changelog/@unreleased/pr-4542.v2.yml
@@ -1,0 +1,8 @@
+type: fix
+fix:
+  description: |
+    The SweepStrategyManager now reloads sweep strategies when the strategy for
+    an unknown table is requested. This fixes consumers of sweep strategies for
+    clients who dynamically create tables or change table metadata.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4542


### PR DESCRIPTION
The primary motivation here is to automatically recompute the cache of
sweep strategies if a request is made for an unknown table reference.
Previously, we were just returning a null sweep strategy (which we
happened to only compare with for reference equality so it never npe'd).

**Goals (and why)**:

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
