### PR TITLE
[Timelock Partitioning] Part 54: Add namespace distribution tracker

### DIFF
--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/MultiLeaderNamespaceDistributionTracker.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/MultiLeaderNamespaceDistributionTracker.java
@@ -1,0 +1,55 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.immutables.value.Value;
+
+import com.palantir.timelock.paxos.NamespaceTracker;
+
+public final class MultiLeaderNamespaceDistributionTracker {
+    private final NamespaceTracker namespaceTracker;
+    private final BatchPingableLeader localBatchPingableLeader;
+
+    public MultiLeaderNamespaceDistributionTracker(
+            NamespaceTracker namespaceTracker,
+            BatchPingableLeader localBatchPingableLeader) {
+        this.namespaceTracker = namespaceTracker;
+        this.localBatchPingableLeader = localBatchPingableLeader;
+    }
+
+    public NamespaceDistribution getCurrentNodeNamespaceDistribution() {
+        Set<Client> trackedNamespaces = namespaceTracker.trackedNamespaces();
+        List<Client> clientsLedByThisNode = localBatchPingableLeader.ping(trackedNamespaces).stream()
+                .sorted(Comparator.comparing(Client::value))
+                .collect(Collectors.toList());
+        return ImmutableNamespaceDistribution.builder()
+                .addAllNamespacesLed(clientsLedByThisNode)
+                .numberOfTrackedNamespaces(trackedNamespaces.size())
+                .build();
+    }
+
+    @Value.Immutable
+    public interface NamespaceDistribution {
+        List<Client> namespacesLed();
+        int numberOfTrackedNamespaces();
+    }
+}

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResources.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResources.java
@@ -33,7 +33,7 @@ public abstract class PaxosResources {
 
     public abstract Factory<ManagedTimestampService> timestampServiceFactory();
     abstract LocalPaxosComponents timestampPaxosComponents();
-    abstract Map<PaxosUseCase, LocalPaxosComponents> leadershipBatchComponents();
+    public abstract Map<PaxosUseCase, LocalPaxosComponents> leadershipBatchComponents();
     abstract LeadershipContextFactory leadershipContextFactory();
     abstract List<Object> adhocResources();
 

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -28,6 +28,7 @@ import com.codahale.metrics.InstrumentedThreadFactory;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Suppliers;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.palantir.atlasdb.AtlasDbMetricNames;
 import com.palantir.atlasdb.config.ImmutableLeaderConfig;
 import com.palantir.atlasdb.http.BlockingTimeoutExceptionMapper;
 import com.palantir.atlasdb.http.NotCurrentLeaderExceptionMapper;
@@ -42,15 +43,20 @@ import com.palantir.atlasdb.timelock.lock.LockLog;
 import com.palantir.atlasdb.timelock.lock.watch.LockWatchTestingService;
 import com.palantir.atlasdb.timelock.paxos.Client;
 import com.palantir.atlasdb.timelock.paxos.ImmutableTimelockPaxosInstallationContext;
+import com.palantir.atlasdb.timelock.paxos.LocalPaxosComponents;
+import com.palantir.atlasdb.timelock.paxos.MultiLeaderNamespaceDistributionTracker;
 import com.palantir.atlasdb.timelock.paxos.PaxosResources;
 import com.palantir.atlasdb.timelock.paxos.PaxosResourcesFactory;
+import com.palantir.atlasdb.timelock.paxos.PaxosUseCase;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.undertow.lib.UndertowService;
 import com.palantir.leader.PaxosLeaderElectionService;
 import com.palantir.lock.LockService;
+import com.palantir.logsafe.Preconditions;
 import com.palantir.timelock.config.DatabaseTsBoundPersisterConfiguration;
+import com.palantir.timelock.config.PaxosInstallConfiguration.PaxosLeaderMode;
 import com.palantir.timelock.config.PaxosTsBoundPersisterConfiguration;
 import com.palantir.timelock.config.TimeLockInstallConfiguration;
 import com.palantir.timelock.config.TimeLockRuntimeConfiguration;
@@ -58,6 +64,7 @@ import com.palantir.timelock.config.TsBoundPersisterConfiguration;
 import com.palantir.timelock.invariants.NoSimultaneousServiceCheck;
 import com.palantir.timelock.invariants.TimeLockActivityCheckerFactory;
 import com.palantir.timestamp.ManagedTimestampService;
+import com.palantir.tritium.metrics.registry.MetricName;
 
 @SuppressWarnings("checkstyle:FinalClass") // This is mocked internally
 public class TimeLockAgent {
@@ -76,6 +83,7 @@ public class TimeLockAgent {
 
     private LeaderPingHealthCheck healthCheck;
     private TimelockNamespaces namespaces;
+    private Optional<MultiLeaderNamespaceDistributionTracker> namespaceDistributionTracker = Optional.empty();
 
     public static TimeLockAgent create(
             MetricsManager metricsManager,
@@ -171,6 +179,23 @@ public class TimeLockAgent {
                 this::createInvalidatingTimeLockServices,
                 Suppliers.compose(TimeLockRuntimeConfiguration::maxNumberOfClients, runtime::get));
 
+        if (install.paxos().leaderMode() == PaxosLeaderMode.LEADER_PER_CLIENT) {
+            LocalPaxosComponents paxosComponents = Preconditions.checkNotNull(
+                    paxosResources.leadershipBatchComponents().get(PaxosUseCase.LEADER_FOR_EACH_CLIENT),
+                    "Timelock setup has gone awfully wrong, this is a bug.");
+
+            MultiLeaderNamespaceDistributionTracker tracker = new MultiLeaderNamespaceDistributionTracker(
+                    namespaces::getActiveClients,
+                    paxosComponents.batchPingableLeader());
+            MetricName metricName = MetricName.builder()
+                    .safeName("timelock-namespace-distribution-tracker.count")
+                    .putSafeTags(AtlasDbMetricNames.TAG_PAXOS_USE_CASE, PaxosUseCase.LEADER_FOR_EACH_CLIENT.name())
+                    .build();
+            metricsManager.getTaggedRegistry()
+                    .gauge(metricName, () -> tracker.getCurrentNodeNamespaceDistribution().namespacesLed().size());
+            namespaceDistributionTracker = Optional.of(tracker);
+        }
+
         // Finally, register the health check, and endpoints associated with the clients.
         TimeLockResource resource = TimeLockResource.create(namespaces);
         healthCheck = paxosResources.leadershipComponents().healthCheck(namespaces::getActiveClients);
@@ -198,6 +223,11 @@ public class TimeLockAgent {
         noSimultaneousServiceCheck.processHealthCheckDigest(status);
 
         return Optional.of(status);
+    }
+
+    @SuppressWarnings("unused") // used by internal timelock
+    public Optional<MultiLeaderNamespaceDistributionTracker> namespaceDistributionTracker() {
+        return namespaceDistributionTracker;
     }
 
     @SuppressWarnings({"unused", "WeakerAccess"}) // used by external health checks


### PR DESCRIPTION
**Goals (and why)**:
In order to validate any sort of balancing strategies that we might have/employ in the future, we need a way to introspect that the distribution is. Having this also can sometimes give a more detailed view as to why a leader might be performing a lot slower relative to its peers i.e. heavily loaded etc.

**Implementation Description (bullets)**:
* Expose a metric that just emits how many namespaces a particular node is the leader for.
* Expose a tracker object that will be consumed by a health check in internal timelock. This will not only tell you how many namespaces a particular leader is leading, but it will also tell you which ones, which is a bit harder to grok in our internal metrics platform.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Class is fairly simple, didn't come up whilst I was iterating, but not sure there would be a valuable test.

**Concerns (what feedback would you like?)**:
None

**Where should we start reviewing?**:
* `MultiLeaderNamespaceDistributionTracker`

**Priority (whenever / two weeks / yesterday)**:
By the end of this week.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
