### PR TITLE
[PDS-114088] Add further warnings about performing a migration

### DIFF
--- a/docs/source/cluster_management/kvs-migration.rst
+++ b/docs/source/cluster_management/kvs-migration.rst
@@ -123,7 +123,7 @@ Running the migration is typically done by invoking the CLI three times, one for
 
     All three steps (Setup, Migrate, Validate) must be run before the migration can be considered finished, and the
     new KVS used. Failure to do so may result in **SEVERE DATA CORRUPTION**. Please ensure this is the case before
-    you re-enable your service.
+    you restart your service with the new KVS.
 
 Setup
 -----

--- a/docs/source/cluster_management/kvs-migration.rst
+++ b/docs/source/cluster_management/kvs-migration.rst
@@ -121,7 +121,7 @@ Running the migration is typically done by invoking the CLI three times, one for
 
 .. danger::
 
-    All three steps (Setup, Migrate, Validate) must be run before the migration can be considered finished, and the
+    **ALL** three steps (Setup, Migrate, Validate) must be run before the migration can be considered finished, and the
     new KVS used. Failure to do so may result in **SEVERE DATA CORRUPTION**. Please ensure this is the case before
     you restart your service with the new KVS.
 

--- a/docs/source/cluster_management/kvs-migration.rst
+++ b/docs/source/cluster_management/kvs-migration.rst
@@ -119,6 +119,12 @@ may contain unrelated YAML objects. For example:
 
 Running the migration is typically done by invoking the CLI three times, one for each main stage of the migration.
 
+.. danger::
+
+    All three steps (Setup, Migrate, Validate) must be run before the migration can be considered finished, and the
+    new KVS used. Failure to do so may result in **SEVERE DATA CORRUPTION**. Please ensure this is the case before
+    you re-enable your service.
+
 Setup
 -----
 


### PR DESCRIPTION
**Goals (and why)**:
Ensure that it is _very_ clear that all steps of a KVS migration must be run before using the new KVS.

**Implementation Description (bullets)**:
* Added another danger note in the KVS migration docs.

**Testing (What was existing testing like?  What have you done to improve it?)**:
N/A

**Concerns (what feedback would you like?)**:
Is this too aggressive? Not aggressive enough? Am I using the right terminology?

**Where should we start reviewing?**:
`kvs-migration`

**Priority (whenever / two weeks / yesterday)**:
This week
