### PR TITLE
PG-148649: AgnosticLightResultSetImpl doesn't fill the finalizer queue

### DIFF
--- a/changelog/@unreleased/pr-4744.v2.yml
+++ b/changelog/@unreleased/pr-4744.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix OOM caused by AgnosticLightResultSetImpl filling the finalizer
+    queue under heavy load.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4744

--- a/commons-db/src/main/java/com/palantir/nexus/db/sql/BasicSQL.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/sql/BasicSQL.java
@@ -65,7 +65,6 @@ import com.palantir.exception.PalantirInterruptedException;
 import com.palantir.exception.PalantirSqlException;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.nexus.db.DBType;
-import com.palantir.nexus.db.ResourceCreationLocation;
 import com.palantir.nexus.db.monitoring.timer.SqlTimer;
 import com.palantir.nexus.db.sql.BasicSQLString.FinalSQLString;
 import com.palantir.nexus.db.sql.monitoring.logger.SqlLoggers;
@@ -661,9 +660,7 @@ public abstract class BasicSQL {
             SqlLoggers.LOGGER.trace("SQL light result set selection query: {}", sql.getQuery());
         }
 
-        final ResourceCreationLocation alrsCreationException = new ResourceCreationLocation("This is where the AgnosticLightResultSet wrapper was created"); //$NON-NLS-1$
         PreparedStatementVisitor<AgnosticLightResultSet> preparedStatementVisitor = ps -> {
-            final ResourceCreationLocation creationException = new ResourceCreationLocation("This is where the ResultsSet was created", alrsCreationException); //$NON-NLS-1$
             final ResultSetVisitor<AgnosticLightResultSet> resultSetVisitor = rs -> {
                 try {
                     return new AgnosticLightResultSetImpl(
@@ -673,8 +670,7 @@ public abstract class BasicSQL {
                             ps,
                             "selectList", //$NON-NLS-1$
                             sql,
-                            getSqlTimer(),
-                            creationException);
+                            getSqlTimer());
                 } catch (Exception e) {
                     closeSilently(rs);
                     BasicSQLUtils.throwUncheckedIfSQLException(e);

--- a/commons-db/src/main/java/com/palantir/nexus/db/sql/SQL.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/sql/SQL.java
@@ -35,7 +35,6 @@ import com.palantir.db.oracle.JdbcHandler.ArrayHandler;
 import com.palantir.db.oracle.JdbcHandler.BlobHandler;
 import com.palantir.exception.PalantirSqlException;
 import com.palantir.nexus.db.DBType;
-import com.palantir.nexus.db.ResourceCreationLocation;
 import com.palantir.nexus.db.monitoring.timer.SqlTimer;
 import com.palantir.nexus.db.sql.BasicSQLString.FinalSQLString;
 import com.palantir.nexus.db.sql.monitoring.logger.SqlLoggers;
@@ -179,7 +178,6 @@ public abstract class SQL extends BasicSQL {
         String timingModule = "visitResultSet";
         ResultSetMetaData metaData = ResultSets.getMetaData(resultSet);
         SqlTimer sqlTimer = getSqlTimer();
-        ResourceCreationLocation creationException = new ResourceCreationLocation("This is where the ResultsSet was created"); //$NON-NLS-1$
         return new AgnosticLightResultSetImpl(
                 resultSet,
                 dbType,
@@ -187,7 +185,6 @@ public abstract class SQL extends BasicSQL {
                 preparedStatement,
                 timingModule,
                 sqlString,
-                sqlTimer,
-                creationException);
+                sqlTimer);
     }
 }


### PR DESCRIPTION
Objects which implement `finalize` end up on the single-threaded
finalizer queue which causes servers to oom.

**Goals (and why)**
oom is bad.

**Implementation Description (bullets)**:
Don't implement finalize.

**Priority (whenever / two weeks / yesterday)**:
yesterday
