### PR TITLE
Fix bug in transaction starter if it fails midway through the batch

### DIFF
--- a/lock-api/src/main/java/com/palantir/lock/client/TransactionStarter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/TransactionStarter.java
@@ -55,7 +55,7 @@ final class TransactionStarter implements AutoCloseable {
 
     private TransactionStarter(LockLeaseService lockLeaseService, LockWatchEventCache lockWatchEventCache) {
         this.autobatcher = Autobatchers
-                .independent(consumer(lockLeaseService, lockWatchEventCache))
+                .independent(consumer(lockWatchEventCache))
                 .safeLoggablePurpose("transaction-starter")
                 .build();
         this.lockLeaseService = lockLeaseService;
@@ -135,12 +135,12 @@ final class TransactionStarter implements AutoCloseable {
 
     @VisibleForTesting
     Consumer<List<BatchElement<Void, StartIdentifiedAtlasDbTransactionResponse>>> consumer(
-            LockLeaseService lockLeaseService, LockWatchEventCache lockWatchEventCache) {
+            LockWatchEventCache lockWatchEventCache) {
         return batch -> {
             int numTransactions = batch.size();
 
             List<StartIdentifiedAtlasDbTransactionResponse> startTransactionResponses =
-                    getStartTransactionResponses(lockLeaseService, lockWatchEventCache, numTransactions);
+                    getStartTransactionResponses(lockWatchEventCache, numTransactions);
 
             for (int i = 0; i < numTransactions; i++) {
                 batch.get(i).result().set(startTransactionResponses.get(i));
@@ -149,7 +149,6 @@ final class TransactionStarter implements AutoCloseable {
     }
 
     private List<StartIdentifiedAtlasDbTransactionResponse> getStartTransactionResponses(
-            LockLeaseService lockLeaseService,
             LockWatchEventCache lockWatchEventCache,
             int numberOfTransactions) {
         List<StartIdentifiedAtlasDbTransactionResponse> result = new ArrayList<>();

--- a/lock-api/src/test/java/com/palantir/lock/client/TransactionStarterTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/TransactionStarterTest.java
@@ -137,7 +137,7 @@ public class TransactionStarterTest {
                         .result(new DisruptorAutobatcher.DisruptorFuture<>("test"))
                         .build())
                 .collect(toList());
-        transactionStarter.consumer(lockLeaseService, lockWatchEventCache).accept(elements);
+        transactionStarter.consumer(lockWatchEventCache).accept(elements);
         return Futures.getUnchecked(Futures.allAsList(Lists.transform(elements, BatchElement::result)));
     }
 

--- a/lock-api/src/test/java/com/palantir/lock/client/TransactionStarterTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/TransactionStarterTest.java
@@ -137,7 +137,7 @@ public class TransactionStarterTest {
                         .result(new DisruptorAutobatcher.DisruptorFuture<>("test"))
                         .build())
                 .collect(toList());
-        transactionStarter.consumer(lockWatchEventCache).accept(elements);
+        TransactionStarter.consumer(lockLeaseService, lockWatchEventCache).accept(elements);
         return Futures.getUnchecked(Futures.allAsList(Lists.transform(elements, BatchElement::result)));
     }
 

--- a/lock-api/src/test/java/com/palantir/lock/client/TransactionStarterTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/TransactionStarterTest.java
@@ -137,7 +137,7 @@ public class TransactionStarterTest {
                         .result(new DisruptorAutobatcher.DisruptorFuture<>("test"))
                         .build())
                 .collect(toList());
-        TransactionStarter.consumer(lockLeaseService, lockWatchEventCache).accept(elements);
+        transactionStarter.consumer(lockLeaseService, lockWatchEventCache).accept(elements);
         return Futures.getUnchecked(Futures.allAsList(Lists.transform(elements, BatchElement::result)));
     }
 


### PR DESCRIPTION
**Goals (and why)**:
* Transaction starter uses an autobatcher to batch start transaction requests. It continually takes batches out until it has enough requests, but if it fails midway through this process, it will drop some immutable TS locks on the floor.
* This PR covers this case (and moves some code around in TransactionStarter).

**Implementation Description (bullets)**:
* Add a try/catch around starting transactions in the batching method in TransactionStarter, and unlock all currently obtained locks if we fail.

**Testing (What was existing testing like?  What have you done to improve it?)**:
* TransactionStarterTests focuses on successful starts, haven't added a test for this case (yet).

**Concerns (what feedback would you like?)**:
* Does this catch the case we are concerned about?

**Where should we start reviewing?**:
* TransactionStarter

**Priority (whenever / two weeks / yesterday)**:
Within a week.