### PR TITLE
[Timelock Partitioning/Perf] Reduce context switches

### DIFF
--- a/changelog/@unreleased/pr-4672.v2.yml
+++ b/changelog/@unreleased/pr-4672.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Reduce number of context switches on the hot path inside `AwaitingLeadershipProxy`
+    when checking for leadership.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4672

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/AsyncRetrier.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/AsyncRetrier.java
@@ -67,7 +67,7 @@ final class AsyncRetrier<T> {
     offload the work onto a separate executor.
      */
     private ListenableFuture<T> execute(Supplier<ListenableFuture<T>> supplier, int retriesRemaining) {
-        return Futures.transformAsync(supplier.get(),
+        return Futures.transformAsync(executeSupplier(supplier),
                 result -> {
                     int newRetriesRemaining = retriesRemaining - 1;
                     if (predicate.test(result) || newRetriesRemaining == 0) {
@@ -82,5 +82,13 @@ final class AsyncRetrier<T> {
                     }
                 }, MoreExecutors.directExecutor());
 
+    }
+
+    private ListenableFuture<T> executeSupplier(Supplier<ListenableFuture<T>> supplier) {
+        try {
+            return supplier.get();
+        } catch (Throwable e) {
+            return Futures.immediateFailedFuture(e);
+        }
     }
 }

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/AsyncRetrier.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/AsyncRetrier.java
@@ -67,7 +67,7 @@ final class AsyncRetrier<T> {
     offload the work onto a separate executor.
      */
     private ListenableFuture<T> execute(Supplier<ListenableFuture<T>> supplier, int retriesRemaining) {
-        return Futures.transformAsync(Futures.submitAsync(supplier::get, MoreExecutors.directExecutor()),
+        return Futures.transformAsync(supplier.get(),
                 result -> {
                     int newRetriesRemaining = retriesRemaining - 1;
                     if (predicate.test(result) || newRetriesRemaining == 0) {

--- a/leader-election-impl/src/main/java/com/palantir/paxos/CoalescingPaxosLatestRoundVerifier.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/CoalescingPaxosLatestRoundVerifier.java
@@ -43,6 +43,7 @@ public class CoalescingPaxosLatestRoundVerifier implements PaxosLatestRoundVerif
         this.delegate = delegate;
     }
 
+    @Override
     public ListenableFuture<PaxosQuorumStatus> isLatestRoundAsync(long round) {
         return verifiersByRound.getUnchecked(round).getAsync();
     }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosAcceptorNetworkClient.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosAcceptorNetworkClient.java
@@ -16,6 +16,9 @@
 
 package com.palantir.paxos;
 
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+
 /**
  * {@link PaxosAcceptorNetworkClient} encapsulates the consensus portion of the request and involves communicating with
  * multiple {@link PaxosAcceptor}s. This should be used over {@link PaxosQuorumChecker} and {@link PaxosAcceptor} where
@@ -49,5 +52,9 @@ public interface PaxosAcceptorNetworkClient {
      *         included if an acceptor has not prepared or accepted any rounds.
      */
     PaxosResponses<PaxosLong> getLatestSequencePreparedOrAccepted();
+
+    default ListenableFuture<PaxosResponses<PaxosLong>> getLatestSequencePreparedOrAcceptedAsync() {
+        return Futures.immediateFuture(getLatestSequencePreparedOrAccepted());
+    }
 
 }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosLatestRoundVerifier.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosLatestRoundVerifier.java
@@ -15,8 +15,9 @@
  */
 package com.palantir.paxos;
 
+import com.google.common.util.concurrent.ListenableFuture;
+
 public interface PaxosLatestRoundVerifier {
-
     PaxosQuorumStatus isLatestRound(long round);
-
+    ListenableFuture<PaxosQuorumStatus> isLatestRoundAsync(long round);
 }

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/Dependencies.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/Dependencies.java
@@ -62,6 +62,7 @@ public interface Dependencies {
         com.palantir.atlasdb.timelock.paxos.NetworkClientFactories networkClientFactories();
         Supplier<PaxosRuntimeConfiguration> runtime();
         AutobatchingLeadershipObserverFactory leadershipObserverFactory();
+        Factories.PaxosLatestRoundVerifierFactory latestRoundVerifierFactory();
     }
 
     interface LeaderElectionService {
@@ -73,6 +74,7 @@ public interface Dependencies {
         PaxosLeadershipEventRecorder eventRecorder();
         PaxosLearner localLearner();
         com.palantir.atlasdb.timelock.paxos.NetworkClientFactories networkClientFactories();
+        Factories.PaxosLatestRoundVerifierFactory latestRoundVerifierFactory();
     }
 
     interface HealthCheckPinger {

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/Factories.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/Factories.java
@@ -25,6 +25,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.palantir.atlasdb.timelock.paxos.NetworkClientFactories.Factory;
 import com.palantir.paxos.LeaderPinger;
+import com.palantir.paxos.PaxosAcceptorNetworkClient;
+import com.palantir.paxos.PaxosLatestRoundVerifier;
 import com.palantir.paxos.SingleLeaderPinger;
 import com.palantir.timelock.paxos.HealthCheckPinger;
 
@@ -41,6 +43,10 @@ public interface Factories {
 
     interface LeaderPingHealthCheckFactory {
         List<HealthCheckPinger> create(Dependencies.HealthCheckPinger dependencies);
+    }
+
+    interface PaxosLatestRoundVerifierFactory {
+        PaxosLatestRoundVerifier create(PaxosAcceptorNetworkClient acceptorNetworkClient);
     }
 
     @Value.Immutable

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeaderElectionServiceFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeaderElectionServiceFactory.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import com.google.common.collect.Maps;
 import com.palantir.leader.BatchingLeaderElectionService;
 import com.palantir.leader.LeaderElectionServiceBuilder;
+import com.palantir.paxos.PaxosAcceptorNetworkClient;
 import com.palantir.paxos.PaxosProposer;
 
 public class LeaderElectionServiceFactory {
@@ -35,6 +36,9 @@ public class LeaderElectionServiceFactory {
     }
 
     private static BatchingLeaderElectionService createNewInstance(Dependencies.LeaderElectionService dependencies) {
+        PaxosAcceptorNetworkClient acceptorClient = dependencies.networkClientFactories().acceptor()
+                .create(dependencies.paxosClient());
+
         return new BatchingLeaderElectionService(new LeaderElectionServiceBuilder()
                 .leaderPinger(dependencies.leaderPinger())
                 .leaderUuid(dependencies.leaderUuid())
@@ -43,8 +47,9 @@ public class LeaderElectionServiceFactory {
                         dependencies.runtime().get().maximumWaitBeforeProposingLeadership())
                 .eventRecorder(dependencies.eventRecorder())
                 .knowledge(dependencies.localLearner())
-                .acceptorClient(dependencies.networkClientFactories().acceptor().create(dependencies.paxosClient()))
+                .acceptorClient(acceptorClient)
                 .learnerClient(dependencies.networkClientFactories().learner().create(dependencies.paxosClient()))
+                .latestRoundVerifier(dependencies.latestRoundVerifierFactory().create(acceptorClient))
                 .decorateProposer(uninstrumentedPaxosProposer -> instrumentProposer(
                         dependencies.paxosClient(),
                         dependencies.metrics(),

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipContextFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipContextFactory.java
@@ -42,6 +42,7 @@ public abstract class LeadershipContextFactory implements
     abstract Factories.LeaderPingHealthCheckFactory healthCheckPingersFactory();
     abstract NetworkClientFactories.Builder networkClientFactoryBuilder();
     abstract Factories.LeaderPingerFactoryContainer.Builder leaderPingerFactoryBuilder();
+    public abstract Factories.PaxosLatestRoundVerifierFactory latestRoundVerifierFactory();
 
     @Value.Derived
     @Override

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResourcesFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResourcesFactory.java
@@ -36,7 +36,9 @@ import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.config.ssl.SslSocketFactories;
 import com.palantir.conjure.java.config.ssl.TrustContext;
 import com.palantir.leader.PingableLeader;
+import com.palantir.paxos.CoalescingPaxosLatestRoundVerifier;
 import com.palantir.paxos.PaxosAcceptorNetworkClient;
+import com.palantir.paxos.PaxosLatestRoundVerifierImpl;
 import com.palantir.paxos.PaxosLearnerNetworkClient;
 import com.palantir.paxos.PaxosProposer;
 import com.palantir.paxos.PaxosProposerImpl;
@@ -99,6 +101,12 @@ public final class PaxosResourcesFactory {
                     .collect(Collectors.toList());
         };
 
+        // we do *not* use CoalescingPaxosLatestRoundVerifier because any coalescing will happen in the
+        // AutobatchingPaxosAcceptorNetworkClient. This is for us to avoid context switching as much as possible on the
+        // hot path since batching twice doesn't necessarily give us anything.
+        Factories.PaxosLatestRoundVerifierFactory latestRoundVerifierFactory = acceptorClient ->
+                new PaxosLatestRoundVerifierImpl(acceptorClient);
+
         LeadershipContextFactory factory = ImmutableLeadershipContextFactory.builder()
                 .install(install)
                 .sharedExecutor(sharedExecutor)
@@ -109,6 +117,7 @@ public final class PaxosResourcesFactory {
                 .networkClientFactoryBuilder(ImmutableBatchingNetworkClientFactories.builder())
                 .leaderPingerFactoryBuilder(ImmutableBatchingLeaderPingerFactory.builder())
                 .healthCheckPingersFactory(healthCheckPingersFactory)
+                .latestRoundVerifierFactory(latestRoundVerifierFactory)
                 .build();
 
         return resourcesBuilder
@@ -136,6 +145,9 @@ public final class PaxosResourcesFactory {
                     .collect(Collectors.toList());
         };
 
+        Factories.PaxosLatestRoundVerifierFactory latestRoundVerifierFactory = acceptorClient ->
+                new CoalescingPaxosLatestRoundVerifier(new PaxosLatestRoundVerifierImpl(acceptorClient));
+
         LeadershipContextFactory factory = ImmutableLeadershipContextFactory.builder()
                 .install(install)
                 .sharedExecutor(sharedExecutor)
@@ -146,6 +158,7 @@ public final class PaxosResourcesFactory {
                 .networkClientFactoryBuilder(ImmutableSingleLeaderNetworkClientFactories.builder())
                 .leaderPingerFactoryBuilder(ImmutableSingleLeaderPingerFactory.builder())
                 .healthCheckPingersFactory(healthCheckPingersFactory)
+                .latestRoundVerifierFactory(latestRoundVerifierFactory)
                 .build();
 
         return resourcesBuilder

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AutobatchingPaxosAcceptorNetworkClientFactory.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AutobatchingPaxosAcceptorNetworkClientFactory.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 
 import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.atlasdb.autobatch.Autobatchers;
 import com.palantir.atlasdb.autobatch.DisruptorAutobatcher;
 import com.palantir.logsafe.Preconditions;
@@ -121,6 +122,11 @@ public class AutobatchingPaxosAcceptorNetworkClientFactory implements Closeable 
             } catch (ExecutionException | InterruptedException e) {
                 throw AutobatcherExecutionExceptions.handleAutobatcherExceptions(e);
             }
+        }
+
+        @Override
+        public ListenableFuture<PaxosResponses<PaxosLong>> getLatestSequencePreparedOrAcceptedAsync() {
+            return latestSequence.apply(client);
         }
     }
 


### PR DESCRIPTION
**Goals (and why)**:
Currently, as a request comes into timelock:
1. it heads into the `AwaitingLeadershipProxy` (`ALP`)
1. `ALP` then checks whether or not it is the leader
1. Since many requests will be coming in (under single leader) you run it through the `CoalescingSupplier` via `CoalescingPaxosLatestRoundVerifier`.
1. This then calls through to the `PaxosAcceptorNetworkClient`, when we're doing multi-leader, we're running through the `AutobatchingPaxosAcceptorNetworkClient`.
1. This is another batcher by the way of `DisruptorAutobatcher`.
1. Then it makes its way to the actual `BatchPaxosAcceptor`.

It doesn't make sense to batch twice, and in any case we pay for it in context switches, which has been killing our `server.response.p95` latency.

The first part (at least for multi-leader) stops us from going through the `CoalescingPaxosLatestRoundVerifier` and just straight to the batcher.

Inside `AwaitingLeadershipProxy` as part of a few async changes that occurred earlier, to check we were still the leader we now have an async retrier for when we get `NO_QUORUM`, however all attempts are immediately done on a separate executor than the calling thread. For the most part it will likely succeed on the first attempt, so we should at least try on the first attempt without switching.

We do as much work as we can on the direct executor and only farm it off when it's off the happy path and might take longer than usual etc.

**Implementation Description (bullets)**:
* Skip `CoalescingPaxosLatestRoundVerifier` if we're running with the multi-leader batching logic.
* `AsyncRetrier` only executes stuff on a separate thread on the second retry, transforms within the same logical request will happen in the same thread.
* `ALP` tries to do as much work in the direct executor, and dispatches when we're no longer on the hot path.	

**Testing (What was existing testing like?  What have you done to improve it?)**:
Ran the `AwaitingLeadershipProxyBenchmarks`, seemed to indicate an improvement, relative to their previous results. 

**Concerns (what feedback would you like?)**:
The `ALP` change really shines when you have a proper async network client, as the call chain to get to that network client happens in a single thread wit hno switches

**Where should we start reviewing?**:
Commit-by-commit

**Priority (whenever / two weeks / yesterday)**:
Whenever

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
