### PR TITLE
Timelock Metric Fixes

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
@@ -148,7 +148,6 @@ public final class Leaders {
                 ServiceCreator.createTrustContext(config.sslConfiguration());
 
         List<PaxosLearner> learners = createProxyAndLocalList(
-                metricsManager,
                 ourLearner,
                 remotePaxosServerSpec.remoteLearnerUris(),
                 remotingClientConfig,
@@ -165,7 +164,6 @@ public final class Leaders {
                 createExecutorsForService(metricsManager, learners, "knowledge-update"));
 
         List<PaxosAcceptor> acceptors = createProxyAndLocalList(
-                metricsManager,
                 ourAcceptor,
                 remotePaxosServerSpec.remoteAcceptorUris(),
                 remotingClientConfig,
@@ -178,7 +176,6 @@ public final class Leaders {
                 createExecutorsForService(metricsManager, acceptors, "latest-round-verifier"));
 
         List<LeaderPingerContext<PingableLeader>> otherLeaders = generatePingables(
-                metricsManager,
                 remotePaxosServerSpec.remoteLeaderUris(),
                 remotingClientConfig,
                 trustContext,
@@ -258,7 +255,6 @@ public final class Leaders {
     }
 
     public static <T> List<T> createProxyAndLocalList(
-            MetricsManager metricsManager,
             T localObject,
             Set<String> remoteUris,
             Supplier<RemotingClientConfig> remotingClientConfig,
@@ -269,7 +265,6 @@ public final class Leaders {
         // TODO (jkong): Enable runtime config for leader election services.
         List<T> remotes = remoteUris.stream()
                 .map(uri -> AtlasDbHttpClients.createProxy(
-                        metricsManager,
                         trustContext,
                         uri,
                         clazz,
@@ -287,14 +282,12 @@ public final class Leaders {
     }
 
     public static List<LeaderPingerContext<PingableLeader>> generatePingables(
-            MetricsManager metricsManager,
             Collection<String> remoteEndpoints,
             Supplier<RemotingClientConfig> remotingClientConfig,
             Optional<TrustContext> trustContext,
             UserAgent userAgent) {
         return KeyedStream.of(remoteEndpoints)
                 .mapKeys(endpoint -> AtlasDbHttpClients.createProxy(
-                        metricsManager,
                         trustContext,
                         endpoint,
                         PingableLeader.class,

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
@@ -37,17 +37,11 @@ public final class AtlasDbHttpClients {
     }
 
     public static <T> T createProxy(
-            MetricsManager metricsManager,
             Optional<TrustContext> trustContext,
             String uri,
             Class<T> type,
             AuxiliaryRemotingParameters parameters) {
-        return createExperimentallyWithFallback(
-                metricsManager,
-                () -> ConjureJavaRuntimeTargetFactory.DEFAULT.createProxy(trustContext, uri, type, parameters),
-                () -> AtlasDbFeignTargetFactory.DEFAULT.createProxy(trustContext, uri, type, parameters),
-                type,
-                parameters);
+        return ConjureJavaRuntimeTargetFactory.DEFAULT.createProxy(trustContext, uri, type, parameters).instance();
     }
 
     /**

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/LeadersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/LeadersTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.math.BigInteger;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -37,13 +38,19 @@ import com.google.common.collect.Iterables;
 import com.palantir.atlasdb.config.RemotingClientConfig;
 import com.palantir.atlasdb.config.RemotingClientConfigs;
 import com.palantir.atlasdb.http.AtlasDbRemotingConstants;
+import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
+import com.palantir.conjure.java.config.ssl.SslSocketFactories;
+import com.palantir.conjure.java.config.ssl.TrustContext;
 import com.palantir.paxos.PaxosAcceptor;
 import com.palantir.paxos.PaxosLearner;
 import com.palantir.paxos.PaxosValue;
 
 public class LeadersTest {
 
-    private static final Set<String> REMOTE_SERVICE_ADDRESSES = ImmutableSet.of("foo:1234", "bar:5678");
+    private static final SslConfiguration SSL_CONFIGURATION
+            = SslConfiguration.of(Paths.get("var/security/trustStore.jks"));
+    private static final TrustContext TRUST_CONTEXT = SslSocketFactories.createTrustContext(SSL_CONFIGURATION);
+    private static final Set<String> REMOTE_SERVICE_ADDRESSES = ImmutableSet.of("https://foo:1234", "https://bar:5678");
     private static final Supplier<RemotingClientConfig> REMOTING_CLIENT_CONFIG
             = () -> RemotingClientConfigs.ALWAYS_USE_CONJURE;
 
@@ -57,7 +64,7 @@ public class LeadersTest {
                 localLearner,
                 REMOTE_SERVICE_ADDRESSES,
                 REMOTING_CLIENT_CONFIG,
-                Optional.empty(),
+                Optional.of(TRUST_CONTEXT),
                 PaxosLearner.class,
                 AtlasDbRemotingConstants.DEFAULT_USER_AGENT);
 
@@ -77,7 +84,7 @@ public class LeadersTest {
                 localAcceptor,
                 REMOTE_SERVICE_ADDRESSES,
                 REMOTING_CLIENT_CONFIG,
-                Optional.empty(),
+                Optional.of(TRUST_CONTEXT),
                 PaxosAcceptor.class,
                 AtlasDbRemotingConstants.DEFAULT_USER_AGENT);
 
@@ -98,7 +105,7 @@ public class LeadersTest {
                 localAcceptor,
                 ImmutableSet.of(),
                 REMOTING_CLIENT_CONFIG,
-                Optional.empty(),
+                Optional.of(TRUST_CONTEXT),
                 PaxosAcceptor.class,
                 AtlasDbRemotingConstants.DEFAULT_USER_AGENT);
 
@@ -117,7 +124,7 @@ public class LeadersTest {
                 localBigInteger,
                 REMOTE_SERVICE_ADDRESSES,
                 REMOTING_CLIENT_CONFIG,
-                Optional.empty(),
+                Optional.of(TRUST_CONTEXT),
                 BigInteger.class,
                 AtlasDbRemotingConstants.DEFAULT_USER_AGENT);
     }
@@ -130,7 +137,7 @@ public class LeadersTest {
                 localAcceptor,
                 REMOTE_SERVICE_ADDRESSES,
                 REMOTING_CLIENT_CONFIG,
-                Optional.empty(),
+                Optional.of(TRUST_CONTEXT),
                 null,
                 AtlasDbRemotingConstants.DEFAULT_USER_AGENT);
     }

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/LeadersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/LeadersTest.java
@@ -37,7 +37,6 @@ import com.google.common.collect.Iterables;
 import com.palantir.atlasdb.config.RemotingClientConfig;
 import com.palantir.atlasdb.config.RemotingClientConfigs;
 import com.palantir.atlasdb.http.AtlasDbRemotingConstants;
-import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.paxos.PaxosAcceptor;
 import com.palantir.paxos.PaxosLearner;
 import com.palantir.paxos.PaxosValue;
@@ -55,7 +54,6 @@ public class LeadersTest {
         when(localLearner.getGreatestLearnedValue()).thenReturn(presentPaxosValue);
 
         List<PaxosLearner> paxosLearners = Leaders.createProxyAndLocalList(
-                MetricsManagers.createForTests(),
                 localLearner,
                 REMOTE_SERVICE_ADDRESSES,
                 REMOTING_CLIENT_CONFIG,
@@ -76,7 +74,6 @@ public class LeadersTest {
         when(localAcceptor.getLatestSequencePreparedOrAccepted()).thenReturn(1L);
 
         List<PaxosAcceptor> paxosAcceptors = Leaders.createProxyAndLocalList(
-                MetricsManagers.createForTests(),
                 localAcceptor,
                 REMOTE_SERVICE_ADDRESSES,
                 REMOTING_CLIENT_CONFIG,
@@ -98,7 +95,6 @@ public class LeadersTest {
         when(localAcceptor.getLatestSequencePreparedOrAccepted()).thenReturn(1L);
 
         List<PaxosAcceptor> paxosAcceptors = Leaders.createProxyAndLocalList(
-                MetricsManagers.createForTests(),
                 localAcceptor,
                 ImmutableSet.of(),
                 REMOTING_CLIENT_CONFIG,
@@ -118,7 +114,6 @@ public class LeadersTest {
         BigInteger localBigInteger = new BigInteger("0");
 
         Leaders.createProxyAndLocalList(
-                MetricsManagers.createForTests(),
                 localBigInteger,
                 REMOTE_SERVICE_ADDRESSES,
                 REMOTING_CLIENT_CONFIG,
@@ -132,7 +127,6 @@ public class LeadersTest {
         PaxosAcceptor localAcceptor = mock(PaxosAcceptor.class);
 
         Leaders.createProxyAndLocalList(
-                MetricsManagers.createForTests(),
                 localAcceptor,
                 REMOTE_SERVICE_ADDRESSES,
                 REMOTING_CLIENT_CONFIG,

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/AtlasDbHttpClientsTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/AtlasDbHttpClientsTest.java
@@ -189,7 +189,6 @@ public class AtlasDbHttpClientsTest {
     @Test
     public void userAgentIsPresentOnClientRequests() {
         TestResource client = AtlasDbHttpClients.createProxy(
-                MetricsManagers.createForTests(),
                 TRUST_CONTEXT,
                 getUriForPort(availablePort1),
                 TestResource.class,

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/EteSetup.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/EteSetup.java
@@ -203,7 +203,6 @@ public abstract class EteSetup {
     private static <T> T createClientFor(Class<T> clazz, String host, short port) {
         String uri = String.format("http://%s:%s", host, port);
         return AtlasDbHttpClients.createProxy(
-                MetricsManagers.createForTests(),
                 Optional.of(TRUST_CONTEXT),
                 uri,
                 clazz,

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TimeLockMigrationEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TimeLockMigrationEteTest.java
@@ -37,7 +37,6 @@ import com.palantir.atlasdb.http.errors.AtlasDbRemoteException;
 import com.palantir.atlasdb.todo.ImmutableTodo;
 import com.palantir.atlasdb.todo.Todo;
 import com.palantir.atlasdb.todo.TodoResource;
-import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.timestamp.TimestampService;
 
 // We don't use EteSetup because we need much finer-grained control of the orchestration here, compared to the other
@@ -183,7 +182,6 @@ public class TimeLockMigrationEteTest {
     private static <T> T createEteClientFor(Class<T> clazz) {
         String uri = String.format("http://%s:%s", ETE_CONTAINER, ETE_PORT);
         return AtlasDbHttpClients.createProxy(
-                MetricsManagers.createForTests(),
                 Optional.empty(),
                 uri,
                 clazz,
@@ -193,7 +191,6 @@ public class TimeLockMigrationEteTest {
     private static TimestampService createTimeLockTimestampClient() {
         String uri = String.format("http://%s:%s/%s", TIMELOCK_CONTAINER, TIMELOCK_PORT, TEST_CLIENT);
         return AtlasDbHttpClients.createProxy(
-                MetricsManagers.createForTests(),
                 Optional.empty(),
                 uri,
                 TimestampService.class,

--- a/changelog/@unreleased/pr-4549.v2.yml
+++ b/changelog/@unreleased/pr-4549.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Correctly report metrics for certain popular Timelock endpoints. Reduced
+    the places where we over report/double count the number of calls of a particular
+    metric
+  links:
+  - https://github.com/palantir/atlasdb/pull/4549

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchingNetworkClientFactories.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchingNetworkClientFactories.java
@@ -64,12 +64,18 @@ abstract class BatchingNetworkClientFactories implements
 
     @Override
     public Factory<PaxosAcceptorNetworkClient> acceptor() {
-        return acceptorNetworkClientFactory()::paxosAcceptorForClient;
+        return client -> metrics().instrument(
+                PaxosAcceptorNetworkClient.class,
+                acceptorNetworkClientFactory().paxosAcceptorForClient(client),
+                client);
     }
 
     @Override
     public Factory<PaxosLearnerNetworkClient> learner() {
-        return learnerNetworkClientFactory()::paxosLearnerForClient;
+        return client -> metrics().instrument(
+                PaxosLearnerNetworkClient.class,
+                learnerNetworkClientFactory().paxosLearnerForClient(client),
+                client);
     }
 
     public abstract static class Builder implements NetworkClientFactories.Builder {}

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClients.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClients.java
@@ -31,7 +31,6 @@ import com.palantir.atlasdb.config.AuxiliaryRemotingParameters;
 import com.palantir.atlasdb.config.RemotingClientConfigs;
 import com.palantir.atlasdb.http.AtlasDbHttpClients;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
-import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.common.streams.KeyedStream;
 import com.palantir.leader.PingableLeader;
 import com.palantir.paxos.ImmutableLeaderPingerContext;
@@ -104,7 +103,6 @@ public abstract class PaxosRemoteClients {
     private <T> KeyedStream<HostAndPort, T> createInstrumentedRemoteProxies(Class<T> clazz, boolean shouldRetry) {
         return KeyedStream.of(context().remoteUris())
                 .map(uri -> AtlasDbHttpClients.createProxy(
-                        MetricsManagers.of(new MetricRegistry(), metrics()),
                         context().trustContext(),
                         uri,
                         clazz,

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/SingleLeaderNetworkClientFactories.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/SingleLeaderNetworkClientFactories.java
@@ -42,11 +42,13 @@ abstract class SingleLeaderNetworkClientFactories implements
                     .wrap(useCase(), remoteClients())
                     .apply(client);
             PaxosAcceptor localAcceptor = components().acceptor(client);
+
             LocalAndRemotes<PaxosAcceptor> allAcceptors = LocalAndRemotes.of(localAcceptor, remoteAcceptors);
-            return new SingleLeaderAcceptorNetworkClient(
+            SingleLeaderAcceptorNetworkClient uninstrumentedAcceptor = new SingleLeaderAcceptorNetworkClient(
                     allAcceptors.all(),
                     quorumSize(),
                     allAcceptors.withSharedExecutor(sharedExecutor()));
+            return metrics().instrument(PaxosAcceptorNetworkClient.class, uninstrumentedAcceptor);
         };
     }
 
@@ -61,11 +63,12 @@ abstract class SingleLeaderNetworkClientFactories implements
             PaxosLearner localLearner = components().learner(client);
 
             LocalAndRemotes<PaxosLearner> allLearners = LocalAndRemotes.of(localLearner, remoteLearners);
-            return new SingleLeaderLearnerNetworkClient(
+            SingleLeaderLearnerNetworkClient uninstrumentedLearner = new SingleLeaderLearnerNetworkClient(
                     allLearners.local(),
                     allLearners.remotes(),
                     quorumSize(),
                     allLearners.withSharedExecutor(sharedExecutor()));
+            return metrics().instrument(PaxosLearnerNetworkClient.class, uninstrumentedLearner);
         };
     }
 

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/SingleLeaderNetworkClientFactories.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/SingleLeaderNetworkClientFactories.java
@@ -43,7 +43,8 @@ abstract class SingleLeaderNetworkClientFactories implements
                     .apply(client);
             PaxosAcceptor localAcceptor = components().acceptor(client);
 
-            LocalAndRemotes<PaxosAcceptor> allAcceptors = LocalAndRemotes.of(localAcceptor, remoteAcceptors);
+            LocalAndRemotes<PaxosAcceptor> allAcceptors = LocalAndRemotes.of(localAcceptor, remoteAcceptors)
+                    .enhanceRemotes(remote -> metrics().instrument(PaxosAcceptor.class, remote, client));
             SingleLeaderAcceptorNetworkClient uninstrumentedAcceptor = new SingleLeaderAcceptorNetworkClient(
                     allAcceptors.all(),
                     quorumSize(),
@@ -62,7 +63,8 @@ abstract class SingleLeaderNetworkClientFactories implements
                     .apply(client);
             PaxosLearner localLearner = components().learner(client);
 
-            LocalAndRemotes<PaxosLearner> allLearners = LocalAndRemotes.of(localLearner, remoteLearners);
+            LocalAndRemotes<PaxosLearner> allLearners = LocalAndRemotes.of(localLearner, remoteLearners)
+                    .enhanceRemotes(remote -> metrics().instrument(PaxosLearner.class, remote, client));
             SingleLeaderLearnerNetworkClient uninstrumentedLearner = new SingleLeaderLearnerNetworkClient(
                     allLearners.local(),
                     allLearners.remotes(),

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/SingleLeaderNetworkClientFactories.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/SingleLeaderNetworkClientFactories.java
@@ -42,11 +42,7 @@ abstract class SingleLeaderNetworkClientFactories implements
                     .wrap(useCase(), remoteClients())
                     .apply(client);
             PaxosAcceptor localAcceptor = components().acceptor(client);
-            LocalAndRemotes<PaxosAcceptor> allAcceptors = metrics().instrumentLocalAndRemotesFor(
-                    PaxosAcceptor.class,
-                    localAcceptor,
-                    remoteAcceptors,
-                    client);
+            LocalAndRemotes<PaxosAcceptor> allAcceptors = LocalAndRemotes.of(localAcceptor, remoteAcceptors);
             return new SingleLeaderAcceptorNetworkClient(
                     allAcceptors.all(),
                     quorumSize(),
@@ -63,11 +59,8 @@ abstract class SingleLeaderNetworkClientFactories implements
                     .wrap(useCase(), remoteClients())
                     .apply(client);
             PaxosLearner localLearner = components().learner(client);
-            LocalAndRemotes<PaxosLearner> allLearners = metrics().instrumentLocalAndRemotesFor(
-                    PaxosLearner.class,
-                    localLearner,
-                    remoteLearners,
-                    client);
+
+            LocalAndRemotes<PaxosLearner> allLearners = LocalAndRemotes.of(localLearner, remoteLearners);
             return new SingleLeaderLearnerNetworkClient(
                     allLearners.local(),
                     allLearners.remotes(),

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalAndRemotes.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalAndRemotes.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 import org.immutables.value.Value;
@@ -49,6 +50,10 @@ interface LocalAndRemotes<T> {
         return ImmutableLocalAndRemotes.of(
                 mapper.apply(local()),
                 remotes().stream().map(mapper).collect(Collectors.toList()));
+    }
+
+    default LocalAndRemotes<T> enhanceRemotes(UnaryOperator<T> mapper) {
+        return ImmutableLocalAndRemotes.of(local(), remotes().stream().map(mapper).collect(Collectors.toList()));
     }
 
     default Map<T, ExecutorService> withSharedExecutor(ExecutorService sharedExecutor) {

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/TimelockPaxosMetrics.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/TimelockPaxosMetrics.java
@@ -16,7 +16,6 @@
 
 package com.palantir.atlasdb.timelock.paxos;
 
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -76,19 +75,6 @@ public abstract class TimelockPaxosMetrics {
                 instance,
                 MetricRegistry.name(clazz),
                 _context -> tags);
-    }
-
-    public <T> LocalAndRemotes<T> instrumentLocalAndRemotesFor(Class<T> clazz, T local, List<T> remotes) {
-        return LocalAndRemotes.of(local, remotes).map(instance -> instrument(clazz, instance));
-    }
-
-    public <T> LocalAndRemotes<T> instrumentLocalAndRemotesFor(
-            Class<T> clazz,
-            T local,
-            List<T> remotes,
-            Client client) {
-        return LocalAndRemotes.of(local, remotes)
-                .map(instance -> instrument(clazz, instance, client));
     }
 
     private void attachToParentMetricRegistry(TaggedMetricRegistry parent) {

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/IsolatedPaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/IsolatedPaxosTimeLockServerIntegrationTest.java
@@ -32,7 +32,6 @@ import com.palantir.atlasdb.timelock.ImmutableTemplateVariables.TimestampPaxos;
 import com.palantir.atlasdb.timelock.paxos.PaxosTimeLockConstants;
 import com.palantir.atlasdb.timelock.util.ExceptionMatchers;
 import com.palantir.atlasdb.timelock.util.TestProxies;
-import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.paxos.PaxosAcceptor;
 import com.palantir.paxos.PaxosLearner;
 
@@ -102,7 +101,6 @@ public class IsolatedPaxosTimeLockServerIntegrationTest {
 
     private <T> T createProxyForInternalNamespacedTestService(Class<T> clazz) {
         return AtlasDbHttpClients.createProxy(
-                MetricsManagers.createForTests(),
                 Optional.of(TestProxies.TRUST_CONTEXT),
                 String.format("https://localhost:%d/%s/%s/%s",
                         SERVER.serverHolder().getTimelockPort(),

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/util/TestProxies.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/util/TestProxies.java
@@ -54,7 +54,6 @@ public class TestProxies {
         String uri = getServerUri(server);
         List<Object> key = ImmutableList.of(serviceInterface, uri, "single");
         return (T) proxies.computeIfAbsent(key, ignored -> AtlasDbHttpClients.createProxy(
-                MetricsManagers.createForTests(),
                 Optional.of(TRUST_CONTEXT),
                 uri,
                 serviceInterface,


### PR DESCRIPTION
**Goals (and why)**:
Metrics on Timelock are somewhat hard to decipher and in some places incorrect. Small fixes to improve 

**Implementation Description (bullets)**:
* We were both instrumenting the local remotes and combination of both the local and remote `Paxos{Acceptor|Learner}`, meaning we had two entries for the local acceptor/learners. We only instrument the "logical" `BatchPaxos{Acceptor|Learner}` that wraps the (already instrumented) remote `BatchPaxos{Acceptor|Learner}RpcClient`.
* The interface to consumers is through `BatchPaxos{Acceptor|Learner}NetworkClient`, however that itself isn't instrumented. This gives the true indication of how long a "call" took taking into account quoroms.
  * Only downside is that it's a result type which encapsulates errors, so an error - which isn't acceptable state - will count as a normal invocation, not entirely sure it's worth the effort to work around that
* `AtlasDbHttpClients#createExperimentallyWithFallback` instruments the proxy that gets returned, which is potentially further instrumented (in timelock's case, this is true). This results in double reported metrics which inflates/confuses what's actually going on. We really want to use scoped registries, but because `AtlasDbHttpClients` is static and has no real state, it's somewhat difficult (since we can't get scoped registries from a tagged metric registry). It's also not necessary, since we're not falling back to atlasdb-feign as the experiment is over.

**Testing (What was existing testing like?  What have you done to improve it?)**:
None.

**Concerns (what feedback would you like?)**:
None.

**Where should we start reviewing?**:
Commit 👏 by 👏 commit 💃 

**Priority (whenever / two weeks / yesterday)**:
Relatively soon pls

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
