### PR TITLE
[PaxosStateLog] Fix Corner Case

### DIFF
--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogMigrator.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogMigrator.java
@@ -77,8 +77,9 @@ public final class PaxosStateLogMigrator<V extends Persistable & Versionable> {
         return Math.max(PaxosAcceptor.NO_LOG_ENTRY, lowerBoundWithAtLeastOneEntry);
     }
 
-    private void runMigration(long lowerBound, Persistable.Hydrator<V> hydrator) {
+    private void runMigration(long cutoff, Persistable.Hydrator<V> hydrator) {
         destinationLog.truncate(destinationLog.getGreatestLogEntry());
+        long lowerBound = cutoff == PaxosAcceptor.NO_LOG_ENTRY ? 0 : cutoff;
         long upperBound = sourceLog.getGreatestLogEntry();
         if (upperBound == PaxosAcceptor.NO_LOG_ENTRY) {
             return;

--- a/leader-election-impl/src/test/java/com/palantir/paxos/FileToSqlitePaxosStateLogIntegrationTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/FileToSqlitePaxosStateLogIntegrationTest.java
@@ -68,6 +68,11 @@ public class FileToSqlitePaxosStateLogIntegrationTest {
     }
 
     @Test
+    public void migrationSucceedsWhenGreatestEntrySmallerThanSafetyBufferAndNotFromZero() {
+        migrateAndVerifyValuesForSequences(LongStream.rangeClosed(10, PaxosStateLogMigrator.SAFETY_BUFFER - 10));
+    }
+    
+    @Test
     public void migrationForContiguousEntriesFromZeroSucceeds() {
         migrateAndVerifyValuesForSequences(LongStream.rangeClosed(0, 100));
     }

--- a/leader-election-impl/src/test/java/com/palantir/paxos/FileToSqlitePaxosStateLogIntegrationTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/FileToSqlitePaxosStateLogIntegrationTest.java
@@ -71,7 +71,7 @@ public class FileToSqlitePaxosStateLogIntegrationTest {
     public void migrationSucceedsWhenGreatestEntrySmallerThanSafetyBufferAndNotFromZero() {
         migrateAndVerifyValuesForSequences(LongStream.rangeClosed(10, PaxosStateLogMigrator.SAFETY_BUFFER - 10));
     }
-    
+
     @Test
     public void migrationForContiguousEntriesFromZeroSucceeds() {
         migrateAndVerifyValuesForSequences(LongStream.rangeClosed(0, 100));

--- a/leader-election-impl/src/test/java/com/palantir/paxos/FileToSqlitePaxosStateLogIntegrationTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/FileToSqlitePaxosStateLogIntegrationTest.java
@@ -89,7 +89,7 @@ public class FileToSqlitePaxosStateLogIntegrationTest {
         source.writeBatchOfRounds(rounds);
 
         migrate();
-        long cutoff = Math.max(PaxosAcceptor.NO_LOG_ENTRY + 1,
+        long cutoff = Math.max(PaxosAcceptor.NO_LOG_ENTRY,
                 source.getGreatestLogEntry() - PaxosStateLogMigrator.SAFETY_BUFFER);
         Map<Long, byte[]> targetEntries = readMigratedValuesFor(expectedValues);
 

--- a/leader-election-impl/src/test/java/com/palantir/paxos/FileToSqlitePaxosStateLogIntegrationTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/FileToSqlitePaxosStateLogIntegrationTest.java
@@ -63,12 +63,17 @@ public class FileToSqlitePaxosStateLogIntegrationTest {
     }
 
     @Test
-    public void contiguousMigrationFromZeroSucceeds() {
+    public void migrationSucceedsWhenGreatestEntrySmallerThanSafetyBuffer() {
+        migrateAndVerifyValuesForSequences(LongStream.rangeClosed(0, PaxosStateLogMigrator.SAFETY_BUFFER - 10));
+    }
+
+    @Test
+    public void migrationForContiguousEntriesFromZeroSucceeds() {
         migrateAndVerifyValuesForSequences(LongStream.rangeClosed(0, 100));
     }
 
     @Test
-    public void contiguousMigrationFromGreaterThanZeroSucceeds() {
+    public void migrationForContiguousEntriesFromGreaterThanZeroSucceeds() {
         migrateAndVerifyValuesForSequences(LongStream.rangeClosed(50, 130));
     }
 
@@ -84,7 +89,8 @@ public class FileToSqlitePaxosStateLogIntegrationTest {
         source.writeBatchOfRounds(rounds);
 
         migrate();
-        long cutoff = source.getGreatestLogEntry() - PaxosStateLogMigrator.SAFETY_BUFFER;
+        long cutoff = Math.max(PaxosAcceptor.NO_LOG_ENTRY + 1,
+                source.getGreatestLogEntry() - PaxosStateLogMigrator.SAFETY_BUFFER);
         Map<Long, byte[]> targetEntries = readMigratedValuesFor(expectedValues);
 
         targetEntries.entrySet().stream()


### PR DESCRIPTION
**Goals (and why)**:
A corner case snuck in where we would fail the migration if the greatest value was smaller than the safety buffer.

**Implementation Description (bullets)**:
If the cutoff for the migration is -1, start reading from sequence 0 instead

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added a test that was failing before

**Concerns (what feedback would you like?)**:
Nothing really

**Where should we start reviewing?**:
tiny

**Priority (whenever / two weeks / yesterday)**:
asap