### PR TITLE
[Proof of Concept] [Dialogue] Dialogue Migration for Atlas->TimeLock comms

### DIFF
--- a/atlasdb-config/build.gradle
+++ b/atlasdb-config/build.gradle
@@ -25,6 +25,8 @@ dependencies {
     compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8'
     compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310'
 
+    implementation 'com.palantir.dialogue:dialogue-clients'
+
     // This is added so that AtlasDB clients can specify the javaAgent as a JVM argument to load jars needed for HTTP/2
     // in the boot classpath
     runtime group: 'org.mortbay.jetty.alpn', name: 'jetty-alpn-agent', version: libVersions.jetty_alpn_agent

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/AtlasDbDialogueServiceProvider.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/AtlasDbDialogueServiceProvider.java
@@ -1,0 +1,147 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.factory;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.Optional;
+
+import com.google.common.collect.ImmutableMap;
+import com.palantir.atlasdb.config.AuxiliaryRemotingParameters;
+import com.palantir.atlasdb.config.ServerListConfig;
+import com.palantir.atlasdb.factory.timelock.BlockingAndNonBlockingServices;
+import com.palantir.atlasdb.factory.timelock.BlockingSensitiveConjureTimelockService;
+import com.palantir.atlasdb.factory.timelock.ImmutableBlockingAndNonBlockingServices;
+import com.palantir.atlasdb.http.AtlasDbHttpProtocolVersion;
+import com.palantir.atlasdb.http.AtlasDbRemotingConstants;
+import com.palantir.atlasdb.http.v2.AtlasDbDialogueFactories;
+import com.palantir.atlasdb.http.v2.FastFailoverProxy;
+import com.palantir.atlasdb.http.v2.ImmutableRemoteServiceConfiguration;
+import com.palantir.atlasdb.http.v2.RemoteServiceConfiguration;
+import com.palantir.atlasdb.timelock.api.ConjureTimelockService;
+import com.palantir.atlasdb.timelock.api.ConjureTimelockServiceBlocking;
+import com.palantir.conjure.java.api.config.service.UserAgent;
+import com.palantir.dialogue.Channel;
+import com.palantir.dialogue.ConjureRuntime;
+import com.palantir.dialogue.clients.DialogueClients;
+import com.palantir.lock.client.DialogueAdaptingConjureTimelockService;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.refreshable.Refreshable;
+
+/**
+ * Provides a mechanism for accessing services that use Dialogue for communication. A service is defined as a cluster of
+ * zero or more nodes, where contacting any of the nodes is legitimate (subject to redirects via 308s and 503s). If
+ * working with heterogeneous nodes and/or broadcast is important (e.g. for Paxos Acceptor use cases), you should be
+ * VERY careful when using this class.
+ *
+ * Proxies must be resilient to servers repeatedly returning 308s that are large in number, but persist for only a short
+ * duration. Furthermore, proxies should include in their {@link com.palantir.conjure.java.api.config.service.UserAgent}
+ * information to allow client services to identify the protocol they are using to talk, via
+ * {@link AtlasDbHttpProtocolVersion}.
+ */
+final class AtlasDbDialogueServiceProvider {
+    private static final String TIMELOCK_NON_BLOCKING = "timelock-non-blocking";
+    private static final String TIMELOCK_BLOCKING = "timelock-blocking";
+    private final DialogueClients.ReloadingFactory dialogueClientFactory;
+
+    private AtlasDbDialogueServiceProvider(DialogueClients.ReloadingFactory dialogueClientFactory) {
+        this.dialogueClientFactory = dialogueClientFactory;
+    }
+
+    static AtlasDbDialogueServiceProvider create(
+            Refreshable<ServerListConfig> timeLockServerListConfig,
+            DialogueClients.ReloadingFactory baseFactory,
+            UserAgent userAgent) {
+        UserAgent versionedAgent = userAgent.addAgent(AtlasDbRemotingConstants.ATLASDB_HTTP_CLIENT_AGENT);
+        Refreshable<Map<String, RemoteServiceConfiguration>> timeLockRemoteConfigurations = timeLockServerListConfig
+                .map(serverListConfig -> ImmutableMap.of(
+                        TIMELOCK_NON_BLOCKING,
+                        createRemoteServiceConfiguration(versionedAgent, serverListConfig, false),
+                        TIMELOCK_BLOCKING,
+                        createRemoteServiceConfiguration(versionedAgent, serverListConfig, true)));
+        DialogueClients.ReloadingFactory reloadingFactory
+                = AtlasDbDialogueFactories.decorateForFailoverServices(baseFactory, timeLockRemoteConfigurations)
+                        .withUserAgent(versionedAgent);
+
+        return new AtlasDbDialogueServiceProvider(reloadingFactory);
+    }
+
+    ConjureTimelockService getConjureTimelockService() {
+        Preconditions.checkState(isDialogue(ConjureTimelockServiceBlocking.class),
+                "Dialogue service provider attempted to provide a non-Dialogue class."
+                        + " This is an AtlasDB bug.");
+        ConjureTimelockServiceBlocking rawBlockingService
+                = dialogueClientFactory.get(ConjureTimelockServiceBlocking.class, TIMELOCK_BLOCKING);
+        ConjureTimelockServiceBlocking rawNonBlockingService
+                = dialogueClientFactory.get(ConjureTimelockServiceBlocking.class, TIMELOCK_NON_BLOCKING);
+
+        // Blocking here is overloaded, sigh: the inner one means that we wait for a response, the outer one
+        // means that requests on the server side might block waiting for resources to be available...
+        BlockingAndNonBlockingServices<ConjureTimelockService> blockingAndNonBlockingServices
+                = ImmutableBlockingAndNonBlockingServices.<ConjureTimelockServiceBlocking>builder()
+                        .blocking(rawBlockingService)
+                        .nonBlocking(rawNonBlockingService)
+                        .build()
+                        .map(proxy -> FastFailoverProxy.newProxyInstance(
+                                ConjureTimelockServiceBlocking.class, () -> proxy))
+                        .map(DialogueAdaptingConjureTimelockService::new);
+
+        return new BlockingSensitiveConjureTimelockService(blockingAndNonBlockingServices);
+    }
+
+    private static ImmutableRemoteServiceConfiguration createRemoteServiceConfiguration(
+            UserAgent userAgent, ServerListConfig serverListConfig, boolean shouldSupportBlockingOperations) {
+        return ImmutableRemoteServiceConfiguration.builder()
+                .remotingParameters(getFailoverRemotingParameters(shouldSupportBlockingOperations, userAgent))
+                .serverList(serverListConfig)
+                .build();
+    }
+
+    private static AuxiliaryRemotingParameters getFailoverRemotingParameters(
+            boolean shouldSupportBlockingOperations, UserAgent userAgent) {
+        return AuxiliaryRemotingParameters.builder()
+                .shouldLimitPayload(true)
+                .shouldRetry(true)
+                .shouldSupportBlockingOperations(shouldSupportBlockingOperations)
+                .userAgent(userAgent)
+                .build();
+    }
+
+    //    public <T> T createService(
+//            Class<T> type,
+//            AuxiliaryRemotingParameters clientParameters,
+//            String serviceName) {
+//        Preconditions.checkState(isDialogue(type),
+//                "Attempted to create a Dialogue service where Dialogue is not supported");
+//        T rawProxy = AtlasDbDialogueFactories.decorateForFailoverServices(
+//                reloadingFactory, serverListConfigRefreshable, serviceName, clientParameters)
+//                .get(type, serviceName);
+//        return FastFailoverProxy.newProxyInstance(type, () -> rawProxy); // Dialogue does its own instrumentation.
+//    }
+
+    private static boolean isDialogue(Class<?> serviceInterface) {
+        return getStaticOfMethod(serviceInterface).isPresent();
+    }
+
+    private static Optional<Method> getStaticOfMethod(Class<?> dialogueInterface) {
+        try {
+            return Optional.ofNullable(dialogueInterface.getMethod("of", Channel.class, ConjureRuntime.class));
+        } catch (NoSuchMethodException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/AtlasDbDialogueServiceProvider.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/AtlasDbDialogueServiceProvider.java
@@ -121,18 +121,6 @@ final class AtlasDbDialogueServiceProvider {
                 .build();
     }
 
-    //    public <T> T createService(
-//            Class<T> type,
-//            AuxiliaryRemotingParameters clientParameters,
-//            String serviceName) {
-//        Preconditions.checkState(isDialogue(type),
-//                "Attempted to create a Dialogue service where Dialogue is not supported");
-//        T rawProxy = AtlasDbDialogueFactories.decorateForFailoverServices(
-//                reloadingFactory, serverListConfigRefreshable, serviceName, clientParameters)
-//                .get(type, serviceName);
-//        return FastFailoverProxy.newProxyInstance(type, () -> rawProxy); // Dialogue does its own instrumentation.
-//    }
-
     private static boolean isDialogue(Class<?> serviceInterface) {
         return getStaticOfMethod(serviceInterface).isPresent();
     }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/AtlasDbDialogueServiceProvider.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/AtlasDbDialogueServiceProvider.java
@@ -53,7 +53,7 @@ import com.palantir.refreshable.Refreshable;
  * information to allow client services to identify the protocol they are using to talk, via
  * {@link AtlasDbHttpProtocolVersion}.
  */
-final class AtlasDbDialogueServiceProvider {
+public final class AtlasDbDialogueServiceProvider {
     private static final String TIMELOCK_NON_BLOCKING = "timelock-non-blocking";
     private static final String TIMELOCK_BLOCKING = "timelock-blocking";
     private final DialogueClients.ReloadingFactory dialogueClientFactory;
@@ -62,7 +62,7 @@ final class AtlasDbDialogueServiceProvider {
         this.dialogueClientFactory = dialogueClientFactory;
     }
 
-    static AtlasDbDialogueServiceProvider create(
+    public static AtlasDbDialogueServiceProvider create(
             Refreshable<ServerListConfig> timeLockServerListConfig,
             DialogueClients.ReloadingFactory baseFactory,
             UserAgent userAgent) {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/BlockingAndNonBlockingServices.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/BlockingAndNonBlockingServices.java
@@ -16,6 +16,8 @@
 
 package com.palantir.atlasdb.factory.timelock;
 
+import java.util.function.Function;
+
 import org.immutables.value.Value;
 
 import com.palantir.atlasdb.factory.ServiceCreator;
@@ -24,6 +26,13 @@ import com.palantir.atlasdb.factory.ServiceCreator;
 public interface BlockingAndNonBlockingServices<T> {
     T blocking();
     T nonBlocking();
+
+    default <U> BlockingAndNonBlockingServices<U> map(Function<T, U> mapper) {
+        return ImmutableBlockingAndNonBlockingServices.<U>builder()
+                .blocking(mapper.apply(blocking()))
+                .nonBlocking(mapper.apply(nonBlocking()))
+                .build();
+    }
 
     static <T> BlockingAndNonBlockingServices<T> create(ServiceCreator serviceCreator, Class<T> clazz) {
         return ImmutableBlockingAndNonBlockingServices.<T>builder()

--- a/atlasdb-conjure/build.gradle
+++ b/atlasdb-conjure/build.gradle
@@ -4,7 +4,12 @@ dependencies {
   compile project(':atlasdb-commons')
   compile project(':atlasdb-remoting-api')
 
-  compile group: 'com.palantir.conjure.java.runtime', name: 'conjure-java-jaxrs-client'
+  implementation 'com.palantir.refreshable:refreshable'
+  implementation 'com.palantir.dialogue:dialogue-apache-hc4-client'
+  implementation 'com.palantir.dialogue:dialogue-clients'
+  implementation 'com.palantir.dialogue:dialogue-serde'
+  implementation 'com.palantir.conjure.java.runtime:conjure-java-jaxrs-client'
+  implementation 'com.palantir.tritium:tritium-lib'
 
   annotationProcessor group: 'org.immutables', name: 'value'
   compileOnly 'org.immutables:value::annotations'

--- a/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/AtlasDbDialogueFactories.java
+++ b/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/AtlasDbDialogueFactories.java
@@ -1,0 +1,43 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.http.v2;
+
+import java.time.Duration;
+import java.util.Map;
+
+import com.palantir.conjure.java.client.config.ClientConfiguration;
+import com.palantir.conjure.java.client.config.NodeSelectionStrategy;
+import com.palantir.dialogue.clients.DialogueClients;
+import com.palantir.refreshable.Refreshable;
+
+public final class AtlasDbDialogueFactories {
+    private static final Duration STANDARD_FAILED_URL_COOLDOWN = Duration.ofMillis(100);
+
+    private AtlasDbDialogueFactories() {
+        // no
+    }
+
+    public static DialogueClients.ReloadingFactory decorateForFailoverServices(
+            DialogueClients.ReloadingFactory baseFactory,
+            Refreshable<Map<String, RemoteServiceConfiguration>> serviceToRemoteConfiguration) {
+        return baseFactory.reloading(serviceToRemoteConfiguration.map(
+                DialogueClientOptions::toServicesConfigBlock))
+                .withFailedUrlCooldown(STANDARD_FAILED_URL_COOLDOWN)
+                .withNodeSelectionStrategy(NodeSelectionStrategy.PIN_UNTIL_ERROR_WITHOUT_RESHUFFLE)
+                .withClientQoS(ClientConfiguration.ClientQoS.DANGEROUS_DISABLE_SYMPATHETIC_CLIENT_QOS);
+    }
+}

--- a/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/DialogueClientOptions.java
+++ b/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/DialogueClientOptions.java
@@ -1,0 +1,85 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.http.v2;
+
+import java.time.Duration;
+import java.util.Map;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.palantir.atlasdb.config.AuxiliaryRemotingParameters;
+import com.palantir.atlasdb.config.ServerListConfig;
+import com.palantir.common.streams.KeyedStream;
+import com.palantir.conjure.java.api.config.service.HumanReadableDuration;
+import com.palantir.conjure.java.api.config.service.PartialServiceConfiguration;
+import com.palantir.conjure.java.api.config.service.ServicesConfigBlock;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+
+public final class DialogueClientOptions {
+    // Under standard settings, throws after expected outages of 1/2 * 0.01 * (2^13 - 1) = 40.96 s
+    private static final HumanReadableDuration STANDARD_BACKOFF_SLOT_SIZE = HumanReadableDuration.milliseconds(10);
+    private static final int STANDARD_MAX_RETRIES = 13;
+    private static final int NO_RETRIES = 0;
+
+    private static final HumanReadableDuration CONNECT_TIMEOUT = HumanReadableDuration.milliseconds(500);
+
+    // The read timeout controls how long the client waits to receive the first byte from the server before giving up,
+    // so in general read timeouts should not be set to less than what is considered an acceptable time for the server
+    // to give a suitable response.
+    // In the context of TimeLock, this timeout must be longer than how long an AwaitingLeadershipProxy takes to
+    // decide whether a node is the leader and still has a quorum.
+    // This is an odd number for debugging.
+    private static final HumanReadableDuration NON_BLOCKING_READ_TIMEOUT = HumanReadableDuration.milliseconds(12566);
+
+    // Should not be reduced below 65 seconds to support workflows involving locking.
+    private static final HumanReadableDuration BLOCKING_READ_TIMEOUT = HumanReadableDuration.seconds(65);
+
+    private DialogueClientOptions() {
+        // No
+    }
+
+    static ServicesConfigBlock toServicesConfigBlock(
+            Map<String, RemoteServiceConfiguration> serviceNameToRemoteConfiguration) {
+        Map<String, PartialServiceConfiguration> configMap = KeyedStream.stream(serviceNameToRemoteConfiguration)
+                .map(remoteServiceConfiguration -> toPartialServiceConfiguration(
+                        remoteServiceConfiguration.serverList(), remoteServiceConfiguration.remotingParameters()))
+                .collectToMap();
+        return ServicesConfigBlock.builder().putAllServices(configMap).build();
+    }
+
+    private static PartialServiceConfiguration toPartialServiceConfiguration(
+            ServerListConfig serverListConfig,
+            AuxiliaryRemotingParameters remotingParameters) {
+        return populateConfigurationWithAtlasDbDefaults()
+                .addAllUris(serverListConfig.servers())
+                .proxyConfiguration(serverListConfig.proxyConfiguration())
+                .security(serverListConfig.sslConfiguration()
+                        .orElseThrow(() -> new SafeIllegalStateException(
+                                "Dialogue must be configured with SSL.")))
+                .maxNumRetries(remotingParameters.shouldRetry() ? NO_RETRIES : STANDARD_MAX_RETRIES)
+                .readTimeout(remotingParameters.shouldSupportBlockingOperations()
+                        ? BLOCKING_READ_TIMEOUT
+                        : NON_BLOCKING_READ_TIMEOUT)
+                .build();
+    }
+
+    private static PartialServiceConfiguration.Builder populateConfigurationWithAtlasDbDefaults() {
+        return PartialServiceConfiguration.builder()
+                .connectTimeout(CONNECT_TIMEOUT)
+                .backoffSlotSize(STANDARD_BACKOFF_SLOT_SIZE)
+                .enableGcmCipherSuites(true);
+    }
+}

--- a/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/RemoteServiceConfiguration.java
+++ b/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/RemoteServiceConfiguration.java
@@ -1,0 +1,28 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.http.v2;
+
+import org.immutables.value.Value;
+
+import com.palantir.atlasdb.config.AuxiliaryRemotingParameters;
+import com.palantir.atlasdb.config.ServerListConfig;
+
+@Value.Immutable
+public interface RemoteServiceConfiguration {
+    ServerListConfig serverList();
+    AuxiliaryRemotingParameters remotingParameters();
+}

--- a/atlasdb-ete-tests/docker/conf/atlasdb-ete.timelock.cassandra.yml
+++ b/atlasdb-ete-tests/docker/conf/atlasdb-ete.timelock.cassandra.yml
@@ -11,7 +11,19 @@ server:
 
 atlasdb:
   keyValueService:
-    type: memory
+    type: cassandra
+    servers:
+      - cassandra:9160
+    poolSize: 20
+    credentials:
+      username: cassandra
+      password: cassandra
+    ssl: false
+    replicationFactor: 1
+    mutationBatchCount: 10000
+    mutationBatchSizeBytes: 10000000
+    fetchBatchCount: 1000
+    autoRefreshNodes: false
   targetedSweep:
     enableSweepQueueWrites: true
   namespace: atlasete

--- a/atlasdb-ete-tests/docker/conf/atlasdb-ete.timelock.cassandra.yml
+++ b/atlasdb-ete-tests/docker/conf/atlasdb-ete.timelock.cassandra.yml
@@ -11,19 +11,7 @@ server:
 
 atlasdb:
   keyValueService:
-    type: cassandra
-    servers:
-      - cassandra:9160
-    poolSize: 20
-    credentials:
-      username: cassandra
-      password: cassandra
-    ssl: false
-    replicationFactor: 1
-    mutationBatchCount: 10000
-    mutationBatchSizeBytes: 10000000
-    fetchBatchCount: 1000
-    autoRefreshNodes: false
+    type: memory
   targetedSweep:
     enableSweepQueueWrites: true
   namespace: atlasete

--- a/lock-api/build.gradle
+++ b/lock-api/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     compile project(":atlasdb-autobatch")
     compile project(":atlasdb-commons")
     compile project(':lock-api-objects')
+    compile project(':timelock-api:timelock-api-dialogue')
     compile project(':timelock-api:timelock-api-jersey')
     compile project(":timestamp-api")
     compile project(":timestamp-client")

--- a/lock-api/src/main/java/com/palantir/lock/DialogueAdaptingConjureTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/DialogueAdaptingConjureTimelockService.java
@@ -1,0 +1,88 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.client;
+
+import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsRequest;
+import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponse;
+import com.palantir.atlasdb.timelock.api.ConjureLockRequest;
+import com.palantir.atlasdb.timelock.api.ConjureLockResponse;
+import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksRequest;
+import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksResponse;
+import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsRequest;
+import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
+import com.palantir.atlasdb.timelock.api.ConjureTimelockService;
+import com.palantir.atlasdb.timelock.api.ConjureTimelockServiceBlocking;
+import com.palantir.atlasdb.timelock.api.ConjureUnlockRequest;
+import com.palantir.atlasdb.timelock.api.ConjureUnlockResponse;
+import com.palantir.atlasdb.timelock.api.ConjureWaitForLocksResponse;
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampsRequest;
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampsResponse;
+import com.palantir.lock.v2.LeaderTime;
+import com.palantir.tokens.auth.AuthHeader;
+
+public class DialogueAdaptingConjureTimelockService implements ConjureTimelockService {
+    private final ConjureTimelockServiceBlocking dialogueDelegate;
+
+    public DialogueAdaptingConjureTimelockService(ConjureTimelockServiceBlocking dialogueDelegate) {
+        this.dialogueDelegate = dialogueDelegate;
+    }
+
+    @Override
+    public ConjureStartTransactionsResponse startTransactions(AuthHeader authHeader, String namespace,
+            ConjureStartTransactionsRequest request) {
+        return dialogueDelegate.startTransactions(authHeader, namespace, request);
+    }
+
+    @Override
+    public ConjureGetFreshTimestampsResponse getFreshTimestamps(AuthHeader authHeader, String namespace,
+            ConjureGetFreshTimestampsRequest request) {
+        return dialogueDelegate.getFreshTimestamps(authHeader, namespace, request);
+    }
+
+    @Override
+    public LeaderTime leaderTime(AuthHeader authHeader, String namespace) {
+        return dialogueDelegate.leaderTime(authHeader, namespace);
+    }
+
+    @Override
+    public ConjureLockResponse lock(AuthHeader authHeader, String namespace, ConjureLockRequest request) {
+        return dialogueDelegate.lock(authHeader, namespace, request);
+    }
+
+    @Override
+    public ConjureWaitForLocksResponse waitForLocks(AuthHeader authHeader, String namespace,
+            ConjureLockRequest request) {
+        return dialogueDelegate.waitForLocks(authHeader, namespace, request);
+    }
+
+    @Override
+    public ConjureRefreshLocksResponse refreshLocks(AuthHeader authHeader, String namespace,
+            ConjureRefreshLocksRequest request) {
+        return dialogueDelegate.refreshLocks(authHeader, namespace, request);
+    }
+
+    @Override
+    public ConjureUnlockResponse unlock(AuthHeader authHeader, String namespace, ConjureUnlockRequest request) {
+        return dialogueDelegate.unlock(authHeader, namespace, request);
+    }
+
+    @Override
+    public GetCommitTimestampsResponse getCommitTimestamps(AuthHeader authHeader, String namespace,
+            GetCommitTimestampsRequest request) {
+        return dialogueDelegate.getCommitTimestamps(authHeader, namespace, request);
+    }
+}

--- a/versions.props
+++ b/versions.props
@@ -27,8 +27,8 @@ com.palantir.config.crypto:encrypted-config-value-module = 2.1.0
 com.palantir.conjure:conjure = 4.10.1
 com.palantir.conjure.java.api:* = 2.9.0
 com.palantir.conjure.java:* = 5.11.2
-com.palantir.dialogue:* = 1.2.0
-com.palantir.conjure.java.runtime:* = 5.7.0
+com.palantir.conjure.java.runtime:* = 5.9.1
+com.palantir.dialogue:* = 1.38.0
 com.palantir.docker.compose:docker-compose-rule* = 1.3.0
 com.palantir.docker.proxy:docker-proxy-rule = 0.8.1
 com.palantir.refreshable:refreshable = 1.0.0
@@ -106,3 +106,7 @@ org.yaml:snakeyaml = 1.23
 com.google.errorprone:error_prone_refaster = 2.3.3
 com.palantir.baseline:baseline-refaster-testing = 2.17.0
 com.google.truth:truth = 1.0
+
+# conflict resolution
+org.apache.httpcomponents:httpclient = 4.5.12
+org.apache.httpcomponents:httpcore = 4.4.13


### PR DESCRIPTION
**Proof of concept only. Before merging, I want to add:**
- [ ] unit tests
- [ ] actually making dialogue configurable - this switches it on just so the ETE tests run with it
- [ ] sanity check all the TODOs I've dumped in
- [ ] implementation of some suggestions from @iamdanfox: changing `BlockingAndNonBlocking` stuff to `ShortAndLongTimeout` or something like that, also no need to specify `withFailedUrlCooldown` in the Dialogue service creator as it doesn't really matter. I might track the former separately.

**Goals (and why)**:
- We're broadly moving towards Dialogue. There is potentially big perf upside + better infra support, we should get on it.

**Implementation Description (bullets)**:
- AtlasDbDialogueServiceProvider creates the services. We take in a `base` ReloadingFactory and do some decoration on top so that it matches the CJR semantics we used to have.
- PredicateSwitchingProxy to allow runtime config between one or the other.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Ran ETE tests using Dialogue, which worked! 
Didn't add unit tests, they will be added before merge.

**Concerns (what feedback would you like?)**:
- An alternative design ([jkong/dialogue-2](https://github.com/palantir/atlasdb/compare/jkong/dialogue-2)) exists that is more complex, but allows for better reuse of the ServiceCreator infra. I actually wrote that first, but I wasn't happy with it: it was too messy and it's fragile to Atlas devs making silly mistakes when instantiating services. It's worth a look for comparison - is the more restrictive but tighter design in this PR the right choice?
- Do my plans for multitenancy make sense? A multitenant service would need to instantiate an `AtlasDbDialogueServiceProvider` by themselves (but that's okay, they have access to atlas config). Then this can be passed in to the TransactionManager: if it doesn't exist we create our own, if it does we just use it.

**Where should we start reviewing?**: AtlasDbDialogueServiceProvider.java

**Priority (whenever / two weeks / yesterday)**: early next week
