### PR TITLE
[PDS-113120] Conjure TimeLock Service had blocking and non-blocking the wrong way round

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -77,6 +77,7 @@ import com.palantir.atlasdb.debug.LockDiagnosticConjureTimelockService;
 import com.palantir.atlasdb.factory.Leaders.LocalPaxosServices;
 import com.palantir.atlasdb.factory.startup.ConsistencyCheckRunner;
 import com.palantir.atlasdb.factory.startup.TimeLockMigrator;
+import com.palantir.atlasdb.factory.timelock.BlockingAndNonBlockingServices;
 import com.palantir.atlasdb.factory.timelock.BlockingSensitiveConjureTimelockService;
 import com.palantir.atlasdb.factory.timelock.BlockingSensitiveLockRpcClient;
 import com.palantir.atlasdb.factory.timelock.TimestampCorroboratingTimelockService;
@@ -987,8 +988,7 @@ public abstract class TransactionManagers {
                 metricsManager, timelockServerListConfig, userAgent, remotingConfigSupplier);
 
         LockRpcClient lockRpcClient = new BlockingSensitiveLockRpcClient(
-                creator.createService(LockRpcClient.class),
-                creator.createServiceWithoutBlockingOperations(LockRpcClient.class));
+                BlockingAndNonBlockingServices.create(creator, LockRpcClient.class));
 
         LockService lockService = AtlasDbMetrics.instrumentTimed(
                 metricsManager.getRegistry(),
@@ -996,8 +996,7 @@ public abstract class TransactionManagers {
                 RemoteLockServiceAdapter.create(lockRpcClient, timelockNamespace));
 
         ConjureTimelockService conjureTimelockService = new BlockingSensitiveConjureTimelockService(
-                creator.createService(ConjureTimelockService.class),
-                creator.createServiceWithoutBlockingOperations(ConjureTimelockService.class));
+                BlockingAndNonBlockingServices.create(creator, ConjureTimelockService.class));
 
         TimelockRpcClient timelockClient = creator.createService(TimelockRpcClient.class);
 

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/BlockingAndNonBlockingServices.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/BlockingAndNonBlockingServices.java
@@ -1,0 +1,34 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.factory.timelock;
+
+import org.immutables.value.Value;
+
+import com.palantir.atlasdb.factory.ServiceCreator;
+
+@Value.Immutable
+public interface BlockingAndNonBlockingServices<T> {
+    T blocking();
+    T nonBlocking();
+
+    static <T> BlockingAndNonBlockingServices<T> create(ServiceCreator serviceCreator, Class<T> clazz) {
+        return ImmutableBlockingAndNonBlockingServices.<T>builder()
+                .blocking(serviceCreator.createService(clazz))
+                .nonBlocking(serviceCreator.createServiceWithoutBlockingOperations(clazz))
+                .build();
+    }
+}

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/BlockingSensitiveConjureTimelockService.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/BlockingSensitiveConjureTimelockService.java
@@ -38,31 +38,30 @@ import com.palantir.tokens.auth.AuthHeader;
  * on the server and one configured not to, routes calls appropriately.
  */
 public final class BlockingSensitiveConjureTimelockService implements ConjureTimelockService {
-    private final ConjureTimelockService nonblocking;
     private final ConjureTimelockService blocking;
+    private final ConjureTimelockService nonBlocking;
 
     public BlockingSensitiveConjureTimelockService(
-            ConjureTimelockService nonblocking,
-            ConjureTimelockService blocking) {
-        this.nonblocking = nonblocking;
-        this.blocking = blocking;
+            BlockingAndNonBlockingServices<ConjureTimelockService> conjureTimelockServices) {
+        this.blocking = conjureTimelockServices.blocking();
+        this.nonBlocking = conjureTimelockServices.nonBlocking();
     }
 
     @Override
     public ConjureStartTransactionsResponse startTransactions(AuthHeader authHeader, String namespace,
             ConjureStartTransactionsRequest request) {
-        return nonblocking.startTransactions(authHeader, namespace, request);
+        return nonBlocking.startTransactions(authHeader, namespace, request);
     }
 
     @Override
     public ConjureGetFreshTimestampsResponse getFreshTimestamps(AuthHeader authHeader, String namespace,
             ConjureGetFreshTimestampsRequest request) {
-        return nonblocking.getFreshTimestamps(authHeader, namespace, request);
+        return nonBlocking.getFreshTimestamps(authHeader, namespace, request);
     }
 
     @Override
     public LeaderTime leaderTime(AuthHeader authHeader, String namespace) {
-        return nonblocking.leaderTime(authHeader, namespace);
+        return nonBlocking.leaderTime(authHeader, namespace);
     }
 
     @Override
@@ -79,17 +78,17 @@ public final class BlockingSensitiveConjureTimelockService implements ConjureTim
     @Override
     public ConjureRefreshLocksResponse refreshLocks(AuthHeader authHeader, String namespace,
             ConjureRefreshLocksRequest request) {
-        return nonblocking.refreshLocks(authHeader, namespace, request);
+        return nonBlocking.refreshLocks(authHeader, namespace, request);
     }
 
     @Override
     public ConjureUnlockResponse unlock(AuthHeader authHeader, String namespace, ConjureUnlockRequest request) {
-        return nonblocking.unlock(authHeader, namespace, request);
+        return nonBlocking.unlock(authHeader, namespace, request);
     }
 
     @Override
     public GetCommitTimestampsResponse getCommitTimestamps(AuthHeader authHeader, String namespace,
             GetCommitTimestampsRequest request) {
-        return nonblocking.getCommitTimestamps(authHeader, namespace, request);
+        return nonBlocking.getCommitTimestamps(authHeader, namespace, request);
     }
 }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/BlockingSensitiveLockRpcClient.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/BlockingSensitiveLockRpcClient.java
@@ -35,127 +35,125 @@ import com.palantir.lock.SimpleHeldLocksToken;
  * operations on the server and one not to, routes calls appropriately.
  */
 public class BlockingSensitiveLockRpcClient implements LockRpcClient {
-    private final LockRpcClient blockingClient;
-    private final LockRpcClient nonBlockingClient;
+    private final LockRpcClient blocking;
+    private final LockRpcClient nonBlocking;
 
-    public BlockingSensitiveLockRpcClient(
-            LockRpcClient blockingClient,
-            LockRpcClient nonBlockingClient) {
-        this.blockingClient = blockingClient;
-        this.nonBlockingClient = nonBlockingClient;
+    public BlockingSensitiveLockRpcClient(BlockingAndNonBlockingServices<LockRpcClient> services) {
+        this.blocking = services.blocking();
+        this.nonBlocking = services.nonBlocking();
     }
 
     @Override
     public Optional<LockResponse> lockWithFullLockResponse(String namespace, LockClient client, LockRequest request)
             throws InterruptedException {
-        return blockingClient.lockWithFullLockResponse(namespace, client, request);
+        return blocking.lockWithFullLockResponse(namespace, client, request);
     }
 
     @Override
     public boolean unlock(String namespace, HeldLocksToken token) {
-        return nonBlockingClient.unlock(namespace, token);
+        return nonBlocking.unlock(namespace, token);
     }
 
     @Override
     public boolean unlock(String namespace, LockRefreshToken token) {
-        return nonBlockingClient.unlock(namespace, token);
+        return nonBlocking.unlock(namespace, token);
     }
 
     @Override
     public boolean unlockSimple(String namespace, SimpleHeldLocksToken token) {
-        return nonBlockingClient.unlockSimple(namespace, token);
+        return nonBlocking.unlockSimple(namespace, token);
     }
 
     @Override
     public boolean unlockAndFreeze(String namespace, HeldLocksToken token) {
         // TODO (jkong): It feels like this could be non-blocking but not 100% sure so going for the safe option.
-        return blockingClient.unlockAndFreeze(namespace, token);
+        return blocking.unlockAndFreeze(namespace, token);
     }
 
     @Override
     public Set<HeldLocksToken> getTokens(String namespace, LockClient client) {
-        return nonBlockingClient.getTokens(namespace, client);
+        return nonBlocking.getTokens(namespace, client);
     }
 
     @Override
     public Set<HeldLocksToken> refreshTokens(String namespace, Iterable<HeldLocksToken> tokens) {
-        return nonBlockingClient.refreshTokens(namespace, tokens);
+        return nonBlocking.refreshTokens(namespace, tokens);
     }
 
     @Override
     public Optional<HeldLocksGrant> refreshGrant(String namespace, HeldLocksGrant grant) {
-        return nonBlockingClient.refreshGrant(namespace, grant);
+        return nonBlocking.refreshGrant(namespace, grant);
     }
 
     @Override
     public Optional<HeldLocksGrant> refreshGrant(String namespace, BigInteger grantId) {
-        return nonBlockingClient.refreshGrant(namespace, grantId);
+        return nonBlocking.refreshGrant(namespace, grantId);
     }
 
     @Override
     public HeldLocksGrant convertToGrant(String namespace, HeldLocksToken token) {
         // TODO (jkong): It feels like this could be non-blocking but not 100% sure so going for the safe option.
-        return blockingClient.convertToGrant(namespace, token);
+        return blocking.convertToGrant(namespace, token);
     }
 
     @Override
     public HeldLocksToken useGrant(String namespace, LockClient client, HeldLocksGrant grant) {
         // TODO (jkong): It feels like this could be non-blocking but not 100% sure so going for the safe option.
-        return blockingClient.useGrant(namespace, client, grant);
+        return blocking.useGrant(namespace, client, grant);
     }
 
     @Override
     public HeldLocksToken useGrant(String namespace, LockClient client, BigInteger grantId) {
         // TODO (jkong): It feels like this could be non-blocking but not 100% sure so going for the safe option.
-        return blockingClient.useGrant(namespace, client, grantId);
+        return blocking.useGrant(namespace, client, grantId);
     }
 
     @Override
     public Optional<Long> getMinLockedInVersionId(String namespace) {
-        return nonBlockingClient.getMinLockedInVersionId(namespace);
+        return nonBlocking.getMinLockedInVersionId(namespace);
     }
 
     @Override
     public Optional<Long> getMinLockedInVersionId(String namespace, LockClient client) {
-        return nonBlockingClient.getMinLockedInVersionId(namespace, client);
+        return nonBlocking.getMinLockedInVersionId(namespace, client);
     }
 
     @Override
     public Optional<Long> getMinLockedInVersionId(String namespace, String client) {
-        return nonBlockingClient.getMinLockedInVersionId(namespace, client);
+        return nonBlocking.getMinLockedInVersionId(namespace, client);
     }
 
     @Override
     public LockServerOptions getLockServerOptions(String namespace) {
-        return nonBlockingClient.getLockServerOptions(namespace);
+        return nonBlocking.getLockServerOptions(namespace);
     }
 
     @Override
     public Optional<LockRefreshToken> lock(String namespace, String client, LockRequest request)
             throws InterruptedException {
-        return blockingClient.lock(namespace, client, request);
+        return blocking.lock(namespace, client, request);
     }
 
     @Override
     public Optional<HeldLocksToken> lockAndGetHeldLocks(String namespace, String client, LockRequest request)
             throws InterruptedException {
-        return blockingClient.lockAndGetHeldLocks(namespace, client, request);
+        return blocking.lockAndGetHeldLocks(namespace, client, request);
     }
 
     @Override
     public Set<LockRefreshToken> refreshLockRefreshTokens(String namespace, Iterable<LockRefreshToken> tokens) {
-        return nonBlockingClient.refreshLockRefreshTokens(namespace, tokens);
+        return nonBlocking.refreshLockRefreshTokens(namespace, tokens);
     }
 
     @Override
     public long currentTimeMillis(String namespace) {
-        return nonBlockingClient.currentTimeMillis(namespace);
+        return nonBlocking.currentTimeMillis(namespace);
     }
 
     @Override
     public void logCurrentState(String namespace) {
         // Even if this does take more than the non-blocking timeout, the request will fail while the server will
         // dump its logs out.
-        nonBlockingClient.logCurrentState(namespace);
+        nonBlocking.logCurrentState(namespace);
     }
 }

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/timelock/BlockingSensitiveLockRpcClientTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/timelock/BlockingSensitiveLockRpcClientTest.java
@@ -39,7 +39,11 @@ public class BlockingSensitiveLockRpcClientTest {
 
     private final LockRpcClient blocking = mock(LockRpcClient.class);
     private final LockRpcClient nonBlocking = mock(LockRpcClient.class);
-    private final LockRpcClient sensitiveClient = new BlockingSensitiveLockRpcClient(blocking, nonBlocking);
+    private final LockRpcClient sensitiveClient = new BlockingSensitiveLockRpcClient(
+            ImmutableBlockingAndNonBlockingServices.<LockRpcClient>builder()
+                    .blocking(blocking)
+                    .nonBlocking(nonBlocking)
+                    .build());
 
     @Test
     public void lockUsesBlockingClient() throws InterruptedException {

--- a/changelog/@unreleased/pr-4638.v2.yml
+++ b/changelog/@unreleased/pr-4638.v2.yml
@@ -1,0 +1,8 @@
+type: fix
+fix:
+  description: RPC calls to TimeLock via Conjure now correctly block for either a
+    short (10s) or long (60s) duration depending on what the call does. Previously,
+    these were swapped, which manifested as lock requests on contended locks aborting
+    from the client side after 10 seconds even though they could be served.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4638


### PR DESCRIPTION
**Goals (and why)**:
- See PDS-113120
- Blocking endpoints were treated as non-blocking and vice versa, this is bad because clients would abort lock requests before the locks were served, even if they could be given out.

**Implementation Description (bullets)**:
- Add a structure `BlockingAndNonBlockingServices<T>` which is created only through a ServiceCreator in one place, so we always get it right
- Refactor the lock RPC client and conjure timelock client so that they use the new structure - this also fixes the swap that they had.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Existing tests passing should be enough. The `BlockingSensitiveLockRpcClient` test passing is enough.

**Concerns (what feedback would you like?)**: nothing in particular

**Where should we start reviewing?**: paired with @felixdesouza, feel free to start where you like

**Priority (whenever / two weeks / yesterday)**: yesterday 🔥 