### PR TITLE
[PDS-111849] Rolling in the Deep, Part 1: Failing Test & Rerouting Internode Calls Through Proxies

### DIFF
--- a/timelock-server/build.gradle
+++ b/timelock-server/build.gradle
@@ -68,6 +68,7 @@ dependencies {
         exclude group: 'org.ow2.asm'
     }
     testCompile group: 'org.mockito', name: 'mockito-core'
+    testCompile group: 'com.github.tomakehurst', name: 'wiremock-standalone'
     testCompile group: 'com.squareup.okhttp3', name: 'okhttp'
 
     testCommonAnnotationProcessor group: 'org.immutables', name: 'value'
@@ -76,7 +77,6 @@ dependencies {
     testCommonImplementation group: 'com.github.peterwippermann.junit4', name: 'parameterized-suite'
     testCommonImplementation group: 'com.ea.agentloader', name: 'ea-agent-loader'
     testCommonImplementation group: 'io.dropwizard', name: 'dropwizard-testing'
-    testCommonImplementation group: 'com.github.tomakehurst', name: 'wiremock-standalone'
     testCommonImplementation (project(":atlasdb-tests-shared")) {
         exclude group: 'com.fasterxml.jackson.jaxrs'
     }

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
@@ -71,8 +71,7 @@ public class PaxosTimeLockServerIntegrationTest {
     private static final TemporaryConfigurationHolder TEMPORARY_CONFIG_HOLDER =
             new TemporaryConfigurationHolder(TEMPORARY_FOLDER, "paxosSingleServer.ftl", DEFAULT_SINGLE_SERVER);
     private static final TimeLockServerHolder TIMELOCK_SERVER_HOLDER =
-            new TimeLockServerHolder(TEMPORARY_CONFIG_HOLDER::getTemporaryConfigFileLocation,
-                    DEFAULT_SINGLE_SERVER.getLocalProxyPort());
+            new TimeLockServerHolder(TEMPORARY_CONFIG_HOLDER::getTemporaryConfigFileLocation, DEFAULT_SINGLE_SERVER);
     private static final TestableTimelockServer TIMELOCK =
             new TestableTimelockServer("https://localhost", TIMELOCK_SERVER_HOLDER);
 

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
@@ -71,7 +71,8 @@ public class PaxosTimeLockServerIntegrationTest {
     private static final TemporaryConfigurationHolder TEMPORARY_CONFIG_HOLDER =
             new TemporaryConfigurationHolder(TEMPORARY_FOLDER, "paxosSingleServer.ftl", DEFAULT_SINGLE_SERVER);
     private static final TimeLockServerHolder TIMELOCK_SERVER_HOLDER =
-            new TimeLockServerHolder(TEMPORARY_CONFIG_HOLDER::getTemporaryConfigFileLocation);
+            new TimeLockServerHolder(TEMPORARY_CONFIG_HOLDER::getTemporaryConfigFileLocation,
+                    DEFAULT_SINGLE_SERVER.getLocalProxyPort());
     private static final TestableTimelockServer TIMELOCK =
             new TestableTimelockServer("https://localhost", TIMELOCK_SERVER_HOLDER);
 

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -48,6 +48,7 @@ import com.palantir.atlasdb.timelock.api.ConjureUnlockRequest;
 import com.palantir.atlasdb.timelock.api.SuccessfulLockResponse;
 import com.palantir.atlasdb.timelock.api.UnsuccessfulLockResponse;
 import com.palantir.atlasdb.timelock.suite.MultiLeaderPaxosSuite;
+import com.palantir.atlasdb.timelock.suite.SingleLeaderPaxosSuite;
 import com.palantir.atlasdb.timelock.util.ExceptionMatchers;
 import com.palantir.atlasdb.timelock.util.ParameterInjector;
 import com.palantir.lock.LockDescriptor;
@@ -130,7 +131,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
 
     @Test
     public void canUseNamespaceStartingWithTlOnLegacyEndpoints() {
-        cluster.client("tl" + "suffix").getFreshTimestamp();
+        cluster.client("tl" + "suffix").throughWireMockProxy().getFreshTimestamp();
     }
 
     @Test
@@ -230,7 +231,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
     @Test
     public void canCreateNewClientsDynamically() {
         for (int i = 0; i < 5; i++) {
-            NamespacedClients randomNamespace = cluster.clientForRandomNamespace();
+            NamespacedClients randomNamespace = cluster.clientForRandomNamespace().throughWireMockProxy();
 
             randomNamespace.getFreshTimestamp();
             LockToken token = randomNamespace.lock(LockRequest.of(LOCKS, DEFAULT_LOCK_TIMEOUT_MS)).getToken();

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -48,7 +48,6 @@ import com.palantir.atlasdb.timelock.api.ConjureUnlockRequest;
 import com.palantir.atlasdb.timelock.api.SuccessfulLockResponse;
 import com.palantir.atlasdb.timelock.api.UnsuccessfulLockResponse;
 import com.palantir.atlasdb.timelock.suite.MultiLeaderPaxosSuite;
-import com.palantir.atlasdb.timelock.suite.SingleLeaderPaxosSuite;
 import com.palantir.atlasdb.timelock.util.ExceptionMatchers;
 import com.palantir.atlasdb.timelock.util.ParameterInjector;
 import com.palantir.lock.LockDescriptor;

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -300,6 +300,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
                         isNonLeaderTakenOut);
                 if (i == 1_000) {
                     makeServerWaitTwoSecondsAndThenReturn503s(nonLeader);
+                    isNonLeaderTakenOut = true;
                 }
             }
         } finally {

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -22,11 +22,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.lang.management.ManagementFactory;
 import java.time.Duration;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -41,9 +39,7 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.google.common.primitives.Ints;
-import com.google.common.util.concurrent.Uninterruptibles;
 import com.palantir.atlasdb.http.v2.ClientOptions;
 import com.palantir.atlasdb.timelock.api.ConjureLockRequest;
 import com.palantir.atlasdb.timelock.api.ConjureLockResponse;
@@ -244,27 +240,25 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
 
     @Test
     public void lockRequestCanBlockForTheFullTimeout() {
-        NamespacedClients wiremockClient = client.throughWireMockProxy();
-        LockToken token = wiremockClient.lock(LockRequest.of(LOCKS, DEFAULT_LOCK_TIMEOUT_MS)).getToken();
+        LockToken token = client.lock(LockRequest.of(LOCKS, DEFAULT_LOCK_TIMEOUT_MS)).getToken();
 
         try {
-            LockResponse response = wiremockClient.lock(LockRequest.of(LOCKS, LONG_LOCK_TIMEOUT_MS));
+            LockResponse response = client.lock(LockRequest.of(LOCKS, LONG_LOCK_TIMEOUT_MS));
             assertThat(response.wasSuccessful()).isFalse();
         } finally {
-            wiremockClient.unlock(token);
+            client.unlock(token);
         }
     }
 
     @Test
     public void waitForLocksRequestCanBlockForTheFullTimeout() {
-        NamespacedClients wiremockClient = client.throughWireMockProxy();
-        LockToken token = wiremockClient.lock(LockRequest.of(LOCKS, DEFAULT_LOCK_TIMEOUT_MS)).getToken();
+        LockToken token = client.lock(LockRequest.of(LOCKS, DEFAULT_LOCK_TIMEOUT_MS)).getToken();
 
         try {
-            WaitForLocksResponse response = wiremockClient.waitForLocks(WaitForLocksRequest.of(LOCKS, LONG_LOCK_TIMEOUT_MS));
+            WaitForLocksResponse response = client.waitForLocks(WaitForLocksRequest.of(LOCKS, LONG_LOCK_TIMEOUT_MS));
             assertThat(response.wasSuccessful()).isFalse();
         } finally {
-            wiremockClient.unlock(token);
+            client.unlock(token);
         }
     }
 

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/SingleLeaderMultiNodePaxosTimeLockIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/SingleLeaderMultiNodePaxosTimeLockIntegrationTest.java
@@ -49,7 +49,7 @@ public class SingleLeaderMultiNodePaxosTimeLockIntegrationTest {
 
     @Before
     public void setUp() {
-        namespace = cluster.clientForRandomNamespace();
+        namespace = cluster.clientForRandomNamespace().throughWireMockProxy();
     }
 
     @Test

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TemplateVariables.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TemplateVariables.java
@@ -31,6 +31,8 @@ import com.palantir.timelock.config.PaxosInstallConfiguration.PaxosLeaderMode;
 @Value.Enclosing
 @Value.Style(attributeBuilderDetection = true)
 public interface TemplateVariables {
+    int PROXY_OFFSET = 100;
+
     @Nullable
     String getDataDirectory();
     List<Integer> getServerPorts();
@@ -38,9 +40,25 @@ public interface TemplateVariables {
     TimestampPaxos getClientPaxos();
     PaxosLeaderMode getLeaderMode();
 
+    @Value.Default
+    default Integer getLocalProxyPort() {
+        return doProxyTransform(getLocalServerPort());
+    }
+
+    @Value.Derived
+    default List<Integer> getServerProxyPorts() {
+        return getServerPorts().stream().map(TemplateVariables::doProxyTransform).collect(Collectors.toList());
+    }
+
+    static int doProxyTransform(int port) {
+        return port + PROXY_OFFSET;
+    }
+
     @Value.Check
     default TemplateVariables putLocalServerPortAmongstAllServerPorts() {
-        if (getServerPorts().contains(getLocalServerPort())) {
+        // It is guaranteed that the transform ensures that after this runs once, the local proxy port will be present
+        // in the server proxy ports.
+        if (getServerProxyPorts().contains(getLocalProxyPort())) {
             return this;
         }
 

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
@@ -110,7 +110,7 @@ public class TestableTimelockCluster implements TestRule {
                 .pollInterval(500, TimeUnit.MILLISECONDS)
                 .until(() -> {
                     try {
-                        namespaces.forEach(namespace -> client(namespace).getFreshTimestamp());
+                        namespaces.forEach(namespace -> client(namespace).throughWireMockProxy().getFreshTimestamp());
                         return true;
                     } catch (Throwable t) {
                         return false;
@@ -250,9 +250,7 @@ public class TestableTimelockCluster implements TestRule {
     private static TimeLockServerHolder getServerHolder(
             TemporaryConfigurationHolder configHolder,
             TemplateVariables templateVariables) {
-        return new TimeLockServerHolder(
-                configHolder::getTemporaryConfigFileLocation,
-                templateVariables.getLocalProxyPort());
+        return new TimeLockServerHolder(configHolder::getTemporaryConfigFileLocation, templateVariables);
     }
 
     private TemporaryConfigurationHolder getConfigHolder(String templateName, TemplateVariables variables) {

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
@@ -45,7 +45,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
-import com.google.common.collect.Streams;
 import com.google.common.hash.Hashing;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
@@ -139,14 +139,7 @@ public class TestableTimelockServer {
     }
 
     void allowAllNamespaces() {
-        serverHolder.wireMock().removeMappings();
-        StubMapping catchAll = any(urlMatching(TimeLockServerHolder.ALL_NAMESPACES))
-                .willReturn(aResponse().proxiedFrom(serverHolder.getTimelockUri())
-                        .withAdditionalRequestHeader(
-                                "User-Agent", UserAgents.format(TimeLockServerHolder.WIREMOCK_USER_AGENT)))
-                .atPriority(Integer.MAX_VALUE)
-                .build();
-        serverHolder.wireMock().register(catchAll);
+        serverHolder.resetWireMock();
     }
 
     private static UrlPattern namespaceEqualTo(String namespace) {

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TimeLockServerHolder.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TimeLockServerHolder.java
@@ -18,7 +18,6 @@ package com.palantir.atlasdb.timelock;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 
 import java.io.File;
 import java.io.IOException;

--- a/timelock-server/src/testCommon/resources/paxosMultiServer.ftl
+++ b/timelock-server/src/testCommon/resources/paxosMultiServer.ftl
@@ -12,10 +12,10 @@ install:
         keyStorePassword: "keystore"
         keyStoreType: "JKS"
       uris:
-<#list serverPorts as serverPort>
-      - "localhost:${serverPort?c}"
+<#list serverProxyPorts as serverProxyPort>
+      - "localhost:${serverProxyPort?c}"
 </#list>
-    local-server: "localhost:${localServerPort?c}"
+    local-server: "localhost:${localProxyPort?c}"
   timestampBoundPersistence:
 
 runtime:


### PR DESCRIPTION
**Goals (and why)**:
- See PDS-111849.
- We have landed on a very plausible RCA, and it's usually good to validate this kind of thing by writing a test that demonstrates what we may have fixed. Here, this test (idea originally from @j-baker) effectively puts a timelock into a mode where it's still alive, but shutting down. Furthermore, I changed it so it takes two seconds before failing, to replicate conditions observed on some internal servers. This is unfortunately a bit more invasive than what I would have liked, but it'll do.

**Implementation Description (bullets)**:
- Write a failing test (see `stressTest`: the number of threads explodes under these circumstances).
- Rewire the `MultiNodePaxosTimeLockIntegrationTest` to go exclusively through WireMock proxies that proxy to the relevant server endpoints. This is basically a glorified, but importantly, dynamically changeable in test filter.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Doesn't really change production code. Existing tests passing would be validation that I haven't broken the world in my refactoring.

**Concerns (what feedback would you like?)**:
- We now use hard-coded https ports for the wiremock servers. Is that really bad? I think we already depended on the hard-coded timelock ones, so this is just another set of numbers.

**Where should we start reviewing?**: `MultiNodePaxosTimeLockServerIntegrationTest.java`

**Priority (whenever / two weeks / yesterday)**: Ideally by Wednesday
