### PR TITLE
Remove some metrics that are dominating the actual computation

### DIFF
--- a/changelog/@unreleased/pr-4629.v2.yml
+++ b/changelog/@unreleased/pr-4629.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Remove some metrics that are dominating the actual computation
+  links:
+  - https://github.com/palantir/atlasdb/pull/4629

--- a/leader-election-api/src/main/java/com/palantir/leader/LeaderElectionService.java
+++ b/leader-election-api/src/main/java/com/palantir/leader/LeaderElectionService.java
@@ -20,7 +20,6 @@ import java.util.Optional;
 
 import com.google.common.net.HostAndPort;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.palantir.atlasdb.metrics.Timed;
 
 public interface LeaderElectionService {
     interface LeadershipToken extends Serializable {
@@ -63,7 +62,6 @@ public interface LeaderElectionService {
      * calls to ensure that the token is valid at the time of invocation, but will return immediately if
      * this node is not the last known leader.
      */
-    @Timed
     Optional<LeadershipToken> getCurrentTokenIfLeading();
 
     /**

--- a/leader-election-impl/src/main/java/com/palantir/leader/LocalPingableLeader.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/LocalPingableLeader.java
@@ -24,11 +24,11 @@ import com.palantir.paxos.PaxosValue;
 public final class LocalPingableLeader implements PingableLeader {
 
     private final PaxosLearner knowledge;
-    private final UUID localUuid;
+    private final String localUuid;
 
     public LocalPingableLeader(PaxosLearner knowledge, UUID localUuid) {
         this.knowledge = knowledge;
-        this.localUuid = localUuid;
+        this.localUuid = localUuid.toString();
     }
 
     @Override
@@ -40,10 +40,10 @@ public final class LocalPingableLeader implements PingableLeader {
 
     @Override
     public String getUUID() {
-        return localUuid.toString();
+        return localUuid;
     }
 
     private boolean isThisNodeTheLeaderFor(PaxosValue value) {
-        return value.getLeaderUUID().equals(localUuid.toString());
+        return value.getLeaderUUID().equals(localUuid);
     }
 }

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipComponents.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipComponents.java
@@ -81,16 +81,8 @@ public class LeadershipComponents {
     private LeadershipContext createNewLeadershipContext(Client client) {
         LeadershipContext uninstrumentedLeadershipContext = leadershipContextFactory.create(client);
         closer.register(uninstrumentedLeadershipContext.closeables());
-
-        LeaderElectionService leaderElectionService = uninstrumentedLeadershipContext.leadershipMetrics().instrument(
-                LeaderElectionService.class,
-                uninstrumentedLeadershipContext.leaderElectionService());
-        closer.register(() -> shutdownLeaderElectionService(leaderElectionService));
-
-        return ImmutableLeadershipContext.builder()
-                .from(uninstrumentedLeadershipContext)
-                .leaderElectionService(leaderElectionService)
-                .build();
+        closer.register(() -> shutdownLeaderElectionService(uninstrumentedLeadershipContext.leaderElectionService()));
+        return uninstrumentedLeadershipContext;
     }
 
     private static void shutdownLeaderElectionService(LeaderElectionService leaderElectionService) {

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponents.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponents.java
@@ -83,21 +83,12 @@ public class LocalPaxosComponents {
         Path clientDirectory = logDirectory.resolve(client.value());
         Path learnerLogDir = Paths.get(clientDirectory.toString(), PaxosTimeLockConstants.LEARNER_SUBDIRECTORY_PATH);
 
-        PaxosLearner learner = metrics.instrument(
-                PaxosLearner.class,
-                PaxosLearnerImpl.newLearner(learnerLogDir.toString()),
-                client);
+        PaxosLearner learner = PaxosLearnerImpl.newLearner(learnerLogDir.toString());
 
         Path acceptorLogDir = Paths.get(clientDirectory.toString(), PaxosTimeLockConstants.ACCEPTOR_SUBDIRECTORY_PATH);
-        PaxosAcceptor acceptor = metrics.instrument(
-                PaxosAcceptor.class,
-                PaxosAcceptorImpl.newAcceptor(acceptorLogDir.toString()),
-                client);
+        PaxosAcceptor acceptor = PaxosAcceptorImpl.newAcceptor(acceptorLogDir.toString());
 
-        PingableLeader localPingableLeader = metrics.instrument(
-                PingableLeader.class,
-                new LocalPingableLeader(learner, leaderUuid),
-                client);
+        PingableLeader localPingableLeader = new LocalPingableLeader(learner, leaderUuid);
 
         return ImmutableComponents.builder()
                 .acceptor(acceptor)


### PR DESCRIPTION
In these cases, in-memory time is dominating actual computation time. E.g. the local leader stuff, the leadership stuff that returns a future, etc.
