### PR TITLE
[PaxosLog] Sqlite implementation without namespaces

### DIFF
--- a/leader-election-impl/build.gradle
+++ b/leader-election-impl/build.gradle
@@ -9,6 +9,7 @@ dependencies {
   compile group: "com.google.protobuf", name: "protobuf-java"
   compile group: "commons-io", name: "commons-io"
   compile group: 'com.palantir.safe-logging', name: 'safe-logging'
+  compile group: 'org.xerial', name: 'sqlite-jdbc'
 
   implementation group: 'com.palantir.common', name: 'streams'
 

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SqliteConnections.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SqliteConnections.java
@@ -21,13 +21,11 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.function.Supplier;
 
-import com.google.common.base.Suppliers;
-
 /**
  * This class is responsible for creating Sqlite connections to an instance.
  * There should be one instance per timelock.
  */
-public class SqliteConnections {
+public final class SqliteConnections {
     private SqliteConnections() {
         // no
     }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SqliteConnections.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SqliteConnections.java
@@ -27,17 +27,16 @@ import com.google.common.base.Suppliers;
  * This class is responsible for creating Sqlite connections to an instance.
  * There should be one instance per timelock.
  */
-public class Sqlites {
-    private Sqlites() {
+public class SqliteConnections {
+    private SqliteConnections() {
         // no
     }
 
-    public static Supplier<Connection> createDatabaseForTests() {
-        Supplier<Connection> memoized = Suppliers.memoize(createSqliteDatabase(":memory:")::get);
-        return memoized;
+    public static Supplier<Connection> createDatabaseForTest() {
+        return createSqliteDatabase(":memory:");
     }
 
-    public static Supplier<Connection> createSqliteDatabase(String path) {
+    private static Supplier<Connection> createSqliteDatabase(String path) {
         String target = String.format("jdbc:sqlite:%s", path);
         return () -> {
             try {

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLog.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLog.java
@@ -17,96 +17,104 @@
 package com.palantir.paxos;
 
 import java.io.IOException;
-import java.math.BigInteger;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import com.google.common.io.ByteStreams;
+import com.palantir.common.base.Throwables;
 import com.palantir.common.persist.Persistable;
-import com.palantir.exception.PalantirSqlException;
 
 public class SqlitePaxosStateLog<V extends Persistable & Versionable> implements PaxosStateLog<V> {
     private final Supplier<Connection> connectionSupplier;
 
-    public SqlitePaxosStateLog(Supplier<Connection> connectionSupplier) {
+    private SqlitePaxosStateLog(Supplier<Connection> connectionSupplier) {
         this.connectionSupplier = connectionSupplier;
-        setup();
     }
 
-    private void setup() {
+    public static <V extends Persistable & Versionable> PaxosStateLog<V> createInitialized(Supplier<Connection> conn) {
+        SqlitePaxosStateLog<V> log = new SqlitePaxosStateLog<>(conn);
+        log.initialize();
+        return log;
+    }
 
-        executeIgnoringError(
-                "CREATE TABLE test (id BIGINT, val BLOB, CONSTRAINT pk_dual PRIMARY KEY (id))",
-                "already exists"
-        );
+    private void initialize() {
+        executeVoid("CREATE TABLE IF NOT EXISTS paxosLog (seq BIGINT, val BLOB, CONSTRAINT pk_dual PRIMARY KEY (seq))");
     }
 
     @Override
     public void writeRound(long seq, V round) {
         try {
             PreparedStatement preparedStatement = connectionSupplier.get().prepareStatement(
-                    "INSERT INTO test (id, val) VALUES (?, ?)");
+                    "INSERT INTO paxosLog (seq, val) VALUES (?, ?)");
             preparedStatement.setLong(1, seq);
             preparedStatement.setBytes(2, round.persistToBytes());
             preparedStatement.execute();
         } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw Throwables.rewrapAndThrowUncheckedException(e);
         }
     }
 
     @Override
     public byte[] readRound(long seq) {
-        try {
-            ResultSet resultSet = executeStatement(String.format("SELECT val FROM test WHERE id = %s;", seq));
-            return ByteStreams.toByteArray(resultSet.getBinaryStream(1));
-        } catch (SQLException | IOException e) {
-            throw new RuntimeException(e);
-        }
+        return executeStatement(String.format("SELECT val FROM paxosLog WHERE seq = %s;", seq))
+                .map(SqlitePaxosStateLog::getByteArrayUnchecked)
+                .orElse(null);
     }
 
     @Override
     public long getLeastLogEntry() {
-        try {
-            ResultSet resultSet = executeStatement("SELECT MIN(id) FROM test");
-            return resultSet.getLong(1);
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
-        }
+        return executeStatement("SELECT MIN(seq) FROM paxosLog")
+                .map(SqlitePaxosStateLog::getLongResultUnchecked)
+                .orElse(PaxosAcceptor.NO_LOG_ENTRY);
     }
 
     @Override
     public long getGreatestLogEntry() {
-        try {
-            ResultSet resultSet = executeStatement("SELECT MAX(id) FROM test");
-            return resultSet.getLong(1);
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
-        }    }
+        return executeStatement("SELECT MAX(seq) FROM paxosLog")
+                .map(SqlitePaxosStateLog::getLongResultUnchecked)
+                .orElse(PaxosAcceptor.NO_LOG_ENTRY);
+    }
 
     @Override
     public void truncate(long toDeleteInclusive) {
-        // TODO (jkong): Actually delete stuff
-        throw new UnsupportedOperationException("no");
+        executeVoid(String.format("DELETE FROM paxosLog WHERE seq <= %s", toDeleteInclusive));
     }
 
-    private void executeIgnoringError(String sql, String errorToIgnore) {
+    private void executeVoid(String statement) {
         try {
-            connectionSupplier.get().prepareStatement(sql).execute();
-        } catch (PalantirSqlException | SQLException e) {
-            if (!e.getMessage().contains(errorToIgnore)) {
-                throw new RuntimeException(e);
-            }
+            connectionSupplier.get().prepareStatement(statement).execute();
+        } catch (SQLException e) {
+            throw Throwables.rewrapAndThrowUncheckedException(e);
         }
     }
 
-    private ResultSet executeStatement(String statement) {
+    private Optional<ResultSet> executeStatement(String statement) {
         try {
-            return connectionSupplier.get().prepareStatement(statement).executeQuery();
+            ResultSet resultSet = connectionSupplier.get().prepareStatement(statement).executeQuery();
+            return resultSet.isClosed() ? Optional.empty() : Optional.of(resultSet);
         } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw Throwables.rewrapAndThrowUncheckedException(e);
+        }
+    }
+
+    private static long getLongResultUnchecked(ResultSet resultSet) {
+        try {
+            long candidate = resultSet.getLong(1);
+            return resultSet.wasNull() ? PaxosAcceptor.NO_LOG_ENTRY : candidate;
+        } catch (SQLException e) {
+            throw Throwables.rewrapAndThrowUncheckedException(e);
+        }
+    }
+
+    private static byte[] getByteArrayUnchecked(ResultSet resultSet) {
+        try {
+            return ByteStreams.toByteArray(resultSet.getBinaryStream(1));
+        } catch (SQLException | IOException e) {
+            throw Throwables.rewrapAndThrowUncheckedException(e);
         }
     }
 }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLog.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLog.java
@@ -60,7 +60,7 @@ public class SqlitePaxosStateLog<V extends Persistable & Versionable> implements
 
     @Override
     public byte[] readRound(long seq) {
-        return executeStatement(String.format("SELECT val FROM paxosLog WHERE seq = %s;", seq))
+        return executeStatement(String.format("SELECT val FROM paxosLog WHERE seq = %s", seq))
                 .map(SqlitePaxosStateLog::getByteArrayUnchecked)
                 .orElse(null);
     }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLog.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLog.java
@@ -1,0 +1,100 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.paxos;
+
+import java.math.BigInteger;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.function.Supplier;
+
+import com.palantir.common.persist.Persistable;
+import com.palantir.exception.PalantirSqlException;
+
+public class SqlitePaxosStateLog<V extends Persistable & Versionable> implements PaxosStateLog<V> {
+    private final Supplier<Connection> connectionSupplier;
+
+    public SqlitePaxosStateLog(Supplier<Connection> connectionSupplier) {
+        this.connectionSupplier = connectionSupplier;
+        setup();
+    }
+
+    private void setup() {
+
+        executeIgnoringError(
+                "CREATE TABLE dual (id BIGINT, CONSTRAINT "
+                        + "pk_dual"
+                        + " PRIMARY KEY (id))",
+                "already exists"
+        );
+
+        try {
+            ResultSet x = connectionSupplier.get().prepareStatement("SELECT sql FROM sqlite_master;").executeQuery();
+            System.out.println(x);
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+
+
+        executeIgnoringError(
+                "INSERT INTO dual (id) SELECT 1 WHERE NOT EXISTS ( SELECT id FROM dual WHERE id = 1 )",
+                "duplicate key"
+        );
+    }
+
+    @Override
+    public void writeRound(long seq, V round) {
+        System.out.println("42");
+    }
+
+    @Override
+    public byte[] readRound(long seq) {
+        try {
+            return BigInteger.valueOf(connectionSupplier.get().prepareStatement(
+                    "SELECT 1 FROM dual;"
+            ).executeQuery().getInt(0)).toByteArray();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public long getLeastLogEntry() {
+        return 0;
+    }
+
+    @Override
+    public long getGreatestLogEntry() {
+        return 0;
+    }
+
+    @Override
+    public void truncate(long toDeleteInclusive) {
+        // TODO (jkong): Actually delete stuff
+        throw new UnsupportedOperationException("no");
+    }
+
+    private void executeIgnoringError(String sql, String errorToIgnore) {
+        try {
+            connectionSupplier.get().prepareStatement(sql).execute();
+        } catch (PalantirSqlException | SQLException e) {
+            if (!e.getMessage().contains(errorToIgnore)) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLog.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLog.java
@@ -28,7 +28,7 @@ import com.google.common.io.ByteStreams;
 import com.palantir.common.base.Throwables;
 import com.palantir.common.persist.Persistable;
 
-public class SqlitePaxosStateLog<V extends Persistable & Versionable> implements PaxosStateLog<V> {
+public final class SqlitePaxosStateLog<V extends Persistable & Versionable> implements PaxosStateLog<V> {
     private final Supplier<Connection> connectionSupplier;
 
     private SqlitePaxosStateLog(Supplier<Connection> connectionSupplier) {

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLog.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLog.java
@@ -49,7 +49,7 @@ public class SqlitePaxosStateLog<V extends Persistable & Versionable> implements
     public void writeRound(long seq, V round) {
         try {
             PreparedStatement preparedStatement = connectionSupplier.get().prepareStatement(
-                    "INSERT INTO paxosLog (seq, val) VALUES (?, ?)");
+                    "INSERT OR REPLACE INTO paxosLog (seq, val) VALUES (?, ?)");
             preparedStatement.setLong(1, seq);
             preparedStatement.setBytes(2, round.persistToBytes());
             preparedStatement.execute();

--- a/leader-election-impl/src/main/java/com/palantir/paxos/Sqlites.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/Sqlites.java
@@ -1,0 +1,47 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.paxos;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.function.Supplier;
+
+/**
+ * This class is responsible for creating Sqlite connections to an instance.
+ * There should be one instance per timelock.
+ */
+public class Sqlites {
+    private Sqlites() {
+        // no
+    }
+
+    public static Supplier<Connection> createDatabaseForTests() {
+        return createSqliteDatabase(":memory:");
+    }
+
+    public static Supplier<Connection> createSqliteDatabase(String path) {
+        String target = String.format("jdbc:sqlite:%s", path);
+        return () -> {
+            try {
+                return DriverManager.getConnection(target);
+            } catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+}

--- a/leader-election-impl/src/main/java/com/palantir/paxos/Sqlites.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/Sqlites.java
@@ -21,6 +21,8 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.function.Supplier;
 
+import com.google.common.base.Suppliers;
+
 /**
  * This class is responsible for creating Sqlite connections to an instance.
  * There should be one instance per timelock.
@@ -31,7 +33,8 @@ public class Sqlites {
     }
 
     public static Supplier<Connection> createDatabaseForTests() {
-        return createSqliteDatabase(":memory:");
+        Supplier<Connection> memoized = Suppliers.memoize(createSqliteDatabase(":memory:")::get);
+        return memoized;
     }
 
     public static Supplier<Connection> createSqliteDatabase(String path) {

--- a/leader-election-impl/src/test/java/com/palantir/paxos/SqlitePaxosStateLogTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/SqlitePaxosStateLogTest.java
@@ -34,7 +34,7 @@ public class SqlitePaxosStateLogTest {
     @Before
     public void setup() {
         Supplier<Connection> connectionSupplier = Suppliers.memoize(SqliteConnections.createDatabaseForTest()::get);
-        stateLog =  SqlitePaxosStateLog.createInitialized(connectionSupplier);
+        stateLog = SqlitePaxosStateLog.createInitialized(connectionSupplier);
     }
 
     @Test

--- a/leader-election-impl/src/test/java/com/palantir/paxos/SqlitePaxosStateLogTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/SqlitePaxosStateLogTest.java
@@ -18,8 +18,11 @@ package com.palantir.paxos;
 
 import java.sql.Connection;
 import java.util.Arrays;
+import java.util.UUID;
 import java.util.function.Supplier;
 
+import org.assertj.core.api.Assertions;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class SqlitePaxosStateLogTest {
@@ -27,7 +30,15 @@ public class SqlitePaxosStateLogTest {
     private final SqlitePaxosStateLog<PaxosValue> stateLog = new SqlitePaxosStateLog<>(connectionSupplier);
 
     @Test
+    public void readingThrows() {
+        System.out.println(Arrays.toString(stateLog.readRound(32)));
+    }
+
+    @Test
     public void canWriteAValue() {
-        System.out.println(Arrays.toString(stateLog.readRound(52)));
+        PaxosValue paxosValue = new PaxosValue("leader", 25, new byte[] {0});
+        stateLog.writeRound(12, paxosValue);
+        Assertions.assertThat(PaxosValue.BYTES_HYDRATOR.hydrateFromBytes(stateLog.readRound(12)))
+                .isEqualTo(paxosValue);
     }
 }

--- a/leader-election-impl/src/test/java/com/palantir/paxos/SqlitePaxosStateLogTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/SqlitePaxosStateLogTest.java
@@ -50,6 +50,13 @@ public class SqlitePaxosStateLogTest {
     }
 
     @Test
+    public void canOverwriteSequences() throws IOException {
+        writeValueForRound(5L);
+        PaxosValue newEntry = writeValueForRound(5L);
+        assertThat(PaxosValue.BYTES_HYDRATOR.hydrateFromBytes(stateLog.readRound(5L))).isEqualTo(newEntry);
+    }
+
+    @Test
     public void returnsDefaultValueForExtremesWhenNoEntries() {
         assertThat(stateLog.getLeastLogEntry()).isEqualTo(PaxosAcceptor.NO_LOG_ENTRY);
         assertThat(stateLog.getGreatestLogEntry()).isEqualTo(PaxosAcceptor.NO_LOG_ENTRY);

--- a/leader-election-impl/src/test/java/com/palantir/paxos/SqlitePaxosStateLogTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/SqlitePaxosStateLogTest.java
@@ -78,6 +78,7 @@ public class SqlitePaxosStateLogTest {
         writeValueForRound(5L);
         writeValueForRound(7L);
         writeValueForRound(9L);
+        writeValueForRound(1L);
 
         stateLog.truncate(7L);
         assertThat(stateLog.getLeastLogEntry()).isEqualTo(9L);

--- a/leader-election-impl/src/test/java/com/palantir/paxos/SqlitePaxosStateLogTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/SqlitePaxosStateLogTest.java
@@ -1,0 +1,33 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.paxos;
+
+import java.sql.Connection;
+import java.util.Arrays;
+import java.util.function.Supplier;
+
+import org.junit.Test;
+
+public class SqlitePaxosStateLogTest {
+    private final Supplier<Connection> connectionSupplier = Sqlites.createDatabaseForTests();
+    private final SqlitePaxosStateLog<PaxosValue> stateLog = new SqlitePaxosStateLog<>(connectionSupplier);
+
+    @Test
+    public void canWriteAValue() {
+        System.out.println(Arrays.toString(stateLog.readRound(52)));
+    }
+}

--- a/versions.props
+++ b/versions.props
@@ -77,6 +77,7 @@ org.codehaus.groovy:* = 2.4.4
 org.derive4j:* = 1.1.1
 org.eclipse.jetty.http2:* = 9.3.9.v20160517
 org.eclipse.jetty:jetty-* = 9.4.27.v20200227
+org.freemarker:freemarker = 2.3.29
 org.glassfish.hk2.external:javax.inject = 2.5.0-b05
 org.glassfish.jersey.containers:jersey-container-servlet* = 2.29.1
 org.glassfish.jersey.core:jersey* = 2.29.1
@@ -97,8 +98,8 @@ org.objenesis:objenesis = 3.1
 org.ow2.asm:asm = 7.0
 org.rocksdb:rocksdbjni = 6.4.6
 org.slf4j:* = 1.7.25
+org.xerial:sqlite-jdbc = 3.30.1
 org.yaml:snakeyaml = 1.23
-org.freemarker:freemarker = 2.3.29
 
 com.google.errorprone:error_prone_refaster = 2.3.3
 com.palantir.baseline:baseline-refaster-testing = 2.17.0


### PR DESCRIPTION
**Goals (and why)**:
This is the basic psqlite implementation, without namespacing which will be added in a subsequent PR.

**Implementation Description (bullets)**:
Relatively straightforward, although there is some magic with how the result sets are interpreted when there are no results

**Testing (What was existing testing like?  What have you done to improve it?)**:
Unit tests using in memory implementation

**Concerns (what feedback would you like?)**:
I think it's fine

**Where should we start reviewing?**:
Tests?

**Priority (whenever / two weeks / yesterday)**:
Now