### PR TITLE
Refactor out Shutdown Runner from SnapshotTransactionManager

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/util/ExceptionHandlingRunner.java
+++ b/atlasdb-commons/src/main/java/com/palantir/util/ExceptionHandlingRunner.java
@@ -24,7 +24,8 @@ import java.util.function.Supplier;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 
 /**
- * Runs runnables and suppliers that may throw exceptions, and swallows those exceptions until the runner is closed.
+ * Runs runnables and suppliers that may throw exceptions, and swallows those exceptions until the runner is closed. If
+ * any exceptions occurred, they are suppressed in the order in which they were thrown.
  * Can be used as a resource in a try block, or delegated to by another resource.
  */
 public final class ExceptionHandlingRunner implements AutoCloseable {

--- a/atlasdb-commons/src/main/java/com/palantir/util/ExceptionHandlingRunner.java
+++ b/atlasdb-commons/src/main/java/com/palantir/util/ExceptionHandlingRunner.java
@@ -24,8 +24,7 @@ import java.util.function.Supplier;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 
 /**
- * Runs runnables and suppliers that may throw exceptions, and swallows those exceptions until the runner is closed. If
- * any exceptions occurred, they are suppressed in the order in which they were thrown.
+ * Runs runnables and suppliers that may throw exceptions, and swallows those exceptions until the runner is closed.
  * Can be used as a resource in a try block, or delegated to by another resource.
  */
 public final class ExceptionHandlingRunner implements AutoCloseable {
@@ -58,8 +57,9 @@ public final class ExceptionHandlingRunner implements AutoCloseable {
     }
 
     /**
-     * Calling close with no failures should be a no-op; equally, calling close multiple times will re-throw a runtime
-     * exception with the same suppressed errors (plus any additional errors suppressed since the last close call).
+     * Calling close with no exceptions is a no-op. If exceptions did occur, then a runtime exception will be thrown
+     * with the errors suppressed in the order in which they were thrown. Calling close multiple times will re-throw
+     * with the same suppressed errors (plus any additional errors suppressed since the last close call).
      */
     @Override
     public void close() {

--- a/atlasdb-commons/src/main/java/com/palantir/util/ExceptionHandlingRunner.java
+++ b/atlasdb-commons/src/main/java/com/palantir/util/ExceptionHandlingRunner.java
@@ -24,8 +24,8 @@ import java.util.function.Supplier;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 
 /**
- * Runs runnables and suppliers that may throw exceptions, and swallows those exceptions until later. Can be used as a
- * resource in a try block, or delegated to by another resource.
+ * Runs runnables and suppliers that may throw exceptions, and swallows those exceptions until the runner is closed.
+ * Can be used as a resource in a try block, or delegated to by another resource.
  */
 public final class ExceptionHandlingRunner implements AutoCloseable {
     private final List<Throwable> failures = new ArrayList<>();

--- a/atlasdb-commons/src/main/java/com/palantir/util/ExceptionHandlingRunner.java
+++ b/atlasdb-commons/src/main/java/com/palantir/util/ExceptionHandlingRunner.java
@@ -1,0 +1,72 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
+
+/**
+ * Runs runnables and suppliers that may throw exceptions, and swallows those exceptions until later. Can be used as a
+ * resource in a try block, or delegated to by another resource.
+ */
+public final class ExceptionHandlingRunner implements AutoCloseable {
+    private final List<Throwable> failures = new ArrayList<>();
+
+    public ExceptionHandlingRunner() {}
+
+    /**
+     * Instantiates the runner with a throwable that has already been caught, to be rethrown when close is complete.
+     */
+    public ExceptionHandlingRunner(Throwable t) {
+        failures.add(t);
+    }
+
+    public void runSafely(Runnable shutdownCallback) {
+        try {
+            shutdownCallback.run();
+        } catch (Throwable throwable) {
+            failures.add(throwable);
+        }
+    }
+
+    public <T> Optional<T> supplySafely(Supplier<T> shutdownCallback) {
+        try {
+            return Optional.of(shutdownCallback.get());
+        } catch (Throwable throwable) {
+            failures.add(throwable);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Calling close with no failures should be a no-op; equally, calling close multiple times will re-throw a runtime
+     * exception with the same suppressed errors (plus any additional errors suppressed since the last close call).
+     */
+    @Override
+    public void close() {
+        if (!failures.isEmpty()) {
+            RuntimeException closeFailed = new SafeRuntimeException(
+                    "Close failed. Please inspect the code and fix the failures");
+            failures.forEach(closeFailed::addSuppressed);
+            throw closeFailed;
+        }
+    }
+}

--- a/atlasdb-commons/src/test/java/com/palantir/util/ExceptionHandlingRunnerTests.java
+++ b/atlasdb-commons/src/test/java/com/palantir/util/ExceptionHandlingRunnerTests.java
@@ -1,0 +1,92 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.util;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.util.function.Supplier;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
+
+public final class ExceptionHandlingRunnerTests {
+    private static final Runnable RUNNABLE_WITH_EXCEPTION = () -> {
+        throw new RuntimeException();
+    };
+
+    private ExceptionHandlingRunner runner;
+
+    @Before
+    public void before() {
+        runner = new ExceptionHandlingRunner();
+    }
+
+    @Test
+    public void runnableExceptionNotThrown() {
+        assertThatRunnableDoesNotThrow(RUNNABLE_WITH_EXCEPTION);
+        assertThatCloseThrows();
+    }
+
+    @Test
+    public void supplierExceptionNotThrown() {
+        Supplier<?> supplierWithException = () -> {
+            throw new RuntimeException();
+        };
+        assertThatSupplierDoesNotThrow(supplierWithException);
+        assertThatCloseThrows();
+    }
+
+    @Test
+    public void closeDoesNotThrowWhenNoExceptionsCaught() {
+        Supplier<Integer> cleanSupplier = () -> 4;
+        Runnable cleanRunnable = () -> {
+        };
+        assertThatSupplierDoesNotThrow(cleanSupplier);
+        assertThatRunnableDoesNotThrow(cleanRunnable);
+        assertThatCode(runner::close).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void closeThrowsWhenInstantiatedWithException() {
+        RuntimeException runtimeException = new RuntimeException();
+        runner = new ExceptionHandlingRunner(runtimeException);
+        assertThatCloseThrows();
+    }
+
+    @Test
+    public void closeMultipleTimesRethrows() {
+        assertThatRunnableDoesNotThrow(RUNNABLE_WITH_EXCEPTION);
+        assertThatCloseThrows();
+        assertThatCloseThrows();
+    }
+
+    private void assertThatRunnableDoesNotThrow(Runnable runnable) {
+        assertThatCode(() -> runner.runSafely(runnable)).doesNotThrowAnyException();
+    }
+
+    private void assertThatSupplierDoesNotThrow(Supplier<?> supplier) {
+        assertThatCode(() -> runner.supplySafely(supplier)).doesNotThrowAnyException();
+    }
+
+    private void assertThatCloseThrows() {
+        assertThatExceptionOfType(SafeRuntimeException.class)
+                .isThrownBy(runner::close);
+    }
+}

--- a/atlasdb-commons/src/test/java/com/palantir/util/ExceptionHandlingRunnerTests.java
+++ b/atlasdb-commons/src/test/java/com/palantir/util/ExceptionHandlingRunnerTests.java
@@ -80,6 +80,23 @@ public final class ExceptionHandlingRunnerTests {
         assertThatCloseThrows();
     }
 
+    @Test
+    public void closeThrowsExceptionsInOrderOfSuppressing() {
+        RuntimeException runtimeException1 = new RuntimeException();
+        RuntimeException runtimeException2 = new RuntimeException();
+        runner.runSafely(() -> {
+            throw runtimeException1;
+        });
+        runner.runSafely(() -> {
+            throw runtimeException2;
+        });
+        try {
+            runner.close();
+        } catch (Throwable t) {
+            assertThat(t.getSuppressed()).containsSequence(runtimeException1, runtimeException2);
+        }
+    }
+
     private void assertThatRunnableDoesNotThrow(Runnable runnable) {
         assertThatCode(() -> runner.runSafely(runnable)).doesNotThrowAnyException();
     }

--- a/atlasdb-commons/src/test/java/com/palantir/util/ExceptionHandlingRunnerTests.java
+++ b/atlasdb-commons/src/test/java/com/palantir/util/ExceptionHandlingRunnerTests.java
@@ -16,6 +16,7 @@
 
 package com.palantir.util;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
@@ -50,6 +51,7 @@ public final class ExceptionHandlingRunnerTests {
             throw new RuntimeException();
         };
         assertThatSupplierDoesNotThrow(supplierWithException);
+        assertThat(runner.supplySafely(supplierWithException)).isEmpty();
         assertThatCloseThrows();
     }
 
@@ -59,6 +61,7 @@ public final class ExceptionHandlingRunnerTests {
         Runnable cleanRunnable = () -> {
         };
         assertThatSupplierDoesNotThrow(cleanSupplier);
+        assertThat(runner.supplySafely(cleanSupplier)).hasValue(4);
         assertThatRunnableDoesNotThrow(cleanRunnable);
         assertThatCode(runner::close).doesNotThrowAnyException();
     }

--- a/atlasdb-commons/src/test/java/com/palantir/util/ExceptionHandlingRunnerTests.java
+++ b/atlasdb-commons/src/test/java/com/palantir/util/ExceptionHandlingRunnerTests.java
@@ -93,7 +93,7 @@ public final class ExceptionHandlingRunnerTests {
         try {
             runner.close();
         } catch (Throwable t) {
-            assertThat(t.getSuppressed()).containsSequence(runtimeException1, runtimeException2);
+            assertThat(t.getSuppressed()).containsExactly(runtimeException1, runtimeException2);
         }
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -165,6 +165,7 @@ import com.palantir.util.ExceptionHandlingRunner;
         StartIdentifiedAtlasDbTransactionResponse transactionResponse
                 = timelockService.startIdentifiedAtlasDbTransaction();
         try {
+            // t
             LockToken immutableTsLock = transactionResponse.immutableTimestamp().getLock();
             long immutableTs = transactionResponse.immutableTimestamp().getImmutableTimestamp();
             recordImmutableTimestamp(immutableTs);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -165,7 +165,6 @@ import com.palantir.util.ExceptionHandlingRunner;
         StartIdentifiedAtlasDbTransactionResponse transactionResponse
                 = timelockService.startIdentifiedAtlasDbTransaction();
         try {
-            // t
             LockToken immutableTsLock = transactionResponse.immutableTimestamp().getLock();
             long immutableTs = transactionResponse.immutableTimestamp().getImmutableTimestamp();
             recordImmutableTimestamp(immutableTs);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -15,7 +15,6 @@
  */
 package com.palantir.atlasdb.transaction.impl;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Callable;
@@ -63,7 +62,6 @@ import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.StartIdentifiedAtlasDbTransactionResponse;
 import com.palantir.lock.v2.TimelockService;
 import com.palantir.logsafe.Preconditions;
-import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.timestamp.TimestampManagementService;
 import com.palantir.timestamp.TimestampService;
 import com.palantir.util.ExceptionHandlingRunner;

--- a/changelog/@unreleased/pr-4718.v2.yml
+++ b/changelog/@unreleased/pr-4718.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Refactor out Shutdown Runner from SnapshotTransactionManager and move
+    into its own class.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4718


### PR DESCRIPTION
**Goals (and why)**:
Factor out the `ShutdownRunner` class from `SnapshotTransactionManager` into a common project so that other classes may use it too. Also add tests and additional functionality.

**Implementation Description (bullets)**:
* `ShutdownRunner` moved to its own class and renamed `ExceptionHandlingRunner`
* Now also swallows exceptions for suppliers
* Can also be instantiated with a throwable therefore guaranteeing it will throw when closed (useful for the future batching PR).

**Testing (What was existing testing like?  What have you done to improve it?)**:
* No tests previously existed for this class
* New test class added, testing the various cases

**Concerns (what feedback would you like?)**:
* Most important is correctness - does this capture the same behaviour as before, and do what we expect it to do?
* Secondarily is style - both of the code, and whether the class is in the right place, and the javadoc has been written correctly.

**Where should we start reviewing?**:
* `ExceptionHandlingRunner`

**Priority (whenever / two weeks / yesterday)**:
* Within a week
