### PR TITLE
[PDS-119588] Relax Cassandra Schema Version Check

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -48,6 +48,13 @@ public interface CassandraKeyValueServiceConfig extends KeyValueServiceConfig {
 
     String TYPE = "cassandra";
 
+    /**
+     * These are only the initial 'contact points' that will be used in connecting with the cluster. AtlasDB will
+     * subsequently discover additional hosts in the cluster. (This is true for both Thrift and CQL endpoints.)
+     *
+     * This value, or values derived from it (e.g. the number of Thrift hosts) MUST NOT be used to ascertain the
+     * current live state of the cluster.
+     */
     CassandraServersConfigs.CassandraServersConfig servers();
 
     @Value.Default

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -52,8 +52,8 @@ public interface CassandraKeyValueServiceConfig extends KeyValueServiceConfig {
      * These are only the initial 'contact points' that will be used in connecting with the cluster. AtlasDB will
      * subsequently discover additional hosts in the cluster. (This is true for both Thrift and CQL endpoints.)
      *
-     * This value, or values derived from it (e.g. the number of Thrift hosts) MUST NOT be used to ascertain the
-     * current live state of the cluster.
+     * This value, or values derived from it (e.g. the number of Thrift hosts) must ONLY be used on KVS initialization
+     * to generate the initial connection(s) to the cluster, or as part of startup checks.
      */
     CassandraServersConfigs.CassandraServersConfig servers();
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -1641,7 +1641,9 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                         client.system_update_column_family(cf);
                     }
 
-                    CassandraKeyValueServices.waitForSchemaVersions(config, client,
+                    CassandraKeyValueServices.waitForSchemaVersions(
+                            config.schemaMutationTimeoutMillis(),
+                            client,
                             schemaChangeDescriptionForPutMetadataForTables(updatedCfs));
                 }
                 // Done with actual schema mutation, push the metadata

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
@@ -91,7 +91,7 @@ public final class CassandraKeyValueServices {
             // This may only include some of the nodes if the coordinator hasn't shaken hands with someone; however,
             // this existed largely as a defense against performance issues with concurrent schema modifications.
             versions = client.describe_schema_versions();
-            if (!clusterKnownToHaveSchemaDivergence(versions)) {
+            if (reachablePartOfClusterHasConsistentSchemaVersions(versions)) {
                 return;
             }
             sleepTime = sleepAndGetNextBackoffTime(sleepTime);
@@ -136,8 +136,8 @@ public final class CassandraKeyValueServices {
         waitForSchemaVersions(config, client, "after " + unsafeSchemaChangeDescription);
     }
 
-    static boolean clusterKnownToHaveSchemaDivergence(Map<String, List<String>> versions) {
-        return getDistinctReachableSchemas(versions).size() > 1;
+    static boolean reachablePartOfClusterHasConsistentSchemaVersions(Map<String, List<String>> versions) {
+        return getDistinctReachableSchemas(versions).size() == 1;
     }
 
     private static List<String> getDistinctReachableSchemas(Map<String, List<String>> versions) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
@@ -21,6 +21,7 @@ import java.nio.ByteOrder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -105,11 +106,9 @@ public final class CassandraKeyValueServices {
                     version.getValue());
         }
 
-        Set<InetSocketAddress> thriftHosts = config.servers().accept(new ThriftHostsExtractingVisitor());
-
-        String configNodes = addNodeInformation(new StringBuilder(),
-                "Nodes specified in config file:",
-                thriftHosts.stream().map(InetSocketAddress::getHostName).collect(Collectors.toList()))
+        String clusterNodes = addNodeInformation(new StringBuilder(),
+                "Nodes believed to exist:",
+                versions.values().stream().flatMap(Collection::stream).collect(Collectors.toList()))
                 .toString();
 
         String errorMessage = String.format("Cassandra cluster cannot come to agreement on schema versions, %s. %s"
@@ -122,7 +121,7 @@ public final class CassandraKeyValueServices {
                         + " and that the nodes specified in the config are up and joined the cluster. %s",
                 unsafeSchemaChangeDescription,
                 schemaVersions.toString(),
-                configNodes);
+                clusterNodes);
         throw new IllegalStateException(errorMessage);
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
@@ -15,7 +15,6 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
-import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.Charset;
@@ -26,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -44,7 +42,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
-import com.palantir.atlasdb.cassandra.CassandraServersConfigs.ThriftHostsExtractingVisitor;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.ColumnSelection;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTables.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTables.java
@@ -82,8 +82,10 @@ class CassandraTables {
     private Set<String> getTableNames(CassandraClient client, String keyspace,
             Function<CfDef, String> nameGetter) throws TException {
         try {
-            CassandraKeyValueServices
-                    .waitForSchemaVersions(config, client, "before making a call to get all table names.");
+            CassandraKeyValueServices.waitForSchemaVersions(
+                    config.schemaMutationTimeoutMillis(),
+                    client,
+                    "before making a call to get all table names.");
         } catch (IllegalStateException e) {
             throw new InsufficientConsistencyException("Could not reach a quorum of nodes agreeing on schema versions "
                     + "before making a call to get all table names.", e);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -210,7 +210,7 @@ public final class CassandraVerifier {
             throws TException {
         try (CassandraClient client = CassandraClientFactory.getClientInternal(host, config)) {
             client.describe_keyspace(config.getKeyspaceOrThrow());
-            CassandraKeyValueServices.waitForSchemaVersions(config, client,
+            CassandraKeyValueServices.waitForSchemaVersions(config.schemaMutationTimeoutMillis(), client,
                     "while checking if schemas diverged on startup");
             return true;
         } catch (NotFoundException e) {
@@ -224,7 +224,7 @@ public final class CassandraVerifier {
             KsDef ksDef = createKsDefForFresh(client, config);
             client.system_add_keyspace(ksDef);
             log.info("Created keyspace: {}", SafeArg.of("keyspace", config.getKeyspaceOrThrow()));
-            CassandraKeyValueServices.waitForSchemaVersions(config, client,
+            CassandraKeyValueServices.waitForSchemaVersions(config.schemaMutationTimeoutMillis(), client,
                     "after adding the initial empty keyspace");
             return true;
         } catch (InvalidRequestException e) {
@@ -258,7 +258,7 @@ public final class CassandraVerifier {
                 modifiedKsDef.setCf_defs(ImmutableList.of());
                 client.system_update_keyspace(modifiedKsDef);
                 CassandraKeyValueServices.waitForSchemaVersions(
-                        config,
+                        config.schemaMutationTimeoutMillis(),
                         client,
                         "after updating the existing keyspace");
             }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -257,7 +257,9 @@ public final class CassandraVerifier {
                 // Can't call system_update_keyspace to update replication factor if CfDefs are set
                 modifiedKsDef.setCf_defs(ImmutableList.of());
                 client.system_update_keyspace(modifiedKsDef);
-                CassandraKeyValueServices.waitForSchemaVersions(config, client,
+                CassandraKeyValueServices.waitForSchemaVersions(
+                        config,
+                        client,
                         "after updating the existing keyspace");
             }
             return null;

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServicesSchemaConsensusTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServicesSchemaConsensusTest.java
@@ -75,13 +75,13 @@ public class CassandraKeyValueServicesSchemaConsensusTest {
     @Test
     public void waitThrowsForAllUnknownSchemaVersion() throws TException {
         when(client.describe_schema_versions()).thenReturn(ImmutableMap.of());
-        assertWaitForSchemaVersionsThrowsAndContainsConfigNodesInformation();
+        assertWaitForSchemaVersionsThrows();
     }
 
     @Test
     public void waitThrowsForAllUnreachableSchemaVersion() throws TException {
         when(client.describe_schema_versions()).thenReturn(ImmutableMap.of(VERSION_UNREACHABLE, ALL_NODES));
-        assertWaitForSchemaVersionsThrowsAndContainsConfigNodesInformation();
+        assertWaitForSchemaVersionsThrows();
     }
 
     @Test
@@ -91,10 +91,10 @@ public class CassandraKeyValueServicesSchemaConsensusTest {
     }
 
     @Test
-    public void waitSucceedsOnMinorityOnSameVersionAndRestUnreachable() throws TException {
+    public void waitFailsOnMinorityOnSameVersionAndRestUnreachable() throws TException {
         when(client.describe_schema_versions())
                 .thenReturn(ImmutableMap.of(VERSION_UNREACHABLE, QUORUM_OF_NODES, VERSION_1, REST_OF_NODES));
-        assertWaitForSchemaVersionsThrowsAndContainsConfigNodesInformation();
+        assertWaitForSchemaVersionsThrows();
     }
 
     @Test
@@ -114,7 +114,7 @@ public class CassandraKeyValueServicesSchemaConsensusTest {
     public void waitThrowsForDifferentSchemaVersion() throws TException {
         when(client.describe_schema_versions())
                 .thenReturn(ImmutableMap.of(VERSION_1, QUORUM_OF_NODES, VERSION_2, REST_OF_NODES));
-        assertWaitForSchemaVersionsThrowsAndContainsConfigNodesInformation();
+        assertWaitForSchemaVersionsThrows();
     }
 
     @Test
@@ -138,10 +138,10 @@ public class CassandraKeyValueServicesSchemaConsensusTest {
         verify(waitingClient, times(4)).describe_schema_versions();
     }
 
-    private void assertWaitForSchemaVersionsThrowsAndContainsConfigNodesInformation() {
+    private void assertWaitForSchemaVersionsThrows() {
         assertThatThrownBy(() -> CassandraKeyValueServices.waitForSchemaVersions(config, client, TABLE))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining(FIVE_SERVERS.iterator().next().getHostName());
+                .hasMessageContaining("Cassandra cluster cannot come to agreement on schema versions");
     }
 
     private void assertWaitForSchemaVersionsDoesNotThrow() throws TException {

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServicesSchemaConsensusTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServicesSchemaConsensusTest.java
@@ -85,16 +85,16 @@ public class CassandraKeyValueServicesSchemaConsensusTest {
     }
 
     @Test
-    public void waitThrowsForFewerThanQuorumOnSameVersion() throws TException {
+    public void waitSucceedsOnMinorityOnSameVersion() throws TException {
         when(client.describe_schema_versions()).thenReturn(ImmutableMap.of(VERSION_1, REST_OF_NODES));
-        assertWaitForSchemaVersionsThrowsAndContainsConfigNodesInformation();
+        assertWaitForSchemaVersionsDoesNotThrow();
     }
 
     @Test
-    public void waitThrowsForQuorumOfUnreachableNodes() throws TException {
+    public void waitSucceedsOnMinorityOnSameVersionAndRestUnreachable() throws TException {
         when(client.describe_schema_versions())
                 .thenReturn(ImmutableMap.of(VERSION_UNREACHABLE, QUORUM_OF_NODES, VERSION_1, REST_OF_NODES));
-        assertWaitForSchemaVersionsThrowsAndContainsConfigNodesInformation();
+        assertWaitForSchemaVersionsDoesNotThrow();
     }
 
     @Test
@@ -129,8 +129,8 @@ public class CassandraKeyValueServicesSchemaConsensusTest {
         CassandraClient waitingClient = mock(CassandraClient.class);
         when(waitingClient.describe_schema_versions()).thenReturn(
                 ImmutableMap.of(),
-                ImmutableMap.of(VERSION_UNREACHABLE, QUORUM_OF_NODES, VERSION_1, REST_OF_NODES),
-                ImmutableMap.of(VERSION_1, QUORUM_OF_NODES, VERSION_UNREACHABLE, REST_OF_NODES),
+                ImmutableMap.of(VERSION_1, QUORUM_OF_NODES, VERSION_2, REST_OF_NODES),
+                ImmutableMap.of(VERSION_1, REST_OF_NODES, VERSION_UNREACHABLE, QUORUM_OF_NODES),
                 ImmutableMap.of(VERSION_1, ALL_NODES));
 
         CassandraKeyValueServices.waitForSchemaVersions(waitingConfig, waitingClient, TABLE);

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServicesSchemaConsensusTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServicesSchemaConsensusTest.java
@@ -85,6 +85,12 @@ public class CassandraKeyValueServicesSchemaConsensusTest {
     }
 
     @Test
+    public void waitSucceedsWithClusterHavingDownsizedAtRuntime() throws TException {
+        when(client.describe_schema_versions()).thenReturn(ImmutableMap.of(VERSION_1, REST_OF_NODES));
+        assertWaitForSchemaVersionsDoesNotThrow();
+    }
+
+    @Test
     public void waitFailsOnMinorityOnSameVersionAndRestUnreachable() throws TException {
         when(client.describe_schema_versions())
                 .thenReturn(ImmutableMap.of(VERSION_UNREACHABLE, QUORUM_OF_NODES, VERSION_1, REST_OF_NODES));

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServicesSchemaConsensusTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServicesSchemaConsensusTest.java
@@ -94,7 +94,7 @@ public class CassandraKeyValueServicesSchemaConsensusTest {
     public void waitSucceedsOnMinorityOnSameVersionAndRestUnreachable() throws TException {
         when(client.describe_schema_versions())
                 .thenReturn(ImmutableMap.of(VERSION_UNREACHABLE, QUORUM_OF_NODES, VERSION_1, REST_OF_NODES));
-        assertWaitForSchemaVersionsDoesNotThrow();
+        assertWaitForSchemaVersionsThrowsAndContainsConfigNodesInformation();
     }
 
     @Test
@@ -131,10 +131,11 @@ public class CassandraKeyValueServicesSchemaConsensusTest {
                 ImmutableMap.of(),
                 ImmutableMap.of(VERSION_1, QUORUM_OF_NODES, VERSION_2, REST_OF_NODES),
                 ImmutableMap.of(VERSION_1, REST_OF_NODES, VERSION_UNREACHABLE, QUORUM_OF_NODES),
+                ImmutableMap.of(VERSION_1, QUORUM_OF_NODES, VERSION_UNREACHABLE, REST_OF_NODES),
                 ImmutableMap.of(VERSION_1, ALL_NODES));
 
         CassandraKeyValueServices.waitForSchemaVersions(waitingConfig, waitingClient, TABLE);
-        verify(waitingClient, times(3)).describe_schema_versions();
+        verify(waitingClient, times(4)).describe_schema_versions();
     }
 
     private void assertWaitForSchemaVersionsThrowsAndContainsConfigNodesInformation() {

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServicesSchemaConsensusTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServicesSchemaConsensusTest.java
@@ -134,17 +134,20 @@ public class CassandraKeyValueServicesSchemaConsensusTest {
                 ImmutableMap.of(VERSION_1, QUORUM_OF_NODES, VERSION_UNREACHABLE, REST_OF_NODES),
                 ImmutableMap.of(VERSION_1, ALL_NODES));
 
-        CassandraKeyValueServices.waitForSchemaVersions(waitingConfig, waitingClient, TABLE);
+        CassandraKeyValueServices.waitForSchemaVersions(
+                waitingConfig.schemaMutationTimeoutMillis(), waitingClient, TABLE);
         verify(waitingClient, times(4)).describe_schema_versions();
     }
 
     private void assertWaitForSchemaVersionsThrows() {
-        assertThatThrownBy(() -> CassandraKeyValueServices.waitForSchemaVersions(config, client, TABLE))
+        assertThatThrownBy(
+                () -> CassandraKeyValueServices.waitForSchemaVersions(
+                        config.schemaMutationTimeoutMillis(), client, TABLE))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Cassandra cluster cannot come to agreement on schema versions");
     }
 
     private void assertWaitForSchemaVersionsDoesNotThrow() throws TException {
-        CassandraKeyValueServices.waitForSchemaVersions(config, client, TABLE);
+        CassandraKeyValueServices.waitForSchemaVersions(config.schemaMutationTimeoutMillis(), client, TABLE);
     }
 }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServicesSchemaConsensusTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServicesSchemaConsensusTest.java
@@ -85,12 +85,6 @@ public class CassandraKeyValueServicesSchemaConsensusTest {
     }
 
     @Test
-    public void waitSucceedsOnMinorityOnSameVersion() throws TException {
-        when(client.describe_schema_versions()).thenReturn(ImmutableMap.of(VERSION_1, REST_OF_NODES));
-        assertWaitForSchemaVersionsDoesNotThrow();
-    }
-
-    @Test
     public void waitFailsOnMinorityOnSameVersionAndRestUnreachable() throws TException {
         when(client.describe_schema_versions())
                 .thenReturn(ImmutableMap.of(VERSION_UNREACHABLE, QUORUM_OF_NODES, VERSION_1, REST_OF_NODES));

--- a/changelog/@unreleased/pr-4831.v2.yml
+++ b/changelog/@unreleased/pr-4831.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: AtlasDB is now more resilient to migrations involving changes in the
+    cluster size relative to the original install config. Previously, if a cluster
+    was downsized at runtime, schema operations would consistently fail until the
+    service was bounced.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4831


### PR DESCRIPTION
**Goals (and why)**:
- Give Atlas a way of being resilient to migrations that change the cluster size. This blocked startup in PDS-119588.

**Implementation Description (bullets)**:
- After discussion with @leonz and @tpetracca, it appears that the check was written in this way because there was a concern over performance (if more schema operations are kicked off while the cluster is not in agreement, this could make reaching said agreement take longer).
- Recent changes to the fork of Cassandra we use should have addressed these concerns.
- Separately: I audited all other uses of the server config, which appear to be either delegating, part of the startup process, or are seeding the Datastax driver (which has its own discovery mechanism).

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Updated unit tests to reflect the new behaviour.

**Concerns (what feedback would you like?)**:
- Do the tests provide good enough coverage?
- I believe this is safe for the gated describe keyspace call as well, because concurrent schema changes may or may not be reflected. Does this make sense?

**Where should we start reviewing?**: CKVSConsensusTest

**Priority (whenever / two weeks / yesterday)**: this week.
