### PR TITLE
Fix old endpoint

### DIFF
--- a/changelog/@unreleased/pr-4634.v2.yml
+++ b/changelog/@unreleased/pr-4634.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Fix old refreshLocks endpoint
+  links:
+  - https://github.com/palantir/atlasdb/pull/4634

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockResource.java
@@ -45,6 +45,7 @@ import com.palantir.lock.v2.LockImmutableTimestampResponse;
 import com.palantir.lock.v2.LockResponse;
 import com.palantir.lock.v2.LockResponseV2;
 import com.palantir.lock.v2.LockToken;
+import com.palantir.lock.v2.RefreshLockResponseV2;
 import com.palantir.lock.v2.StartAtlasDbTransactionResponse;
 import com.palantir.lock.v2.StartAtlasDbTransactionResponseV3;
 import com.palantir.lock.v2.StartIdentifiedAtlasDbTransactionRequest;
@@ -169,7 +170,11 @@ public class AsyncTimelockResource {
     @POST
     @Path("refresh-locks")
     public void deprecatedRefreshLockLeases(@Suspended final AsyncResponse response, Set<LockToken> tokens) {
-        addJerseyCallback(timelock.refreshLockLeases(tokens), response);
+        addJerseyCallback(Futures.transform(
+                timelock.refreshLockLeases(tokens),
+                RefreshLockResponseV2::refreshedTokens,
+                MoreExecutors.directExecutor()),
+                response);
     }
 
     @POST


### PR DESCRIPTION
Accidentally broke this old endpoint in refactors. It shouldn't be used (unused for over a year) but is being caught in some integration tests internally, so I'm fixing it. We can't just downgrade internally, because people need the new endpoints.