### PR TITLE
Support Acquire Timeouts of 0 and Fail Hard on Negative Timeouts

### DIFF
--- a/changelog/@unreleased/pr-4654-fix.v2.yml
+++ b/changelog/@unreleased/pr-4654-fix.v2.yml
@@ -1,0 +1,9 @@
+type: fix
+fix:
+  description: The `BlockEnforcingLockService` now handles `LockRequest`s and `WaitForLocksRequest`s with timeouts
+    of zero correctly. Previously, we would throw a `NullPointerException` on these requests.
+    You should only be affected if you are using the v2 `LockService` directly, as AtlasDB does not, as part of its
+    transactions, create requests with zero timeouts unless `getLockAcquireTimeoutMillis` is explicitly configured
+    as such.
+  links:
+    - https://github.com/palantir/atlasdb/pull/4645

--- a/changelog/@unreleased/pr-4654.v2.yml
+++ b/changelog/@unreleased/pr-4654.v2.yml
@@ -1,0 +1,6 @@
+type: break
+break:
+  description: Exceptions are now thrown if `LockRequest` and `WaitForLocksRequest` are created with negative acquire
+    timeouts. Timeouts of zero are still supported for both types. Please contact the AtlasDB team if this is an issue.
+  links:
+    - https://github.com/palantir/atlasdb/pull/4564

--- a/lock-api-objects/src/main/java/com/palantir/lock/v2/LockRequest.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/v2/LockRequest.java
@@ -23,6 +23,7 @@ import org.immutables.value.Value;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.palantir.lock.LockDescriptor;
+import com.palantir.logsafe.Preconditions;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableLockRequest.class)
@@ -52,4 +53,8 @@ public interface LockRequest {
                 Optional.of(clientDescription));
     }
 
+    @Value.Check
+    default void check() {
+        Preconditions.checkState(getAcquireTimeoutMs() >= 0, "Acquire timeout cannot be negative.");
+    }
 }

--- a/lock-api-objects/src/main/java/com/palantir/lock/v2/WaitForLocksRequest.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/v2/WaitForLocksRequest.java
@@ -26,6 +26,7 @@ import org.immutables.value.Value;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.palantir.lock.LockDescriptor;
+import com.palantir.logsafe.Preconditions;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableWaitForLocksRequest.class)
@@ -54,4 +55,8 @@ public interface WaitForLocksRequest {
                 Optional.ofNullable(clientDescription));
     }
 
+    @Value.Check
+    default void check() {
+        Preconditions.checkState(getAcquireTimeoutMs() >= 0, "Acquire timeout cannot be negative.");
+    }
 }

--- a/lock-api/src/main/java/com/palantir/lock/client/BlockEnforcingLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/BlockEnforcingLockService.java
@@ -146,12 +146,13 @@ final class BlockEnforcingLockService {
                     if (!isTimedOutResponse.test(currentResponse)) {
                         return currentResponse;
                     }
+                    now = clock.instant();
                 } catch (RuntimeException e) {
-                    if (!isPlausiblyTimeout(e) || clock.instant().isAfter(deadline)) {
+                    now = clock.instant();
+                    if (!isPlausiblyTimeout(e) || now.isAfter(deadline)) {
                         throw e;
                     }
                 }
-                now = clock.instant();
             }
 
             Preconditions.checkNotNull(currentResponse, "We attempted to return because a blocking duration was"

--- a/lock-api/src/main/java/com/palantir/lock/client/BlockEnforcingLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/BlockEnforcingLockService.java
@@ -137,7 +137,7 @@ final class BlockEnforcingLockService {
             S currentRequest = request;
             T currentResponse = null;
 
-            while (now.isBefore(deadline)) {
+            while (!now.isAfter(deadline)) {
                 Duration remainingTime = Duration.between(now, deadline);
                 currentRequest = durationLimiter.apply(currentRequest, remainingTime);
 


### PR DESCRIPTION
**Goals (and why)**:
- Fix internal issues reported on internal help channel.
- We have some users of v2 lock directly that use a timeout of 0.

**Implementation Description (bullets)**:
- Change `isBefore()` to `!isAfter()` to support zero timeouts
- Drive-by fix of a funky race condition in the clock logic that could also cause us to throw the NPE when we shouldn't.
- Restrict timeouts to be nonnegative - negative timeouts are awkward and I don't have a use case handy

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Added a test for a request with zero timeout.

**Concerns (what feedback would you like?)**:
- Nothing in particular.

**Where should we start reviewing?**:
- BlockEnforcingLockServiceTest.java

**Priority (whenever / two weeks / yesterday)**: yesterday 🔥 

