### PR TITLE
[Dialogue] Part 9: Shims for Lesser Used Services: AtlasDB -> TimeLock

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/AtlasDbDialogueServiceProvider.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/AtlasDbDialogueServiceProvider.java
@@ -41,12 +41,10 @@ import com.palantir.conjure.java.client.config.NodeSelectionStrategy;
 import com.palantir.dialogue.Channel;
 import com.palantir.dialogue.clients.DialogueClients;
 import com.palantir.lock.LockRpcClient;
-import com.palantir.lock.LockService;
 import com.palantir.lock.client.DialogueAdaptingConjureTimelockService;
 import com.palantir.lock.v2.TimelockRpcClient;
 import com.palantir.refreshable.Refreshable;
 import com.palantir.timestamp.TimestampManagementRpcClient;
-import com.palantir.timestamp.TimestampManagementService;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 
 /**

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
@@ -29,7 +29,6 @@ import com.palantir.atlasdb.http.v2.FastFailoverProxy;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.common.proxy.ReplaceIfExceptionMatchingProxy;
-import com.palantir.conjure.java.client.jaxrs.JaxRsClient;
 import com.palantir.conjure.java.config.ssl.TrustContext;
 import com.palantir.dialogue.Channel;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
@@ -24,10 +24,14 @@ import com.google.common.annotations.VisibleForTesting;
 import com.palantir.atlasdb.config.AuxiliaryRemotingParameters;
 import com.palantir.atlasdb.config.ServerListConfig;
 import com.palantir.atlasdb.http.v2.ConjureJavaRuntimeTargetFactory;
+import com.palantir.atlasdb.http.v2.DialogueShimFactory;
+import com.palantir.atlasdb.http.v2.FastFailoverProxy;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.common.proxy.ReplaceIfExceptionMatchingProxy;
+import com.palantir.conjure.java.client.jaxrs.JaxRsClient;
 import com.palantir.conjure.java.config.ssl.TrustContext;
+import com.palantir.dialogue.Channel;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 
 public final class AtlasDbHttpClients {
@@ -78,6 +82,14 @@ public final class AtlasDbHttpClients {
                         clientParameters),
                 type);
         return wrapWithOkHttpBugHandling(type, clientFactory);
+    }
+
+    public static <T> T createDialogueProxy(TaggedMetricRegistry registry, Class<T> type, Channel channel) {
+        T proxy = DialogueShimFactory.create(type, channel);
+        return AtlasDbMetrics.instrumentWithTaggedMetrics(
+                registry,
+                type,
+                FastFailoverProxy.newProxyInstance(type, () -> proxy));
     }
 
     @VisibleForTesting

--- a/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/ConjureJavaRuntimeTargetFactory.java
+++ b/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/ConjureJavaRuntimeTargetFactory.java
@@ -30,7 +30,9 @@ import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.client.config.ClientConfiguration;
 import com.palantir.conjure.java.client.jaxrs.JaxRsClient;
 import com.palantir.conjure.java.config.ssl.TrustContext;
+import com.palantir.conjure.java.dialogue.serde.DefaultConjureRuntime;
 import com.palantir.conjure.java.okhttp.HostMetricsRegistry;
+import com.palantir.dialogue.Channel;
 import com.palantir.util.CachedTransformingSupplier;
 
 public final class ConjureJavaRuntimeTargetFactory implements TargetFactory {

--- a/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/ConjureJavaRuntimeTargetFactory.java
+++ b/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/ConjureJavaRuntimeTargetFactory.java
@@ -30,9 +30,7 @@ import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.client.config.ClientConfiguration;
 import com.palantir.conjure.java.client.jaxrs.JaxRsClient;
 import com.palantir.conjure.java.config.ssl.TrustContext;
-import com.palantir.conjure.java.dialogue.serde.DefaultConjureRuntime;
 import com.palantir.conjure.java.okhttp.HostMetricsRegistry;
-import com.palantir.dialogue.Channel;
 import com.palantir.util.CachedTransformingSupplier;
 
 public final class ConjureJavaRuntimeTargetFactory implements TargetFactory {

--- a/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/DialogueShimFactory.java
+++ b/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/DialogueShimFactory.java
@@ -1,0 +1,31 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.http.v2;
+
+import com.palantir.conjure.java.client.jaxrs.JaxRsClient;
+import com.palantir.conjure.java.dialogue.serde.DefaultConjureRuntime;
+import com.palantir.dialogue.Channel;
+
+public final class DialogueShimFactory {
+    private DialogueShimFactory() {
+        // Nö
+    }
+
+    public static <T> T create(Class<T> type, Channel channel) {
+        return JaxRsClient.create(type, channel, DefaultConjureRuntime.builder().build());
+    }
+}

--- a/changelog/@unreleased/pr-4794.v2.yml
+++ b/changelog/@unreleased/pr-4794.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: If Dialogue on clients is enabled, then communications to the V1 Lock,
+    Timestamp Management and TimelockRpcClient now take place through Dialogue as
+    well. Previously even if this was enabled they would go through CJR.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4794


### PR DESCRIPTION
**Goals (and why)**:
- Improve performance on lesser used services to some extent
- Don't go through the pain/effort of fully Conjurising these services.

**Implementation Description (bullets)**:
- Allow the usage of the JaxRs client shim for Dialogue across lesser used services.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Existing integration tests should suffice.

**Concerns (what feedback would you like?)**:
Nothing in particular. Does the organisation make sense?

**Where should we start reviewing?**: AtlasDbDialogueServiceProvider

**Priority (whenever / two weeks / yesterday)**: this week
