### PR TITLE
[LW] Change TransactionLockWatchEvents interface

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManager.java
@@ -23,7 +23,7 @@ import com.palantir.common.annotation.Idempotent;
 import com.palantir.lock.watch.CommitUpdate;
 import com.palantir.lock.watch.IdentifiedVersion;
 import com.palantir.lock.watch.LockWatchReferences;
-import com.palantir.lock.watch.TransactionsLockWatchEvents;
+import com.palantir.lock.watch.TransactionsLockWatchUpdate;
 
 public abstract class LockWatchManager {
     /**
@@ -45,8 +45,9 @@ public abstract class LockWatchManager {
 
     /**
      * Given a set of start timestamps, and a lock watch state version, returns a list of all events that occurred since
-     * that version, and a map associating each start timestamp with its respective lock watch state version.
+     * that version, and a map associating each start timestamp with its respective lock watch state version, and a flag
+     * that is true if a snapshot or timelock leader election occurred.
      */
-    abstract TransactionsLockWatchEvents getEventsForTransactions(Set<Long> startTimestamps,
+    abstract TransactionsLockWatchUpdate getUpdateForTransactions(Set<Long> startTimestamps,
             Optional<IdentifiedVersion> version);
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/NoOpLockWatchManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/NoOpLockWatchManager.java
@@ -23,7 +23,7 @@ import com.palantir.lock.watch.CommitUpdate;
 import com.palantir.lock.watch.IdentifiedVersion;
 import com.palantir.lock.watch.LockWatchReferences;
 import com.palantir.lock.watch.NoOpLockWatchEventCache;
-import com.palantir.lock.watch.TransactionsLockWatchEvents;
+import com.palantir.lock.watch.TransactionsLockWatchUpdate;
 
 public final class NoOpLockWatchManager extends LockWatchManager {
     public static final LockWatchManager INSTANCE = new NoOpLockWatchManager();
@@ -39,8 +39,8 @@ public final class NoOpLockWatchManager extends LockWatchManager {
     }
 
     @Override
-    TransactionsLockWatchEvents getEventsForTransactions(Set<Long> startTimestamps,
+    TransactionsLockWatchUpdate getUpdateForTransactions(Set<Long> startTimestamps,
             Optional<IdentifiedVersion> version) {
-        return NoOpLockWatchEventCache.INSTANCE.getEventsForTransactions(startTimestamps, version);
+        return NoOpLockWatchEventCache.INSTANCE.getUpdateForTransactions(startTimestamps, version);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerImpl.java
@@ -33,7 +33,7 @@ import com.palantir.lock.watch.CommitUpdate;
 import com.palantir.lock.watch.IdentifiedVersion;
 import com.palantir.lock.watch.LockWatchEventCache;
 import com.palantir.lock.watch.LockWatchReferences;
-import com.palantir.lock.watch.TransactionsLockWatchEvents;
+import com.palantir.lock.watch.TransactionsLockWatchUpdate;
 import com.palantir.logsafe.UnsafeArg;
 
 public final class LockWatchManagerImpl extends LockWatchManager implements AutoCloseable {
@@ -58,9 +58,9 @@ public final class LockWatchManagerImpl extends LockWatchManager implements Auto
         return lockWatchEventCache.getCommitUpdate(startTs);
     }
 
-    TransactionsLockWatchEvents getEventsForTransactions(Set<Long> startTimestamps,
+    TransactionsLockWatchUpdate getUpdateForTransactions(Set<Long> startTimestamps,
             Optional<IdentifiedVersion> version) {
-        return lockWatchEventCache.getEventsForTransactions(startTimestamps, version);
+        return lockWatchEventCache.getUpdateForTransactions(startTimestamps, version);
     }
 
     @Override

--- a/changelog/@unreleased/pr-4827.v2.yml
+++ b/changelog/@unreleased/pr-4827.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Remove the visitor pattern from `TransactionLockWatchEvents`.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4827

--- a/lock-api-objects/src/main/java/com/palantir/lock/watch/IdentifiedVersion.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/watch/IdentifiedVersion.java
@@ -26,4 +26,8 @@ public interface IdentifiedVersion {
     UUID id();
     @Value.Parameter
     long version();
+
+    static IdentifiedVersion of(UUID id, long version) {
+        return ImmutableIdentifiedVersion.of(id, version);
+    }
 }

--- a/lock-api-objects/src/main/java/com/palantir/lock/watch/LockWatchEventCache.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/watch/LockWatchEventCache.java
@@ -26,7 +26,7 @@ public interface LockWatchEventCache {
     void processGetCommitTimestampsUpdate(Collection<TransactionUpdate> transactionUpdates,
             LockWatchStateUpdate update);
     CommitUpdate getCommitUpdate(long startTs);
-    TransactionsLockWatchEvents getEventsForTransactions(Set<Long> startTimestamps,
+    TransactionsLockWatchUpdate getUpdateForTransactionsg(Set<Long> startTimestamps,
             Optional<IdentifiedVersion> version);
     void removeTransactionStateFromCache(long startTimestamp);
 }

--- a/lock-api-objects/src/main/java/com/palantir/lock/watch/LockWatchEventCache.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/watch/LockWatchEventCache.java
@@ -26,7 +26,7 @@ public interface LockWatchEventCache {
     void processGetCommitTimestampsUpdate(Collection<TransactionUpdate> transactionUpdates,
             LockWatchStateUpdate update);
     CommitUpdate getCommitUpdate(long startTs);
-    TransactionsLockWatchUpdate getUpdateForTransactionsg(Set<Long> startTimestamps,
+    TransactionsLockWatchUpdate getUpdateForTransactions(Set<Long> startTimestamps,
             Optional<IdentifiedVersion> version);
     void removeTransactionStateFromCache(long startTimestamp);
 }

--- a/lock-api-objects/src/main/java/com/palantir/lock/watch/NoOpLockWatchEventCache.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/watch/NoOpLockWatchEventCache.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 @SuppressWarnings("FinalClass") // mocks
 public class NoOpLockWatchEventCache implements LockWatchEventCache {
     public static final LockWatchEventCache INSTANCE = new NoOpLockWatchEventCache();
+    private static final IdentifiedVersion FAKE_VERSION = IdentifiedVersion.of(UUID.randomUUID(), -1L);
 
     private NoOpLockWatchEventCache() {
         // singleton
@@ -50,21 +51,16 @@ public class NoOpLockWatchEventCache implements LockWatchEventCache {
     }
 
     @Override
-    public TransactionsLockWatchEvents getEventsForTransactions(Set<Long> startTimestamps,
+    public TransactionsLockWatchUpdate getUpdateForTransactions(Set<Long> startTimestamps,
             Optional<IdentifiedVersion> version) {
-        IdentifiedVersion fakeVersion = generateFakeVersion();
-        return ImmutableTransactionsLockWatchEvents.builder()
+        return ImmutableTransactionsLockWatchUpdate.builder()
                 .clearCache(true)
                 .startTsToSequence(
-                        startTimestamps.stream().collect(Collectors.toMap(startTs -> startTs, $ -> fakeVersion)))
+                        startTimestamps.stream().collect(Collectors.toMap(startTs -> startTs, $ -> FAKE_VERSION)))
                 .build();
     }
 
     @Override
     public void removeTransactionStateFromCache(long startTimestamp) {
-    }
-
-    private IdentifiedVersion generateFakeVersion() {
-        return IdentifiedVersion.of(UUID.randomUUID(), -1L);
     }
 }

--- a/lock-api-objects/src/main/java/com/palantir/lock/watch/TransactionsLockWatchEvents.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/watch/TransactionsLockWatchEvents.java
@@ -25,53 +25,9 @@ import org.immutables.value.Value;
  * Represents a condensed view of lock watch events occurring between some known version and a set of start transaction
  * calls.
  */
+@Value.Immutable
 public interface TransactionsLockWatchEvents {
-    <T> T accept(Visitor<T> visitor);
-
-    interface Visitor<T> {
-        T visit(Events success);
-        T visit(ForcedSnapshot failure);
-    }
-
-    static Events success(List<LockWatchEvent> events, Map<Long, Long> startTsToSequence) {
-        return ImmutableEvents.of(events, startTsToSequence);
-    }
-
-    static ForcedSnapshot failure(LockWatchStateUpdate.Snapshot snapshot) {
-        return ImmutableForcedSnapshot.of(snapshot);
-    }
-
-    /**
-     * A successful result contains a list of all lock watch events occurring between the last known version and the
-     * last started transaction, and a mapping of start timestamps to their respective last occurred event.
-     */
-    @Value.Immutable
-    interface Events extends TransactionsLockWatchEvents {
-        @Value.Parameter
-        List<LockWatchEvent> events();
-        @Value.Parameter
-        Map<Long, Long> startTsToSequence();
-
-        @Override
-        default <T> T accept(Visitor<T> visitor) {
-            return visitor.visit(this);
-        }
-    }
-
-    /**
-     * A failure denotes that it was not possible to compute the result for all of the requested transactions. Since
-     * that generally implies we will fail to get the necessary information for the commit timestamp anyway, instead of
-     * giving partial information, we return a single snapshot that should be used to reseed the state of lock watches
-     * for all future transactions.
-     */
-    @Value.Immutable
-    interface ForcedSnapshot extends TransactionsLockWatchEvents {
-        @Value.Parameter
-        LockWatchStateUpdate.Snapshot snapshot();
-
-        @Override
-        default <T> T accept(Visitor<T> visitor) {
-            return visitor.visit(this);
-        }
-    }
+    List<LockWatchEvent> events();
+    Map<Long, IdentifiedVersion> startTsToSequence();
+    boolean clearCache();
 }

--- a/lock-api-objects/src/main/java/com/palantir/lock/watch/TransactionsLockWatchUpdate.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/watch/TransactionsLockWatchUpdate.java
@@ -26,7 +26,7 @@ import org.immutables.value.Value;
  * calls.
  */
 @Value.Immutable
-public interface TransactionsLockWatchEvents {
+public interface TransactionsLockWatchUpdate {
     List<LockWatchEvent> events();
     Map<Long, IdentifiedVersion> startTsToSequence();
     boolean clearCache();


### PR DESCRIPTION
**Goals (and why)**:
* This change is introduced in https://github.com/palantir/atlasdb/pull/4806, but that is taking a long time to go through and changes in atlasdb-proxy depends on this.

**Implementation Description (bullets)**:
* Removed visitor pattern from `TransactionLockWatchEvents`; the intent is to always provide an update, even on snapshot.

**Testing (What was existing testing like?  What have you done to improve it?)**:
N/A

**Concerns (what feedback would you like?)**:
* Is this considered a breaking change? Do we need to do a `revapi` anywhere as a result of this change?

**Where should we start reviewing?**:
* `TransactionLockWatchEvents`
* `NoOpLockWatchEventCache`

**Priority (whenever / two weeks / yesterday)**:
Soon