### PR TITLE
Make max threadpool size for Cass calls track connection pool sizes.

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -413,6 +413,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             CassandraMutationTimestampProvider mutationTimestampProvider) {
         super(createInstrumentedFixedThreadPool(
                 config.poolSize() * config.servers().numberOfThriftHosts(),
+                config.maxConnectionBurstSize() * config.servers().numberOfThriftHosts(),
                 metricsManager.getRegistry()
         ));
         this.log = log;
@@ -442,10 +443,11 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                 cassandraTableTruncator);
     }
 
-    private static ExecutorService createInstrumentedFixedThreadPool(int corePoolSize, MetricRegistry registry) {
+    private static ExecutorService createInstrumentedFixedThreadPool(int corePoolSize, int maxPoolSize,
+            MetricRegistry registry) {
         return Tracers.wrap(
                 new InstrumentedExecutorService(
-                        createFixedThreadPool("Atlas Cassandra KVS", corePoolSize),
+                        createThreadPool("Atlas Cassandra KVS", corePoolSize, maxPoolSize),
                         registry,
                         MetricRegistry.name(CassandraKeyValueService.class, "executorService")));
     }

--- a/changelog/@unreleased/pr-4556.v2.yml
+++ b/changelog/@unreleased/pr-4556.v2.yml
@@ -1,5 +1,6 @@
 type: improvement
 improvement:
-  description: Make max threadpool size for Cass calls track connection pool sizes.
+  description: Make max threadpool size for Cass calls track connection pool sizes
+    and improve instrumentation around queueing duration.
   links:
   - https://github.com/palantir/atlasdb/pull/4556

--- a/changelog/@unreleased/pr-4556.v2.yml
+++ b/changelog/@unreleased/pr-4556.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Make max threadpool size for Cass calls track connection pool sizes.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4556


### PR DESCRIPTION
**Goals (and why)**:

This threadpool controls the number of concurrent Cassandra calls we make. Each call is effectively a retrying thing that can call any number of Cassandra hosts, but ideally should be doing just 1. Underneath it there are per host pools that have min and burst size (by default 30/100). If one of those pools is exhausted, the calls will sleep inside of this threadpool to backoff.

**Implementation Description (bullets)**:

Letting this number go up might increase the overall congestion for the connection pools. 

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
