### PR TITLE
[Conjure Undertow, Part 2] Upgrade timelock dependency and inline

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -73,6 +73,7 @@ import com.palantir.atlasdb.config.TimeLockClientConfig;
 import com.palantir.atlasdb.coordination.CoordinationService;
 import com.palantir.atlasdb.debug.ClientLockDiagnosticCollector;
 import com.palantir.atlasdb.debug.ConflictTracer;
+import com.palantir.atlasdb.debug.LockDiagnosticConjureTimelockService;
 import com.palantir.atlasdb.debug.LockDiagnosticTimelockRpcClient;
 import com.palantir.atlasdb.factory.Leaders.LocalPaxosServices;
 import com.palantir.atlasdb.factory.startup.ConsistencyCheckRunner;
@@ -999,10 +1000,15 @@ public abstract class TransactionManagers {
                 .<TimelockRpcClient>map(collector -> new LockDiagnosticTimelockRpcClient(timelockClient, collector))
                 .orElse(timelockClient);
 
+        ConjureTimelockService withDiagnosticsConjureTimelockService = lockDiagnosticCollector
+                .<ConjureTimelockService>map(collector ->
+                        new LockDiagnosticConjureTimelockService(conjureTimelockService, collector))
+                .orElse(conjureTimelockService);
+
         NamespacedTimelockRpcClient namespacedTimelockRpcClient
                 = new NamespacedTimelockRpcClient(withDiagnosticsTimelockClient, timelockNamespace);
         NamespacedConjureTimelockService namespacedConjureTimelockService
-                = new NamespacedConjureTimelockService(conjureTimelockService, timelockNamespace);
+                = new NamespacedConjureTimelockService(withDiagnosticsConjureTimelockService, timelockNamespace);
 
         RemoteTimelockServiceAdapter remoteTimelockServiceAdapter
                 = RemoteTimelockServiceAdapter.create(namespacedTimelockRpcClient, namespacedConjureTimelockService);

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/BlockingSensitiveTimelockRpcClient.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/BlockingSensitiveTimelockRpcClient.java
@@ -21,15 +21,10 @@ import java.util.Set;
 
 import com.palantir.lock.client.IdentifiedLockRequest;
 import com.palantir.lock.v2.IdentifiedTimeLockRequest;
-import com.palantir.lock.v2.LeaderTime;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
 import com.palantir.lock.v2.LockResponseV2;
 import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.RefreshLockResponseV2;
-import com.palantir.lock.v2.StartTransactionRequestV4;
-import com.palantir.lock.v2.StartTransactionRequestV5;
-import com.palantir.lock.v2.StartTransactionResponseV4;
-import com.palantir.lock.v2.StartTransactionResponseV5;
 import com.palantir.lock.v2.TimelockRpcClient;
 import com.palantir.lock.v2.WaitForLocksRequest;
 import com.palantir.lock.v2.WaitForLocksResponse;
@@ -73,17 +68,6 @@ public class BlockingSensitiveTimelockRpcClient implements TimelockRpcClient {
     }
 
     @Override
-    public StartTransactionResponseV4 startTransactions(String namespace, StartTransactionRequestV4 request) {
-        return nonBlockingClient.startTransactions(namespace, request);
-    }
-
-    @Override
-    public StartTransactionResponseV5 startTransactionsWithWatches(String namespace,
-            StartTransactionRequestV5 request) {
-        return nonBlockingClient.startTransactionsWithWatches(namespace, request);
-    }
-
-    @Override
     public long getImmutableTimestamp(String namespace) {
         return nonBlockingClient.getImmutableTimestamp(namespace);
     }
@@ -101,11 +85,6 @@ public class BlockingSensitiveTimelockRpcClient implements TimelockRpcClient {
     @Override
     public RefreshLockResponseV2 refreshLockLeases(String namespace, Set<LockToken> tokens) {
         return nonBlockingClient.refreshLockLeases(namespace, tokens);
-    }
-
-    @Override
-    public LeaderTime getLeaderTime(String namespace) {
-        return nonBlockingClient.getLeaderTime(namespace);
     }
 
     @Override

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/timelock/BlockingSensitiveTimelockRpcClientTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/timelock/BlockingSensitiveTimelockRpcClientTest.java
@@ -20,15 +20,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-import java.util.UUID;
-
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableSet;
 import com.palantir.lock.StringLockDescriptor;
 import com.palantir.lock.client.IdentifiedLockRequest;
-import com.palantir.lock.v2.ImmutableStartTransactionRequestV5;
-import com.palantir.lock.v2.StartTransactionRequestV5;
 import com.palantir.lock.v2.TimelockRpcClient;
 import com.palantir.lock.v2.WaitForLocksRequest;
 
@@ -40,13 +36,6 @@ public class BlockingSensitiveTimelockRpcClientTest {
     private static final WaitForLocksRequest WAIT_FOR_LOCKS_REQUEST = WaitForLocksRequest.of(
             ImmutableSet.of(StringLockDescriptor.of("waiting-lock")),
             60_000);
-    private static final StartTransactionRequestV5 START_TRANSACTION_REQUEST
-            = ImmutableStartTransactionRequestV5.builder()
-            .lastKnownLockLogVersion(88)
-            .numTransactions(66)
-            .requestId(UUID.randomUUID())
-            .requestorId(UUID.randomUUID())
-            .build();
 
     private final TimelockRpcClient blocking = mock(TimelockRpcClient.class);
     private final TimelockRpcClient nonBlocking = mock(TimelockRpcClient.class);
@@ -70,9 +59,9 @@ public class BlockingSensitiveTimelockRpcClientTest {
 
     @Test
     public void startTransactionUsesNonBlockingClient() {
-        sensitiveClient.startTransactionsWithWatches(NAMESPACE, START_TRANSACTION_REQUEST);
+        sensitiveClient.getFreshTimestamp(NAMESPACE);
 
-        verify(nonBlocking).startTransactionsWithWatches(NAMESPACE, START_TRANSACTION_REQUEST);
-        verify(blocking, never()).startTransactionsWithWatches(NAMESPACE, START_TRANSACTION_REQUEST);
+        verify(nonBlocking).getFreshTimestamp(NAMESPACE);
+        verify(blocking, never()).getFreshTimestamp(NAMESPACE);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/debug/LockDiagnosticConjureTimelockService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/debug/LockDiagnosticConjureTimelockService.java
@@ -1,0 +1,55 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.debug;
+
+import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsRequest;
+import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
+import com.palantir.atlasdb.timelock.api.ConjureTimelockService;
+import com.palantir.lock.v2.LeaderTime;
+import com.palantir.tokens.auth.AuthHeader;
+
+/**
+ * TODO(fdesouza): Remove this once PDS-95791 is resolved.
+ * @deprecated Remove this once PDS-95791 is resolved.
+ */
+public class LockDiagnosticConjureTimelockService implements ConjureTimelockService {
+    private final ConjureTimelockService conjureDelegate;
+    private final ClientLockDiagnosticCollector lockDiagnosticCollector;
+
+    public LockDiagnosticConjureTimelockService(
+            ConjureTimelockService conjureDelegate,
+            ClientLockDiagnosticCollector lockDiagnosticCollector) {
+        this.conjureDelegate = conjureDelegate;
+        this.lockDiagnosticCollector = lockDiagnosticCollector;
+    }
+
+    @Override
+    public ConjureStartTransactionsResponse startTransactions(AuthHeader authHeader, String namespace,
+            ConjureStartTransactionsRequest request) {
+        ConjureStartTransactionsResponse response = conjureDelegate.startTransactions(authHeader, namespace, request);
+        lockDiagnosticCollector.collect(
+                response.getTimestamps().stream(),
+                response.getImmutableTimestamp().getImmutableTimestamp(),
+                request.getRequestId());
+        return response;
+    }
+
+    @Override
+    public LeaderTime leaderTime(AuthHeader authHeader, String namespace) {
+        return conjureDelegate.leaderTime(authHeader, namespace);
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/debug/LockDiagnosticConjureTimelockService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/debug/LockDiagnosticConjureTimelockService.java
@@ -26,6 +26,7 @@ import com.palantir.tokens.auth.AuthHeader;
  * TODO(fdesouza): Remove this once PDS-95791 is resolved.
  * @deprecated Remove this once PDS-95791 is resolved.
  */
+@Deprecated
 public class LockDiagnosticConjureTimelockService implements ConjureTimelockService {
     private final ConjureTimelockService conjureDelegate;
     private final ClientLockDiagnosticCollector lockDiagnosticCollector;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/debug/LockDiagnosticTimelockRpcClient.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/debug/LockDiagnosticTimelockRpcClient.java
@@ -21,8 +21,6 @@ import java.util.Optional;
 import com.palantir.lock.client.IdentifiedLockRequest;
 import com.palantir.lock.v2.AutoDelegate_TimelockRpcClient;
 import com.palantir.lock.v2.LockResponseV2;
-import com.palantir.lock.v2.StartTransactionRequestV4;
-import com.palantir.lock.v2.StartTransactionResponseV4;
 import com.palantir.lock.v2.TimelockRpcClient;
 import com.palantir.lock.v2.WaitForLocksRequest;
 import com.palantir.lock.v2.WaitForLocksResponse;
@@ -47,16 +45,6 @@ public class LockDiagnosticTimelockRpcClient implements AutoDelegate_TimelockRpc
     @Override
     public TimelockRpcClient delegate() {
         return delegate;
-    }
-
-    @Override
-    public StartTransactionResponseV4 startTransactions(String namespace, StartTransactionRequestV4 request) {
-        StartTransactionResponseV4 response = delegate().startTransactions(namespace, request);
-        lockDiagnosticCollector.collect(
-                response.timestamps().stream(),
-                response.immutableTimestamp().getImmutableTimestamp(),
-                request.requestId());
-        return response;
     }
 
     @Override
@@ -85,3 +73,4 @@ public class LockDiagnosticTimelockRpcClient implements AutoDelegate_TimelockRpc
         }
     }
 }
+

--- a/changelog/@unreleased/pr-4609.v2.yml
+++ b/changelog/@unreleased/pr-4609.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Actually use conjure undertow endpoints
+  links:
+  - https://github.com/palantir/atlasdb/pull/4609

--- a/lock-api-objects/build.gradle
+++ b/lock-api-objects/build.gradle
@@ -27,7 +27,7 @@ recommendedProductDependencies {
     productDependency {
         productGroup = 'com.palantir.timelock'
         productName = 'timelock-server'
-        minimumVersion = '0.59.0'
+        minimumVersion = '0.137.0'
         maximumVersion = '0.x.x'
     }
 }

--- a/lock-api/build.gradle
+++ b/lock-api/build.gradle
@@ -44,7 +44,7 @@ recommendedProductDependencies {
     productDependency {
         productGroup = 'com.palantir.timelock'
         productName = 'timelock-server'
-        minimumVersion = '0.59.0'
+        minimumVersion = '0.137.0'
         maximumVersion = '0.x.x'
     }
 }

--- a/lock-api/src/main/java/com/palantir/lock/client/LockLeaseService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockLeaseService.java
@@ -34,7 +34,6 @@ import com.palantir.lock.v2.LockResponseV2;
 import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.NamespacedTimelockRpcClient;
 import com.palantir.lock.v2.RefreshLockResponseV2;
-import com.palantir.lock.v2.StartTransactionRequestV4;
 import com.palantir.lock.v2.StartTransactionResponseV4;
 import com.palantir.logsafe.Preconditions;
 

--- a/lock-api/src/main/java/com/palantir/lock/client/LockLeaseService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockLeaseService.java
@@ -66,14 +66,13 @@ class LockLeaseService {
     }
 
     StartTransactionResponseV4 startTransactions(int batchSize) {
-        final StartTransactionResponseV4 response;
         ConjureStartTransactionsRequest request = ConjureStartTransactionsRequest.builder()
                 .requestorId(clientId)
                 .requestId(UUID.randomUUID())
                 .numTransactions(batchSize)
                 .build();
         ConjureStartTransactionsResponse conjureResponse = conjureDelegate.startTransactions(request);
-        response = StartTransactionResponseV4.of(
+        StartTransactionResponseV4 response = StartTransactionResponseV4.of(
                 conjureResponse.getImmutableTimestamp(),
                 conjureResponse.getTimestamps(),
                 conjureResponse.getLease());

--- a/lock-api/src/main/java/com/palantir/lock/v2/NamespacedTimelockRpcClient.java
+++ b/lock-api/src/main/java/com/palantir/lock/v2/NamespacedTimelockRpcClient.java
@@ -16,11 +16,9 @@
 
 package com.palantir.lock.v2;
 
-import java.util.OptionalLong;
 import java.util.Set;
 
 import com.palantir.lock.client.IdentifiedLockRequest;
-import com.palantir.lock.watch.TimestampWithWatches;
 import com.palantir.timestamp.TimestampRange;
 
 /**
@@ -44,20 +42,8 @@ public class NamespacedTimelockRpcClient {
         return timelockRpcClient.getFreshTimestamps(namespace, numTimestampsRequested);
     }
 
-    public TimestampWithWatches getCommitTimestampWithWatches(OptionalLong lastVersion) {
-        return timelockRpcClient.getCommitTimestampWithWatches(namespace, lastVersion);
-    }
-
     public LockImmutableTimestampResponse lockImmutableTimestamp(IdentifiedTimeLockRequest request) {
         return timelockRpcClient.lockImmutableTimestamp(namespace, request);
-    }
-
-    public StartTransactionResponseV4 startTransactions(StartTransactionRequestV4 request) {
-        return timelockRpcClient.startTransactions(namespace, request);
-    }
-
-    public StartTransactionResponseV5 startTransactionsWithWatches(StartTransactionRequestV5 request) {
-        return timelockRpcClient.startTransactionsWithWatches(namespace, request);
     }
 
     public long getImmutableTimestamp() {
@@ -74,10 +60,6 @@ public class NamespacedTimelockRpcClient {
 
     public RefreshLockResponseV2 refreshLockLeases(Set<LockToken> tokens) {
         return timelockRpcClient.refreshLockLeases(namespace, tokens);
-    }
-
-    public LeaderTime getLeaderTime() {
-        return timelockRpcClient.getLeaderTime(namespace);
     }
 
     public Set<LockToken> unlock(Set<LockToken> tokens) {

--- a/lock-api/src/main/java/com/palantir/lock/v2/TimelockRpcClient.java
+++ b/lock-api/src/main/java/com/palantir/lock/v2/TimelockRpcClient.java
@@ -20,7 +20,6 @@ import java.util.OptionalLong;
 import java.util.Set;
 
 import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -66,23 +65,6 @@ public interface TimelockRpcClient {
     LockImmutableTimestampResponse lockImmutableTimestamp(
             @PathParam("namespace") String namespace, IdentifiedTimeLockRequest request);
 
-    /**
-     * Returns a {@link StartTransactionResponseV4} which has a single immutable ts, and a range of timestamps to
-     * be used as start timestamps.
-     *
-     * It is guaranteed to have at least one usable timestamp matching the partition criteria in the returned timestamp
-     * range, but there is no other guarantee given. (It can be less than number of requested timestamps)
-     */
-    @POST
-    @Path("start-atlasdb-transaction-v4")
-    StartTransactionResponseV4 startTransactions(
-            @PathParam("namespace") String namespace, StartTransactionRequestV4 request);
-
-    @POST
-    @Path("start-atlasdb-transaction-v5")
-    StartTransactionResponseV5 startTransactionsWithWatches(
-            @PathParam("namespace") String namespace, StartTransactionRequestV5 request);
-
     @POST
     @Path("immutable-timestamp")
     long getImmutableTimestamp(@PathParam("namespace") String namespace);
@@ -98,10 +80,6 @@ public interface TimelockRpcClient {
     @POST
     @Path("refresh-locks-v2")
     RefreshLockResponseV2 refreshLockLeases(@PathParam("namespace") String namespace, Set<LockToken> tokens);
-
-    @GET
-    @Path("leader-time")
-    LeaderTime getLeaderTime(@PathParam("namespace") String namespace);
 
     @POST
     @Path("unlock")

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceIntegrationTest.java
@@ -41,6 +41,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Iterables;
+import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsRequest;
+import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
 import com.palantir.atlasdb.transaction.impl.TransactionConstants;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.lock.HeldLocksGrant;
@@ -61,8 +63,6 @@ import com.palantir.lock.v2.LockResponse;
 import com.palantir.lock.v2.LockResponseV2;
 import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.StartIdentifiedAtlasDbTransactionResponse;
-import com.palantir.lock.v2.StartTransactionRequestV4;
-import com.palantir.lock.v2.StartTransactionResponseV4;
 import com.palantir.lock.v2.TimelockService;
 import com.palantir.lock.v2.WaitForLocksRequest;
 import com.palantir.lock.v2.WaitForLocksResponse;
@@ -142,17 +142,19 @@ public class AsyncTimelockServiceIntegrationTest extends AbstractAsyncTimelockSe
     @Test
     public void batchedStartTransactionCallShouldLockImmutableTimestamp() {
         // requestor id corresponds to an instance of the timelock service client
-        StartTransactionRequestV4 request = StartTransactionRequestV4.createForRequestor(
-                UUID.randomUUID(),
-                123);
+        ConjureStartTransactionsRequest request = ConjureStartTransactionsRequest.builder()
+                .numTransactions(123)
+                .requestorId(UUID.randomUUID())
+                .requestId(UUID.randomUUID())
+                .build();
 
-        LockImmutableTimestampResponse response1 = namespace.namespacedTimelockRpcClient()
+        LockImmutableTimestampResponse response1 = namespace.namespacedConjureTimelockService()
                 .startTransactions(request)
-                .immutableTimestamp();
+                .getImmutableTimestamp();
 
-        LockImmutableTimestampResponse response2 = namespace.namespacedTimelockRpcClient()
+        LockImmutableTimestampResponse response2 = namespace.namespacedConjureTimelockService()
                 .startTransactions(request)
-                .immutableTimestamp();
+                .getImmutableTimestamp();
 
         // above are two *separate* batches
 
@@ -606,11 +608,13 @@ public class AsyncTimelockServiceIntegrationTest extends AbstractAsyncTimelockSe
     }
 
     private List<Long> getSortedBatchedStartTimestamps(UUID requestorUuid, int numRequestedTimestamps) {
-        StartTransactionRequestV4 request = StartTransactionRequestV4.createForRequestor(
-                requestorUuid,
-                numRequestedTimestamps);
-        StartTransactionResponseV4 response = namespace.namespacedTimelockRpcClient().startTransactions(request);
-        return response.timestamps().stream()
+        ConjureStartTransactionsRequest request = ConjureStartTransactionsRequest.builder()
+                .requestId(UUID.randomUUID())
+                .requestorId(requestorUuid)
+                .numTransactions(numRequestedTimestamps)
+                .build();
+        ConjureStartTransactionsResponse response = namespace.namespacedConjureTimelockService().startTransactions(request);
+        return response.getTimestamps().stream()
                 .boxed()
                 .collect(Collectors.toList());
     }

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceIntegrationTest.java
@@ -613,7 +613,8 @@ public class AsyncTimelockServiceIntegrationTest extends AbstractAsyncTimelockSe
                 .requestorId(requestorUuid)
                 .numTransactions(numRequestedTimestamps)
                 .build();
-        ConjureStartTransactionsResponse response = namespace.namespacedConjureTimelockService().startTransactions(request);
+        ConjureStartTransactionsResponse response = namespace.namespacedConjureTimelockService()
+                .startTransactions(request);
         return response.getTimestamps().stream()
                 .boxed()
                 .collect(Collectors.toList());

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -157,12 +157,12 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
     @Test
     public void leaderIdChangesAcrossFailovers() {
         Set<LeaderTime> leaderTimes = new HashSet<>();
-        leaderTimes.add(client.namespacedTimelockRpcClient().getLeaderTime());
+        leaderTimes.add(client.namespacedConjureTimelockService().leaderTime());
 
         for (int i = 0; i < 3; i++) {
             cluster.failoverToNewLeader(client.namespace());
 
-            LeaderTime leaderTime = client.namespacedTimelockRpcClient().getLeaderTime();
+            LeaderTime leaderTime = client.namespacedConjureTimelockService().leaderTime();
 
             leaderTimes.forEach(previousLeaderTime ->
                     assertThat(previousLeaderTime.isComparableWith(leaderTime)).isFalse());


### PR DESCRIPTION
**Goals (and why)**:
- Actually enable work done in #4545, see if we can get performance numbers

**Implementation Description (bullets)**:
- Update product dependency to 0.137.0, please validate this is correct as part of this review
- Inline previous guarded sections on `HAVE_ROLLED_OUT_CONJURE_CHANGES_INTERNALLY`

**Testing (What was existing testing like?  What have you done to improve it?)**:
- None, beyond existing manual test done on internal herby stack.

**Concerns (what feedback would you like?)**:
- Nothing in particular. Manual test was done on internal herby stack which IMO reduces the risk.

**Where should we start reviewing?**: build.gradles

**Priority (whenever / two weeks / yesterday)**: this week please
