### PR TITLE
[PaxosStateLog] Reintroduce Migration and Verification with Locks

### DIFF
--- a/changelog/@unreleased/pr-4786.v2.yml
+++ b/changelog/@unreleased/pr-4786.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: 'Reintroduced writing timelock paxos state logs both to the file system
+    and into a sqlite implementation on disk. This was previously reverted due to
+    a locking issue in sqlite. '
+  links:
+  - https://github.com/palantir/atlasdb/pull/4786

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosAcceptorImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosAcceptorImpl.java
@@ -22,7 +22,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 
 public final class PaxosAcceptorImpl implements PaxosAcceptor {
     private static final Logger logger = LoggerFactory.getLogger(PaxosAcceptorImpl.class);
@@ -35,10 +34,13 @@ public final class PaxosAcceptorImpl implements PaxosAcceptor {
                 log.getGreatestLogEntry());
     }
 
-    public static PaxosAcceptor newAcceptor(PaxosStorageParameters storageParameters) {
-        String logDirectory = storageParameters.fileBasedLogDirectory()
-                .orElseThrow(() -> new SafeIllegalStateException("We currently need to have file-based storage"));
-        return newAcceptor(logDirectory);
+    public static PaxosAcceptor newVerifyingAcceptor(PaxosStorageParameters storageParameters) {
+        PaxosStateLog<PaxosAcceptorState> log = VerifyingPaxosStateLog
+                .createWithMigration(storageParameters, PaxosAcceptorState.BYTES_HYDRATOR);
+        return new PaxosAcceptorImpl(
+                new ConcurrentSkipListMap<>(),
+                log,
+                log.getGreatestLogEntry());
     }
 
     private final ConcurrentSkipListMap<Long, PaxosAcceptorState> state;

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosAcceptorImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosAcceptorImpl.java
@@ -35,7 +35,7 @@ public final class PaxosAcceptorImpl implements PaxosAcceptor {
     }
 
     public static PaxosAcceptor newVerifyingAcceptor(PaxosStorageParameters storageParameters,
-            SqlitePaxosStateLog.SqlitePaxosStateLogFactory sqliteFactory) {
+            SqlitePaxosStateLogFactory sqliteFactory) {
         PaxosStateLog<PaxosAcceptorState> log = VerifyingPaxosStateLog
                 .createWithMigration(storageParameters, sqliteFactory, PaxosAcceptorState.BYTES_HYDRATOR);
         return new PaxosAcceptorImpl(

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosAcceptorImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosAcceptorImpl.java
@@ -34,9 +34,10 @@ public final class PaxosAcceptorImpl implements PaxosAcceptor {
                 log.getGreatestLogEntry());
     }
 
-    public static PaxosAcceptor newVerifyingAcceptor(PaxosStorageParameters storageParameters) {
+    public static PaxosAcceptor newVerifyingAcceptor(PaxosStorageParameters storageParameters,
+            SqlitePaxosStateLog.SqlitePaxosStateLogFactory sqliteFactory) {
         PaxosStateLog<PaxosAcceptorState> log = VerifyingPaxosStateLog
-                .createWithMigration(storageParameters, PaxosAcceptorState.BYTES_HYDRATOR);
+                .createWithMigration(storageParameters, sqliteFactory, PaxosAcceptorState.BYTES_HYDRATOR);
         return new PaxosAcceptorImpl(
                 new ConcurrentSkipListMap<>(),
                 log,

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosLearnerImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosLearnerImpl.java
@@ -50,8 +50,11 @@ public final class PaxosLearnerImpl implements PaxosLearner {
         return new PaxosLearnerImpl(state, log, eventRecorder);
     }
 
-    public static PaxosLearner newVerifyingLearner(PaxosStorageParameters params, PaxosKnowledgeEventRecorder event) {
-        PaxosStateLog<PaxosValue> log = VerifyingPaxosStateLog.createWithMigration(params, PaxosValue.BYTES_HYDRATOR);
+    public static PaxosLearner newVerifyingLearner(PaxosStorageParameters params,
+            SqlitePaxosStateLog.SqlitePaxosStateLogFactory sqliteFactory,
+            PaxosKnowledgeEventRecorder event) {
+        PaxosStateLog<PaxosValue> log = VerifyingPaxosStateLog
+                .createWithMigration(params, sqliteFactory, PaxosValue.BYTES_HYDRATOR);
         return newLearner(log, event);
     }
 

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosLearnerImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosLearnerImpl.java
@@ -51,7 +51,7 @@ public final class PaxosLearnerImpl implements PaxosLearner {
     }
 
     public static PaxosLearner newVerifyingLearner(PaxosStorageParameters params,
-            SqlitePaxosStateLog.SqlitePaxosStateLogFactory sqliteFactory,
+            SqlitePaxosStateLogFactory sqliteFactory,
             PaxosKnowledgeEventRecorder event) {
         PaxosStateLog<PaxosValue> log = VerifyingPaxosStateLog
                 .createWithMigration(params, sqliteFactory, PaxosValue.BYTES_HYDRATOR);

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStorageParameters.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStorageParameters.java
@@ -16,20 +16,14 @@
 
 package com.palantir.paxos;
 
+import java.nio.file.Path;
 import java.util.Optional;
 
 import org.immutables.value.Value;
 
-import com.palantir.logsafe.Preconditions;
-
 @Value.Immutable
 public interface PaxosStorageParameters {
+    NamespaceAndUseCase namespaceAndUseCase();
+    Path sqliteBasedLogDirectory();
     Optional<String> fileBasedLogDirectory();
-    Optional<String> databaseNamespace();
-
-    @Value.Check
-    default void check() {
-        Preconditions.checkState(fileBasedLogDirectory().isPresent() || databaseNamespace().isPresent(),
-                "At least one of 'fileBasedLogDirectory' and 'databaseNamespace' must be present.");
-    }
 }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLog.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLog.java
@@ -20,7 +20,6 @@ import java.sql.Connection;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -49,7 +48,7 @@ public final class SqlitePaxosStateLog<V extends Persistable & Versionable> impl
         this.sharedLock = sharedLock;
     }
 
-    private static <V extends Persistable & Versionable> PaxosStateLog<V> create(
+    static <V extends Persistable & Versionable> PaxosStateLog<V> create(
             NamespaceAndUseCase namespaceAndUseCase,
             Supplier<Connection> connectionSupplier, ReadWriteLock sharedLock) {
         Jdbi jdbi = Jdbi.create(connectionSupplier::get).installPlugin(new SqlObjectPlugin());
@@ -57,10 +56,6 @@ public final class SqlitePaxosStateLog<V extends Persistable & Versionable> impl
         SqlitePaxosStateLog<V> log = new SqlitePaxosStateLog<>(namespaceAndUseCase, jdbi, sharedLock);
         log.initialize();
         return log;
-    }
-
-    public static SqlitePaxosStateLogFactory createFactory() {
-        return new SqlitePaxosStateLogFactory();
     }
 
     private void initialize() {
@@ -117,16 +112,6 @@ public final class SqlitePaxosStateLog<V extends Persistable & Versionable> impl
 
     private <T> T execute(Function<Queries, T> call) {
         return jdbi.withExtension(Queries.class, call::apply);
-    }
-
-    public static class SqlitePaxosStateLogFactory {
-        private final ReadWriteLock sharedLock = new ReentrantReadWriteLock();
-
-        public <V extends Persistable & Versionable> PaxosStateLog<V> create(
-                NamespaceAndUseCase namespaceAndUseCase,
-                Supplier<Connection> connectionSupplier) {
-            return SqlitePaxosStateLog.create(namespaceAndUseCase, connectionSupplier, sharedLock);
-        }
     }
 
     public interface Queries {

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLogFactory.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLogFactory.java
@@ -1,0 +1,40 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.paxos;
+
+import java.sql.Connection;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Supplier;
+
+import com.palantir.common.persist.Persistable;
+
+public class SqlitePaxosStateLogFactory {
+    private final ReadWriteLock sharedLock = new ReentrantReadWriteLock();
+
+    public <V extends Persistable & Versionable> PaxosStateLog<V> create(
+            NamespaceAndUseCase namespaceAndUseCase,
+            Supplier<Connection> connectionSupplier) {
+        return SqlitePaxosStateLog.create(namespaceAndUseCase, connectionSupplier, sharedLock);
+    }
+
+    public SqlitePaxosStateLogMigrationState createMigrationState(
+            NamespaceAndUseCase namespaceAndUseCase,
+            Supplier<Connection> connectionSupplier) {
+        return SqlitePaxosStateLogMigrationState.create(namespaceAndUseCase, connectionSupplier, sharedLock);
+    }
+}

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLogMigrationState.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLogMigrationState.java
@@ -17,7 +17,7 @@
 package com.palantir.paxos;
 
 import java.sql.Connection;
-import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -28,6 +28,9 @@ import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindPojo;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
 
 public final class SqlitePaxosStateLogMigrationState {
     private final Client namespace;
@@ -54,27 +57,47 @@ public final class SqlitePaxosStateLogMigrationState {
     }
 
     public void migrateToValidationState() {
-        execute(dao -> dao.migrateToVersion(namespace, useCase, States.VALIDATION.schemaVersion));
+        execute(migrateToState(States.VALIDATION));
     }
 
     public void migrateToMigratedState() {
-        execute(dao -> dao.migrateToVersion(namespace, useCase, States.MIGRATED.schemaVersion));
+        execute(migrateToState(States.MIGRATED));
     }
 
     public boolean hasMigratedFromInitialState() {
-        return !Objects.equals(States.NONE.getSchemaVersion(), execute(dao -> dao.getVersion(namespace, useCase)));
+        return execute(dao -> dao.getVersion(namespace, useCase).isPresent());
     }
 
     public boolean isInValidationState() {
-        return States.VALIDATION.getSchemaVersion().equals(execute(dao -> dao.getVersion(namespace, useCase)));
+        return execute(dao -> dao.getVersion(namespace, useCase)
+                .map(States.VALIDATION.getSchemaVersion()::equals)
+                .orElse(false));
     }
 
     public boolean isInMigratedState() {
-        return States.MIGRATED.getSchemaVersion().equals(execute(dao -> dao.getVersion(namespace, useCase)));
+        return execute(dao -> dao.getVersion(namespace, useCase)
+                .map(States.MIGRATED.getSchemaVersion()::equals)
+                .orElse(false));
     }
 
     private <T> T execute(Function<Queries, T> call) {
         return jdbi.withExtension(Queries.class, call::apply);
+    }
+
+    private Function<Queries, Boolean> migrateToState(States state) {
+        return dao -> {
+            assertCurrentStateAtMost(dao, state);
+            return dao.migrateToVersion(namespace, useCase, state.getSchemaVersion());
+        };
+    }
+
+    private void assertCurrentStateAtMost(Queries dao, States state) {
+        dao.getVersion(namespace, useCase).ifPresent(currentVersion ->
+                Preconditions.checkState(currentVersion <= state.getSchemaVersion(),
+                        "Could not update migration state because it would cause us to go back in state version.",
+                        SafeArg.of("currentVersion", currentVersion),
+                        SafeArg.of("migrationState", state),
+                        SafeArg.of("migrationVersion", state.getSchemaVersion())));
     }
 
     public interface Queries {
@@ -90,7 +113,7 @@ public final class SqlitePaxosStateLogMigrationState {
                 @Bind("version") int version);
 
         @SqlQuery("SELECT version FROM migration_state WHERE namespace = :namespace.value AND useCase = :useCase")
-        Integer getVersion(@BindPojo("namespace") Client namespace, @Bind("useCase") String useCase);
+        Optional<Integer> getVersion(@BindPojo("namespace") Client namespace, @Bind("useCase") String useCase);
     }
 
     private enum States {

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLogMigrationState.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLogMigrationState.java
@@ -18,6 +18,7 @@ package com.palantir.paxos;
 
 import java.sql.Connection;
 import java.util.Optional;
+import java.util.concurrent.locks.ReadWriteLock;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -36,48 +37,70 @@ public final class SqlitePaxosStateLogMigrationState {
     private final Client namespace;
     private final String useCase;
     private final Jdbi jdbi;
+    private final ReadWriteLock sharedLock;
 
-    private SqlitePaxosStateLogMigrationState(NamespaceAndUseCase namespaceAndUseCase, Jdbi jdbi) {
+    private SqlitePaxosStateLogMigrationState(NamespaceAndUseCase namespaceAndUseCase, Jdbi jdbi,
+            ReadWriteLock sharedLock) {
         this.namespace = namespaceAndUseCase.namespace();
         this.useCase = namespaceAndUseCase.useCase();
         this.jdbi = jdbi;
+        this.sharedLock = sharedLock;
     }
 
-    public static SqlitePaxosStateLogMigrationState create(NamespaceAndUseCase namespaceAndUseCase,
-            Supplier<Connection> connectionSupplier) {
+    static SqlitePaxosStateLogMigrationState create(NamespaceAndUseCase namespaceAndUseCase,
+            Supplier<Connection> connectionSupplier, ReadWriteLock sharedLock) {
         Jdbi jdbi = Jdbi.create(connectionSupplier::get).installPlugin(new SqlObjectPlugin());
         jdbi.getConfig(JdbiImmutables.class).registerImmutable(Client.class);
-        SqlitePaxosStateLogMigrationState state = new SqlitePaxosStateLogMigrationState(namespaceAndUseCase, jdbi);
+        SqlitePaxosStateLogMigrationState state = new SqlitePaxosStateLogMigrationState(namespaceAndUseCase, jdbi,
+                sharedLock);
         state.initialize();
         return state;
     }
 
     private void initialize() {
-        execute(Queries::createTable);
+        executeWrite(Queries::createTable);
     }
 
     public void migrateToValidationState() {
-        execute(migrateToState(States.VALIDATION));
+        executeWrite(migrateToState(States.VALIDATION));
     }
 
     public void migrateToMigratedState() {
-        execute(migrateToState(States.MIGRATED));
+        executeWrite(migrateToState(States.MIGRATED));
     }
 
     public boolean hasMigratedFromInitialState() {
-        return execute(dao -> dao.getVersion(namespace, useCase).isPresent());
+        return executeRead(dao -> dao.getVersion(namespace, useCase).isPresent());
     }
 
     public boolean isInValidationState() {
-        return execute(dao -> dao.getVersion(namespace, useCase)
+        return executeRead(dao -> dao.getVersion(namespace, useCase)
                 .map(States.VALIDATION.getSchemaVersion()::equals)
                 .orElse(false));
     }
 
     public boolean isInMigratedState() {
-        return execute(dao -> dao.getVersion(namespace, useCase)
+        return executeRead(dao -> dao.getVersion(namespace, useCase)
                 .map(States.MIGRATED.getSchemaVersion()::equals)
                 .orElse(false));
+    }
+
+    private <T> T executeWrite(Function<Queries, T> call) {
+        sharedLock.writeLock().lock();
+        try {
+            return execute(call);
+        } finally {
+            sharedLock.writeLock().unlock();
+        }
+    }
+
+    private <T> T executeRead(Function<Queries, T> call) {
+        sharedLock.readLock().lock();
+        try {
+            return execute(call);
+        } finally {
+            sharedLock.readLock().unlock();
+        }
     }
 
     private <T> T execute(Function<Queries, T> call) {

--- a/leader-election-impl/src/main/java/com/palantir/paxos/VerifyingPaxosStateLog.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/VerifyingPaxosStateLog.java
@@ -18,6 +18,8 @@ package com.palantir.paxos;
 
 import java.io.IOException;
 import java.sql.Connection;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -80,7 +82,14 @@ public final class VerifyingPaxosStateLog<V extends Persistable & Versionable> i
                 .hydrator(settings.hydrator())
                 .migrationState(sqliteFactory.createMigrationState(namespaceUseCase, conn))
                 .build();
+
+        Instant start = Instant.now();
+        log.info("Starting migration for namespace and use case {}.",
+                SafeArg.of("namespaceAndUseCase", parameters.namespaceAndUseCase()));
         PaxosStateLogMigrator.migrateToValidation(migrationContext);
+        log.info("Migration for namespace and use case {} took {}.",
+                SafeArg.of("namespaceAndUseCase", parameters.namespaceAndUseCase()),
+                SafeArg.of("duration", Duration.between(start, Instant.now())));
 
         return new VerifyingPaxosStateLog<>(settings);
     }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/VerifyingPaxosStateLog.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/VerifyingPaxosStateLog.java
@@ -60,7 +60,7 @@ public final class VerifyingPaxosStateLog<V extends Persistable & Versionable> i
 
     public static <V extends Persistable & Versionable> PaxosStateLog<V> createWithMigration(
             PaxosStorageParameters parameters,
-            SqlitePaxosStateLog.SqlitePaxosStateLogFactory sqliteFactory,
+            SqlitePaxosStateLogFactory sqliteFactory,
             Persistable.Hydrator<V> hydrator) {
         String logDirectory = parameters.fileBasedLogDirectory()
                 .orElseThrow(() -> new SafeIllegalStateException("We currently need to have file-based storage"));
@@ -78,7 +78,7 @@ public final class VerifyingPaxosStateLog<V extends Persistable & Versionable> i
                 .sourceLog(settings.currentLog())
                 .destinationLog(settings.experimentalLog())
                 .hydrator(settings.hydrator())
-                .migrationState(SqlitePaxosStateLogMigrationState.create(namespaceUseCase, conn))
+                .migrationState(sqliteFactory.createMigrationState(namespaceUseCase, conn))
                 .build();
         PaxosStateLogMigrator.migrateToValidation(migrationContext);
 

--- a/leader-election-impl/src/main/java/com/palantir/paxos/VerifyingPaxosStateLog.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/VerifyingPaxosStateLog.java
@@ -60,6 +60,7 @@ public final class VerifyingPaxosStateLog<V extends Persistable & Versionable> i
 
     public static <V extends Persistable & Versionable> PaxosStateLog<V> createWithMigration(
             PaxosStorageParameters parameters,
+            SqlitePaxosStateLog.SqlitePaxosStateLogFactory sqliteFactory,
             Persistable.Hydrator<V> hydrator) {
         String logDirectory = parameters.fileBasedLogDirectory()
                 .orElseThrow(() -> new SafeIllegalStateException("We currently need to have file-based storage"));
@@ -69,7 +70,7 @@ public final class VerifyingPaxosStateLog<V extends Persistable & Versionable> i
 
         Settings<V> settings = ImmutableSettings.<V>builder()
                 .currentLog(new PaxosStateLogImpl<>(logDirectory))
-                .experimentalLog(SqlitePaxosStateLog.create(namespaceUseCase, conn))
+                .experimentalLog(sqliteFactory.create(namespaceUseCase, conn))
                 .hydrator(hydrator)
                 .build();
 

--- a/leader-election-impl/src/main/java/com/palantir/paxos/VerifyingPaxosStateLog.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/VerifyingPaxosStateLog.java
@@ -17,11 +17,13 @@
 package com.palantir.paxos;
 
 import java.io.IOException;
+import java.sql.Connection;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.immutables.value.Value;
 import org.slf4j.Logger;
@@ -31,6 +33,7 @@ import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.common.persist.Persistable;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 
 /**
  * This implementation of {@link PaxosStateLog} uses one delegate as the source of truth, but also delegates all calls
@@ -53,6 +56,32 @@ public final class VerifyingPaxosStateLog<V extends Persistable & Versionable> i
         this.currentLog = settings.currentLog();
         this.experimentalLog = settings.experimentalLog();
         this.hydrator = settings.hydrator();
+    }
+
+    public static <V extends Persistable & Versionable> PaxosStateLog<V> createWithMigration(
+            PaxosStorageParameters parameters,
+            Persistable.Hydrator<V> hydrator) {
+        String logDirectory = parameters.fileBasedLogDirectory()
+                .orElseThrow(() -> new SafeIllegalStateException("We currently need to have file-based storage"));
+        Supplier<Connection> conn = SqliteConnections
+                .createDefaultNamedSqliteDatabaseAtPath(parameters.sqliteBasedLogDirectory());
+        NamespaceAndUseCase namespaceUseCase = parameters.namespaceAndUseCase();
+
+        Settings<V> settings = ImmutableSettings.<V>builder()
+                .currentLog(new PaxosStateLogImpl<>(logDirectory))
+                .experimentalLog(SqlitePaxosStateLog.create(namespaceUseCase, conn))
+                .hydrator(hydrator)
+                .build();
+
+        PaxosStateLogMigrator.MigrationContext<V> migrationContext = ImmutableMigrationContext.<V>builder()
+                .sourceLog(settings.currentLog())
+                .destinationLog(settings.experimentalLog())
+                .hydrator(settings.hydrator())
+                .migrationState(SqlitePaxosStateLogMigrationState.create(namespaceUseCase, conn))
+                .build();
+        PaxosStateLogMigrator.migrateToValidation(migrationContext);
+
+        return new VerifyingPaxosStateLog<>(settings);
     }
 
     @Override
@@ -137,7 +166,7 @@ public final class VerifyingPaxosStateLog<V extends Persistable & Versionable> i
         try {
             Long result = extractor.apply(currentLog);
             Long experimentalResult = safeReadFromExperimental(extractor::apply);
-            if (!Objects.equals(result, experimentalResult)) {
+            if (!Objects.equals(result, experimentalResult) && result != PaxosAcceptor.NO_LOG_ENTRY) {
                 log.error("Mismatch in getting the extreme log entry between legacy and current implementations."
                                 + " Legacy result {}, current result {}.",
                         SafeArg.of("legacy", result),

--- a/leader-election-impl/src/test/java/com/palantir/paxos/FileToSqlitePaxosStateLogIntegrationTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/FileToSqlitePaxosStateLogIntegrationTest.java
@@ -47,8 +47,8 @@ public class FileToSqlitePaxosStateLogIntegrationTest {
         source = new PaxosStateLogImpl<>(tempFolder.newFolder("source").getPath());
         Supplier<Connection> targetConnSupplier = SqliteConnections
                 .createDefaultNamedSqliteDatabaseAtPath(tempFolder.newFolder("target").toPath());
-        target = SqlitePaxosStateLog.createFactory().create(NAMESPACE, targetConnSupplier);
-        migrationState = SqlitePaxosStateLogMigrationState.create(NAMESPACE, targetConnSupplier);
+        target = new SqlitePaxosStateLogFactory().create(NAMESPACE, targetConnSupplier);
+        migrationState = new SqlitePaxosStateLogFactory().createMigrationState(NAMESPACE, targetConnSupplier);
     }
 
     @Test

--- a/leader-election-impl/src/test/java/com/palantir/paxos/FileToSqlitePaxosStateLogIntegrationTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/FileToSqlitePaxosStateLogIntegrationTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import static com.palantir.paxos.PaxosStateLogTestUtils.NAMESPACE;
 import static com.palantir.paxos.PaxosStateLogTestUtils.generateRounds;
-import static com.palantir.paxos.PaxosStateLogTestUtils.readRoundUnchecked;
+import static com.palantir.paxos.PaxosStateLogTestUtils.getPaxosValue;
 
 import java.io.IOException;
 import java.sql.Connection;
@@ -90,7 +90,7 @@ public class FileToSqlitePaxosStateLogIntegrationTest {
     }
 
     private void migrate() {
-        PaxosStateLogMigrator.migrate(ImmutableMigrationContext.<PaxosValue>builder()
+        PaxosStateLogMigrator.migrateToValidation(ImmutableMigrationContext.<PaxosValue>builder()
                 .sourceLog(source)
                 .destinationLog(target)
                 .hydrator(PaxosValue.BYTES_HYDRATOR)
@@ -100,7 +100,7 @@ public class FileToSqlitePaxosStateLogIntegrationTest {
 
     private List<PaxosValue> readMigratedValuesFor(List<PaxosValue> values) {
         return values.stream()
-                .map(value -> PaxosValue.BYTES_HYDRATOR.hydrateFromBytes(readRoundUnchecked(target, value.seq)))
+                .map(value -> getPaxosValue(target, value.seq))
                 .collect(Collectors.toList());
     }
 }

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosConsensusTestUtils.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosConsensusTestUtils.java
@@ -59,18 +59,20 @@ public final class PaxosConsensusTestUtils {
         ExecutorService executor = PTExecutors.newCachedThreadPool();
 
         RuntimeException exception = new SafeRuntimeException("mock server failure");
+        SqlitePaxosStateLog.SqlitePaxosStateLogFactory factory = SqlitePaxosStateLog.createFactory();
         for (int i = 0; i < numLeaders; i++) {
             failureToggles.add(new AtomicBoolean(false));
 
             PaxosLearner learner = PaxosLearnerImpl
-                    .newVerifyingLearner(getLearnerStorageParameters(i), PaxosKnowledgeEventRecorder.NO_OP);
+                    .newVerifyingLearner(getLearnerStorageParameters(i), factory, PaxosKnowledgeEventRecorder.NO_OP);
             learners.add(ToggleableExceptionProxy.newProxyInstance(
                     PaxosLearner.class,
                     learner,
                     failureToggles.get(i),
                     exception));
 
-            PaxosAcceptor acceptor = PaxosAcceptorImpl.newVerifyingAcceptor(getAcceptorStorageParameters(i));
+            PaxosAcceptor acceptor = PaxosAcceptorImpl.newVerifyingAcceptor(getAcceptorStorageParameters(i),
+                    factory);
             acceptors.add(ToggleableExceptionProxy.newProxyInstance(
                     PaxosAcceptor.class,
                     acceptor,

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosConsensusTestUtils.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosConsensusTestUtils.java
@@ -16,6 +16,8 @@
 package com.palantir.paxos;
 
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
@@ -32,6 +34,7 @@ import com.google.common.collect.Maps;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.leader.LeaderElectionService;
 import com.palantir.leader.LeaderElectionServiceBuilder;
+import com.palantir.leader.PaxosKnowledgeEventRecorder;
 import com.palantir.leader.proxy.SimulatingFailingServerProxy;
 import com.palantir.leader.proxy.ToggleableExceptionProxy;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
@@ -59,14 +62,15 @@ public final class PaxosConsensusTestUtils {
         for (int i = 0; i < numLeaders; i++) {
             failureToggles.add(new AtomicBoolean(false));
 
-            PaxosLearner learner = PaxosLearnerImpl.newLearner(getLearnerLogDir(i));
+            PaxosLearner learner = PaxosLearnerImpl
+                    .newVerifyingLearner(getLearnerStorageParameters(i), PaxosKnowledgeEventRecorder.NO_OP);
             learners.add(ToggleableExceptionProxy.newProxyInstance(
                     PaxosLearner.class,
                     learner,
                     failureToggles.get(i),
                     exception));
 
-            PaxosAcceptor acceptor = PaxosAcceptorImpl.newAcceptor(getAcceptorLogDir(i));
+            PaxosAcceptor acceptor = PaxosAcceptorImpl.newVerifyingAcceptor(getAcceptorStorageParameters(i));
             acceptors.add(ToggleableExceptionProxy.newProxyInstance(
                     PaxosAcceptor.class,
                     acceptor,
@@ -124,11 +128,31 @@ public final class PaxosConsensusTestUtils {
         }
     }
 
+    private static PaxosStorageParameters getLearnerStorageParameters(int num) {
+        return ImmutablePaxosStorageParameters.builder()
+                .fileBasedLogDirectory(getLearnerLogDir(num))
+                .sqliteBasedLogDirectory(getSqlitePath())
+                .namespaceAndUseCase(ImmutableNamespaceAndUseCase.of(Client.of(Integer.toString(num)), "learner"))
+                .build();
+    }
+
+    private static PaxosStorageParameters getAcceptorStorageParameters(int num) {
+        return ImmutablePaxosStorageParameters.builder()
+                .fileBasedLogDirectory(getAcceptorLogDir(num))
+                .sqliteBasedLogDirectory(getSqlitePath())
+                .namespaceAndUseCase(ImmutableNamespaceAndUseCase.of(Client.of(Integer.toString(num)), "acceptor"))
+                .build();
+    }
+
     private static String getLearnerLogDir(int dir) {
         return LEARNER_DIR_PREFIX + dir;
     }
 
     private static String getAcceptorLogDir(int dir) {
         return ACCEPTOR_DIR_PREFIX + dir;
+    }
+
+    private static Path getSqlitePath() {
+        return Paths.get(LOG_DIR, "sqlite");
     }
 }

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosConsensusTestUtils.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosConsensusTestUtils.java
@@ -59,7 +59,7 @@ public final class PaxosConsensusTestUtils {
         ExecutorService executor = PTExecutors.newCachedThreadPool();
 
         RuntimeException exception = new SafeRuntimeException("mock server failure");
-        SqlitePaxosStateLog.SqlitePaxosStateLogFactory factory = SqlitePaxosStateLog.createFactory();
+        SqlitePaxosStateLogFactory factory = new SqlitePaxosStateLogFactory();
         for (int i = 0; i < numLeaders; i++) {
             failureToggles.add(new AtomicBoolean(false));
 

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosStateLogMigratorTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosStateLogMigratorTest.java
@@ -54,9 +54,10 @@ public class PaxosStateLogMigratorTest {
                 .createDefaultNamedSqliteDatabaseAtPath(tempFolder.newFolder("source").toPath());
         Supplier<Connection> targetConnSupplier = SqliteConnections
                 .createDefaultNamedSqliteDatabaseAtPath(tempFolder.newFolder("target").toPath());
-        source = SqlitePaxosStateLog.createFactory().create(NAMESPACE, sourceConnSupplier);
-        target = SqlitePaxosStateLog.createFactory().create(NAMESPACE, targetConnSupplier);
-        migrationState = SqlitePaxosStateLogMigrationState.create(NAMESPACE, targetConnSupplier);
+        SqlitePaxosStateLogFactory factory = new SqlitePaxosStateLogFactory();
+        source = factory.create(NAMESPACE, sourceConnSupplier);
+        target = factory.create(NAMESPACE, targetConnSupplier);
+        migrationState = factory.createMigrationState(NAMESPACE, targetConnSupplier);
     }
 
     @Test

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosStateLogMigratorTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosStateLogMigratorTest.java
@@ -23,11 +23,13 @@ import static org.mockito.Mockito.when;
 
 import static com.palantir.paxos.PaxosStateLogMigrator.BATCH_SIZE;
 import static com.palantir.paxos.PaxosStateLogTestUtils.NAMESPACE;
+import static com.palantir.paxos.PaxosStateLogTestUtils.getPaxosValue;
 import static com.palantir.paxos.PaxosStateLogTestUtils.readRoundUnchecked;
 import static com.palantir.paxos.PaxosStateLogTestUtils.valueForRound;
 
 import java.io.IOException;
 import java.sql.Connection;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -74,9 +76,7 @@ public class PaxosStateLogMigratorTest {
         assertThat(target.getLeastLogEntry()).isEqualTo(lowerBound);
         assertThat(target.getGreatestLogEntry()).isEqualTo(upperBound);
 
-        valuesWritten.forEach(value ->
-                assertThat(PaxosValue.BYTES_HYDRATOR.hydrateFromBytes(readRoundUnchecked(target, value.seq)))
-                        .isEqualTo(value));
+        valuesWritten.forEach(value -> assertThat(getPaxosValue(target, value.seq)).isEqualTo(value));
     }
 
     @Test
@@ -93,19 +93,44 @@ public class PaxosStateLogMigratorTest {
     }
 
     @Test
-    public void doNotMigrateIfAlreadyMigrated() {
-        migrationState.migrateToValidationState();
+    public void doNotMigrateIfAlreadyMigratedAndNoMismatchDetected() {
+        long lowerBound = 10;
+        long upperBound = 25;
+        List<PaxosValue> expectedValues = insertValuesWithinBounds(lowerBound, upperBound, source);
 
-        long lowerBound = 1;
-        long upperBound = 22;
-        List<PaxosValue> valuesWritten = insertValuesWithinBounds(lowerBound, upperBound, source);
+        migrateFrom(source);
+        assertThat(migrationState.hasMigratedFromInitialState()).isTrue();
+        assertThat(target.getLeastLogEntry()).isEqualTo(lowerBound);
+        assertThat(target.getGreatestLogEntry()).isEqualTo(upperBound);
+
+        List<PaxosValue> unExpectedValues = insertValuesWithinBounds(1, 2, source);
+        migrateFrom(source);
+
+        assertThat(target.getLeastLogEntry()).isNotEqualTo(source.getLeastLogEntry());
+        expectedValues.forEach(value -> assertThat(getPaxosValue(target, value.seq)).isEqualTo(value));
+        unExpectedValues.forEach(value -> assertThat(readRoundUnchecked(target, value.seq)).isNull());
+    }
+
+    @Test
+    public void migrateAgainIfMismatchDetected() {
+        long lowerBound = 10;
+        long upperBound = 25;
+        List<PaxosValue> valuesWritten = new ArrayList<>();
+        valuesWritten.addAll(insertValuesWithinBounds(lowerBound, upperBound, source));
+
+        migrateFrom(source);
+        assertThat(migrationState.hasMigratedFromInitialState()).isTrue();
+        assertThat(target.getLeastLogEntry()).isEqualTo(lowerBound);
+        assertThat(target.getGreatestLogEntry()).isEqualTo(upperBound);
+
+        valuesWritten.addAll(insertValuesWithinBounds(1, 2, source));
+        valuesWritten.addAll(insertValuesWithinBounds(28, 30, source));
 
         migrateFrom(source);
 
-        assertThat(migrationState.hasMigratedFromInitialState()).isTrue();
-        assertThat(target.getLeastLogEntry()).isEqualTo(PaxosAcceptor.NO_LOG_ENTRY);
-        assertThat(target.getGreatestLogEntry()).isEqualTo(PaxosAcceptor.NO_LOG_ENTRY);
-        valuesWritten.forEach(value -> assertThat(readRoundUnchecked(target, value.seq)).isNull());
+        assertThat(target.getLeastLogEntry()).isEqualTo(source.getLeastLogEntry());
+        assertThat(target.getGreatestLogEntry()).isEqualTo(source.getGreatestLogEntry());
+        valuesWritten.forEach(value -> assertThat(getPaxosValue(target, value.seq)).isEqualTo(value));
     }
 
     @Test
@@ -136,7 +161,7 @@ public class PaxosStateLogMigratorTest {
     }
 
     private void migrateFrom(PaxosStateLog<PaxosValue> sourceLog) {
-        PaxosStateLogMigrator.migrate(ImmutableMigrationContext.<PaxosValue>builder()
+        PaxosStateLogMigrator.migrateToValidation(ImmutableMigrationContext.<PaxosValue>builder()
                 .sourceLog(sourceLog)
                 .destinationLog(target)
                 .hydrator(PaxosValue.BYTES_HYDRATOR)

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosStateLogTestUtils.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosStateLogTestUtils.java
@@ -52,6 +52,10 @@ public final class PaxosStateLogTestUtils {
         return buffer.array();
     }
 
+    public static PaxosValue getPaxosValue(PaxosStateLog<PaxosValue> log, long seq) {
+        return PaxosValue.BYTES_HYDRATOR.hydrateFromBytes(readRoundUnchecked(log, seq));
+    }
+
     public static byte[] readRoundUnchecked(PaxosStateLog<?> log, long seq) {
         try {
             return log.readRound(seq);

--- a/leader-election-impl/src/test/java/com/palantir/paxos/SqlitePaxosStateLogMigrationStateTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/SqlitePaxosStateLogMigrationStateTest.java
@@ -41,7 +41,7 @@ public class SqlitePaxosStateLogMigrationStateTest {
     public void setup() {
         connSupplier = SqliteConnections
                 .createDefaultNamedSqliteDatabaseAtPath(tempFolder.getRoot().toPath());
-        migrationState = SqlitePaxosStateLogMigrationState.create(NAMESPACE_AND_USE_CASE, connSupplier);
+        migrationState = new SqlitePaxosStateLogFactory().createMigrationState(NAMESPACE_AND_USE_CASE, connSupplier);
     }
 
     @Test
@@ -88,8 +88,8 @@ public class SqlitePaxosStateLogMigrationStateTest {
     public void finishingMigrationForOneNamespaceDoesNotSetFlagForOthers() {
         migrationState.migrateToValidationState();
 
-        SqlitePaxosStateLogMigrationState otherState = SqlitePaxosStateLogMigrationState
-                .create(ImmutableNamespaceAndUseCase.of(Client.of("other"), "useCase"), connSupplier);
+        SqlitePaxosStateLogMigrationState otherState = new SqlitePaxosStateLogFactory().createMigrationState(
+                ImmutableNamespaceAndUseCase.of(Client.of("other"), "useCase"), connSupplier);
         assertThat(otherState.hasMigratedFromInitialState()).isFalse();
         otherState.migrateToValidationState();
         assertThat(otherState.hasMigratedFromInitialState()).isTrue();
@@ -99,8 +99,8 @@ public class SqlitePaxosStateLogMigrationStateTest {
     public void finishingMigrationForOneUseCaseDoesNotSetFlagForOthers() {
         migrationState.migrateToValidationState();
 
-        SqlitePaxosStateLogMigrationState otherState = SqlitePaxosStateLogMigrationState
-                .create(ImmutableNamespaceAndUseCase.of(Client.of("namespace"), "other"), connSupplier);
+        SqlitePaxosStateLogMigrationState otherState = new SqlitePaxosStateLogFactory().createMigrationState(
+                ImmutableNamespaceAndUseCase.of(Client.of("namespace"), "other"), connSupplier);
         assertThat(otherState.hasMigratedFromInitialState()).isFalse();
         otherState.migrateToValidationState();
         assertThat(otherState.hasMigratedFromInitialState()).isTrue();

--- a/leader-election-impl/src/test/java/com/palantir/paxos/SqlitePaxosStateLogMigrationStateTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/SqlitePaxosStateLogMigrationStateTest.java
@@ -17,6 +17,7 @@
 package com.palantir.paxos;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.sql.Connection;
 import java.util.function.Supplier;
@@ -67,18 +68,20 @@ public class SqlitePaxosStateLogMigrationStateTest {
     }
 
     @Test
-    public void canChangeStates() {
+    public void canProgressThroughAndRepeatMigrationStates() {
         migrationState.migrateToValidationState();
         migrationState.migrateToMigratedState();
         migrationState.migrateToMigratedState();
         assertThat(migrationState.hasMigratedFromInitialState()).isTrue();
         assertThat(migrationState.isInValidationState()).isFalse();
         assertThat(migrationState.isInMigratedState()).isTrue();
+    }
 
+    @Test
+    public void cannotRegressToLowerMigrationState() {
         migrationState.migrateToValidationState();
-        assertThat(migrationState.hasMigratedFromInitialState()).isTrue();
-        assertThat(migrationState.isInValidationState()).isTrue();
-        assertThat(migrationState.isInMigratedState()).isFalse();
+        migrationState.migrateToMigratedState();
+        assertThatThrownBy(migrationState::migrateToValidationState).isInstanceOf(IllegalStateException.class);
     }
 
     @Test

--- a/leader-election-impl/src/test/java/com/palantir/paxos/SqlitePaxosStateLogTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/SqlitePaxosStateLogTest.java
@@ -43,7 +43,7 @@ import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.common.streams.KeyedStream;
 
 public class SqlitePaxosStateLogTest {
-    private static final SqlitePaxosStateLog.SqlitePaxosStateLogFactory FACTORY = SqlitePaxosStateLog.createFactory();
+    private static final SqlitePaxosStateLogFactory FACTORY = new SqlitePaxosStateLogFactory();
 
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipContextFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipContextFactory.java
@@ -57,6 +57,7 @@ public abstract class LeadershipContextFactory implements
                 metrics(),
                 useCase(),
                 install().dataDirectory(),
+                install().sqliteDataDirectory(),
                 leaderUuid(),
                 install().install().paxos().canCreateNewClients());
     }

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResourcesFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResourcesFactory.java
@@ -186,6 +186,7 @@ public final class PaxosResourcesFactory {
                 timelockMetrics,
                 PaxosUseCase.TIMESTAMP,
                 install.dataDirectory(),
+                install.sqliteDataDirectory(),
                 install.nodeUuid(),
                 install.install().paxos().canCreateNewClients());
 
@@ -289,6 +290,11 @@ public final class PaxosResourcesFactory {
         @Value.Derived
         default Path dataDirectory() {
             return install().paxos().dataDirectory().toPath();
+        }
+
+        @Value.Derived
+        default Path sqliteDataDirectory() {
+            return install().paxos().sqlitePersistence().dataDirectory().toPath();
         }
 
         @Value.Derived

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponents.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponents.java
@@ -23,6 +23,7 @@ import java.util.function.Supplier;
 
 import org.immutables.value.Value;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.Maps;
 import com.palantir.common.remoting.ServiceNotAvailableException;
@@ -30,17 +31,20 @@ import com.palantir.leader.LocalPingableLeader;
 import com.palantir.leader.PaxosKnowledgeEventRecorder;
 import com.palantir.leader.PingableLeader;
 import com.palantir.paxos.Client;
+import com.palantir.paxos.ImmutableNamespaceAndUseCase;
 import com.palantir.paxos.ImmutablePaxosStorageParameters;
 import com.palantir.paxos.PaxosAcceptor;
 import com.palantir.paxos.PaxosAcceptorImpl;
 import com.palantir.paxos.PaxosLearner;
 import com.palantir.paxos.PaxosLearnerImpl;
+import com.palantir.paxos.PaxosStorageParameters;
 
 public class LocalPaxosComponents {
 
     private final TimelockPaxosMetrics metrics;
     private final PaxosUseCase paxosUseCase;
     private final Path baseLogDirectory;
+    private final Path sqliteLogDirectory;
     private final UUID leaderUuid;
     private final Map<Client, Components> componentsByClient = Maps.newConcurrentMap();
     private final Supplier<BatchPaxosAcceptor> memoizedBatchAcceptor;
@@ -50,12 +54,14 @@ public class LocalPaxosComponents {
 
     LocalPaxosComponents(TimelockPaxosMetrics metrics,
             PaxosUseCase paxosUseCase,
-            Path baseLogDirectory,
+            Path legacyLogDirectory,
+            Path sqliteLogDirectory,
             UUID leaderUuid,
             boolean canCreateNewClients) {
         this.metrics = metrics;
         this.paxosUseCase = paxosUseCase;
-        this.baseLogDirectory = baseLogDirectory;
+        this.baseLogDirectory = legacyLogDirectory;
+        this.sqliteLogDirectory = sqliteLogDirectory;
         this.leaderUuid = leaderUuid;
         this.memoizedBatchAcceptor = Suppliers.memoize(this::createBatchAcceptor);
         this.memoizedBatchLearner = Suppliers.memoize(this::createBatchLearner);
@@ -92,41 +98,48 @@ public class LocalPaxosComponents {
     }
 
     private Components createComponents(Client client) {
-        Path clientDirectory = paxosUseCase.logDirectoryRelativeToDataDirectory(baseLogDirectory)
+        Path legacyClientDir = paxosUseCase.logDirectoryRelativeToDataDirectory(baseLogDirectory)
                 .resolve(client.value());
 
         // TODO (jkong): This test is no longer valid with the new implementation, it needs to be fixed before
         // the migration.
-        if (!canCreateNewClients && clientDirectoryDoesNotExist(clientDirectory)) {
+        if (!canCreateNewClients && clientDirectoryDoesNotExist(legacyClientDir)) {
             throw new ServiceNotAvailableException("This TimeLock server is not allowed to create new clients at this"
                     + " time, and the client " + client + " provided is novel for this TimeLock server.");
         }
 
-        Path learnerLogDir = Paths.get(clientDirectory.toString(), PaxosTimeLockConstants.LEARNER_SUBDIRECTORY_PATH);
-        String learnerNamespace = String.format("%s!%s!learner", paxosUseCase.toString(), client);
-
-        PaxosLearner learner = PaxosLearnerImpl.newLearner(
-                ImmutablePaxosStorageParameters.builder()
-                        .fileBasedLogDirectory(learnerLogDir.toString())
-                        .databaseNamespace(learnerNamespace)
-                        .build(),
+        PaxosLearner learner = PaxosLearnerImpl.newVerifyingLearner(getLearnerParameters(client),
                 PaxosKnowledgeEventRecorder.NO_OP);
-
-        Path acceptorLogDir = Paths.get(clientDirectory.toString(), PaxosTimeLockConstants.ACCEPTOR_SUBDIRECTORY_PATH);
-        String acceptorNamespace = String.format("%s!%s!acceptor", paxosUseCase.toString(), client);
-
-        PaxosAcceptor acceptor = PaxosAcceptorImpl.newAcceptor(
-                ImmutablePaxosStorageParameters.builder()
-                        .fileBasedLogDirectory(acceptorLogDir.toString())
-                        .databaseNamespace(acceptorNamespace)
-                        .build());
-
+        PaxosAcceptor acceptor = PaxosAcceptorImpl.newVerifyingAcceptor(getAcceptorParameters(client));
         PingableLeader localPingableLeader = new LocalPingableLeader(learner, leaderUuid);
 
         return ImmutableComponents.builder()
                 .acceptor(acceptor)
                 .learner(learner)
                 .pingableLeader(localPingableLeader)
+                .build();
+    }
+
+    @VisibleForTesting
+    PaxosStorageParameters getLearnerParameters(Client client) {
+        Path legacyDir = paxosUseCase.logDirectoryRelativeToDataDirectory(baseLogDirectory).resolve(client.value());
+        Path learnerLogDir = Paths.get(legacyDir.toString(), PaxosTimeLockConstants.LEARNER_SUBDIRECTORY_PATH);
+        String learnerUseCase = String.format("%s!learner", paxosUseCase.toString());
+        return ImmutablePaxosStorageParameters.builder()
+                .fileBasedLogDirectory(learnerLogDir.toString())
+                .sqliteBasedLogDirectory(sqliteLogDirectory)
+                .namespaceAndUseCase(ImmutableNamespaceAndUseCase.of(client, learnerUseCase))
+                .build();
+    }
+
+    private PaxosStorageParameters getAcceptorParameters(Client client) {
+        Path legacyDir = paxosUseCase.logDirectoryRelativeToDataDirectory(baseLogDirectory).resolve(client.value());
+        Path acceptorLogDir = Paths.get(legacyDir.toString(), PaxosTimeLockConstants.ACCEPTOR_SUBDIRECTORY_PATH);
+        String acceptorUseCase = String.format("%s!acceptor", paxosUseCase.toString());
+        return ImmutablePaxosStorageParameters.builder()
+                .fileBasedLogDirectory(acceptorLogDir.toString())
+                .sqliteBasedLogDirectory(sqliteLogDirectory)
+                .namespaceAndUseCase(ImmutableNamespaceAndUseCase.of(client, acceptorUseCase))
                 .build();
     }
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponents.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponents.java
@@ -38,6 +38,7 @@ import com.palantir.paxos.PaxosAcceptorImpl;
 import com.palantir.paxos.PaxosLearner;
 import com.palantir.paxos.PaxosLearnerImpl;
 import com.palantir.paxos.PaxosStorageParameters;
+import com.palantir.paxos.SqlitePaxosStateLog;
 
 public class LocalPaxosComponents {
 
@@ -51,6 +52,7 @@ public class LocalPaxosComponents {
     private final Supplier<BatchPaxosLearner> memoizedBatchLearner;
     private final Supplier<BatchPingableLeader> memoizedBatchPingableLeader;
     private final boolean canCreateNewClients;
+    private final SqlitePaxosStateLog.SqlitePaxosStateLogFactory sqliteFactory = SqlitePaxosStateLog.createFactory();
 
     LocalPaxosComponents(TimelockPaxosMetrics metrics,
             PaxosUseCase paxosUseCase,
@@ -108,9 +110,9 @@ public class LocalPaxosComponents {
                     + " time, and the client " + client + " provided is novel for this TimeLock server.");
         }
 
-        PaxosLearner learner = PaxosLearnerImpl.newVerifyingLearner(getLearnerParameters(client),
+        PaxosLearner learner = PaxosLearnerImpl.newVerifyingLearner(getLearnerParameters(client), sqliteFactory,
                 PaxosKnowledgeEventRecorder.NO_OP);
-        PaxosAcceptor acceptor = PaxosAcceptorImpl.newVerifyingAcceptor(getAcceptorParameters(client));
+        PaxosAcceptor acceptor = PaxosAcceptorImpl.newVerifyingAcceptor(getAcceptorParameters(client), sqliteFactory);
         PingableLeader localPingableLeader = new LocalPingableLeader(learner, leaderUuid);
 
         return ImmutableComponents.builder()

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponents.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponents.java
@@ -38,7 +38,7 @@ import com.palantir.paxos.PaxosAcceptorImpl;
 import com.palantir.paxos.PaxosLearner;
 import com.palantir.paxos.PaxosLearnerImpl;
 import com.palantir.paxos.PaxosStorageParameters;
-import com.palantir.paxos.SqlitePaxosStateLog;
+import com.palantir.paxos.SqlitePaxosStateLogFactory;
 
 public class LocalPaxosComponents {
 
@@ -52,7 +52,7 @@ public class LocalPaxosComponents {
     private final Supplier<BatchPaxosLearner> memoizedBatchLearner;
     private final Supplier<BatchPingableLeader> memoizedBatchPingableLeader;
     private final boolean canCreateNewClients;
-    private final SqlitePaxosStateLog.SqlitePaxosStateLogFactory sqliteFactory = SqlitePaxosStateLog.createFactory();
+    private final SqlitePaxosStateLogFactory sqliteFactory = new SqlitePaxosStateLogFactory();
 
     LocalPaxosComponents(TimelockPaxosMetrics metrics,
             PaxosUseCase paxosUseCase,

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/management/SqliteNamespaceLoaderTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/management/SqliteNamespaceLoaderTest.java
@@ -33,6 +33,7 @@ import com.palantir.paxos.ImmutableNamespaceAndUseCase;
 import com.palantir.paxos.PaxosValue;
 import com.palantir.paxos.SqliteConnections;
 import com.palantir.paxos.SqlitePaxosStateLog;
+import com.palantir.paxos.SqlitePaxosStateLogFactory;
 
 public class SqliteNamespaceLoaderTest {
     private static final Client NAMESPACE_1 = Client.of("eins");
@@ -77,7 +78,7 @@ public class SqliteNamespaceLoaderTest {
     }
 
     private void initializeLog(Client namespace, String sequenceId) {
-        SqlitePaxosStateLog.createFactory()
+        new SqlitePaxosStateLogFactory()
                 .create(ImmutableNamespaceAndUseCase.of(namespace, sequenceId), connectionSupplier)
                 .writeRound(1, PAXOS_VALUE);
     }

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponentsTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponentsTest.java
@@ -53,15 +53,18 @@ public class LocalPaxosComponentsTest {
     public final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
 
     private LocalPaxosComponents paxosComponents;
-    private Path logDirectory;
+    private Path legacyDirectory;
+    private Path sqliteDirectory;
 
     @Before
     public void setUp() throws IOException {
-        logDirectory = TEMPORARY_FOLDER.newFolder().toPath();
+        legacyDirectory = TEMPORARY_FOLDER.newFolder("legacy").toPath();
+        sqliteDirectory = TEMPORARY_FOLDER.newFolder("sqlite").toPath();
         paxosComponents = new LocalPaxosComponents(
                 TimelockPaxosMetrics.of(PaxosUseCase.TIMESTAMP, MetricsManagers.createForTests()),
                 PaxosUseCase.TIMESTAMP,
-                logDirectory,
+                legacyDirectory,
+                sqliteDirectory,
                 UUID.randomUUID(),
                 true);
     }
@@ -82,10 +85,10 @@ public class LocalPaxosComponentsTest {
     @Test
     public void addsClientsInSubdirectory() {
         paxosComponents.learner(CLIENT);
-        File expectedAcceptorLogDir = logDirectory.resolve(
+        File expectedAcceptorLogDir = legacyDirectory.resolve(
                 Paths.get(CLIENT.value(), PaxosTimeLockConstants.ACCEPTOR_SUBDIRECTORY_PATH)).toFile();
         assertThat(expectedAcceptorLogDir.exists()).isTrue();
-        File expectedLearnerLogDir = logDirectory.resolve(
+        File expectedLearnerLogDir = legacyDirectory.resolve(
                 Paths.get(CLIENT.value(), PaxosTimeLockConstants.LEARNER_SUBDIRECTORY_PATH)).toFile();
         assertThat(expectedLearnerLogDir.exists()).isTrue();
     }
@@ -95,7 +98,8 @@ public class LocalPaxosComponentsTest {
         LocalPaxosComponents rejectingComponents = new LocalPaxosComponents(
                 TimelockPaxosMetrics.of(PaxosUseCase.TIMESTAMP, MetricsManagers.createForTests()),
                 PaxosUseCase.TIMESTAMP,
-                logDirectory,
+                legacyDirectory,
+                sqliteDirectory,
                 UUID.randomUUID(),
                 false);
         assertThatThrownBy(() -> rejectingComponents.learner(CLIENT))
@@ -110,7 +114,8 @@ public class LocalPaxosComponentsTest {
         LocalPaxosComponents rejectingComponents = new LocalPaxosComponents(
                 TimelockPaxosMetrics.of(PaxosUseCase.TIMESTAMP, MetricsManagers.createForTests()),
                 PaxosUseCase.TIMESTAMP,
-                logDirectory,
+                legacyDirectory,
+                sqliteDirectory,
                 UUID.randomUUID(),
                 false);
         assertThat(rejectingComponents.learner(CLIENT)).isNotNull();

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosStateLogMigrationIntegrationTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosStateLogMigrationIntegrationTest.java
@@ -41,6 +41,7 @@ import com.palantir.paxos.PaxosStorageParameters;
 import com.palantir.paxos.PaxosValue;
 import com.palantir.paxos.SqliteConnections;
 import com.palantir.paxos.SqlitePaxosStateLog;
+import com.palantir.paxos.SqlitePaxosStateLogFactory;
 
 public class PaxosStateLogMigrationIntegrationTest {
     private static final Client CLIENT = Client.of("test");
@@ -217,6 +218,6 @@ public class PaxosStateLogMigrationIntegrationTest {
     private PaxosStateLog<PaxosValue> createSqliteLog(PaxosStorageParameters parameters) {
         Supplier<Connection> conn = SqliteConnections
                 .createDefaultNamedSqliteDatabaseAtPath(parameters.sqliteBasedLogDirectory());
-        return SqlitePaxosStateLog.createFactory().create(parameters.namespaceAndUseCase(), conn);
+        return new SqlitePaxosStateLogFactory().create(parameters.namespaceAndUseCase(), conn);
     }
 }

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosStateLogMigrationIntegrationTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosStateLogMigrationIntegrationTest.java
@@ -217,6 +217,6 @@ public class PaxosStateLogMigrationIntegrationTest {
     private PaxosStateLog<PaxosValue> createSqliteLog(PaxosStorageParameters parameters) {
         Supplier<Connection> conn = SqliteConnections
                 .createDefaultNamedSqliteDatabaseAtPath(parameters.sqliteBasedLogDirectory());
-        return SqlitePaxosStateLog.create(parameters.namespaceAndUseCase(), conn);
+        return SqlitePaxosStateLog.createFactory().create(parameters.namespaceAndUseCase(), conn);
     }
 }

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosStateLogMigrationIntegrationTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosStateLogMigrationIntegrationTest.java
@@ -1,0 +1,222 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.palantir.atlasdb.util.MetricsManagers;
+import com.palantir.paxos.Client;
+import com.palantir.paxos.ImmutableNamespaceAndUseCase;
+import com.palantir.paxos.ImmutablePaxosStorageParameters;
+import com.palantir.paxos.PaxosLearner;
+import com.palantir.paxos.PaxosStateLog;
+import com.palantir.paxos.PaxosStateLogImpl;
+import com.palantir.paxos.PaxosStorageParameters;
+import com.palantir.paxos.PaxosValue;
+import com.palantir.paxos.SqliteConnections;
+import com.palantir.paxos.SqlitePaxosStateLog;
+
+public class PaxosStateLogMigrationIntegrationTest {
+    private static final Client CLIENT = Client.of("test");
+
+    @Rule
+    public final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+    private LocalPaxosComponents paxosComponents;
+    private PaxosUseCase useCase = PaxosUseCase.LEADER_FOR_ALL_CLIENTS;
+    private Path legacyDirectory;
+    private Path sqliteDirectory;
+
+    @Before
+    public void setUp() throws IOException {
+        legacyDirectory = TEMPORARY_FOLDER.newFolder("legacy").toPath();
+        sqliteDirectory = TEMPORARY_FOLDER.newFolder("sqlite").toPath();
+        resetPaxosComponents();
+    }
+
+    @Test
+    public void learnerMigratesLogStateCorrectly() throws IOException {
+        int round = 100;
+        PaxosStateLog<PaxosValue> fileBasedLog = createFileSystemLog(CLIENT);
+        fileBasedLog.writeRound(round, valueForRound(round));
+
+        PaxosStorageParameters parameters = paxosComponents.getLearnerParameters(CLIENT);
+        PaxosLearner learner = paxosComponents.learner(CLIENT);
+        PaxosStateLog<PaxosValue> sqliteLog = createSqliteLog(parameters);
+
+        assertValuePresent(round, sqliteLog);
+        assertValueLearned(round, learner);
+    }
+
+    @Test
+    public void legacyLogIsTheSourceOfTruthWhenValueOnlyInLegacy() throws IOException {
+        int migratedRound = 100;
+        int nonMigratedRound = 200;
+        PaxosStateLog<PaxosValue> fileBasedLog = createFileSystemLog(CLIENT);
+        fileBasedLog.writeRound(migratedRound, valueForRound(migratedRound));
+
+        PaxosStorageParameters parameters = paxosComponents.getLearnerParameters(CLIENT);
+        PaxosLearner learner = paxosComponents.learner(CLIENT);
+        PaxosStateLog<PaxosValue> sqliteLog = createSqliteLog(parameters);
+
+        fileBasedLog.writeRound(nonMigratedRound, valueForRound(nonMigratedRound));
+
+        assertValueAbsent(nonMigratedRound, sqliteLog);
+        assertValuePresent(nonMigratedRound, fileBasedLog);
+        assertValueLearned(nonMigratedRound, learner);
+    }
+
+    @Test
+    public void legacyLogIsTheSourceOfTruthWhenValueAbsentFromLegacy() throws IOException {
+        int migratedRound = 100;
+        int rogueValue = 200;
+        PaxosStateLog<PaxosValue> fileBasedLog = createFileSystemLog(CLIENT);
+        fileBasedLog.writeRound(migratedRound, valueForRound(migratedRound));
+
+        PaxosStorageParameters parameters = paxosComponents.getLearnerParameters(CLIENT);
+        PaxosLearner learner = paxosComponents.learner(CLIENT);
+        PaxosStateLog<PaxosValue> sqliteLog = createSqliteLog(parameters);
+
+        sqliteLog.writeRound(rogueValue, valueForRound(rogueValue));
+
+        assertValuePresent(rogueValue, sqliteLog);
+        assertValueAbsent(rogueValue, fileBasedLog);
+        assertValueNotLearned(rogueValue, learner);
+    }
+
+    @Test
+    public void doesNotMigrateAgainIfGreatestSequencesMatch() throws IOException {
+        int firstRound = 100;
+        int secondRound = 200;
+        int nonMigratedRound = 150;
+        PaxosStateLog<PaxosValue> fileBasedLog = createFileSystemLog(CLIENT);
+        fileBasedLog.writeRound(firstRound, valueForRound(firstRound));
+        fileBasedLog.writeRound(secondRound, valueForRound(secondRound));
+
+        PaxosStorageParameters parameters = paxosComponents.getLearnerParameters(CLIENT);
+        paxosComponents.learner(CLIENT);
+        PaxosStateLog<PaxosValue> sqliteLog = createSqliteLog(parameters);
+
+        fileBasedLog.writeRound(nonMigratedRound, valueForRound(nonMigratedRound));
+
+        resetPaxosComponents();
+        PaxosLearner learner = paxosComponents.learner(CLIENT);
+
+        assertValuePresent(firstRound, sqliteLog);
+        assertValuePresent(secondRound, sqliteLog);
+        assertValueAbsent(nonMigratedRound, sqliteLog);
+        assertValueLearned(nonMigratedRound, learner);
+    }
+
+    @Test
+    public void migratesAgainIfOutOfSyncDetected() throws IOException {
+        int firstRound = 100;
+        int secondRound = 200;
+        PaxosStateLog<PaxosValue> fileBasedLog = createFileSystemLog(CLIENT);
+        fileBasedLog.writeRound(firstRound, valueForRound(firstRound));
+
+        PaxosStorageParameters parameters = paxosComponents.getLearnerParameters(CLIENT);
+        paxosComponents.learner(CLIENT);
+        PaxosStateLog<PaxosValue> sqliteLog = createSqliteLog(parameters);
+
+        fileBasedLog.writeRound(secondRound, valueForRound(secondRound));
+
+        resetPaxosComponents();
+        PaxosLearner learner = paxosComponents.learner(CLIENT);
+
+        assertValuePresent(secondRound, sqliteLog);
+        assertValueLearned(secondRound, learner);
+    }
+
+    @Test
+    public void noCrossClientPollution() throws IOException {
+        int round = 200;
+        int otherRound = 100;
+        PaxosStateLog<PaxosValue> fileBasedLog = createFileSystemLog(CLIENT);
+        fileBasedLog.writeRound(round, valueForRound(round));
+
+        PaxosLearner learner = paxosComponents.learner(CLIENT);
+
+        Client otherClient = Client.of("other");
+        PaxosStateLog<PaxosValue> otherFileBasedLog = createFileSystemLog(otherClient);
+        otherFileBasedLog.writeRound(otherRound, valueForRound(otherRound));
+
+        PaxosLearner otherLearner = paxosComponents.learner(otherClient);
+        PaxosStorageParameters otherParameters = paxosComponents.getLearnerParameters(otherClient);
+        PaxosStateLog<PaxosValue> otherSqliteLog = createSqliteLog(otherParameters);
+
+        assertValueAbsent(round, otherSqliteLog);
+        assertValuePresent(otherRound, otherSqliteLog);
+        assertValueLearned(round, learner);
+        assertValueNotLearned(otherRound, learner);
+        assertValueNotLearned(round, otherLearner);
+        assertValueLearned(otherRound, otherLearner);
+    }
+
+    private void assertValueLearned(int round, PaxosLearner learner) {
+        assertThat(learner.getLearnedValue(round)).hasValue(valueForRound(round));
+    }
+
+    private void assertValueNotLearned(int round, PaxosLearner learner) {
+        assertThat(learner.getLearnedValue(round)).isEmpty();
+    }
+
+    private void assertValuePresent(int round, PaxosStateLog<PaxosValue> sqliteLog) throws IOException {
+        assertThat(PaxosValue.BYTES_HYDRATOR.hydrateFromBytes(sqliteLog.readRound(round)))
+                .isEqualTo(valueForRound(round));
+    }
+
+    private void assertValueAbsent(int round, PaxosStateLog<PaxosValue> sqliteLog) throws IOException {
+        assertThat(sqliteLog.readRound(round)).isNull();
+    }
+
+    private void resetPaxosComponents() {
+        paxosComponents = new LocalPaxosComponents(
+                TimelockPaxosMetrics.of(useCase, MetricsManagers.createForTests()),
+                useCase,
+                legacyDirectory,
+                sqliteDirectory, UUID.randomUUID(), true);
+    }
+
+    private PaxosValue valueForRound(int num) {
+        return new PaxosValue("value", num, new byte[] { 1 });
+    }
+
+    private PaxosStateLog<PaxosValue> createFileSystemLog(Client client) {
+        Path dir = useCase.logDirectoryRelativeToDataDirectory(legacyDirectory).resolve(client.value());
+        String learnerLogDir = dir.resolve(PaxosTimeLockConstants.LEARNER_SUBDIRECTORY_PATH).toString();
+        return new PaxosStateLogImpl<>(learnerLogDir);
+    }
+
+    private PaxosStateLog<PaxosValue> createSqliteLog(PaxosStorageParameters parameters) {
+        Supplier<Connection> conn = SqliteConnections
+                .createDefaultNamedSqliteDatabaseAtPath(parameters.sqliteBasedLogDirectory());
+        return SqlitePaxosStateLog.create(parameters.namespaceAndUseCase(), conn);
+    }
+}

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
@@ -112,7 +112,8 @@ public class PaxosTimestampBoundStoreTest {
             LocalPaxosComponents components = new LocalPaxosComponents(
                     TimelockPaxosMetrics.of(PaxosUseCase.TIMESTAMP, MetricsManagers.createForTests()),
                     PaxosUseCase.TIMESTAMP,
-                    Paths.get(root, Integer.toString(i)),
+                    Paths.get(root, i + "legacy"),
+                    Paths.get(root, i + "sqlite"),
                     UUID.randomUUID(),
                     true);
 


### PR DESCRIPTION
**Goals (and why)**:
Now that we have locking, we can go ahead with the migration plans

**Implementation Description (bullets)**:
Revert previous revert and wire in the locking mechanism

**Testing (What was existing testing like?  What have you done to improve it?)**:
Existing tests pass

**Concerns (what feedback would you like?)**:
We are not locking in the migration state class. Doesn't seem necessary since we almost never write there, but we can add it if it's valuable

**Where should we start reviewing?**:
The revert is pretty straightforward, so mostly make sure nothing is strange and that the latest commit makes sense

**Priority (whenever / two weeks / yesterday)**:
Today, after the other PR