### PR TITLE
[PaxosStateLog] Implement Different Migration States

### DIFF
--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogMigrator.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogMigrator.java
@@ -52,7 +52,7 @@ public final class PaxosStateLogMigrator<V extends Persistable & Versionable> {
     }
 
     private void runMigration() {
-        if (migrationState.hasAlreadyMigrated()) {
+        if (migrationState.hasMigratedFromInitialState()) {
             return;
         }
 
@@ -60,7 +60,7 @@ public final class PaxosStateLogMigrator<V extends Persistable & Versionable> {
         long lowerBound = lowestSequenceToMigrate();
         long upperBound = sourceLog.getGreatestLogEntry();
         if (upperBound == PaxosAcceptor.NO_LOG_ENTRY) {
-            migrationState.finishMigration();
+            migrationState.migrateToValidationState();
             return;
         }
 
@@ -71,7 +71,7 @@ public final class PaxosStateLogMigrator<V extends Persistable & Versionable> {
                     .mapToObj(sequence -> reader.readBatch(sequence, BATCH_SIZE))
                     .forEach(destinationLog::writeBatchOfRounds);
         }
-        migrationState.finishMigration();
+        migrationState.migrateToValidationState();
     }
 
     private long lowestSequenceToMigrate() {

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLogMigrationState.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLogMigrationState.java
@@ -57,12 +57,20 @@ public final class SqlitePaxosStateLogMigrationState {
         execute(dao -> dao.migrateToVersion(namespace, useCase, States.VALIDATION.schemaVersion));
     }
 
+    public void migrateToMigratedState() {
+        execute(dao -> dao.migrateToVersion(namespace, useCase, States.MIGRATED.schemaVersion));
+    }
+
     public boolean hasMigratedFromInitialState() {
         return !Objects.equals(States.NONE.getSchemaVersion(), execute(dao -> dao.getVersion(namespace, useCase)));
     }
 
     public boolean isInValidationState() {
         return States.VALIDATION.getSchemaVersion().equals(execute(dao -> dao.getVersion(namespace, useCase)));
+    }
+
+    public boolean isInMigratedState() {
+        return States.MIGRATED.getSchemaVersion().equals(execute(dao -> dao.getVersion(namespace, useCase)));
     }
 
     private <T> T execute(Function<Queries, T> call) {
@@ -86,7 +94,7 @@ public final class SqlitePaxosStateLogMigrationState {
     }
 
     private enum States {
-        NONE(null), VALIDATION(0);
+        NONE(null), VALIDATION(0), MIGRATED(1);
 
         Integer schemaVersion;
         States(Integer schemaVersion) {

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLogMigrationState.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLogMigrationState.java
@@ -17,6 +17,7 @@
 package com.palantir.paxos;
 
 import java.sql.Connection;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -52,12 +53,16 @@ public final class SqlitePaxosStateLogMigrationState {
         execute(Queries::createTable);
     }
 
-    public void finishMigration() {
-        execute(dao -> dao.finishMigration(namespace, useCase));
+    public void migrateToValidationState() {
+        execute(dao -> dao.migrateToVersion(namespace, useCase, States.VALIDATION.schemaVersion));
     }
 
-    public boolean hasAlreadyMigrated() {
-        return execute(dao -> dao.hasFinishedMigrating(namespace, useCase));
+    public boolean hasMigratedFromInitialState() {
+        return !Objects.equals(States.NONE.getSchemaVersion(), execute(dao -> dao.getVersion(namespace, useCase)));
+    }
+
+    public boolean isInValidationState() {
+        return States.VALIDATION.getSchemaVersion().equals(execute(dao -> dao.getVersion(namespace, useCase)));
     }
 
     private <T> T execute(Function<Queries, T> call) {
@@ -70,11 +75,26 @@ public final class SqlitePaxosStateLogMigrationState {
         boolean createTable();
 
         @SqlUpdate("INSERT OR REPLACE INTO migration_state (namespace, useCase, version) VALUES"
-                + " (:namespace.value, :useCase, 0)")
-        boolean finishMigration(@BindPojo("namespace") Client namespace, @Bind("useCase") String useCase);
+                + " (:namespace.value, :useCase, :version)")
+        boolean migrateToVersion(
+                @BindPojo("namespace") Client namespace,
+                @Bind("useCase") String useCase,
+                @Bind("version") int version);
 
-        @SqlQuery("SELECT EXISTS (SELECT 1 FROM migration_state WHERE"
-                + " namespace = :namespace.value AND useCase = :useCase)")
-        boolean hasFinishedMigrating(@BindPojo("namespace") Client namespace, @Bind("useCase") String useCase);
+        @SqlQuery("SELECT version FROM migration_state WHERE namespace = :namespace.value AND useCase = :useCase")
+        Integer getVersion(@BindPojo("namespace") Client namespace, @Bind("useCase") String useCase);
+    }
+
+    private enum States {
+        NONE(null), VALIDATION(0);
+
+        Integer schemaVersion;
+        States(Integer schemaVersion) {
+            this.schemaVersion = schemaVersion;
+        }
+
+        Integer getSchemaVersion() {
+            return schemaVersion;
+        }
     }
 }

--- a/leader-election-impl/src/test/java/com/palantir/paxos/FileToSqlitePaxosStateLogIntegrationTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/FileToSqlitePaxosStateLogIntegrationTest.java
@@ -54,7 +54,7 @@ public class FileToSqlitePaxosStateLogIntegrationTest {
     @Test
     public void emptyMigrationSucceeds() {
         migrate();
-        assertThat(migrationState.hasAlreadyMigrated()).isTrue();
+        assertThat(migrationState.hasMigratedFromInitialState()).isTrue();
     }
 
     @Test
@@ -82,7 +82,7 @@ public class FileToSqlitePaxosStateLogIntegrationTest {
         List<PaxosValue> migratedValues = readMigratedValuesFor(expectedValues);
 
         assertThat(migratedValues).isEqualTo(roundsToValues(rounds));
-        assertThat(migrationState.hasAlreadyMigrated()).isTrue();
+        assertThat(migrationState.hasMigratedFromInitialState()).isTrue();
     }
 
     private List<PaxosValue> roundsToValues(List<PaxosRound<PaxosValue>> rounds) {

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosStateLogMigratorTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosStateLogMigratorTest.java
@@ -60,7 +60,7 @@ public class PaxosStateLogMigratorTest {
     @Test
     public void emptyLogMigrationSuccessfullyMarksAsMigrated() {
         migrateFrom(source);
-        assertThat(migrationState.hasAlreadyMigrated()).isTrue();
+        assertThat(migrationState.hasMigratedFromInitialState()).isTrue();
     }
 
     @Test
@@ -70,7 +70,7 @@ public class PaxosStateLogMigratorTest {
         List<PaxosValue> valuesWritten = insertValuesWithinBounds(lowerBound, upperBound, source);
 
         migrateFrom(source);
-        assertThat(migrationState.hasAlreadyMigrated()).isTrue();
+        assertThat(migrationState.hasMigratedFromInitialState()).isTrue();
         assertThat(target.getLeastLogEntry()).isEqualTo(lowerBound);
         assertThat(target.getGreatestLogEntry()).isEqualTo(upperBound);
 
@@ -86,7 +86,7 @@ public class PaxosStateLogMigratorTest {
         List<PaxosValue> valuesWritten = insertValuesWithinBounds(lowerBound, upperBound, target);
 
         migrateFrom(source);
-        assertThat(migrationState.hasAlreadyMigrated()).isTrue();
+        assertThat(migrationState.hasMigratedFromInitialState()).isTrue();
         assertThat(target.getLeastLogEntry()).isEqualTo(PaxosAcceptor.NO_LOG_ENTRY);
         assertThat(target.getGreatestLogEntry()).isEqualTo(PaxosAcceptor.NO_LOG_ENTRY);
         valuesWritten.forEach(value -> assertThat(readRoundUnchecked(target, value.seq)).isNull());
@@ -94,7 +94,7 @@ public class PaxosStateLogMigratorTest {
 
     @Test
     public void doNotMigrateIfAlreadyMigrated() {
-        migrationState.finishMigration();
+        migrationState.migrateToValidationState();
 
         long lowerBound = 1;
         long upperBound = 22;
@@ -102,7 +102,7 @@ public class PaxosStateLogMigratorTest {
 
         migrateFrom(source);
 
-        assertThat(migrationState.hasAlreadyMigrated()).isTrue();
+        assertThat(migrationState.hasMigratedFromInitialState()).isTrue();
         assertThat(target.getLeastLogEntry()).isEqualTo(PaxosAcceptor.NO_LOG_ENTRY);
         assertThat(target.getGreatestLogEntry()).isEqualTo(PaxosAcceptor.NO_LOG_ENTRY);
         valuesWritten.forEach(value -> assertThat(readRoundUnchecked(target, value.seq)).isNull());
@@ -126,7 +126,7 @@ public class PaxosStateLogMigratorTest {
         });
 
         migrateFrom(mockLog);
-        assertThat(migrationState.hasAlreadyMigrated()).isTrue();
+        assertThat(migrationState.hasMigratedFromInitialState()).isTrue();
         assertThat(target.getLeastLogEntry()).isEqualTo(lowerBound);
         assertThat(target.getGreatestLogEntry()).isEqualTo(upperBound);
 

--- a/leader-election-impl/src/test/java/com/palantir/paxos/SqlitePaxosStateLogMigrationStateTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/SqlitePaxosStateLogMigrationStateTest.java
@@ -45,42 +45,45 @@ public class SqlitePaxosStateLogMigrationStateTest {
 
     @Test
     public void initialStateIsNotMigrated() {
-        assertThat(migrationState.hasAlreadyMigrated()).isFalse();
+        assertThat(migrationState.hasMigratedFromInitialState()).isFalse();
+        assertThat(migrationState.isInValidationState()).isFalse();
     }
 
     @Test
     public void canSetStateToMigrated() {
-        migrationState.finishMigration();
-        assertThat(migrationState.hasAlreadyMigrated()).isTrue();
+        migrationState.migrateToValidationState();
+        assertThat(migrationState.hasMigratedFromInitialState()).isTrue();
+        assertThat(migrationState.isInValidationState()).isTrue();
     }
 
     @Test
     public void canSetStateToMigratedMultipleTimes() {
-        migrationState.finishMigration();
-        migrationState.finishMigration();
-        migrationState.finishMigration();
-        assertThat(migrationState.hasAlreadyMigrated()).isTrue();
+        migrationState.migrateToValidationState();
+        migrationState.migrateToValidationState();
+        migrationState.migrateToValidationState();
+        assertThat(migrationState.hasMigratedFromInitialState()).isTrue();
+        assertThat(migrationState.isInValidationState()).isTrue();
     }
 
     @Test
     public void finishingMigrationForOneNamespaceDoesNotSetFlagForOthers() {
-        migrationState.finishMigration();
+        migrationState.migrateToValidationState();
 
         SqlitePaxosStateLogMigrationState otherState = SqlitePaxosStateLogMigrationState
                 .create(ImmutableNamespaceAndUseCase.of(Client.of("other"), "useCase"), connSupplier);
-        assertThat(otherState.hasAlreadyMigrated()).isFalse();
-        otherState.finishMigration();
-        assertThat(otherState.hasAlreadyMigrated()).isTrue();
+        assertThat(otherState.hasMigratedFromInitialState()).isFalse();
+        otherState.migrateToValidationState();
+        assertThat(otherState.hasMigratedFromInitialState()).isTrue();
     }
 
     @Test
     public void finishingMigrationForOneUseCaseDoesNotSetFlagForOthers() {
-        migrationState.finishMigration();
+        migrationState.migrateToValidationState();
 
         SqlitePaxosStateLogMigrationState otherState = SqlitePaxosStateLogMigrationState
                 .create(ImmutableNamespaceAndUseCase.of(Client.of("namespace"), "other"), connSupplier);
-        assertThat(otherState.hasAlreadyMigrated()).isFalse();
-        otherState.finishMigration();
-        assertThat(otherState.hasAlreadyMigrated()).isTrue();
+        assertThat(otherState.hasMigratedFromInitialState()).isFalse();
+        otherState.migrateToValidationState();
+        assertThat(otherState.hasMigratedFromInitialState()).isTrue();
     }
 }

--- a/leader-election-impl/src/test/java/com/palantir/paxos/SqlitePaxosStateLogMigrationStateTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/SqlitePaxosStateLogMigrationStateTest.java
@@ -44,25 +44,41 @@ public class SqlitePaxosStateLogMigrationStateTest {
     }
 
     @Test
-    public void initialStateIsNotMigrated() {
+    public void initialStateTest() {
         assertThat(migrationState.hasMigratedFromInitialState()).isFalse();
         assertThat(migrationState.isInValidationState()).isFalse();
+        assertThat(migrationState.isInMigratedState()).isFalse();
+    }
+
+    @Test
+    public void canSetStateToValidation() {
+        migrationState.migrateToValidationState();
+        assertThat(migrationState.hasMigratedFromInitialState()).isTrue();
+        assertThat(migrationState.isInValidationState()).isTrue();
+        assertThat(migrationState.isInMigratedState()).isFalse();
     }
 
     @Test
     public void canSetStateToMigrated() {
-        migrationState.migrateToValidationState();
+        migrationState.migrateToMigratedState();
         assertThat(migrationState.hasMigratedFromInitialState()).isTrue();
-        assertThat(migrationState.isInValidationState()).isTrue();
+        assertThat(migrationState.isInValidationState()).isFalse();
+        assertThat(migrationState.isInMigratedState()).isTrue();
     }
 
     @Test
-    public void canSetStateToMigratedMultipleTimes() {
+    public void canChangeStates() {
         migrationState.migrateToValidationState();
-        migrationState.migrateToValidationState();
+        migrationState.migrateToMigratedState();
+        migrationState.migrateToMigratedState();
+        assertThat(migrationState.hasMigratedFromInitialState()).isTrue();
+        assertThat(migrationState.isInValidationState()).isFalse();
+        assertThat(migrationState.isInMigratedState()).isTrue();
+
         migrationState.migrateToValidationState();
         assertThat(migrationState.hasMigratedFromInitialState()).isTrue();
         assertThat(migrationState.isInValidationState()).isTrue();
+        assertThat(migrationState.isInMigratedState()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
**Goals (and why)**:
Add support for validation and migrated states

**Implementation Description (bullets)**:
Pretty straightforward, although I would have liked to make it nicer

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added another test and updated existing ones

**Concerns (what feedback would you like?)**:
Any obvious better way to do this?

**Where should we start reviewing?**:
SqlitePaxosStateLogMigrationState.java

**Priority (whenever / two weeks / yesterday)**:
Tomorrow?