### PR TITLE
Increase default buffer size to 4096 

### DIFF
--- a/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/Autobatchers.java
+++ b/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/Autobatchers.java
@@ -32,7 +32,7 @@ import com.palantir.tracing.Observability;
 
 public final class Autobatchers {
 
-    private static final int DEFAULT_BUFFER_SIZE = 2048;
+    private static final int DEFAULT_BUFFER_SIZE = 4096;
 
     /**
      * When invoking an {@link DisruptorAutobatcher autobatcher}, an argument needs to be supplied. In the case of

--- a/changelog/@unreleased/pr-4675.v2.yml
+++ b/changelog/@unreleased/pr-4675.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Increase default autobatcher buffer size to 4096
+  links:
+  - https://github.com/palantir/atlasdb/pull/4675


### PR DESCRIPTION
After #4535 we still see LockSupport.park(1 nanosecond), trying to bump this buffer further
Redo #4671

From @jeremyk-91 :
Cool. Main worry here is that there might be a jump in memory usage, but given that there usually are only a few of these batchers we're probably okay.

@Jolyon-S for awareness: The main risk here is memory impact. I think this is fine, but if anyone gets hit by this it'll be internal ski product, so do keep an eye out when we have the next release.