### PR TITLE
Serializable index need not lock anything

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/ConflictHandler.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/ConflictHandler.java
@@ -82,7 +82,8 @@ public enum ConflictHandler {
      * on index tables. Read/write conflicts should still need to be checked, since we do not need to read the index
      * table with the main table.
      * <p>
-     * This conflict does not lock, because it's assumed that a semantically equivalent lock is taken out on the base table.
+     * This conflict does not lock, because it's assumed that a semantically equivalent lock is taken out on the base 
+     * table.
      */
     SERIALIZABLE_INDEX(false, false, false, true),
 

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/ConflictHandler.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/ConflictHandler.java
@@ -82,8 +82,8 @@ public enum ConflictHandler {
      * on index tables. Read/write conflicts should still need to be checked, since we do not need to read the index
      * table with the main table.
      * <p>
-     * This conflict does not lock, because it's assumed that a semantically equivalent lock is taken out on the base 
-     * table.
+     * This conflict does not lock, because it's assumed that a semantically equivalent lock is taken out on 
+     * the base table.
      */
     SERIALIZABLE_INDEX(false, false, false, true),
 

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/ConflictHandler.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/ConflictHandler.java
@@ -82,10 +82,9 @@ public enum ConflictHandler {
      * on index tables. Read/write conflicts should still need to be checked, since we do not need to read the index
      * table with the main table.
      * <p>
-     * This conflict handler locks at cell level. As index tables use dynamic columns, locking at row level would
-     * result in higher contention.
+     * This conflict does not lock, because it's assumed that a semantically equivalent lock is taken out on the base table.
      */
-    SERIALIZABLE_INDEX(true, false, false, true),
+    SERIALIZABLE_INDEX(false, false, false, true),
 
     /**
      * This conflict handler is designed to be used for migrating a table from SERIALIZABLE to SERIALIZABLE_CELL or

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/ConflictHandler.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/ConflictHandler.java
@@ -82,7 +82,7 @@ public enum ConflictHandler {
      * on index tables. Read/write conflicts should still need to be checked, since we do not need to read the index
      * table with the main table.
      * <p>
-     * This conflict does not lock, because it's assumed that a semantically equivalent lock is taken out on 
+     * This conflict does not lock, because it's assumed that a semantically equivalent lock is taken out on
      * the base table.
      */
     SERIALIZABLE_INDEX(false, false, false, true),

--- a/changelog/@unreleased/pr-4721.v2.yml
+++ b/changelog/@unreleased/pr-4721.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Optimize serializable_index locking strategy to avoid taking out redundant
+    locks.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4721


### PR DESCRIPTION
It's an index table, and so semantically equivalent locks were taken out on the main table. We can avoid taking all locks, and thus reduce some network traffic.