### PR TITLE
[Timelock OOMs] Bisection, on metrics fixes #4549

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
@@ -148,7 +148,6 @@ public final class Leaders {
                 ServiceCreator.createTrustContext(config.sslConfiguration());
 
         List<PaxosLearner> learners = createProxyAndLocalList(
-                metricsManager,
                 ourLearner,
                 remotePaxosServerSpec.remoteLearnerUris(),
                 remotingClientConfig,
@@ -165,7 +164,6 @@ public final class Leaders {
                 createExecutorsForService(metricsManager, learners, "knowledge-update"));
 
         List<PaxosAcceptor> acceptors = createProxyAndLocalList(
-                metricsManager,
                 ourAcceptor,
                 remotePaxosServerSpec.remoteAcceptorUris(),
                 remotingClientConfig,
@@ -178,7 +176,6 @@ public final class Leaders {
                 createExecutorsForService(metricsManager, acceptors, "latest-round-verifier"));
 
         List<LeaderPingerContext<PingableLeader>> otherLeaders = generatePingables(
-                metricsManager,
                 remotePaxosServerSpec.remoteLeaderUris(),
                 remotingClientConfig,
                 trustContext,
@@ -258,7 +255,6 @@ public final class Leaders {
     }
 
     public static <T> List<T> createProxyAndLocalList(
-            MetricsManager metricsManager,
             T localObject,
             Set<String> remoteUris,
             Supplier<RemotingClientConfig> remotingClientConfig,
@@ -269,7 +265,6 @@ public final class Leaders {
         // TODO (jkong): Enable runtime config for leader election services.
         List<T> remotes = remoteUris.stream()
                 .map(uri -> AtlasDbHttpClients.createProxy(
-                        metricsManager,
                         trustContext,
                         uri,
                         clazz,
@@ -287,14 +282,12 @@ public final class Leaders {
     }
 
     public static List<LeaderPingerContext<PingableLeader>> generatePingables(
-            MetricsManager metricsManager,
             Collection<String> remoteEndpoints,
             Supplier<RemotingClientConfig> remotingClientConfig,
             Optional<TrustContext> trustContext,
             UserAgent userAgent) {
         return KeyedStream.of(remoteEndpoints)
                 .mapKeys(endpoint -> AtlasDbHttpClients.createProxy(
-                        metricsManager,
                         trustContext,
                         endpoint,
                         PingableLeader.class,

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
@@ -37,17 +37,11 @@ public final class AtlasDbHttpClients {
     }
 
     public static <T> T createProxy(
-            MetricsManager metricsManager,
             Optional<TrustContext> trustContext,
             String uri,
             Class<T> type,
             AuxiliaryRemotingParameters parameters) {
-        return createExperimentallyWithFallback(
-                metricsManager,
-                () -> ConjureJavaRuntimeTargetFactory.DEFAULT.createProxy(trustContext, uri, type, parameters),
-                () -> AtlasDbFeignTargetFactory.DEFAULT.createProxy(trustContext, uri, type, parameters),
-                type,
-                parameters);
+        return ConjureJavaRuntimeTargetFactory.DEFAULT.createProxy(trustContext, uri, type, parameters).instance();
     }
 
     /**

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/AtlasDbHttpClientsTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/AtlasDbHttpClientsTest.java
@@ -189,7 +189,6 @@ public class AtlasDbHttpClientsTest {
     @Test
     public void userAgentIsPresentOnClientRequests() {
         TestResource client = AtlasDbHttpClients.createProxy(
-                MetricsManagers.createForTests(),
                 TRUST_CONTEXT,
                 getUriForPort(availablePort1),
                 TestResource.class,

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/EteSetup.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/EteSetup.java
@@ -203,7 +203,6 @@ public abstract class EteSetup {
     private static <T> T createClientFor(Class<T> clazz, String host, short port) {
         String uri = String.format("http://%s:%s", host, port);
         return AtlasDbHttpClients.createProxy(
-                MetricsManagers.createForTests(),
                 Optional.of(TRUST_CONTEXT),
                 uri,
                 clazz,

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TimeLockMigrationEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TimeLockMigrationEteTest.java
@@ -37,7 +37,6 @@ import com.palantir.atlasdb.http.errors.AtlasDbRemoteException;
 import com.palantir.atlasdb.todo.ImmutableTodo;
 import com.palantir.atlasdb.todo.Todo;
 import com.palantir.atlasdb.todo.TodoResource;
-import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.timestamp.TimestampService;
 
 // We don't use EteSetup because we need much finer-grained control of the orchestration here, compared to the other
@@ -183,7 +182,6 @@ public class TimeLockMigrationEteTest {
     private static <T> T createEteClientFor(Class<T> clazz) {
         String uri = String.format("http://%s:%s", ETE_CONTAINER, ETE_PORT);
         return AtlasDbHttpClients.createProxy(
-                MetricsManagers.createForTests(),
                 Optional.empty(),
                 uri,
                 clazz,
@@ -193,7 +191,6 @@ public class TimeLockMigrationEteTest {
     private static TimestampService createTimeLockTimestampClient() {
         String uri = String.format("http://%s:%s/%s", TIMELOCK_CONTAINER, TIMELOCK_PORT, TEST_CLIENT);
         return AtlasDbHttpClients.createProxy(
-                MetricsManagers.createForTests(),
                 Optional.empty(),
                 uri,
                 TimestampService.class,

--- a/changelog/@unreleased/pr-4549.v2.yml
+++ b/changelog/@unreleased/pr-4549.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Correctly report metrics for certain popular Timelock endpoints. Reduced
+    the places where we over report/double count the number of calls of a particular
+    metric
+  links:
+  - https://github.com/palantir/atlasdb/pull/4549

--- a/changelog/@unreleased/pr-4571.v2.yml
+++ b/changelog/@unreleased/pr-4571.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Bisection to figure out Timelock OOM issues. Trying commit c4a58c5 which includes metrics fixes.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4571
+  - https://github.com/palantir/atlasdb/pull/4549

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClients.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClients.java
@@ -31,7 +31,6 @@ import com.palantir.atlasdb.config.AuxiliaryRemotingParameters;
 import com.palantir.atlasdb.config.RemotingClientConfigs;
 import com.palantir.atlasdb.http.AtlasDbHttpClients;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
-import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.common.streams.KeyedStream;
 import com.palantir.leader.PingableLeader;
 import com.palantir.paxos.ImmutableLeaderPingerContext;
@@ -119,7 +118,6 @@ public abstract class PaxosRemoteClients {
     private <T> KeyedStream<HostAndPort, T> createInstrumentedRemoteProxies(Class<T> clazz, boolean shouldRetry) {
         return KeyedStream.of(context().remoteUris())
                 .map(uri -> AtlasDbHttpClients.createProxy(
-                        MetricsManagers.of(new MetricRegistry(), metrics()),
                         context().trustContext(),
                         uri,
                         clazz,

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/SingleLeaderNetworkClientFactories.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/SingleLeaderNetworkClientFactories.java
@@ -42,15 +42,14 @@ abstract class SingleLeaderNetworkClientFactories implements
                     .wrap(useCase(), remoteClients())
                     .apply(client);
             PaxosAcceptor localAcceptor = components().acceptor(client);
-            LocalAndRemotes<PaxosAcceptor> allAcceptors = metrics().instrumentLocalAndRemotesFor(
-                    PaxosAcceptor.class,
-                    localAcceptor,
-                    remoteAcceptors,
-                    client);
-            return new SingleLeaderAcceptorNetworkClient(
+
+            LocalAndRemotes<PaxosAcceptor> allAcceptors = LocalAndRemotes.of(localAcceptor, remoteAcceptors)
+                    .enhanceRemotes(remote -> metrics().instrument(PaxosAcceptor.class, remote, client));
+            SingleLeaderAcceptorNetworkClient uninstrumentedAcceptor = new SingleLeaderAcceptorNetworkClient(
                     allAcceptors.all(),
                     quorumSize(),
                     allAcceptors.withSharedExecutor(sharedExecutor()));
+            return metrics().instrument(PaxosAcceptorNetworkClient.class, uninstrumentedAcceptor);
         };
     }
 
@@ -63,16 +62,15 @@ abstract class SingleLeaderNetworkClientFactories implements
                     .wrap(useCase(), remoteClients())
                     .apply(client);
             PaxosLearner localLearner = components().learner(client);
-            LocalAndRemotes<PaxosLearner> allLearners = metrics().instrumentLocalAndRemotesFor(
-                    PaxosLearner.class,
-                    localLearner,
-                    remoteLearners,
-                    client);
-            return new SingleLeaderLearnerNetworkClient(
+
+            LocalAndRemotes<PaxosLearner> allLearners = LocalAndRemotes.of(localLearner, remoteLearners)
+                    .enhanceRemotes(remote -> metrics().instrument(PaxosLearner.class, remote, client));
+            SingleLeaderLearnerNetworkClient uninstrumentedLearner = new SingleLeaderLearnerNetworkClient(
                     allLearners.local(),
                     allLearners.remotes(),
                     quorumSize(),
                     allLearners.withSharedExecutor(sharedExecutor()));
+            return metrics().instrument(PaxosLearnerNetworkClient.class, uninstrumentedLearner);
         };
     }
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalAndRemotes.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalAndRemotes.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 import org.immutables.value.Value;
@@ -49,6 +50,10 @@ interface LocalAndRemotes<T> {
         return ImmutableLocalAndRemotes.of(
                 mapper.apply(local()),
                 remotes().stream().map(mapper).collect(Collectors.toList()));
+    }
+
+    default LocalAndRemotes<T> enhanceRemotes(UnaryOperator<T> mapper) {
+        return ImmutableLocalAndRemotes.of(local(), remotes().stream().map(mapper).collect(Collectors.toList()));
     }
 
     default Map<T, ExecutorService> withSharedExecutor(ExecutorService sharedExecutor) {

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/TimelockPaxosMetrics.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/TimelockPaxosMetrics.java
@@ -16,7 +16,6 @@
 
 package com.palantir.atlasdb.timelock.paxos;
 
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -76,19 +75,6 @@ public abstract class TimelockPaxosMetrics {
                 instance,
                 MetricRegistry.name(clazz),
                 _context -> tags);
-    }
-
-    public <T> LocalAndRemotes<T> instrumentLocalAndRemotesFor(Class<T> clazz, T local, List<T> remotes) {
-        return LocalAndRemotes.of(local, remotes).map(instance -> instrument(clazz, instance));
-    }
-
-    public <T> LocalAndRemotes<T> instrumentLocalAndRemotesFor(
-            Class<T> clazz,
-            T local,
-            List<T> remotes,
-            Client client) {
-        return LocalAndRemotes.of(local, remotes)
-                .map(instance -> instrument(clazz, instance, client));
     }
 
     private void attachToParentMetricRegistry(TaggedMetricRegistry parent) {

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/IsolatedPaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/IsolatedPaxosTimeLockServerIntegrationTest.java
@@ -32,7 +32,6 @@ import com.palantir.atlasdb.timelock.ImmutableTemplateVariables.TimestampPaxos;
 import com.palantir.atlasdb.timelock.paxos.PaxosTimeLockConstants;
 import com.palantir.atlasdb.timelock.util.ExceptionMatchers;
 import com.palantir.atlasdb.timelock.util.TestProxies;
-import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.paxos.PaxosAcceptor;
 import com.palantir.paxos.PaxosLearner;
 import com.palantir.timelock.config.PaxosInstallConfiguration.PaxosLeaderMode;
@@ -104,7 +103,6 @@ public class IsolatedPaxosTimeLockServerIntegrationTest {
 
     private <T> T createProxyForInternalNamespacedTestService(Class<T> clazz) {
         return AtlasDbHttpClients.createProxy(
-                MetricsManagers.createForTests(),
                 Optional.of(TestProxies.TRUST_CONTEXT),
                 String.format("https://localhost:%d/%s/%s/%s",
                         SERVER.serverHolder().getTimelockPort(),

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/util/TestProxies.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/util/TestProxies.java
@@ -54,7 +54,6 @@ public class TestProxies {
         String uri = getServerUri(server);
         List<Object> key = ImmutableList.of(serviceInterface, uri, "single");
         return (T) proxies.computeIfAbsent(key, ignored -> AtlasDbHttpClients.createProxy(
-                MetricsManagers.createForTests(),
                 Optional.of(TRUST_CONTEXT),
                 uri,
                 serviceInterface,


### PR DESCRIPTION
**Goals (and why)**:
Trying to figure out OOMs in Timelock. 

PR #4548 seems to be fine despite appearing contentious (it's a large-ish change that really only affects timelock).

A release containing everything up to #4542 went out and also OOMed.

Includes the following commits:
- https://github.com/palantir/atlasdb/pull/4483 - seems to be okay so far
- https://github.com/palantir/atlasdb/pull/4515 - seems to be okay so far
- https://github.com/palantir/atlasdb/pull/4548 - seems to be okay so far
- https://github.com/palantir/atlasdb/pull/4527 - excavator - candidate
- https://github.com/palantir/atlasdb/pull/4547 - excavator - candidate
- https://github.com/palantir/atlasdb/pull/4549 - **metrics fixes potentially contentious - next candidate**
- https://github.com/palantir/atlasdb/pull/4550 - lock watches, new code can't be used
- https://github.com/palantir/atlasdb/pull/4502 - lock watches, new code can't be used
- https://github.com/palantir/atlasdb/pull/4542 - refactor of Targeted Sweep things, unrelated. - still OOMing


<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
