### PR TITLE
Optimize getRowsColumnRange

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -489,7 +489,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                             raw,
                             x -> x));
             return postFiltered.entrySet().iterator();
-        });
+        }));
     }
 
     private Iterator<Map.Entry<Cell, byte[]>> getRowColumnRangePostFiltered(

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -451,10 +451,10 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                     row.getValue(), entry -> Maps.immutableEntry(entry.getKey(), entry.getValue().getContents()));
             Iterator<Map.Entry<Cell, byte[]>> localIterator = localWrites.entrySet().iterator();
             return IteratorUtils.mergeIterators(localIterator,
-                            remoteIterator,
-                            Ordering.from(UnsignedBytes.lexicographicalComparator())
-                                    .onResultOf(entry -> entry.getKey().getColumnName()),
-                            from -> from.getLhSide());
+                    remoteIterator,
+                    Ordering.from(UnsignedBytes.lexicographicalComparator())
+                            .onResultOf(entry -> entry.getKey().getColumnName()),
+                    from -> from.getLhSide());
         }));
 
         return filterDeletedValues(merged, tableRef);
@@ -533,7 +533,8 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
      * that all columns for a single row are adjacent, so this method will return an {@link Iterator} with exactly one
      * entry per non-empty row.
      */
-    private Iterator<Map.Entry<byte[], RowColumnRangeIterator>> partitionByRow(Iterator<Map.Entry<Cell, Value>> rawResults) {
+    private Iterator<Map.Entry<byte[], RowColumnRangeIterator>> partitionByRow(
+            Iterator<Map.Entry<Cell, Value>> rawResults) {
         PeekingIterator<Map.Entry<Cell, Value>> peekableRawResults = Iterators.peekingIterator(rawResults);
         return new AbstractIterator<Map.Entry<byte[], RowColumnRangeIterator>>() {
             byte[] prevRowName;

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -62,6 +62,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.commons.lang3.mutable.MutableLong;
 import org.apache.commons.lang3.tuple.Pair;
+import org.assertj.core.api.Assertions;
 import org.hamcrest.Matchers;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
@@ -84,6 +85,7 @@ import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Multimaps;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -1169,6 +1171,59 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                         .transform(Map.Entry::getKey)
                         .immutableCopy());
         assertEquals(ImmutableList.of(firstCell, secondCell), cells);
+    }
+
+    @Test
+    public void testRowsColumnRangesSingleIteratorVersion() {
+        runTestForGetRowsColumnRangeSingleIteratorVersion(1, 1, 0);
+        runTestForGetRowsColumnRangeSingleIteratorVersion(1, 10, 0);
+        runTestForGetRowsColumnRangeSingleIteratorVersion(1, 100, 0);
+        runTestForGetRowsColumnRangeSingleIteratorVersion(10, 10, 0);
+        runTestForGetRowsColumnRangeSingleIteratorVersion(10, 1, 0);
+        runTestForGetRowsColumnRangeSingleIteratorVersion(100, 1, 0);
+        runTestForGetRowsColumnRangeSingleIteratorVersion(10, 10, 5);
+        runTestForGetRowsColumnRangeSingleIteratorVersion(10, 10, 10);
+        runTestForGetRowsColumnRangeSingleIteratorVersion(100, 100, 99);
+    }
+
+    private void runTestForGetRowsColumnRangeSingleIteratorVersion(
+            int numRows,
+            int numCellsPerRow,
+            int numDeletedCellsPerRow) {
+        List<byte[]> expectedRows = new ArrayList<>(numRows);
+        List<Cell> expectedCells = new ArrayList<>(numRows * numCellsPerRow);
+        List<Cell> expectedDeletedCells = new ArrayList<>(numRows * numCellsPerRow);
+        for (int iRow = 0; iRow < numRows; iRow++) {
+            String row = String.format("row%02d", iRow);
+            expectedRows.add(row.getBytes());
+            for (int iCell = 0; iCell < numCellsPerRow; iCell++) {
+                String cell = String.format("cell%02d", iCell);
+                if (iCell < numDeletedCellsPerRow) {
+                    expectedDeletedCells.add(Cell.create(row.getBytes(), cell.getBytes()));
+                } else {
+                    expectedCells.add(Cell.create(row.getBytes(), cell.getBytes()));
+                }
+            }
+        }
+        byte[] value = new byte[1];
+
+        serializableTxManager.runTaskWithRetry(tx -> {
+            tx.put(TABLE, Maps.toMap(expectedCells, ignored -> value));
+            return null;
+        });
+        keyValueService.addGarbageCollectionSentinelValues(TABLE, expectedDeletedCells);
+
+        List<Cell> cells = serializableTxManager.runTaskReadOnly(tx ->
+                ImmutableList.copyOf(Iterators.transform(
+                        tx.getRowsColumnRange(
+                                TABLE,
+                                expectedRows,
+                                new ColumnRangeSelection(null, null),
+                                10),
+                        Map.Entry::getKey)));
+        Assertions.assertThat(cells).isEqualTo(expectedCells);
+
+        keyValueService.truncateTable(TABLE);
     }
 
     @Test

--- a/changelog/@unreleased/pr-4668.v2.yml
+++ b/changelog/@unreleased/pr-4668.v2.yml
@@ -1,5 +1,6 @@
 type: improvement
 improvement:
-  description: We expect the performance of `getRowsColumnRange` to have been improved.
+  description: Performance of `getRowsColumnRange` has been improved, especially when
+    querying many rows at the same time.
   links:
   - https://github.com/palantir/atlasdb/pull/4668

--- a/changelog/@unreleased/pr-4668.v2.yml
+++ b/changelog/@unreleased/pr-4668.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: We expect the performance of `getRowsColumnRange` to have been improved.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4668


### PR DESCRIPTION
We're seeing perf issues internally on the random getRowsColumnRange
implementation that works better on Postgres and Oracle. This is the way
to make it both simpler, and faster.

This is an alternative to https://github.com/palantir/atlasdb/pull/4326.

Needs tests.