### PR TITLE
[PD$-110002] Part 2: Economising Snapshot Transaction commitWrites() Timers

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -1659,6 +1659,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             // Acquire row locks and a lock on the start timestamp row in the transactions table.
             // This must happen before conflict checking, otherwise we could complete the checks and then have someone
             // else write underneath us before we proceed (thus missing a write/write conflict).
+            // Timing still useful to distinguish bad lock percentiles from user-generated lock requests.
             LockToken commitLocksToken = timedAndTraced("commitAcquireLocks", this::acquireLocksForCommit);
             try {
                 // Conflict checking. We can actually do this later without compromising correctness, but there is no
@@ -1677,6 +1678,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                 // Now that all writes are done, get the commit timestamp
                 // We must do this before we check that our locks are still valid to ensure that other transactions that
                 // will hold these locks are sure to have start timestamps after our commit timestamp.
+                // Timing is still useful, as this may perform operations pertaining to lock watches.
                 long commitTimestamp = timedAndTraced("getCommitTimestamp",
                         () -> timelockService.getCommitTimestamp(getStartTimestamp(), commitLocksToken));
                 commitTsForScrubbing = commitTimestamp;
@@ -1686,7 +1688,8 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                 // scrub timestamp (same as the hard delete transaction's start timestamp).
                 // May not need to be here specifically, but this is a very cheap operation - scheduling another thread
                 // might well cost more.
-                timedAndTraced("microsForPunch", () -> cleaner.punch(commitTimestamp));
+                // Not timed as this is generally an asynchronous operation.
+                traced("microsForPunch", () -> cleaner.punch(commitTimestamp));
 
                 // Serializable transactions need to check their reads haven't changed, by reading again at
                 // commitTs + 1. This must happen before the lock check for thorough tables, because the lock check
@@ -1700,25 +1703,30 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                 // We check the pre-commit conditions first since they may operate similarly to read write conflict
                 // handling - we should check lock validity last to ensure that sweep hasn't affected the checks.
                 timedAndTraced("userPreCommitCondition", () -> throwIfPreCommitConditionInvalid(commitTimestamp));
-                timedAndTraced("preCommitLockCheck", () -> throwIfImmutableTsOrCommitLocksExpired(commitLocksToken));
+                traced("preCommitLockCheck", () -> throwIfImmutableTsOrCommitLocksExpired(commitLocksToken));
 
-                timedAndTraced("commitPutCommitTs",
+                // TransactionService.putUnlessExists: actually commits the transaction
+                traced("commitPutCommitTs",
                         () -> putCommitTimestamp(commitTimestamp, commitLocksToken, transactionService));
 
                 long microsSinceCreation = TimeUnit.MILLISECONDS.toMicros(System.currentTimeMillis() - timeCreated);
                 getTimer("commitTotalTimeSinceTxCreation").update(microsSinceCreation, TimeUnit.MICROSECONDS);
                 getHistogram(AtlasDbMetricNames.SNAPSHOT_TRANSACTION_BYTES_WRITTEN).update(byteCount.get());
             } finally {
-                timedAndTraced("postCommitUnlock",
-                        () -> timelockService.tryUnlock(ImmutableSet.of(commitLocksToken)));
+                traced("postCommitUnlock", () -> timelockService.tryUnlock(ImmutableSet.of(commitLocksToken)));
             }
         });
     }
 
-    private void timedAndTraced(String timerName, Runnable runnable) {
-        try (Timer.Context timer = getTimer(timerName).time();
-                CloseableTracer tracer = CloseableTracer.startSpan(timerName)) {
+    private void traced(String spanName, Runnable runnable) {
+        try (CloseableTracer tracer = CloseableTracer.startSpan(spanName)) {
             runnable.run();
+        }
+    }
+
+    private void timedAndTraced(String timerName, Runnable runnable) {
+        try (Timer.Context timer = getTimer(timerName).time()) {
+            traced(timerName, runnable);
         }
     }
 

--- a/changelog/@unreleased/pr-4837.v2.yml
+++ b/changelog/@unreleased/pr-4837.v2.yml
@@ -1,0 +1,10 @@
+type: improvement
+improvement:
+  description: |-
+    Snapshot Transaction no longer publishes metrics for
+    - punching the `_punch` table: this operation is asynchronous
+    - refreshing commit locks: consider `ConjureTimelockServiceBlocking.refreshLockLeases`
+    - putting a commit timestamp into the database: consider `TransactionService.putUnlessExists`
+    - unlocking lock tokens after a commit: this operation is asynchronous
+  links:
+  - https://github.com/palantir/atlasdb/pull/4837


### PR DESCRIPTION
**Goals (and why)**:
- Save money on metrics
- But still get as much signal as possible

**Implementation Description (bullets)**:
- In internal atlasdb-proxy, these are a fairly heavily hit set of timers (one per constituent database). Some are useful, but not all.
- I think the least contentious ones are the in-memory operations (tryUnlock, asyncPuncher). There is a middling group that is a bit more open for discussion: I chose them based on how valuable the signal is compared to an already existing metric (e.g. putting the commit timestamp into the database is largely reflected in TransactionService.putUnlessExists and I can believe the latter is representative of the former; but I can't say the same for transaction locks).

**Testing (What was existing testing like?  What have you done to improve it?)**: None

**Concerns (what feedback would you like?)**:
- Consider each decision on whether the timing metric was kept or not - do you agree with each one?

**Where should we start reviewing?**: the one file

**Priority (whenever / two weeks / yesterday)**: this week