### PR TITLE
Better log when rolled back by someone else

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -2260,7 +2260,8 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                         + " because our locks timed out. startTs: " + getStartTimestamp() + ".  "
                         + getExpiredLocksErrorString(commitLocksToken, expiredLocks), ex);
             } else {
-                log.info("This transaction has been rolled back by someone else.",
+                log.info("This transaction has been rolled back by someone else, even though we believe we still hold "
+                                + "the locks. This is not expected to occur frequently.",
                         immutableTimestampLock
                                 .map(token -> token.toSafeArg("immutableTimestampLock"))
                                 .orElseGet(() -> SafeArg.of("immutableTimestampLock", null)),

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -2232,6 +2232,15 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             throws TransactionFailedException {
         Preconditions.checkArgument(commitTimestamp > getStartTimestamp(), "commitTs must be greater than startTs");
         try {
+            if (immutableTimestampLock.isPresent()) {
+                log.error("This transaction has been rolled back by someone else.",
+                        immutableTimestampLock.get().toSafeArg(("immutableTimestampLock")),
+                        locksToken.toSafeArg("commitLocksToken"));
+            } else {
+                log.error("This transaction has been rolled back by someone else.",
+                        SafeArg.of("immutableTimestampLock", "not present"),
+                        locksToken.toSafeArg("commitLocksToken"));
+            }
             transactionService.putUnlessExists(getStartTimestamp(), commitTimestamp);
         } catch (KeyAlreadyExistsException e) {
             handleKeyAlreadyExistsException(commitTimestamp, e, locksToken);
@@ -2262,9 +2271,15 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                         + " because our locks timed out. startTs: " + getStartTimestamp() + ".  "
                         + getExpiredLocksErrorString(commitLocksToken, expiredLocks), ex);
             } else {
-                log.info("This transaction has been rolled back by someone else.",
-                        immutableTimestampLock.map(token -> token.toSafeArg("immutableTimestampLock")),
-                        commitLocksToken.toSafeArg("commitLocksToken"));
+                if (immutableTimestampLock.isPresent()) {
+                    log.info("This transaction has been rolled back by someone else.",
+                            immutableTimestampLock.get().toSafeArg(("immutableTimestampLock")),
+                            commitLocksToken.toSafeArg("commitLocksToken"));
+                } else {
+                    log.info("This transaction has been rolled back by someone else.",
+                            SafeArg.of("immutableTimestampLock", "not present"),
+                            commitLocksToken.toSafeArg("commitLocksToken"));
+                }
             }
         } catch (TransactionFailedException e1) {
             throw e1;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -2260,8 +2260,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                         + " because our locks timed out. startTs: " + getStartTimestamp() + ".  "
                         + getExpiredLocksErrorString(commitLocksToken, expiredLocks), ex);
             } else {
-                log.debug("Possible bug: Someone rolled back our transaction but"
-                        + " our locks were still valid; Atlas code is not allowed to do this, though others can.",
+                log.info("This transaction has been rolled back by someone else.",
                         SafeArg.of("immutableTimestampLock", immutableTimestampLock),
                         SafeArg.of("commitLocksToken", commitLocksToken));
             }

--- a/lock-api/src/main/java/com/palantir/lock/client/LeasedLockToken.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LeasedLockToken.java
@@ -26,7 +26,7 @@ import com.palantir.lock.v2.LockToken;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 
-final class LeasedLockToken implements LockToken {
+public final class LeasedLockToken implements LockToken {
     private final LockToken serverToken;
     private final UUID requestId;
 
@@ -46,7 +46,7 @@ final class LeasedLockToken implements LockToken {
         this.lease = lease;
     }
 
-    LockToken serverToken() {
+    public LockToken serverToken() {
         return serverToken;
     }
 

--- a/lock-api/src/main/java/com/palantir/lock/client/LeasedLockToken.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LeasedLockToken.java
@@ -77,4 +77,9 @@ public final class LeasedLockToken implements LockToken {
     public UUID getRequestId() {
         return requestId;
     }
+
+    @Override
+    public SafeArg<LockToken> toSafeArg(String name) {
+        return serverToken.toSafeArg(name);
+    }
 }

--- a/lock-api/src/main/java/com/palantir/lock/client/LockTokenShare.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockTokenShare.java
@@ -23,6 +23,7 @@ import java.util.stream.Stream;
 
 import com.palantir.lock.v2.LockToken;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
 
 public final class LockTokenShare implements LockToken {
     private final UUID requestId;
@@ -88,5 +89,10 @@ public final class LockTokenShare implements LockToken {
             referenceCount--;
             return referenceCount == 0;
         }
+    }
+
+    @Override
+    public SafeArg<LockToken> toSafeArg(String name) {
+        return sharedLockToken.toSafeArg(name);
     }
 }

--- a/lock-api/src/main/java/com/palantir/lock/client/LockTokenShare.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockTokenShare.java
@@ -25,7 +25,7 @@ import com.palantir.lock.v2.LockToken;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 
-public final class LockTokenShare implements LockToken {
+final class LockTokenShare implements LockToken {
     private final UUID requestId;
     private final LockToken sharedLockToken;
     private final ReferenceCounter referenceCounter;
@@ -73,7 +73,7 @@ public final class LockTokenShare implements LockToken {
         return Optional.empty();
     }
 
-    public LockToken sharedLockToken() {
+    LockToken sharedLockToken() {
         return sharedLockToken;
     }
 

--- a/lock-api/src/main/java/com/palantir/lock/client/LockTokenShare.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockTokenShare.java
@@ -24,7 +24,7 @@ import java.util.stream.Stream;
 import com.palantir.lock.v2.LockToken;
 import com.palantir.logsafe.Preconditions;
 
-final class LockTokenShare implements LockToken {
+public final class LockTokenShare implements LockToken {
     private final UUID requestId;
     private final LockToken sharedLockToken;
     private final ReferenceCounter referenceCounter;
@@ -72,7 +72,7 @@ final class LockTokenShare implements LockToken {
         return Optional.empty();
     }
 
-    LockToken sharedLockToken() {
+    public LockToken sharedLockToken() {
         return sharedLockToken;
     }
 

--- a/lock-api/src/main/java/com/palantir/lock/v2/LockToken.java
+++ b/lock-api/src/main/java/com/palantir/lock/v2/LockToken.java
@@ -21,6 +21,7 @@ import org.immutables.value.Value;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.palantir.logsafe.SafeArg;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableLockToken.class)
@@ -34,4 +35,7 @@ public interface LockToken {
         return ImmutableLockToken.of(requestId);
     }
 
+    default SafeArg<LockToken> toSafeArg(String name) {
+        return SafeArg.of(name, this);
+    }
 }


### PR DESCRIPTION
**Goals (and why)**:
We still want to log something when this occurs, but we don't want to panic users by logging at warn or saying that this cannot happen in atlas normally (as it can)
