### PR TITLE
[PDS-117161] Add additional logging on close of Snapshot Transaction Manager

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -345,7 +345,9 @@ import com.palantir.timestamp.TimestampService;
             }
 
             shutdownRunner.shutdownSafely(metricsManager::deregisterMetrics);
+            log.info("Close callbacks complete in snapshot transaction manager");
         }
+        log.info("Closed snapshot transaction manager without any errors");
     }
 
     private static void shutdownExecutor(ExecutorService executor) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -326,7 +326,9 @@ import com.palantir.timestamp.TimestampService;
      */
     @Override
     public void close() {
+        log.info("Calling close on snapshot transaction manager");
         if (!isClosed.compareAndSet(false, true)) {
+            log.info("Snapshot transaction manager has already been closed, performing no action");
             return;
         }
 


### PR DESCRIPTION
**Goals (and why)**:
As per PDS-117161, there are times where a transaction manager is closed but we do not necessarily call all of the closing callbacks. This PR should help with debugging this case.

**Implementation Description (bullets)**:
* Add logging for when the Snapshot transaction manager closes;
* Add logging for when this close has been called before (i.e. transaction manager is already closed).

**Testing (What was existing testing like?  What have you done to improve it?)**:
N/A

**Concerns (what feedback would you like?)**:
Any other places where logging should be added? I know that internal skiing product doesn't (or should not) close transaction managers too frequently, but if there are other uses that do, this could add more logging noise.

**Where should we start reviewing?**:
`SnapshotTransactionManager`

**Priority (whenever / two weeks / yesterday)**:
Today would be nice.