### PR TITLE
[PD$-110002] Part 3: Remove transactionsReadFromDB

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbMetricNames.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbMetricNames.java
@@ -37,7 +37,6 @@ public final class AtlasDbMetricNames {
     public static final String SNAPSHOT_TRANSACTION_CELLS_RETURNED = "numCellsReturnedAfterFiltering";
     public static final String SNAPSHOT_TRANSACTION_TOO_MANY_BYTES_READ = "tooManyBytesRead";
     public static final String SNAPSHOT_TRANSACTION_BYTES_WRITTEN = "bytesWritten";
-    public static final String NUMBER_OF_TRANSACTIONS_READ_FROM_DB = "transactionsReadFromDB";
 
     public static final String CELLS_EXAMINED = "cellTimestampPairsExamined";
     public static final String CELLS_SWEPT = "staleValuesDeleted";

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -2234,8 +2234,6 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             logLargeNumberOfTransactions(tableRef, gets);
         }
 
-        getCounter(AtlasDbMetricNames.NUMBER_OF_TRANSACTIONS_READ_FROM_DB, tableRef).inc(gets.size());
-
         return Futures.transform(loadCommitTimestamps(asyncTransactionService, gets),
                 rawResults -> {
                     for (Map.Entry<Long, Long> e : rawResults.entrySet()) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -2234,7 +2234,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             logLargeNumberOfTransactions(tableRef, gets);
         }
 
-        getHistogram(AtlasDbMetricNames.NUMBER_OF_TRANSACTIONS_READ_FROM_DB, tableRef).update(gets.size());
+        getCounter(AtlasDbMetricNames.NUMBER_OF_TRANSACTIONS_READ_FROM_DB, tableRef).inc(gets.size());
 
         return Futures.transform(loadCommitTimestamps(asyncTransactionService, gets),
                 rawResults -> {

--- a/changelog/@unreleased/pr-4838.v2.yml
+++ b/changelog/@unreleased/pr-4838.v2.yml
@@ -1,0 +1,9 @@
+type: improvement
+improvement:
+  description: 'AtlasDB no longer publishes `transactionsReadFromDB`: it was a high
+    cardinality metric of limited value. Consider using `TransactionService.get` if
+    attempting to determine the total number of start-commit timestamp mappings looked
+    up from the transactions tables. Otherwise, consider enabling TRACE logging to
+    get this data.'
+  links:
+  - https://github.com/palantir/atlasdb/pull/4838


### PR DESCRIPTION
**Goals (and why)**:
- Save money on metrics
- But retain as much useful signal as possible

**Implementation Description (bullets)**:
- `transactionsReadFromDB` is _the_ highest cardinality metric on AtlasDB-Proxy and many Atlas services. It has cardinality |namespaces||tables|*5.
- The metric (number of unique values a transaction had to read from the transactions table) is possibly useful, but I don't believe it's used on any dashboards currently.
- The aggregated form of this metric across transactions is generally available through `TransactionService.get()`
- Enabling TRACE logs would allow us to reconstruct the data provided by this metric, should we want it.

**Testing (What was existing testing like?  What have you done to improve it?)**: none

**Concerns (what feedback would you like?)**:
- Is there a reason we should hold on to this metric?

**Where should we start reviewing?**: +0/-2 apart from changelog

**Priority (whenever / two weeks / yesterday)**: this week
