### PR TITLE
[PaxosStateLog] Implement locking for SqlitePSL

### DIFF
--- a/leader-election-impl/src/test/java/com/palantir/paxos/FileToSqlitePaxosStateLogIntegrationTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/FileToSqlitePaxosStateLogIntegrationTest.java
@@ -47,7 +47,7 @@ public class FileToSqlitePaxosStateLogIntegrationTest {
         source = new PaxosStateLogImpl<>(tempFolder.newFolder("source").getPath());
         Supplier<Connection> targetConnSupplier = SqliteConnections
                 .createDefaultNamedSqliteDatabaseAtPath(tempFolder.newFolder("target").toPath());
-        target = SqlitePaxosStateLog.create(NAMESPACE, targetConnSupplier);
+        target = SqlitePaxosStateLog.createFactory().create(NAMESPACE, targetConnSupplier);
         migrationState = SqlitePaxosStateLogMigrationState.create(NAMESPACE, targetConnSupplier);
     }
 

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosStateLogMigratorTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosStateLogMigratorTest.java
@@ -52,8 +52,8 @@ public class PaxosStateLogMigratorTest {
                 .createDefaultNamedSqliteDatabaseAtPath(tempFolder.newFolder("source").toPath());
         Supplier<Connection> targetConnSupplier = SqliteConnections
                 .createDefaultNamedSqliteDatabaseAtPath(tempFolder.newFolder("target").toPath());
-        source = SqlitePaxosStateLog.create(NAMESPACE, sourceConnSupplier);
-        target = SqlitePaxosStateLog.create(NAMESPACE, targetConnSupplier);
+        source = SqlitePaxosStateLog.createFactory().create(NAMESPACE, sourceConnSupplier);
+        target = SqlitePaxosStateLog.createFactory().create(NAMESPACE, targetConnSupplier);
         migrationState = SqlitePaxosStateLogMigrationState.create(NAMESPACE, targetConnSupplier);
     }
 

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/management/SqliteNamespaceLoaderTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/management/SqliteNamespaceLoaderTest.java
@@ -77,7 +77,8 @@ public class SqliteNamespaceLoaderTest {
     }
 
     private void initializeLog(Client namespace, String sequenceId) {
-        SqlitePaxosStateLog.create(ImmutableNamespaceAndUseCase.of(namespace, sequenceId), connectionSupplier)
+        SqlitePaxosStateLog.createFactory()
+                .create(ImmutableNamespaceAndUseCase.of(namespace, sequenceId), connectionSupplier)
                 .writeRound(1, PAXOS_VALUE);
     }
 }


### PR DESCRIPTION
**Goals (and why)**:
In a high concurrency setting we've been hitting Sqlite timeouts due to its locking mechanism. We now do our own locking to avoid that.

**Implementation Description (bullets)**:
Quite straightforward

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added test that was failing on develop, now passes

**Concerns (what feedback would you like?)**:
Is the factory approach reasonable and clear enough?

**Where should we start reviewing?**:
Small

**Priority (whenever / two weeks / yesterday)**:
Today
