### PR TITLE
Preserve original range request

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
@@ -117,17 +117,19 @@ public interface Transaction {
             final TableReference tableRef,
             Iterable<RangeRequest> rangeRequests,
             int concurrencyLevel,
-            BiFunction<RangeRequest, BatchingVisitable<RowResult<byte[]>>, T> visitableProcessor);
+            BiFunction<RangeRequest, BatchingVisitable<RowResult<byte[]>>, T> visitableProcessor,
+            Map<RangeRequest, RangeRequest> optimizedToOriginalRequestMap);
 
     /**
-     * Same as {@link #getRanges(TableReference, Iterable, int, BiFunction)} but uses the default concurrency
+     * Same as {@link #getRanges(TableReference, Iterable, int, BiFunction, Map)} but uses the default concurrency
      * value specified by {@link KeyValueServiceConfig#defaultGetRangesConcurrency()}.
      */
     @Idempotent
     <T> Stream<T> getRanges(
             final TableReference tableRef,
             Iterable<RangeRequest> rangeRequests,
-            BiFunction<RangeRequest, BatchingVisitable<RowResult<byte[]>>, T> visitableProcessor);
+            BiFunction<RangeRequest, BatchingVisitable<RowResult<byte[]>>, T> visitableProcessor,
+            Map<RangeRequest, RangeRequest> optimizedToOriginalRequestMap);
 
     /**
      * Returns visitibles that scan the provided ranges. This does no pre-fetching so visiting the resulting

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
@@ -98,7 +98,7 @@ public interface Transaction {
      * than you need and will be slower than it needs to be.  If the batchHint isn't specified it
      * will default to 1 for the first page in each range.
      *
-     * @deprecated Should use either {@link #getRanges(TableReference, Iterable, int, BiFunction)} or
+     * @deprecated Should use either {@link #getRanges(TableReference, Iterable, int, BiFunction, Map)} or
      * {@link #getRangesLazy(TableReference, Iterable)} to ensure you are using an appropriate level
      * of concurrency for your specific workflow.
      */

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransaction.java
@@ -99,16 +99,18 @@ public abstract class ForwardingTransaction extends ForwardingObject implements 
             final TableReference tableRef,
             Iterable<RangeRequest> rangeRequests,
             int concurrencyLevel,
-            BiFunction<RangeRequest, BatchingVisitable<RowResult<byte[]>>, T> visitableProcessor) {
-        return delegate().getRanges(tableRef, rangeRequests, concurrencyLevel, visitableProcessor);
+            BiFunction<RangeRequest, BatchingVisitable<RowResult<byte[]>>, T> visitableProcessor,
+            Map<RangeRequest, RangeRequest> optimizedToOriginalRequestMap) {
+        return delegate().getRanges(tableRef, rangeRequests, concurrencyLevel, visitableProcessor, optimizedToOriginalRequestMap);
     }
 
     @Override
     public <T> Stream<T> getRanges(
             final TableReference tableRef,
             Iterable<RangeRequest> rangeRequests,
-            BiFunction<RangeRequest, BatchingVisitable<RowResult<byte[]>>, T> visitableProcessor) {
-        return delegate().getRanges(tableRef, rangeRequests, visitableProcessor);
+            BiFunction<RangeRequest, BatchingVisitable<RowResult<byte[]>>, T> visitableProcessor,
+            Map<RangeRequest, RangeRequest> optimizedToOriginalRequestMap) {
+        return delegate().getRanges(tableRef, rangeRequests, visitableProcessor, optimizedToOriginalRequestMap);
     }
 
     @Override

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ReadTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ReadTransaction.java
@@ -83,18 +83,20 @@ public class ReadTransaction extends ForwardingTransaction {
             final TableReference tableRef,
             Iterable<RangeRequest> rangeRequests,
             int concurrencyLevel,
-            BiFunction<RangeRequest, BatchingVisitable<RowResult<byte[]>>, T> visitableProcessor) {
+            BiFunction<RangeRequest, BatchingVisitable<RowResult<byte[]>>, T> visitableProcessor,
+            Map<RangeRequest, RangeRequest> optimizedToOriginalRequestMap) {
         checkTableName(tableRef);
-        return delegate().getRanges(tableRef, rangeRequests, concurrencyLevel, visitableProcessor);
+        return delegate().getRanges(tableRef, rangeRequests, concurrencyLevel, visitableProcessor, optimizedToOriginalRequestMap);
     }
 
     @Override
     public <T> Stream<T> getRanges(
             final TableReference tableRef,
             Iterable<RangeRequest> rangeRequests,
-            BiFunction<RangeRequest, BatchingVisitable<RowResult<byte[]>>, T> visitableProcessor) {
+            BiFunction<RangeRequest, BatchingVisitable<RowResult<byte[]>>, T> visitableProcessor,
+            Map<RangeRequest, RangeRequest> optimizedToOriginalRequestMap) {
         checkTableName(tableRef);
-        return delegate().getRanges(tableRef, rangeRequests, visitableProcessor);
+        return delegate().getRanges(tableRef, rangeRequests, visitableProcessor, optimizedToOriginalRequestMap);
     }
 
     @Override

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -37,7 +37,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.FutureTask;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import org.junit.Test;
 
@@ -1361,7 +1363,13 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
         Iterable<BatchingVisitable<RowResult<byte[]>>> getRangesWithPrefetchingImpl =
                 t.getRanges(TEST_TABLE, rangeRequests);
         Iterable<BatchingVisitable<RowResult<byte[]>>> getRangesInParallelImpl =
-                t.getRanges(TEST_TABLE, rangeRequests, 2, (rangeRequest, visitable) -> visitable).collect(Collectors.toList());
+                t.getRanges(TEST_TABLE,
+                        rangeRequests,
+                        2,
+                        (rangeRequest, visitable) -> visitable,
+                        StreamSupport.stream(rangeRequests.spliterator(), false)
+                                .collect(Collectors.toMap(Function.identity(), Function.identity())))
+                        .collect(Collectors.toList());
         Iterable<BatchingVisitable<RowResult<byte[]>>> getRangesLazyImpl =
                 t.getRangesLazy(TEST_TABLE, rangeRequests).collect(Collectors.toList());
 


### PR DESCRIPTION
**Goals (and why)**:

- https://github.com/palantir/atlasdb/pull/4558 modifies the RangeRequest values passed to getRanges
- This is not desirable because if equality doesn't work there is no way figure out which range is which

**Implementation Description (bullets)**:

- Maintain mapping of optimized request instances to original rangeRequest ref 

**Testing (What was existing testing like?  What have you done to improve it?)**:

- Pending

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

- SnapshotTransaction.java 

- SweepPriorityTable.java - demo for generated table

**Priority (whenever / two weeks / yesterday)**:

- End of week.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
