### PR TITLE
stalebot closes PRs after 30+7 days

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,10 @@
+only: pulls
+staleLabel: stale
+pulls:
+  daysUntilStale: 30
+  daysUntilClose: 7
+  exemptLabels: [ long-lived ]
+  markComment: >
+    This PR has been automatically marked as stale because it has not been touched in the last 30 days.
+    If you'd like to keep it open, please leave a comment or add the 'long-lived' label, otherwise it'll be closed in 7 days.
+  closeComment: false


### PR DESCRIPTION
**Goals (and why)**:

Internally, we've found a best practise is for dev teams to maintain a small number of in flight PRs. Stalebot helps with this, but pinging both reviewer and author to double check if a PR is still needed, and closes out everything else to keep the PR queue high signal.

If PRs truly need to be kept around, the `long-lived` label lets you declare this. 

I think this best practise applies externally too, and might be helpful to atlasdb. In general we use a 14 day staleness cutoff, but I figured 30 days might be a gentle introduction.

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
