### PR TITLE
[Timelock Partitioning] Test Switching Between SL and Batched SL

### DIFF
--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosUseCase.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosUseCase.java
@@ -58,7 +58,7 @@ public enum PaxosUseCase {
         this.relativeLogDirectory = relativeLogDirectory;
     }
 
-    static final Client PSEUDO_LEADERSHIP_CLIENT = Client.of(PaxosTimeLockConstants.LEADER_PAXOS_NAMESPACE);
+    public static final Client PSEUDO_LEADERSHIP_CLIENT = Client.of(PaxosTimeLockConstants.LEADER_PAXOS_NAMESPACE);
 
     private final String useCasePath;
     private final Path relativeLogDirectory;

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/SingleLeaderMultiNodePaxosTimeLockIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/SingleLeaderMultiNodePaxosTimeLockIntegrationTest.java
@@ -106,7 +106,7 @@ public class SingleLeaderMultiNodePaxosTimeLockIntegrationTest {
 
         List<Long> sequenceNumbers = new ArrayList<>();
 
-        for (TestableTimelockServer server: cluster.servers()) {
+        for (TestableTimelockServer server : cluster.servers()) {
             server.startUsingBatchedSingleLeader();
             cluster.failoverToNewLeader(client.namespace());
             long sequenceForBatchedEndpoint = getSequenceForServerUsingBatchedEndpoint(server);
@@ -126,7 +126,7 @@ public class SingleLeaderMultiNodePaxosTimeLockIntegrationTest {
         cluster.servers().forEach(TestableTimelockServer::startUsingBatchedSingleLeader);
         List<Long> sequenceNumbers = new ArrayList<>();
 
-        for (TestableTimelockServer server: cluster.servers()) {
+        for (TestableTimelockServer server : cluster.servers()) {
             server.stopUsingBatchedSingleLeader();
             cluster.failoverToNewLeader(client.namespace());
             long sequenceForBatchedEndpoint = getSequenceForServerUsingBatchedEndpoint(server);

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/SingleLeaderMultiNodePaxosTimeLockIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/SingleLeaderMultiNodePaxosTimeLockIntegrationTest.java
@@ -20,18 +20,32 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import static com.palantir.atlasdb.timelock.paxos.PaxosTimeLockConstants.LEADER_PAXOS_NAMESPACE;
+import static com.palantir.atlasdb.timelock.paxos.PaxosUseCase.LEADER_FOR_ALL_CLIENTS;
+import static com.palantir.atlasdb.timelock.paxos.PaxosUseCase.PSEUDO_LEADERSHIP_CLIENT;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.palantir.atlasdb.timelock.paxos.BatchPaxosAcceptorRpcClient;
+import com.palantir.atlasdb.timelock.paxos.Client;
+import com.palantir.atlasdb.timelock.paxos.PaxosRemoteClients;
 import com.palantir.atlasdb.timelock.suite.SingleLeaderPaxosSuite;
 import com.palantir.atlasdb.timelock.util.ExceptionMatchers;
 import com.palantir.atlasdb.timelock.util.ParameterInjector;
+import com.palantir.atlasdb.timelock.util.TestProxies;
 
 @RunWith(Parameterized.class)
 public class SingleLeaderMultiNodePaxosTimeLockIntegrationTest {
+    private static final ImmutableSet<Client> CLIENT_SET = ImmutableSet.of(PSEUDO_LEADERSHIP_CLIENT);
 
     @ClassRule
     public static ParameterInjector<TestableTimelockCluster> injector =
@@ -83,5 +97,62 @@ public class SingleLeaderMultiNodePaxosTimeLockIntegrationTest {
 
         long ts2 = namespace.getFreshTimestamp();
         assertThat(ts1).isLessThan(ts2);
+    }
+
+    @Test
+    public void migrationToBatchedSingleLeaderHasConsistentSequenceNumbers() {
+        NamespacedClients client = cluster.clientForRandomNamespace().throughWireMockProxy();
+        cluster.waitUntilAllServersOnlineAndReadyToServeNamespaces(ImmutableList.of(client.namespace()));
+
+        List<Long> sequenceNumbers = new ArrayList<>();
+
+        for (TestableTimelockServer server: cluster.servers()) {
+            server.startUsingBatchedSingleLeader();
+            cluster.failoverToNewLeader(client.namespace());
+            long sequenceForBatchedEndpoint = getSequenceForServerUsingBatchedEndpoint(server);
+            long sequenceForOldEndpoint = getSequenceForServerUsingOldEndpoint(server);
+            assertThat(sequenceForBatchedEndpoint).isLessThanOrEqualTo(sequenceForOldEndpoint);
+            sequenceNumbers.add(sequenceForBatchedEndpoint);
+        }
+
+        assertThat(sequenceNumbers).isSorted();
+        assertThat(ImmutableSet.copyOf(sequenceNumbers)).hasSameSizeAs(sequenceNumbers);
+    }
+
+    @Test
+    public void reverseMigrationFromBatchedSingleLeaderHasConsistentSequenceNumbers() {
+        NamespacedClients client = cluster.clientForRandomNamespace().throughWireMockProxy();
+        cluster.waitUntilAllServersOnlineAndReadyToServeNamespaces(ImmutableList.of(client.namespace()));
+        cluster.servers().forEach(TestableTimelockServer::startUsingBatchedSingleLeader);
+        List<Long> sequenceNumbers = new ArrayList<>();
+
+        for (TestableTimelockServer server: cluster.servers()) {
+            server.stopUsingBatchedSingleLeader();
+            cluster.failoverToNewLeader(client.namespace());
+            long sequenceForBatchedEndpoint = getSequenceForServerUsingBatchedEndpoint(server);
+            long sequenceForOldEndpoint = getSequenceForServerUsingOldEndpoint(server);
+            assertThat(sequenceForBatchedEndpoint).isLessThanOrEqualTo(sequenceForOldEndpoint);
+            sequenceNumbers.add(sequenceForBatchedEndpoint);
+        }
+
+        assertThat(sequenceNumbers).isSorted();
+        assertThat(ImmutableSet.copyOf(sequenceNumbers)).hasSameSizeAs(sequenceNumbers);
+    }
+
+    private static long getSequenceForServerUsingBatchedEndpoint(TestableTimelockServer server) {
+        BatchPaxosAcceptorRpcClient acceptor = server.client(LEADER_PAXOS_NAMESPACE).proxyFactory().createProxy(
+                BatchPaxosAcceptorRpcClient.class,
+                TestProxies.ProxyMode.DIRECT);
+        return acceptor.latestSequencesPreparedOrAccepted(LEADER_FOR_ALL_CLIENTS, null, CLIENT_SET)
+                .updates()
+                .get(PSEUDO_LEADERSHIP_CLIENT);
+    }
+
+    private static long getSequenceForServerUsingOldEndpoint(TestableTimelockServer server) {
+        PaxosRemoteClients.TimelockSingleLeaderPaxosAcceptorRpcClient acceptor = server.client(
+                LEADER_PAXOS_NAMESPACE).proxyFactory().createProxy(
+                PaxosRemoteClients.TimelockSingleLeaderPaxosAcceptorRpcClient.class,
+                TestProxies.ProxyMode.DIRECT);
+        return acceptor.getLatestSequencePreparedOrAccepted();
     }
 }

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
@@ -18,7 +18,6 @@ package com.palantir.atlasdb.timelock;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
-import static com.palantir.atlasdb.timelock.paxos.PaxosUseCase.PSEUDO_LEADERSHIP_CLIENT;
 
 import java.util.Map;
 import java.util.Set;
@@ -37,6 +36,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.atlasdb.timelock.NamespacedClients.ProxyFactory;
 import com.palantir.atlasdb.timelock.paxos.BatchPingableLeader;
 import com.palantir.atlasdb.timelock.paxos.Client;
+import com.palantir.atlasdb.timelock.paxos.PaxosUseCase;
 import com.palantir.atlasdb.timelock.paxos.api.NamespaceLeadershipTakeoverService;
 import com.palantir.atlasdb.timelock.util.TestProxies;
 import com.palantir.atlasdb.timelock.util.TestProxies.ProxyMode;
@@ -50,7 +50,8 @@ import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 
 public class TestableTimelockServer {
 
-    private static final Set<Client> PSEUDO_LEADERSHIP_CLIENT_SET = ImmutableSet.of(PSEUDO_LEADERSHIP_CLIENT);
+    private static final Set<Client> PSEUDO_LEADERSHIP_CLIENT_SET = ImmutableSet.of(
+            PaxosUseCase.PSEUDO_LEADERSHIP_CLIENT);
     private final TimeLockServerHolder serverHolder;
     private final TestProxies proxies;
     private final ProxyFactory proxyFactory;


### PR DESCRIPTION
**Goals (and why)**:
Test that it is safe to switch to using batched single leader as a runtime change.

**Implementation Description (bullets)**:
- Allow to switch between the two settings at the `TestableTimelockServer` level.
- Test switching the behaviour at one node at a time, forcing a leader election each time and verifying that sequence numbers are consistent both for the old and the new acceptor clients.

Paired with @jeremyk-91 on this
