### PR TITLE
Make createProxy retain refreshing capabilities.

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
@@ -41,7 +41,9 @@ public final class AtlasDbHttpClients {
             String uri,
             Class<T> type,
             AuxiliaryRemotingParameters parameters) {
-        return ConjureJavaRuntimeTargetFactory.DEFAULT.createProxy(trustContext, uri, type, parameters).instance();
+        return VersionSelectingClients.createRefreshingNewClient(
+                () -> ConjureJavaRuntimeTargetFactory.DEFAULT.createProxy(trustContext, uri, type, parameters),
+                type);
     }
 
     /**

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/VersionSelectingClients.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/VersionSelectingClients.java
@@ -24,6 +24,7 @@ import java.util.function.Supplier;
 import org.immutables.value.Value;
 
 import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.atlasdb.AtlasDbMetricNames;
 import com.palantir.atlasdb.config.RemotingClientConfig;
@@ -81,6 +82,19 @@ final class VersionSelectingClients {
                 versionSelectingConfig.enableFallback(),
                 clazz,
                 errorMetric::increment);
+    }
+
+    static <T> T createRefreshingNewClient(
+            Supplier<TargetFactory.InstanceAndVersion<T>> newClientSupplier,
+            Class<T> clazz) {
+
+        return ExperimentRunningProxy.newProxyInstance(
+                Suppliers.compose(TargetFactory.InstanceAndVersion::instance, newClientSupplier::get),
+                null,
+                () -> true,
+                () -> false,
+                clazz,
+                () -> { });
     }
 
     static <T> T instrumentWithClientVersionTag(

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/LeadersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/LeadersTest.java
@@ -116,7 +116,7 @@ public class LeadersTest {
         verifyNoMoreInteractions(localAcceptor);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void createProxyAndLocalListThrowsIfCreatingObjectsWithoutHttpMethodAnnotatedMethods() {
         BigInteger localBigInteger = new BigInteger("0");
 

--- a/changelog/@unreleased/pr-4563.v2.yml
+++ b/changelog/@unreleased/pr-4563.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: |-
+    Ensure `createProxy` retries
+  links:
+  - https://github.com/palantir/atlasdb/pull/4563


### PR DESCRIPTION
**Goals (and why)**:
As part of figuring out why Timelock is OOMing, rolling back potentially contentious changes that occurred between 0.185.3 and 0.185.4 of Atlas

**Implementation Description (bullets)**:
Restore the client refreshing behaviour but drop the extra metrics.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Existing tests should pass

**Concerns (what feedback would you like?)**:
is `null` the worst thing here?

**Where should we start reviewing?**:
Everywhere

**Priority (whenever / two weeks / yesterday)**:
ASAP 💃 

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
