### PR TITLE
SweepStrategyManagers use RecomputingSupplier to initialize async

### DIFF
--- a/changelog/@unreleased/pr-4626.v2.yml
+++ b/changelog/@unreleased/pr-4626.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: SweepStrategyManagers uses RecomputingSupplier again to initialize
+    async while still ensuring that only one thread loads metadata for all tables
+    at once.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4626


### PR DESCRIPTION
**Goals (and why)**:

Fix test flake for TransactionManagersTest#asyncInitializationEventuallySucceeds, which went unnoticed because of circle flakes. Allows us to initialize async while still ensuring that only one thread loads metadata for all tables at once.

