### PR TITLE
Fix incorrect getRangeSlices trace span names

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TracingCassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TracingCassandraClient.java
@@ -99,13 +99,16 @@ public class TracingCassandraClient implements AutoDelegate_CassandraClient {
             KeyRange range,
             ConsistencyLevel consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, TException {
-        int numberOfKeys = predicate.slice_range.count;
-        int numberOfColumns = range.count;
+        int batchHint = range.count;
+        int numberOfColumns = predicate.slice_range.count;
 
         try (CloseableTrace trace = startLocalTrace(
-                "client.get_range_slices(table {}, number of keys {}, number of columns {}, consistency {}) on kvs.{}",
+                "client.get_range_slices(table {}, number of columns {}, batch hint {}, consistency {}) on kvs.{}",
                 LoggingArgs.safeTableOrPlaceholder(tableRef),
-                numberOfKeys, numberOfColumns, consistency_level, kvsMethodName)) {
+                numberOfColumns,
+                batchHint,
+                consistency_level,
+                kvsMethodName)) {
             return client.get_range_slices(kvsMethodName, tableRef, predicate, range, consistency_level);
         }
     }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TracingCassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TracingCassandraClient.java
@@ -99,8 +99,8 @@ public class TracingCassandraClient implements AutoDelegate_CassandraClient {
             KeyRange range,
             ConsistencyLevel consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, TException {
-        int batchHint = range.count;
         int numberOfColumns = predicate.slice_range.count;
+        int batchHint = range.count;
 
         try (CloseableTrace trace = startLocalTrace(
                 "client.get_range_slices(table {}, number of columns {}, batch hint {}, consistency {}) on kvs.{}",

--- a/changelog/@unreleased/pr-4817.v2.yml
+++ b/changelog/@unreleased/pr-4817.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Fix incorrect getRangeSlices trace span names for the Cassandra client;
+    previously the number of columns was reported as the number of rows, and the batch
+    hint was reported as the number of columns.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4817


### PR DESCRIPTION
**Goals (and why)**:
- Fix a misleading trace we ran into (together with @azarum) when debugging a perf issue

**Implementation Description (bullets)**:
- Correctly assign arguments: the count on the range is a batch hint, not number of columns; the count on the slice predicate is the number of columns, not number of rows.

**Testing (What was existing testing like?  What have you done to improve it?)**: None

**Concerns (what feedback would you like?)**:
- Is this the right way round?

**Where should we start reviewing?**: Small PR

**Priority (whenever / two weeks / yesterday)**: this week? It's small