### PR TITLE
SweepStrategyManagers first init is synchronous

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/SweepStrategyManagers.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/SweepStrategyManagers.java
@@ -16,6 +16,7 @@
 package com.palantir.atlasdb.transaction.impl;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
@@ -37,6 +38,7 @@ public class SweepStrategyManagers {
     public static SweepStrategyManager createDefault(KeyValueService kvs) {
         // On a cache miss, load metadata only for the relevant table. Helpful when many dynamic tables.
         LoadingCache<TableReference, SweepStrategy> cache = Caffeine.newBuilder()
+                .expireAfterAccess(1, TimeUnit.DAYS)
                 .build(tableRef -> getSweepStrategy(kvs.getMetadataForTable(tableRef)));
 
         // Add all existing tables immediately, to optimize for cases when using mostly non-dynamic tables.

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/SweepStrategyManagers.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/SweepStrategyManagers.java
@@ -38,13 +38,11 @@ public class SweepStrategyManagers {
         // On a cache miss, load metadata only for the relevant table. Helpful when many dynamic tables.
         LoadingCache<TableReference, SweepStrategy> cache = Caffeine.newBuilder()
                 .build(tableRef -> getSweepStrategy(kvs.getMetadataForTable(tableRef)));
-        return tableRef -> {
-            // Add all existing tables the first time this is called, to optimize for cases when mostly non-dynamic tables.
-            if (cache.estimatedSize() == 0) {
-                cache.putAll(getSweepStrategies(kvs));
-            }
-            return cache.get(tableRef);
-        };
+
+        // Add all existing tables immediately, to optimize for cases when using mostly non-dynamic tables.
+        cache.putAll(getSweepStrategies(kvs));
+
+        return cache::get;
     }
 
     public static SweepStrategyManager createFromSchema(Schema schema) {

--- a/changelog/@unreleased/pr-4625.v2.yml
+++ b/changelog/@unreleased/pr-4625.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: First initialization of SweepStrategyManagers is synchronous. This
+    helps avoid a scenario where multiple queries all try to load all tables' metadata
+    at the same time.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4625

--- a/changelog/@unreleased/pr-4625.v2.yml
+++ b/changelog/@unreleased/pr-4625.v2.yml
@@ -1,7 +1,11 @@
 type: improvement
 improvement:
-  description: First initialization of SweepStrategyManagers is synchronous. This
+  description: |
+    First initialization of SweepStrategyManagers is synchronous. This
     helps avoid a scenario where multiple queries all try to load all tables' metadata
     at the same time.
+
+    Also, add a duration for that cache so that tables that tables that get deleted can
+    eventually leave the cache.
   links:
   - https://github.com/palantir/atlasdb/pull/4625


### PR DESCRIPTION
**Goals (and why)**:

Follow up to https://github.com/palantir/atlasdb/pull/4607, returning initialization perf to the state before https://github.com/palantir/atlasdb/pull/4542. This way we avoid a scenario where multiple queries all try to load all tables' metadata at the same time.