### PR TITLE
Allow overriding just the namespace validation

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/KvTableMappingService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/KvTableMappingService.java
@@ -268,10 +268,15 @@ public class KvTableMappingService implements TableMappingService {
         return kvs.getRange(AtlasDbConstants.NAMESPACE_TABLE, RangeRequest.builder().build(), Long.MAX_VALUE);
     }
 
-    public static TableReference getTableRefFromBytes(byte[] encodedTableRef) {
+    protected TableReference getTableRefFromBytes(byte[] encodedTableRef) {
         String nameSpace = EncodingUtils.decodeVarString(encodedTableRef);
         int offset = EncodingUtils.sizeOfVarString(nameSpace);
         String tableName = PtBytes.toString(encodedTableRef, offset, encodedTableRef.length - offset);
-        return TableReference.create(Namespace.create(nameSpace), tableName);
+        return TableReference.create(createNamespace(nameSpace), tableName);
+    }
+
+    // overrideable to allow using less strict validation patterns.
+    protected Namespace createNamespace(String namespace) {
+        return Namespace.create(namespace);
     }
 }


### PR DESCRIPTION
Currently products are subclassing KvTableMappingService
just to override this one line. Because the getTableRefFromBytes
method was static, this meant also overriding the readTableMap
method.

**Goals (and why)**:

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
