### PR TITLE
[PDS-110262] Meter for Cassandra pool exhaustion events

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/util/MetricsManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/util/MetricsManager.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
@@ -155,6 +156,16 @@ public class MetricsManager {
         Timer timer = metricRegistry.timer(fullyQualifiedHistogramName);
         registerMetricName(fullyQualifiedHistogramName);
         return timer;
+    }
+
+    public Counter registerOrGetCounter(Class clazz, String counterName) {
+        return registerOrGetCounter(MetricRegistry.name(clazz, "", counterName));
+    }
+
+    private Counter registerOrGetCounter(String fullyQualifiedCounterName) {
+        Counter counter = metricRegistry.counter(fullyQualifiedCounterName);
+        registerMetricName(fullyQualifiedCounterName);
+        return counter;
     }
 
     public Meter registerOrGetMeter(Class clazz, String meterName) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -43,6 +43,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraClientPoolMetrics;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.common.pooling.PoolingContainer;
@@ -59,17 +60,20 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Cassand
     private final AtomicInteger openRequests = new AtomicInteger();
     private final GenericObjectPool<CassandraClient> clientPool;
     private final int poolNumber;
+    private final CassandraClientPoolMetrics poolMetrics;
 
     public CassandraClientPoolingContainer(
             MetricsManager metricsManager,
             InetSocketAddress host,
             CassandraKeyValueServiceConfig config,
-            int poolNumber) {
+            int poolNumber,
+            CassandraClientPoolMetrics poolMetrics) {
         this.metricsManager = metricsManager;
         this.host = host;
         this.config = config;
         this.poolNumber = poolNumber;
         this.clientPool = createClientPool();
+        this.poolMetrics = poolMetrics;
     }
 
     public InetSocketAddress getHost() {
@@ -116,6 +120,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Cassand
                         SafeArg.of("maxTotal", clientPool.getMaxTotal()),
                         SafeArg.of("meanActiveTimeMillis", clientPool.getMeanActiveTimeMillis()),
                         SafeArg.of("meanIdleTimeMillis", clientPool.getMeanIdleTimeMillis()));
+                poolMetrics.recordPoolExhaustion(this);
                 if (log.isDebugEnabled()) {
                     logThreadStates();
                 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -120,7 +120,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Cassand
                         SafeArg.of("maxTotal", clientPool.getMaxTotal()),
                         SafeArg.of("meanActiveTimeMillis", clientPool.getMeanActiveTimeMillis()),
                         SafeArg.of("meanIdleTimeMillis", clientPool.getMeanIdleTimeMillis()));
-                poolMetrics.recordPoolExhaustion(this);
+                poolMetrics.recordPoolExhaustion();
                 if (log.isDebugEnabled()) {
                     logThreadStates();
                 }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
@@ -30,6 +30,7 @@ import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.ImmutableDefaultConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.Blacklist;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer;
+import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.atlasdb.util.MetricsManagers;
 
 public class CassandraServiceTest {
@@ -183,7 +184,9 @@ public class CassandraServiceTest {
 
         blacklist = new Blacklist(config);
 
-        CassandraService service = new CassandraService(MetricsManagers.createForTests(), config, blacklist);
+        MetricsManager metricsManager = MetricsManagers.createForTests();
+        CassandraService service = new CassandraService(
+                metricsManager, config, blacklist, new CassandraClientPoolMetrics(metricsManager));
 
         service.cacheInitialCassandraHosts();
         serversInPool.forEach(service::addPool);

--- a/changelog/@unreleased/pr-4555.v2.yml
+++ b/changelog/@unreleased/pr-4555.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: AtlasDB now publishes a metric indicating the count of requests that
+    were dropped owing to saturated Cassandra connection pools.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4555

--- a/changelog/@unreleased/pr-4555.v2.yml
+++ b/changelog/@unreleased/pr-4555.v2.yml
@@ -1,6 +1,6 @@
 type: improvement
 improvement:
-  description: AtlasDB now publishes a metric indicating the count of requests that
-    were dropped owing to saturated Cassandra connection pools.
+  description: AtlasDB now publishes a metric that can be used to monitor Cassandra
+    connection pool exhaustion.
   links:
   - https://github.com/palantir/atlasdb/pull/4555


### PR DESCRIPTION
**Goals (and why)**:
- Allow easy visualisation of when requests are being dropped because our connection pools are getting exhausted. See internal ticket PDS-110262, this would have helped figure things out more quickly.

**Implementation Description (bullets)**:
- Add a meter from the metrics registry that is marked whenever the pool is exhausted on a request

**Testing (What was existing testing like?  What have you done to improve it?)**:
None, admittedly (not breaking existing tests is progress, of course)

**Concerns (what feedback would you like?)**:
- The goal here is to add only one meter per namespace. Was this done correctly?
- Are there cases where this over or under counts the number of request failures?
- Not really a fan of passing the `CassandraClientPoolMetrics` objects around. Should I have passed a callback instead?

**Where should we start reviewing?**: CassandraClientPoolMetrics

**Priority (whenever / two weeks / yesterday)**: early next week?