### PR TITLE
Fix case when fail to register lock after starting transaction

### DIFF
--- a/changelog/@unreleased/pr-4750.v2.yml
+++ b/changelog/@unreleased/pr-4750.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix case when TimeLockClient fails to register lock after starting
+    transaction and drops the immutableTs lock.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4750

--- a/changelog/@unreleased/pr-4750.v2.yml
+++ b/changelog/@unreleased/pr-4750.v2.yml
@@ -1,6 +1,6 @@
 type: fix
 fix:
-  description: Fix case when TimeLockClient fails to register lock after starting
-    transaction and drops the immutableTs lock.
+  description: Fixes the bug where TimeLockClient started a transaction but threw
+    when registering a lock, and so would not unlock the immutableTs lock.
   links:
   - https://github.com/palantir/atlasdb/pull/4750

--- a/lock-api/src/test/java/com/palantir/lock/client/TimeLockClientTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/TimeLockClientTest.java
@@ -191,7 +191,7 @@ public class TimeLockClientTest {
         when(delegate.currentTimeMillis()).thenThrow(new RuntimeException("something else happened"));
 
         assertThatThrownBy(timelock::currentTimeMillis).isInstanceOf(RuntimeException.class)
-                .isNotInstanceOf(AtlasDbDependencyException.class);
+            .isNotInstanceOf(AtlasDbDependencyException.class);
     }
 
     @Test

--- a/lock-api/src/test/java/com/palantir/lock/client/TimeLockClientTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/TimeLockClientTest.java
@@ -19,6 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -43,6 +45,7 @@ import com.palantir.lock.v2.LockImmutableTimestampResponse;
 import com.palantir.lock.v2.LockRequest;
 import com.palantir.lock.v2.LockResponse;
 import com.palantir.lock.v2.LockToken;
+import com.palantir.lock.v2.StartIdentifiedAtlasDbTransactionResponse;
 import com.palantir.lock.v2.TimelockService;
 import com.palantir.lock.v2.WaitForLocksRequest;
 import com.palantir.timestamp.CloseableTimestampService;
@@ -61,6 +64,11 @@ public class TimeLockClientTest {
     private final TimelockService delegate = mock(TimelockService.class);
     private final TimeLockUnlocker unlocker = mock(TimeLockUnlocker.class);
     private final TimelockService timelock = spy(new TimeLockClient(delegate, timestampService, refresher, unlocker));
+    private final StartIdentifiedAtlasDbTransactionResponse response = mock(
+            StartIdentifiedAtlasDbTransactionResponse.class);
+    private final LockToken immutableTsLock = mock(LockToken.class);
+    private final LockImmutableTimestampResponse immutableTimestampResponse = LockImmutableTimestampResponse.of(6,
+            immutableTsLock);
 
     private static final long TIMEOUT = 10_000;
 
@@ -183,7 +191,7 @@ public class TimeLockClientTest {
         when(delegate.currentTimeMillis()).thenThrow(new RuntimeException("something else happened"));
 
         assertThatThrownBy(timelock::currentTimeMillis).isInstanceOf(RuntimeException.class)
-            .isNotInstanceOf(AtlasDbDependencyException.class);
+                .isNotInstanceOf(AtlasDbDependencyException.class);
     }
 
     @Test
@@ -193,5 +201,17 @@ public class TimeLockClientTest {
             client.tryUnlock(ImmutableSet.of(LockToken.of(uuid)));
             verify(timelock, times(1)).unlock(ImmutableSet.of(LockToken.of(uuid)));
         }
+    }
+
+    @Test
+    public void unlocksWhenFailedToRegisterLockAfterStartingTransaction() {
+        when(response.immutableTimestamp()).thenReturn(immutableTimestampResponse);
+        when(delegate.startIdentifiedAtlasDbTransaction()).thenReturn(response);
+
+        doThrow(new RuntimeException()).when(refresher).registerLock(any());
+        assertThatThrownBy(timelock::startIdentifiedAtlasDbTransaction)
+                .isInstanceOf(RuntimeException.class);
+
+        verify(refresher).unregisterLocks(ImmutableSet.of(immutableTsLock));
     }
 }


### PR DESCRIPTION
**Goals (and why)**:
* Fix a bug where the immutable timestamp lock is dropped if `LockRefresher.registerLock` throws.

**Implementation Description (bullets)**:
* Add a try/catch around the call that unlocks the immutableTs lock if `registerLock` throws.

**Testing (What was existing testing like?  What have you done to improve it?)**:
* Added a test to `TimeLockClientTest` to test this case.

**Concerns (what feedback would you like?)**:
* Ensure this correctly handles the problem.
* If the batch start txn piece is merged before this, will need to slightly rework; even so, please verify this solves the problem correctly

**Where should we start reviewing?**:
`TimeLockClient`

**Priority (whenever / two weeks / yesterday)**:
This week