### PR TITLE
Bump Atlas retry timeout to 15 seconds

### DIFF
--- a/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/ClientOptions.java
+++ b/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/ClientOptions.java
@@ -48,6 +48,10 @@ public abstract class ClientOptions {
     // Should not be reduced below 65 seconds to support workflows involving locking.
     static final Duration BLOCKING_READ_TIMEOUT = Duration.ofSeconds(65);
 
+    // Time limit for retrying requests which in turn retry 308s that have reached their 20 retry limit defined
+    // in conjure-java-runtime
+    static final Duration REDIRECT_RETRY_TIME_LIMIT = Duration.ofSeconds(15);
+
     // Under standard settings, throws after expected outages of 1/2 * 0.01 * (2^13 - 1) = 40.96 s
     private static final Duration STANDARD_BACKOFF_SLOT_SIZE = Duration.ofMillis(10);
     private static final int STANDARD_MAX_RETRIES = 13;

--- a/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/FastFailoverProxy.java
+++ b/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/FastFailoverProxy.java
@@ -20,7 +20,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.time.Clock;
-import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -41,7 +40,6 @@ import feign.RetryableException;
  * leader election is still taking place.
  */
 public final class FastFailoverProxy<T> extends AbstractInvocationHandler {
-    private static final Duration TIME_LIMIT = Duration.ofSeconds(15);
 
     private final Supplier<T> delegate;
     private final Clock clock;
@@ -68,7 +66,7 @@ public final class FastFailoverProxy<T> extends AbstractInvocationHandler {
 
     @Override
     protected Object handleInvocation(Object proxy, Method method, Object[] args) throws Throwable {
-        Instant lastRetryInstant = clock.instant().plus(TIME_LIMIT);
+        Instant lastRetryInstant = clock.instant().plus(ClientOptions.REDIRECT_RETRY_TIME_LIMIT);
         ResultOrThrowable attempt = singleInvocation(method, args);
         while (clock.instant().isBefore(lastRetryInstant) && !attempt.isSuccessful()) {
             Throwable cause = attempt.throwable().get();

--- a/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/FastFailoverProxy.java
+++ b/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/FastFailoverProxy.java
@@ -41,7 +41,7 @@ import feign.RetryableException;
  * leader election is still taking place.
  */
 public final class FastFailoverProxy<T> extends AbstractInvocationHandler {
-    private static final Duration TIME_LIMIT = Duration.ofSeconds(10);
+    private static final Duration TIME_LIMIT = Duration.ofSeconds(15);
 
     private final Supplier<T> delegate;
     private final Clock clock;

--- a/atlasdb-conjure/src/test/java/com/palantir/atlasdb/http/v2/FastFailoverProxyTest.java
+++ b/atlasdb-conjure/src/test/java/com/palantir/atlasdb/http/v2/FastFailoverProxyTest.java
@@ -94,7 +94,7 @@ public class FastFailoverProxyTest {
         when(binaryOperator.apply(1, 2)).thenThrow(retryableException);
 
         assertThatThrownBy(() -> proxy.apply(1, 2)).isEqualTo(retryableException);
-        verify(binaryOperator, times(10)).apply(1, 2);
+        verify(binaryOperator, times(15)).apply(1, 2);
     }
 
     @Test

--- a/changelog/@unreleased/pr-4598.v2.yml
+++ b/changelog/@unreleased/pr-4598.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Bump Atlas retry timeout to 15 seocnds
+  links:
+  - https://github.com/palantir/atlasdb/pull/4598


### PR DESCRIPTION
**Goals (and why)**:
PDS-111849 - caused by Timelock being down for >10 seconds during a leader election. Increasing this retry timeout to 15 seconds should vastly reduce the chance of there being a problem.

**Implementation Description (bullets)**:
Changed hard-coded variable from 10 to 15 seconds

**Testing (What was existing testing like?  What have you done to improve it?)**:
N/A

**Concerns (what feedback would you like?)**:
Verify that there are no other places where this limit needs to be changed.

**Where should we start reviewing?**:
`FastFailoverProxy`

**Priority (whenever / two weeks / yesterday)**:
Today

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
