### PR TITLE
[PDS-113349] Clients for Paxos resources should not support blocking operations

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
@@ -275,6 +275,7 @@ public final class Leaders {
                                 .userAgent(userAgent)
                                 .shouldLimitPayload(false)
                                 .shouldRetry(true)
+                                .shouldSupportBlockingOperations(false)
                                 .remotingClientConfig(remotingClientConfig)
                                 .build()))
                 .collect(Collectors.toList());
@@ -294,11 +295,10 @@ public final class Leaders {
                         trustContext,
                         endpoint,
                         PingableLeader.class,
-                        AuxiliaryRemotingParameters.builder() // TODO (jkong): Configurable remoting client config.
-                                .shouldLimitPayload(false)
+                        AuxiliaryRemotingParameters.builder()
+                                .shouldLimitPayload(false) // Guaranteed to be small, no need to limit.
                                 .userAgent(userAgent)
                                 .shouldRetry(false)
-                                .shouldLimitPayload(true)
                                 .remotingClientConfig(remotingClientConfig)
                                 .build()))
                 .map(Leaders::convertAddressToHostAndPort)

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
@@ -296,9 +296,10 @@ public final class Leaders {
                         endpoint,
                         PingableLeader.class,
                         AuxiliaryRemotingParameters.builder()
-                                .shouldLimitPayload(false) // Guaranteed to be small, no need to limit.
                                 .userAgent(userAgent)
+                                .shouldLimitPayload(false) // Guaranteed to be small, no need to limit.
                                 .shouldRetry(false)
+                                .shouldSupportBlockingOperations(false)
                                 .remotingClientConfig(remotingClientConfig)
                                 .build()))
                 .map(Leaders::convertAddressToHostAndPort)

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -1099,6 +1099,7 @@ public abstract class TransactionManagers {
                             .userAgent(userAgent)
                             .shouldRetry(true)
                             .shouldLimitPayload(true)
+                            .shouldSupportBlockingOperations(false)
                             .build());
 
             // Determine asynchronously whether the remote services are talking to our local services.

--- a/changelog/@unreleased/pr-4643.v2.yml
+++ b/changelog/@unreleased/pr-4643.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: Clients for Paxos resources will detect failure more quickly when making
+    remote calls to Paxos endpoints, as there is little reason to believe these requests
+    will complete successfully if they are taking a long time. This may reduce or
+    slow down thread pool saturation when a TimeLock node is unhealthy.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4643

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClients.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClients.java
@@ -126,6 +126,7 @@ public abstract class PaxosRemoteClients {
                                 .shouldLimitPayload(false)
                                 .shouldRetry(shouldRetry)
                                 .remotingClientConfig(() -> RemotingClientConfigs.DEFAULT)
+                                .shouldSupportBlockingOperations(false)
                                 .build()))
                 .map(proxy -> AtlasDbMetrics.instrumentWithTaggedMetrics(
                         metrics(),


### PR DESCRIPTION
**Goals (and why)**:
- See PDS-113349. This is unlikely to be the root cause, but is something I noticed that could be relevant and might help us recover faster, @gmaretic for SA
- Calls to Paxos endpoints should fail fast if it takes the server a long time to respond.

**Implementation Description (bullets)**:
- Remote proxies of (possibly batched) `PingableLeader`, `PaxosLearner` and `PaxosAcceptor` have been changed to a 10 second idle timeout instead of 60 seconds.
  - I believe this is fine, as the endpoints in question should be serviced locally, and generally don't have specific contention issues (that e.g. lock has). 

**Testing (What was existing testing like?  What have you done to improve it?)**:
Existing tests should verify things still work. I don't think we have tests for the limit

**Concerns (what feedback would you like?)**:
- `Leaders#createProxyAndLocalList` is public API. Is it a problem to stop blocking operations from going through? A quick internal code-search suggests it's not currently in use outside of AtlasDB.

**Where should we start reviewing?**: It's small, read as you go

**Priority (whenever / two weeks / yesterday)**: this week please
