### PR TITLE
getRowsColumnRange always has cells grouped by row

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -480,7 +480,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             // N.B. This batch could be spread across multiple rows, and those rows might extend into other
             // batches. We are given cells for a row grouped together, so easiest way to ensure they stay together
             // is to preserve the original order.
-            LinkedHashMap<Cell, Value> raw = new LinkedHashMap<>();
+            Map<Cell, Value> raw = new LinkedHashMap<>();
             batch.forEach(entry -> raw.put(entry.getKey(), entry.getValue()));
             validatePreCommitRequirementsOnReadIfNecessary(tableRef, getStartTimestamp());
             if (raw.isEmpty()) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -497,22 +497,6 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         }));
     }
 
-    private Comparator<Cell> preserveInputRowOrder(List<Map.Entry<Cell, Value>> inputEntries) {
-        // N.B. This batch could be spread across multiple rows, and those rows might extend into other
-        // batches. We are given cells for a row grouped together, so easiest way to ensure they stay together
-        // is to preserve the original row order.
-        return Comparator
-                .comparing(
-                        (Cell cell) -> ByteBuffer.wrap(cell.getRowName()),
-                        Ordering.explicit(inputEntries.stream()
-                                .map(Map.Entry::getKey)
-                                .map(Cell::getRowName)
-                                .map(ByteBuffer::wrap)
-                                .distinct()
-                                .collect(ImmutableList.toImmutableList())))
-                .thenComparing(Cell::getColumnName, PtBytes.BYTES_COMPARATOR);
-    }
-
     private Iterator<Map.Entry<Cell, byte[]>> getRowColumnRangePostFiltered(
             TableReference tableRef,
             byte[] row,
@@ -546,6 +530,22 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             }
         };
         return Iterators.concat(postFilteredBatches);
+    }
+
+    private Comparator<Cell> preserveInputRowOrder(List<Map.Entry<Cell, Value>> inputEntries) {
+        // N.B. This batch could be spread across multiple rows, and those rows might extend into other
+        // batches. We are given cells for a row grouped together, so easiest way to ensure they stay together
+        // is to preserve the original row order.
+        return Comparator
+                .comparing(
+                        (Cell cell) -> ByteBuffer.wrap(cell.getRowName()),
+                        Ordering.explicit(inputEntries.stream()
+                                .map(Map.Entry::getKey)
+                                .map(Cell::getRowName)
+                                .map(ByteBuffer::wrap)
+                                .distinct()
+                                .collect(ImmutableList.toImmutableList())))
+                .thenComparing(Cell::getColumnName, PtBytes.BYTES_COMPARATOR);
     }
 
     /**

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -1226,7 +1226,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
         runTestForGetRowsColumnRangeSingleIteratorVersion(10, 10, 5);
         runTestForGetRowsColumnRangeSingleIteratorVersion(10, 10, 10);
         runTestForGetRowsColumnRangeSingleIteratorVersion(100, 100, 99);
-        // Add a test where the numCellsPerRow (and total number of cells) is not evenly divisible by the batch size.
+        // Add a test where neither the numCellsPerRow and the batch size (10) are divisible by each other.
+        // This tests what happens when a row's cells are spread across multiple batches.
         runTestForGetRowsColumnRangeSingleIteratorVersion(101, 11, 0);
     }
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -1184,6 +1184,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
         runTestForGetRowsColumnRangeSingleIteratorVersion(10, 10, 5);
         runTestForGetRowsColumnRangeSingleIteratorVersion(10, 10, 10);
         runTestForGetRowsColumnRangeSingleIteratorVersion(100, 100, 99);
+        runTestForGetRowsColumnRangeSingleIteratorVersion(10000, 11, 0);
     }
 
     private void runTestForGetRowsColumnRangeSingleIteratorVersion(
@@ -1213,14 +1214,17 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
         });
         keyValueService.addGarbageCollectionSentinelValues(TABLE, expectedDeletedCells);
 
+        List<byte[]> shuffledRows = expectedRows;
+        Collections.shuffle(shuffledRows);
         List<Cell> cells = serializableTxManager.runTaskReadOnly(tx ->
                 ImmutableList.copyOf(Iterators.transform(
                         tx.getRowsColumnRange(
                                 TABLE,
-                                expectedRows,
+                                shuffledRows,
                                 new ColumnRangeSelection(null, null),
                                 10),
                         Map.Entry::getKey)));
+        expectedCells.sort(Cell::compareTo);
         Assertions.assertThat(cells).isEqualTo(expectedCells);
 
         keyValueService.truncateTable(TABLE);

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -1226,7 +1226,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
         runTestForGetRowsColumnRangeSingleIteratorVersion(10, 10, 5);
         runTestForGetRowsColumnRangeSingleIteratorVersion(10, 10, 10);
         runTestForGetRowsColumnRangeSingleIteratorVersion(100, 100, 99);
-        runTestForGetRowsColumnRangeSingleIteratorVersion(100, 11, 0);
+        // Add a test where the numCellsPerRow (and total number of cells) is not evenly divisible by the batch size.
+        runTestForGetRowsColumnRangeSingleIteratorVersion(101, 11, 0);
     }
 
     private void runTestForGetRowsColumnRangeSingleIteratorVersion(

--- a/changelog/@unreleased/pr-4687.v2.yml
+++ b/changelog/@unreleased/pr-4687.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Fixes a bug in 0.198.9. Transaction#getRowsColumnRange (the 4 parameter
+    version) will now properly return cells for a row all grouped together in one
+    batch (no cells from other rows mixed in).
+  links:
+  - https://github.com/palantir/atlasdb/pull/4687


### PR DESCRIPTION
Ensure that throughout the iterator manipulation that happens
internally to getRowsColumnRange that we maintain the invariant
that all cells for a given row will be grouped together at the end.

**Goals (and why)**:
After https://github.com/palantir/atlasdb/pull/4668 (though maybe before as well if the BatchSizeIncreasingIterator didn't kick in?), getRowsColumnRange could return an iterator where the cells for a given row are not always grouped together, which could break assumptions made by clients.

**Implementation Description (bullets)**:
Two potential implementation options, and I'm curious what people think is cleanest: we can sort the rows passed in, so that they're in the same order that we internally sort Cells in, or we should purely rely on the ordering provided by the KVS.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Changing the existing tests to shuffle the order of rows passed in, which was enough to break things somewhat. But that combined with having rows not have a cell count that's a multiple of the number of the batch size is where the test demonstrates what could could actually go bad.

**Concerns (what feedback would you like?)**:
What option to fix this is cleanest?

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

