### PR TITLE
Reduce retained memory in delete executor work queue

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -1935,8 +1935,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     private static void deleteCells(
             KeyValueService keyValueService,
             TableReference tableRef,
-            Map<Cell, Long> keysToDelete
-    ) {
+            Map<Cell, Long> keysToDelete) {
         try {
             log.debug("For table: {} we are deleting values of an uncommitted transaction: {}",
                     LoggingArgs.tableRef(tableRef),

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -1917,7 +1917,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         }
 
         try {
-            deleteExecutor.execute(() -> deleteCells(tableRef, keysToDelete));
+        deleteExecutor.execute(() -> deleteCells(keyValueService, tableRef, keysToDelete));
         } catch (RejectedExecutionException rejected) {
             log.info("Could not delete keys {} for table {}, because the delete executor's queue was full."
                     + " Sweep should eventually clean these values.",
@@ -1928,7 +1928,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         return true;
     }
 
-    private void deleteCells(TableReference tableRef, Map<Cell, Long> keysToDelete) {
+    private static void deleteCells(KeyValueService keyValueService, TableReference tableRef, Map<Cell, Long> keysToDelete) {
         try {
             log.debug("For table: {} we are deleting values of an uncommitted transaction: {}",
                     LoggingArgs.tableRef(tableRef),

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -1928,7 +1928,15 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         return true;
     }
 
-    private static void deleteCells(KeyValueService keyValueService, TableReference tableRef, Map<Cell, Long> keysToDelete) {
+    /**
+     * This method is made static so it loses reference to the SnapshotTransaction reference
+     * when passed to deleteExecutor::execute in a lambda reducing its retained memory size.
+     */
+    private static void deleteCells(
+            KeyValueService keyValueService,
+            TableReference tableRef,
+            Map<Cell, Long> keysToDelete
+    ) {
         try {
             log.debug("For table: {} we are deleting values of an uncommitted transaction: {}",
                     LoggingArgs.tableRef(tableRef),

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -1917,7 +1917,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         }
 
         try {
-        deleteExecutor.execute(() -> deleteCells(keyValueService, tableRef, keysToDelete));
+            deleteExecutor.execute(() -> deleteCells(keyValueService, tableRef, keysToDelete));
         } catch (RejectedExecutionException rejected) {
             log.info("Could not delete keys {} for table {}, because the delete executor's queue was full."
                     + " Sweep should eventually clean these values.",

--- a/changelog/@unreleased/pr-4656.v2.yml
+++ b/changelog/@unreleased/pr-4656.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: |
+    The retained memory in delete executor work queue is reduced. Previously, each runnable in deleteExecutor had SnapshotTransaction reference, which could mean a lot of memory was unnecessarily retained.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4656


### PR DESCRIPTION
**Goals (and why)**:
reduce the retained size of the `deleteExecutor` work queue. Each runnable in `deleteExecutor` currently has a reference to `this`, which is a `SnapshotTransaction` and can be potentially huge.

**Implementation Description (bullets)**:
- make `deleteCells`, the only method passed to `deleteExecutor::execute` in a lambda, be static so the lambda object will lose the `SnapshotTransaction` reference, reducing its retained memory size.

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
