### PR TITLE
[PDS-111849] Rolling in the Deep, Part 2: Bounded Executors for Acceptors (Single and Batched)

### DIFF
--- a/changelog/@unreleased/pr-4690.v2.yml
+++ b/changelog/@unreleased/pr-4690.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: TimeLock Server (and leaders in embedded configurations) should now
+    be much more resilient to a slowly responding individual cluster node. Previously,
+    the number of threads involved in validating consensus could potentially grow
+    unbounded.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4690

--- a/scripts/circle-ci/run-circle-tests.sh
+++ b/scripts/circle-ci/run-circle-tests.sh
@@ -54,24 +54,16 @@ JAVA_GC_LOGGING_OPTIONS="${JAVA_GC_LOGGING_OPTIONS} -XX:+PrintGCDetails"
 JAVA_GC_LOGGING_OPTIONS="${JAVA_GC_LOGGING_OPTIONS} -XX:-TraceClassUnloading"
 JAVA_GC_LOGGING_OPTIONS="${JAVA_GC_LOGGING_OPTIONS} -Xloggc:build-%t-%p.gc.log"
 
-# External builds have a 4GB limit so we have to tune everything so it fits in memory (only just!)
-if [[ $INTERNAL_BUILD == true ]]; then
-    if [ "$CIRCLE_NODE_INDEX" -eq "7" ]; then
-        export _JAVA_OPTIONS="-Xms2g -Xmx4g -XX:ActiveProcessorCount=8 ${JAVA_GC_LOGGING_OPTIONS}"
-    else
-        BASE_GRADLE_ARGS+=" --parallel"
-        export _JAVA_OPTIONS="-Xmx1024m ${JAVA_GC_LOGGING_OPTIONS}"
-        BASE_GRADLE_ARGS+=" --parallel"
-    fi
-    export CASSANDRA_MAX_HEAP_SIZE=512m
-    export CASSANDRA_HEAP_NEWSIZE=64m
+# External builds have a 16gb limit.
+if [ "$CIRCLE_NODE_INDEX" -eq "7" ]; then
+    export _JAVA_OPTIONS="-Xms4g -Xmx8g -XX:ActiveProcessorCount=8 ${JAVA_GC_LOGGING_OPTIONS}"
 else
-    ./gradlew $BASE_GRADLE_ARGS --parallel compileJava compileTestJava
-    export GRADLE_OPTS="-Xss1024K -XX:+CMSClassUnloadingEnabled -XX:InitialCodeCacheSize=32M -XX:CodeCacheExpansionSize=1M -XX:CodeCacheMinimumFreeSpace=1M -XX:ReservedCodeCacheSize=150M -XX:MinMetaspaceExpansion=1M -XX:MaxMetaspaceExpansion=8M -XX:MaxMetaspaceSize=128M -XX:MaxDirectMemorySize=96M -XX:CompressedClassSpaceSize=32M"
-    export _JAVA_OPTIONS="${_JAVA_OPTIONS} ${JAVA_GC_LOGGING_OPTIONS}"
-    export CASSANDRA_MAX_HEAP_SIZE=160m
-    export CASSANDRA_HEAP_NEWSIZE=24m
+    BASE_GRADLE_ARGS+=" --parallel"
+    export _JAVA_OPTIONS="-Xmx4g ${JAVA_GC_LOGGING_OPTIONS}"
+    BASE_GRADLE_ARGS+=" --parallel"
 fi
+export CASSANDRA_MAX_HEAP_SIZE=512m
+export CASSANDRA_HEAP_NEWSIZE=64m
 
 case $CIRCLE_NODE_INDEX in
     0) ./gradlew $BASE_GRADLE_ARGS check $CONTAINER_0_EXCLUDE_ARGS -x :atlasdb-jepsen-tests:check;;

--- a/scripts/circle-ci/run-circle-tests.sh
+++ b/scripts/circle-ci/run-circle-tests.sh
@@ -56,7 +56,7 @@ JAVA_GC_LOGGING_OPTIONS="${JAVA_GC_LOGGING_OPTIONS} -Xloggc:build-%t-%p.gc.log"
 
 # External builds have a 16gb limit.
 if [ "$CIRCLE_NODE_INDEX" -eq "7" ]; then
-    export _JAVA_OPTIONS="-Xms4g -Xmx8g -XX:ActiveProcessorCount=8 ${JAVA_GC_LOGGING_OPTIONS}"
+    export _JAVA_OPTIONS="-Xms2g -Xmx4g -XX:ActiveProcessorCount=8 ${JAVA_GC_LOGGING_OPTIONS}"
 else
     BASE_GRADLE_ARGS+=" --parallel"
     export _JAVA_OPTIONS="-Xmx4g ${JAVA_GC_LOGGING_OPTIONS}"

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/Dependencies.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/Dependencies.java
@@ -54,7 +54,7 @@ public interface Dependencies {
         /**
          * Caution! The shared executor should only be used for tasks that are expected to complete quickly.
          * DO NOT use the shared executor when the concurrency of requests may be very high (e.g. for Paxos round
-         * verification). This may lead to thread explosion.
+         * verification).
          */
         ExecutorService sharedExecutor();
     }

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/Dependencies.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/Dependencies.java
@@ -50,6 +50,12 @@ public interface Dependencies {
         PaxosRemoteClients remoteClients();
         LocalPaxosComponents components();
         int quorumSize();
+
+        /**
+         * Caution! The shared executor should only be used for tasks that are expected to complete quickly.
+         * DO NOT use the shared executor when the concurrency of requests may be very high (e.g. for Paxos round
+         * verification). This may lead to thread explosion.
+         */
         ExecutorService sharedExecutor();
     }
 

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/SingleLeaderNetworkClientFactories.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/SingleLeaderNetworkClientFactories.java
@@ -54,14 +54,14 @@ abstract class SingleLeaderNetworkClientFactories implements
                     .apply(client);
             PaxosAcceptor localAcceptor = components().acceptor(client);
 
-            LocalAndRemotes<PaxosAcceptor> allAcceptors = LocalAndRemotes.of(localAcceptor, remoteAcceptors)
+            LocalAndRemotes<PaxosAcceptor> paxosAcceptors = LocalAndRemotes.of(localAcceptor, remoteAcceptors)
                     .enhanceRemotes(remote -> metrics().instrument(PaxosAcceptor.class, remote, client));
             SingleLeaderAcceptorNetworkClient uninstrumentedAcceptor = new SingleLeaderAcceptorNetworkClient(
-                    allAcceptors.all(),
+                    paxosAcceptors.all(),
                     quorumSize(),
                     TimeLockPaxosExecutors.createBoundedExecutors(
                             metrics().asMetricsManager().getRegistry(),
-                            allAcceptors,
+                            paxosAcceptors,
                             "single-leader-acceptors"),
                     PaxosTimeLockConstants.CANCEL_REMAINING_CALLS);
             return metrics().instrument(PaxosAcceptorNetworkClient.class, uninstrumentedAcceptor);

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/SingleLeaderNetworkClientFactories.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/SingleLeaderNetworkClientFactories.java
@@ -17,20 +17,9 @@
 package com.palantir.atlasdb.timelock.paxos;
 
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.SynchronousQueue;
-import java.util.concurrent.TimeUnit;
 
 import org.immutables.value.Value;
 
-import com.codahale.metrics.InstrumentedExecutorService;
-import com.codahale.metrics.MetricRegistry;
-import com.google.common.util.concurrent.MoreExecutors;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import com.palantir.atlasdb.util.MetricsManager;
-import com.palantir.common.concurrent.PTExecutors;
-import com.palantir.common.streams.KeyedStream;
 import com.palantir.paxos.PaxosAcceptor;
 import com.palantir.paxos.PaxosAcceptorNetworkClient;
 import com.palantir.paxos.PaxosLearner;

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/SingleLeaderNetworkClientFactories.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/SingleLeaderNetworkClientFactories.java
@@ -17,9 +17,20 @@
 package com.palantir.atlasdb.timelock.paxos;
 
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.TimeUnit;
 
 import org.immutables.value.Value;
 
+import com.codahale.metrics.InstrumentedExecutorService;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.palantir.atlasdb.util.MetricsManager;
+import com.palantir.common.concurrent.PTExecutors;
+import com.palantir.common.streams.KeyedStream;
 import com.palantir.paxos.PaxosAcceptor;
 import com.palantir.paxos.PaxosAcceptorNetworkClient;
 import com.palantir.paxos.PaxosLearner;
@@ -48,7 +59,10 @@ abstract class SingleLeaderNetworkClientFactories implements
             SingleLeaderAcceptorNetworkClient uninstrumentedAcceptor = new SingleLeaderAcceptorNetworkClient(
                     allAcceptors.all(),
                     quorumSize(),
-                    allAcceptors.withSharedExecutor(sharedExecutor()),
+                    TimeLockPaxosExecutors.createBoundedExecutors(
+                            metrics().asMetricsManager().getRegistry(),
+                            allAcceptors,
+                            "single-leader-acceptors"),
                     PaxosTimeLockConstants.CANCEL_REMAINING_CALLS);
             return metrics().instrument(PaxosAcceptorNetworkClient.class, uninstrumentedAcceptor);
         };

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/TimeLockPaxosExecutors.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/TimeLockPaxosExecutors.java
@@ -1,0 +1,61 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.TimeUnit;
+
+import com.codahale.metrics.InstrumentedExecutorService;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.palantir.common.concurrent.PTExecutors;
+import com.palantir.common.streams.KeyedStream;
+
+final class TimeLockPaxosExecutors {
+    private TimeLockPaxosExecutors() {
+        // no
+    }
+
+    static <T> Map<T, ExecutorService> createBoundedExecutors(
+            MetricRegistry metricRegistry, LocalAndRemotes<T> localAndRemotes, String useCase) {
+        Map<T, ExecutorService> remoteExecutors = KeyedStream.of(localAndRemotes.remotes())
+                .map(remote -> createBoundedExecutor(metricRegistry, useCase))
+                .collectToMap();
+        remoteExecutors.put(localAndRemotes.local(), MoreExecutors.newDirectExecutorService());
+        return remoteExecutors;
+    }
+
+    private static ExecutorService createBoundedExecutor(MetricRegistry metricRegistry, String useCase) {
+        return new InstrumentedExecutorService(
+                PTExecutors.newThreadPoolExecutor(
+                        1,
+                        100,
+                        5000,
+                        TimeUnit.MILLISECONDS,
+                        new SynchronousQueue<>(),
+                        new ThreadFactoryBuilder()
+                                .setNameFormat("timelock-executors-" + useCase + "-%d")
+                                .setDaemon(true)
+                                .build()),
+                metricRegistry,
+                MetricRegistry.name(TimeLockPaxosExecutors.class, useCase, "executor"));
+    }
+
+}

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/RejectionTrackingCallerRunsPolicy.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/RejectionTrackingCallerRunsPolicy.java
@@ -1,0 +1,51 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.timelock.paxos;
+
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import com.palantir.atlasdb.util.MetricsManager;
+import com.palantir.tritium.metrics.registry.MetricName;
+
+class RejectionTrackingCallerRunsPolicy implements RejectedExecutionHandler {
+    private final Counter rejectionCount;
+
+    private RejectionTrackingCallerRunsPolicy(Counter rejectionCount) {
+        this.rejectionCount = rejectionCount;
+    }
+
+    static RejectionTrackingCallerRunsPolicy createWithSafeLoggableUseCase(
+            MetricsManager metricsManager,
+            String safeLoggableUseCase) {
+        return new RejectionTrackingCallerRunsPolicy(
+                metricsManager.getTaggedRegistry().counter(MetricName.builder()
+                        .safeName(MetricRegistry.name(RejectionTrackingCallerRunsPolicy.class, "rejection"))
+                        .putSafeTags("useCase", safeLoggableUseCase)
+                        .build()));
+    }
+
+    @Override
+    public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+        rejectionCount.inc();
+        if (!executor.isShutdown()) {
+            r.run();
+        }
+    }
+}

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/RejectionTrackingCallerRunsPolicy.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/RejectionTrackingCallerRunsPolicy.java
@@ -24,7 +24,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.tritium.metrics.registry.MetricName;
 
-class RejectionTrackingCallerRunsPolicy implements RejectedExecutionHandler {
+final class RejectionTrackingCallerRunsPolicy implements RejectedExecutionHandler {
     private final Counter rejectionCount;
 
     private RejectionTrackingCallerRunsPolicy(Counter rejectionCount) {
@@ -42,10 +42,10 @@ class RejectionTrackingCallerRunsPolicy implements RejectedExecutionHandler {
     }
 
     @Override
-    public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+    public void rejectedExecution(Runnable runnable, ThreadPoolExecutor executor) {
         rejectionCount.inc();
         if (!executor.isShutdown()) {
-            r.run();
+            runnable.run();
         }
     }
 }

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -19,7 +19,6 @@ import java.net.URL;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -64,7 +64,7 @@ import com.palantir.timestamp.ManagedTimestampService;
 @SuppressWarnings("checkstyle:FinalClass") // This is mocked internally
 public class TimeLockAgent {
     private static final Long SCHEMA_VERSION = 1L;
-    
+
     private static final int MAX_SHARED_EXECUTOR_THREADS = 256;
     private static final int CORE_SHARED_EXECUTOR_THREADS = 10;
     private static final String PAXOS_SHARED_EXECUTOR = "paxos-shared-executor";

--- a/timelock-agent/src/test/java/com/palantir/atlasdb/timelock/paxos/TimeLockPaxosExecutorsTest.java
+++ b/timelock-agent/src/test/java/com/palantir/atlasdb/timelock/paxos/TimeLockPaxosExecutorsTest.java
@@ -1,0 +1,80 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.Uninterruptibles;
+import com.palantir.atlasdb.util.MetricsManagers;
+
+public class TimeLockPaxosExecutorsTest {
+    private static final String TEST = "test";
+    private static final Callable<Integer> SLEEP_FOR_ONE_SECOND = () -> {
+        Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
+        return 42;
+    };
+
+    private final Object local = new Object();
+    private final Object remote1 = new Object();
+    private final Object remote2 = new Object();
+    private final List<Object> remotes = ImmutableList.of(remote1, remote2);
+
+    private final LocalAndRemotes<Object> localAndRemotes = LocalAndRemotes.of(local, remotes);
+
+    private final Map<Object, ExecutorService> executors = TimeLockPaxosExecutors.createBoundedExecutors(
+            MetricsManagers.createForTests().getRegistry(),
+            localAndRemotes,
+            TEST);
+
+    @Test
+    public void hasKeysCollectivelyMatchingLocalAndRemoteElements() {
+        assertThat(executors.keySet()).hasSameElementsAs(localAndRemotes.all());
+    }
+
+    @Test
+    public void remoteExecutorsAreBounded() {
+        for (int i = 0; i < TimeLockPaxosExecutors.MAXIMUM_POOL_SIZE; i++) {
+            executors.get(remote1).submit(SLEEP_FOR_ONE_SECOND);
+        }
+        assertThatThrownBy(() -> executors.get(remote1).submit(SLEEP_FOR_ONE_SECOND))
+                .isInstanceOf(RejectedExecutionException.class);
+    }
+
+    @Test
+    public void remoteExecutorsAreLimitedSeparately() {
+        for (int i = 0; i < TimeLockPaxosExecutors.MAXIMUM_POOL_SIZE; i++) {
+            executors.get(remote1).submit(SLEEP_FOR_ONE_SECOND);
+        }
+        assertThatCode(() -> executors.get(remote2).submit(SLEEP_FOR_ONE_SECOND))
+                .doesNotThrowAnyException();
+    }
+}

--- a/timelock-agent/src/test/java/com/palantir/atlasdb/timelock/paxos/TimeLockPaxosExecutorsTest.java
+++ b/timelock-agent/src/test/java/com/palantir/atlasdb/timelock/paxos/TimeLockPaxosExecutorsTest.java
@@ -19,14 +19,11 @@ package com.palantir.atlasdb.timelock.paxos;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 

--- a/timelock-agent/src/test/java/com/palantir/atlasdb/timelock/paxos/TimeLockPaxosExecutorsTest.java
+++ b/timelock-agent/src/test/java/com/palantir/atlasdb/timelock/paxos/TimeLockPaxosExecutorsTest.java
@@ -24,14 +24,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Uninterruptibles;
+import com.palantir.atlasdb.futures.AtlasFutures;
 import com.palantir.atlasdb.util.MetricsManagers;
+import com.palantir.common.concurrent.PTExecutors;
 
 public class TimeLockPaxosExecutorsTest {
     private static final String TEST = "test";

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AutobatchingPaxosAcceptorNetworkClientFactory.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AutobatchingPaxosAcceptorNetworkClientFactory.java
@@ -53,23 +53,23 @@ public class AutobatchingPaxosAcceptorNetworkClientFactory implements Closeable 
 
     public static AutobatchingPaxosAcceptorNetworkClientFactory create(
             List<BatchPaxosAcceptor> acceptors,
-            ExecutorService executor,
+            Map<BatchPaxosAcceptor, ExecutorService> executors,
             int quorumSize) {
 
         DisruptorAutobatcher<Map.Entry<Client, WithSeq<PaxosProposalId>>, PaxosResponses<PaxosPromise>> prepare =
                 Autobatchers.coalescing(
-                        wrap(acceptors, executor, quorumSize, PrepareCoalescingFunction::new))
+                        wrap(acceptors, executors, quorumSize, PrepareCoalescingFunction::new))
                         .safeLoggablePurpose("batch-paxos-acceptor.prepare")
                         .build();
 
         DisruptorAutobatcher<Map.Entry<Client, PaxosProposal>, PaxosResponses<BooleanPaxosResponse>> accept =
                 Autobatchers.coalescing(
-                        wrap(acceptors, executor, quorumSize, AcceptCoalescingFunction::new))
+                        wrap(acceptors, executors, quorumSize, AcceptCoalescingFunction::new))
                         .safeLoggablePurpose("batch-paxos-acceptor.accept")
                         .build();
 
         DisruptorAutobatcher<Client, PaxosResponses<PaxosLong>> latestSequenceAutobatcher =
-                Autobatchers.coalescing(wrap(acceptors, executor, quorumSize, BatchingPaxosLatestSequenceCache::new))
+                Autobatchers.coalescing(wrap(acceptors, executors, quorumSize, BatchingPaxosLatestSequenceCache::new))
                         .safeLoggablePurpose("batch-paxos-acceptor.latest-sequence-cache")
                         .build();
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AutobatchingPaxosLearnerNetworkClientFactory.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AutobatchingPaxosLearnerNetworkClientFactory.java
@@ -61,12 +61,22 @@ public class AutobatchingPaxosLearnerNetworkClientFactory implements Closeable {
                         .build();
 
         DisruptorAutobatcher<WithSeq<Client>, PaxosResponses<PaxosContainer<Optional<PaxosValue>>>> learnedValues =
-                Autobatchers.coalescing(wrap(learners.all(), executor, quorumSize, LearnedValuesCoalescingFunction::new))
-                        .safeLoggablePurpose("batch-paxos-learner.learned-values")
-                        .build();
+                Autobatchers.coalescing(
+                        wrap(
+                                learners.all(),
+                                learners.withSharedExecutor(executor),
+                                quorumSize,
+                                LearnedValuesCoalescingFunction::new))
+                .safeLoggablePurpose("batch-paxos-learner.learned-values")
+                .build();
 
         DisruptorAutobatcher<WithSeq<Client>, PaxosResponses<PaxosUpdate>> learnedValuesSince =
-                Autobatchers.coalescing(wrap(learners.all(), executor, quorumSize, LearnedValuesSinceCoalescingFunction::new))
+                Autobatchers.coalescing(
+                        wrap(
+                                learners.all(),
+                                learners.withSharedExecutor(executor),
+                                quorumSize,
+                                LearnedValuesSinceCoalescingFunction::new))
                 .safeLoggablePurpose("batch-paxos-learner.learned-values-since")
                 .build();
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosQuorumCheckingCoalescingFunction.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosQuorumCheckingCoalescingFunction.java
@@ -22,7 +22,9 @@ import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosQuorumCheckingCoalescingFunction.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosQuorumCheckingCoalescingFunction.java
@@ -117,7 +117,14 @@ public class PaxosQuorumCheckingCoalescingFunction<
                 .entries()
                 .<FunctionAndExecutor<F>>map(entry -> ImmutableFunctionAndExecutor.of(entry.getKey(), entry.getValue()))
                 .collect(Collectors.toList());
-        return new PaxosQuorumCheckingCoalescingFunction<>(functionsAndExecutors, quorumSize);
+        List<F> functions = new ArrayList<>(services.size());
+        Map<F, ExecutorService> executorMap = new HashMap<>(services.size());
+        for (SERVICE service: services) {
+            F function = functionFactory.apply(service);
+            functions.add(function);
+            executorMap.put(function, executors.get(service));
+        }
+        return new PaxosQuorumCheckingCoalescingFunction<>(functions, executorMap, quorumSize);
     }
 
     public static <REQ, RESP extends PaxosResponse, SERVICE, FUNCTION extends CoalescingRequestFunction<REQ, RESP>>

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosQuorumCheckingCoalescingFunction.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosQuorumCheckingCoalescingFunction.java
@@ -111,7 +111,6 @@ public class PaxosQuorumCheckingCoalescingFunction<
             Map<SERVICE, ExecutorService> executors,
             int quorumSize,
             Function<SERVICE, F> functionFactory) {
-        // Not 100% sure if ordering is important, but assuming so here
         List<FunctionAndExecutor<F>> functionsAndExecutors = KeyedStream.of(services)
                 .map(executors::get)
                 .mapKeys(functionFactory)

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
@@ -49,6 +49,7 @@ import com.google.common.collect.Maps;
 import com.google.common.io.Closer;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.common.remoting.ServiceNotAvailableException;
+import com.palantir.common.streams.KeyedStream;
 import com.palantir.leader.NotCurrentLeaderException;
 import com.palantir.leader.proxy.ToggleableExceptionProxy;
 import com.palantir.paxos.PaxosAcceptor;
@@ -144,8 +145,12 @@ public class PaxosTimestampBoundStoreTest {
 
         if (useBatch) {
             AutobatchingPaxosAcceptorNetworkClientFactory acceptorNetworkClientFactory =
-                    AutobatchingPaxosAcceptorNetworkClientFactory.create(batchPaxosAcceptors, executor, QUORUM_SIZE
-                    );
+                    AutobatchingPaxosAcceptorNetworkClientFactory.create(
+                            batchPaxosAcceptors,
+                            KeyedStream.of(batchPaxosAcceptors.stream())
+                                    .map($ -> executor)
+                                    .collectToMap(),
+                            QUORUM_SIZE);
             acceptorClient = acceptorNetworkClientFactory.paxosAcceptorForClient(CLIENT);
 
             List<AutobatchingPaxosLearnerNetworkClientFactory> learnerNetworkClientFactories = batchPaxosLearners

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -30,7 +30,6 @@ import java.util.stream.Stream;
 
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -286,7 +285,6 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
     }
 
     @Test
-    @Ignore // TODO (jkong): Fix this test by reworking the threading model.
     public void stressTest() {
         TestableTimelockServer nonLeader = Iterables.getFirst(cluster.nonLeaders(client.namespace()).values(), null);
         int startingNumThreads = ManagementFactory.getThreadMXBean().getThreadCount();

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -307,7 +307,9 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
     }
 
     private void assertNumberOfThreadsReasonable(int startingNumThreads, int threadCount, boolean isNonLeaderTakenOut) {
-        int threadLimit = startingNumThreads + 200;
+        // TODO (jkong): Lower the amount over the threshold. This needs to be slightly higher for now because of the
+        // current threading model in batch mode, where separate threads may be spun up on the autobatcher.
+        int threadLimit = startingNumThreads + 300;
         if (isNonLeaderTakenOut) {
             assertThat(threadCount)
                     .as("should not additionally spin up too many threads after a non-leader failed")


### PR DESCRIPTION
**Goals (and why)**:
- Enforce some concurrency limitation of parallel requests: specifically, restrict `PaxosAcceptor` and `AutobatchingPaxosAcceptor` Functions to only be allowed to open up to 100 threads that are doing work on each separate remote.
- See PDS-111849 for how not having this manifests as badness.
- Don't have ignored tests :)

**Implementation Description (bullets)**:
- Single Leader
  - Don't use the shared executor on acceptor codepaths, instead use a separately generated map of executors that maps local to a direct executor, and the remotes to bounded thread pools of core size 1 and burst size 100.
- Multiple Leaders
  - This case is more difficult: I wired all `PaxosAcceptor` functions inside an `AutobatchingPaxosAcceptorNetworkClientFactory` to share a set of executors - across these, the number of threads permitted per remote is 100.
- Un-ignore the stress test in MNPTLSIT, and add a couple of executor tests.

**Testing (What was existing testing like?  What have you done to improve it?)**:
New tests validate that executor construction should hopefully be sane.

**Concerns (what feedback would you like?)**:
- Ideally the core pool size for the multi-leader case should be 3, not 1. I did think about making it configurable, but don't think we lose anything significant going this way as we'll end up keeping a couple of threads alive after the first requests come in. Not really a fan of hard-coding a number here as well, since it depends on the number of distinct autobatcher functions running. Is this a reasonable decision?
- Limiting Acceptors is likely to be the most critical piece of this work, since that is the endpoint that tends to have the highest concurrency. Pingers and Learners are hit much less so I didn't include them in this PR - and still our stress tests pass. Would it make sense to add this to the other classes as well? The caveat here is that the other endpoints are never really barraged, and so I think a shared executor is actually not unreasonable for efficiency.
- I've wired up the executors so they'll throw a `RejectedExecutionException` if the pools get filled. This is largely handled by `PaxosQuorumChecker`, and it's pretty clear to see that this is correct in single leader. I'm less confident in multi-leader (I'm relatively less comfortable with that part of the code).
- Is 100 a reasonable number? Is this too high, since in theory most of these calls get autobatched? Didn't want to be too strict.
- I had to make the stress test a bit more lenient because in a multi-leader world we get 100 threads blocked on the new node plus another 100 threads blocking in the autobatcher. This may be reducible to some extent after #4664. 

**Where should we start reviewing?**: `TimeLockPaxosExecutors`

**Priority (whenever / two weeks / yesterday)**: yesterday 🔥 
