### PR TITLE
Optimize range scans for single column tables 

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
@@ -346,7 +346,7 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
         byte[] contents_2 = results_2.next().getOnlyColumnValue().getContents();
 
         Assert.assertEquals(contents_1, contents_2);
-        Assert.assertEquals(contents_1, "data2");
+        Assert.assertEquals(Arrays.toString(contents_1), "data2");
     }
 
     @Test

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -216,6 +216,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     private final TracingQueryRunner queryRunner;
     private final WrappingQueryRunner wrappingQueryRunner;
     private final CellLoader cellLoader;
+    private final TableMetaDataProvider tableMetaDataProvider;
     private final Optional<AsyncKeyValueService> asyncKeyValueService;
     private final RangeLoader rangeLoader;
     private final TaskRunner taskRunner;
@@ -426,7 +427,9 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         this.cassandraTables = new CassandraTables(clientPool, config);
         this.taskRunner = new TaskRunner(executor);
         this.cellLoader = CellLoader.create(clientPool, wrappingQueryRunner, taskRunner, runtimeConfigSupplier);
-        this.rangeLoader = new RangeLoader(clientPool, queryRunner, metricsManager, readConsistency, this);
+        this.tableMetaDataProvider = new TableMetaDataProvider(this);
+        this.rangeLoader = new RangeLoader(clientPool, queryRunner, metricsManager, readConsistency,
+                this.tableMetaDataProvider);
         this.cellValuePutter = new CellValuePutter(
                 config,
                 clientPool,

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -426,7 +426,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         this.cassandraTables = new CassandraTables(clientPool, config);
         this.taskRunner = new TaskRunner(executor);
         this.cellLoader = CellLoader.create(clientPool, wrappingQueryRunner, taskRunner, runtimeConfigSupplier);
-        this.rangeLoader = new RangeLoader(clientPool, queryRunner, metricsManager, readConsistency);
+        this.rangeLoader = new RangeLoader(clientPool, queryRunner, metricsManager, readConsistency, this);
         this.cellValuePutter = new CellValuePutter(
                 config,
                 clientPool,

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/RangeLoader.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/RangeLoader.java
@@ -19,8 +19,6 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 import java.util.Set;
 import java.util.function.Supplier;
 
-import javax.xml.crypto.dsig.keyinfo.KeyValue;
-
 import org.apache.cassandra.thrift.ConsistencyLevel;
 import org.apache.cassandra.thrift.SlicePredicate;
 
@@ -73,7 +71,7 @@ public class RangeLoader {
         SlicePredicate predicate;
 
         if (rangeRequest.getColumnNames().size() == 1) {
-            predicate = getSlicePredicate(rangeRequest, startTs);
+            predicate = getSlicePredicateForSingleColumn(rangeRequest, startTs);
         } else {
             TableMetadata tableMetadata = metaDataProvider.getMetaDataFromRef(tableRef);
             // todo (sudiksha) : add null check, also refactor
@@ -83,7 +81,7 @@ public class RangeLoader {
                         .endRowExclusive(rangeRequest.getEndExclusive())
                         .retainColumns(allColumnNames)
                         .build();
-               predicate = getSlicePredicate(newRangeRequest, startTs);
+               predicate = getSlicePredicateForSingleColumn(newRangeRequest, startTs);
             } else {
                 // TODO(nziebart): optimize fetching multiple columns by performing a parallel range request for
                 // each column. note that if no columns are specified, it's a special case that means all columns
@@ -96,7 +94,7 @@ public class RangeLoader {
         return getRangeWithPageCreator(rowGetter, predicate, columnGetter, rangeRequest, resultsExtractor, startTs);
     }
 
-    private SlicePredicate getSlicePredicate(RangeRequest rangeRequest, long startTs) {
+    private SlicePredicate getSlicePredicateForSingleColumn(RangeRequest rangeRequest, long startTs) {
         SlicePredicate predicate;
         byte[] colName = rangeRequest.getColumnNames().iterator().next();
         predicate = SlicePredicates.latestVersionForColumn(colName, startTs);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/RangeLoader.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/RangeLoader.java
@@ -95,10 +95,8 @@ public class RangeLoader {
     }
 
     private SlicePredicate getSlicePredicateForSingleColumn(RangeRequest rangeRequest, long startTs) {
-        SlicePredicate predicate;
         byte[] colName = rangeRequest.getColumnNames().iterator().next();
-        predicate = SlicePredicates.latestVersionForColumn(colName, startTs);
-        return predicate;
+        return SlicePredicates.latestVersionForColumn(colName, startTs);
     }
 
     private <T> ClosableIterator<RowResult<T>> getRangeWithPageCreator(

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TableMetaDataProvider.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TableMetaDataProvider.java
@@ -1,0 +1,35 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.impl.KeyValueServices;
+import com.palantir.atlasdb.table.description.TableMetadata;
+
+public class TableMetaDataProvider {
+
+    private KeyValueService keyValueService;
+
+    public TableMetaDataProvider (KeyValueService keyValueService) {
+        this.keyValueService = keyValueService;
+    }
+
+    public TableMetadata getMetaDataFromRef(TableReference tableRef) {
+        return KeyValueServices.getTableMetadataSafe(keyValueService, tableRef);
+    }
+}

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/ColumnMetadataDescription.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/ColumnMetadataDescription.java
@@ -17,12 +17,12 @@ package com.palantir.atlasdb.table.description;
 
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.annotation.concurrent.Immutable;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.primitives.UnsignedBytes;
@@ -70,18 +70,15 @@ public class ColumnMetadataDescription {
     }
 
     public Set<byte[]> getAllColumnNames() {
-        Set<byte[]> ret = Sets.newTreeSet(UnsignedBytes.lexicographicalComparator());
-
         if (dynamicColumn != null) {
-            for (NameComponentDescription rowPart: dynamicColumn.getColumnNameDesc().getRowParts()) {
-                ret.add(rowPart.getComponentName().getBytes());
-            }
-            return ret;
+            return dynamicColumn.getColumnNameDesc().getRowParts().stream()
+                    .map(rowPart -> rowPart.getComponentName().getBytes())
+                    .collect(Collectors.toCollection(() -> Sets.newTreeSet(UnsignedBytes.lexicographicalComparator())));
+        } else {
+            return namedColumns.stream()
+                    .map(column -> column.getShortName().getBytes())
+                    .collect(Collectors.toCollection(() -> Sets.newTreeSet(UnsignedBytes.lexicographicalComparator())));
         }
-        for (NamedColumnDescription col : namedColumns) {
-            ret.add(col.getShortName().getBytes());
-        }
-        return ret;
     }
 
     public int getMaxValueSize() {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/ColumnMetadataDescription.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/ColumnMetadataDescription.java
@@ -22,7 +22,10 @@ import javax.annotation.concurrent.Immutable;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.google.common.primitives.UnsignedBytes;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence.ColumnMetadataDescription.Builder;
 import com.palantir.logsafe.Preconditions;
@@ -62,6 +65,21 @@ public class ColumnMetadataDescription {
         List<ColumnValueDescription> ret = Lists.newArrayList();
         for (NamedColumnDescription col : namedColumns) {
             ret.add(col.value);
+        }
+        return ret;
+    }
+
+    public Set<byte[]> getAllColumnNames() {
+        Set<byte[]> ret = Sets.newTreeSet(UnsignedBytes.lexicographicalComparator());
+
+        if (dynamicColumn != null) {
+            for (NameComponentDescription rowPart: dynamicColumn.getColumnNameDesc().getRowParts()) {
+                ret.add(rowPart.getComponentName().getBytes());
+            }
+            return ret;
+        }
+        for (NamedColumnDescription col : namedColumns) {
+            ret.add(col.getShortName().getBytes());
         }
         return ret;
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Wed Dec 18 16:02:46 GMT 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Wed Dec 18 16:02:46 GMT 2019
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
**Goals (and why)**:
Fixes - [Reference Issue](https://github.com/palantir/atlasdb/issues/4479)

When performing a range scan for a single column table, we simply grab the latest version for the column for each row, rather than pulling all the data for each row.

**Implementation Description (bullets)**:
- Fetch only the latest version for the column when exactly column is specified in the range scan request (existing behavior)
- When columns are not specified, check the number of columns in the table. 
- If there is exactly one column, update the slice predicate to fetch the latest version of the column for each row

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Test added to ensure correctness

**Concerns (what feedback would you like?)**:
- Does this actually improve perf?

**Where should we start reviewing?**:
CassandraKeyValueServiceImpl#getRangeWithPageCreator

**Priority (whenever / two weeks / yesterday)**:
By the end of this week.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
