### PR TITLE
[PaxosLog] Part 6: Namespace Tracking for SqlitePaxosStateLog

### DIFF
--- a/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLogFactory.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLogFactory.java
@@ -20,6 +20,7 @@ import java.sql.Connection;
 import java.util.List;
 import java.util.function.Supplier;
 
+import org.immutables.value.Value;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 import org.jdbi.v3.sqlobject.customizer.Bind;
@@ -46,13 +47,19 @@ public class SqlitePaxosStateLogFactory<V extends Persistable & Versionable> {
         return new SqlitePaxosStateLogFactory<>(connectionSupplier, jdbi);
     }
 
-    public PaxosStateLog<V> createPaxosStateLog(String namespace) {
-        jdbi.withExtension(Queries.class, queries -> queries.registerNamespace(namespace));
-        return SqlitePaxosStateLog.create(namespace, connectionSupplier);
+    public PaxosStateLog<V> createPaxosStateLog(PaxosStateLogCreationContext context) {
+        jdbi.withExtension(Queries.class, queries -> queries.registerNamespace(context.atlasNamespace()));
+        return SqlitePaxosStateLog.create(context.physicalTableName(), connectionSupplier);
     }
 
     public List<String> getAllRegisteredNamespaces() {
         return jdbi.withExtension(Queries.class, Queries::getAllRegisteredNamespaces);
+    }
+
+    @Value.Immutable
+    public interface PaxosStateLogCreationContext {
+        String atlasNamespace();
+        String physicalTableName();
     }
 
     public interface Queries {

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLogFactory.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLogFactory.java
@@ -62,7 +62,7 @@ public class SqlitePaxosStateLogFactory<V extends Persistable & Versionable> {
         String physicalTableName();
     }
 
-    public interface Queries {
+    private interface Queries {
         @SqlUpdate("CREATE TABLE IF NOT EXISTS " + NAMESPACE_TABLE + " (namespace TEXT PRIMARY KEY)")
         boolean createNamespaceTable();
 

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLogFactory.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLogFactory.java
@@ -29,7 +29,7 @@ import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 
 import com.palantir.common.persist.Persistable;
 
-public class SqlitePaxosStateLogFactory<V extends Persistable & Versionable> {
+public final class SqlitePaxosStateLogFactory<V extends Persistable & Versionable> {
     public static final String NAMESPACE_TABLE = "_paxosNamespaces";
 
     private final Supplier<Connection> connectionSupplier;

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLogFactory.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLogFactory.java
@@ -1,0 +1,68 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.paxos;
+
+import java.sql.Connection;
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+
+import com.palantir.common.persist.Persistable;
+
+public class SqlitePaxosStateLogFactory<V extends Persistable & Versionable> {
+    public static final String NAMESPACE_TABLE = "_paxosNamespaces";
+
+    private final Supplier<Connection> connectionSupplier;
+    private final Jdbi jdbi;
+
+    private SqlitePaxosStateLogFactory(Supplier<Connection> connectionSupplier, Jdbi jdbi) {
+        this.connectionSupplier = connectionSupplier;
+        this.jdbi = jdbi;
+    }
+
+    public static <V extends Persistable & Versionable> SqlitePaxosStateLogFactory<V> create(
+            Supplier<Connection> connectionSupplier) {
+        Jdbi jdbi = Jdbi.create(connectionSupplier::get).installPlugin(new SqlObjectPlugin());
+        jdbi.withExtension(Queries.class, Queries::createNamespaceTable);
+        return new SqlitePaxosStateLogFactory<>(connectionSupplier, jdbi);
+    }
+
+    public PaxosStateLog<V> createPaxosStateLog(String namespace) {
+        jdbi.withExtension(Queries.class, queries -> queries.registerNamespace(namespace));
+        return SqlitePaxosStateLog.create(namespace, connectionSupplier);
+    }
+
+    public List<String> getAllRegisteredNamespaces() {
+        return jdbi.withExtension(Queries.class, Queries::getAllRegisteredNamespaces);
+    }
+
+    public interface Queries {
+        @SqlUpdate("CREATE TABLE IF NOT EXISTS " + NAMESPACE_TABLE + " (namespace TEXT PRIMARY KEY)")
+        boolean createNamespaceTable();
+
+        @SqlUpdate("INSERT OR REPLACE INTO " + NAMESPACE_TABLE + " VALUES (:namespace)")
+        boolean registerNamespace(@Bind("namespace") String namespace);
+
+        @SqlQuery("SELECT namespace FROM " + NAMESPACE_TABLE)
+        List<String> getAllRegisteredNamespaces();
+    }
+}

--- a/leader-election-impl/src/test/java/com/palantir/paxos/SqlitePaxosStateLogFactoryTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/SqlitePaxosStateLogFactoryTest.java
@@ -45,8 +45,8 @@ public class SqlitePaxosStateLogFactoryTest {
 
     @Test
     public void namespacesRegisteredWhenStateLogsAreCreated() {
-        factory.createPaxosStateLog(NAMESPACE_1);
-        factory.createPaxosStateLog(NAMESPACE_2);
+        factory.createPaxosStateLog(getCreationContext(NAMESPACE_1, NAMESPACE_1));
+        factory.createPaxosStateLog(getCreationContext(NAMESPACE_2, NAMESPACE_2));
 
         assertThat(factory.getAllRegisteredNamespaces()).containsExactlyInAnyOrder(NAMESPACE_1, NAMESPACE_2);
     }
@@ -57,10 +57,26 @@ public class SqlitePaxosStateLogFactoryTest {
     }
 
     @Test
-    public void canCreateSameLogTwice() {
-        factory.createPaxosStateLog(NAMESPACE_1);
-        factory.createPaxosStateLog(NAMESPACE_1);
+    public void canCreateLogForSameSequenceTwice() {
+        factory.createPaxosStateLog(getCreationContext(NAMESPACE_1, NAMESPACE_1));
+        factory.createPaxosStateLog(getCreationContext(NAMESPACE_1, NAMESPACE_1));
 
         assertThat(factory.getAllRegisteredNamespaces()).containsExactly(NAMESPACE_1);
+    }
+
+    @Test
+    public void canCreateMultipleLogsForSameAtlasNamespace() {
+        factory.createPaxosStateLog(getCreationContext(NAMESPACE_1, NAMESPACE_1));
+        factory.createPaxosStateLog(getCreationContext(NAMESPACE_1, NAMESPACE_2));
+
+        assertThat(factory.getAllRegisteredNamespaces()).containsExactly(NAMESPACE_1);
+    }
+
+    private static SqlitePaxosStateLogFactory.PaxosStateLogCreationContext getCreationContext(
+            String namespace, String physicalTableName) {
+        return ImmutablePaxosStateLogCreationContext.builder()
+                .atlasNamespace(namespace)
+                .physicalTableName(physicalTableName)
+                .build();
     }
 }

--- a/leader-election-impl/src/test/java/com/palantir/paxos/SqlitePaxosStateLogFactoryTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/SqlitePaxosStateLogFactoryTest.java
@@ -1,0 +1,66 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.paxos;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Connection;
+import java.util.function.Supplier;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class SqlitePaxosStateLogFactoryTest {
+    private static final String NAMESPACE_1 = "namespace1";
+    private static final String NAMESPACE_2 = "namespace2";
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    private Supplier<Connection> connSupplier;
+    private SqlitePaxosStateLogFactory<PaxosValue> factory;
+
+    @Before
+    public void setup() {
+        connSupplier = SqliteConnections
+                .createSqliteDatabase(tempFolder.getRoot().toPath().resolve("test.db").toString());
+        factory = SqlitePaxosStateLogFactory.create(connSupplier);
+    }
+
+    @Test
+    public void namespacesRegisteredWhenStateLogsAreCreated() {
+        factory.createPaxosStateLog(NAMESPACE_1);
+        factory.createPaxosStateLog(NAMESPACE_2);
+
+        assertThat(factory.getAllRegisteredNamespaces()).containsExactlyInAnyOrder(NAMESPACE_1, NAMESPACE_2);
+    }
+
+    @Test
+    public void getRegisteredNamespacesReturnsNothingIfNoNamespacesExistYet() {
+        assertThat(factory.getAllRegisteredNamespaces()).containsExactly();
+    }
+
+    @Test
+    public void canCreateSameLogTwice() {
+        factory.createPaxosStateLog(NAMESPACE_1);
+        factory.createPaxosStateLog(NAMESPACE_1);
+
+        assertThat(factory.getAllRegisteredNamespaces()).containsExactly(NAMESPACE_1);
+    }
+}


### PR DESCRIPTION
**Goals (and why)**:
- Keep track of all AtlasDB namespaces via a table in SQLite. Possibly contentious: please read the Concerns section.

**Implementation Description (bullets)**:
- Create the SqlitePaxosStateLog through a Factory that tracks namespaces.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Added some small tests.

**Concerns (what feedback would you like?)**:
- An alternative is to parse the namespaces from string table names. I'm not entirely happy about that. Is that a better choice?
- Do we need delete/decommission operations?
- Is there any other tracking we should include?

**Where should we start reviewing?**: SqlitePaxosStateLogFactory

**Priority (whenever / two weeks / yesterday)**: this week
