### PR TITLE
Fix flaky test

### DIFF
--- a/leader-election-impl/build.gradle
+++ b/leader-election-impl/build.gradle
@@ -24,8 +24,9 @@ dependencies {
     exclude group: 'org.hamcrest'
     exclude group: 'org.ow2.asm'
   }
-  testCompile group: 'org.mockito', name: 'mockito-core'
   testCompile group: 'org.assertj', name: 'assertj-core'
+  testCompile group: 'org.awaitility', name: 'awaitility'
+  testCompile group: 'org.mockito', name: 'mockito-core'
   testCompile group: 'com.palantir.tracing', name: 'tracing-test-utils'
 }
 

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosConsensusFastTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosConsensusFastTest.java
@@ -34,6 +34,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.FileUtils;
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -206,7 +207,7 @@ public class PaxosConsensusFastTest {
         assertThat(Futures.getUnchecked(state.leader(0).isStillLeading(token1)))
                 .isEqualTo(StillLeadingStatus.LEADING);
 
-        state.leader(1).hostileTakeover();
+        Awaitility.waitAtMost(5, TimeUnit.SECONDS).until(() -> state.leader(1).hostileTakeover());
         assertThat(Futures.getUnchecked(state.leader(0).isStillLeading(token1)))
                 .isEqualTo(StillLeadingStatus.NOT_LEADING);
         assertThat(state.leader(1).getCurrentTokenIfLeading())


### PR DESCRIPTION
**Goals (and why)**:
This test has flaked, because leadership was not lost. However, takeover could legitimately fail, so keep retrying for 5 seconds instead
