### PR TITLE
[PDS-117310] Add trace logging when updating the namespace mapping

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/KvTableMappingService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/KvTableMappingService.java
@@ -23,6 +23,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.LongSupplier;
 
 import org.apache.commons.lang3.Validate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
@@ -55,8 +57,12 @@ import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.common.base.ClosableIterator;
 import com.palantir.common.exception.TableMappingNotFoundException;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
 
 public class KvTableMappingService implements TableMappingService {
+    private static final Logger log = LoggerFactory.getLogger(KvTableMappingService.class);
+
     public static final TableMetadata NAMESPACE_TABLE_METADATA = TableMetadata.internal()
             .rowMetadata(NameMetadataDescription.create(ImmutableList.of(
                     NameComponentDescription.of("namespace", ValueType.VAR_STRING),
@@ -234,6 +240,11 @@ public class KvTableMappingService implements TableMappingService {
     }
 
     protected BiMap<TableReference, TableReference> readTableMap() {
+        // TODO (jkong) Remove after PDS-117310 is resolved.
+        if (log.isTraceEnabled()) {
+            log.trace("Attempting to read the table mapping from the namespace table.",
+                    new SafeRuntimeException("I exist to show you the stack trace"));
+        }
         BiMap<TableReference, TableReference> ret = HashBiMap.create();
         try (ClosableIterator<RowResult<Value>> range = rangeScanNamespaceTable()) {
             while (range.hasNext()) {
@@ -243,6 +254,12 @@ public class KvTableMappingService implements TableMappingService {
                 TableReference ref = getTableRefFromBytes(row.getRowName());
                 ret.put(ref, TableReference.createWithEmptyNamespace(shortName));
             }
+        }
+        // TODO (jkong) Remove after PDS-117310 is resolved.
+        if (log.isTraceEnabled()) {
+            log.trace("Successfully read {} entries from the namespace table, to refresh the table map.",
+                    SafeArg.of("entriesRead", ret.size()),
+                    new SafeRuntimeException("I exist to show you the stack trace"));
         }
         return ret;
     }


### PR DESCRIPTION
**Goals (and why)**:
- See PDS-117310: the namespace table is queried a lot, and we don't really understand why.

**Implementation Description (bullets)**:
- Add trace logging to `KvTableMappingService`.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Nothing in particular: this change should not affect behaviour.

**Concerns (what feedback would you like?)**:
- Is there a potential perf problem? Given this we're only doing this when TRACE logging is enabled, I think this is fine as long as it _only_ affects perf when TRACE logging _is_ enabled.

**Where should we start reviewing?**: KvTableMappingService

**Priority (whenever / two weeks / yesterday)**: this week
