### PR TITLE
[Dialogue] Part 5: Fix Missing Instrumentation

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/AtlasDbDialogueServiceProvider.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/AtlasDbDialogueServiceProvider.java
@@ -90,11 +90,11 @@ public final class AtlasDbDialogueServiceProvider {
                 .longTimeout(longTimeoutService)
                 .shortTimeout(shortTimeoutService)
                 .build()
+                .map(proxy -> FastFailoverProxy.newProxyInstance(ConjureTimelockServiceBlocking.class, () -> proxy))
                 .map(service -> AtlasDbMetrics.instrumentWithTaggedMetrics(
                         taggedMetricRegistry,
                         ConjureTimelockServiceBlocking.class,
                         service))
-                .map(proxy -> FastFailoverProxy.newProxyInstance(ConjureTimelockServiceBlocking.class, () -> proxy))
                 .map(DialogueAdaptingConjureTimelockService::new);
 
         return new TimeoutSensitiveConjureTimelockService(shortAndLongTimeoutServices);

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -1012,7 +1012,7 @@ public abstract class TransactionManagers {
         DialogueClients.ReloadingFactory reloadingFactory = DialogueClients.create(
                 Refreshable.only(ServicesConfigBlock.builder().build()));
         AtlasDbDialogueServiceProvider serviceProvider = AtlasDbDialogueServiceProvider.create(
-                timelockServerListConfig, reloadingFactory, userAgent);
+                timelockServerListConfig, reloadingFactory, userAgent, metricsManager.getTaggedRegistry());
 
         ServiceCreator creator = ServiceCreator.withPayloadLimiter(
                 metricsManager, timelockServerListConfig, userAgent, remotingClientConfig);

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/AtlasDbDialogueServiceProviderTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/AtlasDbDialogueServiceProviderTest.java
@@ -57,6 +57,7 @@ import com.palantir.atlasdb.timelock.api.ConjureLockRequest;
 import com.palantir.atlasdb.timelock.api.ConjureLockResponse;
 import com.palantir.atlasdb.timelock.api.ConjureTimelockService;
 import com.palantir.atlasdb.timelock.api.UnsuccessfulLockResponse;
+import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.conjure.java.api.config.service.ServicesConfigBlock;
 import com.palantir.conjure.java.api.config.service.UserAgent;
@@ -97,7 +98,10 @@ public class AtlasDbDialogueServiceProviderTest {
                 .build();
 
         AtlasDbDialogueServiceProvider provider = AtlasDbDialogueServiceProvider.create(
-                Refreshable.only(serverListConfig), DIALOGUE_BASE_FACTORY, USER_USER_AGENT);
+                Refreshable.only(serverListConfig),
+                DIALOGUE_BASE_FACTORY,
+                USER_USER_AGENT,
+                MetricsManagers.createForTests().getTaggedRegistry());
         conjureTimelockService = provider.getConjureTimelockService();
     }
 

--- a/changelog/@unreleased/pr-4776.v2.yml
+++ b/changelog/@unreleased/pr-4776.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Proxies made with Dialogue are now instrumented with Tritium metrics.
+    Previously, they were not instrumented.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4776


### PR DESCRIPTION
**Goals (and why)**:
- Make AtlasDB client measured performance when talking to TimeLock easy to see.

**Implementation Description (bullets)**:
- Instrument services with tagged metrics.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- None added. Existing tests should validate we haven't broken anything. We can use internal stack to validate metrics are sane.

**Concerns (what feedback would you like?)**:
- Metric name changes: `ConjureTimelockService` becomes `ConjureTimelockServiceBlocking`. The alternative is to name it with the old name, which is fine but I imagine someone new to the codebase will find that surprising!
- Is this inserted at precisely the correct layer? I did this to be consistent with the old layer, and in part because FastFailoverProxy retries should be treated the same as general 429/503 backoff that we do anyway.

**Where should we start reviewing?**: AtlasDbDialogueServiceProvider

**Priority (whenever / two weeks / yesterday)**: this week