### PR TITLE
[Jepsen tests] Fix Clojure Missing Namespace Error

### DIFF
--- a/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
+++ b/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
@@ -11,8 +11,8 @@
   (:import com.palantir.atlasdb.jepsen.JepsenHistoryCheckers)
   (:import com.palantir.atlasdb.http.JepsenLockClient)
   (:import com.palantir.atlasdb.http.SynchronousLockClient)
-  (:import com.palantir.atlasdb.http.AsyncLockClient))
-  (:import com.palantir.atlasdb.util.MetricsManagers)
+  (:import com.palantir.atlasdb.http.AsyncLockClient)
+  (:import com.palantir.atlasdb.util.MetricsManagers))
 
 (def lock-names ["alpha" "bravo" "charlie" "delta"])
 

--- a/atlasdb-jepsen-tests/src/jepsen/atlasdb/timestamp.clj
+++ b/atlasdb-jepsen-tests/src/jepsen/atlasdb/timestamp.clj
@@ -10,8 +10,8 @@
             [knossos.history :as history])
   ;; We can import any Java objects, since Clojure runs on the JVM
   (:import com.palantir.atlasdb.http.TimestampClient)
-  (:import com.palantir.atlasdb.jepsen.JepsenHistoryCheckers))
-  (:import com.palantir.atlasdb.util.MetricsManagers)
+  (:import com.palantir.atlasdb.jepsen.JepsenHistoryCheckers)
+  (:import com.palantir.atlasdb.util.MetricsManagers))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Defining the set of of operations that you can do with a client


### PR DESCRIPTION
**Goals (and why)**:
- Get Jepsen tests running again.

**Implementation Description (bullets)**:
- Jepsen tests were failing on a missing namespace `MetricsManagers`.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Nothing much, see Concerns

**Concerns (what feedback would you like?)**:
- I spent half an hour attempting to chase down a method for running these tests premerge but failed. Is there an easy way to do this that I'm not seeing?

**Where should we start reviewing?**: +4/-4

**Priority (whenever / two weeks / yesterday)**: four months ago 🔥 