### PR TITLE
Add implementation of getFreshTimestamps to the conjure timelock service

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/debug/LockDiagnosticConjureTimelockService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/debug/LockDiagnosticConjureTimelockService.java
@@ -16,6 +16,8 @@
 
 package com.palantir.atlasdb.debug;
 
+import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsRequest;
+import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponse;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsRequest;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
 import com.palantir.atlasdb.timelock.api.ConjureTimelockService;
@@ -47,6 +49,12 @@ public class LockDiagnosticConjureTimelockService implements ConjureTimelockServ
                 response.getImmutableTimestamp().getImmutableTimestamp(),
                 request.getRequestId());
         return response;
+    }
+
+    @Override
+    public ConjureGetFreshTimestampsResponse getFreshTimestamps(AuthHeader authHeader, String namespace,
+            ConjureGetFreshTimestampsRequest request) {
+        return conjureDelegate.getFreshTimestamps(authHeader, namespace, request);
     }
 
     @Override

--- a/timelock-api/src/main/conjure/timelock-api.yml
+++ b/timelock-api/src/main/conjure/timelock-api.yml
@@ -20,6 +20,10 @@ types:
       base-type: any
       external:
         java: com.palantir.lock.v2.Lease
+    Long:
+      base-type: safelong
+      external:
+        java: java.lang.Long
   definitions:
     default-package: com.palantir.atlasdb.timelock.api
     objects:
@@ -33,6 +37,13 @@ types:
           immutableTimestamp: LockImmutableTimestampResponse
           timestamps: PartitionedTimestamps
           lease: Lease
+      ConjureGetFreshTimestampsRequest:
+        fields:
+          numTimestamps: integer
+      ConjureGetFreshTimestampsResponse:
+        fields:
+          inclusiveLower: Long
+          inclusiveUpper: Long
 
 services:
   ConjureTimelockService:
@@ -47,6 +58,12 @@ services:
           namespace: string
           request: ConjureStartTransactionsRequest
         returns: ConjureStartTransactionsResponse
+      getFreshTimestamps:
+        http: POST /ts/{namespace}
+        args:
+          namespace: string
+          request: ConjureGetFreshTimestampsRequest
+        returns: ConjureGetFreshTimestampsResponse
       leaderTime:
         http: POST /lt/{namespace}
         args:


### PR DESCRIPTION
Should be dead easy to validate as correct. Means we can move this (very frequently called) endpoint to using the async leadership stuff in a week or two.