### PR TITLE
Implement better TM closing

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/util/SafeShutdownRunner.java
+++ b/atlasdb-commons/src/main/java/com/palantir/util/SafeShutdownRunner.java
@@ -1,0 +1,67 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.util;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import com.palantir.common.concurrent.NamedThreadFactory;
+import com.palantir.common.concurrent.PTExecutors;
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
+
+public class SafeShutdownRunner implements AutoCloseable {
+    private final ExecutorService executor = PTExecutors
+            .newFixedThreadPool(5, new NamedThreadFactory("safe-shutdown-runner", true));
+    private final List<Throwable> failures = new ArrayList<>();
+    private final Duration timeoutDuration;
+
+    public SafeShutdownRunner(Duration timeoutDuration) {
+        this.timeoutDuration = timeoutDuration;
+    }
+
+    public void shutdownSafely(Runnable shutdownCallback) {
+        Future<?> future = executor.submit(shutdownCallback);
+        try {
+            future.get(timeoutDuration.toMillis(), TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            failures.add(e);
+        } catch (ExecutionException e) {
+            failures.add(e.getCause());
+        } catch (TimeoutException e) {
+            future.cancel(true);
+            failures.add(e);
+        }
+    }
+
+    @Override
+    public void close() {
+        executor.shutdown();
+        if (!failures.isEmpty()) {
+            RuntimeException closeFailed = new SafeRuntimeException(
+                    "Close failed. Please inspect the code and fix the failures");
+            failures.forEach(closeFailed::addSuppressed);
+            throw closeFailed;
+        }
+    }
+}

--- a/atlasdb-commons/src/main/java/com/palantir/util/SafeShutdownRunner.java
+++ b/atlasdb-commons/src/main/java/com/palantir/util/SafeShutdownRunner.java
@@ -25,13 +25,11 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import com.palantir.common.concurrent.NamedThreadFactory;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 
 public class SafeShutdownRunner implements AutoCloseable {
-    private final ExecutorService executor = PTExecutors
-            .newFixedThreadPool(5, new NamedThreadFactory("safe-shutdown-runner", true));
+    private final ExecutorService executor = PTExecutors.newCachedThreadPool("safe-shutdown-runner");
     private final List<Throwable> failures = new ArrayList<>();
     private final Duration timeoutDuration;
 

--- a/atlasdb-commons/src/test/java/com/palantir/util/SafeShutdownRunnerTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/util/SafeShutdownRunnerTest.java
@@ -1,0 +1,128 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.util.concurrent.Uninterruptibles;
+
+public class SafeShutdownRunnerTest {
+    private static final RuntimeException EXCEPTION = new RuntimeException("test");
+
+    private Runnable mockRunnable = mock(Runnable.class);
+    private Runnable throwingRunnable = mock(Runnable.class);
+    private Runnable verySlowUninterruptibleRunnable = mock(Runnable.class);
+
+    @Before
+    public void setupMocks() {
+        doAnswer(invocation -> {
+            Uninterruptibles.sleepUninterruptibly(10_000, TimeUnit.MILLISECONDS);
+            return null;
+        }).when(verySlowUninterruptibleRunnable).run();
+        doThrow(EXCEPTION).when(throwingRunnable).run();
+    }
+
+    @Test
+    public void runnerRunsOneTask() {
+        SafeShutdownRunner runner = new SafeShutdownRunner(Duration.ofSeconds(1));
+
+        runner.shutdownSafely(mockRunnable);
+
+        verify(mockRunnable, times(1)).run();
+        assertThatCode(runner::close).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void exceptionsAreSuppressedAndReportedWhenClosing() {
+        SafeShutdownRunner runner = new SafeShutdownRunner(Duration.ofSeconds(1));
+
+        assertThatCode(() -> runner.shutdownSafely(throwingRunnable)).doesNotThrowAnyException();
+        assertThatThrownBy(runner::close)
+                .isInstanceOf(RuntimeException.class)
+                .hasSuppressedException(EXCEPTION);
+    }
+
+    @Test
+    public void slowTasksTimeOutWithoutThrowing() {
+        SafeShutdownRunner runner = new SafeShutdownRunner(Duration.ofMillis(50));
+
+        runner.shutdownSafely(verySlowUninterruptibleRunnable);
+        runner.shutdownSafely(verySlowUninterruptibleRunnable);
+
+        verify(verySlowUninterruptibleRunnable, times(2)).run();
+
+        closeAndAssertNumberOfTimeouts(runner, 2);
+    }
+
+    @Test
+    public void otherTasksStillRunAfterSlowTasksThatTimeOut() {
+        SafeShutdownRunner runner = new SafeShutdownRunner(Duration.ofMillis(50));
+
+        runner.shutdownSafely(verySlowUninterruptibleRunnable);
+        runner.shutdownSafely(verySlowUninterruptibleRunnable);
+        runner.shutdownSafely(mockRunnable);
+
+        verify(verySlowUninterruptibleRunnable, times(2)).run();
+        verify(mockRunnable, times(1)).run();
+
+        closeAndAssertNumberOfTimeouts(runner, 2);
+    }
+
+    @Test
+    public void neverRunsRemainingTasksIfExecutorFillsUpWithUninteruptibleTasks() {
+        SafeShutdownRunner runner = new SafeShutdownRunner(Duration.ofMillis(50));
+
+        runner.shutdownSafely(verySlowUninterruptibleRunnable);
+        runner.shutdownSafely(verySlowUninterruptibleRunnable);
+        runner.shutdownSafely(verySlowUninterruptibleRunnable);
+        runner.shutdownSafely(verySlowUninterruptibleRunnable);
+        runner.shutdownSafely(verySlowUninterruptibleRunnable);
+        runner.shutdownSafely(verySlowUninterruptibleRunnable);
+        runner.shutdownSafely(mockRunnable);
+
+        verify(verySlowUninterruptibleRunnable, times(5)).run();
+        verify(mockRunnable, never()).run();
+
+        closeAndAssertNumberOfTimeouts(runner, 7);
+    }
+
+    private void closeAndAssertNumberOfTimeouts(SafeShutdownRunner runner, int number) {
+        assertThatThrownBy(runner::close)
+                .isInstanceOf(RuntimeException.class)
+                .satisfies(exception -> {
+                    Throwable[] suppressed = exception.getSuppressed();
+                    assertThat(suppressed.length).isEqualTo(number);
+                    Stream.of(suppressed).forEach(th -> assertThat(th).isInstanceOf(TimeoutException.class));
+                });
+    }
+}

--- a/changelog/@unreleased/pr-4757.v2.yml
+++ b/changelog/@unreleased/pr-4757.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Transaction Manager closing is now more resilient to a single subtask
+    blocking indefinitely.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4757


### PR DESCRIPTION
**Goals (and why)**:
The current hypothesis for why sometimes closing the transaction manager fails to close all the background tasks is that we end up blocking during closing one of them. This addresses the issue by timeboxing each.

**Implementation Description (bullets)**:
We attempt to synchronously run the closing runnable, then attempt to cancel after 20 seconds. We defend against being unable to interrupt the task by using a fixed threadpool of size 5 just in case.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Unit tests

**Concerns (what feedback would you like?)**:
Should be fine, but shout if I missed something

**Where should we start reviewing?**:
tests?

**Priority (whenever / two weeks / yesterday)**:
ASAP