### PR TITLE
bump version of timeLock product dependency

### DIFF
--- a/changelog/@unreleased/pr-4858.v2.yml
+++ b/changelog/@unreleased/pr-4858.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: |
+    The TimeLock product dependency needs to be bumped for to incorporate changes in TimeLock Adjudication metrics schema.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4858

--- a/lock-api-objects/build.gradle
+++ b/lock-api-objects/build.gradle
@@ -27,7 +27,7 @@ recommendedProductDependencies {
     productDependency {
         productGroup = 'com.palantir.timelock'
         productName = 'timelock-server'
-        minimumVersion = '0.199.0'
+        minimumVersion = '0.200.0'
         maximumVersion = '0.x.x'
     }
 }


### PR DESCRIPTION
**Goals (and why)**:
The TimeLock product dependency needs to be bumped for TimeLock Adjudication workstream. 

**Implementation Description (bullets)**:
Bump the TimeLockproduct dependency

**Priority (whenever / two weeks / yesterday)**:
🔥 ASAP
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
