### PR TITLE
[Timelock Partitioning] Part 50b: Fix develop

### DIFF
--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClients.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClients.java
@@ -74,7 +74,7 @@ public abstract class PaxosRemoteClients {
 
     @Value.Derived
     public List<BatchPaxosAcceptorRpcClient> batchAcceptor() {
-        return createInstrumentedRemoteProxyList(BatchPaxosAcceptorRpcClient.class, true);
+        return createInstrumentedRemoteProxyList(BatchPaxosAcceptorRpcClient.class, false);
     }
 
     @Value.Derived


### PR DESCRIPTION
**Goals (and why)**:
As part of #4517, we disabled retries of `PaxosAcceptor` since it's generally in a loop elsewhere, either in Proposer loop or loop in `AwaitingLeadershipProxy`.

We did not set `retry=false` for `BatchPaxosAcceptor`, whilst simultaneously lowering the read timeout, this resulted in socket timeout in the face of partitions instead of a `RetryOther` exception (what we expect).

**Implementation Description (bullets)**:
Change parameter from `true` to `false`.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Existing tests pass. They pass for single leader which does not use the `BatchPaxosAcceptor`, and should pass when we run a multi-leader configuration.

**Concerns (what feedback would you like?)**:
None

**Where should we start reviewing?**:
Everywhere

**Priority (whenever / two weeks / yesterday)**:
As important as develop being green 💃 

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
