### PR TITLE
[Timelock Partitioning] Tag remote hosts for internode communication

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbMetricNames.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbMetricNames.java
@@ -71,6 +71,7 @@ public final class AtlasDbMetricNames {
     public static final String TAG_CURRENT_SUSPECTED_LEADER = "isCurrentSuspectedLeader";
     public static final String TAG_CLIENT = "client";
     public static final String TAG_PAXOS_USE_CASE = "paxosUseCase";
+    public static final String TAG_REMOTE_HOST = "remoteHost";
 
     public static final String COORDINATION_LAST_VALID_BOUND = "lastValidBound";
     public static final String COORDINATION_CURRENT_TRANSACTIONS_SCHEMA_VERSION = "currentTransactionsSchemaVersion";

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClients.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClients.java
@@ -28,6 +28,7 @@ import org.immutables.value.Value;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HostAndPort;
+import com.palantir.atlasdb.AtlasDbMetricNames;
 import com.palantir.atlasdb.config.AuxiliaryRemotingParameters;
 import com.palantir.atlasdb.config.RemotingClientConfigs;
 import com.palantir.atlasdb.http.AtlasDbHttpClients;
@@ -160,7 +161,11 @@ public abstract class PaxosRemoteClients {
                                 .remotingClientConfig(() -> RemotingClientConfigs.DEFAULT)
                                 .shouldSupportBlockingOperations(false)
                                 .build()))
-                .map(proxy -> AtlasDbMetrics.instrumentWithTaggedMetrics(metrics().getTaggedRegistry(), clazz, proxy));
+                .map((host, proxy) -> AtlasDbMetrics.instrumentWithTaggedMetrics(
+                        metrics().getTaggedRegistry(),
+                        clazz,
+                        proxy,
+                        any -> ImmutableMap.of(AtlasDbMetricNames.TAG_REMOTE_HOST, host)));
     }
 
     private static HostAndPort convertAddressToHostAndPort(String url) {


### PR DESCRIPTION
**Goals (and why)**:
Tag remote hosts for internode communication

**Implementation Description (bullets)**:
Add the tag at the rpc client level

**Testing (What was existing testing like?  What have you done to improve it?)**:
None

**Concerns (what feedback would you like?)**:
We don't tag the clients at the level of `NetworkClientFactories`. We can easily do this, but it requires some more wiring, and increases our metrics cardinality. Is it worth it>

**Where should we start reviewing?**:
tiny

**Priority (whenever / two weeks / yesterday)**:
Now?
