### PR TITLE
[PaxosStateLog] Use Singlethreaded access to Sqlite

### DIFF
--- a/leader-election-impl/src/main/java/com/palantir/paxos/SqliteConnections.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SqliteConnections.java
@@ -19,8 +19,6 @@ package com.palantir.paxos;
 import java.io.IOException;
 import java.nio.file.Path;
 
-import javax.sql.DataSource;
-
 import org.apache.commons.io.FileUtils;
 import org.sqlite.SQLiteConfig;
 import org.sqlite.javax.SQLiteConnectionPoolDataSource;
@@ -41,7 +39,7 @@ public final class SqliteConnections {
         // no
     }
 
-    public static DataSource getPooledDataSource(Path path) {
+    public static HikariDataSource getPooledDataSource(Path path) {
         createDirectoryIfNotExists(path);
         String target = String.format("jdbc:sqlite:%s", path.resolve(DEFAULT_SQLITE_DATABASE_NAME).toString());
 

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SqliteConnections.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SqliteConnections.java
@@ -47,8 +47,8 @@ public final class SqliteConnections {
 
         SQLiteConfig config = new SQLiteConfig();
         config.setPragma(SQLiteConfig.Pragma.JOURNAL_MODE, SQLiteConfig.JournalMode.WAL.getValue());
+        config.setPragma(SQLiteConfig.Pragma.LOCKING_MODE, SQLiteConfig.LockingMode.EXCLUSIVE.getValue());
         config.setPragma(SQLiteConfig.Pragma.SYNCHRONOUS, "EXTRA");
-        config.setBusyTimeout(5_000);
 
         SQLiteConnectionPoolDataSource dataSource = new SQLiteConnectionPoolDataSource();
         dataSource.setUrl(target);
@@ -56,7 +56,7 @@ public final class SqliteConnections {
 
         HikariConfig hikariConfig = new HikariConfig();
         hikariConfig.setDataSource(dataSource);
-        hikariConfig.setMaximumPoolSize(16);
+        hikariConfig.setMaximumPoolSize(1);
         return new HikariDataSource(hikariConfig);
     }
 

--- a/leader-election-impl/src/test/java/com/palantir/paxos/SqlitePaxosStateLogTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/SqlitePaxosStateLogTest.java
@@ -193,7 +193,7 @@ public class SqlitePaxosStateLogTest {
 
     @Test
     public void highConcurrencyDoesNotTimeout() {
-        int numThreads = 1000;
+        int numThreads = 100;
         ExecutorService executor = PTExecutors.newFixedThreadPool(numThreads);
         List<Future<?>> futures = IntStream.range(0, numThreads)
                 .mapToObj(ignore -> executor.submit(() -> {

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipContextFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipContextFactory.java
@@ -30,7 +30,6 @@ import com.palantir.leader.PingableLeader;
 import com.palantir.paxos.Client;
 import com.palantir.paxos.LeaderPinger;
 import com.palantir.paxos.PaxosLearner;
-import com.zaxxer.hikari.HikariDataSource;
 
 @Value.Immutable
 public abstract class LeadershipContextFactory implements
@@ -41,7 +40,6 @@ public abstract class LeadershipContextFactory implements
         Dependencies.HealthCheckPinger {
 
     abstract PaxosResourcesFactory.TimelockPaxosInstallationContext install();
-    public abstract HikariDataSource sqliteDataSource();
     abstract Factories.LeaderPingHealthCheckFactory healthCheckPingersFactory();
     abstract NetworkClientFactories.Builder networkClientFactoryBuilder();
     abstract Factories.LeaderPingerFactoryContainer.Builder leaderPingerFactoryBuilder();
@@ -59,7 +57,7 @@ public abstract class LeadershipContextFactory implements
                 metrics(),
                 useCase(),
                 install().dataDirectory(),
-                sqliteDataSource(),
+                install().sqliteDataSource(),
                 leaderUuid(),
                 install().install().paxos().canCreateNewClients());
     }

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipContextFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipContextFactory.java
@@ -30,6 +30,7 @@ import com.palantir.leader.PingableLeader;
 import com.palantir.paxos.Client;
 import com.palantir.paxos.LeaderPinger;
 import com.palantir.paxos.PaxosLearner;
+import com.zaxxer.hikari.HikariDataSource;
 
 @Value.Immutable
 public abstract class LeadershipContextFactory implements
@@ -40,6 +41,7 @@ public abstract class LeadershipContextFactory implements
         Dependencies.HealthCheckPinger {
 
     abstract PaxosResourcesFactory.TimelockPaxosInstallationContext install();
+    public abstract HikariDataSource sqliteDataSource();
     abstract Factories.LeaderPingHealthCheckFactory healthCheckPingersFactory();
     abstract NetworkClientFactories.Builder networkClientFactoryBuilder();
     abstract Factories.LeaderPingerFactoryContainer.Builder leaderPingerFactoryBuilder();
@@ -57,7 +59,7 @@ public abstract class LeadershipContextFactory implements
                 metrics(),
                 useCase(),
                 install().dataDirectory(),
-                install().sqliteDataDirectory(),
+                sqliteDataSource(),
                 leaderUuid(),
                 install().install().paxos().canCreateNewClients());
     }

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResources.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResources.java
@@ -34,7 +34,7 @@ public abstract class PaxosResources {
     public abstract Factory<ManagedTimestampService> timestampServiceFactory();
     abstract LocalPaxosComponents timestampPaxosComponents();
     abstract Map<PaxosUseCase, LocalPaxosComponents> leadershipBatchComponents();
-    abstract LeadershipContextFactory leadershipContextFactory();
+    public abstract LeadershipContextFactory leadershipContextFactory();
     abstract List<Object> adhocResources();
 
     @Value.Derived

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/SqlitePaxosPersistenceConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/SqlitePaxosPersistenceConfiguration.java
@@ -21,9 +21,12 @@ import java.io.File;
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
+@JsonDeserialize(as = ImmutableSqlitePaxosPersistenceConfiguration.class)
+@JsonSerialize(as = ImmutableSqlitePaxosPersistenceConfiguration.class)
 @Value.Immutable
-// TODO (jkong): Allow serialization/deserialization, once we want this to actually be configurable
 public interface SqlitePaxosPersistenceConfiguration {
     SqlitePaxosPersistenceConfiguration DEFAULT = ImmutableSqlitePaxosPersistenceConfiguration.builder()
             .dataDirectory(new File("var/data/sqlitePaxos"))

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponents.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponents.java
@@ -58,13 +58,13 @@ public class LocalPaxosComponents {
     LocalPaxosComponents(TimelockPaxosMetrics metrics,
             PaxosUseCase paxosUseCase,
             Path legacyLogDirectory,
-            Path sqliteLogDirectory,
+            DataSource sqliteDataSource,
             UUID leaderUuid,
             boolean canCreateNewClients) {
         this.metrics = metrics;
         this.paxosUseCase = paxosUseCase;
         this.baseLogDirectory = legacyLogDirectory;
-        this.sqliteDataSource = SqliteConnections.getPooledDataSource(sqliteLogDirectory);
+        this.sqliteDataSource = sqliteDataSource;
         this.leaderUuid = leaderUuid;
         this.memoizedBatchAcceptor = Suppliers.memoize(this::createBatchAcceptor);
         this.memoizedBatchLearner = Suppliers.memoize(this::createBatchLearner);

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponentsTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponentsTest.java
@@ -24,6 +24,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.UUID;
 
+import javax.sql.DataSource;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,6 +39,7 @@ import com.palantir.paxos.PaxosLearner;
 import com.palantir.paxos.PaxosProposal;
 import com.palantir.paxos.PaxosProposalId;
 import com.palantir.paxos.PaxosValue;
+import com.palantir.paxos.SqliteConnections;
 
 public class LocalPaxosComponentsTest {
     private static final Client CLIENT = Client.of("alice");
@@ -54,17 +57,17 @@ public class LocalPaxosComponentsTest {
 
     private LocalPaxosComponents paxosComponents;
     private Path legacyDirectory;
-    private Path sqliteDirectory;
+    private DataSource sqlite;
 
     @Before
     public void setUp() throws IOException {
         legacyDirectory = TEMPORARY_FOLDER.newFolder("legacy").toPath();
-        sqliteDirectory = TEMPORARY_FOLDER.newFolder("sqlite").toPath();
+        sqlite = SqliteConnections.getPooledDataSource(TEMPORARY_FOLDER.newFolder("sqlite").toPath());
         paxosComponents = new LocalPaxosComponents(
                 TimelockPaxosMetrics.of(PaxosUseCase.TIMESTAMP, MetricsManagers.createForTests()),
                 PaxosUseCase.TIMESTAMP,
                 legacyDirectory,
-                sqliteDirectory,
+                sqlite,
                 UUID.randomUUID(),
                 true);
     }
@@ -99,7 +102,7 @@ public class LocalPaxosComponentsTest {
                 TimelockPaxosMetrics.of(PaxosUseCase.TIMESTAMP, MetricsManagers.createForTests()),
                 PaxosUseCase.TIMESTAMP,
                 legacyDirectory,
-                sqliteDirectory,
+                sqlite,
                 UUID.randomUUID(),
                 false);
         assertThatThrownBy(() -> rejectingComponents.learner(CLIENT))
@@ -115,7 +118,7 @@ public class LocalPaxosComponentsTest {
                 TimelockPaxosMetrics.of(PaxosUseCase.TIMESTAMP, MetricsManagers.createForTests()),
                 PaxosUseCase.TIMESTAMP,
                 legacyDirectory,
-                sqliteDirectory,
+                sqlite,
                 UUID.randomUUID(),
                 false);
         assertThat(rejectingComponents.learner(CLIENT)).isNotNull();

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosStateLogMigrationIntegrationTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosStateLogMigrationIntegrationTest.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.UUID;
 
+import javax.sql.DataSource;
+
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -35,6 +37,7 @@ import com.palantir.paxos.PaxosStateLog;
 import com.palantir.paxos.PaxosStateLogImpl;
 import com.palantir.paxos.PaxosStorageParameters;
 import com.palantir.paxos.PaxosValue;
+import com.palantir.paxos.SqliteConnections;
 import com.palantir.paxos.SqlitePaxosStateLog;
 
 public class PaxosStateLogMigrationIntegrationTest {
@@ -46,12 +49,12 @@ public class PaxosStateLogMigrationIntegrationTest {
     private LocalPaxosComponents paxosComponents;
     private PaxosUseCase useCase = PaxosUseCase.LEADER_FOR_ALL_CLIENTS;
     private Path legacyDirectory;
-    private Path sqliteDirectory;
+    private DataSource sqlite;
 
     @Before
     public void setUp() throws IOException {
         legacyDirectory = TEMPORARY_FOLDER.newFolder("legacy").toPath();
-        sqliteDirectory = TEMPORARY_FOLDER.newFolder("sqlite").toPath();
+        sqlite = SqliteConnections.getPooledDataSource(TEMPORARY_FOLDER.newFolder("sqlite").toPath());
         resetPaxosComponents();
     }
 
@@ -202,7 +205,9 @@ public class PaxosStateLogMigrationIntegrationTest {
                 TimelockPaxosMetrics.of(useCase, MetricsManagers.createForTests()),
                 useCase,
                 legacyDirectory,
-                sqliteDirectory, UUID.randomUUID(), true);
+                sqlite,
+                UUID.randomUUID(),
+                true);
     }
 
     private PaxosValue valueForRound(int num) {

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
@@ -63,6 +63,7 @@ import com.palantir.paxos.PaxosProposerImpl;
 import com.palantir.paxos.PaxosRoundFailureException;
 import com.palantir.paxos.SingleLeaderAcceptorNetworkClient;
 import com.palantir.paxos.SingleLeaderLearnerNetworkClient;
+import com.palantir.paxos.SqliteConnections;
 
 @RunWith(Parameterized.class)
 public class PaxosTimestampBoundStoreTest {
@@ -113,7 +114,7 @@ public class PaxosTimestampBoundStoreTest {
                     TimelockPaxosMetrics.of(PaxosUseCase.TIMESTAMP, MetricsManagers.createForTests()),
                     PaxosUseCase.TIMESTAMP,
                     Paths.get(root, i + "legacy"),
-                    Paths.get(root, i + "sqlite"),
+                    SqliteConnections.getPooledDataSource(Paths.get(root, i + "sqlite")),
                     UUID.randomUUID(),
                     true);
 

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/SingleLeaderMultiNodePaxosTimeLockIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/SingleLeaderMultiNodePaxosTimeLockIntegrationTest.java
@@ -111,6 +111,10 @@ public class SingleLeaderMultiNodePaxosTimeLockIntegrationTest {
 
         for (TestableTimelockServer server : cluster.servers()) {
             server.startUsingBatchedSingleLeader();
+            if (cluster.currentLeaderFor(client.namespace()) == server) {
+                // if we are the leader failover twice to ensure we see the new sequence
+                cluster.failoverToNewLeader(client.namespace());
+            }
             cluster.failoverToNewLeader(client.namespace());
             long sequenceForBatchedEndpoint = getSequenceForServerUsingBatchedEndpoint(server);
             long sequenceForOldEndpoint = getSequenceForServerUsingOldEndpoint(server);

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TemplateVariables.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TemplateVariables.java
@@ -35,6 +35,8 @@ public interface TemplateVariables {
 
     @Nullable
     String getDataDirectory();
+    @Nullable
+    String getSqliteDataDirectory();
     List<Integer> getServerPorts();
     Integer getLocalServerPort();
     TimestampPaxos getClientPaxos();

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TemporaryConfigurationHolder.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TemporaryConfigurationHolder.java
@@ -62,8 +62,9 @@ public class TemporaryConfigurationHolder extends ExternalResource {
 
     private void createTemporaryConfigFile() throws Exception {
         Template template = TEMPLATE_CONFIG.getTemplate(templateName);
-        template.process(
-                variables.withDataDirectory(temporaryFolder.newFolder().getAbsolutePath()),
+        template.process(variables
+                        .withDataDirectory(temporaryFolder.newFolder("legacy" + variables.getLocalServerPort()).getAbsolutePath())
+                        .withSqliteDataDirectory(temporaryFolder.newFolder("sqlite" + variables.getLocalServerPort()).getAbsolutePath()),
                 new FileWriter(temporaryConfigFile));
     }
 

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TemporaryConfigurationHolder.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TemporaryConfigurationHolder.java
@@ -62,10 +62,14 @@ public class TemporaryConfigurationHolder extends ExternalResource {
 
     private void createTemporaryConfigFile() throws Exception {
         Template template = TEMPLATE_CONFIG.getTemplate(templateName);
-        template.process(variables
-                        .withDataDirectory(temporaryFolder.newFolder("legacy" + variables.getLocalServerPort()).getAbsolutePath())
-                        .withSqliteDataDirectory(temporaryFolder.newFolder("sqlite" + variables.getLocalServerPort()).getAbsolutePath()),
-                new FileWriter(temporaryConfigFile));
+        TemplateVariables variablesWithFolders = variables
+                .withDataDirectory(temporaryFolder.newFolder(appendPort("legacy")).getAbsolutePath())
+                .withSqliteDataDirectory(temporaryFolder.newFolder(appendPort("sqlite")).getAbsolutePath());
+        template.process(variablesWithFolders, new FileWriter(temporaryConfigFile));
+    }
+
+    private String appendPort(String legacy) {
+        return legacy + variables.getLocalServerPort();
     }
 
     String getTemporaryConfigFileLocation() {

--- a/timelock-server/src/testCommon/resources/paxosMultiServer.ftl
+++ b/timelock-server/src/testCommon/resources/paxosMultiServer.ftl
@@ -1,6 +1,8 @@
 install:
   paxos:
     data-directory: "${dataDirectory}"
+    sqlite-persistence:
+      data-directory: "${sqliteDataDirectory}"
     is-new-service: false
     leader-mode: ${leaderMode}
   cluster:


### PR DESCRIPTION
**Goals (and why)**:
Tests were flaking due to timeouts on writes in a multithreaded approach. This avoids the problem by ensuring there is always only a single connection.

**Implementation Description (bullets)**:
Use just a single connection. This is ideal for writes, but makes reads somewhat slower as reads are allowed to happen in parallel.
This made other tests fail, revealing that we in fact instantiate LocalPaxosComponents twice. We additionally created a connection to sqlite for the namespace loader, and we were creating multiple connections in PaxosTimelockIntegration tests on every bounce.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Existing tests

**Concerns (what feedback would you like?)**:
Discussed implementing our own read/write locking which would allow us to have parallel reads. This would give us faster reads, but decided against it for now as it makes the implementation more difficult and does not seem necessary.
The fixes for the test failures / bad instantiations of connections may be cleaner so let's discuss.
 
**Where should we start reviewing?**:
tiny

**Priority (whenever / two weeks / yesterday)**:
ASAP as fixes test flakes