### PR TITLE
[GCV Blocker] Don't use org.json.simple

### DIFF
--- a/atlasdb-client/build.gradle
+++ b/atlasdb-client/build.gradle
@@ -45,9 +45,6 @@ dependencies {
   compile project(":atlasdb-commons")
   compile project(":atlasdb-api")
   compile project(":atlasdb-client-protobufs")
-  compile (group: 'com.googlecode.json-simple', name: 'json-simple') {
-    exclude group: 'junit'
-  }
   compile group: "org.xerial.snappy", name: "snappy-java", version: libVersions.snappy
   compile group: "com.github.ben-manes.caffeine", name: "caffeine"
   compile group: "com.googlecode.protobuf-java-format", name: "protobuf-java-format", version: "1.2"

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/ValueType.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/ValueType.java
@@ -15,11 +15,10 @@
  */
 package com.palantir.atlasdb.table.description;
 
+import java.io.IOException;
 import java.util.UUID;
 
-import org.json.simple.JSONValue;
-
-import com.google.common.base.Preconditions;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
 import com.palantir.atlasdb.ptobject.EncodingUtils;
@@ -454,7 +453,7 @@ public enum ValueType {
         @Override
         public Pair<String, Integer> convertToJson(byte[] value, int offset) {
             Pair<String, Integer> p = convertToString(value, offset);
-            return Pair.create(JSONValue.toJSONString(p.getLhSide()), p.getRhSide());
+            return Pair.create(ValueType.writeJson(p.getLhSide()), p.getRhSide());
         }
 
         @Override
@@ -464,9 +463,7 @@ public enum ValueType {
 
         @Override
         public byte[] convertFromJson(String jsonValue) {
-            Object s = JSONValue.parse(jsonValue);
-            Preconditions.checkArgument(s instanceof String, "%s must be a json string", jsonValue);
-            return convertFromString((String) s);
+            return convertFromString(ValueType.readJson(jsonValue, String.class));
         }
 
         @Override
@@ -527,7 +524,7 @@ public enum ValueType {
         @Override
         public Pair<String, Integer> convertToJson(byte[] value, int offset) {
             Pair<String, Integer> p = convertToString(value, offset);
-            return Pair.create(JSONValue.toJSONString(p.getLhSide()), p.getRhSide());
+            return Pair.create(ValueType.writeJson(p.getLhSide()), p.getRhSide());
         }
 
         @Override
@@ -537,9 +534,7 @@ public enum ValueType {
 
         @Override
         public byte[] convertFromJson(String jsonValue) {
-            Object s = JSONValue.parse(jsonValue);
-            Preconditions.checkArgument(s instanceof String, "%s must be a json string", jsonValue);
-            return convertFromString((String) s);
+            return convertFromString(ValueType.readJson(jsonValue, String.class));
         }
 
         @Override
@@ -828,14 +823,12 @@ public enum ValueType {
 
         @Override
         public Pair<String, Integer> convertToJson(byte[] value, int offset) {
-            return Pair.create(JSONValue.toJSONString(convertToJava(value, offset).toString()), 16);
+            return Pair.create(ValueType.writeJson(convertToJava(value, offset).toString()), 16);
         }
 
         @Override
         public byte[] convertFromJson(String jsonValue) {
-            Object s = JSONValue.parse(jsonValue);
-            Preconditions.checkArgument(s instanceof String, "%s must be a json string", jsonValue);
-            return convertFromString((String) s);
+            return convertFromString(ValueType.readJson(jsonValue, String.class));
         }
 
         @Override
@@ -870,6 +863,8 @@ public enum ValueType {
 
     }
     ;
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     public abstract Object convertToJava(byte[] value, int offset);
     public abstract Pair<String, Integer> convertToJson(byte[] value, int offset);
@@ -921,4 +916,19 @@ public enum ValueType {
         return valueOf(message.name());
     }
 
+    private static <T> T readJson(String json, Class<T> clazz) {
+        try {
+            return OBJECT_MAPPER.readValue(json, clazz);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static String writeJson(Object value) {
+        try {
+            return OBJECT_MAPPER.writeValueAsString(value);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/ValueType.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/ValueType.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
 import com.palantir.atlasdb.ptobject.EncodingUtils;
+import com.palantir.logsafe.UnsafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.util.Pair;
 import com.palantir.util.crypto.Sha256Hash;
 
@@ -920,7 +922,7 @@ public enum ValueType {
         try {
             return OBJECT_MAPPER.readValue(json, clazz);
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new SafeIllegalArgumentException("{} must be a JSON string", UnsafeArg.of("json", json));
         }
     }
 

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/NameMetadataDescriptionTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/NameMetadataDescriptionTest.java
@@ -17,7 +17,6 @@
 package com.palantir.atlasdb.table.description;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Test;
@@ -31,7 +30,6 @@ import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
 import com.palantir.atlasdb.ptobject.EncodingUtils;
 import com.palantir.common.exception.PalantirRuntimeException;
-import com.palantir.conjure.java.serialization.ObjectMappers;
 
 public class NameMetadataDescriptionTest {
     private static final NameMetadataDescription SIMPLE_NAME_METADATA_DESCRIPTION = NameMetadataDescription.safe(
@@ -54,7 +52,7 @@ public class NameMetadataDescriptionTest {
     private static final byte[] SAMPLE_ROW = EncodingUtils.add(SAMPLE_ALPHA, SAMPLE_BETA, SAMPLE_GAMMA, SAMPLE_OMEGA);
     private static final byte[] SAMPLE_ROW_PREFIX = EncodingUtils.add(SAMPLE_ALPHA, SAMPLE_BETA);
 
-    private static final ObjectMapper OBJECT_MAPPER = ObjectMappers.newServerObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Test
     public void parseAndRenderAreInverses_Simple() {

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/NameMetadataDescriptionTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/NameMetadataDescriptionTest.java
@@ -147,7 +147,7 @@ public class NameMetadataDescriptionTest {
         JsonNode jsonNode = OBJECT_MAPPER.readTree(MULTIPART_NAME_METADATA_DESCRIPTION.renderToJson(SAMPLE_ROW));
         ((ObjectNode) jsonNode).remove(ImmutableList.of("alpha", "omega"));
 
-        assertThatThrownBy(() -> MULTIPART_NAME_METADATA_DESCRIPTION.parseFromJson(jsonNode.toString(), false))
+        assertThatThrownBy(() -> MULTIPART_NAME_METADATA_DESCRIPTION.parseFromJson(jsonNode.toString(), true))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("JSON object is missing field: alpha");
     }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/NameMetadataDescriptionTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/NameMetadataDescriptionTest.java
@@ -34,6 +34,7 @@ import com.palantir.common.exception.PalantirRuntimeException;
 public class NameMetadataDescriptionTest {
     private static final NameMetadataDescription SIMPLE_NAME_METADATA_DESCRIPTION = NameMetadataDescription.safe(
             "string", ValueType.STRING);
+
     private static final NameMetadataDescription MULTIPART_NAME_METADATA_DESCRIPTION = NameMetadataDescription.create(
             ImmutableList.of(
                     new NameComponentDescription.Builder()
@@ -69,10 +70,12 @@ public class NameMetadataDescriptionTest {
     }
 
     @Test
-    // TODO (jkong): This looks ridiculous, but I don't wish to change existing behaviour.
+    // TODO (jkong): Tolerating duplicate fields was permitted, even though it is a bit dubious.
     public void duplicateFieldsAreTolerated() {
         String invalidJson = "{\"string\": \"tom\", \"string\": \"robert\"}";
         byte[] result = SIMPLE_NAME_METADATA_DESCRIPTION.parseFromJson(invalidJson, false);
+        
+        // Which value is selected is an implementation detail - we should not guarantee this.
         assertThat(result).satisfiesAnyOf(
                 (bytes) -> assertThat(bytes).containsExactly(PtBytes.toBytes("tom")),
                 (bytes) -> assertThat(bytes).containsExactly(PtBytes.toBytes("robert")));

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/NameMetadataDescriptionTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/NameMetadataDescriptionTest.java
@@ -1,0 +1,142 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.table.description;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableList;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
+import com.palantir.atlasdb.ptobject.EncodingUtils;
+import com.palantir.conjure.java.serialization.ObjectMappers;
+
+public class NameMetadataDescriptionTest {
+    private static final NameMetadataDescription SIMPLE_NAME_METADATA_DESCRIPTION = NameMetadataDescription.safe(
+            "string", ValueType.STRING);
+    private static final NameMetadataDescription MULTIPART_NAME_METADATA_DESCRIPTION = NameMetadataDescription.create(
+            ImmutableList.of(
+                    new NameComponentDescription.Builder()
+                            .componentName("alpha")
+                            .type(ValueType.VAR_LONG)
+                            .byteOrder(TableMetadataPersistence.ValueByteOrder.DESCENDING)
+                            .build(),
+                    NameComponentDescription.safe("beta", ValueType.SIZED_BLOB),
+                    NameComponentDescription.safe("gamma", ValueType.VAR_STRING),
+                    NameComponentDescription.safe("omega", ValueType.STRING)));
+
+    private static final byte[] SAMPLE_ALPHA = EncodingUtils.flipAllBits(ValueType.VAR_LONG.convertFromJava(42L));
+    private static final byte[] SAMPLE_BETA = ValueType.SIZED_BLOB.convertFromJava(new byte[5]);
+    private static final byte[] SAMPLE_GAMMA = ValueType.VAR_STRING.convertFromString("boo");
+    private static final byte[] SAMPLE_OMEGA = ValueType.STRING.convertFromString("O(n)");
+    private static final byte[] SAMPLE_ROW = EncodingUtils.add(SAMPLE_ALPHA, SAMPLE_BETA, SAMPLE_GAMMA, SAMPLE_OMEGA);
+    private static final byte[] SAMPLE_ROW_PREFIX = EncodingUtils.add(SAMPLE_ALPHA, SAMPLE_BETA);
+
+    private static final ObjectMapper OBJECT_MAPPER = ObjectMappers.newServerObjectMapper();
+
+    @Test
+    public void parseAndRenderAreInverses_Simple() {
+        byte[] row = PtBytes.toBytes("theData");
+        assertThat(SIMPLE_NAME_METADATA_DESCRIPTION.parseFromJson(
+                SIMPLE_NAME_METADATA_DESCRIPTION.renderToJson(row), false)).containsExactly(row);
+    }
+
+    @Test
+    public void extraFieldsAreTolerated() throws JsonProcessingException {
+        byte[] row = PtBytes.toBytes("someData");
+        JsonNode jsonNode = OBJECT_MAPPER.readTree(SIMPLE_NAME_METADATA_DESCRIPTION.renderToJson(row));
+        ((ObjectNode) jsonNode).put("extraneousThing", "nein");
+        System.out.println(jsonNode.toString());
+        assertThatCode(() -> SIMPLE_NAME_METADATA_DESCRIPTION.parseFromJson(jsonNode.toString(), false))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    // TODO (jkong): This looks ridiculous, but I don't wish to change existing behaviour.
+    public void duplicateFieldsAreTolerated() {
+        String invalidJson = "{\"string\": \"tom\", \"string\": \"robert\"}";
+        byte[] result = SIMPLE_NAME_METADATA_DESCRIPTION.parseFromJson(invalidJson, false);
+        assertThat(result).satisfiesAnyOf(
+                (bytes) -> assertThat(bytes).containsExactly(PtBytes.toBytes("tom")),
+                (bytes) -> assertThat(bytes).containsExactly(PtBytes.toBytes("robert")));
+    }
+
+    @Test
+    public void throwsIfNoRelevantFieldsProvided() {
+        String missingFields = "{\"type\": \"string\"}";
+
+        assertThatThrownBy(() -> SIMPLE_NAME_METADATA_DESCRIPTION.parseFromJson(missingFields, false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("JSON object needs a field named: string.");
+    }
+
+
+    @Test
+    public void parseAndRenderAreInverses_MultiPart() {
+        assertThat(MULTIPART_NAME_METADATA_DESCRIPTION.parseFromJson(
+                MULTIPART_NAME_METADATA_DESCRIPTION.renderToJson(SAMPLE_ROW), false)).containsExactly(SAMPLE_ROW);
+    }
+
+    @Test
+    public void missingFieldsAreNotToleratedWithoutPrefix() throws JsonProcessingException {
+        JsonNode jsonNode = OBJECT_MAPPER.readTree(MULTIPART_NAME_METADATA_DESCRIPTION.renderToJson(SAMPLE_ROW));
+        ((ObjectNode) jsonNode).remove(ImmutableList.of("gamma", "omega"));
+
+        assertThatThrownBy(() -> MULTIPART_NAME_METADATA_DESCRIPTION.parseFromJson(jsonNode.toString(), false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("JSON object has 2 defined fields, but the number of row components is 4.");
+    }
+
+    @Test
+    public void missingSuffixFieldsAreToleratedInPrefixMode() throws JsonProcessingException {
+        JsonNode jsonNode = OBJECT_MAPPER.readTree(MULTIPART_NAME_METADATA_DESCRIPTION.renderToJson(SAMPLE_ROW));
+        ((ObjectNode) jsonNode).remove(ImmutableList.of("gamma", "omega"));
+
+        byte[] bytes = MULTIPART_NAME_METADATA_DESCRIPTION.parseFromJson(jsonNode.toString(), true);
+        assertThat(bytes).containsExactly(SAMPLE_ROW_PREFIX);
+    }
+
+    @Test
+    public void missingNonSuffixFieldsAreNotToleratedInPrefixMode() throws JsonProcessingException {
+        JsonNode jsonNode = OBJECT_MAPPER.readTree(MULTIPART_NAME_METADATA_DESCRIPTION.renderToJson(SAMPLE_ROW));
+        ((ObjectNode) jsonNode).remove(ImmutableList.of("alpha", "omega"));
+
+        assertThatThrownBy(() -> MULTIPART_NAME_METADATA_DESCRIPTION.parseFromJson(jsonNode.toString(), false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("JSON object is missing field: alpha");
+    }
+
+    @Test
+    public void differentOrderingOfFieldsInSerializedFormIsAcceptable() {
+        String beginWithEnd = "{\"omega\": \"O(n)\", \"alpha\": 42, \"beta\": \"AAAAAAA==\", \"gamma\": \"boo\"}";
+        assertThat(MULTIPART_NAME_METADATA_DESCRIPTION.parseFromJson(beginWithEnd, false)).containsExactly(SAMPLE_ROW);
+    }
+
+    @Test
+    public void differentOrderingOfFieldsInSerializedPrefixIsAcceptable() {
+        String jumbledPrefix = "{\"beta\": \"AAAAAAA==\", \"alpha\": 42}";
+        assertThat(MULTIPART_NAME_METADATA_DESCRIPTION.parseFromJson(jumbledPrefix, true))
+                .containsExactly(SAMPLE_ROW_PREFIX);
+    }
+}

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/ValueTypeTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/ValueTypeTest.java
@@ -17,7 +17,12 @@ package com.palantir.atlasdb.table.description;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.UUID;
+
 import org.junit.Test;
+
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.util.Pair;
 
 public class ValueTypeTest {
     private static final String BYTE_ARRAY = "byte[]";
@@ -40,5 +45,29 @@ public class ValueTypeTest {
     @Test
     public void arrayTypesReturnClassNameForObjectClassName() {
         assertThat(ValueType.BLOB.getJavaClassName()).isEqualTo(BYTE_ARRAY);
+    }
+
+    @Test
+    public void stringTypesConvertToAndFromJsonStrings() {
+        String string = "tom";
+        String jsonString = "\"" + string + "\"";
+        assertThat(ValueType.VAR_STRING.convertFromJson(jsonString)).isEqualTo(
+                ValueType.VAR_STRING.convertFromJava(string));
+        assertThat(ValueType.VAR_STRING.convertToJson(ValueType.VAR_STRING.convertFromJava(string), 0))
+                .isEqualTo(Pair.create(jsonString, 4));
+        assertThat(ValueType.STRING.convertFromJson(jsonString)).isEqualTo(
+                ValueType.STRING.convertFromJava(string));
+        assertThat(ValueType.STRING.convertToJson(ValueType.STRING.convertFromJava(string), 0))
+                .isEqualTo(Pair.create(jsonString, 3));
+    }
+
+    @Test
+    public void uuidJsonConversions() {
+        UUID uuid = UUID.randomUUID();
+        byte[] uuidBytes = ValueType.UUID.convertFromJava(uuid);
+        String quotedUuidString = "\"" + uuid.toString() + "\"";
+        assertThat(ValueType.UUID.convertToJson(uuidBytes, 0)).isEqualTo(
+                Pair.create(quotedUuidString, 16));
+        assertThat(ValueType.UUID.convertFromJson(quotedUuidString)).isEqualTo(uuidBytes);
     }
 }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/ValueTypeTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/ValueTypeTest.java
@@ -16,6 +16,7 @@
 package com.palantir.atlasdb.table.description;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.UUID;
 
@@ -59,6 +60,19 @@ public class ValueTypeTest {
                 ValueType.STRING.convertFromJava(string));
         assertThat(ValueType.STRING.convertToJson(ValueType.STRING.convertFromJava(string), 0))
                 .isEqualTo(Pair.create(jsonString, 3));
+    }
+
+    @Test
+    public void illegalArgumentExceptionThrownOnNonJsonStrings() {
+        assertThatThrownBy(() -> ValueType.STRING.convertFromJson("{\"data\": 42}"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must be a JSON string");
+        assertThatThrownBy(() -> ValueType.STRING.convertFromJson("[2, 3, 4, 5, 6]"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must be a JSON string");
+        assertThatThrownBy(() -> ValueType.STRING.convertFromJson("103-jv1-qg58n"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must be a JSON string");
     }
 
     @Test


### PR DESCRIPTION
**Goals (and why)**:
- Unblock #4769, gradle consistent versions is good.
- This PR is nontrivial enough that I feel it needs a review nonetheless.

**Implementation Description (bullets)**:
- Swap out the implementation of the JSON parser library in `NameMetadataDescription`, from json.simple to Jackson (which we use everywhere anyway)
- Validate that the behaviour of parsing is unchanged.
- Note that while it might not look like this is used anywhere, actually *it is* internally!

**Testing (What was existing testing like?  What have you done to improve it?)**:
- I wrote a heavy set of tests, mainly because I need to understand the nuances of this codepath myself.

**Concerns (what feedback would you like?)**:
There are some minor behaviour breaks:
- Passing in JSON of the wrong type (e.g. `"bleh"`) used to give you a `ClassCastException`, while now it gives you an `IllegalStateException`. I think this is fine.
- Causes of PalantirRuntimeExceptions owing to parser failures are going to be different, especially for the 'gobbledygook' case.

Is there anything else I missed out on?

**Where should we start reviewing?**: NameMetadataDescriptionTest

**Priority (whenever / two weeks / yesterday)**: this week

@j-baker for SA