### PR TITLE
[PaxosLog] Part 8 & [CentOS] Part 3: Merged PersistentNamespaceLoaders

### DIFF
--- a/leader-election-impl/src/main/java/com/palantir/paxos/SqliteConnections.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SqliteConnections.java
@@ -26,7 +26,6 @@ import java.util.function.Supplier;
 import org.apache.commons.io.FileUtils;
 
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 
 /**

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SqliteConnections.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SqliteConnections.java
@@ -16,22 +16,33 @@
 
 package com.palantir.paxos;
 
+import java.io.IOException;
+import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.function.Supplier;
+
+import org.apache.commons.io.FileUtils;
+
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
 
 /**
  * This class is responsible for creating Sqlite connections to an instance.
  * There should be one instance per timelock.
  */
 public final class SqliteConnections {
+    private static final String DEFAULT_SQLITE_DATABASE_NAME = "sqliteData.db";
+
     private SqliteConnections() {
         // no
     }
 
-    public static Supplier<Connection> createSqliteDatabase(String path) {
-        String target = String.format("jdbc:sqlite:%s", path);
+    public static Supplier<Connection> createDefaultNamedSqliteDatabaseAtPath(Path path) {
+        createDirectoryIfNotExists(path);
+        String target = String.format("jdbc:sqlite:%s", path.resolve(DEFAULT_SQLITE_DATABASE_NAME).toString());
         return () -> {
             try {
                 return DriverManager.getConnection(target);
@@ -39,5 +50,13 @@ public final class SqliteConnections {
                 throw new RuntimeException(e);
             }
         };
+    }
+
+    private static void createDirectoryIfNotExists(Path path) {
+        try {
+            FileUtils.forceMkdir(path.toFile());
+        } catch (IOException e) {
+            throw new SafeRuntimeException("Could not create directory at path", e, SafeArg.of("path", path));
+        }
     }
 }

--- a/leader-election-impl/src/test/java/com/palantir/paxos/SqlitePaxosStateLogTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/SqlitePaxosStateLogTest.java
@@ -49,7 +49,7 @@ public class SqlitePaxosStateLogTest {
     @Before
     public void setup() {
         connSupplier = SqliteConnections
-                .createSqliteDatabase(tempFolder.getRoot().toPath().resolve("test.db").toString());
+                .createDefaultNamedSqliteDatabaseAtPath(tempFolder.getRoot().toPath());
         stateLog = SqlitePaxosStateLog.create(CLIENT_1, SEQUENCE_1, connSupplier);
     }
 

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -173,8 +173,8 @@ public class TimeLockAgent {
         registerPaxosResource();
         registerExceptionMappers();
 
-        Supplier<Connection> sqliteConnectionSupplier = SqliteConnections.createSqliteDatabase(
-                install.paxos().sqlitePersistence().dataDirectory().toString());
+        Supplier<Connection> sqliteConnectionSupplier = SqliteConnections.createDefaultNamedSqliteDatabaseAtPath(
+                install.paxos().sqlitePersistence().dataDirectory().toPath());
         namespaces = new TimelockNamespaces(
                 metricsManager,
                 this::createInvalidatingTimeLockServices,

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/DiskNamespaceLoader.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/DiskNamespaceLoader.java
@@ -28,8 +28,9 @@ import org.slf4j.LoggerFactory;
 
 import com.palantir.atlasdb.timelock.paxos.PaxosUseCase;
 import com.palantir.logsafe.SafeArg;
+import com.palantir.paxos.Client;
 
-final class DiskNamespaceLoader {
+final class DiskNamespaceLoader implements PersistentNamespaceLoader {
     private static final Logger log = LoggerFactory.getLogger(DiskNamespaceLoader.class);
     private final Path rootDataDirectory;
 
@@ -37,11 +38,13 @@ final class DiskNamespaceLoader {
         this.rootDataDirectory = rootDataDirectory;
     }
 
-    Set<String> getNamespaces() {
+    @Override
+    public Set<Client> getAllPersistedNamespaces() {
         return Arrays.stream(PaxosUseCase.values())
                 .filter(useCase -> useCase != PaxosUseCase.LEADER_FOR_ALL_CLIENTS)
                 .map(useCase -> useCase.logDirectoryRelativeToDataDirectory(rootDataDirectory))
                 .flatMap(DiskNamespaceLoader::getNamespacesFromUseCaseResolvedDirectory)
+                .map(Client::of)
                 .collect(Collectors.toSet());
     }
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/PersistentNamespaceContext.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/PersistentNamespaceContext.java
@@ -1,0 +1,37 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.management;
+
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.util.function.Supplier;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface PersistentNamespaceContext {
+    Path fileDataDirectory();
+
+    Supplier<Connection> sqliteConnectionSupplier();
+
+    static PersistentNamespaceContext of(Path fileDataDirectory, Supplier<Connection> sqliteConnectionSupplier) {
+        return ImmutablePersistentNamespaceContext.builder()
+                .fileDataDirectory(fileDataDirectory)
+                .sqliteConnectionSupplier(sqliteConnectionSupplier)
+                .build();
+    }
+}

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/PersistentNamespaceLoader.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/PersistentNamespaceLoader.java
@@ -1,0 +1,28 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.management;
+
+import java.util.Set;
+
+import com.palantir.paxos.Client;
+
+public interface PersistentNamespaceLoader {
+    /**
+     * Gets all namespaces that have been persisted (via the persistence method under question).
+     */
+    Set<Client> getAllPersistedNamespaces();
+}

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/SqliteNamespaceLoader.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/SqliteNamespaceLoader.java
@@ -28,7 +28,7 @@ import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 import com.palantir.paxos.Client;
 import com.palantir.paxos.SqlitePaxosStateLog;
 
-public final class SqliteNamespaceLoader {
+final class SqliteNamespaceLoader implements PersistentNamespaceLoader {
     private final Jdbi jdbi;
 
     private SqliteNamespaceLoader(Jdbi jdbi) {
@@ -41,7 +41,8 @@ public final class SqliteNamespaceLoader {
         return new SqliteNamespaceLoader(jdbi);
     }
 
-    public Set<Client> getAllRegisteredNamespaces() {
+    @Override
+    public Set<Client> getAllPersistedNamespaces() {
         return jdbi.withExtension(SqlitePaxosStateLog.Queries.class, SqlitePaxosStateLog.Queries::getAllNamespaces)
                 .stream()
                 .map(Client::of)

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/SqliteNamespaceLoader.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/SqliteNamespaceLoader.java
@@ -35,7 +35,7 @@ final class SqliteNamespaceLoader implements PersistentNamespaceLoader {
         this.jdbi = jdbi;
     }
 
-    public static SqliteNamespaceLoader create(Supplier<Connection> connectionSupplier) {
+    public static PersistentNamespaceLoader create(Supplier<Connection> connectionSupplier) {
         Jdbi jdbi = Jdbi.create(connectionSupplier::get).installPlugin(new SqlObjectPlugin());
         jdbi.withExtension(SqlitePaxosStateLog.Queries.class, SqlitePaxosStateLog.Queries::createTable);
         return new SqliteNamespaceLoader(jdbi);

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/management/SqliteNamespaceLoaderTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/management/SqliteNamespaceLoaderTest.java
@@ -50,7 +50,7 @@ public class SqliteNamespaceLoaderTest {
     @Before
     public void setup() {
         connectionSupplier = SqliteConnections
-                .createSqliteDatabase(tempFolder.getRoot().toPath().resolve("test.db").toString());
+                .createDefaultNamedSqliteDatabaseAtPath(tempFolder.getRoot().toPath());
         namespaceLoader = SqliteNamespaceLoader.create(connectionSupplier);
     }
 

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/management/SqliteNamespaceLoaderTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/management/SqliteNamespaceLoaderTest.java
@@ -56,14 +56,14 @@ public class SqliteNamespaceLoaderTest {
 
     @Test
     public void canReturnZeroNamespaces() {
-        assertThat(namespaceLoader.getAllRegisteredNamespaces()).isEmpty();
+        assertThat(namespaceLoader.getAllPersistedNamespaces()).isEmpty();
     }
 
     @Test
     public void returnsOneNamespaceEvenIfMultipleSequencesPresent() {
         initializeLog(NAMESPACE_1, SEQUENCE_ID_1);
         initializeLog(NAMESPACE_1, SEQUENCE_ID_2);
-        assertThat(namespaceLoader.getAllRegisteredNamespaces()).containsExactlyInAnyOrder(NAMESPACE_1);
+        assertThat(namespaceLoader.getAllPersistedNamespaces()).containsExactlyInAnyOrder(NAMESPACE_1);
     }
 
     @Test
@@ -72,7 +72,7 @@ public class SqliteNamespaceLoaderTest {
         initializeLog(NAMESPACE_1, SEQUENCE_ID_2);
         initializeLog(NAMESPACE_2, SEQUENCE_ID_1);
         initializeLog(NAMESPACE_2, SEQUENCE_ID_2);
-        assertThat(namespaceLoader.getAllRegisteredNamespaces()).containsExactlyInAnyOrder(NAMESPACE_1, NAMESPACE_2);
+        assertThat(namespaceLoader.getAllPersistedNamespaces()).containsExactlyInAnyOrder(NAMESPACE_1, NAMESPACE_2);
     }
 
     private void initializeLog(Client namespace, String sequenceId) {

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/management/SqliteNamespaceLoaderTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/management/SqliteNamespaceLoaderTest.java
@@ -45,7 +45,7 @@ public class SqliteNamespaceLoaderTest {
     public TemporaryFolder tempFolder = new TemporaryFolder();
 
     private Supplier<Connection> connectionSupplier;
-    private SqliteNamespaceLoader namespaceLoader;
+    private PersistentNamespaceLoader namespaceLoader;
 
     @Before
     public void setup() {

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -41,7 +41,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.google.common.primitives.Ints;
-import com.google.common.util.concurrent.Futures;
 import com.palantir.atlasdb.http.v2.ClientOptions;
 import com.palantir.atlasdb.timelock.api.ConjureLockRequest;
 import com.palantir.atlasdb.timelock.api.ConjureLockResponse;

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -290,7 +290,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
     @Test
     public void canGetAllNamespaces() {
         String randomNamespace = UUID.randomUUID().toString();
-        cluster.client(randomNamespace).getFreshTimestamp();
+        cluster.client(randomNamespace).throughWireMockProxy().getFreshTimestamp();
 
         Set<String> knownNamespaces = getKnownNamespaces();
         assertThat(knownNamespaces).contains(randomNamespace);

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -24,6 +24,7 @@ import java.time.Duration;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -38,7 +39,9 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
 import com.google.common.primitives.Ints;
+import com.google.common.util.concurrent.Futures;
 import com.palantir.atlasdb.http.v2.ClientOptions;
 import com.palantir.atlasdb.timelock.api.ConjureLockRequest;
 import com.palantir.atlasdb.timelock.api.ConjureLockResponse;
@@ -58,6 +61,7 @@ import com.palantir.lock.v2.LockResponse;
 import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.WaitForLocksRequest;
 import com.palantir.lock.v2.WaitForLocksResponse;
+import com.palantir.tokens.auth.AuthHeader;
 
 @RunWith(Parameterized.class)
 public class MultiNodePaxosTimeLockServerIntegrationTest {
@@ -282,6 +286,36 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
                     .collect(Collectors.toSet());
             client.namespacedConjureTimelockService().unlock(ConjureUnlockRequest.of(tokens));
         }
+    }
+
+    @Test
+    public void canGetAllNamespaces() {
+        String randomNamespace = UUID.randomUUID().toString();
+        cluster.client(randomNamespace).getFreshTimestamp();
+
+        Set<String> knownNamespaces = getKnownNamespaces();
+        assertThat(knownNamespaces).contains(randomNamespace);
+
+        for (TestableTimelockServer server : cluster.servers()) {
+            server.killSync();
+            server.start();
+        }
+
+        cluster.waitUntilAllServersOnlineAndReadyToServeNamespaces(
+                ImmutableList.of(cluster.clientForRandomNamespace().namespace()));
+
+        Set<String> namespacesAfterRestart = getKnownNamespaces();
+        assertThat(namespacesAfterRestart).contains(randomNamespace);
+        assertThat(Sets.difference(knownNamespaces, namespacesAfterRestart)).isEmpty();
+    }
+
+    private Set<String> getKnownNamespaces() {
+        return cluster.servers()
+                .stream()
+                .map(TestableTimelockServer::timeLockManagementService)
+                .map(resource -> resource.getNamespaces(AuthHeader.valueOf("Bearer omitted")))
+                .flatMap(Set::stream)
+                .collect(Collectors.toSet());
     }
 
     @Test

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/NamespacedClients.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/NamespacedClients.java
@@ -20,6 +20,7 @@ import org.immutables.value.Value;
 
 import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.timelock.api.ConjureTimelockService;
+import com.palantir.atlasdb.timelock.api.management.TimeLockManagementService;
 import com.palantir.atlasdb.timelock.util.TestProxies.ProxyMode;
 import com.palantir.lock.LockRpcClient;
 import com.palantir.lock.LockService;

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/NamespacedClients.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/NamespacedClients.java
@@ -20,7 +20,6 @@ import org.immutables.value.Value;
 
 import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.timelock.api.ConjureTimelockService;
-import com.palantir.atlasdb.timelock.api.management.TimeLockManagementService;
 import com.palantir.atlasdb.timelock.util.TestProxies.ProxyMode;
 import com.palantir.lock.LockRpcClient;
 import com.palantir.lock.LockService;

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
@@ -35,7 +35,6 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.atlasdb.timelock.NamespacedClients.ProxyFactory;
 import com.palantir.atlasdb.timelock.api.management.TimeLockManagementService;
-import com.palantir.atlasdb.timelock.management.TimeLockManagementResource;
 import com.palantir.atlasdb.timelock.paxos.BatchPingableLeader;
 import com.palantir.atlasdb.timelock.paxos.PaxosUseCase;
 import com.palantir.atlasdb.timelock.paxos.api.NamespaceLeadershipTakeoverService;

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
@@ -34,6 +34,8 @@ import com.google.common.collect.Streams;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.atlasdb.timelock.NamespacedClients.ProxyFactory;
+import com.palantir.atlasdb.timelock.api.management.TimeLockManagementService;
+import com.palantir.atlasdb.timelock.management.TimeLockManagementResource;
 import com.palantir.atlasdb.timelock.paxos.BatchPingableLeader;
 import com.palantir.atlasdb.timelock.paxos.PaxosUseCase;
 import com.palantir.atlasdb.timelock.paxos.api.NamespaceLeadershipTakeoverService;
@@ -181,6 +183,10 @@ public class TestableTimelockServer {
     public boolean takeOverLeadershipForNamespace(String namespace) {
         return proxies.singleNode(serverHolder, NamespaceLeadershipTakeoverService.class, ProxyMode.DIRECT)
                 .takeover(AuthHeader.valueOf("omitted"), namespace);
+    }
+
+    public TimeLockManagementService timeLockManagementService() {
+        return proxies.singleNode(serverHolder, TimeLockManagementService.class, ProxyMode.WIREMOCK);
     }
 
     private static final class SingleNodeProxyFactory implements ProxyFactory {


### PR DESCRIPTION
Bit of a fun PR at the seam between these two workstreams...

**Goals (and why)**:
- Ensure that retrieving the namespaces in a CentOS/timelock migration in general include namespaces that only existed after a migration to the SQLite store.
- There's a drive by fix too, please see concerns section.

**Implementation Description (bullets)**:
- Introduce a namespace loader interface, and create one for each of disk and SQLite. Union the results.
- Wire up TimeLock Agent to create both namespace loaders correctly.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Added an ETE test for the disk functionality.
- Existing tests should validate that I haven't messed up the setup in general.

**Concerns (what feedback would you like?)**:
- **Directory Creation and File Layout.** The previous tests for SQLite assumed that all directories on the path to the target file already existed. I opted to have users instead specify a path and for us to have a specific constant DB file to be written in to that path. Then, on creation we create all directories needed (throwing on failure). Does this layout make sense?
- **Slight Limitation in Tests.** We don't yet have a good way to write to the SQLite database only, so that behaviour isn't tested yet.

**Where should we start reviewing?**: PersistentNamespaceContext

**Priority (whenever / two weeks / yesterday)**: this week please
