### PR TITLE
Fix flakes

### DIFF
--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/http/TestProxyUtils.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/http/TestProxyUtils.java
@@ -31,6 +31,12 @@ public final class TestProxyUtils {
                     .shouldRetry(true)
                     .build();
 
+    public static final AuxiliaryRemotingParameters AUXILIARY_REMOTING_PARAMETERS_NO_RETRYING
+            = AuxiliaryRemotingParameters.builder()
+            .from(AUXILIARY_REMOTING_PARAMETERS_RETRYING)
+            .shouldRetry(false)
+            .build();
+
     private TestProxyUtils() {
         // constants
     }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosQuorumChecker.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosQuorumChecker.java
@@ -234,7 +234,11 @@ public final class PaxosQuorumChecker {
             }
 
             if (!receivedResponses.hasQuorum()) {
-                encounteredErrors.forEach(throwable -> log.warn(PAXOS_MESSAGE_ERROR, throwable));
+                RuntimeException exceptionForSuppression = new RuntimeException("exception for suppresion");
+                encounteredErrors.forEach(throwable -> {
+                    throwable.addSuppressed(exceptionForSuppression);
+                    log.warn(PAXOS_MESSAGE_ERROR, throwable);
+                });
             }
         }
         return receivedResponses.collect();

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TimeLockServerDownIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TimeLockServerDownIntegrationTest.java
@@ -20,6 +20,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import static com.palantir.atlasdb.timelock.AbstractAsyncTimelockServiceIntegrationTest.DEFAULT_SINGLE_SERVER;
 
+import java.util.concurrent.ExecutionException;
+
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -45,7 +47,7 @@ public class TimeLockServerDownIntegrationTest {
     public static final RuleChain ruleChain = CLUSTER.getRuleChain();
 
     @Test
-    public void getsDependencyExceptionFromTransactionsWhenDown() {
+    public void getsDependencyExceptionFromTransactionsWhenDown() throws ExecutionException {
         TransactionManager txnManager = TimeLockTestUtils.createTransactionManager(CLUSTER);
         txnManager.getKeyValueService().createTable(TABLE, AtlasDbConstants.GENERIC_TABLE_METADATA);
 
@@ -67,8 +69,8 @@ public class TimeLockServerDownIntegrationTest {
                 .isExactlyInstanceOf(AtlasDbDependencyException.class);
     }
 
-    private static void takeDownTimeLock() {
-        CLUSTER.servers().forEach(TestableTimelockServer::kill);
+    private static void takeDownTimeLock() throws ExecutionException {
+        CLUSTER.killAndAwaitTermination(CLUSTER.servers());
     }
 
 }

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -46,6 +47,8 @@ import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 import com.google.common.hash.Hashing;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.atlasdb.timelock.paxos.PaxosQuorumCheckingCoalescingFunction.PaxosContainer;
 import com.palantir.atlasdb.timelock.util.TestProxies;
 import com.palantir.common.streams.KeyedStream;
@@ -117,6 +120,15 @@ public class TestableTimelockCluster implements TestRule {
         waitUntilReadyToServeNamespaces(namespaces);
     }
 
+    void killAndAwaitTermination(Iterable<TestableTimelockServer> servers) throws ExecutionException {
+        Set<ListenableFuture<Void>> shutdownFutures = ImmutableSet.copyOf(servers)
+                .stream()
+                .map(TestableTimelockServer::killAsync)
+                .collect(Collectors.toSet());
+
+        Futures.getDone(Futures.allAsList(shutdownFutures));
+    }
+
     TestableTimelockServer currentLeaderFor(String namespace) {
         return Iterables.getOnlyElement(currentLeaders(namespace).get(namespace));
     }
@@ -175,7 +187,7 @@ public class TestableTimelockCluster implements TestRule {
 
     private boolean tryFailoverToNewLeader(String namespace) {
         TestableTimelockServer leader = currentLeaderFor(namespace);
-        leader.kill();
+        leader.killSync();
         waitUntilLeaderIsElected(ImmutableList.of(namespace));
         leader.start();
 

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
@@ -120,8 +120,8 @@ public class TestableTimelockCluster implements TestRule {
         waitUntilReadyToServeNamespaces(namespaces);
     }
 
-    void killAndAwaitTermination(Iterable<TestableTimelockServer> servers) throws ExecutionException {
-        Set<ListenableFuture<Void>> shutdownFutures = ImmutableSet.copyOf(servers)
+    void killAndAwaitTermination(Iterable<TestableTimelockServer> serversToKill) throws ExecutionException {
+        Set<ListenableFuture<Void>> shutdownFutures = ImmutableSet.copyOf(serversToKill)
                 .stream()
                 .map(TestableTimelockServer::killAsync)
                 .collect(Collectors.toSet());

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
@@ -23,6 +23,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Streams;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.atlasdb.timelock.NamespacedClients.ProxyFactory;
 import com.palantir.atlasdb.timelock.paxos.BatchPingableLeader;
 import com.palantir.atlasdb.timelock.paxos.Client;
@@ -51,8 +53,12 @@ public class TestableTimelockServer {
         return serverHolder;
     }
 
-    void kill() {
-        serverHolder.kill();
+    ListenableFuture<Void> killAsync() {
+        return serverHolder.kill();
+    }
+
+    void killSync() {
+        Futures.getUnchecked(killAsync());
     }
 
     void start() {

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
@@ -64,7 +64,7 @@ public class TestableTimelockServer {
 
         switch (mode) {
             case SINGLE_LEADER:
-                PingableLeader pingableLeader = proxies.singleNode(serverHolder, PingableLeader.class);
+                PingableLeader pingableLeader = proxies.singleNode(serverHolder, PingableLeader.class, false);
                 return namespaces -> {
                     if (pingableLeader.ping()) {
                         return ImmutableSet.copyOf(namespaces);
@@ -73,7 +73,8 @@ public class TestableTimelockServer {
                     }
                 };
             case LEADER_PER_CLIENT:
-                BatchPingableLeader batchPingableLeader = proxies.singleNode(serverHolder, BatchPingableLeader.class);
+                BatchPingableLeader batchPingableLeader =
+                        proxies.singleNode(serverHolder, BatchPingableLeader.class, false);
                 return namespaces -> {
                     Set<Client> typedNamespaces = Streams.stream(namespaces)
                             .map(Client::of)

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/util/TestProxies.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/util/TestProxies.java
@@ -58,9 +58,9 @@ public class TestProxies {
     public <T> T singleNode(TimeLockServerHolder server, Class<T> serviceInterface, boolean shouldRetry) {
         String uri = getServerUri(server);
         List<Object> key = ImmutableList.of(serviceInterface, uri, "single");
-        AuxiliaryRemotingParameters parameters = shouldRetry ?
-                TestProxyUtils.AUXILIARY_REMOTING_PARAMETERS_RETRYING :
-                TestProxyUtils.AUXILIARY_REMOTING_PARAMETERS_NO_RETRYING;
+        AuxiliaryRemotingParameters parameters = shouldRetry
+                ? TestProxyUtils.AUXILIARY_REMOTING_PARAMETERS_RETRYING
+                : TestProxyUtils.AUXILIARY_REMOTING_PARAMETERS_NO_RETRYING;
         return (T) proxies.computeIfAbsent(key, ignored -> AtlasDbHttpClients.createProxy(
                 Optional.of(TRUST_CONTEXT),
                 uri,


### PR DESCRIPTION
**Goals (and why)**:
Tests would sporadically fail with
```
feign.RetryableException: Exceeded the maximum number of allowed redirects: 
{requestUrl=https://localhost:9087/de01b90e-a948-4f88-92ab-08fdcffceee9/timelock/fresh-timestamp} 
executing POST 
https://localhost:9087/de01b90e-a948-4f88-92ab-08fdcffceee9/timelock/fresh-timestamp
```

Especially on multi-leader paxos, which was worrying as it brings into question whether or not the implementation is working.

Turns out that we would kill some nodes, and then not start them back up again. This occurred because for the given namespace we would query who the non-leaders are before doing the action (which involves finding out who the leader is). If there is a leader election between the two calls, the single node remaining will say it's not the leader, and the other nodes are dead, so there will be no nodes to start:

```
// B, C wlog where A is the leader
nonLeaders <- getNonLeaders(namespace) 

// leader election happens here and A is no longer the leader for <namespace>

// kill B, C
nonLeaders.forEach(kill)

// this time empty since B, C dead and can't respond, and A is correctly not the leader
nonLeaders2 <- getNonLeaders(namespace) 

// nothing to start
nonLeaders2.forEach(start)
```

**Implementation Description (bullets)**:
* Ensure that we start the nodes that we killed, instead of trying to find the nodes to kill again (which may or may not be the same as the initial set).
* Make sure tests don't retry on interfaces that aren't retried on in prod i.e. no retrying on the test client of `BatchPingableLeader` or `PingableLeader`.
* Something that was useful in debugging was adding a suppressed exception to any throwables that arise out of `PaxosQuorumChecker`. This allows us to see what was calling `PaxosQuorumChecker`. This was super useful because both tests and timelock server use `PQC`, and when getting errors it was quite confusing to see what was going on and where the errors were coming from.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Ran the test repeatedly, 

**Concerns (what feedback would you like?)**:
It's unclear why there seem to be more leader elections in the multi leader case. 

**Where should we start reviewing?**:
Commit by commit

**Priority (whenever / two weeks / yesterday)**:
ASAP, should eliminate random flakey builds due to this class.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
