### PR TITLE
[LW] Fix corner case in registering lock watches

### DIFF
--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockEventLogImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockEventLogImpl.java
@@ -52,12 +52,16 @@ public class LockEventLogImpl implements LockEventLog {
 
     @Override
     public void logLock(Set<LockDescriptor> locksTakenOut, LockToken lockToken) {
-        slidingWindow.add(LockEvent.builder(locksTakenOut, lockToken));
+        if (!locksTakenOut.isEmpty()) {
+            slidingWindow.add(LockEvent.builder(locksTakenOut, lockToken));
+        }
     }
 
     @Override
     public void logUnlock(Set<LockDescriptor> locksUnlocked) {
-        slidingWindow.add(UnlockEvent.builder(locksUnlocked));
+        if (!locksUnlocked.isEmpty()) {
+            slidingWindow.add(UnlockEvent.builder(locksUnlocked));
+        }
     }
 
     @Override


### PR DESCRIPTION
**Goals (and why)**:
Primary goal of this PR is to prevent the following race condition:
1. In-flight lock request checks if lock descriptor A is being watched, and it is not. Enter GC.
2. A request to start watching A is received and an inspection of open locks determines A is not locked.
3. The lock request from 1. is processed. Since A was filtered out as it was not being watched at the time, it will not be logged in the lock event.
4. Severe data corruption (TM)

Additionally, two smaller fixes:
- do not log anything on locks/unlocks if all lock descriptors are filtered out (oops)
- exit early if ranges being registered are already fully covered by existing ranges (in a follow up PR this will be made a noop, but requires some additional changes first)
  
**Implementation Description (bullets)**:
Use fair read/write locks to force registration of new lock watches to wait for all in-flight lock/unlock requests to complete before the change is made and, consequently, guaranteed to be reflected in all subsequent lock/unlock events. See concerns for further comments.

**Testing (What was existing testing like?  What have you done to improve it?)**:
I spent a couple of hours trying to write a test that would catch the above bug, but have failed and moved on.

**Concerns (what feedback would you like?)**:
The issue here is that, due to the fair locking mechanism, lock and unlock requests may end up blocking waiting for an update that is waiting on in-flight lock/unlock requests. I think this is fine given that:
- registering lock watches is going to be extremely infrequent
- the write lock is only acquired if there is an actual change to ranges being watched
- the work done holding the write lock is tiny
However, if there is an in-flight lock/unlock with a huge number of lock descriptors, and a waiting lock watch registration, it is possible many incoming locks/unlocks will have to block until the huge request is processed.

The difficult part is that we must ensure that, once we start iterating through heldLocksCollection any change that could happen to the set of open locks is reflected in the log. This PR seems like the least intrusive way of doing this.

**Where should we start reviewing?**:
PR is tiny

**Priority (whenever / two weeks / yesterday)**:
Today please, let's pair when you have a moment to discuss
