### PR TITLE
Avoid setting insecure hostname verification

### DIFF
--- a/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/ClientOptions.java
+++ b/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/ClientOptions.java
@@ -74,7 +74,6 @@ public abstract class ClientOptions {
                 .failedUrlCooldown(failedUrlCooldown())
                 .enableGcmCipherSuites(true)
                 .enableHttp2(true)
-                .fallbackToCommonNameVerification(true)
                 .clientQoS(clientQoS())
                 .build();
     }
@@ -94,7 +93,6 @@ public abstract class ClientOptions {
                 .maxNumRetries(maxNumRetries())
                 .enableGcmCipherSuites(true)
                 .enableHttp2(true)
-                .fallbackToCommonNameVerification(true)
                 .clientQoS(clientQoS())
                 .serverQoS(serverQoS());
 

--- a/changelog/@unreleased/pr-4824.v2.yml
+++ b/changelog/@unreleased/pr-4824.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Avoid setting insecure hostname verification
+  links:
+  - https://github.com/palantir/atlasdb/pull/4824


### PR DESCRIPTION
Insecure hostname verification isn't a good idea.
Modern versions of jaxrs-clients do not allow this to be set.

**Goals (and why)**:
impacts a large internal project

**Priority (whenever / two weeks / yesterday)**:
soon please
