### PR TITLE
Always send full last known version, including id.

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManager.java
@@ -16,6 +16,7 @@
 
 package com.palantir.atlasdb.keyvalue.api.watch;
 
+import java.util.Optional;
 import java.util.Set;
 
 import com.palantir.common.annotation.Idempotent;
@@ -36,5 +37,6 @@ public interface LockWatchManager {
      * @param startTimestamps a set of start timestamps identifying transactions
      * @param lastKnownVersion exclusive start version to get events from
      */
-    TransactionsLockWatchEvents getEventsForTransactions(Set<Long> startTimestamps, IdentifiedVersion lastKnownVersion);
+    TransactionsLockWatchEvents getEventsForTransactions(Set<Long> startTimestamps,
+            Optional<IdentifiedVersion> lastKnownVersion);
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerImpl.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerImpl.java
@@ -16,6 +16,7 @@
 
 package com.palantir.atlasdb.keyvalue.api.watch;
 
+import java.util.Optional;
 import java.util.Set;
 
 import com.palantir.atlasdb.timelock.api.LockWatchRequest;
@@ -40,7 +41,8 @@ public final class LockWatchManagerImpl implements LockWatchManager {
     }
 
     @Override
-    public TransactionsLockWatchEvents getEventsForTransactions(Set<Long> startTimestamps, IdentifiedVersion version) {
+    public TransactionsLockWatchEvents getEventsForTransactions(Set<Long> startTimestamps,
+            Optional<IdentifiedVersion> version) {
         return cache.getEventsForTransactions(startTimestamps, version);
     }
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/NoOpLockWatchManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/NoOpLockWatchManager.java
@@ -16,6 +16,7 @@
 
 package com.palantir.atlasdb.keyvalue.api.watch;
 
+import java.util.Optional;
 import java.util.Set;
 
 import com.palantir.lock.watch.IdentifiedVersion;
@@ -37,7 +38,7 @@ public final class NoOpLockWatchManager implements LockWatchManager {
 
     @Override
     public TransactionsLockWatchEvents getEventsForTransactions(Set<Long> startTimestamps,
-            IdentifiedVersion lastKnownVersion) {
+            Optional<IdentifiedVersion> lastKnownVersion) {
         return NoOpLockWatchEventCache.INSTANCE.getEventsForTransactions(startTimestamps, lastKnownVersion);
     }
 }

--- a/lock-api-objects/src/main/java/com/palantir/lock/v2/StartTransactionRequestV5.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/v2/StartTransactionRequestV5.java
@@ -16,13 +16,14 @@
 
 package com.palantir.lock.v2;
 
-import java.util.OptionalLong;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.palantir.lock.watch.IdentifiedVersion;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableStartTransactionRequestV5.class)
@@ -30,6 +31,6 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 public interface StartTransactionRequestV5 {
     UUID requestId();
     UUID requestorId();
-    OptionalLong lastKnownLockLogVersion();
+    Optional<IdentifiedVersion> lastKnownLockLogVersion();
     int numTransactions();
 }

--- a/lock-api-objects/src/main/java/com/palantir/lock/watch/IdentifiedVersion.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/watch/IdentifiedVersion.java
@@ -25,5 +25,5 @@ public interface IdentifiedVersion {
     @Value.Parameter
     UUID id();
     @Value.Parameter
-    Long version();
+    long version();
 }

--- a/lock-api-objects/src/main/java/com/palantir/lock/watch/IdentifiedVersion.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/watch/IdentifiedVersion.java
@@ -16,7 +16,6 @@
 
 package com.palantir.lock.watch;
 
-import java.util.Optional;
 import java.util.UUID;
 
 import org.immutables.value.Value;
@@ -26,5 +25,5 @@ public interface IdentifiedVersion {
     @Value.Parameter
     UUID id();
     @Value.Parameter
-    Optional<Long> version();
+    Long version();
 }

--- a/lock-api-objects/src/main/java/com/palantir/lock/watch/LockWatchEventCache.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/watch/LockWatchEventCache.java
@@ -16,11 +16,13 @@
 
 package com.palantir.lock.watch;
 
+import java.util.Optional;
 import java.util.Set;
 
 public interface LockWatchEventCache {
-    IdentifiedVersion lastKnownVersion();
+    Optional<IdentifiedVersion> lastKnownVersion();
     IdentifiedVersion processStartTransactionsUpdate(Set<Long> startTimestamps, LockWatchStateUpdate update);
     void processUpdate(LockWatchStateUpdate update);
-    TransactionsLockWatchEvents getEventsForTransactions(Set<Long> startTimestamps, IdentifiedVersion version);
+    TransactionsLockWatchEvents getEventsForTransactions(Set<Long> startTimestamps,
+            Optional<IdentifiedVersion> version);
 }

--- a/lock-api-objects/src/main/java/com/palantir/lock/watch/NoOpLockWatchEventCache.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/watch/NoOpLockWatchEventCache.java
@@ -25,18 +25,17 @@ import com.google.common.collect.ImmutableSet;
 @SuppressWarnings("FinalClass") // mocks
 public class NoOpLockWatchEventCache implements LockWatchEventCache {
     public static final LockWatchEventCache INSTANCE = new NoOpLockWatchEventCache();
-    private static final IdentifiedVersion FAKE = ImmutableIdentifiedVersion
-            .of(UUID.randomUUID(), Optional.empty());
+    private static final IdentifiedVersion FAKE = ImmutableIdentifiedVersion.of(UUID.randomUUID(), 0L);
     private static final TransactionsLockWatchEvents NONE = TransactionsLockWatchEvents.failure(
-            LockWatchStateUpdate.snapshot(UUID.randomUUID(), 0L, ImmutableSet.of(), ImmutableSet.of()));
+            LockWatchStateUpdate.snapshot(UUID.randomUUID(), -1L, ImmutableSet.of(), ImmutableSet.of()));
 
     private NoOpLockWatchEventCache() {
         // singleton
     }
 
     @Override
-    public IdentifiedVersion lastKnownVersion() {
-        return FAKE;
+    public Optional<IdentifiedVersion> lastKnownVersion() {
+        return Optional.empty();
     }
 
     @Override
@@ -50,7 +49,8 @@ public class NoOpLockWatchEventCache implements LockWatchEventCache {
     }
 
     @Override
-    public TransactionsLockWatchEvents getEventsForTransactions(Set<Long> startTimestamps, IdentifiedVersion version) {
+    public TransactionsLockWatchEvents getEventsForTransactions(Set<Long> startTimestamps,
+            Optional<IdentifiedVersion> version) {
         return NONE;
     }
 }

--- a/lock-api-objects/src/main/java/com/palantir/lock/watch/NoOpLockWatchEventCache.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/watch/NoOpLockWatchEventCache.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableSet;
 public class NoOpLockWatchEventCache implements LockWatchEventCache {
     public static final LockWatchEventCache INSTANCE = new NoOpLockWatchEventCache();
     private static final IdentifiedVersion FAKE = ImmutableIdentifiedVersion.of(UUID.randomUUID(), 0L);
+    private static final Optional<IdentifiedVersion> FAKE_OPTIONAL_VERSION = Optional.of(FAKE);
     private static final TransactionsLockWatchEvents NONE = TransactionsLockWatchEvents.failure(
             LockWatchStateUpdate.snapshot(UUID.randomUUID(), -1L, ImmutableSet.of(), ImmutableSet.of()));
 
@@ -35,7 +36,7 @@ public class NoOpLockWatchEventCache implements LockWatchEventCache {
 
     @Override
     public Optional<IdentifiedVersion> lastKnownVersion() {
-        return Optional.empty();
+        return FAKE_OPTIONAL_VERSION;
     }
 
     @Override

--- a/lock-api/src/main/java/com/palantir/lock/client/LockLeaseService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockLeaseService.java
@@ -31,7 +31,6 @@ import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsRequest;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
 import com.palantir.atlasdb.timelock.api.ConjureUnlockRequest;
 import com.palantir.common.concurrent.CoalescingSupplier;
-import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.lock.v2.LeaderTime;
 import com.palantir.lock.v2.Lease;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
@@ -100,7 +99,7 @@ class LockLeaseService {
                 .numTransactions(batchSize)
                 .lastKnownVersion(maybeVersion.map(identifiedVersion -> ConjureIdentifiedVersion.builder()
                         .id(identifiedVersion.id())
-                        .version(SafeLong.of(identifiedVersion.version()))
+                        .version(identifiedVersion.version())
                         .build()))
                 .build();
         ConjureStartTransactionsResponse response = delegate.startTransactions(request);

--- a/lock-api/src/main/java/com/palantir/lock/client/LockLeaseService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockLeaseService.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
+import com.palantir.atlasdb.timelock.api.ConjureIdentifiedVersion;
 import com.palantir.atlasdb.timelock.api.ConjureLockToken;
 import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksRequest;
 import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksResponse;
@@ -30,6 +31,7 @@ import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsRequest;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
 import com.palantir.atlasdb.timelock.api.ConjureUnlockRequest;
 import com.palantir.common.concurrent.CoalescingSupplier;
+import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.lock.v2.LeaderTime;
 import com.palantir.lock.v2.Lease;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
@@ -39,6 +41,7 @@ import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.StartTransactionResponseV4;
 import com.palantir.lock.v2.WaitForLocksRequest;
 import com.palantir.lock.v2.WaitForLocksResponse;
+import com.palantir.lock.watch.IdentifiedVersion;
 import com.palantir.logsafe.Preconditions;
 
 class LockLeaseService {
@@ -89,12 +92,16 @@ class LockLeaseService {
                 lease);
     }
 
-    ConjureStartTransactionsResponse startTransactionsWithWatches(Optional<Long> version, int batchSize) {
+    ConjureStartTransactionsResponse startTransactionsWithWatches(Optional<IdentifiedVersion> maybeVersion,
+            int batchSize) {
         ConjureStartTransactionsRequest request = ConjureStartTransactionsRequest.builder()
                 .requestorId(clientId)
                 .requestId(UUID.randomUUID())
                 .numTransactions(batchSize)
-                .lastKnownVersion(version)
+                .lastKnownVersion(maybeVersion.map(identifiedVersion -> ConjureIdentifiedVersion.builder()
+                        .id(identifiedVersion.id())
+                        .version(SafeLong.of(identifiedVersion.version()))
+                        .build()))
                 .build();
         ConjureStartTransactionsResponse response = delegate.startTransactions(request);
         Lease lease = response.getLease();

--- a/lock-api/src/main/java/com/palantir/lock/client/TransactionStarter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/TransactionStarter.java
@@ -164,7 +164,7 @@ final class TransactionStarter implements AutoCloseable {
         while (result.size() < numberOfTransactions) {
             try {
                 ConjureStartTransactionsResponse response = lockLeaseService.startTransactionsWithWatches(
-                        lockWatchEventCache.lastKnownVersion().version(), numberOfTransactions - result.size());
+                        lockWatchEventCache.lastKnownVersion(), numberOfTransactions - result.size());
                 lockWatchEventCache.processStartTransactionsUpdate(
                         response.getTimestamps().stream().boxed().collect(Collectors.toSet()),
                         response.getLockWatchUpdate());

--- a/lock-api/src/test/java/com/palantir/lock/client/TransactionStarterTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/TransactionStarterTest.java
@@ -20,8 +20,8 @@ import static java.util.stream.Collectors.toList;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -59,6 +59,7 @@ import com.palantir.lock.v2.LockImmutableTimestampResponse;
 import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.PartitionedTimestamps;
 import com.palantir.lock.v2.StartIdentifiedAtlasDbTransactionResponse;
+import com.palantir.lock.watch.IdentifiedVersion;
 import com.palantir.lock.watch.LockEvent;
 import com.palantir.lock.watch.LockWatchEventCache;
 import com.palantir.lock.watch.LockWatchStateUpdate;
@@ -70,6 +71,7 @@ public class TransactionStarterTest {
     @Mock
     private LockLeaseService lockLeaseService;
     private final LockWatchEventCache lockWatchEventCache = spy(NoOpLockWatchEventCache.INSTANCE);
+    private final Optional<IdentifiedVersion> version = lockWatchEventCache.lastKnownVersion();
     private TransactionStarter transactionStarter;
 
     private static final int NUM_PARTITIONS = 16;
@@ -101,7 +103,7 @@ public class TransactionStarterTest {
     public void shouldDeriveStartTransactionResponseFromBatchedResponse_singleTransaction() {
         ConjureStartTransactionsResponse startTransactionResponse = getStartTransactionResponse(12, 1);
 
-        when(lockLeaseService.startTransactionsWithWatches(Optional.empty(), 1)).thenReturn(startTransactionResponse);
+        when(lockLeaseService.startTransactionsWithWatches(version, 1)).thenReturn(startTransactionResponse);
         StartIdentifiedAtlasDbTransactionResponse response =
                 Iterables.getOnlyElement(transactionStarter.startIdentifiedAtlasDbTransactionBatch(1));
 
@@ -112,7 +114,7 @@ public class TransactionStarterTest {
     public void shouldDeriveStartTransactionResponseBatchFromBatchedResponse_multipleTransactions() {
         ConjureStartTransactionsResponse batchResponse = getStartTransactionResponse(12, 5);
 
-        when(lockLeaseService.startTransactionsWithWatches(Optional.empty(), 5)).thenReturn(batchResponse);
+        when(lockLeaseService.startTransactionsWithWatches(version, 5)).thenReturn(batchResponse);
         List<StartIdentifiedAtlasDbTransactionResponse> responses =
                 transactionStarter.startIdentifiedAtlasDbTransactionBatch(5);
 
@@ -132,7 +134,7 @@ public class TransactionStarterTest {
     @Test
     public void shouldDeriveStartTransactionResponseFromBatchedResponse_multipleTransactions() {
         ConjureStartTransactionsResponse batchResponse = getStartTransactionResponse(40, 3);
-        when(lockLeaseService.startTransactionsWithWatches(Optional.empty(), 3))
+        when(lockLeaseService.startTransactionsWithWatches(version, 3))
                 .thenReturn(batchResponse);
 
         List<StartIdentifiedAtlasDbTransactionResponse> responses = requestSingularBatches(3);
@@ -145,7 +147,7 @@ public class TransactionStarterTest {
     @Test
     public void shouldDeriveStartTransactionResponseFromBatchedResponse_nonTrivialBatchSize() {
         ConjureStartTransactionsResponse batchResponse = getStartTransactionResponse(40, 10);
-        when(lockLeaseService.startTransactionsWithWatches(Optional.empty(), 10))
+        when(lockLeaseService.startTransactionsWithWatches(version, 10))
                 .thenReturn(batchResponse);
 
         ImmutableList<Integer> sizes = ImmutableList.of(2, 3, 4, 1);
@@ -162,13 +164,13 @@ public class TransactionStarterTest {
 
     @Test
     public void shouldCallTimelockMultipleTimesUntilCollectsAllRequiredTimestampsAndProcessUpdates() {
-        when(lockLeaseService.startTransactionsWithWatches(any(Optional.class), anyInt()))
+        when(lockLeaseService.startTransactionsWithWatches(eq(version), anyInt()))
                 .thenReturn(getStartTransactionResponse(40, 2))
                 .thenReturn(getStartTransactionResponse(100, 1));
 
         requestSingularBatches(3);
-        verify(lockLeaseService).startTransactionsWithWatches(Optional.empty(), 3);
-        verify(lockLeaseService).startTransactionsWithWatches(Optional.empty(), 1);
+        verify(lockLeaseService).startTransactionsWithWatches(version, 3);
+        verify(lockLeaseService).startTransactionsWithWatches(version, 1);
         verify(lockWatchEventCache).processStartTransactionsUpdate(ImmutableSet.of(40L, 56L), UPDATE);
     }
 

--- a/timelock-api/src/main/conjure/timelock-api.yml
+++ b/timelock-api/src/main/conjure/timelock-api.yml
@@ -36,12 +36,18 @@ types:
   definitions:
     default-package: com.palantir.atlasdb.timelock.api
     objects:
+      ConjureIdentifiedVersion:
+        fields:
+          id: uuid
+          version: safelong
+        docs: |
+          ``version`` is always an inclusive number. If the event log is empty, ``-1`` is returned.
       ConjureStartTransactionsRequest:
         fields:
           requestId: uuid
           requestorId: uuid
           numTransactions: integer
-          lastKnownVersion: optional<Long>
+          lastKnownVersion: optional<ConjureIdentifiedVersion>
       ConjureStartTransactionsResponse:
         fields:
           immutableTimestamp: LockImmutableTimestampResponse
@@ -95,7 +101,7 @@ types:
       GetCommitTimestampsRequest:
         fields:
           numTimestamps: integer
-          lastKnownVersion: optional<Long>
+          lastKnownVersion: optional<ConjureIdentifiedVersion>
       GetCommitTimestampsResponse:
         fields:
           inclusiveLower: Long

--- a/timelock-api/src/main/conjure/timelock-api.yml
+++ b/timelock-api/src/main/conjure/timelock-api.yml
@@ -39,7 +39,7 @@ types:
       ConjureIdentifiedVersion:
         fields:
           id: uuid
-          version: safelong
+          version: Long
         docs: |
           ``version`` is always an inclusive number. If the event log is empty, ``-1`` is returned.
       ConjureStartTransactionsRequest:

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockService.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockService.java
@@ -16,7 +16,7 @@
 package com.palantir.atlasdb.timelock;
 
 import java.io.Closeable;
-import java.util.OptionalLong;
+import java.util.Optional;
 import java.util.Set;
 
 import com.google.common.util.concurrent.ListenableFuture;
@@ -38,6 +38,7 @@ import com.palantir.lock.v2.StartTransactionResponseV4;
 import com.palantir.lock.v2.StartTransactionResponseV5;
 import com.palantir.lock.v2.WaitForLocksRequest;
 import com.palantir.lock.v2.WaitForLocksResponse;
+import com.palantir.lock.watch.IdentifiedVersion;
 import com.palantir.timestamp.ManagedTimestampService;
 import com.palantir.timestamp.TimestampRange;
 
@@ -65,7 +66,8 @@ public interface AsyncTimelockService extends ManagedTimestampService, LockWatch
 
     ListenableFuture<StartTransactionResponseV5> startTransactionsWithWatches(StartTransactionRequestV5 request);
 
-    ListenableFuture<GetCommitTimestampsResponse> getCommitTimestamps(int numTimestamps, OptionalLong lastKnownVersion);
+    ListenableFuture<GetCommitTimestampsResponse> getCommitTimestamps(int numTimestamps,
+            Optional<IdentifiedVersion> lastKnownVersion);
 
     ListenableFuture<LeaderTime> leaderTime();
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceImpl.java
@@ -15,7 +15,7 @@
  */
 package com.palantir.atlasdb.timelock;
 
-import java.util.OptionalLong;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Supplier;
@@ -52,6 +52,7 @@ import com.palantir.lock.v2.StartTransactionResponseV5;
 import com.palantir.lock.v2.TimestampAndPartition;
 import com.palantir.lock.v2.WaitForLocksRequest;
 import com.palantir.lock.v2.WaitForLocksResponse;
+import com.palantir.lock.watch.IdentifiedVersion;
 import com.palantir.lock.watch.LockWatchStateUpdate;
 import com.palantir.timestamp.ManagedTimestampService;
 import com.palantir.timestamp.TimestampRange;
@@ -220,7 +221,7 @@ public class AsyncTimelockServiceImpl implements AsyncTimelockService {
 
     @Override
     public ListenableFuture<GetCommitTimestampsResponse> getCommitTimestamps(
-            int numTimestamps, OptionalLong lastKnownVersion) {
+            int numTimestamps, Optional<IdentifiedVersion> lastKnownVersion) {
         TimestampRange freshTimestamps = getFreshTimestamps(numTimestamps);
         return Futures.immediateFuture(GetCommitTimestampsResponse.of(
                 freshTimestamps.getLowerBound(),
@@ -264,12 +265,12 @@ public class AsyncTimelockServiceImpl implements AsyncTimelockService {
     }
 
     @Override
-    public LockWatchStateUpdate getWatchStateUpdate(OptionalLong lastKnownVersion) {
+    public LockWatchStateUpdate getWatchStateUpdate(Optional<IdentifiedVersion> lastKnownVersion) {
         return lockService.getLockWatchingService().getWatchStateUpdate(lastKnownVersion);
     }
 
     @Override
-    public LockWatchStateUpdate getWatchStateUpdate(OptionalLong lastKnownVersion, long endVersion) {
+    public LockWatchStateUpdate getWatchStateUpdate(Optional<IdentifiedVersion> lastKnownVersion, long endVersion) {
         return lockService.getLockWatchingService().getWatchStateUpdate(lastKnownVersion, endVersion);
     }
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/ConjureTimelockResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/ConjureTimelockResource.java
@@ -17,7 +17,6 @@
 package com.palantir.atlasdb.timelock;
 
 import java.util.HashSet;
-import java.util.OptionalLong;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -30,6 +29,7 @@ import com.palantir.atlasdb.futures.AtlasFutures;
 import com.palantir.atlasdb.http.RedirectRetryTargeter;
 import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsRequest;
 import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponse;
+import com.palantir.atlasdb.timelock.api.ConjureIdentifiedVersion;
 import com.palantir.atlasdb.timelock.api.ConjureLockDescriptor;
 import com.palantir.atlasdb.timelock.api.ConjureLockRequest;
 import com.palantir.atlasdb.timelock.api.ConjureLockResponse;
@@ -63,6 +63,8 @@ import com.palantir.lock.v2.StartTransactionRequestV5;
 import com.palantir.lock.v2.StartTransactionResponseV5;
 import com.palantir.lock.v2.WaitForLocksRequest;
 import com.palantir.lock.v2.WaitForLocksResponse;
+import com.palantir.lock.watch.IdentifiedVersion;
+import com.palantir.lock.watch.ImmutableIdentifiedVersion;
 import com.palantir.timestamp.TimestampRange;
 import com.palantir.tokens.auth.AuthHeader;
 
@@ -98,9 +100,7 @@ public final class ConjureTimelockResource implements UndertowConjureTimelockSer
                     .requestId(request.getRequestId())
                     .requestorId(request.getRequestorId())
                     .numTransactions(request.getNumTransactions())
-                    .lastKnownLockLogVersion(request.getLastKnownVersion()
-                            .map(OptionalLong::of)
-                            .orElseGet(OptionalLong::empty))
+                    .lastKnownLockLogVersion(request.getLastKnownVersion().map(this::toIdentifiedVersion))
                     .build();
             ListenableFuture<StartTransactionResponseV5> responseFuture =
                     forNamespace(namespace).startTransactionsWithWatches(legacyRequest);
@@ -218,7 +218,7 @@ public final class ConjureTimelockResource implements UndertowConjureTimelockSer
             AuthHeader authHeader, String namespace, GetCommitTimestampsRequest request) {
         return handleExceptions(() -> forNamespace(namespace).getCommitTimestamps(
                 request.getNumTimestamps(),
-                request.getLastKnownVersion().map(OptionalLong::of).orElseGet(OptionalLong::empty)));
+                request.getLastKnownVersion().map(this::toIdentifiedVersion)));
     }
 
     private AsyncTimelockService forNamespace(String namespace) {
@@ -288,5 +288,10 @@ public final class ConjureTimelockResource implements UndertowConjureTimelockSer
         private static <T> T unwrap(ListenableFuture<T> future) {
             return AtlasFutures.getUnchecked(future);
         }
+    }
+
+    private IdentifiedVersion toIdentifiedVersion(ConjureIdentifiedVersion conjureIdentifiedVersion) {
+        return ImmutableIdentifiedVersion.of(conjureIdentifiedVersion.getId(),
+                conjureIdentifiedVersion.getVersion().longValue());
     }
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/ConjureTimelockResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/ConjureTimelockResource.java
@@ -291,7 +291,6 @@ public final class ConjureTimelockResource implements UndertowConjureTimelockSer
     }
 
     private IdentifiedVersion toIdentifiedVersion(ConjureIdentifiedVersion conjureIdentifiedVersion) {
-        return ImmutableIdentifiedVersion.of(conjureIdentifiedVersion.getId(),
-                conjureIdentifiedVersion.getVersion().longValue());
+        return ImmutableIdentifiedVersion.of(conjureIdentifiedVersion.getId(), conjureIdentifiedVersion.getVersion());
     }
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockEventLog.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockEventLog.java
@@ -16,17 +16,18 @@
 
 package com.palantir.atlasdb.timelock.lock.watch;
 
-import java.util.OptionalLong;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
 import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.v2.LockToken;
+import com.palantir.lock.watch.IdentifiedVersion;
 import com.palantir.lock.watch.LockWatchStateUpdate;
 
 public interface LockEventLog {
-    LockWatchStateUpdate getLogDiff(OptionalLong fromVersion);
-    LockWatchStateUpdate getLogDiff(OptionalLong fromVersion, long toVersion);
+    LockWatchStateUpdate getLogDiff(Optional<IdentifiedVersion> fromVersion);
+    LockWatchStateUpdate getLogDiff(Optional<IdentifiedVersion> fromVersion, long toVersion);
     <T> ValueAndVersion<T> runTaskAndAtomicallyReturnVersion(Supplier<T> task);
     void logLock(Set<LockDescriptor> locksTakenOut, LockToken lockToken);
     void logUnlock(Set<LockDescriptor> locksUnlocked);

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockWatchingService.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockWatchingService.java
@@ -16,19 +16,20 @@
 
 package com.palantir.atlasdb.timelock.lock.watch;
 
-import java.util.OptionalLong;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
 import com.palantir.atlasdb.timelock.api.LockWatchRequest;
 import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.v2.LockToken;
+import com.palantir.lock.watch.IdentifiedVersion;
 import com.palantir.lock.watch.LockWatchStateUpdate;
 
 public interface LockWatchingService {
     void startWatching(LockWatchRequest locksToWatch);
-    LockWatchStateUpdate getWatchStateUpdate(OptionalLong lastKnownVersion);
-    LockWatchStateUpdate getWatchStateUpdate(OptionalLong lastKnownVersion, long endVersion);
+    LockWatchStateUpdate getWatchStateUpdate(Optional<IdentifiedVersion> lastKnownVersion);
+    LockWatchStateUpdate getWatchStateUpdate(Optional<IdentifiedVersion> lastKnownVersion, long endVersion);
     <T> ValueAndVersion<T> runTaskAndAtomicallyReturnLockWatchVersion(Supplier<T> task);
     void registerLock(Set<LockDescriptor> locksTakenOut, LockToken token);
     void registerUnlock(Set<LockDescriptor> locksUnlocked);

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockWatchingServiceImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockWatchingServiceImpl.java
@@ -18,14 +18,15 @@ package com.palantir.atlasdb.timelock.lock.watch;
 
 import java.util.HashSet;
 import java.util.Optional;
-import java.util.OptionalLong;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 import com.google.common.collect.TreeRangeSet;
@@ -33,6 +34,7 @@ import com.palantir.atlasdb.timelock.api.LockWatchRequest;
 import com.palantir.atlasdb.timelock.lock.HeldLocksCollection;
 import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.v2.LockToken;
+import com.palantir.lock.watch.IdentifiedVersion;
 import com.palantir.lock.watch.LockWatchReferences;
 import com.palantir.lock.watch.LockWatchReferences.LockWatchReference;
 import com.palantir.lock.watch.LockWatchStateUpdate;
@@ -57,7 +59,12 @@ public class LockWatchingServiceImpl implements LockWatchingService {
     private final ReadWriteLock watchesLock = new ReentrantReadWriteLock(true);
 
     public LockWatchingServiceImpl(HeldLocksCollection heldLocksCollection) {
-        this.lockEventLog = new LockEventLogImpl(watches::get, heldLocksCollection);
+        this(UUID.randomUUID(), heldLocksCollection);
+    }
+
+    @VisibleForTesting
+    LockWatchingServiceImpl(UUID logId, HeldLocksCollection heldLocksCollection) {
+        this.lockEventLog = new LockEventLogImpl(logId, watches::get, heldLocksCollection);
     }
 
     @Override
@@ -67,12 +74,12 @@ public class LockWatchingServiceImpl implements LockWatchingService {
     }
 
     @Override
-    public LockWatchStateUpdate getWatchStateUpdate(OptionalLong lastKnownVersion) {
+    public LockWatchStateUpdate getWatchStateUpdate(Optional<IdentifiedVersion> lastKnownVersion) {
         return lockEventLog.getLogDiff(lastKnownVersion);
     }
 
     @Override
-    public LockWatchStateUpdate getWatchStateUpdate(OptionalLong lastKnownVersion, long endVersion) {
+    public LockWatchStateUpdate getWatchStateUpdate(Optional<IdentifiedVersion> lastKnownVersion, long endVersion) {
         return lockEventLog.getLogDiff(lastKnownVersion, endVersion);
     }
 

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/lock/watch/LockWatchingServiceImplTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/lock/watch/LockWatchingServiceImplTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
-import java.util.OptionalLong;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -43,6 +43,7 @@ import com.palantir.lock.AtlasCellLockDescriptor;
 import com.palantir.lock.AtlasRowLockDescriptor;
 import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.v2.LockToken;
+import com.palantir.lock.watch.ImmutableIdentifiedVersion;
 import com.palantir.lock.watch.LockEvent;
 import com.palantir.lock.watch.LockWatchCreatedEvent;
 import com.palantir.lock.watch.LockWatchEvent;
@@ -51,6 +52,7 @@ import com.palantir.lock.watch.LockWatchStateUpdate;
 import com.palantir.lock.watch.UnlockEvent;
 
 public class LockWatchingServiceImplTest {
+    private static final UUID LOG_ID = UUID.randomUUID();
     private static final TableReference TABLE = TableReference.createFromFullyQualifiedName("test.table");
     private static final TableReference TABLE_2 = TableReference.createFromFullyQualifiedName("prod.table");
     private static final LockToken TOKEN = LockToken.of(UUID.randomUUID());
@@ -64,7 +66,7 @@ public class LockWatchingServiceImplTest {
     private static final AsyncLock LOCK_2 = new ExclusiveLock(descriptorForOtherTable());
 
     private final HeldLocksCollection locks = mock(HeldLocksCollection.class);
-    private final LockWatchingService lockWatcher = new LockWatchingServiceImpl(locks);
+    private final LockWatchingService lockWatcher = new LockWatchingServiceImpl(LOG_ID, locks);
 
     private final HeldLocks heldLocks = mock(HeldLocks.class);
 
@@ -291,7 +293,8 @@ public class LockWatchingServiceImplTest {
     }
 
     private void assertLoggedEvents(List<LockWatchEvent> expectedEvents) {
-        LockWatchStateUpdate update = lockWatcher.getWatchStateUpdate(OptionalLong.of(-1));
+        LockWatchStateUpdate update = lockWatcher.getWatchStateUpdate(
+                Optional.of(ImmutableIdentifiedVersion.of(LOG_ID, -1L)));
         List<LockWatchEvent> events = UpdateVisitors.assertSuccess(update).events();
         assertThat(events).isEqualTo(expectedEvents);
     }


### PR DESCRIPTION
**Goals (and why)**:

This is an obviously more correct way to specify this in the API. If the leader changes, the new leader should be forced to recompute a clean snapshot. Without pushing the client's view of the leader id, it is technically possible that timelock would not compute a snapshot if the log event sequences somehow overlap in weird ways.

**Implementation Description (bullets)**:

Pass Optional<IdentifiedVersion> around, which is a bit more awkward, but I believe, correct.

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

This changes the conjure API, so **technically** a break. But the client's would've only pushed Optional.empty() there, so should be fine.

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
