### PR TITLE
Revert "switch to using lighter-weight JDBC connection testing (#4602)"

### DIFF
--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/HikariCPConnectionManager.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/HikariCPConnectionManager.java
@@ -111,7 +111,7 @@ public class HikariCPConnectionManager extends BaseConnectionManager {
             profiler.logAcquisitionAndRestart();
 
             try {
-                conn.isValid(connConfig.getCheckoutTimeout());
+                testConnection(conn);
                 profiler.logConnectionTest();
                 return conn;
             } catch (SQLException e) {

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
@@ -158,6 +158,9 @@ public abstract class ConnectionConfig {
         // ConnectionConfig.connectionTimeoutSeconds is passed in via getHikariProperties(), in subclasses.
         config.setConnectionTimeout(getCheckoutTimeout());
 
+        // TODO (bullman): See if driver supports JDBC4 (isValid()) and use it.
+        config.setConnectionTestQuery(getTestQuery());
+
         if (!props.isEmpty()) {
             config.setDataSourceProperties(props);
         }

--- a/changelog/0.190.3/pr-4602.v2.yml
+++ b/changelog/0.190.3/pr-4602.v2.yml
@@ -1,6 +1,0 @@
-type: improvement
-improvement:
-  description: Switched to using lighter-weight JDBC connection testing on pool check-in
-    and check-out
-  links:
-  - https://github.com/palantir/atlasdb/pull/4602

--- a/changelog/@unreleased/pr-4617.v2.yml
+++ b/changelog/@unreleased/pr-4617.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Revert "switch to using lighter-weight JDBC connection testing (#4602)"
+  links:
+  - https://github.com/palantir/atlasdb/pull/4617


### PR DESCRIPTION
This reverts commit 2cc4e39d618d9b09d495e10061bdb076af136636.

**Goals (and why)**:
I think this is just straight up an oracle jdbc bug. It throws new types of exceptions on interrupted connections (that's okay, we can adjust our code) but also it NPEs in its own code on interrupted channels as well (I don't think I can fix that one).

```
Caused by: java.sql.SQLRecoverableException: Closed Connection
	at oracle.jdbc.driver.PhysicalConnection.getAutoCommit(PhysicalConnection.java:2089)
	at sun.reflect.GeneratedMethodAccessor28.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.palantir.nexus.db.pool.InterceptorConnection.handleInvocation(InterceptorConnection.java:53)
	at com.google.common.reflect.AbstractInvocationHandler.invoke(AbstractInvocationHandler.java:86)
	at com.sun.proxy.$Proxy58.getAutoCommit(Unknown Source)
	at com.zaxxer.hikari.pool.HikariProxyConnection.getAutoCommit(HikariProxyConnection.java)
	at com.palantir.sql.Connections.getAutoCommit(Connections.java:100)
```

```
java.lang.NullPointerException
	at oracle.net.nt.SocketChannelWrapper.implConfigureBlocking(SocketChannelWrapper.java:172)
	at java.nio.channels.spi.AbstractSelectableChannel.configureBlocking(AbstractSelectableChannel.java:294)
	at oracle.net.ns.NIOPacket.readInbandNotificationCtlPacket(NIOPacket.java:530)
	at oracle.net.ns.NSProtocolNIO.readInbandNotification(NSProtocolNIO.java:604)
	at oracle.jdbc.driver.T4CConnection.drainOnInbandNotification(T4CConnection.java:5524)
	at oracle.jdbc.driver.PhysicalConnection.checkAndDrain(PhysicalConnection.java:10188)
	at oracle.jdbc.driver.PhysicalConnection.pingDatabase(PhysicalConnection.java:5708)
	at oracle.jdbc.driver.PhysicalConnection.isValid(PhysicalConnection.java:10225)
	at oracle.jdbc.driver.PhysicalConnection.isValid(PhysicalConnection.java:10197)
```
