### PR TITLE
Remove deprecation until downstream services catch up.

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -205,9 +205,8 @@ public abstract class TransactionManagers {
     abstract Optional<Refreshable<Optional<AtlasDbRuntimeConfig>>> runtimeConfig();
 
     /**
-     * @deprecated use {@link #runtimeConfig} instead.
+     * Use {@link #runtimeConfig} instead.
      */
-    @Deprecated
     abstract Optional<Supplier<Optional<AtlasDbRuntimeConfig>>> runtimeConfigSupplier();
 
     abstract Set<Schema> schemas();

--- a/changelog/@unreleased/pr-4733.v2.yml
+++ b/changelog/@unreleased/pr-4733.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Remove deprecation on TransactionManagers#runtimeConfigSupplier until
+    downstream services catch up.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4733


### PR DESCRIPTION
**Goals (and why)**:

Services running with -Xlint:deprecation will fail merging the version bump, until we have made them switch.

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
