### PR TITLE
[PDS-111849] Rolling in the Deep, Part 3: Fix Metrics Plughole

### DIFF
--- a/changelog/@unreleased/pr-4698.v2.yml
+++ b/changelog/@unreleased/pr-4698.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Executors used internally by TimeLock for its Paxos protocol now publish
+    execution metrics as intended. Previously, they failed to do so.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4698

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResourcesFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResourcesFactory.java
@@ -89,7 +89,7 @@ public final class PaxosResourcesFactory {
             ExecutorService sharedExecutor,
             PaxosRemoteClients remoteClients) {
         TimelockPaxosMetrics timelockMetrics =
-                TimelockPaxosMetrics.of(PaxosUseCase.LEADER_FOR_EACH_CLIENT, metrics.getTaggedRegistry());
+                TimelockPaxosMetrics.of(PaxosUseCase.LEADER_FOR_EACH_CLIENT, metrics);
 
         Factories.LeaderPingHealthCheckFactory healthCheckPingersFactory = dependencies -> {
             BatchPingableLeader local = dependencies.components().batchPingableLeader();
@@ -126,7 +126,7 @@ public final class PaxosResourcesFactory {
             ExecutorService sharedExecutor,
             PaxosRemoteClients remoteClients) {
         TimelockPaxosMetrics timelockMetrics =
-                TimelockPaxosMetrics.of(PaxosUseCase.LEADER_FOR_ALL_CLIENTS, metrics.getTaggedRegistry());
+                TimelockPaxosMetrics.of(PaxosUseCase.LEADER_FOR_ALL_CLIENTS, metrics);
 
         Factories.LeaderPingHealthCheckFactory healthCheckPingersFactory = dependencies -> {
             PingableLeader local = dependencies.components().pingableLeader(PaxosUseCase.PSEUDO_LEADERSHIP_CLIENT);
@@ -167,7 +167,7 @@ public final class PaxosResourcesFactory {
             ExecutorService sharedExecutor,
             PaxosRemoteClients remoteClients) {
         TimelockPaxosMetrics timelockMetrics =
-                TimelockPaxosMetrics.of(PaxosUseCase.TIMESTAMP, metrics.getTaggedRegistry());
+                TimelockPaxosMetrics.of(PaxosUseCase.TIMESTAMP, metrics);
 
         LocalPaxosComponents paxosComponents = new LocalPaxosComponents(
                 timelockMetrics,

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/SingleLeaderNetworkClientFactories.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/SingleLeaderNetworkClientFactories.java
@@ -49,7 +49,7 @@ abstract class SingleLeaderNetworkClientFactories implements
                     paxosAcceptors.all(),
                     quorumSize(),
                     TimeLockPaxosExecutors.createBoundedExecutors(
-                            metrics().asMetricsManager().getRegistry(),
+                            metrics().legacyMetrics(),
                             paxosAcceptors,
                             "single-leader-acceptors"),
                     PaxosTimeLockConstants.CANCEL_REMAINING_CALLS);

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/TimeLockPaxosExecutors.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/TimeLockPaxosExecutors.java
@@ -26,11 +26,9 @@ import com.codahale.metrics.InstrumentedExecutorService;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.palantir.common.concurrent.PTExecutors;
-import com.palantir.common.streams.KeyedStream;
 
 final class TimeLockPaxosExecutors {
     @VisibleForTesting

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/TimelockPaxosMetrics.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/TimelockPaxosMetrics.java
@@ -47,8 +47,7 @@ public abstract class TimelockPaxosMetrics {
 
     @Value.Derived
     MetricsManager asMetricsManager() {
-        // we don't use the normal metric registry so we don't care about this
-        return MetricsManagers.of(new MetricRegistry(), metrics());
+        return MetricsManagers.of(legacyMetrics(), metrics());
     }
 
     public static TimelockPaxosMetrics of(

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/TimelockPaxosMetrics.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/TimelockPaxosMetrics.java
@@ -33,6 +33,8 @@ public abstract class TimelockPaxosMetrics {
 
     abstract PaxosUseCase paxosUseCase();
 
+    abstract MetricRegistry legacyMetrics();
+
     @Value.Derived
     TaggedMetricRegistry metrics() {
         return new SlidingWindowTaggedMetricRegistry(35, TimeUnit.SECONDS);
@@ -49,9 +51,14 @@ public abstract class TimelockPaxosMetrics {
         return MetricsManagers.of(new MetricRegistry(), metrics());
     }
 
-    public static TimelockPaxosMetrics of(PaxosUseCase paxosUseCase, TaggedMetricRegistry parentRegistry) {
-        TimelockPaxosMetrics metrics = ImmutableTimelockPaxosMetrics.builder().paxosUseCase(paxosUseCase).build();
-        metrics.attachToParentMetricRegistry(parentRegistry);
+    public static TimelockPaxosMetrics of(
+            PaxosUseCase paxosUseCase,
+            MetricsManager metricsManager) {
+        TimelockPaxosMetrics metrics = ImmutableTimelockPaxosMetrics.builder()
+                .legacyMetrics(metricsManager.getRegistry())
+                .paxosUseCase(paxosUseCase)
+                .build();
+        metrics.attachToParentMetricRegistry(metricsManager.getTaggedRegistry());
         return metrics;
     }
 

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponentsTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponentsTest.java
@@ -28,6 +28,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.paxos.PaxosAcceptor;
 import com.palantir.paxos.PaxosLearner;
 import com.palantir.paxos.PaxosProposal;
@@ -56,7 +57,7 @@ public class LocalPaxosComponentsTest {
     public void setUp() throws IOException {
         logDirectory = TEMPORARY_FOLDER.newFolder().toPath();
         paxosComponents = new LocalPaxosComponents(
-                TimelockPaxosMetrics.of(PaxosUseCase.TIMESTAMP, new DefaultTaggedMetricRegistry()),
+                TimelockPaxosMetrics.of(PaxosUseCase.TIMESTAMP, MetricsManagers.createForTests()),
                 logDirectory,
                 UUID.randomUUID());
     }

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
@@ -47,6 +47,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.Closer;
+import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.common.remoting.ServiceNotAvailableException;
 import com.palantir.common.streams.KeyedStream;
@@ -109,7 +110,7 @@ public class PaxosTimestampBoundStoreTest {
         for (int i = 0; i < NUM_NODES; i++) {
             String root = temporaryFolder.getRoot().getAbsolutePath();
             LocalPaxosComponents components = new LocalPaxosComponents(
-                    TimelockPaxosMetrics.of(PaxosUseCase.TIMESTAMP, SharedTaggedMetricRegistries.getSingleton()),
+                    TimelockPaxosMetrics.of(PaxosUseCase.TIMESTAMP, MetricsManagers.createForTests()),
                     Paths.get(root, Integer.toString(i)),
                     UUID.randomUUID());
 


### PR DESCRIPTION
**Goals (and why)**:
- Actually allow legacy metrics to be propagated from TimeLock codepaths. Previous impl claimed that we don't, but we now do indirectly with instrumented executor services.

**Implementation Description (bullets)**:
- Rewire TimelockPaxosMetrics to take a MetricsManager instead.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Not much, unfortunately.

**Concerns (what feedback would you like?)**:
- Did I miss another blackhole?

**Where should we start reviewing?**: TimelockPaxosMetrics.java

**Priority (whenever / two weeks / yesterday)**: yesterday 🔥 
