### PR TITLE
[Proof of Concept] TimeLock Partitioning: Single Leader Batched Paxos

### DIFF
--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/Factories.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/Factories.java
@@ -70,6 +70,32 @@ public interface Factories {
     }
 
     @Value.Immutable
+    abstract class PinningLeaderPingerFactory implements LeaderPingerFactoryContainer, Dependencies.LeaderPinger {
+
+        @Value.Derived
+        AutobatchingPingableLeaderFactory pingableLeaderFactory() {
+            return AutobatchingPingableLeaderFactory.create(
+                    Maps.toMap(remoteClients().batchPingableLeadersWithContext(), _pingableLeader -> sharedExecutor()),
+                    leaderPingRate(),
+                    leaderPingResponseWait(),
+                    leaderUuid());
+        }
+
+        @Override
+        public Factory<LeaderPinger> get() {
+            return $ -> pingableLeaderFactory().leaderPingerFor(PaxosUseCase.PSEUDO_LEADERSHIP_CLIENT);
+        }
+
+        @Override
+        @Value.Derived
+        public List<Closeable> closeables() {
+            return ImmutableList.of(pingableLeaderFactory());
+        }
+
+        public abstract static class Builder implements LeaderPingerFactoryContainer.Builder {}
+    }
+
+    @Value.Immutable
     abstract class SingleLeaderPingerFactory implements LeaderPingerFactoryContainer, Dependencies.LeaderPinger {
 
         @Value.Derived

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LegacyPaxosAcceptorShim.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LegacyPaxosAcceptorShim.java
@@ -1,0 +1,68 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import com.palantir.atlasdb.metrics.Timed;
+import com.palantir.paxos.BooleanPaxosResponse;
+import com.palantir.paxos.PaxosAcceptor;
+import com.palantir.paxos.PaxosPromise;
+import com.palantir.paxos.PaxosProposal;
+import com.palantir.paxos.PaxosProposalId;
+
+@Path("/" + PaxosTimeLockConstants.INTERNAL_NAMESPACE
+        + "/" + PaxosTimeLockConstants.LEADER_PAXOS_NAMESPACE
+        + "/acceptor")
+public class LegacyPaxosAcceptorShim {
+    private final PaxosAcceptor delegate;
+
+    public LegacyPaxosAcceptorShim(PaxosAcceptor delegate) {
+        this.delegate = delegate;
+    }
+
+    @POST
+    @Path("prepare/{seq}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Timed
+    public PaxosPromise prepare(@PathParam("seq") long seq, PaxosProposalId pid) {
+        return delegate.prepare(seq, pid);
+    }
+
+    @POST
+    @Path("accept/{seq}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Timed
+    public BooleanPaxosResponse accept(@PathParam("seq") long seq, PaxosProposal proposal) {
+        return delegate.accept(seq, proposal);
+    }
+
+    @POST // This is marked as a POST because we cannot accept stale or cached results for this method.
+    @Path("latest-sequence-prepared-or-accepted")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Timed
+    public long getLatestSequencePreparedOrAccepted() {
+        return delegate.getLatestSequencePreparedOrAccepted();
+    }
+}

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LegacyPaxosLearnerShim.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LegacyPaxosLearnerShim.java
@@ -1,0 +1,76 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import java.util.Collection;
+import java.util.Optional;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import com.palantir.atlasdb.metrics.Timed;
+import com.palantir.common.annotation.Inclusive;
+import com.palantir.paxos.PaxosLearner;
+import com.palantir.paxos.PaxosValue;
+
+@Path("/" + PaxosTimeLockConstants.INTERNAL_NAMESPACE
+        + "/" + PaxosTimeLockConstants.LEADER_PAXOS_NAMESPACE
+        + "/learner")
+public class LegacyPaxosLearnerShim {
+    private final PaxosLearner delegate;
+
+    public LegacyPaxosLearnerShim(PaxosLearner delegate) {
+        this.delegate = delegate;
+    }
+
+    @POST
+    @Path("learn/{seq:.+}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Timed
+    public void learn(@PathParam("seq") long seq, PaxosValue val) {
+        delegate.learn(seq, val);
+    }
+
+    @GET
+    @Path("learned-value/{seq:.+}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Timed
+    public Optional<PaxosValue> getLearnedValue(@PathParam("seq") long seq) {
+        return delegate.getLearnedValue(seq);
+    }
+
+    @GET
+    @Path("greatest-learned-value")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Timed
+    public Optional<PaxosValue> getGreatestLearnedValue() {
+        return delegate.getGreatestLearnedValue();
+    }
+
+    @GET
+    @Path("learned-values-since/{seq:.+}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Timed
+    public Collection<PaxosValue> getLearnedValuesSince(@PathParam("seq") @Inclusive long seq) {
+        return delegate.getLearnedValuesSince(seq);
+    }
+}

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResourcesFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResourcesFactory.java
@@ -143,8 +143,8 @@ public final class PaxosResourcesFactory {
                 .runtime(paxosRuntime)
                 .useCase(PaxosUseCase.LEADER_FOR_ALL_CLIENTS)
                 .metrics(timelockMetrics)
-                .networkClientFactoryBuilder(ImmutablePinningNetworkClientFactories.builder())
-                .leaderPingerFactoryBuilder(ImmutableBatchingLeaderPingerFactory.builder())
+                .networkClientFactoryBuilder(ImmutableSingleLeaderNetworkClientFactories.builder())
+                .leaderPingerFactoryBuilder(ImmutableSingleLeaderPingerFactory.builder())
                 .healthCheckPingersFactory(healthCheckPingersFactory)
                 .build();
 
@@ -153,11 +153,15 @@ public final class PaxosResourcesFactory {
                 .putLeadershipBatchComponents(PaxosUseCase.LEADER_FOR_ALL_CLIENTS, factory.components())
                 .addAdhocResources(new BatchPingableLeaderResource(install.nodeUuid(), factory.components()))
                 .addAdhocResources(
-                        // The following are nasty, but need to exist to avoid problems with the JAX-RS algorithm
-                        // picking resources before it identifies specific methods.
+//                        // The following are nasty, but need to exist to avoid problems with the JAX-RS algorithm
+//                        // picking resources before it identifies specific methods.
                         new LegacyPaxosAcceptorShim(
                                 factory.components().acceptor(PaxosUseCase.PSEUDO_LEADERSHIP_CLIENT)),
                         new LegacyPaxosLearnerShim(factory.components().learner(PaxosUseCase.PSEUDO_LEADERSHIP_CLIENT)),
+//                        new LeadershipResource(
+//                                factory.components().acceptor(PaxosUseCase.PSEUDO_LEADERSHIP_CLIENT),
+//                                factory.components().learner(PaxosUseCase.PSEUDO_LEADERSHIP_CLIENT)
+//                        ),
                         factory.components().pingableLeader(PaxosUseCase.PSEUDO_LEADERSHIP_CLIENT))
                 .build();
     }

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PinningNetworkClientFactories.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PinningNetworkClientFactories.java
@@ -1,0 +1,89 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import java.io.Closeable;
+import java.util.List;
+
+import org.immutables.value.Value;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.paxos.PaxosAcceptorNetworkClient;
+import com.palantir.paxos.PaxosLearnerNetworkClient;
+
+@Value.Immutable
+abstract class PinningNetworkClientFactories implements
+        NetworkClientFactories, Dependencies.NetworkClientFactories {
+
+    @Value.Auxiliary
+    @Value.Derived
+    AutobatchingPaxosAcceptorNetworkClientFactory acceptorNetworkClientFactory() {
+        BatchPaxosAcceptor local = components().batchAcceptor();
+        List<BatchPaxosAcceptor> remotes =
+                UseCaseAwareBatchPaxosAcceptorAdapter.wrap(useCase(), remoteClients().batchAcceptor());
+        List<BatchPaxosAcceptor> allBatchAcceptors = LocalAndRemotes.of(local, remotes)
+                .enhanceRemotes(remote -> metrics().instrument(BatchPaxosAcceptor.class, remote))
+                .all();
+
+        return AutobatchingPaxosAcceptorNetworkClientFactory.create(
+                allBatchAcceptors,
+                sharedExecutor(),
+                quorumSize());
+    }
+
+    @Value.Auxiliary
+    @Value.Derived
+    AutobatchingPaxosLearnerNetworkClientFactory learnerNetworkClientFactory() {
+        BatchPaxosLearner local = components().batchLearner();
+        List<BatchPaxosLearner> remotes =
+                UseCaseAwareBatchPaxosLearnerAdapter.wrap(useCase(), remoteClients().batchLearner());
+
+        LocalAndRemotes<BatchPaxosLearner> allBatchLearners = LocalAndRemotes.of(local, remotes)
+                .enhanceRemotes(remote -> metrics().instrument(BatchPaxosLearner.class, remote));
+
+        return AutobatchingPaxosLearnerNetworkClientFactory.create(
+                allBatchLearners,
+                sharedExecutor(),
+                quorumSize());
+    }
+
+    @Value.Auxiliary
+    @Value.Derived
+    @Override
+    public List<Closeable> closeables() {
+        return ImmutableList.of(acceptorNetworkClientFactory(), learnerNetworkClientFactory());
+    }
+
+    @Override
+    public Factory<PaxosAcceptorNetworkClient> acceptor() {
+        return $ -> metrics().instrument(
+                PaxosAcceptorNetworkClient.class,
+                acceptorNetworkClientFactory().paxosAcceptorForClient(PaxosUseCase.PSEUDO_LEADERSHIP_CLIENT),
+                PaxosUseCase.PSEUDO_LEADERSHIP_CLIENT);
+    }
+
+    @Override
+    public Factory<PaxosLearnerNetworkClient> learner() {
+        return $ -> metrics().instrument(
+                PaxosLearnerNetworkClient.class,
+                learnerNetworkClientFactory().paxosLearnerForClient(PaxosUseCase.PSEUDO_LEADERSHIP_CLIENT),
+                PaxosUseCase.PSEUDO_LEADERSHIP_CLIENT);
+    }
+
+    public abstract static class Builder implements NetworkClientFactories.Builder {}
+
+}

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosUseCase.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosUseCase.java
@@ -58,7 +58,7 @@ public enum PaxosUseCase {
         this.relativeLogDirectory = relativeLogDirectory;
     }
 
-    static final Client PSEUDO_LEADERSHIP_CLIENT = Client.of(PaxosTimeLockConstants.LEADER_PAXOS_NAMESPACE);
+    public static final Client PSEUDO_LEADERSHIP_CLIENT = Client.of(PaxosTimeLockConstants.LEADER_PAXOS_NAMESPACE);
 
     private final String useCasePath;
     private final Path relativeLogDirectory;

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -44,6 +44,7 @@ import com.palantir.atlasdb.timelock.api.ConjureUnlockRequest;
 import com.palantir.atlasdb.timelock.api.SuccessfulLockResponse;
 import com.palantir.atlasdb.timelock.api.UnsuccessfulLockResponse;
 import com.palantir.atlasdb.timelock.suite.MultiLeaderPaxosSuite;
+import com.palantir.atlasdb.timelock.suite.SingleLeaderPaxosSuite;
 import com.palantir.atlasdb.timelock.util.ExceptionMatchers;
 import com.palantir.atlasdb.timelock.util.ParameterInjector;
 import com.palantir.lock.LockDescriptor;
@@ -61,7 +62,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
 
     @ClassRule
     public static ParameterInjector<TestableTimelockCluster> injector =
-            ParameterInjector.withFallBackConfiguration(() -> MultiLeaderPaxosSuite.MULTI_LEADER_PAXOS);
+            ParameterInjector.withFallBackConfiguration(() -> SingleLeaderPaxosSuite.NON_BATCHED_TIMESTAMP_PAXOS);
 
     @Parameterized.Parameter
     public TestableTimelockCluster cluster;

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
@@ -36,6 +36,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.atlasdb.timelock.NamespacedClients.ProxyFactory;
 import com.palantir.atlasdb.timelock.paxos.BatchPingableLeader;
 import com.palantir.atlasdb.timelock.paxos.Client;
+import com.palantir.atlasdb.timelock.paxos.PaxosUseCase;
 import com.palantir.atlasdb.timelock.util.TestProxies;
 import com.palantir.atlasdb.timelock.util.TestProxies.ProxyMode;
 import com.palantir.conjure.java.api.config.service.UserAgents;


### PR DESCRIPTION
_More of a proof of concept: not intended for style review, or merging as is. If we decide this is the right approach, I can own breaking this into more manageable pieces and refactoring accordingly._

**Goals (and why)**:
- Allow testing of @felixdesouza's new smart clients for leadership checks, without necessarily introducing timelock partitioning entirely. **The method in this PR is sufficient for testing with a shutdown migration: it may NOT be suitable for rolling from existing single leader. Doing so may cause SEVERE DATA CORRUPTION™️ - need to check.  🔥**
- The idea is that we are able to evaluate a majority of the new features e.g. acceptor caches without committing to timelock partitioning. 
- It is also the goal, and I believe realistic, that we are able to get into this state without any downtime migrations (though no op schema bumps may be required). As mentioned what is written here as is requires a downtime migration!

**Implementation Description (bullets)**:
- Use all the new infra, but still establish a single leader. The `PinningFoo` classes are versions of `BatchingFoo` except the factories always point you at `PaxosUseCase.PSEUDO_LEADERSHIP_CLIENT`. Note that we can't change `BatchingFoo` because the behaviour of using whatever client is named is correct for timestamp bound Paxoses. There was copypasting here: we would probably refactor this more elegantly if we decide this approach is what we want to go with. I think this is still safe, since the use case is passed in as the legacy one.
- There is some nasty magic with `LegacyPaxos(Accepto|Learne)rShim` because of the way the JAX-RS algorithm works where it identifies which resource should be matched first, meaning that `LeadershipResource` would cause a lot of 404s.

**Testing (What was existing testing like?  What have you done to improve it?)**:
I verified MNPTLSIT for single leader (and clients using single leader methods, which the testsuite does).

**Concerns (what feedback would you like?)**:
Not so much at this stage. Is this along the lines of what we were expecting?

**Where should we start reviewing?**: `PaxosResourcesFactory`

**Priority (whenever / two weeks / yesterday)**: this week
