### PR TITLE
[CentOS Migration] Part 1: Configurable Ban on New Clients

### DIFF
--- a/changelog/@unreleased/pr-4712.v2.yml
+++ b/changelog/@unreleased/pr-4712.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: |-
+    Allow timelock to be configured to prohibit new clients from being created (via setting `can-create-new-clients` to false). The operation of extracting all live clients is common in operational workflows.
+
+    Note that this configuration takes place on a node level. Thus, if there are clients where some nodes never participated in any quorum, then these nodes may reject requests made for these clients. The cluster will be able to service clients which a majority of nodes knew about before this configuration option was enabled.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4712

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipContextFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipContextFactory.java
@@ -55,7 +55,8 @@ public abstract class LeadershipContextFactory implements
         return new LocalPaxosComponents(
                 metrics(),
                 useCase().logDirectoryRelativeToDataDirectory(install().dataDirectory()),
-                leaderUuid());
+                leaderUuid(),
+                install().install().paxos().canCreateNewClients());
     }
 
     @Value.Derived

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResourcesFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResourcesFactory.java
@@ -185,7 +185,8 @@ public final class PaxosResourcesFactory {
         LocalPaxosComponents paxosComponents = new LocalPaxosComponents(
                 timelockMetrics,
                 PaxosUseCase.TIMESTAMP.logDirectoryRelativeToDataDirectory(install.dataDirectory()),
-                install.nodeUuid());
+                install.nodeUuid(),
+                install.install().paxos().canCreateNewClients());
 
         NetworkClientFactories batchClientFactories = ImmutableBatchingNetworkClientFactories.builder()
                 .useCase(PaxosUseCase.TIMESTAMP)

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosInstallConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosInstallConfiguration.java
@@ -45,6 +45,16 @@ public interface PaxosInstallConfiguration {
     @JsonProperty("is-new-service")
     boolean isNewService();
 
+    /**
+     * If true, TimeLock is allowed to create clients that it has never seen before.
+     * If false, then TimeLock will continue to serve requests for clients that it already knows about (across the
+     * history of its persistent state, not just the life of the current JVM), but it will not accept any new clients.
+     */
+    @JsonProperty("can-create-new-clients")
+    default boolean canCreateNewClients() {
+        return true;
+    }
+
     enum PaxosLeaderMode {
         SINGLE_LEADER,
         LEADER_PER_CLIENT,

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponents.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponents.java
@@ -91,7 +91,7 @@ public class LocalPaxosComponents {
 
     private Components createComponents(Client client) {
         Path clientDirectory = logDirectory.resolve(client.value());
-        if (!canCreateNewClients && !clientDirectory.toFile().exists()) {
+        if (!canCreateNewClients && clientDirectoryDoesNotExist(clientDirectory)) {
             throw new ServiceNotAvailableException("This TimeLock server is not allowed to create new clients at this"
                     + " time, and the client " + client + " provided is novel for this TimeLock server.");
         }
@@ -110,6 +110,10 @@ public class LocalPaxosComponents {
                 .learner(learner)
                 .pingableLeader(localPingableLeader)
                 .build();
+    }
+
+    private boolean clientDirectoryDoesNotExist(Path clientDirectory) {
+        return !clientDirectory.toFile().exists();
     }
 
     private BatchPaxosAcceptor createBatchAcceptor() {

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponents.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponents.java
@@ -91,7 +91,7 @@ public class LocalPaxosComponents {
 
     private Components createComponents(Client client) {
         Path clientDirectory = logDirectory.resolve(client.value());
-        if (!canCreateNewClients && !Files.exists(clientDirectory)) {
+        if (!canCreateNewClients && !clientDirectory.toFile().exists()) {
             throw new ServiceNotAvailableException("This TimeLock server is not allowed to create new clients at this"
                     + " time, and the client " + client + " provided is novel for this TimeLock server.");
         }

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponentsTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponentsTest.java
@@ -96,7 +96,10 @@ public class LocalPaxosComponentsTest {
                 logDirectory,
                 UUID.randomUUID(),
                 false);
-        assertThatThrownBy(() -> rejectingComponents.learner(CLIENT)).isInstanceOf(ServiceNotAvailableException.class);
+        assertThatThrownBy(() -> rejectingComponents.learner(CLIENT))
+                .isInstanceOf(ServiceNotAvailableException.class)
+                .hasMessageContaining("not allowed to create new clients at this time")
+                .hasMessageContaining(CLIENT.value());
     }
 
     @Test

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
@@ -112,7 +112,8 @@ public class PaxosTimestampBoundStoreTest {
             LocalPaxosComponents components = new LocalPaxosComponents(
                     TimelockPaxosMetrics.of(PaxosUseCase.TIMESTAMP, MetricsManagers.createForTests()),
                     Paths.get(root, Integer.toString(i)),
-                    UUID.randomUUID());
+                    UUID.randomUUID(),
+                    true);
 
             AtomicBoolean failureController = new AtomicBoolean(false);
             failureToggles.add(failureController);


### PR DESCRIPTION
**Goals (and why)**:
- Many support procedures including the internal migration work we're planning make assumptions that the list of clients is fixed.
- Ordinarily TimeLock allows you to just register a new client freely, so these procedures aren't fully tight.

**Implementation Description (bullets)**:
- Add an *install* time config that allows configuration of whether operations on novel namespaces should be permitted. A novel namespace is one that a node has never seen before (but, importantly, including in the lifetime of previous JVMs), and is adjudicated based on the Paxos directory state.
- Prevent creating Paxos components for novel namespaces, as defined above.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added two tests: with `false` you can't create a client, but you can for something already there.

**Concerns (what feedback would you like?)**:
- Should this be runtime config? I preferred install so you could force a rolling bounce to ensure everyone is up to date.
- Is there a problem with using the existence of the Paxos directory as a check on what namespaces have historically been seen?

**Where should we start reviewing?**: LocalPaxosComponents

**Priority (whenever / two weeks / yesterday)**: This week.
