### PR TITLE
Restoring the Range Request Contract, Part 1: Parameter Objects for getRange

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/GetRangesQuery.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/GetRangesQuery.java
@@ -1,0 +1,51 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.api;
+
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.UnaryOperator;
+
+import org.immutables.value.Value;
+
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.atlasdb.keyvalue.api.RowResult;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.common.base.BatchingVisitable;
+
+@Value.Immutable
+public interface GetRangesQuery<RESPONSE_TYPE> {
+    TableReference tableRef();
+    Iterable<RangeRequest> rangeRequests();
+
+    /**
+     * Parallelism to run this getRanges query with. If not specified, a default value is selected.
+     */
+    Optional<Integer> concurrencyLevel();
+
+    /**
+     * An operator invoked on each range request, to possibly improve the performance of range requests based on schema
+     * knowledge. The output of this operator is only used for internal queries: the user-provided visitable processor
+     * will receive the original range requests from {@link #rangeRequests()}.
+     */
+    @Value.Default
+    default UnaryOperator<RangeRequest> rangeRequestOptimizer() {
+        return x -> x;
+    }
+
+    BiFunction<RangeRequest, BatchingVisitable<RowResult<byte[]>>, RESPONSE_TYPE> visitableProcessor();
+}

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
@@ -109,8 +109,11 @@ public interface Transaction {
             Iterable<RangeRequest> rangeRequests);
 
     /**
-     * Creates unvisited visitibles that scan the provided ranges and then applies the provided visitableProcessor
+     * Creates unvisited visitables that scan the provided ranges and then applies the provided visitableProcessor
      * function with concurrency specified by the concurrencyLevel parameter.
+     *
+     * It is guaranteed that the range requests seen by the provided visitable processor are equal to the provided
+     * iterable of range requests, though no guarantees are made on the order they are encountered in.
      */
     @Idempotent
     <T> Stream<T> getRanges(

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
@@ -130,6 +130,13 @@ public interface Transaction {
             BiFunction<RangeRequest, BatchingVisitable<RowResult<byte[]>>, T> visitableProcessor);
 
     /**
+     * Same as {@link #getRanges(TableReference, Iterable, int, BiFunction)}. However, additionally allows for the
+     * specification of additional parameters specific to {@link GetRangesQuery}.
+     */
+    @Idempotent
+    <T> Stream<T> getRanges(GetRangesQuery<T> getRangesQuery);
+
+    /**
      * Returns visitibles that scan the provided ranges. This does no pre-fetching so visiting the resulting
      * visitibles will incur database reads on first access.
      */

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransaction.java
@@ -33,6 +33,7 @@ import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.transaction.api.ConstraintCheckable;
+import com.palantir.atlasdb.transaction.api.GetRangesQuery;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionFailedException;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
@@ -109,6 +110,11 @@ public abstract class ForwardingTransaction extends ForwardingObject implements 
             Iterable<RangeRequest> rangeRequests,
             BiFunction<RangeRequest, BatchingVisitable<RowResult<byte[]>>, T> visitableProcessor) {
         return delegate().getRanges(tableRef, rangeRequests, visitableProcessor);
+    }
+
+    @Override
+    public <T> Stream<T> getRanges(GetRangesQuery<T> getRangesQuery) {
+        return delegate().getRanges(getRangesQuery);
     }
 
     @Override

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ReadTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ReadTransaction.java
@@ -32,6 +32,7 @@ import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.logging.LoggingArgs;
 import com.palantir.atlasdb.table.description.SweepStrategy;
+import com.palantir.atlasdb.transaction.api.GetRangesQuery;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.common.base.BatchingVisitable;
 import com.palantir.logsafe.Preconditions;
@@ -95,6 +96,11 @@ public class ReadTransaction extends ForwardingTransaction {
             BiFunction<RangeRequest, BatchingVisitable<RowResult<byte[]>>, T> visitableProcessor) {
         checkTableName(tableRef);
         return delegate().getRanges(tableRef, rangeRequests, visitableProcessor);
+    }
+
+    @Override
+    public <T> Stream<T> getRanges(GetRangesQuery<T> getRangesQuery) {
+        return delegate().getRanges(getRangesQuery);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -881,15 +881,6 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         return getRanges(tableRef, rangeRequests, defaultGetRangesConcurrency, visitableProcessor);
     }
 
-    private static boolean isSingleton(Iterable<?> elements) {
-        Iterator<?> it = elements.iterator();
-        if (it.hasNext()) {
-            it.next();
-            return !it.hasNext();
-        }
-        return false;
-    }
-
     @Override
     public <T> Stream<T> getRanges(GetRangesQuery<T> query) {
         if (!Iterables.isEmpty(query.rangeRequests())) {
@@ -913,6 +904,15 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                 pair -> processor.apply(pair.getLeft(), pair.getRight()),
                 getRangesExecutor,
                 concurrencyLevel);
+    }
+
+    private static boolean isSingleton(Iterable<?> elements) {
+        Iterator<?> it = elements.iterator();
+        if (it.hasNext()) {
+            it.next();
+            return !it.hasNext();
+        }
+        return false;
     }
 
     @Override

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -1379,7 +1379,8 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
         putDirect("tom", "col", "value", 0);
 
         BiFunction<RangeRequest, BatchingVisitable<RowResult<byte[]>>, byte[]> singleValueExtractor
-                = ($, visitable) -> Iterables.getOnlyElement(BatchingVisitables.copyToList(visitable)).getRowName();
+                = ($, visitable) -> Iterables.getOnlyElement(BatchingVisitables.copyToList(visitable))
+                        .getOnlyColumnValue();
 
         Transaction transaction = startTransaction();
         List<byte[]> extractedValue = transaction.getRanges(ImmutableGetRangesQuery.<byte[]>builder()
@@ -1389,7 +1390,7 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
                 .visitableProcessor(singleValueExtractor)
                 .build())
                 .collect(Collectors.toList());
-        assertThat(extractedValue).containsExactly(PtBytes.toBytes("tom"));
+        assertThat(extractedValue).containsExactly(PtBytes.toBytes("value"));
     }
 
     private void verifyAllGetRangesImplsRangeSizes(Transaction t, RangeRequest templateRangeRequest, int expectedRangeSize) {

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -91,7 +90,6 @@ import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionConflictException;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
 import com.palantir.atlasdb.transaction.api.TransactionTask;
-import com.palantir.common.base.AbortingVisitor;
 import com.palantir.common.base.AbortingVisitors;
 import com.palantir.common.base.BatchingVisitable;
 import com.palantir.common.base.BatchingVisitables;


### PR DESCRIPTION
**Goals (and why)**:
- See #4693. The goal here is to preserve original range requests in a getRanges call: see the new API guarantee I'm adding to the contract. Deviating from this caused problems for some internal products.

```
     * It is guaranteed that the range requests seen by the provided visitable processor are equal to the provided
     * iterable of range requests, though no guarantees are made on the order they are encountered in.
```

- We still want the range requests to be optimised, and want the freedom to rewrite these.

**Implementation Description (bullets)**:
- Add a new version of the endpoint that takes a parameter object.
- Refactor existing versions of the endpoint to use the new version.
- Codegen needs to use the new endpoints before the issue is fully fixed (that's part 2).

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Added new tests _at the transaction level_ that getRanges works as advertised.
- Existing transaction tests passing should give us confidence that the codepath is not broken.

**Concerns (what feedback would you like?)**:
- An alternative was considered of maintaining a reverse mapping. The problem though is that the optimisation isn't an injection (e.g. equal queries, one with no columns specified and one retaining all columns), and doing a reverse mapping kind of boxes us in to ensuring invertibility. Behaviour for handling multiple user-level queries that would be rewritten to exactly the same query, and managing the order of these under possible concurrency seemed less than ideal. Note that it is not possible to push the optimisation layer directly into the transaction because it depends on the user's generated schema.
- I wasn't a fan of breaking the APIs as was done in 4693.

**Where should we start reviewing?**: `Transaction.java`

**Priority (whenever / two weeks / yesterday)**: next week
