### PR TITLE
[Timelock Partitioning] Part 53: Latest sequence cache concurrent

### DIFF
--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AcceptorCache.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AcceptorCache.java
@@ -36,14 +36,23 @@ public interface AcceptorCache {
      * <p>
      * Implementations <b><em>SHOULD</em></b> ignore any pairs where the given sequence number is lower than what has already
      * been seen by this cache.
+     * <p>
+     * If there have been updates applied, then subsequent calls to {@link AcceptorCache#updateSequenceNumbers} and
+     * {@link AcceptorCache#updatesSinceCacheKey} should return a {@link AcceptorCacheDigest} with a new
+     * <b>cache key</b> and a <b>strictly increasing</b> {@link AcceptorCacheDigest#cacheTimestamp}.
      */
     void updateSequenceNumbers(Set<WithSeq<Client>> clientsAndSeqs);
 
     /**
      * Get all latest sequence numbers for each client this cache has seen so far.
      * <p>
-     * A {@link AcceptorCacheDigest digest} is returned which also contains a {@link AcceptorCacheKey cacheKey} that
-     * should be used with {@link AcceptorCache#updatesSinceCacheKey}.
+     * A {@link AcceptorCacheDigest digest} is returned which also contains a {@link AcceptorCacheKey cache key} that
+     * should be used with {@link AcceptorCache#updatesSinceCacheKey}. It also contains a
+     * {@link AcceptorCacheDigest#cacheTimestamp() cache timestamp} to aid in ordering responses received from this
+     * cache.
+     * <p>
+     * The digests returned from this method <b>must</b> always contain non-negative
+     * {@link AcceptorCacheDigest#cacheTimestamp() cache timestamps}.
      *
      * @return digest containing all latest sequence numbers for clients seen by this cache.
      */
@@ -60,14 +69,19 @@ public interface AcceptorCache {
      *     </li>
      *     <li>
      *         If there <em>have</em> been updates since {@code cacheKey} was issued, an {@link Optional} is returned
-     *         with a {@link AcceptorCacheDigest} containing the respective updates and also a new
-     *         {@link AcceptorCacheKey cache key} to use on the next invocation.
+     *         with a {@link AcceptorCacheDigest} containing the respective updates and also a <b>new</b>
+     *         {@link AcceptorCacheKey cache key} to use on the next invocation. It should also contain a
+     *         {@link AcceptorCacheDigest#cacheTimestamp()} that is strictly greater than the cacheTimestamp associated
+     *         with the <em>latest</em> cache timestamp.
      *     </li>
      *     <li>
      *         If the {@code cacheKey} is invalid either because it was not issued by the cache or it has expired for
      *         example, the implementation must throw a {@link InvalidAcceptorCacheKeyException}.
      *     </li>
      * </ul>
+     *
+     * The digests returned from this method <b>must</b> always contain non-negative
+     * {@link AcceptorCacheDigest#cacheTimestamp() cache timestamps}.
      *
      * @param cacheKey effective point in time where updates are requested from
      * @return a {@link AcceptorCacheDigest digest} containing the updates and a new cache key if any

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AcceptorCacheDigest.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AcceptorCacheDigest.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 @JsonDeserialize(as = ImmutableAcceptorCacheDigest.class)
 @JsonSerialize(as = ImmutableAcceptorCacheDigest.class)
 public interface AcceptorCacheDigest {
+    long cacheTimestamp();
     AcceptorCacheKey newCacheKey();
     Map<Client, Long> updates();
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AcceptorCacheImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AcceptorCacheImpl.java
@@ -39,30 +39,33 @@ import com.palantir.common.streams.KeyedStream;
 public class AcceptorCacheImpl implements AcceptorCache {
 
     private final ReadWriteLock lock = new ReentrantReadWriteLock();
-    private final Cache<AcceptorCacheKey, Long> cacheKeyToTimestamp;
+    private final Cache<AcceptorCacheKey, TimestampedAcceptorCacheKey> cacheKeyToTimestamp;
     private final Map<Client, WithSeq<Long>> clientToTimeAndSeq = Maps.newHashMap();
     private final TreeMultimap<Long, WithSeq<Client>> clientsByLatestTimestamp = TreeMultimap.create(
             Comparator.naturalOrder(),
             Comparator.comparing(clientWithSeq -> clientWithSeq.value().value(), Comparator.naturalOrder()));
 
     @GuardedBy("lock")
-    private long currentTimestamp = 0;
-    @GuardedBy("lock")
-    private AcceptorCacheKey latestAcceptorCacheKey = AcceptorCacheKey.newCacheKey();
+    private TimestampedAcceptorCacheKey latestTimestampedAcceptorCacheKey =
+            TimestampedAcceptorCacheKey.of(AcceptorCacheKey.newCacheKey(), 0);
 
     public AcceptorCacheImpl() {
-        Cache<AcceptorCacheKey, Long> cacheKeyToTime = Caffeine.newBuilder()
+        Cache<AcceptorCacheKey, TimestampedAcceptorCacheKey> cacheKeyToTime = Caffeine.newBuilder()
                 .expireAfterAccess(Duration.ofMinutes(10))
                 .build();
-        cacheKeyToTime.put(latestAcceptorCacheKey, currentTimestamp);
+        cacheKeyToTime.put(latestTimestampedAcceptorCacheKey.cacheKey(), latestTimestampedAcceptorCacheKey);
         this.cacheKeyToTimestamp = cacheKeyToTime;
     }
 
     @Override
     public void updateSequenceNumbers(Set<WithSeq<Client>> clientsAndSeqs) {
+        if (clientsAndSeqs.isEmpty()) {
+            return;
+        }
+
         lock.writeLock().lock();
         try {
-            long nextTimestamp = currentTimestamp + 1;
+            long nextTimestamp = latestTimestampedAcceptorCacheKey.timestamp() + 1;
             AtomicBoolean updated = new AtomicBoolean(false);
 
             clientsAndSeqs.forEach(clientAndSeq -> {
@@ -89,10 +92,10 @@ public class AcceptorCacheImpl implements AcceptorCache {
             }
 
             AcceptorCacheKey nextCacheKey = AcceptorCacheKey.newCacheKey();
-            cacheKeyToTimestamp.put(nextCacheKey, nextTimestamp);
-
-            currentTimestamp = nextTimestamp;
-            latestAcceptorCacheKey = nextCacheKey;
+            TimestampedAcceptorCacheKey newTimestampedCacheKey =
+                    TimestampedAcceptorCacheKey.of(nextCacheKey, nextTimestamp);
+            cacheKeyToTimestamp.put(nextCacheKey, newTimestampedCacheKey);
+            latestTimestampedAcceptorCacheKey = newTimestampedCacheKey;
         } finally {
             lock.writeLock().unlock();
         }
@@ -106,7 +109,8 @@ public class AcceptorCacheImpl implements AcceptorCache {
                     .map(WithSeq::seq)
                     .collectToMap();
             return ImmutableAcceptorCacheDigest.builder()
-                    .newCacheKey(latestAcceptorCacheKey)
+                    .newCacheKey(latestTimestampedAcceptorCacheKey.cacheKey())
+                    .cacheTimestamp(latestTimestampedAcceptorCacheKey.timestamp())
                     .updates(clientsToLatest)
                     .build();
         } finally {
@@ -119,14 +123,13 @@ public class AcceptorCacheImpl implements AcceptorCache {
             throws InvalidAcceptorCacheKeyException {
         lock.readLock().lock();
         try {
-            if (cacheKey.equals(latestAcceptorCacheKey)) {
+            if (cacheKey.equals(latestTimestampedAcceptorCacheKey.cacheKey())) {
                 return Optional.empty();
             }
 
-            Long cacheKeyTimestamp = cacheKeyToTimestamp.getIfPresent(cacheKey);
-            if (cacheKeyTimestamp == null) {
-                throw new InvalidAcceptorCacheKeyException(cacheKey);
-            }
+            long cacheKeyTimestamp = Optional.ofNullable(cacheKeyToTimestamp.getIfPresent(cacheKey))
+                    .map(TimestampedAcceptorCacheKey::timestamp)
+                    .orElseThrow(() -> new InvalidAcceptorCacheKeyException(cacheKey));
 
             Map<Client, Long> diff = clientsByLatestTimestamp.asMap().tailMap(cacheKeyTimestamp, false).values()
                     .stream()
@@ -134,7 +137,8 @@ public class AcceptorCacheImpl implements AcceptorCache {
                     .collect(Collectors.toMap(WithSeq::value, WithSeq::seq));
 
             return Optional.of(ImmutableAcceptorCacheDigest.builder()
-                    .newCacheKey(latestAcceptorCacheKey)
+                    .newCacheKey(latestTimestampedAcceptorCacheKey.cacheKey())
+                    .cacheTimestamp(latestTimestampedAcceptorCacheKey.timestamp())
                     .updates(diff)
                     .build());
         } finally {

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AcceptorCacheKey.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AcceptorCacheKey.java
@@ -24,6 +24,12 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
+/**
+ * This represents a snapshot of the {@link AcceptorCache}. That is, if you were to receive a
+ * {@link AcceptorCacheDigest} with this {@link AcceptorCacheKey} and then you were to make a subsequent request with
+ * this particular cache key, you will either receive an empty response or updates that occurred to the cache after the
+ * point in time that is associated with this cache key.
+ */
 @Value.Immutable
 @JsonDeserialize(as = ImmutableAcceptorCacheKey.class)
 @JsonSerialize(as = ImmutableAcceptorCacheKey.class)

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosLatestSequenceCache.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosLatestSequenceCache.java
@@ -137,6 +137,8 @@ final class BatchingPaxosLatestSequenceCache implements CoalescingRequestFunctio
     private void maybeSetNewCacheKey(TimestampedAcceptorCacheKey newCacheKey) {
         while (true) {
             TimestampedAcceptorCacheKey current = cacheKey.get();
+            // either the new cache key is older or the same as the current
+            // or we race to set it and try again if we lose
             if ((current != null && newCacheKey.timestamp() <= current.timestamp())
                     || cacheKey.compareAndSet(current, newCacheKey)) {
                 return;

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosLatestSequenceCache.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosLatestSequenceCache.java
@@ -161,7 +161,7 @@ final class BatchingPaxosLatestSequenceCache implements CoalescingRequestFunctio
         @Value.Parameter
         AcceptorCacheKey cacheKey();
 
-        // this exists to give ordering to
+        // this exists to give ordering to cache keys especially when they're coming back concurrently.
         @Value.Parameter
         long timestamp();
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosLatestSequenceCache.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosLatestSequenceCache.java
@@ -51,11 +51,11 @@ final class BatchingPaxosLatestSequenceCache implements CoalescingRequestFunctio
     private final BatchPaxosAcceptor delegate;
 
     // we accumulate all clients that we've seen so far such that if we need to invalidate the cache and request a new
-    // update, we receive a cache update that's consistent with the clients we've seen e.g. in the face of leader
-    // elections
+    // update, we receive a cache update that's consistent with the clients we've seen e.g. in the face of remote node
+    // restarts or cache expirations
     private final Set<Client> clientsSeenSoFar = Sets.newConcurrentHashSet();
 
-    // represents the latest cache digest that this client side cache has processed
+    // represents the cache digest with the highest timestamp that this client side cache has processed
     private final AtomicReference<TimestampedAcceptorCacheKey> latestCacheKey = new AtomicReference<>();
 
     // each value refers to a materialised version of the cache in terms of namespaces and the latest sequence at that

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosLatestSequenceCache.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosLatestSequenceCache.java
@@ -16,92 +16,157 @@
 
 package com.palantir.atlasdb.timelock.paxos;
 
+import java.time.Duration;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
 
-import javax.annotation.Nullable;
-import javax.annotation.concurrent.NotThreadSafe;
+import javax.annotation.concurrent.ThreadSafe;
 
+import org.immutables.value.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.autobatch.CoalescingRequestFunction;
 import com.palantir.common.streams.KeyedStream;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.paxos.PaxosLong;
 
-/*
-    This is not thread safe, but it is okay because it is run within an autobatcher, which is configured to not process
-    multiple batches in parallel.
- */
-@NotThreadSafe
+@ThreadSafe
 final class BatchingPaxosLatestSequenceCache implements CoalescingRequestFunction<Client, PaxosLong> {
 
     private static final Logger log = LoggerFactory.getLogger(BatchingPaxosLatestSequenceCache.class);
     private static final PaxosLong DEFAULT_VALUE = PaxosLong.of(BatchPaxosAcceptor.NO_LOG_ENTRY);
 
-    @Nullable
-    private AcceptorCacheKey cacheKey = null;
-    private Map<Client, PaxosLong> cachedEntries = Maps.newHashMap();
-    private BatchPaxosAcceptor delegate;
+    private final BatchPaxosAcceptor delegate;
+
+    private final Set<Client> clientsSeenSoFar = Sets.newConcurrentHashSet();
+
+    private final AtomicReference<TimestampedAcceptorCacheKey> cacheKey = new AtomicReference<>();
+    private final LoadingCache<TimestampedAcceptorCacheKey, ConcurrentMap<Client, PaxosLong>> cacheKeysToCaches =
+            Caffeine.newBuilder()
+                    .expireAfterAccess(Duration.ofMinutes(1))
+                    .build($ -> Maps.newConcurrentMap());
 
     BatchingPaxosLatestSequenceCache(BatchPaxosAcceptor delegate) {
         this.delegate = delegate;
     }
 
     @Override
-    public Map<Client, PaxosLong> apply(Set<Client> clients) {
-        try {
-            return unsafeGetLatest(clients);
-        } catch (InvalidAcceptorCacheKeyException e) {
-            log.info("Cache key is invalid, invalidating cache - using deprecated detection method");
-            return handleCacheMiss(clients);
+    public Map<Client, PaxosLong> apply(Set<Client> requestedClients) {
+        // always add requested clients so we can easily query with everything we've ever seen when our cache is invalid
+        clientsSeenSoFar.addAll(requestedClients);
+
+        int attempt = 0;
+        while (attempt < 3) {
+            TimestampedAcceptorCacheKey timestampedCacheKey = cacheKey.get();
+            try {
+                if (timestampedCacheKey == null) {
+                    return populateNewCache(requestedClients);
+                } else {
+                    return populateExistingCache(
+                            timestampedCacheKey,
+                            cacheKeysToCaches.get(timestampedCacheKey),
+                            requestedClients);
+                }
+            } catch (InvalidAcceptorCacheKeyException e) {
+                log.info("Cache key is invalid, invalidating cache and retrying",
+                        SafeArg.of("attempt", attempt),
+                        e);
+                cacheKey.compareAndSet(timestampedCacheKey, null);
+                attempt++;
+            }
         }
+
+        throw new SafeIllegalStateException("could not request complete request due to contention in the cache");
     }
 
-    private Map<Client, PaxosLong> handleCacheMiss(Set<Client> requestedClients) {
-        cacheKey = null;
-        Set<Client> allClients = ImmutableSet.<Client>builder()
-                .addAll(requestedClients)
-                .addAll(cachedEntries.keySet())
-                .build();
-        cachedEntries.clear();
-        try {
-            return unsafeGetLatest(allClients);
-        } catch (InvalidAcceptorCacheKeyException e) {
-            log.warn("Empty cache key is still invalid indicates product bug, failing request.");
-            throw new RuntimeException(e);
-        }
+    private Map<Client, PaxosLong> populateNewCache(Set<Client> requestedClients)
+            throws InvalidAcceptorCacheKeyException {
+        AcceptorCacheDigest digest = delegate.latestSequencesPreparedOrAccepted(Optional.empty(), clientsSeenSoFar);
+        ConcurrentMap<Client, PaxosLong> newEntriesToCache =
+                cacheKeysToCaches.get(TimestampedAcceptorCacheKey.of(digest));
+        processDigest(newEntriesToCache, digest);
+        return getResponseMap(newEntriesToCache, requestedClients);
     }
 
-    private Map<Client, PaxosLong> unsafeGetLatest(Set<Client> clients) throws InvalidAcceptorCacheKeyException {
-        if (cacheKey == null) {
-            processDigest(delegate.latestSequencesPreparedOrAccepted(Optional.empty(), clients));
-            return getResponseMap(clients);
-        }
-
-        Set<Client> newClients = Sets.difference(clients, cachedEntries.keySet());
+    private Map<Client, PaxosLong> populateExistingCache(
+            TimestampedAcceptorCacheKey timestampedCacheKey,
+            ConcurrentMap<Client, PaxosLong> currentCachedEntries,
+            Set<Client> requestedClients)
+            throws InvalidAcceptorCacheKeyException {
+        Set<Client> newClients = ImmutableSet.copyOf(Sets.difference(requestedClients, currentCachedEntries.keySet()));
         if (newClients.isEmpty()) {
-            delegate.latestSequencesPreparedOrAcceptedCached(cacheKey).ifPresent(this::processDigest);
-            return getResponseMap(clients);
+            delegate.latestSequencesPreparedOrAcceptedCached(timestampedCacheKey.cacheKey())
+                    .ifPresent(digest -> processDigest(currentCachedEntries, digest));
+            return getResponseMap(currentCachedEntries, requestedClients);
         } else {
-            processDigest(delegate.latestSequencesPreparedOrAccepted(Optional.of(cacheKey), newClients));
-            return getResponseMap(clients);
+            processDigest(currentCachedEntries, delegate.latestSequencesPreparedOrAccepted(
+                    Optional.of(timestampedCacheKey.cacheKey()),
+                    newClients));
+            return getResponseMap(currentCachedEntries, requestedClients);
         }
     }
 
-    private Map<Client, PaxosLong> getResponseMap(Set<Client> clientsInRequest) {
-        return Maps.toMap(clientsInRequest, client -> cachedEntries.getOrDefault(client, DEFAULT_VALUE));
+    private void processDigest(ConcurrentMap<Client, PaxosLong> currentCachedEntries, AcceptorCacheDigest digest) {
+        TimestampedAcceptorCacheKey newCacheKey = TimestampedAcceptorCacheKey.of(digest);
+        // this shares the same map with "previous" cache keys, if it's too confusing we can always copy it potentially
+        ConcurrentMap<Client, PaxosLong> newCachedEntries =
+                cacheKeysToCaches.get(newCacheKey, $ -> currentCachedEntries);
+        KeyedStream.stream(digest.updates())
+                .map(PaxosLong::of)
+                .forEach((client, paxosLong) ->
+                        newCachedEntries.merge(client, paxosLong, BatchingPaxosLatestSequenceCache::max));
+
+        // for a *new* mapping, setting the cache key must happen *after* we've setup the mapping, so that concurrent
+        // clients will not reference an in-progress populating map which can be empty.
+        maybeSetNewCacheKey(newCacheKey);
     }
 
-    private void processDigest(AcceptorCacheDigest digest) {
-        cacheKey = digest.newCacheKey();
-        Map<Client, PaxosLong> asPaxosLong = KeyedStream.stream(digest.updates())
-                .map(PaxosLong::of)
-                .collectToMap();
-        cachedEntries.putAll(asPaxosLong);
+    private void maybeSetNewCacheKey(TimestampedAcceptorCacheKey newCacheKey) {
+        while (true) {
+            TimestampedAcceptorCacheKey current = cacheKey.get();
+            if ((current != null && newCacheKey.timestamp() <= current.timestamp())
+                    || cacheKey.compareAndSet(current, newCacheKey)) {
+                return;
+            }
+        }
+    }
+
+    private static Map<Client, PaxosLong> getResponseMap(
+            ConcurrentMap<Client, PaxosLong> currentCachedEntries,
+            Set<Client> requestedClients) {
+        return Maps.toMap(requestedClients, client -> currentCachedEntries.getOrDefault(client, DEFAULT_VALUE));
+    }
+
+    private static PaxosLong max(PaxosLong a, PaxosLong b) {
+        return Stream.of(a, b)
+                .max(Comparator.comparingLong(PaxosLong::getValue))
+                .orElseThrow(() -> { throw new SafeIllegalArgumentException("No Paxos Value could be picked"); });
+    }
+
+    @Value.Immutable
+    interface TimestampedAcceptorCacheKey {
+        @Value.Parameter
+        AcceptorCacheKey cacheKey();
+
+        // this exists to give ordering to
+        @Value.Parameter
+        long timestamp();
+
+        static TimestampedAcceptorCacheKey of(AcceptorCacheDigest digest) {
+            return ImmutableTimestampedAcceptorCacheKey.of(digest.newCacheKey(), digest.cacheTimestamp());
+        }
     }
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosLatestSequenceCache.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosLatestSequenceCache.java
@@ -155,7 +155,7 @@ final class BatchingPaxosLatestSequenceCache implements CoalescingRequestFunctio
     private static PaxosLong max(PaxosLong a, PaxosLong b) {
         return Stream.of(a, b)
                 .max(Comparator.comparingLong(PaxosLong::getValue))
-                .orElseThrow(() -> { throw new SafeIllegalArgumentException("No Paxos Value could be picked"); });
+                .orElseThrow(() -> new SafeIllegalArgumentException("No Paxos Value could be picked"));
     }
 
     @Value.Immutable

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalBatchPaxosAcceptor.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalBatchPaxosAcceptor.java
@@ -95,8 +95,9 @@ public class LocalBatchPaxosAcceptor implements BatchPaxosAcceptor {
     private static AcceptorCacheDigest emptyDigest(AcceptorCacheKey cacheKey) {
         return ImmutableAcceptorCacheDigest.builder()
                 .newCacheKey(cacheKey)
-                // HACK: this is okay, the digest is empty so doesn't do anything, -1 means it won't even
-                .cacheTimestamp(-1)
+                // HACK: this is okay, the digest is empty so doesn't do anything, Long.MIN_VALUE means it will never
+                // accepted as the latest cache key
+                .cacheTimestamp(Long.MIN_VALUE)
                 .build();
     }
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalBatchPaxosAcceptor.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalBatchPaxosAcceptor.java
@@ -95,6 +95,8 @@ public class LocalBatchPaxosAcceptor implements BatchPaxosAcceptor {
     private static AcceptorCacheDigest emptyDigest(AcceptorCacheKey cacheKey) {
         return ImmutableAcceptorCacheDigest.builder()
                 .newCacheKey(cacheKey)
+                // HACK: this is okay, the digest is empty so doesn't do anything, -1 means it won't even
+                .cacheTimestamp(-1)
                 .build();
     }
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/TimestampedAcceptorCacheKey.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/TimestampedAcceptorCacheKey.java
@@ -1,0 +1,37 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+interface TimestampedAcceptorCacheKey {
+    @Value.Parameter
+    AcceptorCacheKey cacheKey();
+
+    // this exists to give ordering to cache keys especially when they're coming back concurrently.
+    @Value.Parameter
+    long timestamp();
+
+    static TimestampedAcceptorCacheKey of(AcceptorCacheDigest digest) {
+        return of(digest.newCacheKey(), digest.cacheTimestamp());
+    }
+
+    static TimestampedAcceptorCacheKey of(AcceptorCacheKey cacheKey, long timestamp) {
+        return ImmutableTimestampedAcceptorCacheKey.of(cacheKey, timestamp);
+    }
+}

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/TimestampedAcceptorCacheKey.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/TimestampedAcceptorCacheKey.java
@@ -20,10 +20,23 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 interface TimestampedAcceptorCacheKey {
+    /**
+     * Represents snapshot of the {@link AcceptorCache}.
+     *
+     * @see AcceptorCacheKey
+     */
     @Value.Parameter
     AcceptorCacheKey cacheKey();
 
-    // this exists to give ordering to cache keys especially when they're coming back concurrently.
+    /**
+     * A logical clock that is, numerically, independent of Paxos sequence numbers and AtlasDB timestamps. It exists to
+     * give us an ordering to the cache keys when they are processed concurrently.
+     * <p>
+     * This is incremented together with the current cache state advancing whenever a
+     * {@link BatchPaxosAcceptor#prepare prepare} or a {@link BatchPaxosAcceptor#accept accept} occur.
+     * <p>
+     * This is also reset to zero, together with the current cache state in the presence of leader election.
+     */
     @Value.Parameter
     long timestamp();
 

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosLatestSequenceCacheTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosLatestSequenceCacheTests.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -49,6 +50,8 @@ public class BatchingPaxosLatestSequenceCacheTests {
             .put(CLIENT_3, PaxosLong.of(15L))
             .build();
 
+    private final AtomicLong cacheTimestamp = new AtomicLong();
+
     @Mock
     private BatchPaxosAcceptor remote;
 
@@ -58,6 +61,7 @@ public class BatchingPaxosLatestSequenceCacheTests {
                 .newCacheKey(AcceptorCacheKey.newCacheKey())
                 .putUpdates(CLIENT_1, 5)
                 .putUpdates(CLIENT_2, 10)
+                .cacheTimestamp(cacheTimestamp.getAndIncrement())
                 .build();
 
         when(remote.latestSequencesPreparedOrAccepted(Optional.empty(), ImmutableSet.of(CLIENT_1, CLIENT_2)))
@@ -79,7 +83,6 @@ public class BatchingPaxosLatestSequenceCacheTests {
 
         assertThat(cache.apply(ImmutableSet.of(CLIENT_1)))
                 .containsEntry(CLIENT_1, INITIAL_UPDATES.get(CLIENT_1));
-
     }
 
     @Test
@@ -126,6 +129,7 @@ public class BatchingPaxosLatestSequenceCacheTests {
         AcceptorCacheDigest newDigest = ImmutableAcceptorCacheDigest.builder()
                 .newCacheKey(AcceptorCacheKey.newCacheKey())
                 .putAllUpdates(newMap)
+                .cacheTimestamp(cacheTimestamp.getAndIncrement())
                 .build();
 
         doReturn(newDigest).when(remote)
@@ -143,6 +147,7 @@ public class BatchingPaxosLatestSequenceCacheTests {
         AcceptorCacheDigest digest = ImmutableAcceptorCacheDigest.builder()
                 .newCacheKey(AcceptorCacheKey.newCacheKey())
                 .putAllUpdates(asLong)
+                .cacheTimestamp(cacheTimestamp.getAndIncrement())
                 .build();
 
         when(remote.latestSequencesPreparedOrAccepted(Optional.empty(), ImmutableSet.of(CLIENT_1, CLIENT_2, CLIENT_3)))
@@ -153,10 +158,11 @@ public class BatchingPaxosLatestSequenceCacheTests {
         return cache;
     }
 
-    private static AcceptorCacheDigest digestWithUpdates(Map.Entry<Client, Long>... entries) {
+    private AcceptorCacheDigest digestWithUpdates(Map.Entry<Client, Long>... entries) {
         return ImmutableAcceptorCacheDigest.builder()
                 .newCacheKey(AcceptorCacheKey.newCacheKey())
                 .updates(ImmutableMap.copyOf(ImmutableSet.copyOf(entries)))
+                .cacheTimestamp(cacheTimestamp.getAndIncrement())
                 .build();
     }
 }

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalBatchPaxosAcceptorTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalBatchPaxosAcceptorTests.java
@@ -145,6 +145,7 @@ public class LocalBatchPaxosAcceptorTests {
                 .newCacheKey(AcceptorCacheKey.newCacheKey())
                 .putUpdates(CLIENT_1, 1L)
                 .putUpdates(CLIENT_2, 2L)
+                .cacheTimestamp(5)
                 .build();
 
         when(cache.getAllUpdates()).thenReturn(digest);
@@ -167,6 +168,7 @@ public class LocalBatchPaxosAcceptorTests {
         AcceptorCacheDigest digest = ImmutableAcceptorCacheDigest.builder()
                 .newCacheKey(AcceptorCacheKey.newCacheKey())
                 .putUpdates(CLIENT_2, 2L)
+                .cacheTimestamp(5)
                 .build();
 
         when(cache.updatesSinceCacheKey(cacheKey))
@@ -206,6 +208,7 @@ public class LocalBatchPaxosAcceptorTests {
         return ImmutableAcceptorCacheDigest.builder()
                 .newCacheKey(AcceptorCacheKey.newCacheKey())
                 .putUpdates(CLIENT_1, 50L)
+                .cacheTimestamp(1L)
                 .build();
     }
 }


### PR DESCRIPTION
**Goals (and why)**:
`BatchingPaxosLatestSequenceCache` is stateful, I correctly identified it as not thread-safe but gave an incorrect justification as to why. i.e. the claim was that it’s in an `Autobatcher` so it’s fine. But it’s actually launched in `PaxosQuorumChecker` *from* an `Autobatcher`, so it’s not fine. i.e. with `B` and `C` as followers, if `C` is slow, `Autobatcher` will have returned a result from itself and `B`, and is free to send another `PaxosQuorumChecker` call => two concurrent threads to a class that’s explicitly not thread safe.

**Implementation Description (bullets)**:
A separate approach that I considered:
* Actually have another Autobatcher that we call instead of calling the cache directly. This would allow us to use `BatchingPaxosLatestSequenceCache` as is without any changes because then it would serialise calls into the cache (autobatcher has only one thread). I did not go with this approach because I want to try getting rid of threads generated in `PaxosQuorumChecker` that leverages async retrofit.

Current approach:
* Each cache key is timestamped (it's timestamped internally, just not exposed over the wire). This is a break, but this is fine, this hasn't gone out anywhere.
  * Multiple threads can come in and make requests, if they get back differing cache keys because updates have occurred in between, which do we pick? The timestamp is what orders them all.
  * Similarly still process all sequences returned, but merge them with what already exists in the map.
* Use concurrent collections for safe access
* Make it easier to expose the timestamp from the server side, see `AcceptorCacheImpl`

**Testing (What was existing testing like?  What have you done to improve it?)**:
Existing tests pass, not sure how to go about the concurrent pieces since there aren't that many levers I can pull to force certain orderings.

**Concerns (what feedback would you like?)**:
Am I missing anything?

**Where should we start reviewing?**:
* `BatchingPaxosLatestSequenceCache`
* `AcceptorCacheImpl`

**Priority (whenever / two weeks / yesterday)**:
ASAP please.
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
