### PR TITLE
Close resource in RemoteTimelockServiceAdapter

### DIFF
--- a/changelog/@unreleased/pr-4828.v2.yml
+++ b/changelog/@unreleased/pr-4828.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix a resource leak in RemoteTimelockServiceAdapter.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4828

--- a/lock-api/src/main/java/com/palantir/lock/client/RemoteTimelockServiceAdapter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/RemoteTimelockServiceAdapter.java
@@ -135,5 +135,6 @@ public final class RemoteTimelockServiceAdapter implements TimelockService, Auto
     @Override
     public void close() {
         transactionStarter.close();
+        commitTimestampGetter.close();
     }
 }


### PR DESCRIPTION
**Goals (and why)**:
I believe https://github.com/palantir/atlasdb/pull/4811 introduced a memory leak.  `RemoteTimelockServiceAdapter` creates a `CommitTimestampGetter` but never closes it, holding onto the resources.

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
