### PR TITLE
[PaxosLog] Use JDBI and add namespacing

### DIFF
--- a/leader-election-impl/build.gradle
+++ b/leader-election-impl/build.gradle
@@ -9,6 +9,8 @@ dependencies {
   compile group: "com.google.protobuf", name: "protobuf-java"
   compile group: "commons-io", name: "commons-io"
   compile group: 'com.palantir.safe-logging', name: 'safe-logging'
+  compile group: "org.jdbi", name: 'jdbi3-core'
+  compile group: "org.jdbi", name: 'jdbi3-sqlobject'
   compile group: 'org.xerial', name: 'sqlite-jdbc'
 
   implementation group: 'com.palantir.common', name: 'streams'

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SqliteConnections.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SqliteConnections.java
@@ -30,11 +30,7 @@ public final class SqliteConnections {
         // no
     }
 
-    public static Supplier<Connection> createDatabaseForTest() {
-        return createSqliteDatabase(":memory:");
-    }
-
-    private static Supplier<Connection> createSqliteDatabase(String path) {
+    public static Supplier<Connection> createSqliteDatabase(String path) {
         String target = String.format("jdbc:sqlite:%s", path);
         return () -> {
             try {

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLog.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLog.java
@@ -42,11 +42,8 @@ public final class SqlitePaxosStateLog<V extends Persistable & Versionable> impl
 
     public static <V extends Persistable & Versionable> PaxosStateLog<V> create(String namespace,
             Supplier<Connection> connectionSupplier) {
-        return create(namespace, Jdbi.create(connectionSupplier::get));
-    }
-
-    static <V extends Persistable & Versionable> PaxosStateLog<V> create(String namespace, Jdbi jdbi) {
-        SqlitePaxosStateLog<V> log = new SqlitePaxosStateLog<>(namespace, jdbi.installPlugin(new SqlObjectPlugin()));
+        Jdbi jdbi = Jdbi.create(connectionSupplier::get).installPlugin(new SqlObjectPlugin());
+        SqlitePaxosStateLog<V> log = new SqlitePaxosStateLog<>(namespace, jdbi);
         log.initialize();
         return log;
     }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLog.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLog.java
@@ -45,7 +45,7 @@ public final class SqlitePaxosStateLog<V extends Persistable & Versionable> impl
         return create(namespace, Jdbi.create(connectionSupplier::get));
     }
 
-    public static <V extends Persistable & Versionable> PaxosStateLog<V> create(String namespace, Jdbi jdbi) {
+    static <V extends Persistable & Versionable> PaxosStateLog<V> create(String namespace, Jdbi jdbi) {
         SqlitePaxosStateLog<V> log = new SqlitePaxosStateLog<>(namespace, jdbi.installPlugin(new SqlObjectPlugin()));
         log.initialize();
         return log;

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLog.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLog.java
@@ -16,105 +16,92 @@
 
 package com.palantir.paxos;
 
-import java.io.IOException;
 import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
-import com.google.common.io.ByteStreams;
-import com.palantir.common.base.Throwables;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.sqlobject.SingleValue;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.customizer.Define;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+
 import com.palantir.common.persist.Persistable;
 
 public final class SqlitePaxosStateLog<V extends Persistable & Versionable> implements PaxosStateLog<V> {
-    private final Supplier<Connection> connectionSupplier;
+    private final String namespace;
+    private final Jdbi jdbi;
 
-    private SqlitePaxosStateLog(Supplier<Connection> connectionSupplier) {
-        this.connectionSupplier = connectionSupplier;
+    private SqlitePaxosStateLog(String namespace, Jdbi jdbi) {
+        this.namespace = namespace;
+        this.jdbi = jdbi;
     }
 
-    public static <V extends Persistable & Versionable> PaxosStateLog<V> createInitialized(Supplier<Connection> conn) {
-        SqlitePaxosStateLog<V> log = new SqlitePaxosStateLog<>(conn);
+    public static <V extends Persistable & Versionable> PaxosStateLog<V> create(String namespace,
+            Supplier<Connection> connectionSupplier) {
+        return create(namespace, Jdbi.create(connectionSupplier::get));
+    }
+
+    public static <V extends Persistable & Versionable> PaxosStateLog<V> create(String namespace, Jdbi jdbi) {
+        SqlitePaxosStateLog<V> log = new SqlitePaxosStateLog<>(namespace, jdbi.installPlugin(new SqlObjectPlugin()));
         log.initialize();
         return log;
     }
 
     private void initialize() {
-        executeVoid("CREATE TABLE IF NOT EXISTS paxosLog (seq BIGINT, val BLOB, CONSTRAINT pk_dual PRIMARY KEY (seq))");
+        execute(dao -> dao.createTable(namespace));
     }
 
     @Override
     public void writeRound(long seq, V round) {
-        try {
-            PreparedStatement preparedStatement = connectionSupplier.get().prepareStatement(
-                    "INSERT OR REPLACE INTO paxosLog (seq, val) VALUES (?, ?)");
-            preparedStatement.setLong(1, seq);
-            preparedStatement.setBytes(2, round.persistToBytes());
-            preparedStatement.execute();
-        } catch (SQLException e) {
-            throw Throwables.rewrapAndThrowUncheckedException(e);
-        }
+        execute(dao -> dao.writeRound(namespace, seq, round.persistToBytes()));
     }
 
     @Override
     public byte[] readRound(long seq) {
-        return executeStatement(String.format("SELECT val FROM paxosLog WHERE seq = %s", seq))
-                .map(SqlitePaxosStateLog::getByteArrayUnchecked)
-                .orElse(null);
+        return execute(dao -> dao.readRound(namespace, seq));
     }
 
     @Override
     public long getLeastLogEntry() {
-        return executeStatement("SELECT MIN(seq) FROM paxosLog")
-                .map(SqlitePaxosStateLog::getLongResultUnchecked)
-                .orElse(PaxosAcceptor.NO_LOG_ENTRY);
+        return execute(x -> x.getLeastLogEntry(namespace)).orElse(PaxosAcceptor.NO_LOG_ENTRY);
     }
 
     @Override
     public long getGreatestLogEntry() {
-        return executeStatement("SELECT MAX(seq) FROM paxosLog")
-                .map(SqlitePaxosStateLog::getLongResultUnchecked)
-                .orElse(PaxosAcceptor.NO_LOG_ENTRY);
+        return execute(x -> x.getGreatestLogEntry(namespace)).orElse(PaxosAcceptor.NO_LOG_ENTRY);
     }
 
     @Override
     public void truncate(long toDeleteInclusive) {
-        executeVoid(String.format("DELETE FROM paxosLog WHERE seq <= %s", toDeleteInclusive));
+        execute(dao -> dao.truncate(namespace, toDeleteInclusive));
     }
 
-    private void executeVoid(String statement) {
-        try {
-            connectionSupplier.get().prepareStatement(statement).execute();
-        } catch (SQLException e) {
-            throw Throwables.rewrapAndThrowUncheckedException(e);
-        }
+    private <T> T execute(Function<Queries, T> call) {
+        return jdbi.withExtension(Queries.class, call::apply);
     }
 
-    private Optional<ResultSet> executeStatement(String statement) {
-        try {
-            ResultSet resultSet = connectionSupplier.get().prepareStatement(statement).executeQuery();
-            return resultSet.isClosed() ? Optional.empty() : Optional.of(resultSet);
-        } catch (SQLException e) {
-            throw Throwables.rewrapAndThrowUncheckedException(e);
-        }
-    }
+    public interface Queries {
+        @SqlUpdate("CREATE TABLE IF NOT EXISTS <table> (seq BIGINT PRIMARY KEY, val BLOB)")
+        boolean createTable(@Define("table") String table);
 
-    private static long getLongResultUnchecked(ResultSet resultSet) {
-        try {
-            long candidate = resultSet.getLong(1);
-            return resultSet.wasNull() ? PaxosAcceptor.NO_LOG_ENTRY : candidate;
-        } catch (SQLException e) {
-            throw Throwables.rewrapAndThrowUncheckedException(e);
-        }
-    }
+        @SqlUpdate("INSERT OR REPLACE INTO <table> (seq, val) VALUES (:seq, :value)")
+        boolean writeRound(@Define("table") String table, @Bind("seq") long seq, @Bind("value") byte[] value);
 
-    private static byte[] getByteArrayUnchecked(ResultSet resultSet) {
-        try {
-            return ByteStreams.toByteArray(resultSet.getBinaryStream(1));
-        } catch (SQLException | IOException e) {
-            throw Throwables.rewrapAndThrowUncheckedException(e);
-        }
+        @SqlQuery("SELECT val FROM <table> WHERE seq = :seq")
+        @SingleValue
+        byte[] readRound(@Define("table") String table, @Bind("seq") long seq);
+
+        @SqlQuery("SELECT MIN(seq) FROM <table>")
+        OptionalLong getLeastLogEntry(@Define("table") String table);
+
+        @SqlQuery("SELECT MAX(seq) FROM <table>")
+        OptionalLong getGreatestLogEntry(@Define("table") String table);
+
+        @SqlUpdate("DELETE FROM <table> WHERE seq <= :seq")
+        boolean truncate(@Define("table") String table, @Bind("seq") long seq);
     }
 }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLog.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLog.java
@@ -64,12 +64,12 @@ public final class SqlitePaxosStateLog<V extends Persistable & Versionable> impl
 
     @Override
     public long getLeastLogEntry() {
-        return execute(x -> x.getLeastLogEntry(namespace)).orElse(PaxosAcceptor.NO_LOG_ENTRY);
+        return execute(dao -> dao.getLeastLogEntry(namespace)).orElse(PaxosAcceptor.NO_LOG_ENTRY);
     }
 
     @Override
     public long getGreatestLogEntry() {
-        return execute(x -> x.getGreatestLogEntry(namespace)).orElse(PaxosAcceptor.NO_LOG_ENTRY);
+        return execute(dao -> dao.getGreatestLogEntry(namespace)).orElse(PaxosAcceptor.NO_LOG_ENTRY);
     }
 
     @Override

--- a/leader-election-impl/src/test/java/com/palantir/paxos/SqlitePaxosStateLogTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/SqlitePaxosStateLogTest.java
@@ -19,22 +19,19 @@ package com.palantir.paxos;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
-import java.sql.Connection;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.function.Supplier;
 
+import org.jdbi.v3.core.Jdbi;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.base.Suppliers;
-
 public class SqlitePaxosStateLogTest {
+    private Jdbi jdbi = Jdbi.create(SqliteConnections.createDatabaseForTest().get());
     private PaxosStateLog<PaxosValue> stateLog;
 
     @Before
     public void setup() {
-        Supplier<Connection> connectionSupplier = Suppliers.memoize(SqliteConnections.createDatabaseForTest()::get);
-        stateLog = SqlitePaxosStateLog.createInitialized(connectionSupplier);
+        stateLog = SqlitePaxosStateLog.create("test", jdbi);
     }
 
     @Test

--- a/leader-election-impl/src/test/java/com/palantir/paxos/SqlitePaxosStateLogTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/SqlitePaxosStateLogTest.java
@@ -142,6 +142,11 @@ public class SqlitePaxosStateLogTest {
                 connectionSupplier::get);
     }
 
+    /**
+     * JDBI closes the connection after executing a query. This is desired behaviour, but does not play nicely with in
+     * memory sqlite as we cannot recreate a connection to the same in memory instance, so we use this to keep the
+     * connection open instead in tests.
+     */
     private static final class CloseIgnoringInvocationHandler extends AbstractInvocationHandler {
         private final Connection delegate;
 

--- a/versions.props
+++ b/versions.props
@@ -90,6 +90,7 @@ org.hibernate:hibernate-validator = 5.1.3.Final
 org.hibernate.validator:hibernate-validator = 6.1.2.Final
 org.immutables:* = 2.8.2
 org.javassist:javassist = 3.18.2-GA
+org.jdbi:* = 3.13.0
 org.jmock:jmock* = 2.12.0
 org.mockito:mockito-* = 3.1.0
 org.mortbay.jetty.alpn:jetty-alpn-agent = 2.0.9


### PR DESCRIPTION
**Goals (and why)**:
Address comments on previous PR and clean up the implementation

**Implementation Description (bullets)**:
Straightforward, also added namespacing to avoid having to redo work

**Testing (What was existing testing like?  What have you done to improve it?)**:
Existing tests pass

**Concerns (what feedback would you like?)**:
To use in memory sqlite we have to make sure our connection does not get closed. This is done by creating the Jdbi object in tests and passing it in as an argument to the log. This factory is exposed to allow testing multiple namespaces, but the factory that should generally be called is the one with the connection supplier, as that will create and close connections appropriately. 

**Where should we start reviewing?**:
anywhere

**Priority (whenever / two weeks / yesterday)**:
asap