### PR TITLE
Log an error if it takes >10 seconds to close executors when shutting down STM

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -353,7 +353,7 @@ import com.palantir.timestamp.TimestampService;
     private static void shutdownExecutor(ExecutorService executor) {
         executor.shutdown();
         try {
-            if(!executor.awaitTermination(10, TimeUnit.SECONDS)) {
+            if (!executor.awaitTermination(10, TimeUnit.SECONDS)) {
                 log.error("Failed to shutdown the executor after 10 seconds.");
             }
         } catch (InterruptedException ex) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -353,7 +353,9 @@ import com.palantir.timestamp.TimestampService;
     private static void shutdownExecutor(ExecutorService executor) {
         executor.shutdown();
         try {
-            executor.awaitTermination(10, TimeUnit.SECONDS);
+            if(!executor.awaitTermination(10, TimeUnit.SECONDS)) {
+                log.error("Failed to shutdown the executor after 10 seconds.");
+            }
         } catch (InterruptedException ex) {
             // Continue with further clean-up
             Thread.currentThread().interrupt();

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
@@ -69,7 +69,7 @@ public class SnapshotTransactionManagerTest {
     private final KeyValueService keyValueService = mock(KeyValueService.class);
 
     private final MetricsManager metricsManager = MetricsManagers.createForTests();
-    private final ExecutorService executorService = Executors.newSingleThreadExecutor();
+    private final ExecutorService deleteExecutor = Executors.newSingleThreadExecutor();
 
     private final InMemoryTimestampService timestampService = new InMemoryTimestampService();
     private final SnapshotTransactionManager snapshotTransactionManager = new SnapshotTransactionManager(
@@ -90,7 +90,7 @@ public class SnapshotTransactionManagerTest {
             TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY,
             DefaultTimestampCache.createForTests(),
             MultiTableSweepQueueWriter.NO_OP,
-            executorService,
+            deleteExecutor,
             true,
             () -> ImmutableTransactionConfig.builder().build(),
             ConflictTracer.NO_OP);
@@ -121,7 +121,7 @@ public class SnapshotTransactionManagerTest {
     @Test
     public void closesDeleteExecutorOnClosingTransactionManager() {
         snapshotTransactionManager.close();
-        assertThat(executorService.isTerminated()).isTrue();
+        assertThat(deleteExecutor.isTerminated()).isTrue();
     }
 
     @Test
@@ -145,7 +145,7 @@ public class SnapshotTransactionManagerTest {
                 TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY,
                 DefaultTimestampCache.createForTests(),
                 MultiTableSweepQueueWriter.NO_OP,
-                executorService,
+                deleteExecutor,
                 true,
                 () -> ImmutableTransactionConfig.builder().build(),
                 ConflictTracer.NO_OP);
@@ -265,7 +265,7 @@ public class SnapshotTransactionManagerTest {
                 TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY,
                 DefaultTimestampCache.createForTests(),
                 MultiTableSweepQueueWriter.NO_OP,
-                executorService,
+                deleteExecutor,
                 true,
                 () -> ImmutableTransactionConfig.builder()
                         .lockImmutableTsOnReadOnlyTransactions(grabImmutableTsLockOnReads)

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
@@ -119,6 +119,12 @@ public class SnapshotTransactionManagerTest {
     }
 
     @Test
+    public void closesDeleteExecutorOnClosingTransactionManager() {
+        snapshotTransactionManager.close();
+        assertThat(executorService.isTerminated()).isTrue();
+    }
+
+    @Test
     public void canCloseTransactionManagerWithNonCloseableLockService() {
         InMemoryTimestampService ts = new InMemoryTimestampService();
         SnapshotTransactionManager newTransactionManager = new SnapshotTransactionManager(

--- a/changelog/@unreleased/pr-4745.v2.yml
+++ b/changelog/@unreleased/pr-4745.v2.yml
@@ -1,0 +1,26 @@
+type: improvement
+improvement:
+  description: |-
+    Log an error if it takes >10 seconds to close executors when shutting down STM
+
+    **Goals (and why)**:
+    * Executors are closed when `SnapshotTransactionManager` is closed;
+    * The `shutdownExecutor` method awaits termination but doesn't do anything in the case that termination is slow.
+    * Now log an error if the executor was not shutdown in under 10 seconds - this may indicate a leak or other error.
+
+    **Implementation Description (bullets)**:
+    * Log on slow shutdown of executors during closing
+
+    **Testing (What was existing testing like?  What have you done to improve it?)**:
+    There is no testing that these executors (specifically, the `deleteExecutor` and the `getRangesExecutor`) close when `SnapshotTransactionManager` is closed. I have added a test to verify that the `deleteExecutor` is closed (the other one is created in the constructor and therefore harder to test).
+
+    **Concerns (what feedback would you like?)**:
+    Will this catch any meaningful information? A similar thing is done in other places throughout the codebase so I would expect so.
+
+    **Where should we start reviewing?**:
+    `SnapshotTransactionManager`
+
+    **Priority (whenever / two weeks / yesterday)**:
+    This week.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4745

--- a/changelog/@unreleased/pr-4745.v2.yml
+++ b/changelog/@unreleased/pr-4745.v2.yml
@@ -1,26 +1,6 @@
 type: improvement
 improvement:
-  description: |-
-    Log an error if it takes >10 seconds to close executors when shutting down STM
-
-    **Goals (and why)**:
-    * Executors are closed when `SnapshotTransactionManager` is closed;
-    * The `shutdownExecutor` method awaits termination but doesn't do anything in the case that termination is slow.
-    * Now log an error if the executor was not shutdown in under 10 seconds - this may indicate a leak or other error.
-
-    **Implementation Description (bullets)**:
-    * Log on slow shutdown of executors during closing
-
-    **Testing (What was existing testing like?  What have you done to improve it?)**:
-    There is no testing that these executors (specifically, the `deleteExecutor` and the `getRangesExecutor`) close when `SnapshotTransactionManager` is closed. I have added a test to verify that the `deleteExecutor` is closed (the other one is created in the constructor and therefore harder to test).
-
-    **Concerns (what feedback would you like?)**:
-    Will this catch any meaningful information? A similar thing is done in other places throughout the codebase so I would expect so.
-
-    **Where should we start reviewing?**:
-    `SnapshotTransactionManager`
-
-    **Priority (whenever / two weeks / yesterday)**:
-    This week.
+  description: Log an error if it takes >10 seconds to close executors when shutting
+    down a `SnapshotTransactionManager`
   links:
   - https://github.com/palantir/atlasdb/pull/4745


### PR DESCRIPTION
**Goals (and why)**:
* Executors are closed when `SnapshotTransactionManager` is closed;
* The `shutdownExecutor` method awaits termination but doesn't do anything in the case that termination is slow.
* Now log an error if the executor was not shutdown in under 10 seconds - this may indicate a leak or other error.

**Implementation Description (bullets)**:
* Log on slow shutdown of executors during closing

**Testing (What was existing testing like?  What have you done to improve it?)**:
There is no testing that these executors (specifically, the `deleteExecutor` and the `getRangesExecutor`) close when `SnapshotTransactionManager` is closed. I have added a test to verify that the `deleteExecutor` is closed (the other one is created in the constructor and therefore harder to test).

**Concerns (what feedback would you like?)**:
Will this catch any meaningful information? A similar thing is done in other places throughout the codebase so I would expect so.

**Where should we start reviewing?**:
`SnapshotTransactionManager`

**Priority (whenever / two weeks / yesterday)**:
This week.