### PR TITLE
Override blocking thrift threadpool.

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -19,6 +19,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketTimeoutException;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
 
 import org.immutables.value.Value;
 
@@ -188,6 +189,16 @@ public interface CassandraKeyValueServiceConfig extends KeyValueServiceConfig {
     @JsonIgnore
     default CassandraAsyncKeyValueServiceFactory asyncKeyValueServiceFactory() {
         return DefaultCassandraAsyncKeyValueServiceFactory.DEFAULT;
+    }
+
+    /**
+     * If provided, will be used to perform some blocking calls to Cassandra. Otherwise,
+     * a new executor service will be created.
+     */
+    @Value.Default
+    @JsonIgnore
+    default Optional<ExecutorService> thriftExecutorService() {
+        return Optional.empty();
     }
 
     int replicationFactor();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraReloadableKvsConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraReloadableKvsConfig.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.cassandra;
 import java.net.InetSocketAddress;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -131,6 +132,11 @@ public class CassandraReloadableKvsConfig implements CassandraKeyValueServiceCon
     @Override
     public CassandraAsyncKeyValueServiceFactory asyncKeyValueServiceFactory() {
         return config.asyncKeyValueServiceFactory();
+    }
+
+    @Override
+    public Optional<ExecutorService> thriftExecutorService() {
+        return config.thriftExecutorService();
     }
 
     @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -417,7 +417,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             Supplier<CassandraKeyValueServiceRuntimeConfig> runtimeConfigSupplier,
             CassandraClientPool clientPool,
             CassandraMutationTimestampProvider mutationTimestampProvider) {
-        super(createInstrumentedFixedThreadPool(config, metricsManager.getTaggedRegistry()));
+        super(createBlockingThreadpool(config, metricsManager));
         this.log = log;
         this.metricsManager = metricsManager;
         this.config = config;
@@ -444,6 +444,12 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         this.cassandraTableDropper = new CassandraTableDropper(config, clientPool, tableMetadata,
                 cassandraTableTruncator);
         this.runtimeConfigSupplier = runtimeConfigSupplier;
+    }
+
+    private static ExecutorService createBlockingThreadpool(CassandraKeyValueServiceConfig config,
+            MetricsManager metricsManager) {
+        return config.thriftExecutorService()
+                .orElseGet(() -> createInstrumentedFixedThreadPool(config, metricsManager.getTaggedRegistry()));
     }
 
     private static ExecutorService createInstrumentedFixedThreadPool(

--- a/changelog/@unreleased/pr-4826.v2.yml
+++ b/changelog/@unreleased/pr-4826.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Allow overriding blocking Cassandra thrift blocking call threadpool.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4826


### PR DESCRIPTION
**Goals (and why)**:

Allow overriding blocking Cassandra threadpool. atlas-proxy ends up creating a lot of TransactionManagers and these threads add up to thousands of threads.

The large number of threads along with the fact that they are configured to terminate after 1 minute of inactivity, leads to a lot of thread churn. Internally we have discovered either a JVM or Kernel bug which non-deterministically leads to slowdowns around the thread creation, slowing the service down to a crawl.

**Implementation Description (bullets)**:

Optional ExecutorService is passed to CassandraKeyValueServiceImpl. I looked at whether this could be an Executor, but, rightly, under normal operation CassandraKeyValueServiceImpl should be responsible for closing the threadpool, so it needs those methods from ExecutorService.

**Testing (What was existing testing like?  What have you done to improve it?)**:

I have tested this on the affected stacks, and run into CassandraReloadableKvsConfig gotcha, where my config was not being applied.

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

Now