### PR TITLE
PG-151833: Apply the default cancel-remaining-calls value globally

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
@@ -188,7 +188,7 @@ public final class Leaders {
                 createExecutorsForService(metricsManager, otherLeaders, "leader-ping"),
                 config.leaderPingResponseWait(),
                 leaderUuid,
-                true);
+                PaxosConstants.CANCEL_REMAINING_CALLS);
 
         LeaderElectionService uninstrumentedLeaderElectionService = new LeaderElectionServiceBuilder()
                 .leaderUuid(leaderUuid)

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
@@ -68,6 +68,7 @@ import com.palantir.paxos.LeaderPingerContext;
 import com.palantir.paxos.PaxosAcceptor;
 import com.palantir.paxos.PaxosAcceptorImpl;
 import com.palantir.paxos.PaxosAcceptorNetworkClient;
+import com.palantir.paxos.PaxosConstants;
 import com.palantir.paxos.PaxosLearner;
 import com.palantir.paxos.PaxosLearnerImpl;
 import com.palantir.paxos.PaxosLearnerNetworkClient;
@@ -162,7 +163,7 @@ public final class Leaders {
                 remoteLearners,
                 config.quorumSize(),
                 createExecutorsForService(metricsManager, learners, "knowledge-update"),
-                true);
+                PaxosConstants.CANCEL_REMAINING_CALLS);
 
         List<PaxosAcceptor> acceptors = createProxyAndLocalList(
                 ourAcceptor,
@@ -175,7 +176,7 @@ public final class Leaders {
                 acceptors,
                 config.quorumSize(),
                 createExecutorsForService(metricsManager, acceptors, "latest-round-verifier"),
-                true);
+                PaxosConstants.CANCEL_REMAINING_CALLS);
 
         List<LeaderPingerContext<PingableLeader>> otherLeaders = generatePingables(
                 remotePaxosServerSpec.remoteLeaderUris(),

--- a/changelog/@unreleased/pr-4835.v2.yml
+++ b/changelog/@unreleased/pr-4835.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Apply the default cancel-remaining-calls value globally to prevent
+    excessive handshaking due to lack of connection reuse when request are interrupted.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4835

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosConstants.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosConstants.java
@@ -1,0 +1,24 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.paxos;
+
+public final class PaxosConstants {
+
+    public static final boolean CANCEL_REMAINING_CALLS = false;
+
+    private PaxosConstants() {
+    }
+}

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosConsensusTestUtils.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosConsensusTestUtils.java
@@ -92,7 +92,7 @@ public final class PaxosConsensusTestUtils {
                 acceptors,
                 quorumSize,
                 Maps.toMap(acceptors, $ -> executor),
-                true);
+                PaxosConstants.CANCEL_REMAINING_CALLS);
 
         for (int i = 0; i < numLeaders; i++) {
             UUID leaderUuid = UUID.randomUUID();
@@ -102,7 +102,7 @@ public final class PaxosConsensusTestUtils {
                     .filter(learner -> !learner.equals(ourLearner))
                     .collect(ImmutableList.toImmutableList());
             PaxosLearnerNetworkClient learnerNetworkClient = new SingleLeaderLearnerNetworkClient(
-                    ourLearner, remoteLearners, quorumSize, Maps.toMap(learners, $ -> executor), true);
+                    ourLearner, remoteLearners, quorumSize, Maps.toMap(learners, $ -> executor), PaxosConstants.CANCEL_REMAINING_CALLS);
 
             LeaderElectionService leader = new LeaderElectionServiceBuilder()
                     .leaderUuid(leaderUuid)

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosConsensusTestUtils.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosConsensusTestUtils.java
@@ -102,7 +102,8 @@ public final class PaxosConsensusTestUtils {
                     .filter(learner -> !learner.equals(ourLearner))
                     .collect(ImmutableList.toImmutableList());
             PaxosLearnerNetworkClient learnerNetworkClient = new SingleLeaderLearnerNetworkClient(
-                    ourLearner, remoteLearners, quorumSize, Maps.toMap(learners, $ -> executor), PaxosConstants.CANCEL_REMAINING_CALLS);
+                    ourLearner, remoteLearners, quorumSize, Maps.toMap(learners, $ -> executor),
+                    PaxosConstants.CANCEL_REMAINING_CALLS);
 
             LeaderElectionService leader = new LeaderElectionServiceBuilder()
                     .leaderUuid(leaderUuid)

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/Factories.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/Factories.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Maps;
 import com.palantir.atlasdb.timelock.paxos.NetworkClientFactories.Factory;
 import com.palantir.paxos.LeaderPinger;
 import com.palantir.paxos.PaxosAcceptorNetworkClient;
+import com.palantir.paxos.PaxosConstants;
 import com.palantir.paxos.PaxosLatestRoundVerifier;
 import com.palantir.paxos.SingleLeaderPinger;
 import com.palantir.timelock.paxos.HealthCheckPinger;
@@ -84,7 +85,7 @@ public interface Factories {
                     Maps.toMap(remoteClients().nonBatchPingableLeadersWithContext(), _pingable -> sharedExecutor()),
                     leaderPingResponseWait(),
                     leaderUuid(),
-                    PaxosTimeLockConstants.CANCEL_REMAINING_CALLS);
+                    PaxosConstants.CANCEL_REMAINING_CALLS);
         }
 
         @Override

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/SingleLeaderNetworkClientFactories.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/SingleLeaderNetworkClientFactories.java
@@ -26,6 +26,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.common.streams.KeyedStream;
 import com.palantir.paxos.PaxosAcceptor;
 import com.palantir.paxos.PaxosAcceptorNetworkClient;
+import com.palantir.paxos.PaxosConstants;
 import com.palantir.paxos.PaxosLearner;
 import com.palantir.paxos.PaxosLearnerNetworkClient;
 import com.palantir.paxos.SingleLeaderAcceptorNetworkClient;
@@ -64,7 +65,7 @@ abstract class SingleLeaderNetworkClientFactories implements
                             .mapKeys(WithDedicatedExecutor::service)
                             .map(WithDedicatedExecutor::executor)
                             .collectToMap(),
-                    PaxosTimeLockConstants.CANCEL_REMAINING_CALLS);
+                    PaxosConstants.CANCEL_REMAINING_CALLS);
             return metrics().instrument(PaxosAcceptorNetworkClient.class, uninstrumentedAcceptor);
         };
     }
@@ -85,7 +86,7 @@ abstract class SingleLeaderNetworkClientFactories implements
                     allLearners.remotes(),
                     quorumSize(),
                     allLearners.withSharedExecutor(sharedExecutor()),
-                    PaxosTimeLockConstants.CANCEL_REMAINING_CALLS);
+                    PaxosConstants.CANCEL_REMAINING_CALLS);
             return metrics().instrument(PaxosLearnerNetworkClient.class, uninstrumentedLearner);
         };
     }

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/LeaderPingHealthCheck.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/LeaderPingHealthCheck.java
@@ -32,6 +32,7 @@ import com.palantir.common.concurrent.NamedThreadFactory;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.common.streams.KeyedStream;
 import com.palantir.paxos.Client;
+import com.palantir.paxos.PaxosConstants;
 import com.palantir.paxos.PaxosQuorumChecker;
 import com.palantir.paxos.PaxosResponses;
 import com.palantir.timelock.TimeLockStatus;
@@ -63,7 +64,7 @@ public class LeaderPingHealthCheck {
                         pinger -> PaxosContainer.of(pinger.apply(namespacesToCheck)),
                         executorService,
                         HEALTH_CHECK_TIME_LIMIT,
-                        PaxosTimeLockConstants.CANCEL_REMAINING_CALLS);
+                        PaxosConstants.CANCEL_REMAINING_CALLS);
 
         Map<Client, PaxosResponses<HealthCheckResponse>> responsesByClient = responses.stream()
                 .map(PaxosContainer::get)

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/LeaderPingHealthCheck.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/LeaderPingHealthCheck.java
@@ -27,7 +27,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.google.common.collect.SetMultimap;
 import com.palantir.atlasdb.timelock.paxos.PaxosQuorumCheckingCoalescingFunction.PaxosContainer;
-import com.palantir.atlasdb.timelock.paxos.PaxosTimeLockConstants;
 import com.palantir.common.concurrent.NamedThreadFactory;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.common.streams.KeyedStream;

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/GetSuspectedLeaderWithUuid.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/GetSuspectedLeaderWithUuid.java
@@ -46,6 +46,7 @@ import com.palantir.atlasdb.timelock.paxos.PaxosQuorumCheckingCoalescingFunction
 import com.palantir.common.base.Throwables;
 import com.palantir.common.streams.KeyedStream;
 import com.palantir.paxos.LeaderPingerContext;
+import com.palantir.paxos.PaxosConstants;
 import com.palantir.paxos.PaxosQuorumChecker;
 import com.palantir.paxos.PaxosResponsesWithRemote;
 
@@ -108,7 +109,7 @@ class GetSuspectedLeaderWithUuid implements Consumer<List<BatchElement<UUID, Opt
                         leaderPingResponseWait,
                         state -> state.responses().values().stream().map(PaxosContainer::get).collect(toSet())
                                 .containsAll(uncachedUuids),
-                        PaxosTimeLockConstants.CANCEL_REMAINING_CALLS);
+                        PaxosConstants.CANCEL_REMAINING_CALLS);
 
         for (Map.Entry<LeaderPingerContext<BatchPingableLeader>, PaxosContainer<UUID>> resultEntries : results.responses().entrySet()) {
             LeaderPingerContext<BatchPingableLeader> pingable = resultEntries.getKey();

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosQuorumCheckingCoalescingFunction.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosQuorumCheckingCoalescingFunction.java
@@ -39,6 +39,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.palantir.atlasdb.autobatch.CoalescingRequestFunction;
 import com.palantir.common.streams.KeyedStream;
+import com.palantir.paxos.PaxosConstants;
 import com.palantir.paxos.PaxosQuorumChecker;
 import com.palantir.paxos.PaxosResponse;
 import com.palantir.paxos.PaxosResponses;
@@ -82,7 +83,7 @@ public class PaxosQuorumCheckingCoalescingFunction<
                 quorumSize,
                 executors,
                 PaxosQuorumChecker.DEFAULT_REMOTE_REQUESTS_TIMEOUT,
-                PaxosTimeLockConstants.CANCEL_REMAINING_CALLS);
+                PaxosConstants.CANCEL_REMAINING_CALLS);
 
         Map<REQ, PaxosResponsesWithRemote<FUNC, RESP>> responseMap = responses.stream()
                 .map(PaxosContainer::get)

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimeLockConstants.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimeLockConstants.java
@@ -16,6 +16,7 @@
 package com.palantir.atlasdb.timelock.paxos;
 
 import com.palantir.paxos.Client;
+import com.palantir.paxos.PaxosConstants;
 
 public final class PaxosTimeLockConstants {
     public static final String LEARNER_SUBDIRECTORY_PATH = "learner";
@@ -32,7 +33,12 @@ public final class PaxosTimeLockConstants {
 
     public static final Client LEGACY_PAXOS_AS_CLIENT = Client.of(LEADER_PAXOS_NAMESPACE);
 
-    public static final boolean CANCEL_REMAINING_CALLS = false;
+    /**
+     * Prefer {@link PaxosConstants#CANCEL_REMAINING_CALLS}.
+     * @deprecated in favor of {@link PaxosConstants#CANCEL_REMAINING_CALLS}
+     */
+    @Deprecated
+    public static final boolean CANCEL_REMAINING_CALLS = PaxosConstants.CANCEL_REMAINING_CALLS;
 
     private PaxosTimeLockConstants() {
     }

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
@@ -56,6 +56,7 @@ import com.palantir.leader.proxy.ToggleableExceptionProxy;
 import com.palantir.paxos.Client;
 import com.palantir.paxos.PaxosAcceptor;
 import com.palantir.paxos.PaxosAcceptorNetworkClient;
+import com.palantir.paxos.PaxosConstants;
 import com.palantir.paxos.PaxosLearner;
 import com.palantir.paxos.PaxosLearnerNetworkClient;
 import com.palantir.paxos.PaxosProposer;
@@ -179,7 +180,7 @@ public class PaxosTimestampBoundStoreTest {
             learnerNetworkClientFactories.forEach(closer::register);
         } else {
             acceptorClient = new SingleLeaderAcceptorNetworkClient(
-                    acceptors, QUORUM_SIZE, Maps.toMap(acceptors, $ -> executor), true);
+                    acceptors, QUORUM_SIZE, Maps.toMap(acceptors, $ -> executor), PaxosConstants.CANCEL_REMAINING_CALLS);
 
             learnerClientsByNode = learners.stream()
                     .map(learner -> new SingleLeaderLearnerNetworkClient(
@@ -187,7 +188,7 @@ public class PaxosTimestampBoundStoreTest {
                             learners.stream().filter(otherLearners -> otherLearners != learner).collect(toList()),
                             QUORUM_SIZE,
                             Maps.toMap(learners, $ -> executor),
-                            true))
+                            PaxosConstants.CANCEL_REMAINING_CALLS))
                     .collect(toList());
         }
 


### PR DESCRIPTION
**Goals (and why)**:

Prevent excessive handshaking due to lack of connection reuse when request are interrupted.

**Implementation Description (bullets)**:

Use the same default across all paths
