### PR TITLE
[PDS-114184] Increase transaction read timeout in CLI to 8 hours

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/KeyValueServiceValidator.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/KeyValueServiceValidator.java
@@ -115,7 +115,7 @@ public class KeyValueServiceValidator {
     private void validateTable(final TableReference table) {
         final int limit = getBatchSize(table);
         // read only, but need to use a write tx in case the source table has SweepStrategy.THOROUGH
-        validationFromTransactionManager.runTaskWithRetry(
+        validationFromTransactionManager.runTaskThrowOnConflict(
                 (TransactionTask<Map<Cell, byte[]>, RuntimeException>) t1 -> {
                     validateTable(table, limit, t1);
                     return null;
@@ -126,7 +126,7 @@ public class KeyValueServiceValidator {
 
     private void validateTable(final TableReference table, final int limit, final Transaction t1) {
         // read only, but need to use a write tx in case the source table has SweepStrategy.THOROUGH
-        validationToTransactionManager.runTaskWithRetry(
+        validationToTransactionManager.runTaskThrowOnConflict(g
                 (TransactionTask<Map<Cell, byte[]>, RuntimeException>) t2 -> {
                     validateTable(table, limit, t1, t2);
                     return null;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/KeyValueServiceValidator.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/KeyValueServiceValidator.java
@@ -126,7 +126,7 @@ public class KeyValueServiceValidator {
 
     private void validateTable(final TableReference table, final int limit, final Transaction t1) {
         // read only, but need to use a write tx in case the source table has SweepStrategy.THOROUGH
-        validationToTransactionManager.runTaskThrowOnConflict(g
+        validationToTransactionManager.runTaskThrowOnConflict(
                 (TransactionTask<Map<Cell, byte[]>, RuntimeException>) t2 -> {
                     validateTable(table, limit, t1, t2);
                     return null;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/KeyValueServiceValidator.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/KeyValueServiceValidator.java
@@ -115,6 +115,7 @@ public class KeyValueServiceValidator {
     private void validateTable(final TableReference table) {
         final int limit = getBatchSize(table);
         // read only, but need to use a write tx in case the source table has SweepStrategy.THOROUGH
+        // not using retries as each attempt could take up to 8 hours
         validationFromTransactionManager.runTaskThrowOnConflict(
                 (TransactionTask<Map<Cell, byte[]>, RuntimeException>) t1 -> {
                     validateTable(table, limit, t1);
@@ -126,6 +127,7 @@ public class KeyValueServiceValidator {
 
     private void validateTable(final TableReference table, final int limit, final Transaction t1) {
         // read only, but need to use a write tx in case the source table has SweepStrategy.THOROUGH
+        // not using retries as each attempt could take up to 8 hours
         validationToTransactionManager.runTaskThrowOnConflict(
                 (TransactionTask<Map<Cell, byte[]>, RuntimeException>) t2 -> {
                     validateTable(table, limit, t1, t2);

--- a/changelog/@unreleased/pr-4680.v2.yml
+++ b/changelog/@unreleased/pr-4680.v2.yml
@@ -1,5 +1,0 @@
-type: improvement
-improvement:
-  description: '[PDS-114184] Increase transaction read timeout in CLI to 8 hours'
-  links:
-  - https://github.com/palantir/atlasdb/pull/4680

--- a/changelog/@unreleased/pr-4680.v2.yml
+++ b/changelog/@unreleased/pr-4680.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '[PDS-114184] Increase transaction read timeout in CLI to 8 hours'
+  links:
+  - https://github.com/palantir/atlasdb/pull/4680


### PR DESCRIPTION
**Goals (and why)**:
The validation step of a KVS migration is performed within a single transaction for a given table. For large tables, this step will fail as the transaction will timeout after one hour.

The aim here is to improve this by increasing the transaction timeout for the CLI.

**Implementation Description (bullets)**:
* Overrides `TransactionReadTimeoutMillis` in the AtlasDBConfigs provided to the CLI

**Testing (What was existing testing like?  What have you done to improve it?)**:
Not tested.

**Concerns (what feedback would you like?)**:
* My approach is to hard-code the value - may be more desirable to provide the ability to config (but in reality, how often will people configure this?)
* Should there be additional logging to map progress, so that people know the validation step is running successfully (but is just taking a long time)?

**Where should we start reviewing?**:
`KvsMigrationCommand`

**Priority (whenever / two weeks / yesterday)**:
Within a week.