### PR TITLE
Add Conjureable analogues for remaining endpoints

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/BlockingSensitiveTimelockRpcClient.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/BlockingSensitiveTimelockRpcClient.java
@@ -19,8 +19,6 @@ package com.palantir.atlasdb.factory.timelock;
 import java.util.Set;
 
 import com.palantir.lock.client.IdentifiedLockRequest;
-import com.palantir.lock.v2.IdentifiedTimeLockRequest;
-import com.palantir.lock.v2.LockImmutableTimestampResponse;
 import com.palantir.lock.v2.LockResponseV2;
 import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.RefreshLockResponseV2;
@@ -52,12 +50,6 @@ public class BlockingSensitiveTimelockRpcClient implements TimelockRpcClient {
     @Override
     public TimestampRange getFreshTimestamps(String namespace, int numTimestampsRequested) {
         return nonBlockingClient.getFreshTimestamps(namespace, numTimestampsRequested);
-    }
-
-    @Override
-    public LockImmutableTimestampResponse lockImmutableTimestamp(String namespace, IdentifiedTimeLockRequest request) {
-        // Despite the name, these locks are not exclusive so we do not expect blocking.
-        return nonBlockingClient.lockImmutableTimestamp(namespace, request);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/debug/LockDiagnosticConjureTimelockService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/debug/LockDiagnosticConjureTimelockService.java
@@ -18,9 +18,16 @@ package com.palantir.atlasdb.debug;
 
 import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsRequest;
 import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponse;
+import com.palantir.atlasdb.timelock.api.ConjureLockRequest;
+import com.palantir.atlasdb.timelock.api.ConjureLockResponse;
+import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksRequest;
+import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksResponse;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsRequest;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
 import com.palantir.atlasdb.timelock.api.ConjureTimelockService;
+import com.palantir.atlasdb.timelock.api.ConjureUnlockRequest;
+import com.palantir.atlasdb.timelock.api.ConjureUnlockResponse;
+import com.palantir.atlasdb.timelock.api.ConjureWaitForLocksResponse;
 import com.palantir.atlasdb.timelock.api.GetCommitTimestampsRequest;
 import com.palantir.atlasdb.timelock.api.GetCommitTimestampsResponse;
 import com.palantir.lock.v2.LeaderTime;
@@ -62,6 +69,28 @@ public class LockDiagnosticConjureTimelockService implements ConjureTimelockServ
     @Override
     public LeaderTime leaderTime(AuthHeader authHeader, String namespace) {
         return conjureDelegate.leaderTime(authHeader, namespace);
+    }
+
+    @Override
+    public ConjureLockResponse lock(AuthHeader authHeader, String namespace, ConjureLockRequest request) {
+        return conjureDelegate.lock(authHeader, namespace, request);
+    }
+
+    @Override
+    public ConjureWaitForLocksResponse waitForLocks(AuthHeader authHeader, String namespace,
+            ConjureLockRequest request) {
+        return conjureDelegate.waitForLocks(authHeader, namespace, request);
+    }
+
+    @Override
+    public ConjureRefreshLocksResponse refreshLocks(AuthHeader authHeader, String namespace,
+            ConjureRefreshLocksRequest request) {
+        return conjureDelegate.refreshLocks(authHeader, namespace, request);
+    }
+
+    @Override
+    public ConjureUnlockResponse unlock(AuthHeader authHeader, String namespace, ConjureUnlockRequest request) {
+        return conjureDelegate.unlock(authHeader, namespace, request);
     }
 
     @Override

--- a/changelog/@unreleased/pr-4627.v2.yml
+++ b/changelog/@unreleased/pr-4627.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: |-
+    Add Conjureable analogues for remaining endpoints
+
+    Most of the remaining endpoints in timelockrpcclient end up being Conjured (including lock endpoints).
+  links:
+  - https://github.com/palantir/atlasdb/pull/4627

--- a/lock-api/src/main/java/com/palantir/lock/v2/NamespacedTimelockRpcClient.java
+++ b/lock-api/src/main/java/com/palantir/lock/v2/NamespacedTimelockRpcClient.java
@@ -42,10 +42,6 @@ public class NamespacedTimelockRpcClient {
         return timelockRpcClient.getFreshTimestamps(namespace, numTimestampsRequested);
     }
 
-    public LockImmutableTimestampResponse lockImmutableTimestamp(IdentifiedTimeLockRequest request) {
-        return timelockRpcClient.lockImmutableTimestamp(namespace, request);
-    }
-
     public long getImmutableTimestamp() {
         return timelockRpcClient.getImmutableTimestamp(namespace);
     }

--- a/lock-api/src/main/java/com/palantir/lock/v2/TimelockRpcClient.java
+++ b/lock-api/src/main/java/com/palantir/lock/v2/TimelockRpcClient.java
@@ -54,11 +54,6 @@ public interface TimelockRpcClient {
             @PathParam("namespace") String namespace, @Safe @QueryParam("number") int numTimestampsRequested);
 
     @POST
-    @Path("lock-immutable-timestamp")
-    LockImmutableTimestampResponse lockImmutableTimestamp(
-            @PathParam("namespace") String namespace, IdentifiedTimeLockRequest request);
-
-    @POST
     @Path("immutable-timestamp")
     long getImmutableTimestamp(@PathParam("namespace") String namespace);
 

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/AsyncTimeLockServicesCreator.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/AsyncTimeLockServicesCreator.java
@@ -114,7 +114,8 @@ public class AsyncTimeLockServicesCreator implements TimeLockServicesCreator {
                         reaperExecutor,
                         timeoutExecutor
                 ),
-                timestampServiceSupplier.get());
+                timestampServiceSupplier.get(),
+                maybeEnhancedLockLog);
     }
 
     /**

--- a/timelock-api/src/main/conjure/timelock-api.yml
+++ b/timelock-api/src/main/conjure/timelock-api.yml
@@ -51,6 +51,43 @@ types:
         fields:
           inclusiveLower: Long
           inclusiveUpper: Long
+      ConjureLockDescriptor:
+        alias: binary
+      ConjureLockRequest:
+        fields:
+          requestId: uuid
+          lockDescriptors: set<ConjureLockDescriptor>
+          acquireTimeoutMs: integer
+          clientDescription: optional<string>
+      ConjureLockToken:
+        fields:
+          requestId: uuid
+      SuccessfulLockResponse:
+        fields:
+          lockToken: ConjureLockToken
+          lease: Lease
+      UnsuccessfulLockResponse:
+        fields: {}
+      ConjureLockResponse:
+        union:
+          successful: SuccessfulLockResponse
+          unsuccessful: UnsuccessfulLockResponse
+      ConjureWaitForLocksResponse:
+        fields:
+          wasSuccessful: boolean
+      ConjureRefreshLocksRequest:
+        fields:
+          tokens: set<ConjureLockToken>
+      ConjureRefreshLocksResponse:
+        fields:
+          refreshedTokens: set<ConjureLockToken>
+          lease: Lease
+      ConjureUnlockRequest:
+        fields:
+          tokens: set<ConjureLockToken>
+      ConjureUnlockResponse:
+        fields:
+          tokens: set<ConjureLockToken>
       GetCommitTimestampsRequest:
         fields:
           numTimestamps: integer
@@ -60,6 +97,7 @@ types:
           inclusiveLower: Long
           inclusiveUpper: Long
           lockWatchUpdate: LockWatchStateUpdate
+
 
 services:
   ConjureTimelockService:
@@ -85,6 +123,31 @@ services:
         args:
           namespace: string
         returns: LeaderTime
+      lock:
+        http: POST /l/{namespace}
+        args:
+          namespace: string
+          request: ConjureLockRequest
+        returns: ConjureLockResponse
+      waitForLocks:
+        http: POST /wl/{namespace}
+        args:
+          namespace: string
+          request: ConjureLockRequest
+        returns: ConjureWaitForLocksResponse
+      refreshLocks:
+        http: POST /rl/{namespace}
+        args:
+          namespace: string
+          request: ConjureRefreshLocksRequest
+        returns: ConjureRefreshLocksResponse
+      unlock:
+        http: POST /ul/{namespace}
+        args:
+          namespace: string
+          request: ConjureUnlockRequest
+        returns: ConjureUnlockResponse
+
       getCommitTimestamps:
         http: POST /gct/{namespace}
         args:

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockService.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockService.java
@@ -21,13 +21,12 @@ import java.util.Set;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.atlasdb.timelock.api.GetCommitTimestampsResponse;
-import com.palantir.atlasdb.timelock.lock.AsyncResult;
-import com.palantir.atlasdb.timelock.lock.Leased;
 import com.palantir.atlasdb.timelock.lock.watch.LockWatchingService;
 import com.palantir.lock.client.IdentifiedLockRequest;
 import com.palantir.lock.v2.IdentifiedTimeLockRequest;
 import com.palantir.lock.v2.LeaderTime;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
+import com.palantir.lock.v2.LockResponseV2;
 import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.RefreshLockResponseV2;
 import com.palantir.lock.v2.StartAtlasDbTransactionResponse;
@@ -38,6 +37,7 @@ import com.palantir.lock.v2.StartTransactionRequestV5;
 import com.palantir.lock.v2.StartTransactionResponseV4;
 import com.palantir.lock.v2.StartTransactionResponseV5;
 import com.palantir.lock.v2.WaitForLocksRequest;
+import com.palantir.lock.v2.WaitForLocksResponse;
 import com.palantir.timestamp.ManagedTimestampService;
 import com.palantir.timestamp.TimestampRange;
 
@@ -49,9 +49,9 @@ public interface AsyncTimelockService extends ManagedTimestampService, LockWatch
 
     ListenableFuture<RefreshLockResponseV2> refreshLockLeases(Set<LockToken> tokens);
 
-    ListenableFuture<AsyncResult<Void>> waitForLocks(WaitForLocksRequest request);
+    ListenableFuture<WaitForLocksResponse> waitForLocks(WaitForLocksRequest request);
 
-    ListenableFuture<AsyncResult<Leased<LockToken>>> lock(IdentifiedLockRequest request);
+    ListenableFuture<LockResponseV2> lock(IdentifiedLockRequest request);
 
     long getImmutableTimestamp();
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockService.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockService.java
@@ -45,13 +45,13 @@ public interface AsyncTimelockService extends ManagedTimestampService, LockWatch
 
     long currentTimeMillis();
 
-    Set<LockToken> unlock(Set<LockToken> tokens);
+    ListenableFuture<Set<LockToken>> unlock(Set<LockToken> tokens);
 
-    RefreshLockResponseV2 refreshLockLeases(Set<LockToken> tokens);
+    ListenableFuture<RefreshLockResponseV2> refreshLockLeases(Set<LockToken> tokens);
 
-    AsyncResult<Void> waitForLocks(WaitForLocksRequest request);
+    ListenableFuture<AsyncResult<Void>> waitForLocks(WaitForLocksRequest request);
 
-    AsyncResult<Leased<LockToken>> lock(IdentifiedLockRequest request);
+    ListenableFuture<AsyncResult<Leased<LockToken>>> lock(IdentifiedLockRequest request);
 
     long getImmutableTimestamp();
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceImpl.java
@@ -92,29 +92,29 @@ public class AsyncTimelockServiceImpl implements AsyncTimelockService {
     }
 
     @Override
-    public AsyncResult<Leased<LockToken>> lock(IdentifiedLockRequest request) {
+    public ListenableFuture<AsyncResult<Leased<LockToken>>> lock(IdentifiedLockRequest request) {
         return lockService.lock(
                 request.getRequestId(),
                 request.getLockDescriptors(),
-                TimeLimit.of(request.getAcquireTimeoutMs()));
+                TimeLimit.of(request.getAcquireTimeoutMs())).asListenableFuture();
     }
 
     @Override
-    public AsyncResult<Void> waitForLocks(WaitForLocksRequest request) {
+    public ListenableFuture<AsyncResult<Void>> waitForLocks(WaitForLocksRequest request) {
         return lockService.waitForLocks(
                 request.getRequestId(),
                 request.getLockDescriptors(),
-                TimeLimit.of(request.getAcquireTimeoutMs()));
+                TimeLimit.of(request.getAcquireTimeoutMs())).asListenableFuture();
     }
 
     @Override
-    public RefreshLockResponseV2 refreshLockLeases(Set<LockToken> tokens) {
-        return lockService.refresh(tokens);
+    public ListenableFuture<RefreshLockResponseV2> refreshLockLeases(Set<LockToken> tokens) {
+        return Futures.immediateFuture(lockService.refresh(tokens));
     }
 
     @Override
-    public Set<LockToken> unlock(Set<LockToken> tokens) {
-        return lockService.unlock(tokens);
+    public ListenableFuture<Set<LockToken>> unlock(Set<LockToken> tokens) {
+        return Futures.immediateFuture(lockService.unlock(tokens));
     }
 
     @Override

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/ConjureTimelockResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/ConjureTimelockResource.java
@@ -16,8 +16,12 @@
 
 package com.palantir.atlasdb.timelock;
 
+import static com.palantir.logsafe.Preconditions.checkState;
+
 import java.time.Duration;
+import java.util.HashSet;
 import java.util.OptionalLong;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -30,22 +34,42 @@ import com.palantir.atlasdb.futures.AtlasFutures;
 import com.palantir.atlasdb.http.RedirectRetryTargeter;
 import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsRequest;
 import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponse;
+import com.palantir.atlasdb.timelock.api.ConjureLockDescriptor;
+import com.palantir.atlasdb.timelock.api.ConjureLockRequest;
+import com.palantir.atlasdb.timelock.api.ConjureLockResponse;
+import com.palantir.atlasdb.timelock.api.ConjureLockToken;
+import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksRequest;
+import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksResponse;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsRequest;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
 import com.palantir.atlasdb.timelock.api.ConjureTimelockService;
 import com.palantir.atlasdb.timelock.api.ConjureTimelockServiceEndpoints;
+import com.palantir.atlasdb.timelock.api.ConjureUnlockRequest;
+import com.palantir.atlasdb.timelock.api.ConjureUnlockResponse;
+import com.palantir.atlasdb.timelock.api.ConjureWaitForLocksResponse;
 import com.palantir.atlasdb.timelock.api.GetCommitTimestampsRequest;
 import com.palantir.atlasdb.timelock.api.GetCommitTimestampsResponse;
+import com.palantir.atlasdb.timelock.api.SuccessfulLockResponse;
 import com.palantir.atlasdb.timelock.api.UndertowConjureTimelockService;
+import com.palantir.atlasdb.timelock.api.UnsuccessfulLockResponse;
+import com.palantir.atlasdb.timelock.lock.AsyncResult;
+import com.palantir.atlasdb.timelock.lock.Leased;
 import com.palantir.conjure.java.api.errors.QosException;
 import com.palantir.conjure.java.undertow.lib.UndertowService;
 import com.palantir.leader.NotCurrentLeaderException;
+import com.palantir.lock.ByteArrayLockDescriptor;
+import com.palantir.lock.LockDescriptor;
+import com.palantir.lock.client.IdentifiedLockRequest;
+import com.palantir.lock.client.ImmutableIdentifiedLockRequest;
 import com.palantir.lock.impl.TooManyRequestsException;
 import com.palantir.lock.remoting.BlockingTimeoutException;
 import com.palantir.lock.v2.ImmutableStartTransactionRequestV5;
+import com.palantir.lock.v2.ImmutableWaitForLocksRequest;
 import com.palantir.lock.v2.LeaderTime;
+import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.StartTransactionRequestV5;
 import com.palantir.lock.v2.StartTransactionResponseV5;
+import com.palantir.lock.v2.WaitForLocksRequest;
 import com.palantir.timestamp.TimestampRange;
 import com.palantir.tokens.auth.AuthHeader;
 
@@ -116,8 +140,102 @@ public final class ConjureTimelockResource implements UndertowConjureTimelockSer
     }
 
     @Override
-    public ListenableFuture<GetCommitTimestampsResponse> getCommitTimestamps(AuthHeader authHeader, String namespace,
-            GetCommitTimestampsRequest request) {
+    public ListenableFuture<ConjureLockResponse> lock(
+            AuthHeader authHeader, String namespace, ConjureLockRequest request) {
+        return handleExceptions(() -> {
+            IdentifiedLockRequest lockRequest = ImmutableIdentifiedLockRequest.builder()
+                    .lockDescriptors(fromConjureLockDescriptors(request.getLockDescriptors()))
+                    .clientDescription(request.getClientDescription())
+                    .requestId(request.getRequestId())
+                    .acquireTimeoutMs(request.getAcquireTimeoutMs())
+                    .build();
+            ListenableFuture<AsyncResult<Leased<LockToken>>> tokenFuture = forNamespace(namespace).lock(lockRequest);
+            return Futures.transformAsync(tokenFuture, token -> {
+                if (token.isCompletedSuccessfully()) {
+                    Leased<LockToken> result = token.get();
+                    return Futures.immediateFuture(ConjureLockResponse.successful(SuccessfulLockResponse.of(
+                            ConjureLockToken.of(result.value().getRequestId()), result.lease())));
+                } else if (token.isTimedOut()) {
+                    return Futures.immediateFuture(ConjureLockResponse.unsuccessful(UnsuccessfulLockResponse.of()));
+                } else {
+                    checkState(token.isFailed(), "token.isFailed()");
+                    return Futures.immediateFailedFuture(token.getError());
+                }
+            }, MoreExecutors.directExecutor());
+        });
+    }
+
+    @Override
+    public ListenableFuture<ConjureWaitForLocksResponse> waitForLocks(
+            AuthHeader authHeader, String namespace, ConjureLockRequest request) {
+        return handleExceptions(() -> {
+            WaitForLocksRequest lockRequest = ImmutableWaitForLocksRequest.builder()
+                    .lockDescriptors(fromConjureLockDescriptors(request.getLockDescriptors()))
+                    .clientDescription(request.getClientDescription())
+                    .requestId(request.getRequestId())
+                    .acquireTimeoutMs(request.getAcquireTimeoutMs())
+                    .build();
+            ListenableFuture<AsyncResult<Void>> tokenFuture = forNamespace(namespace).waitForLocks(lockRequest);
+            return Futures.transformAsync(tokenFuture, token -> {
+                if (token.isCompletedSuccessfully()) {
+                    return Futures.immediateFuture(ConjureWaitForLocksResponse.of(true));
+                } else if (token.isTimedOut()) {
+                    return Futures.immediateFuture(ConjureWaitForLocksResponse.of(false));
+                } else {
+                    checkState(token.isFailed(), "token.isFailed()");
+                    return Futures.immediateFailedFuture(token.getError());
+                }
+            }, MoreExecutors.directExecutor());
+        });
+    }
+
+    private static Set<LockDescriptor> fromConjureLockDescriptors(Set<ConjureLockDescriptor> lockDescriptors) {
+        Set<LockDescriptor> descriptors = new HashSet<>(lockDescriptors.size());
+        for (ConjureLockDescriptor descriptor : lockDescriptors) {
+            descriptors.add(ByteArrayLockDescriptor.of(descriptor.get().asNewByteArray()));
+        }
+        return descriptors;
+    }
+
+    @Override
+    public ListenableFuture<ConjureRefreshLocksResponse> refreshLocks(
+            AuthHeader authHeader, String namespace, ConjureRefreshLocksRequest request) {
+        return handleExceptions(() -> Futures.transform(
+                forNamespace(namespace).refreshLockLeases(fromConjureLockTokens(request.getTokens())),
+                refreshed -> ConjureRefreshLocksResponse.of(
+                        toConjureLockTokens(refreshed.refreshedTokens()),
+                        refreshed.getLease()),
+                MoreExecutors.directExecutor()));
+    }
+
+    @Override
+    public ListenableFuture<ConjureUnlockResponse> unlock(
+            AuthHeader authHeader, String namespace, ConjureUnlockRequest request) {
+        return handleExceptions(() -> Futures.transform(
+                forNamespace(namespace).unlock(fromConjureLockTokens(request.getTokens())),
+                unlocked -> ConjureUnlockResponse.of(toConjureLockTokens(unlocked)),
+                MoreExecutors.directExecutor()));
+    }
+
+    private static Set<LockToken> fromConjureLockTokens(Set<ConjureLockToken> lockTokens) {
+        Set<LockToken> tokens = new HashSet<>(lockTokens.size());
+        for (ConjureLockToken token : lockTokens) {
+            tokens.add(LockToken.of(token.getRequestId()));
+        }
+        return tokens;
+    }
+
+    private static Set<ConjureLockToken> toConjureLockTokens(Set<LockToken> lockTokens) {
+        Set<ConjureLockToken> tokens = new HashSet<>(lockTokens.size());
+        for (LockToken token : lockTokens) {
+            tokens.add(ConjureLockToken.of(token.getRequestId()));
+        }
+        return tokens;
+    }
+
+    @Override
+    public ListenableFuture<GetCommitTimestampsResponse> getCommitTimestamps(
+            AuthHeader authHeader, String namespace, GetCommitTimestampsRequest request) {
         return handleExceptions(() -> forNamespace(namespace).getCommitTimestamps(
                 request.getNumTimestamps(),
                 request.getLastKnownVersion().map(OptionalLong::of).orElseGet(OptionalLong::empty)));
@@ -172,6 +290,28 @@ public final class ConjureTimelockResource implements UndertowConjureTimelockSer
         @Override
         public LeaderTime leaderTime(AuthHeader authHeader, String namespace) {
             return unwrap(resource.leaderTime(authHeader, namespace));
+        }
+
+        @Override
+        public ConjureLockResponse lock(AuthHeader authHeader, String namespace, ConjureLockRequest request) {
+            return unwrap(resource.lock(authHeader, namespace, request));
+        }
+
+        @Override
+        public ConjureWaitForLocksResponse waitForLocks(AuthHeader authHeader, String namespace,
+                ConjureLockRequest request) {
+            return unwrap(resource.waitForLocks(authHeader, namespace, request));
+        }
+
+        @Override
+        public ConjureRefreshLocksResponse refreshLocks(AuthHeader authHeader, String namespace,
+                ConjureRefreshLocksRequest request) {
+            return unwrap(resource.refreshLocks(authHeader, namespace, request));
+        }
+
+        @Override
+        public ConjureUnlockResponse unlock(AuthHeader authHeader, String namespace, ConjureUnlockRequest request) {
+            return unwrap(resource.unlock(authHeader, namespace, request));
         }
 
         @Override

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/AsyncResult.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/AsyncResult.java
@@ -22,11 +22,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.MoreExecutors;
-import com.google.common.util.concurrent.SettableFuture;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 
@@ -59,34 +54,6 @@ public class AsyncResult<T> {
         Preconditions.checkState(
                 future.complete(value),
                 "This result is already completed");
-    }
-
-    public ListenableFuture<AsyncResult<T>> asListenableFuture() {
-        SettableFuture<AsyncResult<T>> listenable = SettableFuture.create();
-        future.whenComplete((ignored1, ignored2) -> listenable.set(this));
-        return listenable;
-    }
-
-    public static <T> AsyncResult<T> fromListenableFuture(ListenableFuture<AsyncResult<T>> future) {
-        AsyncResult<T> copiedResult = new AsyncResult<>();
-        Futures.addCallback(future, new FutureCallback<AsyncResult<T>>() {
-            @Override
-            public void onSuccess(AsyncResult<T> result) {
-                result.future.whenComplete((success, failure) -> {
-                    if (failure != null) {
-                        copiedResult.future.completeExceptionally(failure);
-                    } else {
-                        copiedResult.future.complete(success);
-                    }
-                });
-            }
-
-            @Override
-            public void onFailure(Throwable thrown) {
-                copiedResult.fail(thrown);
-            }
-        }, MoreExecutors.directExecutor());
-        return copiedResult;
     }
 
     /**

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LockLog.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LockLog.java
@@ -32,7 +32,7 @@ import com.palantir.lock.client.IdentifiedLockRequest;
 import com.palantir.lock.v2.WaitForLocksRequest;
 import com.palantir.logsafe.Preconditions;
 
-public final class LockLog {
+public class LockLog {
 
     private final LockEvents events;
     private final Optional<LockDiagnosticCollector> lockDiagnosticInfoCollector;

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceImplTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceImplTest.java
@@ -23,13 +23,17 @@ import static org.mockito.Mockito.when;
 import org.junit.Test;
 
 import com.palantir.atlasdb.timelock.lock.AsyncLockService;
+import com.palantir.atlasdb.timelock.lock.LockLog;
 import com.palantir.timestamp.ManagedTimestampService;
 
 public class AsyncTimelockServiceImplTest {
     @Test
     public void delegatesInitializationCheck() {
         ManagedTimestampService mockMts = mock(ManagedTimestampService.class);
-        AsyncTimelockServiceImpl service = new AsyncTimelockServiceImpl(mock(AsyncLockService.class), mockMts);
+        AsyncTimelockServiceImpl service = new AsyncTimelockServiceImpl(
+                mock(AsyncLockService.class),
+                mockMts,
+                mock(LockLog.class));
         when(mockMts.isInitialized())
                 .thenReturn(false)
                 .thenReturn(true);


### PR DESCRIPTION
Most of the remaining endpoints in timelockrpcclient end up being Conjured (including lock endpoints).