### PR TITLE
[PDS-113496] Martin Lewis's Muse Part 1: Snapshot Transaction

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/util/MetricsManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/util/MetricsManager.java
@@ -208,6 +208,16 @@ public class MetricsManager {
         return histogram;
     }
 
+    public Counter registerOrGetTaggedCounter(
+            Class clazz,
+            String metricName,
+            Map<String, String> tags) {
+        MetricName name = getTaggedMetricName(clazz, metricName, tags);
+        Counter counter = taggedMetricRegistry.counter(name);
+        registerTaggedMetricName(name);
+        return counter;
+    }
+
     private void registerMetricName(String fullyQualifiedMeterName) {
         lock.readLock().lock();
         try {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ResultsExtractor.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ResultsExtractor.java
@@ -24,6 +24,7 @@ import java.util.SortedMap;
 
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;
 
+import com.codahale.metrics.Counter;
 import com.codahale.metrics.Meter;
 import com.palantir.atlasdb.AtlasDbMetricNames;
 import com.palantir.atlasdb.encoding.PtBytes;
@@ -106,8 +107,9 @@ public abstract class ResultsExtractor<T> {
 
     public abstract Map<Cell, T> asMap();
 
-    protected Meter getNotlatestVisibleValueCellFilterMeter(Class clazz) {
+    protected Counter getNotLatestVisibleValueCellFilterCounter(Class clazz) {
         // TODO(hsaraogi): add table names as a tag
-        return metricsManager.registerOrGetMeter(clazz, AtlasDbMetricNames.CellFilterMetrics.NOT_LATEST_VISIBLE_VALUE);
+        return metricsManager.registerOrGetCounter(
+                clazz, AtlasDbMetricNames.CellFilterMetrics.NOT_LATEST_VISIBLE_VALUE);
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ResultsExtractor.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ResultsExtractor.java
@@ -25,7 +25,6 @@ import java.util.SortedMap;
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;
 
 import com.codahale.metrics.Counter;
-import com.codahale.metrics.Meter;
 import com.palantir.atlasdb.AtlasDbMetricNames;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.Cell;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/RowColumnRangeExtractor.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/RowColumnRangeExtractor.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;
 
+import com.codahale.metrics.Counter;
 import com.codahale.metrics.Meter;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -73,10 +74,10 @@ class RowColumnRangeExtractor {
     private final Map<byte[], Column> rowsToLastCompositeColumns = Maps.newHashMap();
     private final Map<byte[], Integer> rowsToRawColumnCount = Maps.newHashMap();
     private final Set<byte[]> emptyRows = Sets.newHashSet();
-    private final Meter notLatestVisibleValueCellFilterMeter;
+    private final Counter notLatestVisibleValueCellFilterCounter;
 
     RowColumnRangeExtractor(MetricsManager metricsManager) {
-        notLatestVisibleValueCellFilterMeter = metricsManager.registerOrGetMeter(
+        notLatestVisibleValueCellFilterCounter = metricsManager.registerOrGetCounter(
                 RowColumnRangeExtractor.class,
                 AtlasDbMetricNames.CellFilterMetrics.NOT_LATEST_VISIBLE_VALUE);
     }
@@ -113,10 +114,10 @@ class RowColumnRangeExtractor {
             } else if (!collector.get(row).containsKey(cell)) {
                 collector.get(row).put(cell, Value.create(val, ts));
             } else {
-                notLatestVisibleValueCellFilterMeter.mark();
+                notLatestVisibleValueCellFilterCounter.inc();
             }
         } else {
-            notLatestVisibleValueCellFilterMeter.mark();
+            notLatestVisibleValueCellFilterCounter.inc();
         }
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/RowColumnRangeExtractor.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/RowColumnRangeExtractor.java
@@ -26,7 +26,6 @@ import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;
 
 import com.codahale.metrics.Counter;
-import com.codahale.metrics.Meter;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.AtlasDbMetricNames;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ValueExtractor.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ValueExtractor.java
@@ -17,7 +17,7 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 
 import java.util.Map;
 
-import com.codahale.metrics.Meter;
+import com.codahale.metrics.Counter;
 import com.google.common.collect.Maps;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
@@ -26,8 +26,8 @@ import com.palantir.atlasdb.util.MetricsManager;
 
 class ValueExtractor extends ResultsExtractor<Value> {
     private final Map<Cell, Value> collector;
-    private final Meter notLatestVisibleValueCellFilterMeter =
-            getNotlatestVisibleValueCellFilterMeter(ValueExtractor.class);
+    private final Counter notLatestVisibleValueCellFilterCounter =
+            getNotLatestVisibleValueCellFilterCounter(ValueExtractor.class);
 
     ValueExtractor(MetricsManager metricsManager, Map<Cell, Value> collector) {
         super(metricsManager);
@@ -50,10 +50,10 @@ class ValueExtractor extends ResultsExtractor<Value> {
             if (!collector.containsKey(cell)) {
                 collector.put(cell, Value.create(val, ts));
             } else {
-                notLatestVisibleValueCellFilterMeter.mark();
+                notLatestVisibleValueCellFilterCounter.inc();
             }
         } else {
-            notLatestVisibleValueCellFilterMeter.mark();
+            notLatestVisibleValueCellFilterCounter.inc();
         }
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -2375,13 +2375,6 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                 metricsManager.getTableNameTagFor(tableRef));
     }
 
-    private Meter getMeter(String name, TableReference tableRef) {
-        return metricsManager.registerOrGetTaggedMeter(
-                SnapshotTransaction.class,
-                name,
-                metricsManager.getTableNameTagFor(tableRef));
-    }
-
     private Counter getCounter(String name, TableReference tableRef) {
         return metricsManager.registerOrGetTaggedCounter(
                 SnapshotTransaction.class,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -49,7 +49,6 @@ import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Histogram;
-import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
 import com.google.common.base.Function;
 import com.google.common.base.Functions;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -47,6 +47,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.codahale.metrics.Counter;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
@@ -447,10 +448,10 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     private Iterator<Map.Entry<Cell, byte[]>> filterDeletedValues(
             Iterator<Map.Entry<Cell, byte[]>> unfiltered,
             TableReference tableReference) {
-        Meter emptyValueMeter = getMeter(AtlasDbMetricNames.CellFilterMetrics.EMPTY_VALUE, tableReference);
+        Counter emptyValueCounter = getCounter(AtlasDbMetricNames.CellFilterMetrics.EMPTY_VALUE, tableReference);
         return Iterators.filter(unfiltered, entry -> {
             if (entry.getValue().length == 0) {
-                emptyValueMeter.mark();
+                emptyValueCounter.inc();
                 return false;
             }
             return true;
@@ -576,8 +577,8 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
 
     private Map<Cell, byte[]> removeEmptyColumns(Map<Cell, byte[]> unfiltered, TableReference tableReference) {
         Map<Cell, byte[]> filtered = Maps.filterValues(unfiltered, Predicates.not(Value::isTombstone));
-        getMeter(AtlasDbMetricNames.CellFilterMetrics.EMPTY_VALUE, tableReference)
-                .mark(unfiltered.size() - filtered.size());
+        getCounter(AtlasDbMetricNames.CellFilterMetrics.EMPTY_VALUE, tableReference)
+                .inc(unfiltered.size() - filtered.size());
         return filtered;
     }
 
@@ -986,8 +987,8 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         return Iterators.transform(unfilteredRows, unfilteredRow -> {
             SortedMap<byte[], byte[]> filteredColumns =
                     Maps.filterValues(unfilteredRow.getColumns(), Predicates.not(Value::isTombstone));
-            getMeter(AtlasDbMetricNames.CellFilterMetrics.EMPTY_VALUE, tableReference)
-                    .mark(unfilteredRow.getColumns().size() - filteredColumns.size());
+            getCounter(AtlasDbMetricNames.CellFilterMetrics.EMPTY_VALUE, tableReference)
+                    .inc(unfilteredRow.getColumns().size() - filteredColumns.size());
             return RowResult.create(unfilteredRow.getRowName(), filteredColumns);
         });
     }
@@ -1022,7 +1023,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                 numEmptyValues++;
             }
         }
-        getMeter(AtlasDbMetricNames.CellFilterMetrics.EMPTY_VALUE, tableRef).mark(numEmptyValues);
+        getCounter(AtlasDbMetricNames.CellFilterMetrics.EMPTY_VALUE, tableRef).inc(numEmptyValues);
         return mergedWritesWithoutEmptyValues;
     }
 
@@ -1181,7 +1182,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             getHistogram(AtlasDbMetricNames.SNAPSHOT_TRANSACTION_TOO_MANY_BYTES_READ, tableRef).update(bytes);
         }
 
-        getMeter(AtlasDbMetricNames.SNAPSHOT_TRANSACTION_CELLS_READ, tableRef).mark(rawResults.size());
+        getCounter(AtlasDbMetricNames.SNAPSHOT_TRANSACTION_CELLS_READ, tableRef).inc(rawResults.size());
 
         // LinkedList is chosen for fast append operation since we just add to this collection.
         Collection<Map.Entry<Cell, T>> resultsAccumulator = new LinkedList<>();
@@ -1218,8 +1219,8 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             AsyncKeyValueService asyncKeyValueService,
             AsyncTransactionService asyncTransactionService) {
         if (remainingResultsToPostFilter.isEmpty()) {
-            getMeter(AtlasDbMetricNames.SNAPSHOT_TRANSACTION_CELLS_RETURNED, tableReference)
-                    .mark(resultsAccumulator.size());
+            getCounter(AtlasDbMetricNames.SNAPSHOT_TRANSACTION_CELLS_RETURNED, tableReference)
+                    .inc(resultsAccumulator.size());
             return Futures.immediateFuture(resultsAccumulator);
         }
 
@@ -1307,7 +1308,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             Value value = e.getValue();
 
             if (isSweepSentinel(value)) {
-                getMeter(AtlasDbMetricNames.CellFilterMetrics.INVALID_START_TS, tableRef).mark();
+                getCounter(AtlasDbMetricNames.CellFilterMetrics.INVALID_START_TS, tableRef).inc();
 
                 // This means that this transaction started too long ago. When we do garbage collection,
                 // we clean up old values, and this transaction started at a timestamp before the garbage collection.
@@ -1334,7 +1335,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                     if (shouldDeleteAndRollback()) {
                         // This is from a failed transaction so we can roll it back and then reload it.
                         keysToDelete.put(key, value.getTimestamp());
-                        getMeter(AtlasDbMetricNames.CellFilterMetrics.INVALID_COMMIT_TS, tableRef).mark();
+                        getCounter(AtlasDbMetricNames.CellFilterMetrics.INVALID_COMMIT_TS, tableRef).inc();
                     }
                 } else if (theirCommitTimestamp > getStartTimestamp()) {
                     // The value's commit timestamp is after our start timestamp.
@@ -1342,8 +1343,8 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                     // after our transaction began. We need to try reading at an
                     // earlier timestamp.
                     keysToReload.put(key, value.getTimestamp());
-                    getMeter(AtlasDbMetricNames.CellFilterMetrics.COMMIT_TS_GREATER_THAN_TRANSACTION_TS, tableRef)
-                            .mark();
+                    getCounter(AtlasDbMetricNames.CellFilterMetrics.COMMIT_TS_GREATER_THAN_TRANSACTION_TS, tableRef)
+                            .inc();
                 } else {
                     // The value has a commit timestamp less than our start timestamp, and is visible and valid.
                     if (value.getContents().length != 0) {
@@ -2376,6 +2377,13 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
 
     private Meter getMeter(String name, TableReference tableRef) {
         return metricsManager.registerOrGetTaggedMeter(
+                SnapshotTransaction.class,
+                name,
+                metricsManager.getTableNameTagFor(tableRef));
+    }
+
+    private Counter getCounter(String name, TableReference tableRef) {
+        return metricsManager.registerOrGetTaggedCounter(
                 SnapshotTransaction.class,
                 name,
                 metricsManager.getTableNameTagFor(tableRef));

--- a/changelog/@unreleased/pr-4646.v2.yml
+++ b/changelog/@unreleased/pr-4646.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: '`SnapshotTransaction` now produces counters instead of meters for
+    previously counter-backed `CellFilterMetrics`, and also for `numCellsRead` and
+    `numCellsReturnedAfterFiltering`.'
+  links:
+  - https://github.com/palantir/atlasdb/pull/4646


### PR DESCRIPTION
**Goals (and why)**:
- See internal ticket.
- Having fewer metrics saves money.

**Implementation Description (bullets)**:
- Counters don't publish a 1m rate metric while meters do, but a lot of our 1m rate metrics are nto being used.
- Change cell filter based metrics and broad cells-read metrics to use counters, not meters.

**Testing (What was existing testing like?  What have you done to improve it?)**: none

**Concerns (what feedback would you like?)**:
- The cells read metric _is_ actually used, but you really should be using `per_second(count)` in internal infrastructure. It's true that that is different from the 1m rate, but I don't think the difference is material here.

**Where should we start reviewing?**: no preference, it's small

**Priority (whenever / two weeks / yesterday)**: this week please

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
