### PR TITLE
Fix deserialization issue.

### DIFF
--- a/changelog/@unreleased/pr-4795.v2.yml
+++ b/changelog/@unreleased/pr-4795.v2.yml
@@ -1,0 +1,27 @@
+type: improvement
+improvement:
+  description: |-
+    Fix deserialization issue.
+
+    * Previous released broke the API under the assumption that we were always sending Optional.empty before.
+    * But then we pushed the wrong version, so pushing an Optional.of.
+
+    **Goals (and why)**:
+
+    **Implementation Description (bullets)**:
+
+    **Testing (What was existing testing like?  What have you done to improve it?)**:
+
+    **Concerns (what feedback would you like?)**:
+
+    **Where should we start reviewing?**:
+
+    **Priority (whenever / two weeks / yesterday)**:
+
+    <!---
+    Please remember to:
+    - Add any necessary release notes (including breaking changes)
+    - Make sure the documentation is up to date for your change
+    --->
+  links:
+  - https://github.com/palantir/atlasdb/pull/4795

--- a/changelog/@unreleased/pr-4795.v2.yml
+++ b/changelog/@unreleased/pr-4795.v2.yml
@@ -2,26 +2,5 @@ type: improvement
 improvement:
   description: |-
     Fix deserialization issue.
-
-    * Previous released broke the API under the assumption that we were always sending Optional.empty before.
-    * But then we pushed the wrong version, so pushing an Optional.of.
-
-    **Goals (and why)**:
-
-    **Implementation Description (bullets)**:
-
-    **Testing (What was existing testing like?  What have you done to improve it?)**:
-
-    **Concerns (what feedback would you like?)**:
-
-    **Where should we start reviewing?**:
-
-    **Priority (whenever / two weeks / yesterday)**:
-
-    <!---
-    Please remember to:
-    - Add any necessary release notes (including breaking changes)
-    - Make sure the documentation is up to date for your change
-    --->
   links:
   - https://github.com/palantir/atlasdb/pull/4795

--- a/lock-api-objects/src/main/java/com/palantir/lock/watch/NoOpLockWatchEventCache.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/watch/NoOpLockWatchEventCache.java
@@ -26,7 +26,6 @@ import com.google.common.collect.ImmutableSet;
 public class NoOpLockWatchEventCache implements LockWatchEventCache {
     public static final LockWatchEventCache INSTANCE = new NoOpLockWatchEventCache();
     private static final IdentifiedVersion FAKE = ImmutableIdentifiedVersion.of(UUID.randomUUID(), 0L);
-    private static final Optional<IdentifiedVersion> FAKE_OPTIONAL_VERSION = Optional.of(FAKE);
     private static final TransactionsLockWatchEvents NONE = TransactionsLockWatchEvents.failure(
             LockWatchStateUpdate.snapshot(UUID.randomUUID(), -1L, ImmutableSet.of(), ImmutableSet.of()));
 
@@ -36,7 +35,7 @@ public class NoOpLockWatchEventCache implements LockWatchEventCache {
 
     @Override
     public Optional<IdentifiedVersion> lastKnownVersion() {
-        return FAKE_OPTIONAL_VERSION;
+        return Optional.empty();
     }
 
     @Override


### PR DESCRIPTION
* Previous released broke the API under the assumption that we were always sending Optional.empty before.
* But then we pushed the wrong version, so pushing an Optional.of.

**Goals (and why)**:

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
