### PR TITLE
Error rates

### DIFF
--- a/lock-api-objects/build.gradle
+++ b/lock-api-objects/build.gradle
@@ -27,7 +27,7 @@ recommendedProductDependencies {
     productDependency {
         productGroup = 'com.palantir.timelock'
         productName = 'timelock-server'
-        minimumVersion = '0.195.0'
+        minimumVersion = '0.198.0'
         maximumVersion = '0.x.x'
     }
 }

--- a/lock-api/src/main/java/com/palantir/lock/client/DialogueAdaptingConjureTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/DialogueAdaptingConjureTimelockService.java
@@ -15,8 +15,10 @@
  */
 
 package com.palantir.lock.client;
+
 import java.util.function.Supplier;
 
+import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
 import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsRequest;
 import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponse;
@@ -49,8 +51,9 @@ public class DialogueAdaptingConjureTimelockService implements ConjureTimelockSe
     @Override
     public ConjureStartTransactionsResponse startTransactions(AuthHeader authHeader, String namespace,
             ConjureStartTransactionsRequest request) {
-        return executeInTimerContext(() -> dialogueDelegate.startTransactions(authHeader, namespace, request),
-                () -> conjureTimelockServiceBlockingMetrics.startTransactions().time());
+        return executeInstrumented(() -> dialogueDelegate.startTransactions(authHeader, namespace, request),
+                () -> conjureTimelockServiceBlockingMetrics.startTransactions().time(),
+                conjureTimelockServiceBlockingMetrics.startTransactions().mark(););
     }
 
     @Override
@@ -61,8 +64,9 @@ public class DialogueAdaptingConjureTimelockService implements ConjureTimelockSe
 
     @Override
     public LeaderTime leaderTime(AuthHeader authHeader, String namespace) {
-        return executeInTimerContext(() -> dialogueDelegate.leaderTime(authHeader, namespace),
-                () -> conjureTimelockServiceBlockingMetrics.leaderTime().time());
+        return executeInstrumented(() -> dialogueDelegate.leaderTime(authHeader, namespace),
+                () -> conjureTimelockServiceBlockingMetrics.leaderTime().time(),
+                () -> conjureTimelockServiceBlockingMetrics.leaderTime());
     }
 
     @Override
@@ -93,9 +97,13 @@ public class DialogueAdaptingConjureTimelockService implements ConjureTimelockSe
         return dialogueDelegate.getCommitTimestamps(authHeader, namespace, request);
     }
 
-    private <T> T executeInTimerContext(Supplier<T> supplier, Supplier<Timer.Context> timerSupplier) {
+    private <T> T executeInstrumented(Supplier<T> supplier, Supplier<Timer.Context> timerSupplier,
+            Supplier<Meter> meterSupplier) {
         try (Timer.Context timer = timerSupplier.get()) {
             return supplier.get();
+        } catch (RuntimeException e) {
+            meterSupplier.get().mark();
+            throw e;
         }
     }
 }

--- a/lock-api/src/main/java/com/palantir/lock/client/DialogueAdaptingConjureTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/DialogueAdaptingConjureTimelockService.java
@@ -53,7 +53,7 @@ public class DialogueAdaptingConjureTimelockService implements ConjureTimelockSe
             ConjureStartTransactionsRequest request) {
         return executeInstrumented(() -> dialogueDelegate.startTransactions(authHeader, namespace, request),
                 () -> conjureTimelockServiceBlockingMetrics.startTransactions().time(),
-                conjureTimelockServiceBlockingMetrics.startTransactions().mark(););
+                () -> conjureTimelockServiceBlockingMetrics.startTransactionErrors());
     }
 
     @Override
@@ -66,7 +66,7 @@ public class DialogueAdaptingConjureTimelockService implements ConjureTimelockSe
     public LeaderTime leaderTime(AuthHeader authHeader, String namespace) {
         return executeInstrumented(() -> dialogueDelegate.leaderTime(authHeader, namespace),
                 () -> conjureTimelockServiceBlockingMetrics.leaderTime().time(),
-                () -> conjureTimelockServiceBlockingMetrics.leaderTime());
+                () -> conjureTimelockServiceBlockingMetrics.leaderTimeErrors());
     }
 
     @Override

--- a/lock-api/src/main/java/com/palantir/lock/client/metrics/TimeLockFeedbackBackgroundTask.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/metrics/TimeLockFeedbackBackgroundTask.java
@@ -115,7 +115,7 @@ public final class TimeLockFeedbackBackgroundTask implements AutoCloseable {
         return EndpointStatistics
                 .builder()
                 .p99(getP99ForLeaderTime())
-                .minRate(getOneMinuteRateForLeaderTime())
+                .oneMin(getOneMinuteRateForLeaderTime())
                 .errorRate(getErrorRateForLeaderTime())
                 .build();
     }
@@ -137,7 +137,7 @@ public final class TimeLockFeedbackBackgroundTask implements AutoCloseable {
         return EndpointStatistics
                 .builder()
                 .p99(getP99ForStartTxn())
-                .minRate(getOneMinuteRateForStartTxn())
+                .oneMin(getOneMinuteRateForStartTxn())
                 .errorRate(getErrorRateForStartTxn())
                 .build();
     }

--- a/lock-api/src/main/java/com/palantir/lock/client/metrics/TimeLockFeedbackBackgroundTask.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/metrics/TimeLockFeedbackBackgroundTask.java
@@ -112,8 +112,16 @@ public final class TimeLockFeedbackBackgroundTask implements AutoCloseable {
     }
 
     private EndpointStatistics getEndpointStatsForLeaderTime() {
-        return EndpointStatistics.of(getP99ForLeaderTime(),
-                getOneMinuteRateForLeaderTime());
+        return EndpointStatistics
+                .builder()
+                .p99(getP99ForLeaderTime())
+                .minRate(getOneMinuteRateForLeaderTime())
+                .errorRate(getErrorRateForLeaderTime())
+                .build();
+    }
+
+    private double getErrorRateForLeaderTime() {
+        return conjureTimelockServiceBlockingMetrics.leaderTimeErrors().getOneMinuteRate();
     }
 
     private double getOneMinuteRateForLeaderTime() {
@@ -126,8 +134,16 @@ public final class TimeLockFeedbackBackgroundTask implements AutoCloseable {
     }
 
     private EndpointStatistics getEndpointStatsForStartTxn() {
-        return EndpointStatistics.of(getP99ForStartTxn(),
-                getOneMinuteRateForStartTxn());
+        return EndpointStatistics
+                .builder()
+                .p99(getP99ForStartTxn())
+                .minRate(getOneMinuteRateForStartTxn())
+                .errorRate(getErrorRateForStartTxn())
+                .build();
+    }
+
+    private double getErrorRateForStartTxn() {
+        return conjureTimelockServiceBlockingMetrics.startTransactionErrors().getOneMinuteRate();
     }
 
     private double getOneMinuteRateForStartTxn() {

--- a/lock-api/src/main/metrics/metric-schema.yml
+++ b/lock-api/src/main/metrics/metric-schema.yml
@@ -11,4 +11,8 @@ namespaces:
       startTransactions:
         type: timer
         docs: how long it takes to start transaction in timelock
+      startTransactionErrors:
+        type: meter
+        docs: error rate for start transaction in timelock
+
 

--- a/lock-api/src/main/metrics/metric-schema.yml
+++ b/lock-api/src/main/metrics/metric-schema.yml
@@ -13,9 +13,9 @@ namespaces:
         docs: how long it takes to start transaction in timelock
       leaderTimeErrors:
           type: meter
-          docs: error rate for startTransaction api in timelock
+          docs: error rate for leaderTime api in timelock
       startTransactionErrors:
         type: meter
-        docs: error rate for leaderTime api in timelock
+        docs: error rate for startTransaction api in timelock
 
 

--- a/lock-api/src/main/metrics/metric-schema.yml
+++ b/lock-api/src/main/metrics/metric-schema.yml
@@ -12,8 +12,8 @@ namespaces:
         type: timer
         docs: how long it takes to start transaction in timelock
       leaderTimeErrors:
-          type: meter
-          docs: error rate for leaderTime api in timelock
+        type: meter
+        docs: error rate for leaderTime api in timelock
       startTransactionErrors:
         type: meter
         docs: error rate for startTransaction api in timelock

--- a/lock-api/src/main/metrics/metric-schema.yml
+++ b/lock-api/src/main/metrics/metric-schema.yml
@@ -11,8 +11,11 @@ namespaces:
       startTransactions:
         type: timer
         docs: how long it takes to start transaction in timelock
+      leaderTimeErrors:
+          type: meter
+          docs: error rate for startTransaction api in timelock
       startTransactionErrors:
         type: meter
-        docs: error rate for start transaction in timelock
+        docs: error rate for leaderTime api in timelock
 
 

--- a/timelock-api/src/main/conjure/timelock-feedback.yml
+++ b/timelock-api/src/main/conjure/timelock-feedback.yml
@@ -12,7 +12,8 @@ types:
       EndpointStatistics:
         fields:
           p99: double
-          oneMin: double
+          minRate: double
+          errorRate: double
 
 services:
   TimeLockClientFeedbackService:

--- a/timelock-api/src/main/conjure/timelock-feedback.yml
+++ b/timelock-api/src/main/conjure/timelock-feedback.yml
@@ -12,8 +12,8 @@ types:
       EndpointStatistics:
         fields:
           p99: double
-          minRate: double
-          errorRate: double
+          oneMin: double
+          errorRate: optional<double>
 
 services:
   TimeLockClientFeedbackService:

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/adjudicate/FeedbackMetricsTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/adjudicate/FeedbackMetricsTest.java
@@ -56,6 +56,7 @@ public class FeedbackMetricsTest {
         when(conjureTimelockServiceBlocking.leaderTime(AUTH_HEADER, NAMESPACE)).thenReturn(leaderTime);
         service.leaderTime(AUTH_HEADER, NAMESPACE);
         assertThat(metrics.leaderTime().getCount()).isEqualTo(1L);
+        assertThat(metrics.leaderTime().getSnapshot().get99thPercentile()).isNotZero();
         assertThat(metrics.leaderTimeErrors().getCount()).isEqualTo(0);
     }
 
@@ -68,6 +69,7 @@ public class FeedbackMetricsTest {
             // no op
         }
         assertThat(metrics.leaderTime().getCount()).isEqualTo(1);
+        assertThat(metrics.leaderTime().getSnapshot().get99thPercentile()).isNotZero();
         assertThat(metrics.leaderTimeErrors().getCount()).isEqualTo(1);
     }
 
@@ -77,6 +79,7 @@ public class FeedbackMetricsTest {
                 .thenReturn(conjureStartTransactionsResponse);
         service.startTransactions(AUTH_HEADER, NAMESPACE, request);
         assertThat(metrics.startTransactions().getCount()).isEqualTo(1L);
+        assertThat(metrics.startTransactions().getSnapshot().get99thPercentile()).isNotZero();
         assertThat(metrics.startTransactionErrors().getCount()).isEqualTo(0);
     }
 
@@ -91,6 +94,7 @@ public class FeedbackMetricsTest {
             // no op
         }
         assertThat(metrics.startTransactions().getCount()).isEqualTo(1);
+        assertThat(metrics.startTransactions().getSnapshot().get99thPercentile()).isNotZero();
         assertThat(metrics.startTransactionErrors().getCount()).isEqualTo(1);
     }
 }

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/adjudicate/FeedbackMetricsTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/adjudicate/FeedbackMetricsTest.java
@@ -17,6 +17,7 @@
 package com.palantir.atlasdb.timelock.adjudicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -62,12 +63,11 @@ public class FeedbackMetricsTest {
 
     @Test
     public void leaderTimeErrorMetricsAreRecordedOnException() {
-        when(conjureTimelockServiceBlocking.leaderTime(AUTH_HEADER, NAMESPACE)).thenThrow(new RuntimeException());
-        try {
-            service.leaderTime(AUTH_HEADER, NAMESPACE);
-        } catch (RuntimeException e) {
-            // no op
-        }
+        when(conjureTimelockServiceBlocking.leaderTime(AUTH_HEADER, NAMESPACE))
+                .thenThrow(new RuntimeException("Failed to get leader time."));
+        assertThatThrownBy(() -> service.leaderTime(AUTH_HEADER, NAMESPACE))
+                .isInstanceOf(RuntimeException.class).hasMessage("Failed to get leader time.");
+
         assertThat(metrics.leaderTime().getCount()).isEqualTo(1);
         assertThat(metrics.leaderTime().getSnapshot().get99thPercentile()).isNotZero();
         assertThat(metrics.leaderTimeErrors().getCount()).isEqualTo(1);
@@ -87,12 +87,11 @@ public class FeedbackMetricsTest {
     @Test
     public void startTransactionErrorMetricsAreRecordedOnException() {
         when(conjureTimelockServiceBlocking.startTransactions(AUTH_HEADER, NAMESPACE, request))
-                .thenThrow(new RuntimeException());
-        try {
-            service.startTransactions(AUTH_HEADER, NAMESPACE, request);
-        } catch (RuntimeException e) {
-            // no op
-        }
+                .thenThrow(new RuntimeException("Failed to start transaction."));
+
+        assertThatThrownBy(() -> service.startTransactions(AUTH_HEADER, NAMESPACE, request))
+                .isInstanceOf(RuntimeException.class).hasMessage("Failed to start transaction.");
+
         assertThat(metrics.startTransactions().getCount()).isEqualTo(1);
         assertThat(metrics.startTransactions().getSnapshot().get99thPercentile()).isNotZero();
         assertThat(metrics.startTransactionErrors().getCount()).isEqualTo(1);

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/adjudicate/FeedbackMetricsTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/adjudicate/FeedbackMetricsTest.java
@@ -1,0 +1,96 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.adjudicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsRequest;
+import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
+import com.palantir.atlasdb.timelock.api.ConjureTimelockServiceBlocking;
+import com.palantir.atlasdb.util.MetricsManagers;
+import com.palantir.lock.client.ConjureTimelockServiceBlockingMetrics;
+import com.palantir.lock.client.DialogueAdaptingConjureTimelockService;
+import com.palantir.lock.v2.LeaderTime;
+import com.palantir.tokens.auth.AuthHeader;
+
+public class FeedbackMetricsTest {
+    private static final AuthHeader AUTH_HEADER = AuthHeader.valueOf("Bearer test");
+    private static final String NAMESPACE = "test";
+    private ConjureTimelockServiceBlockingMetrics metrics;
+    private ConjureTimelockServiceBlocking conjureTimelockServiceBlocking = mock(ConjureTimelockServiceBlocking.class);
+    private DialogueAdaptingConjureTimelockService service;
+
+    @Mock private LeaderTime leaderTime;
+    @Mock private ConjureStartTransactionsRequest request;
+    @Mock private ConjureStartTransactionsResponse conjureStartTransactionsResponse;
+
+    @Before
+    public void cleanMetrics() {
+        metrics = ConjureTimelockServiceBlockingMetrics.of(
+                        MetricsManagers.createForTests().getTaggedRegistry());
+        service = new DialogueAdaptingConjureTimelockService(conjureTimelockServiceBlocking, metrics);
+    }
+
+    @Test
+    public void leaderTimeMetricsAreRecordedOnSuccess() {
+        when(conjureTimelockServiceBlocking.leaderTime(AUTH_HEADER, NAMESPACE)).thenReturn(leaderTime);
+        service.leaderTime(AUTH_HEADER, NAMESPACE);
+        assertThat(metrics.leaderTime().getCount()).isEqualTo(1L);
+        assertThat(metrics.leaderTimeErrors().getCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void leaderTimeErrorMetricsAreRecordedOnException() {
+        when(conjureTimelockServiceBlocking.leaderTime(AUTH_HEADER, NAMESPACE)).thenThrow(new RuntimeException());
+        try {
+            service.leaderTime(AUTH_HEADER, NAMESPACE);
+        } catch (RuntimeException e) {
+            // no op
+        }
+        assertThat(metrics.leaderTime().getCount()).isEqualTo(1);
+        assertThat(metrics.leaderTimeErrors().getCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void startTransactionMetricsAreRecordedOnSuccess() {
+        when(conjureTimelockServiceBlocking.startTransactions(AUTH_HEADER, NAMESPACE, request))
+                .thenReturn(conjureStartTransactionsResponse);
+        service.startTransactions(AUTH_HEADER, NAMESPACE, request);
+        assertThat(metrics.startTransactions().getCount()).isEqualTo(1L);
+        assertThat(metrics.startTransactionErrors().getCount()).isEqualTo(0);
+    }
+
+
+    @Test
+    public void startTransactionErrorMetricsAreRecordedOnException() {
+        when(conjureTimelockServiceBlocking.startTransactions(AUTH_HEADER, NAMESPACE, request))
+                .thenThrow(new RuntimeException());
+        try {
+            service.startTransactions(AUTH_HEADER, NAMESPACE, request);
+        } catch (RuntimeException e) {
+            // no op
+        }
+        assertThat(metrics.startTransactions().getCount()).isEqualTo(1);
+        assertThat(metrics.startTransactionErrors().getCount()).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
**Goals (and why)**:
Incorporate error in TimeLock feedback health report.

**Implementation Description (bullets)**:

- Update metrics schema to record startTransaction and leaderTime error rates

- Update feedback background task in Atlas so it builds the health report with error rate

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added some new tests

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:
DialogueAdaptingConjureTimelockService.java

**Priority (whenever / two weeks / yesterday)**:
EOD 23 June
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
