### PR TITLE
PTExecutors improvements for cached executor resource utilization

### DIFF
--- a/changelog/@unreleased/pr-4701.v2.yml
+++ b/changelog/@unreleased/pr-4701.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: PTExecutors cached thread pools reuse the same underlying pool of threads.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4701

--- a/commons-db/src/main/java/com/palantir/nexus/db/sql/BasicSQL.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/sql/BasicSQL.java
@@ -56,7 +56,6 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.palantir.common.base.Throwables;
-import com.palantir.common.concurrent.NamedThreadFactory;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.common.concurrent.ThreadNamingCallable;
 import com.palantir.db.oracle.JdbcHandler;
@@ -361,15 +360,12 @@ public abstract class BasicSQL {
 
     private static final String SELECT_THREAD_NAME = "SQL select statement"; //$NON-NLS-1$
     private static final String EXECUTE_THREAD_NAME = "SQL execute statement"; //$NON-NLS-1$
-    private static final int KEEP_SQL_THREAD_ALIVE_TIMEOUT = 3000; //3 seconds
 
     // TODO (jkong): Should these be lazily initialized?
     private static final Supplier<ExecutorService> DEFAULT_SELECT_EXECUTOR =
-            Suppliers.memoize(() -> PTExecutors.newCachedThreadPool(
-                    new NamedThreadFactory(SELECT_THREAD_NAME, true), KEEP_SQL_THREAD_ALIVE_TIMEOUT));
+            Suppliers.memoize(() -> PTExecutors.newCachedThreadPool(SELECT_THREAD_NAME));
     static final Supplier<ExecutorService> DEFAULT_EXECUTE_EXECUTOR =
-            Suppliers.memoize(() -> PTExecutors.newCachedThreadPool(
-                    new NamedThreadFactory(EXECUTE_THREAD_NAME, true), KEEP_SQL_THREAD_ALIVE_TIMEOUT));
+            Suppliers.memoize(() -> PTExecutors.newCachedThreadPool(EXECUTE_THREAD_NAME));
 
     private ExecutorService selectStatementExecutor;
     private ExecutorService executeStatementExecutor;

--- a/commons-executors/build.gradle
+++ b/commons-executors/build.gradle
@@ -11,4 +11,5 @@ dependencies {
     implementation "com.palantir.tritium:tritium-metrics"
 
     testCompile group: 'com.google.guava', name: 'guava'
+    testCompile group: 'org.awaitility', name: 'awaitility'
 }

--- a/commons-executors/src/main/java/com/palantir/common/concurrent/ThreadNamingExecutorService.java
+++ b/commons-executors/src/main/java/com/palantir/common/concurrent/ThreadNamingExecutorService.java
@@ -1,0 +1,199 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.palantir.common.concurrent;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import javax.annotation.Nullable;
+
+import com.google.common.collect.Collections2;
+import com.palantir.logsafe.Preconditions;
+
+/** An ExecutorService decorator which updates names of threads while tasks run. */
+final class ThreadNamingExecutorService implements ExecutorService {
+    private final ExecutorService delegate;
+    private final ThreadNameFunction nameFunction;
+
+    private ThreadNamingExecutorService(ExecutorService delegate, ThreadNameFunction nameFunction) {
+        this.delegate = Preconditions.checkNotNull(delegate, "ExecutorService is required");
+        this.nameFunction = Preconditions.checkNotNull(nameFunction, "Name function is required");
+    }
+
+    @Override
+    public void shutdown() {
+        delegate.shutdown();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        return delegate.shutdownNow();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return delegate.isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return delegate.isTerminated();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return delegate.awaitTermination(timeout, unit);
+    }
+
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        return delegate.submit(wrap(task));
+    }
+
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        return delegate.submit(wrap(task), result);
+    }
+
+    @Override
+    public Future<?> submit(Runnable task) {
+        return delegate.submit(wrap(task));
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        return delegate.invokeAll(Collections2.transform(tasks, this::wrap));
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+            throws InterruptedException {
+        return delegate.invokeAll(Collections2.transform(tasks, this::wrap), timeout, unit);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+        return delegate.invokeAny(Collections2.transform(tasks, this::wrap));
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        return delegate.invokeAny(Collections2.transform(tasks, this::wrap), timeout, unit);
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        delegate.execute(wrap(command));
+    }
+
+    private Runnable wrap(Runnable in) {
+        return new NamingRunnable(in, nameFunction);
+    }
+
+    private <T> Callable<T> wrap(Callable<T> in) {
+        return new NamingCallable<>(in, nameFunction);
+    }
+
+    private static final class NamingRunnable implements Runnable {
+
+        private final Runnable delegate;
+        private final ThreadNameFunction nameFunction;
+
+        NamingRunnable(Runnable delegate, ThreadNameFunction nameFunction) {
+            this.delegate = delegate;
+            this.nameFunction = nameFunction;
+        }
+
+        @Override
+        public void run() {
+            Thread current = Thread.currentThread();
+            String originalName = current.getName();
+            current.setName(nameFunction.rename(originalName));
+            try {
+                delegate.run();
+            } finally {
+                current.setName(originalName);
+            }
+        }
+    }
+
+    private static final class NamingCallable<T> implements Callable<T> {
+
+        private final Callable<T> delegate;
+        private final ThreadNameFunction nameFunction;
+
+        NamingCallable(Callable<T> delegate, ThreadNameFunction nameFunction) {
+            this.delegate = delegate;
+            this.nameFunction = nameFunction;
+        }
+
+        @Override
+        public T call() throws Exception {
+            Thread current = Thread.currentThread();
+            String originalName = current.getName();
+            current.setName(nameFunction.rename(originalName));
+            try {
+                return delegate.call();
+            } finally {
+                current.setName(originalName);
+            }
+        }
+    }
+
+    interface ThreadNameFunction {
+        String rename(String original);
+    }
+
+    static Builder builder() {
+        return new Builder();
+    }
+
+    static final class Builder {
+
+        @Nullable
+        private ExecutorService executor;
+
+        @Nullable
+        private ThreadNameFunction nameFunction;
+
+        private Builder() {}
+
+        Builder executor(ExecutorService value) {
+            this.executor = Preconditions.checkNotNull(value, "ExecutorService is required");
+            return this;
+        }
+
+        Builder threadNameFunction(ThreadNameFunction value) {
+            this.nameFunction = Preconditions.checkNotNull(value, "ThreadNameFunction is required");
+            return this;
+        }
+
+        ExecutorService build() {
+            return new ThreadNamingExecutorService(
+                    Preconditions.checkNotNull(executor, "ExecutorService is required"),
+                    Preconditions.checkNotNull(nameFunction, "ThreadNameFunction is required"));
+        }
+    }
+}

--- a/commons-executors/src/test/java/com/palantir/common/concurrent/CachedExecutorViewTest.java
+++ b/commons-executors/src/test/java/com/palantir/common/concurrent/CachedExecutorViewTest.java
@@ -1,0 +1,119 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.palantir.common.concurrent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.awaitility.Awaitility;
+import org.junit.Test;
+
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.Runnables;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.common.util.concurrent.Uninterruptibles;
+
+public class CachedExecutorViewTest {
+
+    @Test
+    public void testShutdownNow() throws InterruptedException {
+        AtomicBoolean interrupted = new AtomicBoolean();
+        ExecutorService cached = Executors.newCachedThreadPool(new ThreadFactoryBuilder()
+                .setDaemon(true)
+                .setNameFormat("CachedExecutorViewTest-%d")
+                .build());
+        ExecutorService view = CachedExecutorView.of(cached);
+        assertThat(view.isShutdown()).isEqualTo(cached.isShutdown()).isFalse();
+        assertThat(view.isTerminated()).isEqualTo(cached.isTerminated()).isFalse();
+        CountDownLatch executionStartedLatch = new CountDownLatch(1);
+        CountDownLatch interruptedLatch = new CountDownLatch(1);
+        view.execute(() -> {
+            try {
+                executionStartedLatch.countDown();
+                Thread.sleep(10_000);
+            } catch (InterruptedException e) {
+                interrupted.set(true);
+                // Wait so we can validate the time between shutdown and terminated
+                Uninterruptibles.awaitUninterruptibly(interruptedLatch);
+            }
+        });
+        executionStartedLatch.await();
+        assertThat(view.shutdownNow()).as("Cached executors have no queue").isEmpty();
+        assertThat(view.isShutdown()).isTrue();
+        assertThatThrownBy(() -> view.execute(Runnables.doNothing()))
+                .as("Submitting work after invoking shutdown or shutdownNow should fail")
+                .isInstanceOf(RejectedExecutionException.class);
+        Awaitility.waitAtMost(500, TimeUnit.MILLISECONDS).untilAsserted(() -> {
+            assertThat(interrupted).isTrue();
+            assertThat(view.isTerminated()).isFalse();
+        });
+        interruptedLatch.countDown();
+        Awaitility.waitAtMost(500, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> assertThat(view.isTerminated()).isTrue());
+
+        assertThat(cached.isShutdown()).isFalse();
+        assertThat(cached.isTerminated()).isFalse();
+        assertThat(MoreExecutors.shutdownAndAwaitTermination(cached, 1, TimeUnit.SECONDS))
+                .as("Failed to clean up the delegate executor")
+                .isTrue();
+    }
+
+    @Test
+    public void testShutdown() throws InterruptedException {
+        AtomicBoolean interrupted = new AtomicBoolean();
+        ExecutorService cached = Executors.newCachedThreadPool(new ThreadFactoryBuilder()
+                .setDaemon(true)
+                .setNameFormat("CachedExecutorViewTest-%d")
+                .build());
+        ExecutorService view = CachedExecutorView.of(cached);
+        assertThat(view.isShutdown()).isEqualTo(cached.isShutdown()).isFalse();
+        assertThat(view.isTerminated()).isEqualTo(cached.isTerminated()).isFalse();
+        CountDownLatch executionStartedLatch = new CountDownLatch(1);
+        view.execute(() -> {
+            try {
+                executionStartedLatch.countDown();
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                interrupted.set(true);
+            }
+        });
+        executionStartedLatch.await();
+        view.shutdown();
+        assertThat(view.isShutdown()).isTrue();
+        assertThatThrownBy(() -> view.execute(Runnables.doNothing()))
+                .as("Submitting work after invoking shutdown or shutdown should fail")
+                .isInstanceOf(RejectedExecutionException.class);
+        assertThat(view.isTerminated()).isFalse();
+        Awaitility.waitAtMost(600, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> assertThat(view.isTerminated()).isTrue());
+        assertThat(interrupted).isFalse();
+
+        assertThat(cached.isShutdown()).isFalse();
+        assertThat(cached.isTerminated()).isFalse();
+        assertThat(MoreExecutors.shutdownAndAwaitTermination(cached, 1, TimeUnit.SECONDS))
+                .as("Failed to clean up the delegate executor")
+                .isTrue();
+    }
+}

--- a/commons-executors/src/test/java/com/palantir/common/concurrent/ThreadNamingExecutorServiceTest.java
+++ b/commons-executors/src/test/java/com/palantir/common/concurrent/ThreadNamingExecutorServiceTest.java
@@ -18,7 +18,12 @@
 package com.palantir.common.concurrent;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -90,5 +95,95 @@ public class ThreadNamingExecutorServiceTest {
                     .as("Failed to clean up the delegate executor")
                     .isTrue();
         }
+    }
+
+    @Test
+    public void testUncaughtExceptionHandlerCalledWithUpdatedName_runnable_execute() {
+        List<String> uncaughtExceptionThreadNames = new CopyOnWriteArrayList<>();
+        String expectedBase = "ThreadNamingExecutorServiceTest-0";
+        String expectedRenamed = "renamed-" + expectedBase;
+        Thread.UncaughtExceptionHandler handler =
+                (thread, ignored) -> uncaughtExceptionThreadNames.add(thread.getName());
+        ExecutorService executorService = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder()
+                .setNameFormat("ThreadNamingExecutorServiceTest-%d")
+                .setDaemon(true)
+                .setUncaughtExceptionHandler(handler)
+                .build());
+        try {
+            ExecutorService renaming = ThreadNamingExecutorService.builder()
+                    .executor(executorService)
+                    .threadNameFunction(original -> "renamed-" + original)
+                    .build();
+            renaming.execute(() -> {
+                throw new RuntimeException();
+            });
+        } finally {
+            assertThat(MoreExecutors.shutdownAndAwaitTermination(executorService, 1, TimeUnit.SECONDS))
+                    .as("Failed to clean up the delegate executor")
+                    .isTrue();
+        }
+        assertThat(uncaughtExceptionThreadNames).containsExactly(expectedRenamed);
+    }
+
+    @Test
+    public void testUncaughtExceptionHandlerCalledWithUpdatedName_runnable_submit() {
+        List<String> uncaughtExceptionThreadNames = new CopyOnWriteArrayList<>();
+        Thread.UncaughtExceptionHandler handler =
+                (thread, ignored) -> uncaughtExceptionThreadNames.add(thread.getName());
+        ExecutorService executorService = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder()
+                .setNameFormat("ThreadNamingExecutorServiceTest-%d")
+                .setDaemon(true)
+                .setUncaughtExceptionHandler(handler)
+                .build());
+        try {
+            ExecutorService renaming = ThreadNamingExecutorService.builder()
+                    .executor(executorService)
+                    .threadNameFunction(original -> "renamed-" + original)
+                    .build();
+            Runnable throwingRunnable = () -> {
+                throw new RuntimeException();
+            };
+            assertThatThrownBy(renaming.submit(throwingRunnable)::get)
+                    .isInstanceOf(ExecutionException.class);
+        } finally {
+            assertThat(MoreExecutors.shutdownAndAwaitTermination(executorService, 1, TimeUnit.SECONDS))
+                    .as("Failed to clean up the delegate executor")
+                    .isTrue();
+        }
+        assertThat(uncaughtExceptionThreadNames)
+                .as("executor.submit should not interact with the uncaught exception handler, "
+                        + "failures are recorded to the returned future")
+                .isEmpty();
+    }
+
+    @Test
+    public void testUncaughtExceptionHandlerCalledWithUpdatedName_callable_submit() {
+        List<String> uncaughtExceptionThreadNames = new CopyOnWriteArrayList<>();
+        Thread.UncaughtExceptionHandler handler =
+                (thread, ignored) -> uncaughtExceptionThreadNames.add(thread.getName());
+        ExecutorService executorService = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder()
+                .setNameFormat("ThreadNamingExecutorServiceTest-%d")
+                .setDaemon(true)
+                .setUncaughtExceptionHandler(handler)
+                .build());
+        try {
+            ExecutorService renaming = ThreadNamingExecutorService.builder()
+                    .executor(executorService)
+                    .threadNameFunction(original -> "renamed-" + original)
+                    .build();
+            Callable<Object> throwingCallable = () -> {
+                throw new RuntimeException();
+            };
+            assertThatThrownBy(renaming.submit(throwingCallable)::get)
+                    .isInstanceOf(ExecutionException.class);
+        } finally {
+            assertThat(MoreExecutors.shutdownAndAwaitTermination(executorService, 1, TimeUnit.SECONDS))
+                    .as("Failed to clean up the delegate executor")
+                    .isTrue();
+        }
+        assertThat(uncaughtExceptionThreadNames)
+                .as("executor.submit should not interact with the uncaught exception handler, "
+                        + "failures are recorded to the returned future")
+                .isEmpty();
     }
 }

--- a/commons-executors/src/test/java/com/palantir/common/concurrent/ThreadNamingExecutorServiceTest.java
+++ b/commons-executors/src/test/java/com/palantir/common/concurrent/ThreadNamingExecutorServiceTest.java
@@ -1,0 +1,94 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.palantir.common.concurrent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+public class ThreadNamingExecutorServiceTest {
+
+    @Test
+    public void testThreadRenaming_runnable() throws Exception {
+        ExecutorService executorService = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder()
+                .setNameFormat("ThreadNamingExecutorServiceTest-%d")
+                .setDaemon(true)
+                .build());
+        try {
+            String expectedBase = "ThreadNamingExecutorServiceTest-0";
+            String expectedRenamed = "renamed-" + expectedBase;
+            ExecutorService renaming = ThreadNamingExecutorService.builder()
+                    .executor(executorService)
+                    .threadNameFunction(original -> "renamed-" + original)
+                    .build();
+            AtomicReference<Thread> capturedThread = new AtomicReference<>();
+            renaming.submit(() -> {
+                Thread current = Thread.currentThread();
+                capturedThread.set(current);
+                assertThat(current.getName()).isEqualTo(expectedRenamed);
+            })
+                    .get();
+            assertThat(capturedThread.get().getName())
+                    .as("Expected the thread name to be reverted to its original value")
+                    .isEqualTo(expectedBase);
+        } finally {
+            assertThat(MoreExecutors.shutdownAndAwaitTermination(executorService, 1, TimeUnit.SECONDS))
+                    .as("Failed to clean up the delegate executor")
+                    .isTrue();
+        }
+    }
+
+    @Test
+    public void testThreadRenaming_callable() throws Exception {
+        ExecutorService executorService = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder()
+                .setNameFormat("ThreadNamingExecutorServiceTest-%d")
+                .setDaemon(true)
+                .build());
+        try {
+            String expectedBase = "ThreadNamingExecutorServiceTest-0";
+            String expectedRenamed = "renamed-" + expectedBase;
+            ExecutorService renaming = ThreadNamingExecutorService.builder()
+                    .executor(executorService)
+                    .threadNameFunction(original -> "renamed-" + original)
+                    .build();
+            AtomicReference<Thread> capturedThread = new AtomicReference<>();
+            renaming.submit(() -> {
+                Thread current = Thread.currentThread();
+                capturedThread.set(current);
+                assertThat(current.getName()).isEqualTo(expectedRenamed);
+                return "result";
+            })
+                    .get();
+            assertThat(capturedThread.get().getName())
+                    .as("Expected the thread name to be reverted to its original value")
+                    .isEqualTo(expectedBase);
+        } finally {
+            assertThat(MoreExecutors.shutdownAndAwaitTermination(executorService, 1, TimeUnit.SECONDS))
+                    .as("Failed to clean up the delegate executor")
+                    .isTrue();
+        }
+    }
+}

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -24,10 +24,8 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import com.codahale.metrics.InstrumentedExecutorService;
-import com.codahale.metrics.InstrumentedThreadFactory;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Suppliers;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.palantir.atlasdb.config.ImmutableLeaderConfig;
 import com.palantir.atlasdb.http.BlockingTimeoutExceptionMapper;
 import com.palantir.atlasdb.http.NotCurrentLeaderExceptionMapper;
@@ -144,10 +142,7 @@ public class TimeLockAgent {
 
     private static ExecutorService createSharedExecutor(MetricsManager metricsManager) {
         return new InstrumentedExecutorService(
-                PTExecutors.newCachedThreadPool(new InstrumentedThreadFactory(new ThreadFactoryBuilder()
-                        .setNameFormat("paxos-timestamp-creator-%d")
-                        .setDaemon(true)
-                        .build(), metricsManager.getRegistry())),
+                PTExecutors.newCachedThreadPool("paxos-timestamp-creator"),
                 metricsManager.getRegistry(),
                 MetricRegistry.name(PaxosLeaderElectionService.class, PAXOS_SHARED_EXECUTOR, "executor"));
     }


### PR DESCRIPTION
**Goals (and why)**:

We have a ton of threads at any given point in time. While we have a ton of threads, we're also actively creating and destroying threads across existing thread pools where we could reuse the resources we've already created.

PTExecutors cached executors use a short timeout duration of 5 seconds (3 second for BasicSQL.java) which contributes heavily to the aforementioned thread churn, especially in real world environments that can't keep the executors saturated like synthetic benchmarking.

**Implementation Description (bullets)**:

* PTExecutors thread factory uses daemon threads by default. Most consumers prefer daemon threads to avoid propping up JVMs that want to die.
* PTExecutors.newCachedThreadPool returns ExecutorService instances instead of ThreadPoolExecutor concrete types. This is an ABI break. Please use WC executor factories wherever possible (note this optimization is not applied there quite yet, on on my list)
* Cached pool factories that don't take a ThreadFactory provide a decorated view onto a shared cached executors so that threads may flow freely between all cached executors.

**Testing (What was existing testing like?  What have you done to improve it?)**:

Existing testing covers behavior of the refactored code, added test coverage for new functionality.

**Concerns (what feedback would you like?)**:
¯\_(ツ)_/¯

**Where should we start reviewing?**:
¯\_(ツ)_/¯

**Priority (whenever / two weeks / yesterday)**:
¯\_(ツ)_/¯