### PR TITLE
[Timelock OOMs] Bisection, on metrics fixes #4547

### DIFF
--- a/changelog/@unreleased/pr-4572.v2.yml
+++ b/changelog/@unreleased/pr-4572.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Bisection to figure out Timelock OOM issues. Trying commit 506167ebd which is just publishing changes.
+  links:
+    - https://github.com/palantir/atlasdb/pull/4571
+    - https://github.com/palantir/atlasdb/pull/4527
+    - https://github.com/palantir/atlasdb/pull/4547


### PR DESCRIPTION
**Goals (and why)**:
Trying to figure out OOMs in Timelock. 

PR #4548 seems to be fine despite appearing contentious (it's a large-ish change that really only affects timelock).

A release containing everything up to #4542 went out and also OOMed.

Commit range:
- https://github.com/palantir/atlasdb/pull/4483 - seems to be okay so far
- https://github.com/palantir/atlasdb/pull/4515 - seems to be okay so far
- https://github.com/palantir/atlasdb/pull/4548 - seems to be okay so far
- https://github.com/palantir/atlasdb/pull/4527 - excavator - candidate
- https://github.com/palantir/atlasdb/pull/4547 - **excavator - next candidate**
- https://github.com/palantir/atlasdb/pull/4549 - metrics fixes potentially contentious - candidate
- https://github.com/palantir/atlasdb/pull/4550 - lock watches, new code can't be used
- https://github.com/palantir/atlasdb/pull/4502 - lock watches, new code can't be used
- https://github.com/palantir/atlasdb/pull/4542 - refactor of Targeted Sweep things, unrelated. - still OOMing

Changes include publishing plugin upgrade that does stuff with `shadow` plugin (which we do use), wonder whether that has any adverse effects..
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
