### PR TITLE
Allow invalidating SweepStrategyManager cache

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/SweepStrategyManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/SweepStrategyManager.java
@@ -15,9 +15,15 @@
  */
 package com.palantir.atlasdb.transaction.impl;
 
+import java.util.Set;
+
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.table.description.SweepStrategy;
 
 public interface SweepStrategyManager {
     SweepStrategy get(TableReference tableRef);
+
+    default void invalidateCaches(Set<TableReference> tableRefs) {
+        // No-op. Assume no cache if not implemented.
+    }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/SweepStrategyManagers.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/SweepStrategyManagers.java
@@ -16,6 +16,7 @@
 package com.palantir.atlasdb.transaction.impl;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -51,7 +52,17 @@ public class SweepStrategyManagers {
                     return cache;
                 });
 
-        return tableRef -> sweepStrategySupplierLoadingCache.get().get(tableRef);
+        return new SweepStrategyManager() {
+            @Override
+            public SweepStrategy get(TableReference tableRef) {
+                return sweepStrategySupplierLoadingCache.get().get(tableRef);
+            }
+
+            @Override
+            public void invalidateCaches(Set<TableReference> tableRefs) {
+                sweepStrategySupplierLoadingCache.get().invalidateAll(tableRefs);
+            }
+        };
     }
 
     public static SweepStrategyManager createFromSchema(Schema schema) {

--- a/changelog/@unreleased/pr-4770.v2.yml
+++ b/changelog/@unreleased/pr-4770.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Expose a new method on SweepStrategyManager to allow invalidating the
+    table metadata cache on specific tables. Useful for clients that want to change
+    the sweep strategy on an existing table without bouncing the service.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4770


### PR DESCRIPTION
**Goals (and why)**:

Useful to change the sweep strategy on an existing table without
bouncing the service.

**Implementation Description (bullets)**:

Just expose a new method that allows cache invalidation.

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
