### PR TITLE
[PDS-109527 FLUP] TimeLock Invariant Enforcement, Part 2: The ServerKiller is out for blood

### DIFF
--- a/changelog/@unreleased/pr-4560.v2.yml
+++ b/changelog/@unreleased/pr-4560.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: TimeLock now shuts itself down if it detects that the cluster is serving
+    timestamps in an inconsistent way.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4560


### PR DESCRIPTION
**DO NOT MERGE until we are confident that we aren't exposing ourselves to too many false positives.**

**Goals (and why)**:
- Actually shut down rogue timelocks faster.

**Implementation Description (bullets)**:
- Change the penalty for an invariant violation from an ERROR log to actually taking out the cluster.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- None beyond existing testing to validate that in the normal case things still work.

**Concerns (what feedback would you like?)**:
- Nothing in particular.

**Where should we start reviewing?**: `NoSimultaneousServiceCheck.java`

**Priority (whenever / two weeks / yesterday)**: If there are zero instances of the ERROR state logs by Monday next week, I think we should be good to merge.
