### PR TITLE
Fix bug in CoalescingSupplier

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/common/concurrent/CoalescingSupplier.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/concurrent/CoalescingSupplier.java
@@ -119,7 +119,7 @@ public class CoalescingSupplier<T> implements Supplier<T> {
         }
 
         ListenableFuture<T> getResultAsync() {
-            return future;
+            return Futures.nonCancellationPropagating(future);
         }
 
         T getResult() {

--- a/atlasdb-commons/src/main/java/com/palantir/common/concurrent/CoalescingSupplier.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/concurrent/CoalescingSupplier.java
@@ -57,11 +57,11 @@ public class CoalescingSupplier<T> implements Supplier<T> {
         return next.getResult();
     }
 
-    @SuppressWarnings("CheckReturnValue")
     public ListenableFuture<T> getAsync() {
         return Futures.nonCancellationPropagating(getAsyncNotHandlingCancellation());
     }
 
+    @SuppressWarnings("CheckReturnValue")
     private ListenableFuture<T> getAsyncNotHandlingCancellation() {
         Round present = round;
         if (present.isFirstToArrive()) {

--- a/atlasdb-commons/src/main/java/com/palantir/common/concurrent/CoalescingSupplier.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/concurrent/CoalescingSupplier.java
@@ -59,6 +59,10 @@ public class CoalescingSupplier<T> implements Supplier<T> {
 
     @SuppressWarnings("CheckReturnValue")
     public ListenableFuture<T> getAsync() {
+        return Futures.nonCancellationPropagating(getAsyncNotHandlingCancellation());
+    }
+
+    private ListenableFuture<T> getAsyncNotHandlingCancellation() {
         Round present = round;
         if (present.isFirstToArrive()) {
             return Futures.submitAsync(() -> {
@@ -119,7 +123,7 @@ public class CoalescingSupplier<T> implements Supplier<T> {
         }
 
         ListenableFuture<T> getResultAsync() {
-            return Futures.nonCancellationPropagating(future);
+            return future;
         }
 
         T getResult() {

--- a/atlasdb-commons/src/test/java/com/palantir/common/concurrent/CoalescingSupplierTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/common/concurrent/CoalescingSupplierTest.java
@@ -169,7 +169,6 @@ public class CoalescingSupplierTest {
         CoalescingSupplier<Long> supplier = new CoalescingSupplier<>(() -> Futures.getUnchecked(future));
         ListenableFuture<Long> returned = supplier.getAsync();
         returned.cancel(true);
-        assertThat(future).isNotCancelled();
         ListenableFuture<Long> after = supplier.getAsync();
         future.set(1L);
         assertThat(Futures.getUnchecked(after)).isOne();

--- a/atlasdb-commons/src/test/java/com/palantir/common/concurrent/CoalescingSupplierTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/common/concurrent/CoalescingSupplierTest.java
@@ -155,7 +155,7 @@ public class CoalescingSupplierTest {
             sleep(2);
             return counter.incrementAndGet();
         });
-        List<ListenableFuture<?>> futures = IntStream.range(0, poolSize)
+        List<ListenableFuture<?>> futures = IntStream.range(0, poolSize * 10)
                 .mapToObj(index -> executorService.submit(() -> assertIncreasing(supplier)))
                 .collect(Collectors.toList());
         executorService.shutdown();

--- a/atlasdb-commons/src/test/java/com/palantir/common/concurrent/CoalescingSupplierTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/common/concurrent/CoalescingSupplierTest.java
@@ -156,7 +156,7 @@ public class CoalescingSupplierTest {
             sleep(2);
             return counter.incrementAndGet();
         });
-        List<ListenableFuture<?>> futures = IntStream.range(0, poolSize * 10)
+        List<ListenableFuture<?>> futures = IntStream.range(0, poolSize)
                 .mapToObj(index -> executorService.submit(() -> assertIncreasing(supplier)))
                 .collect(Collectors.toList());
         executorService.shutdown();

--- a/changelog/@unreleased/pr-4647.v2.yml
+++ b/changelog/@unreleased/pr-4647.v2.yml
@@ -1,5 +1,5 @@
-type: improvement
-improvement:
+type: feature
+feature:
   description: Fix bug in CoalescingSupplier that leads to the async method cancellation
     messing up the state.
   links:

--- a/changelog/@unreleased/pr-4647.v2.yml
+++ b/changelog/@unreleased/pr-4647.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Fix bug in CoalescingSupplier that leads to the async method cancellation
+    messing up the state.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4647


### PR DESCRIPTION
    Currently doesn't handle cancellation. This totally messes up the state
    machine, because it means that the future is complete before next is
    set (and next may never be set) which means that it can all totally
    crash.