### PR TITLE
[PD$-110002] CONTENTIOUS - Part 4: Redirect All Metrics To TaggedMetricRegistries

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/metrics/DisjointUnionTaggedMetricSet.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/metrics/DisjointUnionTaggedMetricSet.java
@@ -1,0 +1,53 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.metrics;
+
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import com.codahale.metrics.Metric;
+import com.google.common.collect.ImmutableMap;
+import com.palantir.tritium.metrics.registry.MetricName;
+import com.palantir.tritium.metrics.registry.TaggedMetricSet;
+
+/**
+ * Combines two {@link TaggedMetricSet}s. It is expected that the metric names present from the two sets are disjoint.
+ */
+public class DisjointUnionTaggedMetricSet implements TaggedMetricSet {
+    private final TaggedMetricSet first;
+    private final TaggedMetricSet second;
+
+    public DisjointUnionTaggedMetricSet(TaggedMetricSet first, TaggedMetricSet second) {
+        this.first = first;
+        this.second = second;
+    }
+
+    @Override
+    public Map<MetricName, Metric> getMetrics() {
+        return ImmutableMap.<MetricName, Metric>builder()
+                .putAll(first.getMetrics())
+                .putAll(second.getMetrics())
+                .build();
+    }
+
+    @Override
+    public void forEachMetric(BiConsumer<MetricName, Metric> consumer) {
+        first.getMetrics().forEach(consumer);
+        second.getMetrics().forEach(consumer);
+    }
+
+}

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/metrics/DisjointUnionTaggedMetricSet.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/metrics/DisjointUnionTaggedMetricSet.java
@@ -46,8 +46,8 @@ public class DisjointUnionTaggedMetricSet implements TaggedMetricSet {
 
     @Override
     public void forEachMetric(BiConsumer<MetricName, Metric> consumer) {
-        first.getMetrics().forEach(consumer);
-        second.getMetrics().forEach(consumer);
+        first.forEachMetric(consumer);
+        second.forEachMetric(consumer);
     }
 
 }

--- a/atlasdb-api/src/test/java/com/palantir/atlasdb/metrics/DisjointUnionTaggedMetricSetTest.java
+++ b/atlasdb-api/src/test/java/com/palantir/atlasdb/metrics/DisjointUnionTaggedMetricSetTest.java
@@ -1,0 +1,98 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Map;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.Timer;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
+import com.palantir.tritium.metrics.registry.MetricName;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+
+public class DisjointUnionTaggedMetricSetTest {
+    private static final MetricName METRIC_NAME_1 = MetricName.builder()
+            .safeName("com.palantir.atlasdb.metrics.lockAndGetHeldMetrics.p99")
+            .build();
+    private static final MetricName METRIC_NAME_2 = MetricName.builder()
+            .safeName("com.palantir.atlasdb.metrics.releaseAllMetrics.p99")
+            .build();
+    private static final MetricName METRIC_NAME_3 = MetricName.builder()
+            .safeName("com.palantir.atlasdb.metrics.logMetricsLogs.p99")
+            .build();
+
+    private final TaggedMetricRegistry registry1 = new DefaultTaggedMetricRegistry();
+    private final TaggedMetricRegistry registry2 = new DefaultTaggedMetricRegistry();
+    private final DisjointUnionTaggedMetricSet disjointUnionTaggedMetricSet
+            = new DisjointUnionTaggedMetricSet(registry1, registry2);
+
+    @Test
+    public void unionOfEmptyMetricSetsIsEmpty() {
+        assertThat(disjointUnionTaggedMetricSet.getMetrics()).isEmpty();
+    }
+
+    @Test
+    public void metricsInEachSetAreReflectedInUnion() {
+        Timer timer = registry1.timer(METRIC_NAME_1);
+        Histogram histogram = registry2.histogram(METRIC_NAME_2);
+        Meter meter = registry1.meter(METRIC_NAME_3);
+
+        assertThat(disjointUnionTaggedMetricSet.getMetrics()).containsExactlyInAnyOrderEntriesOf(
+                ImmutableMap.of(METRIC_NAME_1, timer, METRIC_NAME_2, histogram, METRIC_NAME_3, meter));
+    }
+
+    @Test
+    public void deregisteringMetricsIsReflectedInUnion() {
+        registry1.timer(METRIC_NAME_1);
+        Histogram histogram = registry2.histogram(METRIC_NAME_2);
+        Meter meter = registry1.meter(METRIC_NAME_3);
+        registry1.remove(METRIC_NAME_1);
+
+        assertThat(disjointUnionTaggedMetricSet.getMetrics()).containsExactlyInAnyOrderEntriesOf(
+                ImmutableMap.of(METRIC_NAME_2, histogram, METRIC_NAME_3, meter));
+    }
+
+    @Test
+    public void throwsIfConflictDetected() {
+        registry1.timer(METRIC_NAME_1);
+        registry2.timer(METRIC_NAME_1);
+
+        assertThatThrownBy(disjointUnionTaggedMetricSet::getMetrics).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void forEachWorksOnMetricsFromBothRegistries() {
+        Timer timer = registry1.timer(METRIC_NAME_1);
+        Histogram histogram = registry2.histogram(METRIC_NAME_2);
+        Meter meter = registry1.meter(METRIC_NAME_3);
+
+        Map<MetricName, Metric> stateOfTheWorld = Maps.newHashMap();
+        disjointUnionTaggedMetricSet.forEachMetric(stateOfTheWorld::put);
+        assertThat(stateOfTheWorld).containsExactlyInAnyOrderEntriesOf(
+                ImmutableMap.of(METRIC_NAME_1, timer, METRIC_NAME_2, histogram, METRIC_NAME_3, meter));
+    }
+}

--- a/atlasdb-api/src/test/java/com/palantir/atlasdb/metrics/DisjointUnionTaggedMetricSetTest.java
+++ b/atlasdb-api/src/test/java/com/palantir/atlasdb/metrics/DisjointUnionTaggedMetricSetTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Map;
 
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.codahale.metrics.Histogram;

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbMetricNames.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbMetricNames.java
@@ -33,6 +33,9 @@ public final class AtlasDbMetricNames {
         public static final String EMPTY_VALUE = "emptyValuesCellFilterCount";
     }
 
+    public static final String LIBRARY_ORIGIN_TAG = "libraryOrigin";
+    public static final String LIBRARY_ORIGIN_VALUE = "atlasdb";
+
     public static final String SNAPSHOT_TRANSACTION_CELLS_READ = "numCellsRead";
     public static final String SNAPSHOT_TRANSACTION_CELLS_RETURNED = "numCellsReturnedAfterFiltering";
     public static final String SNAPSHOT_TRANSACTION_TOO_MANY_BYTES_READ = "tooManyBytesRead";

--- a/changelog/@unreleased/pr-4846.v2.yml
+++ b/changelog/@unreleased/pr-4846.v2.yml
@@ -1,0 +1,9 @@
+type: break
+break:
+  description: 'AtlasDB now publishes all of its metrics with `metricOrigin: atlasdb`.
+    _This also means that AtlasDB publishes all metrics as tagged metrics: this may
+    break users that have workflows that involve reading values directly from a `MetricRegistry`.
+    The same metric will be published in the `TaggedMetricRegistry` that users would
+    have provided to AtlasDB._'
+  links:
+  - https://github.com/palantir/atlasdb/pull/4846


### PR DESCRIPTION
**Reviewable, but DO NOT MERGE: I want to do a quick smoke-test internally.**

**Goals (and why)**:
- Collect AtlasDB's metrics neatly into a `TaggedMetricSet` so that filtering and pre-processing can be performed before they are released into the wild.

**Implementation Description (bullets)**:
- Implement DisjointUnionTaggedMetricSet which combines metrics.
- Reorganise TransactionManagers to publish everything to the tagged metric registry.

**Testing (What was existing testing like?  What have you done to improve it?)**: DisjointUnionTaggedMetricSetTest. I will manually smoke-test with a service internally as well.

**Concerns (what feedback would you like?)**:
- Adding the origin tags is not really what I was going for (see https://github.com/palantir/metric-schema/pull/288), but this change, and even the combination of this change and the metric-schema change will not add metric cardinality (both tags are applied to all metric-schema metrics, and this tag is applied to all existing AtlasDB metrics). I opted to avoid conflict with metric-schema's intended tag. Is that correct?
- If users expect their metrics to be in specifically the untagged metric registry and try and read from it directly, that might cause pain. With that in mind, is this change too heavy-handed? Is that a reasonable use case?
- Should I just have added the Dropwizard metric set and the tagged metric set as _two_ metrics sets, maybe atlasdb-tagged and atlasdb-untagged? I don't know if internal metrics platforms are good at performing disjunctive aggregations across tag values though.

**Where should we start reviewing?**: TransactionManagers

**Priority (whenever / two weeks / yesterday)**: this week