### PR TITLE
[Async ALP] Make getLeadershipToken return ListenableFuture and chain it to avoid throwing

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/common/concurrent/CoalescingSupplier.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/concurrent/CoalescingSupplier.java
@@ -55,6 +55,7 @@ public class CoalescingSupplier<T> implements Supplier<T> {
         }
     }
 
+    @SuppressWarnings("CheckReturnValue")
     public ListenableFuture<T> getAsync() {
         Round present = round;
         if (present.isFirstToArrive()) {

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/AwaitingLeadershipProxyBenchmark.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/AwaitingLeadershipProxyBenchmark.java
@@ -1,0 +1,138 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.performance.benchmarks;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+import com.google.common.net.HostAndPort;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.palantir.common.concurrent.PTExecutors;
+import com.palantir.leader.LeaderElectionService;
+import com.palantir.leader.proxy.AwaitingLeadershipProxy;
+
+@Measurement(iterations = 10, time = 2)
+@Warmup(iterations = 6, time = 1)
+@Fork(value = 1)
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class AwaitingLeadershipProxyBenchmark {
+    private final LeaderAwareService service =
+            AwaitingLeadershipProxy.newProxyInstance(
+                    LeaderAwareService.class,
+                    () -> LeaderAwareImpl.INSTANCE,
+                    FakeLeaderElectionService.INSTANCE);
+    private static final int ASYNC_ITERATIONS = 1000;
+
+    @Benchmark
+    @Threads(256)
+    public int benchmarkBlocking() {
+        return service.somethingBlocking();
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(ASYNC_ITERATIONS)
+    @Threads(12)
+    public List<Object> benchmarkAsync() {
+        List<ListenableFuture<?>> futures = new ArrayList<>(ASYNC_ITERATIONS);
+        for (int i = 0; i < ASYNC_ITERATIONS; i++) {
+            futures.add(service.somethingAsync());
+        }
+        ListenableFuture<List<Object>> composition = Futures.allAsList(futures);
+        return Futures.getUnchecked(composition);
+    }
+
+
+    public interface LeaderAwareService {
+        int somethingBlocking();
+        ListenableFuture<?> somethingAsync();
+    }
+
+    private enum LeaderAwareImpl implements LeaderAwareService {
+        INSTANCE;
+
+        @Override
+        public int somethingBlocking() {
+            return ThreadLocalRandom.current().nextInt();
+        }
+
+        @Override
+        public ListenableFuture<?> somethingAsync() {
+            return Futures.immediateFuture(null);
+        }
+    }
+
+    private enum FakeLeaderElectionService implements LeaderElectionService {
+        INSTANCE;
+
+        private static final ListeningScheduledExecutorService executor = MoreExecutors.listeningDecorator(
+                PTExecutors.newScheduledThreadPool(4));
+        private static final LeadershipToken token = new LeadershipToken() {
+            @Override
+            public boolean sameAs(LeadershipToken other) {
+                return other == this;
+            }
+        };
+
+        @Override
+        public void markNotEligibleForLeadership() {}
+
+        @Override
+        public LeadershipToken blockOnBecomingLeader() {
+            return token;
+        }
+
+        @Override
+        public Optional<LeadershipToken> getCurrentTokenIfLeading() {
+            return Optional.of(token);
+        }
+
+        @Override
+        public ListenableFuture<StillLeadingStatus> isStillLeading(LeadershipToken token) {
+            return executor.schedule(() -> StillLeadingStatus.LEADING, 2, TimeUnit.MILLISECONDS);
+        }
+
+        @Override
+        public boolean stepDown() {
+            return false;
+        }
+
+        @Override
+        public Optional<HostAndPort> getRecentlyPingedLeaderHost() {
+            return Optional.empty();
+        }
+    }
+}

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/AwaitingLeadershipProxyBenchmark.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/AwaitingLeadershipProxyBenchmark.java
@@ -91,7 +91,7 @@ public class AwaitingLeadershipProxyBenchmark {
 
         @Override
         public ListenableFuture<?> somethingAsync() {
-            return Futures.immediateFuture(null);
+            return Futures.immediateFuture(somethingBlocking());
         }
     }
 

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/AwaitingLeadershipProxyBenchmark.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/AwaitingLeadershipProxyBenchmark.java
@@ -76,6 +76,7 @@ public class AwaitingLeadershipProxyBenchmark {
     }
 
 
+
     public interface LeaderAwareService {
         int somethingBlocking();
         ListenableFuture<?> somethingAsync();

--- a/leader-election-api/src/main/java/com/palantir/leader/LeaderElectionService.java
+++ b/leader-election-api/src/main/java/com/palantir/leader/LeaderElectionService.java
@@ -19,6 +19,7 @@ import java.io.Serializable;
 import java.util.Optional;
 
 import com.google.common.net.HostAndPort;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.atlasdb.metrics.Timed;
 
 public interface LeaderElectionService {
@@ -75,6 +76,8 @@ public interface LeaderElectionService {
      */
     @Timed
     StillLeadingStatus isStillLeading(LeadershipToken token);
+
+    ListenableFuture<StillLeadingStatus> isStillLeadingAsync(LeadershipToken token);
 
     /**
      * Attempts to give up leadership. Note that this does not guarantee that a different node will be elected the

--- a/leader-election-api/src/main/java/com/palantir/leader/LeaderElectionService.java
+++ b/leader-election-api/src/main/java/com/palantir/leader/LeaderElectionService.java
@@ -74,10 +74,7 @@ public interface LeaderElectionService {
      * @param token leadership token
      * @return LEADING if the token is still the leader
      */
-    @Timed
-    StillLeadingStatus isStillLeading(LeadershipToken token);
-
-    ListenableFuture<StillLeadingStatus> isStillLeadingAsync(LeadershipToken token);
+    ListenableFuture<StillLeadingStatus> isStillLeading(LeadershipToken token);
 
     /**
      * Attempts to give up leadership. Note that this does not guarantee that a different node will be elected the

--- a/leader-election-impl/src/main/java/com/palantir/leader/BatchingLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/BatchingLeaderElectionService.java
@@ -62,13 +62,8 @@ public class BatchingLeaderElectionService implements LeaderElectionService, Clo
     }
 
     @Override
-    public StillLeadingStatus isStillLeading(LeadershipToken token) {
+    public ListenableFuture<StillLeadingStatus> isStillLeading(LeadershipToken token) {
         return delegate.isStillLeading(token);
-    }
-
-    @Override
-    public ListenableFuture<StillLeadingStatus> isStillLeadingAsync(LeadershipToken token) {
-        return delegate.isStillLeadingAsync(token);
     }
 
     @Override

--- a/leader-election-impl/src/main/java/com/palantir/leader/BatchingLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/BatchingLeaderElectionService.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
 import com.google.common.net.HostAndPort;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.atlasdb.autobatch.Autobatchers;
 import com.palantir.atlasdb.autobatch.BatchElement;
 import com.palantir.atlasdb.autobatch.DisruptorAutobatcher;
@@ -63,6 +64,11 @@ public class BatchingLeaderElectionService implements LeaderElectionService, Clo
     @Override
     public StillLeadingStatus isStillLeading(LeadershipToken token) {
         return delegate.isStillLeading(token);
+    }
+
+    @Override
+    public ListenableFuture<StillLeadingStatus> isStillLeadingAsync(LeadershipToken token) {
+        return delegate.isStillLeadingAsync(token);
     }
 
     @Override

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
@@ -209,12 +209,7 @@ public class PaxosLeaderElectionService implements LeaderElectionService {
     }
 
     @Override
-    public StillLeadingStatus isStillLeading(LeadershipToken token) {
-        return Futures.getUnchecked(isStillLeadingAsync(token));
-    }
-
-    @Override
-    public ListenableFuture<StillLeadingStatus> isStillLeadingAsync(LeadershipToken token) {
+    public ListenableFuture<StillLeadingStatus> isStillLeading(LeadershipToken token) {
         if (!(token instanceof PaxosLeadershipToken)) {
             return Futures.immediateFuture(StillLeadingStatus.NOT_LEADING);
         }

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/AsyncRetrier.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/AsyncRetrier.java
@@ -1,0 +1,72 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.leader.proxy;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+
+/**
+ * Class that uses ListenableFuture primitives to provide a simple delay-retry loop. Should be kept very simple.
+ */
+final class AsyncRetrier<T> {
+    private final int maxAttempts;
+    private final Duration delayBetweenAttempts;
+    private final ListeningScheduledExecutorService schedulingExecutor;
+    private final ListeningExecutorService executionExecutor;
+    private final Predicate<T> predicate;
+
+    AsyncRetrier(
+            int maxAttempts,
+            Duration delayBetweenAttempts,
+            ListeningScheduledExecutorService schedulingExecutor,
+            ListeningExecutorService executionExecutor,
+            Predicate<T> predicate) {
+        this.maxAttempts = maxAttempts;
+        this.delayBetweenAttempts = delayBetweenAttempts;
+        this.schedulingExecutor = schedulingExecutor;
+        this.executionExecutor = executionExecutor;
+        this.predicate = predicate;
+    }
+
+    public ListenableFuture<T> retryUntilSatistfied(Supplier<ListenableFuture<T>> supplier) {
+        return retryUntilSatistfied(supplier, maxAttempts);
+    }
+
+    private ListenableFuture<T> retryUntilSatistfied(Supplier<ListenableFuture<T>> supplier, int retriesRemaining) {
+        return Futures.transformAsync(Futures.submitAsync(supplier::get, executionExecutor),
+                result -> {
+                    int newRetriesRemaining = retriesRemaining - 1;
+                    if (predicate.test(result) || newRetriesRemaining == 0) {
+                        return Futures.immediateFuture(result);
+                    } else {
+                        return Futures.transformAsync(
+                                schedulingExecutor.schedule(
+                                        () -> { }, delayBetweenAttempts.toMillis(), TimeUnit.MILLISECONDS),
+                                $ -> retryUntilSatistfied(supplier, newRetriesRemaining),
+                                executionExecutor);
+                    }
+                }, executionExecutor);
+
+    }
+}

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
@@ -34,7 +34,6 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.reflect.AbstractInvocationHandler;

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
@@ -196,12 +196,12 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
     }
 
     // Wait for at most 6.3 seconds in case of a momentary network partition
-    private ListenableFuture<StillLeadingStatus> isStillLeadingAsync(LeadershipToken token) {
-        return isStillLeadingAsync(token, MAX_NO_QUORUM_RETRIES);
+    private ListenableFuture<StillLeadingStatus> isStillLeading(LeadershipToken token) {
+        return isStillLeading(token, MAX_NO_QUORUM_RETRIES);
     }
 
-    private ListenableFuture<StillLeadingStatus> isStillLeadingAsync(LeadershipToken token, int retriesRemaining) {
-        return Futures.transformAsync(leaderElectionService.isStillLeadingAsync(token),
+    private ListenableFuture<StillLeadingStatus> isStillLeading(LeadershipToken token, int retriesRemaining) {
+        return Futures.transformAsync(leaderElectionService.isStillLeading(token),
                 leading -> {
                     int newRetriesRemaining = retriesRemaining - 1;
                     if (leading != StillLeadingStatus.NO_QUORUM || newRetriesRemaining == 0) {
@@ -209,7 +209,7 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
                     } else {
                         return Futures.transformAsync(
                                 schedulingExecutor.schedule(() -> { }, 700, TimeUnit.MILLISECONDS),
-                                $ -> isStillLeadingAsync(token, newRetriesRemaining),
+                                $ -> isStillLeading(token, newRetriesRemaining),
                                 executionExecutor);
                     }
                 }, executionExecutor);
@@ -229,7 +229,7 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
 
         Object maybeValidDelegate = delegateRef.get();
 
-        ListenableFuture<StillLeadingStatus> leadingFuture = isStillLeadingAsync(leadershipToken);
+        ListenableFuture<StillLeadingStatus> leadingFuture = isStillLeading(leadershipToken);
 
         ListenableFuture<Object> delegateFuture = Futures.transform(leadingFuture,
                 leading -> {

--- a/leader-election-impl/src/main/java/com/palantir/paxos/CoalescingPaxosLatestRoundVerifier.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/CoalescingPaxosLatestRoundVerifier.java
@@ -18,6 +18,7 @@ package com.palantir.paxos;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.common.concurrent.CoalescingSupplier;
 
 /**
@@ -40,6 +41,10 @@ public class CoalescingPaxosLatestRoundVerifier implements PaxosLatestRoundVerif
 
     public CoalescingPaxosLatestRoundVerifier(PaxosLatestRoundVerifier delegate) {
         this.delegate = delegate;
+    }
+
+    public ListenableFuture<PaxosQuorumStatus> isLatestRoundAsync(long round) {
+        return verifiersByRound.getUnchecked(round).getAsync();
     }
 
     @Override

--- a/leader-election-impl/src/test/java/com/palantir/leader/proxy/AsyncRetrierTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/proxy/AsyncRetrierTest.java
@@ -1,0 +1,126 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.leader.proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import org.jmock.lib.concurrent.DeterministicScheduler;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.SettableFuture;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AsyncRetrierTest {
+    private static final int MAX_ATTEMPTS = 3;
+    private static final Duration RETRY_PERIOD = Duration.ofSeconds(1);
+    private static final Duration DELTA = Duration.ofMillis(1);
+
+    private final DeterministicScheduler scheduler = new DeterministicScheduler();
+
+    private SettableFuture<Integer> future = SettableFuture.create();
+    private Supplier<ListenableFuture<Integer>> replaceableFunction = () -> future;
+
+    @Mock private Supplier<ListenableFuture<Integer>> function;
+
+    private AsyncRetrier<Integer> retrier;
+
+    @Before
+    public void before() {
+        retrier = new AsyncRetrier<>(
+                MAX_ATTEMPTS,
+                RETRY_PERIOD,
+                MoreExecutors.listeningDecorator(scheduler),
+                MoreExecutors.listeningDecorator(scheduler),
+                new Predicate<Integer>() {
+                    private int seen = 0;
+
+                    @Override
+                    public boolean test(Integer integer) {
+                        return seen++ == integer;
+                    }
+                });
+        when(function.get()).thenAnswer(inv -> replaceableFunction.get());
+    }
+
+    @Test
+    public void failsFutureIfSupplierThrows() {
+        RuntimeException exception = new RuntimeException();
+        replaceableFunction = () -> {
+            throw exception;
+        };
+        ListenableFuture<Integer> hopefullyFailedFuture = retrier.retryUntilSatistfied(function);
+        scheduler.runUntilIdle();
+        assertThatThrownBy(() -> Futures.getDone(hopefullyFailedFuture)).hasCause(exception);
+    }
+
+    @Test
+    public void returnsImmediatelyIfPredicatePasses() throws ExecutionException {
+        ListenableFuture<Integer> result = retrier.retryUntilSatistfied(function);
+        future.set(0);
+        scheduler.runUntilIdle();
+        assertThat(Futures.getDone(result)).isZero();
+    }
+
+    @Test
+    public void retriesIfPredicateFails() throws ExecutionException {
+        ListenableFuture<Integer> result = retrier.retryUntilSatistfied(function);
+        future.set(-1);
+        scheduler.runUntilIdle();
+        verify(function, times(1)).get();
+        tick(RETRY_PERIOD.minus(DELTA));
+        verify(function, times(1)).get();
+        assertThat(result).isNotDone();
+        tick(DELTA);
+        verify(function, times(2)).get();
+        assertThat(result).isNotDone();
+        tick(RETRY_PERIOD.minus(DELTA));
+        verify(function, times(2)).get();
+        future = SettableFuture.create();
+        future.set(2);
+        tick(DELTA);
+        assertThat(Futures.getDone(result)).isEqualTo(2);
+    }
+
+    @Test
+    public void doesNotRetryIndefinitely() throws ExecutionException {
+        ListenableFuture<Integer> result = retrier.retryUntilSatistfied(function);
+        future.set(-1);
+        tick(RETRY_PERIOD.multipliedBy(MAX_ATTEMPTS));
+        assertThat(Futures.getDone(result)).isEqualTo(-1);
+    }
+
+    private void tick(Duration duration) {
+        scheduler.tick(duration.toMillis(), TimeUnit.MILLISECONDS);
+    }
+}

--- a/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
@@ -59,7 +59,7 @@ public class AwaitingLeadershipProxyTest {
     public void before() throws InterruptedException {
         when(leaderElectionService.blockOnBecomingLeader()).thenReturn(leadershipToken);
         when(leaderElectionService.getCurrentTokenIfLeading()).thenReturn(Optional.empty());
-        when(leaderElectionService.isStillLeadingAsync(leadershipToken)).thenReturn(
+        when(leaderElectionService.isStillLeading(leadershipToken)).thenReturn(
                 Futures.immediateFuture(LeaderElectionService.StillLeadingStatus.LEADING));
     }
 
@@ -69,7 +69,7 @@ public class AwaitingLeadershipProxyTest {
     // the .equals call to the instance its being proxied.
     public void shouldAllowObjectMethodsWhenLeading() {
         when(mockLeader.getCurrentTokenIfLeading()).thenReturn(Optional.empty());
-        when(mockLeader.isStillLeadingAsync(any(LeaderElectionService.LeadershipToken.class)))
+        when(mockLeader.isStillLeading(any(LeaderElectionService.LeadershipToken.class)))
                 .thenReturn(Futures.immediateFuture(LeaderElectionService.StillLeadingStatus.LEADING));
 
         Runnable proxy = AwaitingLeadershipProxy.newProxyInstance(Runnable.class, delegateSupplier, mockLeader);
@@ -86,7 +86,7 @@ public class AwaitingLeadershipProxyTest {
     // the .equals call to the instance its being proxied.
     public void shouldAllowObjectMethodsWhenNotLeading() {
         when(mockLeader.getCurrentTokenIfLeading()).thenReturn(Optional.empty());
-        when(mockLeader.isStillLeadingAsync(any(LeaderElectionService.LeadershipToken.class)))
+        when(mockLeader.isStillLeading(any(LeaderElectionService.LeadershipToken.class)))
                 .thenReturn(Futures.immediateFuture(LeaderElectionService.StillLeadingStatus.NOT_LEADING));
 
         Runnable proxy = AwaitingLeadershipProxy.newProxyInstance(Runnable.class, delegateSupplier, mockLeader);
@@ -200,7 +200,7 @@ public class AwaitingLeadershipProxyTest {
     }
 
     private void loseLeadership(Callable proxy) throws InterruptedException {
-        when(leaderElectionService.isStillLeadingAsync(any()))
+        when(leaderElectionService.isStillLeading(any()))
                 .thenReturn(Futures.immediateFuture(LeaderElectionService.StillLeadingStatus.NOT_LEADING));
         when(leaderElectionService.blockOnBecomingLeader()).then(invocation -> {
             // never return

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosTestState.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosTestState.java
@@ -15,7 +15,7 @@
  */
 package com.palantir.paxos;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.assertj.core.api.Assertions;
 
+import com.google.common.util.concurrent.Futures;
 import com.palantir.leader.LeaderElectionService;
 import com.palantir.leader.LeaderElectionService.LeadershipToken;
 import com.palantir.leader.LeaderElectionService.StillLeadingStatus;
@@ -64,10 +65,8 @@ public class PaxosTestState {
             Assertions.fail(e.getMessage(), e);
         }
         if (checkAfterwards) {
-            assertEquals(
-                    "leader should still be leading right after becoming leader",
-                    StillLeadingStatus.LEADING,
-                    leader(leaderNum).isStillLeading(token));
+            assertThat(Futures.getUnchecked(leader(leaderNum).isStillLeading(token)))
+                    .isEqualTo(StillLeadingStatus.LEADING);
         }
         return token;
     }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockService.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockService.java
@@ -19,6 +19,7 @@ import java.io.Closeable;
 import java.util.OptionalLong;
 import java.util.Set;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.atlasdb.timelock.lock.AsyncResult;
 import com.palantir.atlasdb.timelock.lock.Leased;
 import com.palantir.atlasdb.timelock.lock.watch.LockWatchingService;
@@ -61,9 +62,9 @@ public interface AsyncTimelockService extends ManagedTimestampService, LockWatch
 
     StartTransactionResponseV4 startTransactions(StartTransactionRequestV4 request);
 
-    StartTransactionResponseV5 startTransactionsWithWatches(StartTransactionRequestV5 request);
+    ListenableFuture<StartTransactionResponseV5> startTransactionsWithWatches(StartTransactionRequestV5 request);
 
     TimestampWithWatches getCommitTimestampWithWatches(OptionalLong lastKnownVersion);
 
-    LeaderTime leaderTime();
+    ListenableFuture<LeaderTime> leaderTime();
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceImpl.java
@@ -19,6 +19,8 @@ import java.util.OptionalLong;
 import java.util.Set;
 import java.util.UUID;
 
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.atlasdb.timelock.lock.AsyncLockService;
 import com.palantir.atlasdb.timelock.lock.AsyncResult;
 import com.palantir.atlasdb.timelock.lock.Leased;
@@ -165,14 +167,14 @@ public class AsyncTimelockServiceImpl implements AsyncTimelockService {
     }
 
     @Override
-    public StartTransactionResponseV5 startTransactionsWithWatches(StartTransactionRequestV5 request) {
-        return StartTransactionResponseV5.fromV4(
+    public ListenableFuture<StartTransactionResponseV5> startTransactionsWithWatches(StartTransactionRequestV5 request) {
+        return Futures.immediateFuture(StartTransactionResponseV5.fromV4(
                 startTransactions(ImmutableStartTransactionRequestV4.builder()
                         .requestId(request.requestId())
                         .requestorId(request.requestorId())
                         .numTransactions(request.numTransactions())
                         .build()),
-                getWatchStateUpdate(request.lastKnownLockLogVersion()));
+                getWatchStateUpdate(request.lastKnownLockLogVersion())));
     }
 
     @Override
@@ -181,8 +183,8 @@ public class AsyncTimelockServiceImpl implements AsyncTimelockService {
     }
 
     @Override
-    public LeaderTime leaderTime() {
-        return lockService.leaderTime();
+    public ListenableFuture<LeaderTime> leaderTime() {
+        return Futures.immediateFuture(lockService.leaderTime());
     }
 
     @Override

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/ConjureTimelockResourceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/ConjureTimelockResourceTest.java
@@ -67,7 +67,7 @@ public class ConjureTimelockResourceTest {
     public void before() {
         resource = new ConjureTimelockResource(TARGETER, unused -> timelockService);
         service = ConjureTimelockResource.jersey(TARGETER, unused -> timelockService);
-        when(timelockService.leaderTime()).thenReturn(leaderTime);
+        when(timelockService.leaderTime()).thenReturn(Futures.immediateFuture(leaderTime));
     }
 
     @Test


### PR DESCRIPTION
Note: This PR is pointed at #4610, not at develop.

**Goals (and why)**:
- Normally if I call a method `blahAsync()` returning `ListenableFuture<T>` and the underlying call fails, I expect a failed future, not my async thing throwing an exception.

**Implementation Description (bullets)**:
- Change `getLeadershipToken()` to use `ListenableFuture` and chain it accordingly.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Added a test that would have thrown the `NCLE` directly in the implementation James and I paired on.
- Test failures happen in the base branch for the paxos consensus fast test.

**Concerns (what feedback would you like?)**:
- At points I just get the value of the future, but I think this makes sense, as when these occur on the async path they're part of future-transforms.

**Where should we start reviewing?**: AwaitingLeadershipProxy?

**Priority (whenever / two weeks / yesterday)**: this week