### PR TITLE
Address Some Known Flakes

### DIFF
--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -345,7 +345,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
     private static void assertNumberOfThreadsReasonable(int startingThreads, int threadCount, boolean nonLeaderDown) {
         // TODO (jkong): Lower the amount over the threshold. This needs to be slightly higher for now because of the
         // current threading model in batch mode, where separate threads may be spun up on the autobatcher.
-        int threadLimit = startingThreads + 300;
+        int threadLimit = startingThreads + 400;
         if (nonLeaderDown) {
             assertThat(threadCount)
                     .as("should not additionally spin up too many threads after a non-leader failed")


### PR DESCRIPTION
**Goals (and why)**:
- Build flakes are annoying

**Implementation Description (bullets)**:
- **MultiNodePaxosTimeLockServerIntegrationTest**: Don't have a good strategy for making this one nondeterministic, other than by loosening the bound (in bad times this soared by thousands, so this is still fine).
- **SafeShutdownRunnerTest**: The point is that it's fine to have those runnables hang arbitrarily.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Do the same tests flake?

**Concerns (what feedback would you like?)**:
- Should I bother about releasing the semaphores in SafeShutdownRunnerTest after a while?

**Where should we start reviewing?**: Each test, one at a time

**Priority (whenever / two weeks / yesterday)**: whenever, though flakes are annoying!
