### PR TITLE
AtlasFutures no longer destroys thread interruption state

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/atlasdb/futures/AtlasFutures.java
+++ b/atlasdb-commons/src/main/java/com/palantir/atlasdb/futures/AtlasFutures.java
@@ -93,6 +93,10 @@ public final class AtlasFutures {
             return listenableFuture.get();
         } catch (ExecutionException e) {
             throw Throwables.rewrapAndThrowUncheckedException(e.getCause());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            listenableFuture.cancel(true);
+            throw Throwables.rewrapAndThrowUncheckedException(e);
         } catch (Exception e) {
             throw Throwables.rewrapAndThrowUncheckedException(e);
         }

--- a/atlasdb-commons/src/test/java/com/palantir/atlasdb/futures/AtlasFuturesTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/atlasdb/futures/AtlasFuturesTest.java
@@ -19,6 +19,8 @@ package com.palantir.atlasdb.futures;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.concurrent.Future;
+
 import org.junit.Test;
 
 import com.google.common.util.concurrent.SettableFuture;
@@ -33,5 +35,14 @@ public class AtlasFuturesTest {
         assertThat(Thread.interrupted())
                 .as("Expected getUnchecked to retain thread interruption state")
                 .isTrue();
+    }
+
+    @Test
+    public void testAtlasFuturesCancelsDelegateOnInterruption() {
+        Thread.currentThread().interrupt();
+        Future<Object> delegate = SettableFuture.create();
+        assertThatThrownBy(() -> AtlasFutures.getUnchecked(delegate))
+                .hasRootCauseExactlyInstanceOf(InterruptedException.class);
+        assertThat(delegate).isCancelled();
     }
 }

--- a/atlasdb-commons/src/test/java/com/palantir/atlasdb/futures/AtlasFuturesTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/atlasdb/futures/AtlasFuturesTest.java
@@ -1,0 +1,37 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.futures;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+import com.google.common.util.concurrent.SettableFuture;
+
+public class AtlasFuturesTest {
+
+    @Test
+    public void testAtlasFuturesResetsInterrupted() {
+        Thread.currentThread().interrupt();
+        assertThatThrownBy(() -> AtlasFutures.getUnchecked(SettableFuture.create()))
+                .hasRootCauseExactlyInstanceOf(InterruptedException.class);
+        assertThat(Thread.interrupted())
+                .as("Expected getUnchecked to retain thread interruption state")
+                .isTrue();
+    }
+}

--- a/changelog/@unreleased/pr-4743.v2.yml
+++ b/changelog/@unreleased/pr-4743.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: AtlasFutures.getUnchecked no longer destroys thread interruption state
+  links:
+  - https://github.com/palantir/atlasdb/pull/4743


### PR DESCRIPTION
**Goals (and why)**:

Interrupted threads shouldn't forget they're interrupted.

**Implementation Description (bullets)**:

Standard InterruptedException handling.
