### PR TITLE
[PDS-119625] Log the Exception, not UnsafeArg.of(exceptionMessage)

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -113,7 +113,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Cassand
             return runWithGoodResource(fn);
         } catch (Throwable t) {
             log.warn("Error occurred talking to host '{}': {}",
-                    SafeArg.of("host", CassandraLogHelper.host(host)), UnsafeArg.of("exception", t.toString()));
+                    SafeArg.of("host", CassandraLogHelper.host(host)), t);
             if (t instanceof NoSuchElementException && t.getMessage().contains("Pool exhausted")) {
                 log.warn("Extra information about exhausted pool",
                         SafeArg.of("numActive", clientPool.getNumActive()),

--- a/changelog/@unreleased/pr-4822.v2.yml
+++ b/changelog/@unreleased/pr-4822.v2.yml
@@ -1,0 +1,8 @@
+type: fix
+fix:
+  description: The type and stack trace of Exceptions when talking to Cassandra are
+    now logged (and in the case of Safe exceptions, the exception message will also
+    be available). Previously, only the exception message was logged, and this was
+    always Unsafe.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4822


### PR DESCRIPTION
**Goals (and why)**:
- See PDS-119625
- This made debugging somewhat annoying: you lose the failure type stack trace (and in the event `t` is actually Safe, you lose all information!)

**Implementation Description (bullets)**:
- Log the exception, not UnsafeArg.of(exceptionMessage).

**Testing (What was existing testing like?  What have you done to improve it?)**: none

**Concerns (what feedback would you like?)**:
- This may increase logging payloads. It won't pollute the logs from a user PoV so this would primarily be in terms of logging infra. I think the cost is reasonable.

**Where should we start reviewing?**: CCPC

**Priority (whenever / two weeks / yesterday)**: this week
