### PR TITLE
ProfilingTimelockService delegates initialization check

### DIFF
--- a/changelog/@unreleased/pr-4691.v2.yml
+++ b/changelog/@unreleased/pr-4691.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Timelock and timestamp services used in transaction managers now correctly
+    report whether or not they are initialized.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4691

--- a/lock-api/src/main/java/com/palantir/lock/client/ProfilingTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/ProfilingTimelockService.java
@@ -91,6 +91,11 @@ public class ProfilingTimelockService implements AutoCloseable, TimelockService 
     }
 
     @Override
+    public boolean isInitialized() {
+        return delegate.isInitialized();
+    }
+
+    @Override
     public long getFreshTimestamp() {
         return runTaskTimed("getFreshTimestamp", delegate::getFreshTimestamp);
     }

--- a/lock-api/src/test/java/com/palantir/lock/client/ProfilingTimelockServiceTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/ProfilingTimelockServiceTest.java
@@ -69,6 +69,16 @@ public class ProfilingTimelockServiceTest {
             logger, delegate, () -> Stopwatch.createStarted(ticker), loggingPermissionSupplier);
 
     @Test
+    public void delegatesInitializationCheck() {
+        when(delegate.isInitialized())
+                .thenReturn(false)
+                .thenReturn(true);
+
+        assertThat(profilingTimelockService.isInitialized()).isFalse();
+        assertThat(profilingTimelockService.isInitialized()).isTrue();
+    }
+
+    @Test
     public void doesNotLogIfOperationsAreFast() {
         flushLogsWithCall(SHORT_DURATION, profilingTimelockService::getFreshTimestamp);
         flushLogsWithCall(SHORT_DURATION, profilingTimelockService::startIdentifiedAtlasDbTransaction);


### PR DESCRIPTION
**Goals (and why)**:
Fixes #4689 

**Implementation Description (bullets)**:
`ProfilingTimelockService` does correctly delegate the `isInitialized` method. As a result, it is possible for the transaction manager to report that it is initialized but for transactions to fail because the underlying timelock or timestamp service is not actually initialized. This PR adds a delegating implementation of `isInitialized` to `ProfilingTimelockService`.