### PR TITLE
Local and remote health pinger

### DIFF
--- a/changelog/@unreleased/pr-4863.v2.yml
+++ b/changelog/@unreleased/pr-4863.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: The TimeLock client feedback resource only processes feedback for clients
+    for which it is the leader.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4863

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/Factories.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/Factories.java
@@ -43,7 +43,7 @@ public interface Factories {
     }
 
     interface LeaderPingHealthCheckFactory {
-        List<HealthCheckPinger> create(Dependencies.HealthCheckPinger dependencies);
+        LocalAndRemotes<HealthCheckPinger> create(Dependencies.HealthCheckPinger dependencies);
     }
 
     interface PaxosLatestRoundVerifierFactory {

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipComponents.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipComponents.java
@@ -47,11 +47,12 @@ public class LeadershipComponents {
     private final ShutdownAwareCloser closer = new ShutdownAwareCloser();
 
     private final Factory<LeadershipContext> leadershipContextFactory;
-    private final List<HealthCheckPinger> healthCheckPingers;
+//    private final List<HealthCheckPinger> oldHealthCheckPingers;
+    private final LocalAndRemotes<HealthCheckPinger> healthCheckPingers;
 
     LeadershipComponents(
             Factory<LeadershipContext> leadershipContextFactory,
-            List<HealthCheckPinger> healthCheckPingers) {
+            LocalAndRemotes<HealthCheckPinger> healthCheckPingers) {
         this.leadershipContextFactory = leadershipContextFactory;
         this.healthCheckPingers = healthCheckPingers;
     }
@@ -71,8 +72,12 @@ public class LeadershipComponents {
         closer.shutdown();
     }
 
+    public HealthCheckPinger getLocalHealthCheckPinger() {
+        return healthCheckPingers.local();
+    }
+
     public LeaderPingHealthCheck healthCheck(NamespaceTracker namespaceTracker) {
-        return new LeaderPingHealthCheck(namespaceTracker, healthCheckPingers);
+        return new LeaderPingHealthCheck(namespaceTracker, healthCheckPingers.all());
     }
 
     public boolean requestHostileTakeover(Client client) {

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipComponents.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipComponents.java
@@ -47,7 +47,6 @@ public class LeadershipComponents {
     private final ShutdownAwareCloser closer = new ShutdownAwareCloser();
 
     private final Factory<LeadershipContext> leadershipContextFactory;
-//    private final List<HealthCheckPinger> oldHealthCheckPingers;
     private final LocalAndRemotes<HealthCheckPinger> healthCheckPingers;
 
     LeadershipComponents(

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipContextFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipContextFactory.java
@@ -17,7 +17,6 @@
 package com.palantir.atlasdb.timelock.paxos;
 
 import java.time.Duration;
-import java.util.List;
 import java.util.UUID;
 
 import org.immutables.value.Value;
@@ -30,6 +29,7 @@ import com.palantir.leader.PingableLeader;
 import com.palantir.paxos.Client;
 import com.palantir.paxos.LeaderPinger;
 import com.palantir.paxos.PaxosLearner;
+import com.palantir.timelock.paxos.HealthCheckPinger;
 
 @Value.Immutable
 public abstract class LeadershipContextFactory implements
@@ -88,7 +88,7 @@ public abstract class LeadershipContextFactory implements
     }
 
     @Value.Derived
-    List<com.palantir.timelock.paxos.HealthCheckPinger> healthCheckPingers() {
+    LocalAndRemotes<HealthCheckPinger> healthCheckPingers() {
         return healthCheckPingersFactory().create(this);
     }
 

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResourcesFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResourcesFactory.java
@@ -143,9 +143,11 @@ public final class PaxosResourcesFactory {
         Factories.LeaderPingHealthCheckFactory healthCheckPingersFactory = dependencies -> {
             PingableLeader local = dependencies.components().pingableLeader(PaxosUseCase.PSEUDO_LEADERSHIP_CLIENT);
             List<PingableLeader> remotes = dependencies.remoteClients().nonBatchPingableLeaders();
-            return LocalAndRemotes.of(new SingleLeaderHealthCheckPinger(local), remotes.stream()
-                    .map(SingleLeaderHealthCheckPinger::new)
-                    .collect(Collectors.toList()));
+            return LocalAndRemotes.of(new SingleLeaderHealthCheckPinger(local),
+                    remotes
+                            .stream()
+                            .map(SingleLeaderHealthCheckPinger::new)
+                            .collect(Collectors.toList()));
         };
 
         Factories.PaxosLatestRoundVerifierFactory latestRoundVerifierFactory = acceptorClient ->

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -250,8 +250,10 @@ public class TimeLockAgent {
     }
 
     private boolean isLeaderForClients(Client client) {
-        Map<Client, HealthCheckResponse> healthCheckResponseMap = paxosResources.leadershipComponents().getLocalHealthCheckPinger().apply(
-                ImmutableSet.of(client));
+        Map<Client, HealthCheckResponse> healthCheckResponseMap = paxosResources
+                .leadershipComponents()
+                .getLocalHealthCheckPinger()
+                .apply(ImmutableSet.of(client));
         return healthCheckResponseMap.get(client).isLeader();
     }
 

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -243,13 +243,13 @@ public class TimeLockAgent {
 
     private void registerClientFeedbackService() {
         if (undertowRegistrar.isPresent()) {
-            undertowRegistrar.get().accept(TimeLockClientFeedbackResource.undertow(this::isLeaderForClients));
+            undertowRegistrar.get().accept(TimeLockClientFeedbackResource.undertow(this::isLeaderForClient));
         } else {
-            registrar.accept(TimeLockClientFeedbackResource.jersey(this::isLeaderForClients));
+            registrar.accept(TimeLockClientFeedbackResource.jersey(this::isLeaderForClient));
         }
     }
 
-    private boolean isLeaderForClients(Client client) {
+    private boolean isLeaderForClient(Client client) {
         Map<Client, HealthCheckResponse> healthCheckResponseMap = paxosResources
                 .leadershipComponents()
                 .getLocalHealthCheckPinger()

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/adjudicate/TimeLockClientFeedbackResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/adjudicate/TimeLockClientFeedbackResource.java
@@ -16,7 +16,7 @@
 
 package com.palantir.atlasdb.timelock.adjudicate;
 
-import java.util.function.Function;
+import java.util.function.Predicate;
 
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -29,26 +29,26 @@ import com.palantir.timelock.feedback.ConjureTimeLockClientFeedback;
 import com.palantir.tokens.auth.AuthHeader;
 
 public class TimeLockClientFeedbackResource implements UndertowTimeLockClientFeedbackService {
-    private Function<Client, Boolean> leadershipCheck;
+    private Predicate<Client> leadershipCheck;
 
-    private TimeLockClientFeedbackResource(Function<Client, Boolean> leadershipCheck) {
+    private TimeLockClientFeedbackResource(Predicate<Client> leadershipCheck) {
         this.leadershipCheck = leadershipCheck;
     }
 
-    public static TimeLockClientFeedbackResource create(Function<Client, Boolean> leadershipCheck) {
+    public static TimeLockClientFeedbackResource create(Predicate<Client> leadershipCheck) {
         return new TimeLockClientFeedbackResource(leadershipCheck);
     }
 
-    public static UndertowService undertow(Function<Client, Boolean> leadershipCheck) {
+    public static UndertowService undertow(Predicate<Client> leadershipCheck) {
         return TimeLockClientFeedbackServiceEndpoints.of(TimeLockClientFeedbackResource.create(leadershipCheck));
     }
 
-    public static TimeLockClientFeedbackService jersey(Function<Client, Boolean> leadershipCheck) {
+    public static TimeLockClientFeedbackService jersey(Predicate<Client> leadershipCheck) {
         return new JerseyAdapter(TimeLockClientFeedbackResource.create(leadershipCheck));
     }
     @Override
     public ListenableFuture<Void> reportFeedback(AuthHeader authHeader, ConjureTimeLockClientFeedback feedbackReport) {
-        if (leadershipCheck.apply(Client.of(feedbackReport.getServiceName()))) {
+        if (leadershipCheck.test(Client.of(feedbackReport.getServiceName()))) {
             // process feedback
         }
         return Futures.immediateVoidFuture();

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/adjudicate/TimeLockClientFeedbackResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/adjudicate/TimeLockClientFeedbackResource.java
@@ -49,7 +49,6 @@ public class TimeLockClientFeedbackResource implements UndertowTimeLockClientFee
     @Override
     public ListenableFuture<Void> reportFeedback(AuthHeader authHeader, ConjureTimeLockClientFeedback feedbackReport) {
         // todo - this will not work for Alta
-        // todo - drop messages for the first minute of leadership
         if (leadershipCheck.apply(Client.of(feedbackReport.getServiceName()))) {
             // process feedback
         }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/adjudicate/TimeLockClientFeedbackResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/adjudicate/TimeLockClientFeedbackResource.java
@@ -48,7 +48,6 @@ public class TimeLockClientFeedbackResource implements UndertowTimeLockClientFee
     }
     @Override
     public ListenableFuture<Void> reportFeedback(AuthHeader authHeader, ConjureTimeLockClientFeedback feedbackReport) {
-        // todo - this will not work for Alta
         if (leadershipCheck.apply(Client.of(feedbackReport.getServiceName()))) {
             // process feedback
         }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/adjudicate/TimeLockClientFeedbackResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/adjudicate/TimeLockClientFeedbackResource.java
@@ -50,7 +50,9 @@ public class TimeLockClientFeedbackResource implements UndertowTimeLockClientFee
     public ListenableFuture<Void> reportFeedback(AuthHeader authHeader, ConjureTimeLockClientFeedback feedbackReport) {
         // todo - this will not work for Alta
         // todo - drop messages for the first minute of leadership
-        leadershipCheck.apply(Client.of(feedbackReport.getServiceName()));
+        if (leadershipCheck.apply(Client.of(feedbackReport.getServiceName()))) {
+            // process feedback
+        }
         return Futures.immediateVoidFuture();
     }
 


### PR DESCRIPTION
**Goals (and why)**:
The TimeLock client feedback resource should only process feedback for clients for which it is the leader.

**Implementation Description (bullets)**:

- Segregate health check pingers into local and remote components.


**Testing (What was existing testing like?  What have you done to improve it?)**:
Existing tests should suffice

**Concerns (what feedback would you like?)**:
Is the wiring correct?

**Where should we start reviewing?**:
TimeLockAgent

**Priority (whenever / two weeks / yesterday)**:
Today

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
