### PR TITLE
[PaxosLog] Correctly Log Operation Durations

### DIFF
--- a/changelog/@unreleased/pr-4818.v2.yml
+++ b/changelog/@unreleased/pr-4818.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: The Paxos state log migration now correctly logs durations as safe.
+    Previously they weren't wrapped in an Arg and thus treated as unsafe.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4818

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogMigrator.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogMigrator.java
@@ -96,13 +96,12 @@ public final class PaxosStateLogMigrator<V extends Persistable & Versionable> {
         Instant afterRead = Instant.now();
         log.info("Reading {} entries from file backed paxos state log took {}.",
                 SafeArg.of("numEntries", roundsToMigrate.size()),
-                Duration.between(start, afterRead));
+                SafeArg.of("duration", Duration.between(start, afterRead)));
         Iterables.partition(roundsToMigrate, BATCH_SIZE)
                 .forEach(batch -> writeBatchRetryingUpToFiveTimes(destinationLog, batch));
         log.info("Writing {} entries to sqlite backed paxos state log took {}.",
                 SafeArg.of("numEntries", roundsToMigrate.size()),
-                Duration.between(afterRead, Instant.now()));
-
+                SafeArg.of("duration", Duration.between(afterRead, Instant.now())));
     }
 
     private void writeBatchRetryingUpToFiveTimes(PaxosStateLog<V> target, List<PaxosRound<V>> batch) {


### PR DESCRIPTION
**Goals (and why)**:
- Provide better visibility into how the paxos log migration is performing.

**Implementation Description (bullets)**:
- Actually wrap durations provided to loggers in proper Args so that they are safe
- This info is already recoverable given intervals between calls, but is easier to analyse in aggregate this way.

**Testing (What was existing testing like?  What have you done to improve it?)**: NA

**Concerns (what feedback would you like?)**: not much

**Where should we start reviewing?**: PaxosStateLogMigrator

**Priority (whenever / two weeks / yesterday)**: before the migration goes out, so tomorrow (Wednesday).
