### PR TITLE
switch to using lighter-weight JDBC connection testing

### DIFF
--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/HikariCPConnectionManager.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/HikariCPConnectionManager.java
@@ -111,7 +111,7 @@ public class HikariCPConnectionManager extends BaseConnectionManager {
             profiler.logAcquisitionAndRestart();
 
             try {
-                testConnection(conn);
+                conn.isValid(connConfig.getCheckoutTimeout());
                 profiler.logConnectionTest();
                 return conn;
             } catch (SQLException e) {

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
@@ -158,9 +158,6 @@ public abstract class ConnectionConfig {
         // ConnectionConfig.connectionTimeoutSeconds is passed in via getHikariProperties(), in subclasses.
         config.setConnectionTimeout(getCheckoutTimeout());
 
-        // TODO (bullman): See if driver supports JDBC4 (isValid()) and use it.
-        config.setConnectionTestQuery(getTestQuery());
-
         if (!props.isEmpty()) {
             config.setDataSourceProperties(props);
         }

--- a/changelog/@unreleased/pr-4602.v2.yml
+++ b/changelog/@unreleased/pr-4602.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Switched to using lighter-weight JDBC connection testing on pool check-in
+    and check-out
+  links:
+  - https://github.com/palantir/atlasdb/pull/4602


### PR DESCRIPTION
(for background, removing setConnectionTestQuery switches hikari over to using jdbc Connection#isValid)

We could have switched this a while ago; previously the postgres jdbc driver we were using didn't support it, but now it does.

I've been seeing some weirdly slow connection checkouts that attribute their slow time to connection validation. I'm not sure it will be fixed by this, or if its some systemic problem, maybe with slightly old connections that for some reason come good after a few seconds while getting the request for the test query select.

I left in testQuery() config to set the queries per DB (e.g. 'select 1 from dual;') as I kept it still used in the initial pool creation, where it is probably a slightly higher quality test and pool startup perf isn't as important.

**Priority (whenever / two weeks / yesterday)**:
I'd like to get this in quite soon so I can test it and keep debugging my problem. (and it's an easy CR)