### PR TITLE
[Dialogue] Part 12: Fix Misdeclared Product Dependencies

### DIFF
--- a/changelog/@unreleased/pr-4830.v2.yml
+++ b/changelog/@unreleased/pr-4830.v2.yml
@@ -1,0 +1,8 @@
+type: fix
+fix:
+  description: The Conjure version of the V1 lock service now correctly depends on
+    a version of TimeLock server that exposes these endpoints. Previously this wasn't
+    the case, and a service which attempted to use the Conjure version would run into
+    404s when attempting to acquire or release locks.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4830

--- a/lock-conjure-api/build.gradle
+++ b/lock-conjure-api/build.gradle
@@ -1,6 +1,5 @@
 apply from: "../gradle/shared.gradle"
 
-apply plugin: 'com.palantir.sls-recommended-dependencies'
 apply plugin: 'com.palantir.conjure'
 
 conjure {
@@ -22,6 +21,8 @@ dependencies {
 
 subprojects {
     apply from: "../../gradle/shared.gradle"
+    apply plugin: 'com.palantir.sls-recommended-dependencies'
+
     dependencies {
         compile project(':lock-api-objects')
         compile 'com.palantir.conjure.java:conjure-lib'

--- a/lock-conjure-api/build.gradle
+++ b/lock-conjure-api/build.gradle
@@ -20,15 +20,6 @@ dependencies {
     conjureJava 'com.palantir.conjure.java:conjure-java'
 }
 
-recommendedProductDependencies {
-    productDependency {
-        productGroup = 'com.palantir.timelock'
-        productName = 'timelock-server'
-        minimumVersion = '0.187.0' // TODO (jkong): Bump
-        maximumVersion = '0.x.x'
-    }
-}
-
 subprojects {
     apply from: "../../gradle/shared.gradle"
     dependencies {
@@ -36,4 +27,13 @@ subprojects {
         compile 'com.palantir.conjure.java:conjure-lib'
     }
     tasks.licenseMain.enabled = false
+
+    recommendedProductDependencies {
+        productDependency {
+            productGroup = 'com.palantir.timelock'
+            productName = 'timelock-server'
+            minimumVersion = '0.189.0'
+            maximumVersion = '0.x.x'
+        }
+    }
 }


### PR DESCRIPTION
**Goals (and why)**:
- @jackwickham notes that the product dependencies were not set up correctly for AtlasDB users of internal TimeLock. The main problem is that these were applied to the `lock-conjure-api` project, not its subprojects. The version was also inconveniently two versions too early.

**Implementation Description (bullets)**:
- Declare the product dependencies as pertaining to the scope of subprojects.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- I built the artifacts and read the manifest of the jars. No automated test written here.

**Concerns (what feedback would you like?)**:
- Should more aggressive corrective action be taken internally? I doubt it given that in spite of potentially incorrect dependencies, all monitored internal stacks are past the true minimum version needed.

**Where should we start reviewing?**: build.gradle

**Priority (whenever / two weeks / yesterday)**: this week please