### PR TITLE
Bump sls-cassandra max dependency to 6.x

### DIFF
--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -101,6 +101,6 @@ recommendedProductDependencies {
         productGroup = 'com.palantir.cassandra'
         productName = 'sls-cassandra'
         minimumVersion = '3.31.0'
-        maximumVersion = '4.x.x'
+        maximumVersion = '6.x.x'
     }
 }

--- a/changelog/@unreleased/pr-4716.v2.yml
+++ b/changelog/@unreleased/pr-4716.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Bump sls-cassandra max dependency to 6.x.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4716


### PR DESCRIPTION
**Goals (and why)**:

We are intending to release Cassandra 3 under sls-cassandra 6.x.  The first step to permit this rollout is to raise Atlas's max dependency.

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:
See https://github.com/palantir/atlasdb/pull/4539 for Atlas ETE tests run against Cassandra 3.  Lots of manual testing and validation has been done as well.

**Concerns (what feedback would you like?)**:
New PRs will not run against Cassandra 3 until the above PR is merged.  However, I will not deploy Cassandra 3 to a production environment until Atlas is running tests against Cassandra 3 by default.

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

ASAP

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
