### PR TITLE
[Timelock Perf] Disruptor future

### DIFF
--- a/atlasdb-autobatch/build.gradle
+++ b/atlasdb-autobatch/build.gradle
@@ -29,4 +29,5 @@ dependencies {
       exclude group: 'org.hamcrest'
     }
     testCompile group: 'org.mockito', name: 'mockito-core'
+    testCompile group: 'com.palantir.tracing', name: 'tracing-test-utils'
 }

--- a/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/Autobatchers.java
+++ b/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/Autobatchers.java
@@ -116,7 +116,7 @@ public final class Autobatchers {
             EventHandler<BatchElement<I, O>> handler = this.handlerFactory.apply(DEFAULT_BUFFER_SIZE);
 
             EventHandler<BatchElement<I, O>> tracingHandler =
-                    new TracingEventHandler<>(handler, purpose, observability);
+                    new TracingEventHandler<>(handler, DEFAULT_BUFFER_SIZE);
 
             EventHandler<BatchElement<I, O>> profiledHandler =
                     new ProfilingEventHandler<>(tracingHandler, purpose, safeTags.build());

--- a/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/BatchElement.java
+++ b/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/BatchElement.java
@@ -16,9 +16,7 @@
 
 package com.palantir.atlasdb.autobatch;
 
-import com.google.common.util.concurrent.SettableFuture;
-
 public interface BatchElement<T, R> {
     T argument();
-    SettableFuture<R> result();
+    DisruptorAutobatcher.DisruptorFuture<R> result();
 }

--- a/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/CoalescingBatchingEventHandler.java
+++ b/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/CoalescingBatchingEventHandler.java
@@ -23,7 +23,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
-import com.google.common.util.concurrent.SettableFuture;
 import com.lmax.disruptor.EventHandler;
 import com.palantir.logsafe.SafeArg;
 
@@ -32,7 +31,7 @@ final class CoalescingBatchingEventHandler<T, R> implements EventHandler<BatchEl
     private static final Logger log = LoggerFactory.getLogger(CoalescingBatchingEventHandler.class);
 
     private final CoalescingRequestFunction<T, R> function;
-    private final SetMultimap<T, SettableFuture<R>> pending;
+    private final SetMultimap<T, DisruptorAutobatcher.DisruptorFuture<R>> pending;
 
     CoalescingBatchingEventHandler(CoalescingRequestFunction<T, R> function, int bufferSize) {
         this.function = function;

--- a/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/DisruptorAutobatcher.java
+++ b/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/DisruptorAutobatcher.java
@@ -128,7 +128,6 @@ public final class DisruptorAutobatcher<T, R>
         private DetachedSpan runningSpan = null;
 
         public DisruptorFuture(String safeLoggablePurpose) {
-            super();
             this.parent = DetachedSpan.start(safeLoggablePurpose + " disruptor task");
             this.waitingSpan = parent.childDetachedSpan("task waiting to be run");
             this.addListener(() -> {

--- a/atlasdb-autobatch/src/test/java/com/palantir/atlasdb/autobatch/CoalescingBatchingEventHandlerTests.java
+++ b/atlasdb-autobatch/src/test/java/com/palantir/atlasdb/autobatch/CoalescingBatchingEventHandlerTests.java
@@ -35,7 +35,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.util.concurrent.SettableFuture;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CoalescingBatchingEventHandlerTests {
@@ -204,8 +203,8 @@ public class CoalescingBatchingEventHandlerTests {
 
         @Value.Derived
         @Override
-        default SettableFuture<Response> result() {
-            return SettableFuture.create();
+        default DisruptorAutobatcher.DisruptorFuture<Response> result() {
+            return new DisruptorAutobatcher.DisruptorFuture<>("test");
         }
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/WriteBatchingTransactionService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/WriteBatchingTransactionService.java
@@ -35,7 +35,6 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.MultimapBuilder;
 import com.google.common.collect.Multimaps;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
 import com.palantir.atlasdb.autobatch.Autobatchers;
 import com.palantir.atlasdb.autobatch.BatchElement;
 import com.palantir.atlasdb.autobatch.DisruptorAutobatcher;
@@ -271,7 +270,7 @@ public final class WriteBatchingTransactionService implements TransactionService
         });
     }
 
-    private static void markSuccessful(SettableFuture<Void> result) {
+    private static void markSuccessful(DisruptorAutobatcher.DisruptorFuture<Void> result) {
         result.set(null);
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/WriteBatchingTransactionServiceTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/WriteBatchingTransactionServiceTest.java
@@ -43,8 +43,8 @@ import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.util.concurrent.SettableFuture;
 import com.palantir.atlasdb.autobatch.BatchElement;
+import com.palantir.atlasdb.autobatch.DisruptorAutobatcher;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
 import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
@@ -311,7 +311,7 @@ public class WriteBatchingTransactionServiceTest {
         static TestTransactionBatchElement of(long startTimestamp, long commitTimestamp) {
             return ImmutableTestTransactionBatchElement.builder()
                     .argument(ImmutableTimestampPair.of(startTimestamp, commitTimestamp))
-                    .result(SettableFuture.create())
+                    .result(new DisruptorAutobatcher.DisruptorFuture<>("test"))
                     .build();
         }
     }

--- a/changelog/@unreleased/pr-4674.v2.yml
+++ b/changelog/@unreleased/pr-4674.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Disruptor Autobatchers now has a special future that allows it track
+    the different phases of the batching process.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4674

--- a/changelog/@unreleased/pr-4674.v2.yml
+++ b/changelog/@unreleased/pr-4674.v2.yml
@@ -1,6 +1,6 @@
 type: improvement
 improvement:
-  description: Disruptor Autobatchers now has a special future that allows it track
-    the different phases of the batching process.
+  description: Disruptor Autobatchers now trace their calls. Time spent waiting for the
+    batch to start and for the batch to be processed are also tracked in child spans.
   links:
   - https://github.com/palantir/atlasdb/pull/4674

--- a/lock-api/src/test/java/com/palantir/lock/client/TransactionStarterTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/TransactionStarterTest.java
@@ -45,8 +45,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.SettableFuture;
 import com.palantir.atlasdb.autobatch.BatchElement;
+import com.palantir.atlasdb.autobatch.DisruptorAutobatcher;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
 import com.palantir.common.time.NanoTime;
 import com.palantir.lock.StringLockDescriptor;
@@ -66,7 +66,7 @@ import com.palantir.lock.watch.NoOpLockWatchEventCache;
 @RunWith(MockitoJUnitRunner.class)
 public class TransactionStarterTest {
     @Mock private LockLeaseService lockLeaseService;
-    private LockWatchEventCache lockWatchEventCache = spy(NoOpLockWatchEventCache.INSTANCE);
+    private final LockWatchEventCache lockWatchEventCache = spy(NoOpLockWatchEventCache.INSTANCE);
     private TransactionStarter transactionStarter;
 
     private static final int NUM_PARTITIONS = 16;
@@ -134,7 +134,7 @@ public class TransactionStarterTest {
         List<BatchElement<Void, StartIdentifiedAtlasDbTransactionResponse>> elements = IntStream.range(0, size)
                 .mapToObj(unused -> ImmutableTestBatchElement.builder()
                         .argument(null)
-                        .result(SettableFuture.create())
+                        .result(new DisruptorAutobatcher.DisruptorFuture<>("test"))
                         .build())
                 .collect(toList());
         TransactionStarter.consumer(lockLeaseService, lockWatchEventCache).accept(elements);

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/GetSuspectedLeaderWithUuid.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/GetSuspectedLeaderWithUuid.java
@@ -40,8 +40,8 @@ import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
-import com.google.common.util.concurrent.SettableFuture;
 import com.palantir.atlasdb.autobatch.BatchElement;
+import com.palantir.atlasdb.autobatch.DisruptorAutobatcher.DisruptorFuture;
 import com.palantir.atlasdb.timelock.paxos.PaxosQuorumCheckingCoalescingFunction.PaxosContainer;
 import com.palantir.common.base.Throwables;
 import com.palantir.common.streams.KeyedStream;
@@ -83,7 +83,7 @@ class GetSuspectedLeaderWithUuid implements Consumer<List<BatchElement<UUID, Opt
 
     @Override
     public void accept(List<BatchElement<UUID, Optional<ClientAwareLeaderPinger>>> batchElements) {
-        Multimap<UUID, SettableFuture<Optional<ClientAwareLeaderPinger>>> uuidsToRequests = batchElements.stream()
+        Multimap<UUID, DisruptorFuture<Optional<ClientAwareLeaderPinger>>> uuidsToRequests = batchElements.stream()
                 .collect(ImmutableListMultimap.toImmutableListMultimap(BatchElement::argument, BatchElement::result));
 
         KeyedStream.of(uuidsToRequests.keySet())
@@ -127,7 +127,7 @@ class GetSuspectedLeaderWithUuid implements Consumer<List<BatchElement<UUID, Opt
     }
 
     private static void completeRequest(
-            Collection<SettableFuture<Optional<ClientAwareLeaderPinger>>> futures,
+            Collection<DisruptorFuture<Optional<ClientAwareLeaderPinger>>> futures,
             Optional<ClientAwareLeaderPinger> outcome) {
         futures.forEach(result -> result.set(outcome));
     }

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/GetSuspectedLeaderWithUuidTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/GetSuspectedLeaderWithUuidTests.java
@@ -44,8 +44,8 @@ import org.mockito.Answers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
-import com.google.common.util.concurrent.SettableFuture;
 import com.palantir.atlasdb.autobatch.BatchElement;
+import com.palantir.atlasdb.autobatch.DisruptorAutobatcher;
 import com.palantir.paxos.LeaderPingerContext;
 
 public class GetSuspectedLeaderWithUuidTests {
@@ -164,8 +164,8 @@ public class GetSuspectedLeaderWithUuidTests {
 
         @Value.Lazy
         @Override
-        default SettableFuture<Optional<ClientAwareLeaderPinger>> result() {
-            return SettableFuture.create();
+        default DisruptorAutobatcher.DisruptorFuture<Optional<ClientAwareLeaderPinger>> result() {
+            return new DisruptorAutobatcher.DisruptorFuture<>("test");
         }
 
         default Optional<ClientAwareLeaderPinger> get()

--- a/timestamp-client/src/test/java/com/palantir/timestamp/RequestBatchingTimestampServiceTest.java
+++ b/timestamp-client/src/test/java/com/palantir/timestamp/RequestBatchingTimestampServiceTest.java
@@ -41,14 +41,14 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.SettableFuture;
 import com.palantir.atlasdb.autobatch.BatchElement;
+import com.palantir.atlasdb.autobatch.DisruptorAutobatcher;
 
 @RunWith(MockitoJUnitRunner.class)
 public final class RequestBatchingTimestampServiceTest {
     private static final int MAX_TIMESTAMPS = 10_000;
 
-    @Spy private TimestampService unbatchedDelegate = new MaxTimestampsToGiveTimestampService();
+    @Spy private final TimestampService unbatchedDelegate = new MaxTimestampsToGiveTimestampService();
 
     private CloseableTimestampService timestamp;
 
@@ -103,7 +103,7 @@ public final class RequestBatchingTimestampServiceTest {
         List<BatchElement<Integer, TimestampRange>> elements = Arrays.stream(sizes)
                 .mapToObj(size -> ImmutableTestBatchElement.builder()
                         .argument(size)
-                        .result(SettableFuture.create())
+                        .result(new DisruptorAutobatcher.DisruptorFuture<>("test"))
                         .build())
                 .collect(toList());
         RequestBatchingTimestampService.consumer(unbatchedDelegate).accept(elements);


### PR DESCRIPTION
**Goals (and why)**:
Not immediately clear where time is spent when a task is submitted to an autobatcher. Add tracing to numerous parts.

**Implementation Description (bullets)**:
Changed the future such that it tracks the different stages a task goes through.
When the future is created, it'll start a `DetachedSpan` so this will inherit the trace of the thread that *submitted* to the autobatcher, so we should have provenance from client request all the way to before the rpc (which can only have a single parent, but that's fine I suppose).

I removed starting new traces around the actual handler, as  I think this approach is easier to navigate with our tracing infra.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Used `RenderTracingRule` to verify what's going on.

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:
`DisruptorAutobatcher`.

**Priority (whenever / two weeks / yesterday)**:
Whenever, would be nice to get it in fairly soon.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
