### PR TITLE
[LW] Part 9(?): Lock Descriptor Utils

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/AtlasLockDescriptorUtils.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/AtlasLockDescriptorUtils.java
@@ -1,0 +1,82 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.api;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.immutables.value.Value;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Bytes;
+import com.palantir.lock.LockDescriptor;
+
+import okio.ByteString;
+
+public final class AtlasLockDescriptorUtils {
+    private static final byte[] ZERO_ARRAY = new byte[] {0};
+
+    private AtlasLockDescriptorUtils() {
+        // NOPE
+    }
+
+    public static List<CellReference> candidateCells(LockDescriptor lockDescriptor) {
+        Optional<TableRefAndRemainder> tableRefAndRemainder = tryParseTableRef(lockDescriptor);
+        if (!tableRefAndRemainder.isPresent()) {
+            return ImmutableList.of();
+        }
+
+        TableReference tableRef = tableRefAndRemainder.get().tableRef();
+        ByteString remainingBytes = tableRefAndRemainder.get().remainder();
+
+        int lookupFrom = 0;
+        int nextCandidate;
+        List<Cell> cells = new ArrayList<>();
+        while ((nextCandidate = remainingBytes.indexOf(ZERO_ARRAY, lookupFrom)) != -1) {
+            if (nextCandidate > 0 && nextCandidate < remainingBytes.size() - 2) {
+                byte[] row = remainingBytes.substring(0, nextCandidate).toByteArray();
+                byte[] col = remainingBytes.substring(nextCandidate + 1, remainingBytes.size()).toByteArray();
+                cells.add(Cell.create(row, col));
+            }
+            lookupFrom = nextCandidate + 1;
+        }
+        return cells.stream().map(cell -> CellReference.of(tableRef, cell)).collect(Collectors.toList());
+    }
+
+    public static Optional<TableRefAndRemainder> tryParseTableRef(LockDescriptor lockDescriptor) {
+        byte[] rawBytes = lockDescriptor.getBytes();
+
+        int endOfTableName = Bytes.indexOf(rawBytes, (byte) 0);
+        if (endOfTableName == -1) {
+            return Optional.empty();
+        }
+        String fullyQualifiedName = new String(rawBytes, 0, endOfTableName);
+        TableReference tableRef = TableReference.createFromFullyQualifiedName(fullyQualifiedName);
+        ByteString remainingBytes = ByteString.of(rawBytes, endOfTableName + 1, rawBytes.length - 1 - endOfTableName);
+        return Optional.of(ImmutableTableRefAndRemainder.of(tableRef, remainingBytes));
+    }
+
+    @Value.Immutable
+    public interface TableRefAndRemainder {
+        @Value.Parameter
+        TableReference tableRef();
+        @Value.Parameter
+        ByteString remainder();
+    }
+}

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/CellReference.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/CellReference.java
@@ -21,4 +21,8 @@ import org.immutables.value.Value;
 public interface CellReference {
     TableReference tableRef();
     Cell cell();
+
+    static CellReference of(TableReference tableRef, Cell cell) {
+        return ImmutableCellReference.builder().tableRef(tableRef).cell(cell).build();
+    }
 }

--- a/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/AtlasLockDescriptorUtilsTest.java
+++ b/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/AtlasLockDescriptorUtilsTest.java
@@ -1,0 +1,139 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.lock.AtlasCellLockDescriptor;
+import com.palantir.lock.AtlasRowLockDescriptor;
+import com.palantir.lock.LockDescriptor;
+import com.palantir.lock.StringLockDescriptor;
+
+import okio.ByteString;
+
+public class AtlasLockDescriptorUtilsTest {
+    private static final TableReference TABLE = TableReference.createFromFullyQualifiedName("test.table");
+    private static final byte[] NO_ZERO_ROW = new byte[] {1, 2, 3};
+    private static final byte[] NO_ZERO_COL = new byte[] {4, 5, 6};
+    private static final byte[] ROW_WITH_ZEROS = new byte[] {1, 0, 2, 0, 3};
+    private static final byte[] COL_WITH_ZEROS = new byte[] {4, 0, 0, 5, 6};
+    private static final byte[] START_WITH_ZERO = new byte[] {0, 1, 2, 3};
+    private static final byte[] END_WITH_ZERO = new byte[] {4, 5, 6, 0};
+
+    @Test
+    public void lockDescriptorWithNoZerosReturnsEmptyForCells() {
+        LockDescriptor descriptor = StringLockDescriptor.of("test");
+        assertThat(AtlasLockDescriptorUtils.candidateCells(descriptor)).isEmpty();
+    }
+
+    @Test
+    public void lockDescriptorWithOneZeroReturnsEmptyForCells() {
+        LockDescriptor descriptor = AtlasRowLockDescriptor.of(TABLE.getQualifiedName(), NO_ZERO_ROW);
+        assertThat(AtlasLockDescriptorUtils.candidateCells(descriptor)).isEmpty();
+    }
+
+    @Test
+    public void uniqueCellLockDescriptorIsDecodedCorrectlyForCells() {
+        LockDescriptor descriptor = AtlasCellLockDescriptor.of(TABLE.getQualifiedName(), NO_ZERO_ROW, NO_ZERO_COL);
+        assertThat(AtlasLockDescriptorUtils.candidateCells(descriptor))
+                .containsExactly(CellReference.of(TABLE, Cell.create(NO_ZERO_ROW, NO_ZERO_COL)));
+    }
+
+    @Test
+    public void rowWithNullsParsesAllCombinationsForCells() {
+        LockDescriptor descriptor = AtlasCellLockDescriptor.of(TABLE.getQualifiedName(), ROW_WITH_ZEROS, NO_ZERO_COL);
+
+        List<CellReference> expected = ImmutableList.of(
+                Cell.create(new byte[] {1}, new byte[] {2, 0, 3, 0, 4, 5, 6}),
+                Cell.create(new byte[] {1, 0, 2}, new byte[] {3, 0, 4, 5, 6}),
+                Cell.create(new byte[] {1, 0, 2, 0, 3}, new byte[] {4, 5, 6}))
+                .stream()
+                .map(cell -> CellReference.of(TABLE, cell))
+                .collect(Collectors.toList());
+
+        assertThat(AtlasLockDescriptorUtils.candidateCells(descriptor)).isEqualTo(expected);
+        assertThat(AtlasLockDescriptorUtils.candidateCells(descriptor))
+                .contains(CellReference.of(TABLE, Cell.create(ROW_WITH_ZEROS, NO_ZERO_COL)));
+    }
+
+    @Test
+    public void colWithNullsParsesAllCombinationsForCells() {
+        LockDescriptor descriptor = AtlasCellLockDescriptor.of(TABLE.getQualifiedName(), NO_ZERO_ROW, COL_WITH_ZEROS);
+
+        List<CellReference> expected = ImmutableList.of(
+                Cell.create(new byte[] {1, 2, 3}, new byte[] {4, 0, 0, 5, 6}),
+                Cell.create(new byte[] {1, 2, 3, 0, 4}, new byte[] {0, 5, 6}),
+                Cell.create(new byte[] {1, 2, 3, 0, 4, 0}, new byte[] {5, 6}))
+                .stream()
+                .map(cell -> CellReference.of(TABLE, cell))
+                .collect(Collectors.toList());
+
+        assertThat(AtlasLockDescriptorUtils.candidateCells(descriptor)).isEqualTo(expected);
+        assertThat(AtlasLockDescriptorUtils.candidateCells(descriptor))
+                .contains(CellReference.of(TABLE, Cell.create(NO_ZERO_ROW, COL_WITH_ZEROS)));
+    }
+
+    @Test
+    public void rowEndingWithZeroIsCorrectlyParsedForCombinationsForCells() {
+        LockDescriptor descriptor = AtlasCellLockDescriptor.of(TABLE.getQualifiedName(), END_WITH_ZERO, NO_ZERO_COL);
+
+        List<CellReference> expected = ImmutableList.of(
+                Cell.create(new byte[] {4, 5, 6}, new byte[] {0, 4, 5, 6}),
+                Cell.create(new byte[] {4, 5, 6, 0}, new byte[] {4, 5, 6}))
+                .stream()
+                .map(cell -> CellReference.of(TABLE, cell))
+                .collect(Collectors.toList());
+
+        assertThat(AtlasLockDescriptorUtils.candidateCells(descriptor)).isEqualTo(expected);
+        assertThat(AtlasLockDescriptorUtils.candidateCells(descriptor))
+                .contains(CellReference.of(TABLE, Cell.create(END_WITH_ZERO, NO_ZERO_COL)));
+    }
+
+    @Test
+    public void rowStartingWithZeroIsIgnoredForCells() {
+        LockDescriptor descriptor = AtlasCellLockDescriptor.of(TABLE.getQualifiedName(), START_WITH_ZERO, NO_ZERO_COL);
+        assertThat(AtlasLockDescriptorUtils.candidateCells(descriptor))
+                .containsExactly(CellReference.of(TABLE, Cell.create(START_WITH_ZERO, NO_ZERO_COL)));
+    }
+
+    @Test
+    public void columnEndingWithZeroIsIgnoredForCells() {
+        LockDescriptor descriptor = AtlasCellLockDescriptor.of(TABLE.getQualifiedName(), NO_ZERO_ROW, END_WITH_ZERO);
+        assertThat(AtlasLockDescriptorUtils.candidateCells(descriptor))
+                .containsExactly(CellReference.of(TABLE, Cell.create(NO_ZERO_ROW, END_WITH_ZERO)));
+    }
+
+    @Test
+    public void lockDescriptorWithOneZeroReturnsCorrectTableAndRemainder() {
+        LockDescriptor descriptor = AtlasRowLockDescriptor.of(TABLE.getQualifiedName(), NO_ZERO_ROW);
+        assertThat(AtlasLockDescriptorUtils.tryParseTableRef(descriptor))
+                .hasValue(ImmutableTableRefAndRemainder.of(TABLE, ByteString.of(NO_ZERO_ROW)));
+    }
+
+    @Test
+    public void lockDescriptorWithMultipleZerosReturnsCorrectTableAndRemainder() {
+        LockDescriptor descriptor = AtlasRowLockDescriptor.of(TABLE.getQualifiedName(), ROW_WITH_ZEROS);
+        assertThat(AtlasLockDescriptorUtils.tryParseTableRef(descriptor))
+                .hasValue(ImmutableTableRefAndRemainder.of(TABLE, ByteString.of(ROW_WITH_ZEROS)));
+    }
+}


### PR DESCRIPTION
**Goals (and why)**:
Utility methods for mapping lock descriptors to original table reference and cell/row.

**Implementation Description (bullets)**:
Since the mapping from cell to lock descriptor is not an injection, the reverse mapping returns a list. I tried to make the code as painless as possible, but byte array manipulation is always fun.

**Testing (What was existing testing like?  What have you done to improve it?)**:
It is quite thoroughly tested, trying all reasonable corner cases. Feel free to suggest others if I missed something.

**Concerns (what feedback would you like?)**:
Did I miss something?

**Where should we start reviewing?**:
small

**Priority (whenever / two weeks / yesterday)**:
asap