### PR TITLE
[PDS-105073] Support Specifying Service Name in Oracle Connection Config

### DIFF
--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
@@ -134,7 +134,7 @@ public abstract class ConnectionConfig {
     }
 
     @JsonIgnore
-    @Value.Derived
+    @Value.Lazy
     public HikariConfig getHikariConfig() {
         // Initialize the Hikari configuration
         HikariConfig config = new HikariConfig();

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/OracleConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/OracleConnectionConfig.java
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.nexus.db.DBType;

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/OracleConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/OracleConnectionConfig.java
@@ -218,6 +218,6 @@ public abstract class OracleConnectionConfig extends ConnectionConfig {
             return "SERVICE_NAME=" + getServiceName().get();
         }
 
-        throw new IllegalArgumentException("Both the sid and service name are absent! This is unexpected.");
+        throw new IllegalArgumentException("Both the sid and service name are absent! One needs to be specified.");
     }
 }

--- a/atlasdb-dbkvs-hikari/src/test/java/com/palantir/nexus/db/pool/config/OracleConnectionConfigTest.java
+++ b/atlasdb-dbkvs-hikari/src/test/java/com/palantir/nexus/db/pool/config/OracleConnectionConfigTest.java
@@ -1,0 +1,96 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.nexus.db.pool.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import com.palantir.nexus.db.pool.config.OracleConnectionConfig.ServiceNameConfiguration;
+
+public class OracleConnectionConfigTest {
+
+    private static final String LOGIN = "login";
+    private static final String HOST = "host";
+    private static final int PORT = 42;
+    private static final MaskedValue PASSWORD = ImmutableMaskedValue.of("password");
+    private static final String SID = "sid";
+    private static final ServiceNameConfiguration SERVICE_NAME_CONFIGURATION = new ServiceNameConfiguration.Builder()
+            .serviceName("serviceName")
+            .namespaceOverride("namespaceOverride")
+            .build();
+
+    @Test
+    public void throwsIfNeitherSidNorServiceNameConfigurationIsSpecified() {
+        assertThatThrownBy(getBaseBuilder()::build)
+                .isInstanceOf(SafeIllegalArgumentException.class)
+                .hasMessageContaining("Both the sid and serviceNameConfiguration are absent.");
+    }
+
+    @Test
+    public void throwsIfBothSidAndServiceNameConfigurationAreSpecified() {
+        OracleConnectionConfig.Builder builder = getBaseBuilder()
+                .sid(SID)
+                .serviceNameConfiguration(SERVICE_NAME_CONFIGURATION);
+        assertThatThrownBy(builder::build)
+                .isInstanceOf(SafeIllegalArgumentException.class)
+                .hasMessageContaining("Exactly one of sid and serviceNameConfiguration should be provided.");
+    }
+
+    @Test
+    public void databaseUrlGeneratedCorrectlyFromSid() {
+        OracleConnectionConfig connectionConfig = getBaseBuilder()
+                .sid(SID)
+                .build();
+        assertThat(connectionConfig.getUrl()).contains("SID=" + SID);
+    }
+
+    @Test
+    public void databaseUrlGeneratedCorrectlyFromServiceName() {
+        OracleConnectionConfig connectionConfig = getBaseBuilder()
+                .serviceNameConfiguration(SERVICE_NAME_CONFIGURATION)
+                .build();
+        assertThat(connectionConfig.getUrl()).contains("SERVICE_NAME=" + SERVICE_NAME_CONFIGURATION.serviceName());
+    }
+
+    @Test
+    public void namespaceIsSidIfPresent() {
+        OracleConnectionConfig connectionConfig = getBaseBuilder()
+                .sid(SID)
+                .build();
+        assertThat(connectionConfig.namespace()).contains(SID);
+    }
+
+    @Test
+    public void namespaceIsNamespaceOverrideIfServiceNameConfigurationSpecified() {
+        OracleConnectionConfig connectionConfig = getBaseBuilder()
+                .serviceNameConfiguration(SERVICE_NAME_CONFIGURATION)
+                .build();
+        assertThat(connectionConfig.namespace()).contains(SERVICE_NAME_CONFIGURATION.namespaceOverride());
+    }
+
+    private static OracleConnectionConfig.Builder getBaseBuilder() {
+        return new OracleConnectionConfig.Builder()
+                .dbPassword(PASSWORD)
+                .dbLogin(LOGIN)
+                .host(HOST)
+                .port(PORT);
+    }
+
+}

--- a/changelog/@unreleased/pr-4599.v2.yml
+++ b/changelog/@unreleased/pr-4599.v2.yml
@@ -1,6 +1,6 @@
 type: improvement
 improvement:
-  description: Oracle users may now connect to an Oracle database via `serviceName`
+  description: Oracle users may now connect to an Oracle database via `serviceNameConfiguration`
     as opposed to `sid`.
   links:
   - https://github.com/palantir/atlasdb/pull/4599

--- a/docs/source/configuration/key_value_service_configs/oracle_key_value_service_config.rst
+++ b/docs/source/configuration/key_value_service_configs/oracle_key_value_service_config.rst
@@ -152,7 +152,11 @@ These are the required parameters:
 
     *    - sid
          - The site identifier for the Oracle server.
-         - Yes
+         - No, but one of sid and serviceName must be specified.
+
+    *    - serviceName
+         - The service name for the Oracle server.
+         - No, but one of sid and serviceName must be specified.
 
     *    - dbLogin
          - The Oracle DB username.

--- a/docs/source/configuration/key_value_service_configs/oracle_key_value_service_config.rst
+++ b/docs/source/configuration/key_value_service_configs/oracle_key_value_service_config.rst
@@ -152,11 +152,18 @@ These are the required parameters:
 
     *    - sid
          - The site identifier for the Oracle server.
-         - No, but one of sid and serviceName must be specified.
+         - No, but one of sid and serviceNameConfiguration must be specified.
 
-    *    - serviceName
+    *    - serviceNameConfiguration.serviceName
          - The service name for the Oracle server.
-         - No, but one of sid and serviceName must be specified.
+         - No, but one of sid and serviceNameConfiguration must be specified.
+
+    *    - serviceNameConfiguration.namespaceOverride
+         - The namespace for this Oracle key-value service. If you are migrating from a database with a given sid,
+           this value should be set to the value of that sid before the migration. If you are bootstrapping a new
+           stack, this value should be set to the value of the top-level AtlasDB namespace config if present; otherwise,
+           it may be set arbitrarily (but *must* be set to some value).
+         - No, but one of sid and serviceNameConfiguration must be specified.
 
     *    - dbLogin
          - The Oracle DB username.
@@ -165,3 +172,26 @@ These are the required parameters:
     *    - dbPassword
          - The Oracle DB password.
          - Yes
+
+Migrating Connection Methods
+----------------------------
+
+.. danger::
+
+   Improperly migrating from one method of connecting to Oracle to another can result in **SEVERE DATA CORRUPTION**!
+   Please contact the AtlasDB team before attempting such a migration.
+
+.. danger::
+
+   The processes outlined below **ONLY** apply for Oracle users using embedded timestamp and lock services.
+   TimeLock users should contact the AtlasDB team before attempting such a migration. The procedures outlined below
+   employed naively can result in **SEVERE DATA CORRUPTION**!
+
+AtlasDB supports connecting to an Oracle database via its `sid`, or through a `serviceName` (the latter is configured
+through a `serviceNameConfiguration`).
+
+When migrating from using `sid` to `serviceName`, the user must specify the original value of the `sid` before the
+migration as `serviceNameConfiguration.namespaceOverride`.
+
+This migration can be reversed trivially (just by changing the config to reference the now-correct `sid`) if you are
+using embedded timestamp and lock services.


### PR DESCRIPTION
**Goals (and why)**:
- See internal ticket, internal deployment needs to specify a service name instead of SID for their Oracle database.

**Implementation Description (bullets)**:
- Configure the URL to allow referencing an Oracle database by service name.
- This is technically possible with the existing configuration by overriding the URL, but extremely fragile.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- For various reasons the Oracle driver is only available internally. Please consult the branch of the same name on the AtlasDB interface to the Oracle driver: tests have been added there.

**Concerns (what feedback would you like?)**:
- Does this actually work?

**Where should we start reviewing?**: OracleConnectionConfig

**Priority (whenever / two weeks / yesterday)**: this week
