### PR TITLE
[Large Internal Product] Oracle config builders must be public

### DIFF
--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/OracleConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/OracleConnectionConfig.java
@@ -222,10 +222,10 @@ public abstract class OracleConnectionConfig extends ConnectionConfig {
                 + " One needs to be specified.");
     }
 
-    static class Builder extends ImmutableOracleConnectionConfig.Builder {}
+    public static class Builder extends ImmutableOracleConnectionConfig.Builder {}
 
     @Value.Immutable
-    interface ServiceNameConfiguration {
+    public interface ServiceNameConfiguration {
         String serviceName();
         String namespaceOverride();
 


### PR DESCRIPTION
**Goals (and why)**:
- Fix large internal product auto bump

**Implementation Description (bullets)**:
- Specify builders as public

**Testing (What was existing testing like?  What have you done to improve it?)**:
- I verified you can change the test package and it still works

**Concerns (what feedback would you like?)**: none

**Where should we start reviewing?**: +2

**Priority (whenever / two weeks / yesterday)**: yesterday 🔥 
