### PR TITLE
Async Metrics

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/AtlasDbMetrics.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/AtlasDbMetrics.java
@@ -75,12 +75,10 @@ public final class AtlasDbMetrics {
             TaggedMetricRegistry taggedMetrics,
             Class<T> serviceInterface,
             U service) {
-        return Instrumentation.builder(serviceInterface, service)
-                .withHandler(new TaggedMetricsInvocationEventHandler(
-                        taggedMetrics,
-                        MetricRegistry.name(serviceInterface)))
-                .withPerformanceTraceLogging()
-                .build();
+        return buildInstrumentation(
+                serviceInterface,
+                service,
+                new TaggedMetricsInvocationEventHandler(taggedMetrics, MetricRegistry.name(serviceInterface)));
     }
 
     public static <T, U extends T> T instrumentWithTaggedMetrics(
@@ -88,9 +86,21 @@ public final class AtlasDbMetrics {
             Class<T> serviceInterface,
             U service,
             Function<InvocationContext, Map<String, String>> tagFunction) {
-        String name = MetricRegistry.name(serviceInterface);
+        return buildInstrumentation(
+                serviceInterface,
+                service,
+                new TaggedMetricsInvocationEventHandler(
+                        taggedMetrics,
+                        MetricRegistry.name(serviceInterface),
+                        tagFunction));
+    }
+
+    private static <T, U extends T> T buildInstrumentation(
+            Class<T> serviceInterface,
+            U service,
+            TaggedMetricsInvocationEventHandler handler) {
         return Instrumentation.builder(serviceInterface, service)
-                .withHandler(new TaggedMetricsInvocationEventHandler(taggedMetrics, name, tagFunction))
+                .withHandler(handler)
                 .withPerformanceTraceLogging()
                 .build();
     }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/AtlasDbMetrics.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/AtlasDbMetrics.java
@@ -75,10 +75,12 @@ public final class AtlasDbMetrics {
             TaggedMetricRegistry taggedMetrics,
             Class<T> serviceInterface,
             U service) {
-        return buildInstrumentation(
-                serviceInterface,
-                service,
-                new TaggedMetricsInvocationEventHandler(taggedMetrics, MetricRegistry.name(serviceInterface)));
+        return Instrumentation.builder(serviceInterface, service)
+                .withHandler(new TaggedMetricsInvocationEventHandler(
+                        taggedMetrics,
+                        MetricRegistry.name(serviceInterface)))
+                .withPerformanceTraceLogging()
+                .build();
     }
 
     public static <T, U extends T> T instrumentWithTaggedMetrics(
@@ -86,21 +88,11 @@ public final class AtlasDbMetrics {
             Class<T> serviceInterface,
             U service,
             Function<InvocationContext, Map<String, String>> tagFunction) {
-        return buildInstrumentation(
-                serviceInterface,
-                service,
-                new TaggedMetricsInvocationEventHandler(
+        return Instrumentation.builder(serviceInterface, service)
+                .withHandler(new TaggedMetricsInvocationEventHandler(
                         taggedMetrics,
                         MetricRegistry.name(serviceInterface),
-                        tagFunction));
-    }
-
-    private static <T, U extends T> T buildInstrumentation(
-            Class<T> serviceInterface,
-            U service,
-            TaggedMetricsInvocationEventHandler handler) {
-        return Instrumentation.builder(serviceInterface, service)
-                .withHandler(handler)
+                        tagFunction))
                 .withPerformanceTraceLogging()
                 .build();
     }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/AtlasDbMetrics.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/AtlasDbMetrics.java
@@ -74,15 +74,24 @@ public final class AtlasDbMetrics {
     public static <T, U extends T> T instrumentWithTaggedMetrics(
             TaggedMetricRegistry taggedMetrics,
             Class<T> serviceInterface,
+            U service) {
+        return Instrumentation.builder(serviceInterface, service)
+                .withHandler(new TaggedMetricsInvocationEventHandler(
+                        taggedMetrics,
+                        MetricRegistry.name(serviceInterface)))
+                .withPerformanceTraceLogging()
+                .build();
+    }
+
+    public static <T, U extends T> T instrumentWithTaggedMetrics(
+            TaggedMetricRegistry taggedMetrics,
+            Class<T> serviceInterface,
             U service,
-            String name,
             Function<InvocationContext, Map<String, String>> tagFunction) {
+        String name = MetricRegistry.name(serviceInterface);
         return Instrumentation.builder(serviceInterface, service)
                 .withHandler(new TaggedMetricsInvocationEventHandler(taggedMetrics, name, tagFunction))
-                .withLogging(
-                        LoggerFactory.getLogger("performance." + name),
-                        LoggingLevel.TRACE,
-                        LoggingInvocationEventHandler.LOG_DURATIONS_GREATER_THAN_1_MICROSECOND)
+                .withPerformanceTraceLogging()
                 .build();
     }
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/TaggedMetricsInvocationEventHandler.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/TaggedMetricsInvocationEventHandler.java
@@ -106,7 +106,9 @@ public class TaggedMetricsInvocationEventHandler extends AbstractInvocationEvent
             return;
         }
 
-        if (result != null && ListenableFuture.class.isAssignableFrom(context.getMethod().getReturnType())) {
+        if (result != null
+                && ListenableFuture.class.isAssignableFrom(context.getMethod().getReturnType())
+                && ListenableFuture.class.isAssignableFrom(result.getClass())) {
             Futures.addCallback((ListenableFuture<?>) result, new FutureCallback<Object>() {
                         @Override
                         public void onSuccess(@NullableDecl Object result) {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/TaggedMetricsInvocationEventHandler.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/TaggedMetricsInvocationEventHandler.java
@@ -33,7 +33,6 @@ import org.slf4j.LoggerFactory;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.google.common.collect.Maps;
-import com.google.common.util.concurrent.FluentFuture;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -108,12 +107,6 @@ public class TaggedMetricsInvocationEventHandler extends AbstractInvocationEvent
         }
 
         if (result != null && ListenableFuture.class.isAssignableFrom(context.getMethod().getReturnType())) {
-            FluentFuture.from((ListenableFuture<?>) result)
-                    .transform(s -> s, MoreExecutors.directExecutor())
-                    .catchingAsync(Throwable.class, t -> {
-                        TaggedMetricsInvocationEventHandler.this.onFailure(context, t);
-                        return Futures.immediateFailedFuture(t);
-                    }, MoreExecutors.directExecutor());
             Futures.addCallback((ListenableFuture<?>) result, new FutureCallback<Object>() {
                         @Override
                         public void onSuccess(@NullableDecl Object result) {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/TaggedMetricsInvocationEventHandler.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/TaggedMetricsInvocationEventHandler.java
@@ -17,16 +17,21 @@ package com.palantir.atlasdb.util;
 
 import java.lang.reflect.Method;
 import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import org.immutables.value.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.google.common.collect.Maps;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.tritium.event.AbstractInvocationEventHandler;
@@ -48,7 +53,26 @@ public class TaggedMetricsInvocationEventHandler extends AbstractInvocationEvent
     private final TaggedMetricRegistry taggedMetricRegistry;
     private final String serviceName;
 
-    private final Function<InvocationContext, Map<String, String>> tagFunction;
+    private final Optional<Function<InvocationContext, Map<String, String>>> tagFunction;
+
+    @Nullable
+    private final Function<Method, Timer> onSuccessTimerMappingFunctionUntagged;
+    private final ConcurrentMap<Method, Timer> untaggedTimerCache = Maps.newConcurrentMap();
+
+    @Nullable
+    private final Function<MethodWithExtraTags, Timer> onSuccessTimerMappingFunctionExtraTags;
+    private final ConcurrentMap<MethodWithExtraTags, Timer> extraTagsTimerCache = Maps.newConcurrentMap();
+
+    public TaggedMetricsInvocationEventHandler(TaggedMetricRegistry taggedMetricRegistry, String serviceName) {
+        super(InstrumentationUtils.getEnabledSupplier(serviceName));
+        this.taggedMetricRegistry = Preconditions.checkNotNull(taggedMetricRegistry, "metricRegistry");
+        this.serviceName = Preconditions.checkNotNull(serviceName, "serviceName");
+        this.tagFunction = Optional.empty();
+        this.onSuccessTimerMappingFunctionUntagged = method -> taggedMetricRegistry.timer(MetricName.builder()
+                .safeName(MetricRegistry.name(serviceName, method.getName()))
+                .build());
+        this.onSuccessTimerMappingFunctionExtraTags = null;
+    }
 
     public TaggedMetricsInvocationEventHandler(
             TaggedMetricRegistry taggedMetricRegistry,
@@ -57,7 +81,12 @@ public class TaggedMetricsInvocationEventHandler extends AbstractInvocationEvent
         super(InstrumentationUtils.getEnabledSupplier(serviceName));
         this.taggedMetricRegistry = Preconditions.checkNotNull(taggedMetricRegistry, "metricRegistry");
         this.serviceName = Preconditions.checkNotNull(serviceName, "serviceName");
-        this.tagFunction = tagFunction;
+        this.tagFunction = Optional.of(tagFunction);
+        this.onSuccessTimerMappingFunctionUntagged = null;
+        this.onSuccessTimerMappingFunctionExtraTags = methodAndTags -> taggedMetricRegistry.timer(MetricName.builder()
+                .safeName(MetricRegistry.name(serviceName, methodAndTags.method().getName()))
+                .putAllSafeTags(methodAndTags.extraTags())
+                .build());
     }
 
     @Override
@@ -73,11 +102,34 @@ public class TaggedMetricsInvocationEventHandler extends AbstractInvocationEvent
         }
 
         long nanos = System.nanoTime() - context.getStartTimeNanos();
-        MetricName finalMetricName = MetricName.builder()
-                .safeName(MetricRegistry.name(serviceName, context.getMethod().getName()))
-                .putAllSafeTags(tagFunction.apply(context))
-                .build();
-        taggedMetricRegistry.timer(finalMetricName).update(nanos, TimeUnit.NANOSECONDS);
+        getSuccessTimer(context).update(nanos, TimeUnit.NANOSECONDS);
+    }
+
+    private Timer getSuccessTimer(InvocationContext context) {
+        if (tagFunction.isPresent()) {
+            Map<String, String> extraTags = tagFunction.get().apply(context);
+            return getSuccessTimerExtraTags(ImmutableMethodWithExtraTags.of(context.getMethod(), extraTags));
+        } else {
+            return getSuccessTimerUntagged(context.getMethod());
+        }
+    }
+
+    private Timer getSuccessTimerUntagged(Method method) {
+        Preconditions.checkNotNull(onSuccessTimerMappingFunctionUntagged);
+        return untaggedTimerCache.computeIfAbsent(method, onSuccessTimerMappingFunctionUntagged);
+    }
+
+    private Timer getSuccessTimerExtraTags(MethodWithExtraTags methodWithExtraTags) {
+        Preconditions.checkNotNull(onSuccessTimerMappingFunctionExtraTags);
+        return extraTagsTimerCache.computeIfAbsent(methodWithExtraTags, onSuccessTimerMappingFunctionExtraTags);
+    }
+
+    @Value.Immutable
+    interface MethodWithExtraTags {
+        @Value.Parameter
+        Method method();
+        @Value.Parameter
+        Map<String, String> extraTags();
     }
 
     @Override
@@ -95,7 +147,6 @@ public class TaggedMetricsInvocationEventHandler extends AbstractInvocationEvent
         taggedMetricRegistry.meter(MetricName.builder().safeName(
                 MetricRegistry.name(failuresMetricName, cause.getClass().getName())).build())
                 .mark();
-
     }
 
     private void markGlobalFailure() {

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/util/AtlasDbMetricsTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/util/AtlasDbMetricsTest.java
@@ -17,12 +17,32 @@ package com.palantir.atlasdb.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
+import org.awaitility.Awaitility;
+import org.junit.After;
 import org.junit.Test;
 
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Snapshot;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.atlasdb.metrics.Timed;
+import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
+import com.palantir.tritium.metrics.registry.MetricName;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 
 public final class AtlasDbMetricsTest {
 
@@ -32,6 +52,7 @@ public final class AtlasDbMetricsTest {
     private static final String PING_REQUEST_METRIC = MetricRegistry.name(TestService.class, PING_METHOD);
     private static final String PING_NOT_TIMED_METRIC = MetricRegistry.name(TestService.class, PING_NOT_TIMED_METHOD);
     private static final String PING_RESPONSE = "pong";
+    private static final Duration ASYNC_DURATION_TTL = Duration.ofSeconds(2);
 
     private final MetricRegistry metrics = new MetricRegistry();
     private final TestService testService = new TestService() {
@@ -46,6 +67,16 @@ public final class AtlasDbMetricsTest {
         }
     };
     private final TestService testServiceDelegate = (TestServiceAutoDelegate) () -> testService;
+
+    private final ListeningScheduledExecutorService executorService = MoreExecutors.listeningDecorator(Executors.newSingleThreadScheduledExecutor());
+    private final TaggedMetricRegistry taggedMetrics = new DefaultTaggedMetricRegistry();
+    private final AsyncTestService asyncTestService =
+            () -> executorService.schedule(() -> "pong", ASYNC_DURATION_TTL.toMillis(), TimeUnit.MILLISECONDS);
+
+    @After
+    public void tearDown() {
+        executorService.shutdown();
+    }
 
     @Test
     public void instrumentWithDefaultNameTimedDoesNotWorkWithDelegates() {
@@ -91,6 +122,77 @@ public final class AtlasDbMetricsTest {
         assertMethodInstrumented(MetricRegistry.name(CUSTOM_METRIC_NAME, PING_NOT_TIMED_METHOD), service::pingNotTimed);
     }
 
+    @Test
+    public void instrumentTaggedAsyncFunction() throws InterruptedException, ExecutionException {
+        AsyncTestService asyncTestService = AtlasDbMetrics.instrumentWithTaggedMetrics(taggedMetrics,
+                AsyncTestService.class, this.asyncTestService);
+
+        String asyncPingMetricName = MetricRegistry.name(AsyncTestService.class, "asyncPing");
+        assertTimerNotRegistered(asyncPingMetricName);
+
+        List<ListenableFuture<String>> futures = IntStream.range(0, 10)
+                .mapToObj($ -> asyncTestService.asyncPing())
+                .collect(Collectors.toList());
+
+        Instant now = Instant.now();
+        MetricName metricName = MetricName.builder().safeName(asyncPingMetricName).build();
+        ListenableFuture<Boolean> done = Futures.whenAllSucceed(futures).call(() -> {
+            // have to do it this because we can't edit the future we get back and it's only a callback as opposed to a
+            // transformed future
+            Awaitility.await()
+                    .atMost(ASYNC_DURATION_TTL.toMillis(), TimeUnit.MILLISECONDS)
+                    .until(() -> taggedMetrics.timer(metricName).getSnapshot().size() > 0);
+            return true;
+        }, MoreExecutors.directExecutor());
+
+        assertThat(done.get()).isEqualTo(true);
+
+        assertThat(done.get()).isEqualTo(true);
+        assertThat(Instant.now())
+                .as("in the event of scheduling issues, and despite having 10 concurrent futures, we complete "
+                        + "everything with 2*ttl")
+                .isBefore(now.plus(ASYNC_DURATION_TTL.plus(ASYNC_DURATION_TTL)));
+        Snapshot snapshot = taggedMetrics.timer(metricName).getSnapshot();
+        assertThat(Duration.ofNanos(snapshot.getMin())).isGreaterThan(ASYNC_DURATION_TTL);
+        assertThat(snapshot.size()).isEqualTo(10);
+    }
+
+    @Test
+    public void instrumentTaggedAsyncFunctionWithExtraTags() throws InterruptedException, ExecutionException {
+        Map<String, String> extraTags = ImmutableMap.of("key", "value");
+        AsyncTestService asyncTestService = AtlasDbMetrics.instrumentWithTaggedMetrics(
+                taggedMetrics,
+                AsyncTestService.class,
+                this.asyncTestService,
+                $ -> extraTags);
+
+        String asyncPingMetricName = MetricRegistry.name(AsyncTestService.class, "asyncPing");
+
+        List<ListenableFuture<String>> futures = IntStream.range(0, 10)
+                .mapToObj($ -> asyncTestService.asyncPing())
+                .collect(Collectors.toList());
+
+        Instant now = Instant.now();
+        MetricName metricName = MetricName.builder().safeName(asyncPingMetricName).safeTags(extraTags).build();
+        ListenableFuture<Boolean> done = Futures.whenAllSucceed(futures).call(() -> {
+            // have to do it this because we can't edit the future we get back and it's only a callback as opposed to a
+            // transformed future
+            Awaitility.await()
+                    .atMost(ASYNC_DURATION_TTL.toMillis(), TimeUnit.MILLISECONDS)
+                    .until(() -> taggedMetrics.timer(metricName).getSnapshot().size() > 0);
+            return true;
+        }, MoreExecutors.directExecutor());
+
+        assertThat(done.get()).isEqualTo(true);
+        assertThat(Instant.now())
+                .as("in the event of scheduling issues, and despite having 10 concurrent futures, we complete "
+                        + "everything with 2*ttl")
+                .isBefore(now.plus(ASYNC_DURATION_TTL.plus(ASYNC_DURATION_TTL)));
+        Snapshot snapshot = taggedMetrics.timer(metricName).getSnapshot();
+        assertThat(Duration.ofNanos(snapshot.getMin())).isGreaterThan(ASYNC_DURATION_TTL);
+        assertThat(snapshot.size()).isEqualTo(10);
+    }
+
     private void assertMethodInstrumented(
             String methodTimerName,
             Supplier<String> invocation) {
@@ -127,6 +229,10 @@ public final class AtlasDbMetricsTest {
         String ping();
 
         String pingNotTimed();
+    }
+
+    public interface AsyncTestService {
+        ListenableFuture<String> asyncPing();
     }
 
     public interface TestServiceAutoDelegate extends TestService {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
@@ -20,10 +20,8 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
-import com.codahale.metrics.MetricRegistry;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
-import com.google.common.collect.ImmutableMap;
 import com.palantir.atlasdb.config.AuxiliaryRemotingParameters;
 import com.palantir.atlasdb.config.ServerListConfig;
 import com.palantir.atlasdb.http.v2.ConjureJavaRuntimeTargetFactory;
@@ -101,12 +99,7 @@ public final class AtlasDbHttpClients {
             TaggedMetricRegistry taggedMetricRegistry,
             TargetFactory.InstanceAndVersion<T> client,
             Class<T> clazz) {
-        return AtlasDbMetrics.instrumentWithTaggedMetrics(
-                taggedMetricRegistry,
-                clazz,
-                client.instance(),
-                MetricRegistry.name(clazz),
-                $ -> ImmutableMap.of());
+        return AtlasDbMetrics.instrumentWithTaggedMetrics(taggedMetricRegistry, clazz, client.instance());
     }
 
     /**

--- a/changelog/@unreleased/pr-4661.v2.yml
+++ b/changelog/@unreleased/pr-4661.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Methods returning `ListenableFuture`s now have their metrics accurately
+    tracked.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4661

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClients.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClients.java
@@ -24,8 +24,6 @@ import javax.ws.rs.Path;
 
 import org.immutables.value.Value;
 
-import com.codahale.metrics.MetricRegistry;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HostAndPort;
 import com.palantir.atlasdb.config.AuxiliaryRemotingParameters;
 import com.palantir.atlasdb.config.RemotingClientConfigs;
@@ -128,12 +126,7 @@ public abstract class PaxosRemoteClients {
                                 .remotingClientConfig(() -> RemotingClientConfigs.DEFAULT)
                                 .shouldSupportBlockingOperations(false)
                                 .build()))
-                .map(proxy -> AtlasDbMetrics.instrumentWithTaggedMetrics(
-                        metrics(),
-                        clazz,
-                        proxy,
-                        MetricRegistry.name(clazz),
-                        _unused -> ImmutableMap.of()))
+                .map(proxy -> AtlasDbMetrics.instrumentWithTaggedMetrics(metrics(), clazz, proxy))
                 .mapKeys(PaxosRemoteClients::convertAddressToHostAndPort);
     }
 

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/TimelockLeadershipMetrics.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/TimelockLeadershipMetrics.java
@@ -23,7 +23,6 @@ import java.util.function.Predicate;
 
 import org.immutables.value.Value;
 
-import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.SetMultimap;
@@ -65,7 +64,6 @@ public abstract class TimelockLeadershipMetrics implements Dependencies.Leadersh
                 metrics().clientScopedMetrics().metricRegistryForClient(proxyClient()),
                 clazz,
                 instance,
-                MetricRegistry.name(clazz),
                 _context -> ImmutableMap.of(
                         AtlasDbMetricNames.TAG_CURRENT_SUSPECTED_LEADER, String.valueOf(localPingableLeader().ping())));
     }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/TimelockPaxosMetrics.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/TimelockPaxosMetrics.java
@@ -16,13 +16,11 @@
 
 package com.palantir.atlasdb.timelock.paxos;
 
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.immutables.value.Value;
 
 import com.codahale.metrics.MetricRegistry;
-import com.google.common.collect.ImmutableMap;
 import com.palantir.atlasdb.AtlasDbMetricNames;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
 import com.palantir.atlasdb.util.MetricsManager;
@@ -58,23 +56,14 @@ public abstract class TimelockPaxosMetrics {
     }
 
     public <T, U extends T> T instrument(Class<T> clazz, U instance) {
-        Map<String, String> tags = ImmutableMap.of();
-        return AtlasDbMetrics.instrumentWithTaggedMetrics(
-                metrics(),
-                clazz,
-                instance,
-                MetricRegistry.name(clazz),
-                _context -> tags);
+        return AtlasDbMetrics.instrumentWithTaggedMetrics(metrics(), clazz, instance);
     }
 
     public <T, U extends T> T instrument(Class<T> clazz, U instance, Client client) {
-        Map<String, String> tags = ImmutableMap.of();
         return AtlasDbMetrics.instrumentWithTaggedMetrics(
                 clientScopedMetrics().metricRegistryForClient(client),
                 clazz,
-                instance,
-                MetricRegistry.name(clazz),
-                _context -> tags);
+                instance);
     }
 
     private void attachToParentMetricRegistry(TaggedMetricRegistry parent) {


### PR DESCRIPTION
**Goals (and why)**:
As part of some of the conjure-undertow changes, async versions of requests were added. The sad part is, the metrics as we know currently are off since they measure the time it takes to be given back the `ListenableFuture` vs how long the `ListenableFuture` takes to complete.

Ideally this would go in https://github.com/palantir/tritium, but given that we've hacked together the `TaggedMetricsInvocationHandler` for our own (nefarious?) gains, I didn't want to unwind that change as I'm working on Timelock Partitioning etc. @schlosna for SA. My proposed impl would be that it goes in `ByteBuddyInstrumentationAdvice` or `InvocationEventProxy` then every `InvocationHandler` gets async metrics stuff for free!

**Implementation Description (bullets)**:
* Backport some of the metrics changes in the `TaggedMetricsInvocationHandler` wrt metric name cache etc. Since the metric name doesn't change for most invocations we're wasting time doing the string concat and the allocations for `MetricName`. For the ones with the extra tags, have a specialised cache for those calls.
* Check if the return type is `ListenableFuture` and if so, add a `listener` that will update the metric. Otherwise we leave it as is.

**Testing (What was existing testing like?  What have you done to improve it?)**:
* Hard to test properly since we can't change the future that gets returned, we can only act on it => we can have a race condition where if we were to wait for the future to be done, it's not necessarily the case that the metrics would have been tracked correctly. Only fix I see for this is in upstream in tritium.

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:
* `TaggedMetricsEventInvocationHandler`
* `AtlasDbMetrics`

**Priority (whenever / two weeks / yesterday)**:
ASAP! Some metrics in our internal dashboard is a lie until fixed.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
