### PR TITLE
Lazy Initialization for ReplaceIfExceptionMatchingProxy

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/common/proxy/ReplaceIfExceptionMatchingProxy.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/proxy/ReplaceIfExceptionMatchingProxy.java
@@ -42,8 +42,7 @@ public final class ReplaceIfExceptionMatchingProxy<T> extends AbstractInvocation
     @Override
     protected Object handleInvocation(Object proxy, Method method, Object[] args) throws Throwable {
         try {
-            setUpDelegateIfNecessary();
-            return method.invoke(delegate, args);
+            return method.invoke(getAndPossiblyInitializeDelegate(), args);
         } catch (InvocationTargetException e) {
             Throwable cause = e.getCause();
             replaceIfNecessary(cause);
@@ -51,16 +50,17 @@ public final class ReplaceIfExceptionMatchingProxy<T> extends AbstractInvocation
         }
     }
 
-    private void setUpDelegateIfNecessary() {
+    private T getAndPossiblyInitializeDelegate() {
         T perceivedDelegate = delegate;
         if (perceivedDelegate == null) {
             synchronized (this) {
                 perceivedDelegate = delegate;
                 if (perceivedDelegate == null) {
-                    delegate = delegateFactory.get();
+                    perceivedDelegate = delegate = delegateFactory.get();
                 }
             }
         }
+        return perceivedDelegate;
     }
 
     private void replaceIfNecessary(Throwable thrown) {

--- a/atlasdb-commons/src/test/java/com/palantir/common/proxy/ReplaceIfExceptionMatchingProxyTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/common/proxy/ReplaceIfExceptionMatchingProxyTest.java
@@ -19,6 +19,7 @@ package com.palantir.common.proxy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -43,6 +44,15 @@ public class ReplaceIfExceptionMatchingProxyTest {
     @Before
     public void before() {
         when(supplier.get()).thenReturn(delegate);
+    }
+
+    @Test
+    public void lazilyInitialized() {
+        TestInterface iface = ReplaceIfExceptionMatchingProxy.newProxyInstance(
+                TestInterface.class, supplier, _thrown -> true);
+        verify(supplier, never()).get();
+        iface.doSomething();
+        verify(supplier, times(1)).get();
     }
 
     @Test

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
@@ -18,11 +18,9 @@ package com.palantir.atlasdb.http;
 import java.net.SocketTimeoutException;
 import java.time.Duration;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Suppliers;
 import com.palantir.atlasdb.config.AuxiliaryRemotingParameters;
 import com.palantir.atlasdb.config.ServerListConfig;
 import com.palantir.atlasdb.http.v2.ConjureJavaRuntimeTargetFactory;

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
@@ -111,7 +111,7 @@ public final class AtlasDbHttpClients {
     private static <T> T wrapWithOkHttpBugHandling(Class<T> type, Supplier<T> supplier) {
         return ReplaceIfExceptionMatchingProxy.create(
                 type,
-                supplier::get,
+                supplier,
                 Duration.ofMinutes(20),
                 AtlasDbHttpClients::isPossiblyOkHttpTimeoutBug);
     }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
@@ -16,6 +16,7 @@
 package com.palantir.atlasdb.http;
 
 import java.net.SocketTimeoutException;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
@@ -108,9 +109,10 @@ public final class AtlasDbHttpClients {
      * 2. At most once every 20 minutes
      */
     private static <T> T wrapWithOkHttpBugHandling(Class<T> type, Supplier<T> supplier) {
-        return ReplaceIfExceptionMatchingProxy.newProxyInstance(
+        return ReplaceIfExceptionMatchingProxy.create(
                 type,
-                Suppliers.memoizeWithExpiration(supplier::get, 20, TimeUnit.MINUTES),
+                supplier::get,
+                Duration.ofMinutes(20),
                 AtlasDbHttpClients::isPossiblyOkHttpTimeoutBug);
     }
 

--- a/changelog/@unreleased/pr-4669.v2.yml
+++ b/changelog/@unreleased/pr-4669.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: '`ReplaceIfExceptionMatchingProxy` is now lazy, allowing users that
+    manipulate static remoting-layer state to (generally) have static proxies again.
+    Previously these might be initialised before static state changes have gone through.'
+  links:
+  - https://github.com/palantir/atlasdb/pull/4669


### PR DESCRIPTION
**Goals (and why)**:
- Make `ReplaceIfExceptionMatchingProxy` lazy. Generally `AtlasDbHttpClients` classes should attempt not to do eager initialisations, because this can result in ordering issues with setting up global OkHttp state (e.g. for Conscrypt in various internal servers).

**Implementation Description (bullets)**:
- Maybe initialise the delegate as part of each invocation, rather than doing it upfront.
- Implement this with a double-checked locking algorithm to minimise perf overhead.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added 1 test for the lazy initialisation case. Existing tests still pass.

**Concerns (what feedback would you like?)**:
- Is there a concurrency bug?
- For `replaceIfNecessary`, it seemed weird we did another get on the supplier. I know in the specific use case it is memoized-with-expiration, but seems like an unexpected dependency.

**Where should we start reviewing?**: ReplaceIfExceptionMatchingProxy

**Priority (whenever / two weeks / yesterday)**: Wednesday please, blocks internal rolling investigations because an important internal service cannot take AtlasDB bumps since this was introduced.
