### PR TITLE
Get all namespaces

### DIFF
--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -16,6 +16,7 @@
 package com.palantir.timelock.paxos;
 
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
@@ -40,6 +41,7 @@ import com.palantir.atlasdb.timelock.TimeLockServices;
 import com.palantir.atlasdb.timelock.TimelockNamespaces;
 import com.palantir.atlasdb.timelock.TooManyRequestsExceptionMapper;
 import com.palantir.atlasdb.timelock.lock.LockLog;
+import com.palantir.atlasdb.timelock.management.TimeLockManagementResource;
 import com.palantir.atlasdb.timelock.paxos.Client;
 import com.palantir.atlasdb.timelock.paxos.ImmutableTimelockPaxosInstallationContext;
 import com.palantir.atlasdb.timelock.paxos.PaxosResources;
@@ -168,6 +170,7 @@ public class TimeLockAgent {
     private void createAndRegisterResources() {
         registerPaxosResource();
         registerExceptionMappers();
+        registerManagementResource();
 
         namespaces = new TimelockNamespaces(
                 metricsManager,
@@ -187,6 +190,15 @@ public class TimeLockAgent {
         } else {
             registrar.accept(ConjureTimelockResource.jersey(redirectRetryTargeter(), creator));
             registrar.accept(ConjureLockWatchingResource.jersey(redirectRetryTargeter(), creator));
+        }
+    }
+
+    private void registerManagementResource() {
+        Path rootDataDirectory = install.paxos().dataDirectory().toPath();
+        if (undertowRegistrar.isPresent()) {
+            undertowRegistrar.get().accept(TimeLockManagementResource.undertow(rootDataDirectory));
+        } else {
+            registrar.accept(TimeLockManagementResource.jersey(rootDataDirectory));
         }
     }
 

--- a/timelock-api/src/main/conjure/timelock-management-api.yml
+++ b/timelock-api/src/main/conjure/timelock-management-api.yml
@@ -2,7 +2,7 @@ services:
   TimeLockManagementService:
     name: TimeLock Management Service
     default-auth: header
-    package: com.palantir.atlasdb.timelock.api
+    package: com.palantir.atlasdb.timelock.api.management
     base-path: /tl/management
     endpoints:
       getNamespaces:

--- a/timelock-api/src/main/conjure/timelock-management-api.yml
+++ b/timelock-api/src/main/conjure/timelock-management-api.yml
@@ -1,0 +1,10 @@
+services:
+  TimeLockManagementService:
+    name: TimeLock Management Service
+    default-auth: header
+    package: com.palantir.atlasdb.timelock.api
+    base-path: /tl/management
+    endpoints:
+      getNamespaces:
+        http: POST /getNamespaces
+        returns: set<string>

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/DiskNamespaceLoader.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/DiskNamespaceLoader.java
@@ -23,12 +23,14 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.palantir.atlasdb.timelock.paxos.PaxosUseCase;
 import com.palantir.logsafe.SafeArg;
 
 final class DiskNamespaceLoader {
+    private static final Logger logger = LoggerFactory.getLogger(DiskNamespaceLoader.class);
     private final Path rootDataDirectory;
 
     DiskNamespaceLoader(Path rootDataDirectory) {
@@ -44,11 +46,13 @@ final class DiskNamespaceLoader {
     }
 
     private static Stream<String> getNamespacesFromUseCaseResolvedDirectory(Path logDirectory) {
+        if (logDirectory == null) {
+            return Stream.of();
+        }
         File[] directories = logDirectory.toFile().listFiles(File::isDirectory);
         if (directories == null) {
-            LoggerFactory.getLogger(DiskNamespaceLoader.class)
-                    .error("Could not get file for the directory {}", SafeArg.of("dirName", logDirectory));
-            return Stream.of();
+            logger.error("Could not get file for the directory {}", SafeArg.of("dirName", logDirectory));
+            throw new IllegalStateException("No namespace exists for the directory : " + logDirectory);
         }
         return Arrays.stream(directories).map(File::getName);
     }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/DiskNamespaceLoader.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/DiskNamespaceLoader.java
@@ -31,7 +31,7 @@ import com.palantir.atlasdb.timelock.paxos.PaxosUseCase;
 import com.palantir.logsafe.SafeArg;
 
 final class DiskNamespaceLoader {
-    private static final Logger logger = LoggerFactory.getLogger(DiskNamespaceLoader.class);
+    private static final Logger log = LoggerFactory.getLogger(DiskNamespaceLoader.class);
     private final Path rootDataDirectory;
 
     DiskNamespaceLoader(Path rootDataDirectory) {
@@ -48,14 +48,15 @@ final class DiskNamespaceLoader {
 
     private static Stream<String> getNamespacesFromUseCaseResolvedDirectory(Path logDirectory) {
         if (Files.notExists(logDirectory)) {
+            log.info("No namespace directory exists at path: {}", SafeArg.of("dirName", logDirectory));
             return Stream.of();
         }
         File[] directories = logDirectory.toFile().listFiles(File::isDirectory);
         if (directories == null) {
-            logger.error("Namespace(s) cannot be read from directory : {}."
+            log.error("Namespace(s) cannot be read from directory: {}."
                     + " Either the path does not denote a directory or an I/O error has occurred.",
                     SafeArg.of("dirName", logDirectory));
-            throw new IllegalStateException("Failed to read directory : " + logDirectory +
+            throw new IllegalStateException("Failed to read directory: " + logDirectory +
                     ". Either the path is invalid or an I/O error has occurred.");
         }
         return Arrays.stream(directories).map(File::getName);

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/DiskNamespaceLoader.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/DiskNamespaceLoader.java
@@ -23,7 +23,10 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.slf4j.LoggerFactory;
+
 import com.palantir.atlasdb.timelock.paxos.PaxosUseCase;
+import com.palantir.logsafe.SafeArg;
 
 final class DiskNamespaceLoader {
     private final Path rootDataDirectory;
@@ -42,6 +45,11 @@ final class DiskNamespaceLoader {
 
     private static Stream<String> getNamespacesFromUseCaseResolvedDirectory(Path logDirectory) {
         File[] directories = logDirectory.toFile().listFiles(File::isDirectory);
+        if (directories == null) {
+            LoggerFactory.getLogger(DiskNamespaceLoader.class)
+                    .error("Could not get file for the directory {}", SafeArg.of("dirName", logDirectory));
+            return Stream.of();
+        }
         return Arrays.stream(directories).map(File::getName);
     }
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/DiskNamespaceLoader.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/DiskNamespaceLoader.java
@@ -17,6 +17,7 @@
 package com.palantir.atlasdb.timelock.management;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Set;
@@ -46,13 +47,16 @@ final class DiskNamespaceLoader {
     }
 
     private static Stream<String> getNamespacesFromUseCaseResolvedDirectory(Path logDirectory) {
-        if (logDirectory == null) {
+        if (Files.notExists(logDirectory)) {
             return Stream.of();
         }
         File[] directories = logDirectory.toFile().listFiles(File::isDirectory);
         if (directories == null) {
-            logger.error("Could not get file for the directory {}", SafeArg.of("dirName", logDirectory));
-            throw new IllegalStateException("No namespace exists for the directory : " + logDirectory);
+            logger.error("Namespace(s) cannot be read from directory : {}."
+                    + " Either the path does not denote a directory or an I/O error has occurred.",
+                    SafeArg.of("dirName", logDirectory));
+            throw new IllegalStateException("Failed to read directory : " + logDirectory +
+                    ". Either the path is invalid or an I/O error has occurred.");
         }
         return Arrays.stream(directories).map(File::getName);
     }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/DiskNamespaceLoader.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/DiskNamespaceLoader.java
@@ -1,0 +1,47 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.management;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.palantir.atlasdb.timelock.paxos.PaxosUseCase;
+
+final class DiskNamespaceLoader {
+    private final Path rootDataDirectory;
+
+    DiskNamespaceLoader(Path rootDataDirectory) {
+        this.rootDataDirectory = rootDataDirectory;
+    }
+
+    Set<String> getNamespaces() {
+        return Arrays.stream(PaxosUseCase.values())
+                .filter(useCase -> useCase != PaxosUseCase.LEADER_FOR_ALL_CLIENTS)
+                .map(useCase -> useCase.logDirectoryRelativeToDataDirectory(rootDataDirectory))
+                .flatMap(DiskNamespaceLoader::getNamespacesFromUseCaseResolvedDirectory)
+                .collect(Collectors.toSet());
+    }
+
+    private static Stream<String> getNamespacesFromUseCaseResolvedDirectory(Path logDirectory) {
+        File[] directories = logDirectory.toFile().listFiles(File::isDirectory);
+        return Arrays.stream(directories).map(File::getName);
+    }
+}

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/TimeLockManagementResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/TimeLockManagementResource.java
@@ -1,0 +1,86 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.management;
+
+import java.util.Set;
+import java.util.function.Function;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.atlasdb.futures.AtlasFutures;
+import com.palantir.atlasdb.http.RedirectRetryTargeter;
+import com.palantir.atlasdb.timelock.AsyncTimelockService;
+import com.palantir.atlasdb.timelock.ConjureTimelockResource;
+import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsRequest;
+import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponse;
+import com.palantir.atlasdb.timelock.api.ConjureLockRequest;
+import com.palantir.atlasdb.timelock.api.ConjureLockResponse;
+import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksRequest;
+import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksResponse;
+import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsRequest;
+import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
+import com.palantir.atlasdb.timelock.api.ConjureTimelockService;
+import com.palantir.atlasdb.timelock.api.ConjureUnlockRequest;
+import com.palantir.atlasdb.timelock.api.ConjureUnlockResponse;
+import com.palantir.atlasdb.timelock.api.ConjureWaitForLocksResponse;
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampsRequest;
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampsResponse;
+import com.palantir.atlasdb.timelock.api.TimeLockManagementService;
+import com.palantir.atlasdb.timelock.api.TimeLockManagementServiceEndpoints;
+import com.palantir.atlasdb.timelock.api.UndertowTimeLockManagementService;
+import com.palantir.conjure.java.undertow.lib.UndertowService;
+import com.palantir.lock.v2.LeaderTime;
+import com.palantir.tokens.auth.AuthHeader;
+
+public class TimeLockManagementResource implements UndertowTimeLockManagementService {
+    private final DiskNamespaceLoader diskNamespaceLoader;
+
+    public TimeLockManagementResource(DiskNamespaceLoader diskNamespaceLoader) {
+        this.diskNamespaceLoader = diskNamespaceLoader;
+    }
+
+    public static UndertowService undertow(DiskNamespaceLoader loader) {
+        return TimeLockManagementServiceEndpoints.of(new TimeLockManagementResource(loader));
+    }
+
+    public static TimeLockManagementService jersey(DiskNamespaceLoader loader) {
+        return new JerseyAdapter(new TimeLockManagementResource(loader));
+    }
+
+    @Override
+    public ListenableFuture<Set<String>> getNamespaces(AuthHeader authHeader) {
+        // This endpoint is not used frequently (only called by migration cli), so I'm ok with this NOT being async.
+        return Futures.immediateFuture(diskNamespaceLoader.getNamespaces());
+    }
+
+    public static final class JerseyAdapter implements TimeLockManagementService {
+        private final TimeLockManagementResource resource;
+
+        private JerseyAdapter(TimeLockManagementResource resource) {
+            this.resource = resource;
+        }
+
+        @Override
+        public Set<String> getNamespaces(AuthHeader authHeader) {
+            return unwrap(resource.getNamespaces(authHeader));
+        }
+
+        private static <T> T unwrap(ListenableFuture<T> future) {
+            return AtlasFutures.getUnchecked(future);
+        }
+    }
+}

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/TimeLockManagementResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/TimeLockManagementResource.java
@@ -16,49 +16,35 @@
 
 package com.palantir.atlasdb.timelock.management;
 
+import java.nio.file.Path;
 import java.util.Set;
-import java.util.function.Function;
 
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.atlasdb.futures.AtlasFutures;
-import com.palantir.atlasdb.http.RedirectRetryTargeter;
-import com.palantir.atlasdb.timelock.AsyncTimelockService;
-import com.palantir.atlasdb.timelock.ConjureTimelockResource;
-import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsRequest;
-import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponse;
-import com.palantir.atlasdb.timelock.api.ConjureLockRequest;
-import com.palantir.atlasdb.timelock.api.ConjureLockResponse;
-import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksRequest;
-import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksResponse;
-import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsRequest;
-import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
-import com.palantir.atlasdb.timelock.api.ConjureTimelockService;
-import com.palantir.atlasdb.timelock.api.ConjureUnlockRequest;
-import com.palantir.atlasdb.timelock.api.ConjureUnlockResponse;
-import com.palantir.atlasdb.timelock.api.ConjureWaitForLocksResponse;
-import com.palantir.atlasdb.timelock.api.GetCommitTimestampsRequest;
-import com.palantir.atlasdb.timelock.api.GetCommitTimestampsResponse;
 import com.palantir.atlasdb.timelock.api.TimeLockManagementService;
 import com.palantir.atlasdb.timelock.api.TimeLockManagementServiceEndpoints;
 import com.palantir.atlasdb.timelock.api.UndertowTimeLockManagementService;
 import com.palantir.conjure.java.undertow.lib.UndertowService;
-import com.palantir.lock.v2.LeaderTime;
 import com.palantir.tokens.auth.AuthHeader;
 
 public class TimeLockManagementResource implements UndertowTimeLockManagementService {
     private final DiskNamespaceLoader diskNamespaceLoader;
 
-    public TimeLockManagementResource(DiskNamespaceLoader diskNamespaceLoader) {
+    private TimeLockManagementResource(DiskNamespaceLoader diskNamespaceLoader) {
         this.diskNamespaceLoader = diskNamespaceLoader;
     }
 
-    public static UndertowService undertow(DiskNamespaceLoader loader) {
-        return TimeLockManagementServiceEndpoints.of(new TimeLockManagementResource(loader));
+    public static TimeLockManagementResource create(Path rootDataDirectory) {
+        return new TimeLockManagementResource(new DiskNamespaceLoader(rootDataDirectory));
     }
 
-    public static TimeLockManagementService jersey(DiskNamespaceLoader loader) {
-        return new JerseyAdapter(new TimeLockManagementResource(loader));
+    public static UndertowService undertow(Path rootDataDirectory) {
+        return TimeLockManagementServiceEndpoints.of(TimeLockManagementResource.create(rootDataDirectory));
+    }
+
+    public static TimeLockManagementService jersey(Path rootDataDirectory) {
+        return new JerseyAdapter(TimeLockManagementResource.create(rootDataDirectory));
     }
 
     @Override

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/TimeLockManagementResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/TimeLockManagementResource.java
@@ -22,9 +22,9 @@ import java.util.Set;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.atlasdb.futures.AtlasFutures;
-import com.palantir.atlasdb.timelock.api.TimeLockManagementService;
-import com.palantir.atlasdb.timelock.api.TimeLockManagementServiceEndpoints;
-import com.palantir.atlasdb.timelock.api.UndertowTimeLockManagementService;
+import com.palantir.atlasdb.timelock.api.management.TimeLockManagementService;
+import com.palantir.atlasdb.timelock.api.management.TimeLockManagementServiceEndpoints;
+import com.palantir.atlasdb.timelock.api.management.UndertowTimeLockManagementService;
 import com.palantir.conjure.java.undertow.lib.UndertowService;
 import com.palantir.tokens.auth.AuthHeader;
 


### PR DESCRIPTION
**Goals (and why)**:
TimeLock migration requires consensus to be achieved on all namespaces after a node is removed. 
This PR is part I, adds an endpoint on TimeLock to get all namespaces (including non active clients). 

**Implementation Description (bullets)**:

- namespaces are retrieved by reading files in Paxos data directory for relevant use cases.


**Testing (What was existing testing like?  What have you done to improve it?)**:
Tested on IL stack.

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:
DiskNamespaceLoader.java

**Priority (whenever / two weeks / yesterday)**:
End of this week

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
