### PR TITLE
Use structured locks for observability

### DIFF
--- a/changelog/@unreleased/pr-4715.v2.yml
+++ b/changelog/@unreleased/pr-4715.v2.yml
@@ -1,0 +1,9 @@
+type: improvement
+improvement:
+  description: |-
+    PaxosStateLogImpl and PaxosLeaderElectionService use structured
+    locks (the synchronized keyword) for better observability.
+    This makes it easier to discover which thread is holding locks
+    while others wait from a jstack.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4715

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
@@ -191,7 +191,8 @@ public class PaxosLeaderElectionService implements LeaderElectionService {
                 log.debug("Proposing leadership with value [{}]", SafeArg.of("paxosValue", value));
                 if (!isLatestRound(value)) {
                     // This means that new data has come in so we shouldn't propose leadership.
-                    // We do this check in a lock to ensure concurrent callers to blockOnBecomingLeader behaves correctly.
+                    // We do this check in a lock to ensure concurrent callers to blockOnBecomingLeader
+                    // behaves correctly.
                     return;
                 }
 


### PR DESCRIPTION
**Goals (and why)**:

PaxosStateLogImpl and PaxosLeaderElectionService use structured
locks (the synchronized keyword) for better observability.
This makes it easier to discover which thread is holding locks
while others wait from a jstack.

Structured locks allow the jit to perform optimziations that
aren't possible for unstructured locks, for example lock coarsening[1]
and lock elision[2], on top of generally better performance of
`synchronized` on modern JVMs.

1. https://shipilev.net/jvm/anatomy-quarks/1-lock-coarsening-for-loops/
2. https://shipilev.net/jvm/anatomy-quarks/19-lock-elision/

**Implementation Description (bullets)**:

`synchronized`

**Testing (What was existing testing like?  What have you done to improve it?)**:

No behavior change, existing testing is sufficient.
