### PR TITLE
Standardize on NamedThreadFactory for observability

### DIFF
--- a/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/DisruptorAutobatcher.java
+++ b/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/DisruptorAutobatcher.java
@@ -33,11 +33,11 @@ import com.google.common.util.concurrent.AbstractFuture;
 import com.google.common.util.concurrent.AsyncFunction;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.lmax.disruptor.EventHandler;
 import com.lmax.disruptor.RingBuffer;
 import com.lmax.disruptor.TimeoutException;
 import com.lmax.disruptor.dsl.Disruptor;
+import com.palantir.common.concurrent.NamedThreadFactory;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.tracing.DetachedSpan;
 
@@ -61,11 +61,7 @@ public final class DisruptorAutobatcher<T, R>
     }
 
     private static ThreadFactory createThreadFactory(String safeLoggablePurpose) {
-        String namePrefix = String.format("autobatcher.%s-", safeLoggablePurpose);
-        return new ThreadFactoryBuilder()
-                .setDaemon(true)
-                .setNameFormat(namePrefix + "%d")
-                .build();
+        return new NamedThreadFactory("autobatcher." + safeLoggablePurpose, true);
     }
 
     private final Disruptor<DefaultBatchElement<T, R>> disruptor;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -39,7 +39,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.RangeMap;
 import com.google.common.collect.Sets;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.palantir.async.initializer.AsyncInitializer;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
@@ -49,6 +48,7 @@ import com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraClientPoolMetrics;
 import com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraService;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.common.base.FunctionCheckedException;
+import com.palantir.common.concurrent.NamedThreadFactory;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
@@ -183,10 +183,9 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
             CassandraClientPoolMetrics metrics) {
         this(config,
                 startupChecks,
-                PTExecutors.newScheduledThreadPool(1, new ThreadFactoryBuilder()
-                        .setDaemon(true)
-                        .setNameFormat("CassandraClientPoolRefresh-%d")
-                        .build()),
+                PTExecutors.newScheduledThreadPool(
+                        1,
+                        new NamedThreadFactory("CassandraClientPoolRefresh")),
                 exceptionHandler,
                 blacklist,
                 new CassandraService(metricsManager, config, blacklist, metrics),

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -185,7 +185,7 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
                 startupChecks,
                 PTExecutors.newScheduledThreadPool(
                         1,
-                        new NamedThreadFactory("CassandraClientPoolRefresh")),
+                        new NamedThreadFactory("CassandraClientPoolRefresh", true)),
                 exceptionHandler,
                 blacklist,
                 new CassandraService(metricsManager, config, blacklist, metrics),

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionManager.java
@@ -25,7 +25,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.util.concurrent.RateLimiter;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.palantir.atlasdb.cache.TimestampCache;
 import com.palantir.atlasdb.health.MetricsBasedTimelockHealthCheck;
 import com.palantir.atlasdb.health.TimelockHealthCheck;
@@ -35,6 +34,7 @@ import com.palantir.atlasdb.transaction.api.TransactionFailedException;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.atlasdb.transaction.api.TransactionTask;
 import com.palantir.atlasdb.util.MetricsManager;
+import com.palantir.common.concurrent.NamedThreadFactory;
 import com.palantir.logsafe.Preconditions;
 
 public abstract class AbstractTransactionManager implements TransactionManager {
@@ -115,8 +115,7 @@ public abstract class AbstractTransactionManager implements TransactionManager {
         };
         return new ThreadPoolExecutor(
                 numThreads, numThreads, 0L, TimeUnit.MILLISECONDS, workQueue,
-                new ThreadFactoryBuilder().setNameFormat(
-                        AbstractTransactionManager.this.getClass().getSimpleName() + "-get-ranges-%d").build());
+                new NamedThreadFactory(AbstractTransactionManager.this.getClass().getSimpleName() + "-get-ranges"));
     }
 
     @Override

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
@@ -40,7 +40,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.net.HostAndPort;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.palantir.atlasdb.config.AuxiliaryRemotingParameters;
 import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.config.LeaderRuntimeConfig;
@@ -50,6 +49,7 @@ import com.palantir.atlasdb.http.AtlasDbHttpClients;
 import com.palantir.atlasdb.http.NotCurrentLeaderExceptionMapper;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
 import com.palantir.atlasdb.util.MetricsManager;
+import com.palantir.common.concurrent.NamedThreadFactory;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.common.streams.KeyedStream;
 import com.palantir.conjure.java.api.config.service.UserAgent;
@@ -251,10 +251,7 @@ public final class Leaders {
     }
 
     private static ThreadFactory daemonThreadFactory(String name) {
-        return new ThreadFactoryBuilder()
-                .setNameFormat(name + "-%d")
-                .setDaemon(true)
-                .build();
+        return new NamedThreadFactory(name, true);
     }
 
     public static <T> List<T> createProxyAndLocalList(

--- a/changelog/@unreleased/pr-4741.v2.yml
+++ b/changelog/@unreleased/pr-4741.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Standardize on NamedThreadFactory for observability. All Executors
+    produce tagged thread-factory instrumentation.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4741

--- a/lock-api/src/main/java/com/palantir/lock/client/TimeLockClient.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/TimeLockClient.java
@@ -22,8 +22,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledExecutorService;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.palantir.common.base.Throwables;
+import com.palantir.common.concurrent.NamedThreadFactory;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.leader.NotCurrentLeaderException;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
@@ -180,10 +180,7 @@ public class TimeLockClient implements AutoCloseable, TimelockService {
 
     private static ScheduledExecutorService createSingleThreadScheduledExecutor(String operation) {
         return PTExecutors.newSingleThreadScheduledExecutor(
-                new ThreadFactoryBuilder()
-                        .setNameFormat(TimeLockClient.class.getSimpleName() + "-" + operation + "-%d")
-                        .setDaemon(true)
-                        .build());
+                new NamedThreadFactory(TimeLockClient.class.getSimpleName() + "-" + operation, true));
     }
 
     private static final class TimelockServiceErrorDecorator implements CloseableTimestampService {

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/TimeLockPaxosExecutors.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/TimeLockPaxosExecutors.java
@@ -27,7 +27,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.MoreExecutors;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.palantir.common.concurrent.NamedThreadFactory;
 import com.palantir.common.concurrent.PTExecutors;
 
 final class TimeLockPaxosExecutors {
@@ -76,10 +76,7 @@ final class TimeLockPaxosExecutors {
                         THREAD_KEEP_ALIVE.toMillis(),
                         TimeUnit.MILLISECONDS,
                         new SynchronousQueue<>(),
-                        new ThreadFactoryBuilder()
-                                .setNameFormat("timelock-executors-" + useCase + "-%d")
-                                .setDaemon(true)
-                                .build()),
+                        new NamedThreadFactory("timelock-executors-" + useCase, true)),
                 metricRegistry,
                 MetricRegistry.name(TimeLockPaxosExecutors.class, useCase, "executor-" + index));
     }

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -28,7 +28,6 @@ import com.codahale.metrics.InstrumentedExecutorService;
 import com.codahale.metrics.InstrumentedThreadFactory;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Suppliers;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.palantir.atlasdb.config.ImmutableLeaderConfig;
 import com.palantir.atlasdb.http.BlockingTimeoutExceptionMapper;
 import com.palantir.atlasdb.http.NotCurrentLeaderExceptionMapper;
@@ -47,6 +46,7 @@ import com.palantir.atlasdb.timelock.paxos.ImmutableTimelockPaxosInstallationCon
 import com.palantir.atlasdb.timelock.paxos.PaxosResources;
 import com.palantir.atlasdb.timelock.paxos.PaxosResourcesFactory;
 import com.palantir.atlasdb.util.MetricsManager;
+import com.palantir.common.concurrent.NamedThreadFactory;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.undertow.lib.UndertowService;
@@ -146,10 +146,9 @@ public class TimeLockAgent {
 
     private static ExecutorService createSharedExecutor(MetricsManager metricsManager) {
         return new InstrumentedExecutorService(
-                PTExecutors.newCachedThreadPool(new InstrumentedThreadFactory(new ThreadFactoryBuilder()
-                        .setNameFormat("paxos-timestamp-creator-%d")
-                        .setDaemon(true)
-                        .build(), metricsManager.getRegistry())),
+                PTExecutors.newCachedThreadPool(new InstrumentedThreadFactory(
+                        new NamedThreadFactory("paxos-timestamp-creator", true),
+                        metricsManager.getRegistry())),
                 metricsManager.getRegistry(),
                 MetricRegistry.name(PaxosLeaderElectionService.class, PAXOS_SHARED_EXECUTOR, "executor"));
     }


### PR DESCRIPTION
Instead of using a mix of both ThreadFactoryBuilder and
NamedThreadFactory, we standardize on the latter for the provided
instrumentation.