### PR TITLE
SweepStrategyManagers only load one table metadata on cache miss

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/SweepStrategyManagers.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/SweepStrategyManagers.java
@@ -43,8 +43,7 @@ public class SweepStrategyManagers {
             if (cache.estimatedSize() == 0) {
                 cache.putAll(getSweepStrategies(kvs));
             }
-            SweepStrategy strategy = cache.get(tableRef);
-            return Preconditions.checkNotNull(strategy, "unknown table", SafeArg.of("tableRef", tableRef));
+            return cache.get(tableRef);
         };
     }
 

--- a/changelog/@unreleased/pr-4607.v2.yml
+++ b/changelog/@unreleased/pr-4607.v2.yml
@@ -1,28 +1,8 @@
 type: fix
 fix:
   description: |-
-    SweepStrategyManagers only load one table metadata on cache miss
-
-    **Goals (and why)**:
-
-    Do not have to reload all tables' metadata (which could include a LOT of tables) every single time there is a cache miss.
-
-    **Implementation Description (bullets)**:
-
-    Rather than have a supplier that recalculates the entire map each time, just get and cache each entry. But still add all initial tables at the beginning as a perf optimization.
-
-    **Testing (What was existing testing like?  What have you done to improve it?)**:
-
-    **Concerns (what feedback would you like?)**:
-
-    **Where should we start reviewing?**:
-
-    **Priority (whenever / two weeks / yesterday)**:
-
-    <!---
-    Please remember to:
-    - Add any necessary release notes (including breaking changes)
-    - Make sure the documentation is up to date for your change
-    --->
+    After first initialization, SweepStrategyManagers now only loads one table metadata on a cache miss, rather than
+    loading all tables' metadata each time (which could include a LOT of tables). This should improve performance
+    when there are many dynamic tables being created.
   links:
   - https://github.com/palantir/atlasdb/pull/4607

--- a/changelog/@unreleased/pr-4607.v2.yml
+++ b/changelog/@unreleased/pr-4607.v2.yml
@@ -1,0 +1,28 @@
+type: fix
+fix:
+  description: |-
+    SweepStrategyManagers only load one table metadata on cache miss
+
+    **Goals (and why)**:
+
+    Do not have to reload all tables' metadata (which could include a LOT of tables) every single time there is a cache miss.
+
+    **Implementation Description (bullets)**:
+
+    Rather than have a supplier that recalculates the entire map each time, just get and cache each entry. But still add all initial tables at the beginning as a perf optimization.
+
+    **Testing (What was existing testing like?  What have you done to improve it?)**:
+
+    **Concerns (what feedback would you like?)**:
+
+    **Where should we start reviewing?**:
+
+    **Priority (whenever / two weeks / yesterday)**:
+
+    <!---
+    Please remember to:
+    - Add any necessary release notes (including breaking changes)
+    - Make sure the documentation is up to date for your change
+    --->
+  links:
+  - https://github.com/palantir/atlasdb/pull/4607


### PR DESCRIPTION
**Goals (and why)**:

Do not have to reload all tables' metadata (which could include a LOT of tables) every single time there is a cache miss.

**Implementation Description (bullets)**:

Rather than have a supplier that recalculates the entire map each time, just get and cache each entry. But still add all initial tables at the beginning as a perf optimization.

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
