### PR TITLE
[PaxosLog] Part 7: Configuration Sketch :fire: CONTENTIOUS :fire:

### DIFF
--- a/timelock-agent/src/main/java/com/palantir/timelock/config/FilePaxosPersistenceConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/FilePaxosPersistenceConfiguration.java
@@ -1,0 +1,24 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.timelock.config;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+interface FilePaxosPersistenceConfiguration extends PaxosPersistenceConfiguration {
+    String TYPE = "file";
+}

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosInstallConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosInstallConfiguration.java
@@ -43,23 +43,10 @@ public interface PaxosInstallConfiguration {
      * Allows users to select an implementation of how the Paxos logs are persisted on disk. Changing this setting
      * MAY involve a blocking migration the next time TimeLock starts up.
      */
-    @JsonProperty("persistence-mode")
+    @JsonProperty("persistence")
     @Value.Default
-    default PaxosPersistenceMode persistenceMode() {
-        return PaxosPersistenceMode.FILE;
-    }
-
-    @Value.Check
-    default void checkPersistenceModeIsFileBased() {
-        Preconditions.checkArgument(
-                persistenceMode() == PaxosPersistenceMode.FILE,
-                "SQLite for Paxos persistence is not supported yet");
-    }
-
-    enum PaxosPersistenceMode {
-        FILE,
-        FILE_WITH_SQLITE_VALIDATION,
-        SQLITE
+    default PaxosPersistenceConfiguration persistence() {
+        return ImmutableFilePaxosPersistenceConfiguration.builder().build();
     }
 
     /**
@@ -95,6 +82,10 @@ public interface PaxosInstallConfiguration {
         Preconditions.checkArgument(
                 leaderMode() != PaxosLeaderMode.AUTO_MIGRATION_MODE,
                 "Auto migration mode is not supported just yet");
+    }
+
+    @Value.Check
+    default void separatelySpecifiedDataDirectoriesMustBeConsistent() {
     }
 
     @Value.Check

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosInstallConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosInstallConfiguration.java
@@ -40,6 +40,29 @@ public interface PaxosInstallConfiguration {
     }
 
     /**
+     * Allows users to select an implementation of how the Paxos logs are persisted on disk. Changing this setting
+     * MAY involve a blocking migration the next time TimeLock starts up.
+     */
+    @JsonProperty("persistence-mode")
+    @Value.Default
+    default PaxosPersistenceMode persistenceMode() {
+        return PaxosPersistenceMode.FILE;
+    }
+
+    @Value.Check
+    default void checkPersistenceModeIsFileBased() {
+        Preconditions.checkArgument(
+                persistenceMode() == PaxosPersistenceMode.FILE,
+                "SQLite for Paxos persistence is not supported yet");
+    }
+
+    enum PaxosPersistenceMode {
+        FILE,
+        FILE_WITH_SQLITE_VALIDATION,
+        SQLITE
+    }
+
+    /**
      * Set to true if this is a new stack. Otherwise, set to false.
      */
     @JsonProperty("is-new-service")
@@ -69,7 +92,7 @@ public interface PaxosInstallConfiguration {
 
     @Value.Check
     default void checkLeaderModeIsNotInAutoMigrationMode() {
-        Preconditions.checkState(
+        Preconditions.checkArgument(
                 leaderMode() != PaxosLeaderMode.AUTO_MIGRATION_MODE,
                 "Auto migration mode is not supported just yet");
     }

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosPersistenceConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosPersistenceConfiguration.java
@@ -16,10 +16,6 @@
 
 package com.palantir.timelock.config;
 
-import java.io.File;
-import java.util.Optional;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
@@ -32,4 +28,11 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
                 name = FilePaxosPersistenceConfiguration.TYPE)})
 interface PaxosPersistenceConfiguration {
     // Marker interface
+
+    <T> T visit(Visitor<T> visitor);
+
+    interface Visitor<T> {
+        T visit(FilePaxosPersistenceConfiguration file);
+        T visit(SqlitePaxosPersistenceConfiguration sqlite);
+    }
 }

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosPersistenceConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosPersistenceConfiguration.java
@@ -1,0 +1,35 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.timelock.config;
+
+import java.io.File;
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        property = "type",
+        defaultImpl = FilePaxosPersistenceConfiguration.class)
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = FilePaxosPersistenceConfiguration.class,
+                name = FilePaxosPersistenceConfiguration.TYPE)})
+interface PaxosPersistenceConfiguration {
+    // Marker interface
+}

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/SqlitePaxosPersistenceConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/SqlitePaxosPersistenceConfiguration.java
@@ -24,11 +24,14 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 @Value.Immutable
-@JsonSerialize(as = ImmutableFilePaxosPersistenceConfiguration.class)
-@JsonDeserialize(as = ImmutableFilePaxosPersistenceConfiguration.class)
-interface FilePaxosPersistenceConfiguration extends PaxosPersistenceConfiguration {
-    String TYPE = "file";
+@JsonSerialize(as = ImmutableSqlitePaxosPersistenceConfiguration.class)
+@JsonDeserialize(as = ImmutableSqlitePaxosPersistenceConfiguration.class)
+interface SqlitePaxosPersistenceConfiguration extends PaxosPersistenceConfiguration {
+    String TYPE = "sqlite";
 
+    /**
+     * Directory where the SQLite database and related persistence information should be stored.
+     */
     File dataDirectory();
 
     default <T> T visit(Visitor<T> visitor) {

--- a/timelock-agent/src/test/java/com/palantir/timelock/config/PaxosInstallConfigurationIntegrationTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/config/PaxosInstallConfigurationIntegrationTest.java
@@ -1,0 +1,131 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.timelock.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class PaxosInstallConfigurationIntegrationTest {
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void configurationWithoutExplicitPersistenceConfigurationIsFileBacked() {
+        File newFolder = getRandomSubdirectory();
+        PaxosInstallConfiguration installConfiguration = ImmutablePaxosInstallConfiguration.builder()
+                .dataDirectory(newFolder)
+                .isNewService(false)
+                .build();
+
+        assertThat(installConfiguration.persistence())
+                .isInstanceOf(FilePaxosPersistenceConfiguration.class)
+                .satisfies(persistence -> assertThat(((FilePaxosPersistenceConfiguration) persistence).dataDirectory())
+                        .isEqualTo(newFolder));
+    }
+
+    @Test
+    public void fileBackedConfigurationMustAgree() {
+        assertThatThrownBy(() -> ImmutablePaxosInstallConfiguration.builder()
+                .dataDirectory(getRandomSubdirectory())
+                .persistence(ImmutableFilePaxosPersistenceConfiguration.builder()
+                        .dataDirectory(getRandomSubdirectory())
+                        .build())
+                .isNewService(false)
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("If using file based persistence, data directories must match");
+    }
+
+    @Test
+    public void canConfigureFileBackedConfigurationExplicitly() {
+        File newFolder = getRandomSubdirectory();
+
+        assertThatCode(() -> ImmutablePaxosInstallConfiguration.builder()
+                .dataDirectory(newFolder)
+                .persistence(ImmutableFilePaxosPersistenceConfiguration.builder().dataDirectory(newFolder).build())
+                .isNewService(false)
+                .build())
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void sqliteBackedConfigurationMustNotShareDataDirectory() {
+        File newFolder = getRandomSubdirectory();
+
+        assertThatThrownBy(() -> ImmutablePaxosInstallConfiguration.builder()
+                .dataDirectory(newFolder)
+                .persistence(ImmutableSqlitePaxosPersistenceConfiguration.builder().dataDirectory(newFolder).build())
+                .isNewService(false)
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("If using SQLite based persistence")
+                .hasMessageContaining("the SQLite data directory must NOT equal the file based directory.");
+    }
+
+    @Test
+    public void existenceOfEitherDataDirectorySufficesToIndicateServiceIsNotNew() {
+        File fileBackedDirectory = getRandomSubdirectory();
+        File sqliteBackedDirectory = getRandomSubdirectory();
+        File otherFileBackedDirectory = getRandomSubdirectory();
+
+        assertCanCreateConfigWithSqlitePersistence(fileBackedDirectory, sqliteBackedDirectory);
+        fileBackedDirectory.delete();
+        assertCanCreateConfigWithSqlitePersistence(fileBackedDirectory, sqliteBackedDirectory);
+        sqliteBackedDirectory.delete();
+        assertCanCreateConfigWithSqlitePersistence(otherFileBackedDirectory, sqliteBackedDirectory);
+    }
+
+    @Test
+    public void serviceIsNewIfNoDataDirectoriesPresent() {
+        ImmutablePaxosInstallConfiguration.Builder partialConfiguration = ImmutablePaxosInstallConfiguration.builder()
+                .dataDirectory(temporaryFolder.getRoot().toPath().resolve("file").toFile())
+                .persistence(ImmutableSqlitePaxosPersistenceConfiguration.builder()
+                        .dataDirectory(temporaryFolder.getRoot().toPath().resolve("sqlite").toFile())
+                        .build());
+        assertThatCode(() -> partialConfiguration.isNewService(true).build()).doesNotThrowAnyException();
+        assertThatThrownBy(() -> partialConfiguration.isNewService(false).build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("The timelock data directories do not appear to exist.");
+    }
+
+    public void assertCanCreateConfigWithSqlitePersistence(File fileBackedDirectory, File sqliteBackedDirectory) {
+        assertThatCode(() -> ImmutablePaxosInstallConfiguration.builder()
+                .dataDirectory(fileBackedDirectory)
+                .persistence(ImmutableSqlitePaxosPersistenceConfiguration.builder()
+                        .dataDirectory(sqliteBackedDirectory)
+                        .build())
+                .isNewService(false)
+                .build())
+                .doesNotThrowAnyException();
+    }
+
+    private File getRandomSubdirectory() {
+        try {
+            return temporaryFolder.newFolder();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/timelock-agent/src/test/java/com/palantir/timelock/config/PaxosInstallConfigurationTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/config/PaxosInstallConfigurationTest.java
@@ -70,20 +70,6 @@ public class PaxosInstallConfigurationTest {
                 .isNewService(false));
     }
 
-    @Test
-    public void throwsIfUsingSqlitePersistenceModes() {
-        File mockFile = getMockFileWith(true, false);
-
-        assertFailsToBuildConfiguration(ImmutablePaxosInstallConfiguration.builder()
-                .dataDirectory(mockFile)
-                .isNewService(false)
-                .persistenceMode(PaxosInstallConfiguration.PaxosPersistenceMode.FILE_WITH_SQLITE_VALIDATION));
-        assertFailsToBuildConfiguration(ImmutablePaxosInstallConfiguration.builder()
-                .dataDirectory(mockFile)
-                .isNewService(false)
-                .persistenceMode(PaxosInstallConfiguration.PaxosPersistenceMode.SQLITE));
-    }
-
     private File getMockFileWith(boolean isDirectory, boolean canCreateDirectory) {
         File mockFile = mock(File.class);
         when(mockFile.mkdirs()).thenReturn(canCreateDirectory);

--- a/timelock-agent/src/test/java/com/palantir/timelock/config/PaxosInstallConfigurationTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/config/PaxosInstallConfigurationTest.java
@@ -70,6 +70,20 @@ public class PaxosInstallConfigurationTest {
                 .isNewService(false));
     }
 
+    @Test
+    public void throwsIfUsingSqlitePersistenceModes() {
+        File mockFile = getMockFileWith(true, false);
+
+        assertFailsToBuildConfiguration(ImmutablePaxosInstallConfiguration.builder()
+                .dataDirectory(mockFile)
+                .isNewService(false)
+                .persistenceMode(PaxosInstallConfiguration.PaxosPersistenceMode.FILE_WITH_SQLITE_VALIDATION));
+        assertFailsToBuildConfiguration(ImmutablePaxosInstallConfiguration.builder()
+                .dataDirectory(mockFile)
+                .isNewService(false)
+                .persistenceMode(PaxosInstallConfiguration.PaxosPersistenceMode.SQLITE));
+    }
+
     private File getMockFileWith(boolean isDirectory, boolean canCreateDirectory) {
         File mockFile = mock(File.class);
         when(mockFile.mkdirs()).thenReturn(canCreateDirectory);


### PR DESCRIPTION
**Goals (and why)**:
- Outline how users can enable SQLite.

**Implementation Description (bullets)**:

```
paxos:
  # (no more data directory - if present and conflicting with persistence config, explode)
  persistence:
    type: FILE
    data-directory: var/data/paxos
  is-new-service: false
```

or

```
paxos:
  # (no more data directory - if present and *equal to* persistence config, explode)
  persistence:
    type: SQLITE
    data-directory: var/data/paxos
    magicDatabaseTuning: 42 # this is an advantage of method 2
  is-new-service: false
```

- This is more complicated than it looks, because existing mechanisms e.g. is-new-service now need to rely on potentially two directories, depending on the persistence type!
- Note that users can't actually configure SQLite yet: the config doesn't deserialize.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Added several unit tests

**Concerns (what feedback would you like?)**:
- There is a simpler alternative:

```
paxos:
  data-directory: var/data/paxos
  persistence-mode: FILE # or SQLITE
  is-new-service: false
```

And the data directory is reusable (since Paxos uses directories, we can coordinate so that we use a SQLite file in the root). This is hackier though.

**Where should we start reviewing?**: PaxosInstallConfiguration.java

**Priority (whenever / two weeks / yesterday)**: this week
