### PR TITLE
[PD$-110002] Part 6: One-Shots and Legacies

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/metrics/MetricPublicationFilter.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/metrics/MetricPublicationFilter.java
@@ -20,5 +20,7 @@ package com.palantir.atlasdb.metrics;
  * Determines whether a metric should be published.
  */
 public interface MetricPublicationFilter {
+    MetricPublicationFilter NEVER_PUBLISH = () -> false;
+
     boolean shouldPublish();
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/util/MetricsManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/util/MetricsManager.java
@@ -110,6 +110,10 @@ public class MetricsManager {
         publicationArbiter.registerMetricsFilter(metricName, publicationFilter);
     }
 
+    public void doNotPublish(MetricName metricName) {
+        publicationArbiter.registerMetricsFilter(metricName, MetricPublicationFilter.NEVER_PUBLISH);
+    }
+
     public void addMetricFilter(
             Class clazz,
             String metricName,

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/util/MetricsManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/util/MetricsManager.java
@@ -110,16 +110,16 @@ public class MetricsManager {
         publicationArbiter.registerMetricsFilter(metricName, publicationFilter);
     }
 
-    public void doNotPublish(MetricName metricName) {
-        publicationArbiter.registerMetricsFilter(metricName, MetricPublicationFilter.NEVER_PUBLISH);
-    }
-
     public void addMetricFilter(
             Class clazz,
             String metricName,
             Map<String, String> tags,
             MetricPublicationFilter publicationFilter) {
         addMetricFilter(getTaggedMetricName(clazz, metricName, tags), publicationFilter);
+    }
+
+    public void doNotPublish(MetricName metricName) {
+        publicationArbiter.registerMetricsFilter(metricName, MetricPublicationFilter.NEVER_PUBLISH);
     }
 
     public TaggedMetricSet getPublishableMetrics() {

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/util/MetricsManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/util/MetricsManager.java
@@ -110,6 +110,14 @@ public class MetricsManager {
         publicationArbiter.registerMetricsFilter(metricName, publicationFilter);
     }
 
+    public void addMetricFilter(
+            Class clazz,
+            String metricName,
+            Map<String, String> tags,
+            MetricPublicationFilter publicationFilter) {
+        addMetricFilter(getTaggedMetricName(clazz, metricName, tags), publicationFilter);
+    }
+
     public TaggedMetricSet getPublishableMetrics() {
         return publishableMetricsView;
     }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/health/MetricsBasedTimelockHealthCheck.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/health/MetricsBasedTimelockHealthCheck.java
@@ -18,27 +18,33 @@ package com.palantir.atlasdb.health;
 import java.util.Map;
 
 import com.codahale.metrics.Meter;
+import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
 import com.palantir.atlasdb.AtlasDbMetricNames;
 import com.palantir.atlasdb.transaction.api.TimelockServiceStatus;
+import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import com.palantir.tritium.metrics.registry.MetricName;
 
 public class MetricsBasedTimelockHealthCheck implements TimelockHealthCheck{
-    private final MetricRegistry metricRegistry;
+    private final MetricsManager metricsManager;
 
-    public MetricsBasedTimelockHealthCheck(MetricRegistry metricRegistry) {
-        this.metricRegistry = metricRegistry;
+    public MetricsBasedTimelockHealthCheck(MetricsManager metricsManager) {
+        this.metricsManager = metricsManager;
     }
 
     @Override public TimelockServiceStatus getStatus() {
-        Map<String, Meter> meters = metricRegistry.getMeters();
-        if (!meters.containsKey(AtlasDbMetricNames.TIMELOCK_SUCCESSFUL_REQUEST)
-                || !meters.containsKey(AtlasDbMetricNames.TIMELOCK_FAILED_REQUEST)) {
+        Map<MetricName, Metric> metrics = metricsManager.getTaggedRegistry().getMetrics();
+        Metric success = metrics.get(MetricName.builder().safeName(AtlasDbMetricNames.TIMELOCK_SUCCESSFUL_REQUEST)
+                .build());
+        Metric failure = metrics.get(MetricName.builder().safeName(AtlasDbMetricNames.TIMELOCK_FAILED_REQUEST).build());
+
+        if (!(success instanceof Meter) || !(failure instanceof Meter)) {
             throw new SafeIllegalStateException("Timelock client metrics is not properly set");
         }
 
-        double successfulRequestRate = meters.get(AtlasDbMetricNames.TIMELOCK_SUCCESSFUL_REQUEST).getFiveMinuteRate();
-        double failedRequestRate = meters.get(AtlasDbMetricNames.TIMELOCK_FAILED_REQUEST).getFiveMinuteRate();
+        double successfulRequestRate = ((Meter) success).getFiveMinuteRate();
+        double failedRequestRate = ((Meter) failure).getFiveMinuteRate();
         if (successfulRequestRate >= failedRequestRate) {
             return TimelockServiceStatus.HEALTHY;
         } else {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionManager.java
@@ -47,7 +47,7 @@ public abstract class AbstractTransactionManager implements TransactionManager {
     private final TimelockHealthCheck timelockHealthCheck;
 
     AbstractTransactionManager(MetricsManager metricsManager, TimestampCache timestampCache) {
-        this.timelockHealthCheck = new MetricsBasedTimelockHealthCheck(metricsManager.getRegistry());
+        this.timelockHealthCheck = new MetricsBasedTimelockHealthCheck(metricsManager);
         this.timestampValidationReadCache = timestampCache;
     }
 

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/AtlasDbDialogueServiceProvider.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/AtlasDbDialogueServiceProvider.java
@@ -113,7 +113,8 @@ public final class AtlasDbDialogueServiceProvider {
     }
 
     TimestampManagementRpcClient getTimestampManagementRpcClient() {
-        return createDialogueProxyWithShortTimeout(TimestampManagementRpcClient.class);
+        return AtlasDbHttpClients.createUninstrumentedDialogueProxy(
+                TimestampManagementRpcClient.class, dialogueClientFactory.getChannel(TIMELOCK_SHORT_TIMEOUT));
     }
 
     LockRpcClient getLockRpcClient() {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -1001,9 +1001,9 @@ public abstract class TransactionManagers {
             MetricsManager metricsManager,
             LockAndTimestampServices lockAndTimestampServices) {
         TimelockService timelockServiceWithBatching = lockAndTimestampServices.timelock();
-        TimelockService instrumentedTimelockService = new InstrumentedTimelockService(
+        TimelockService instrumentedTimelockService = InstrumentedTimelockService.create(
                 timelockServiceWithBatching,
-                metricsManager.getRegistry());
+                metricsManager);
 
         return ImmutableLockAndTimestampServices.builder()
                 .from(lockAndTimestampServices)

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
@@ -84,11 +84,15 @@ public final class AtlasDbHttpClients {
     }
 
     public static <T> T createDialogueProxy(TaggedMetricRegistry registry, Class<T> type, Channel channel) {
-        T proxy = DialogueShimFactory.create(type, channel);
         return AtlasDbMetrics.instrumentWithTaggedMetrics(
                 registry,
                 type,
-                FastFailoverProxy.newProxyInstance(type, () -> proxy));
+                createUninstrumentedDialogueProxy(type, channel));
+    }
+
+    public static <T> T createUninstrumentedDialogueProxy(Class<T> type, Channel channel) {
+        T proxy = DialogueShimFactory.create(type, channel);
+        return FastFailoverProxy.newProxyInstance(type, () -> proxy);
     }
 
     @VisibleForTesting

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/persistence/CoordinationServices.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/persistence/CoordinationServices.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.internalschema.persistence;
 
 import java.util.function.LongSupplier;
 
+import com.codahale.metrics.MetricRegistry;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.coordination.CoordinationService;
 import com.palantir.atlasdb.coordination.CoordinationServiceImpl;
@@ -26,10 +27,13 @@ import com.palantir.atlasdb.coordination.TransformingCoordinationService;
 import com.palantir.atlasdb.coordination.keyvalue.KeyValueServiceCoordinationStore;
 import com.palantir.atlasdb.internalschema.InternalSchemaMetadata;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.metrics.MetricPublicationFilter;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
+import com.palantir.atlasdb.util.MetricNameUtils;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.conjure.java.serialization.ObjectMappers;
 import com.palantir.timestamp.TimestampService;
+import com.palantir.tritium.metrics.registry.MetricName;
 
 public final class CoordinationServices {
     private CoordinationServices() {
@@ -51,13 +55,7 @@ public final class CoordinationServices {
                 boolean initializeAsync) {
         CoordinationService<VersionedInternalSchemaMetadata> versionedService = new CoordinationServiceImpl<>(
                 createCoordinationStore(keyValueService, timestampSupplier, initializeAsync));
-
-        @SuppressWarnings("unchecked") // The service has the same type as the version-hiding service.
-        CoordinationService<InternalSchemaMetadata> instrumentedService = AtlasDbMetrics.instrumentTimed(
-                metricsManager.getRegistry(),
-                CoordinationService.class,
-                wrapHidingVersionSerialization(versionedService));
-        return instrumentedService;
+        return wrapHidingVersionSerialization(versionedService);
     }
 
     private static CoordinationStore<VersionedInternalSchemaMetadata> createCoordinationStore(

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/persistence/CoordinationServices.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/persistence/CoordinationServices.java
@@ -18,7 +18,6 @@ package com.palantir.atlasdb.internalschema.persistence;
 
 import java.util.function.LongSupplier;
 
-import com.codahale.metrics.MetricRegistry;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.coordination.CoordinationService;
 import com.palantir.atlasdb.coordination.CoordinationServiceImpl;
@@ -27,13 +26,9 @@ import com.palantir.atlasdb.coordination.TransformingCoordinationService;
 import com.palantir.atlasdb.coordination.keyvalue.KeyValueServiceCoordinationStore;
 import com.palantir.atlasdb.internalschema.InternalSchemaMetadata;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
-import com.palantir.atlasdb.metrics.MetricPublicationFilter;
-import com.palantir.atlasdb.util.AtlasDbMetrics;
-import com.palantir.atlasdb.util.MetricNameUtils;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.conjure.java.serialization.ObjectMappers;
 import com.palantir.timestamp.TimestampService;
-import com.palantir.tritium.metrics.registry.MetricName;
 
 public final class CoordinationServices {
     private CoordinationServices() {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/AdjustableSweepBatchConfigSource.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/AdjustableSweepBatchConfigSource.java
@@ -24,10 +24,8 @@ import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.Gauge;
 import com.google.common.collect.ImmutableMap;
-import com.palantir.atlasdb.metrics.MetricPublicationFilter;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.tritium.metrics.registry.MetricName;
 
 public final class AdjustableSweepBatchConfigSource {
     private static final Logger log = LoggerFactory.getLogger(BackgroundSweeperImpl.class);
@@ -47,10 +45,12 @@ public final class AdjustableSweepBatchConfigSource {
         AdjustableSweepBatchConfigSource configSource = new AdjustableSweepBatchConfigSource(rawSweepBatchConfig);
 
         Gauge<Double> gauge = AdjustableSweepBatchConfigSource::getBatchSizeMultiplier;
+
+        // We are generally only interested in the batch size if an error occurred, i.e. it was less than 1.
         metricsManager.addMetricFilter(AdjustableSweepBatchConfigSource.class,
                 "batchSizeMultiplier",
                 ImmutableMap.of(),
-                () -> gauge.getValue() != 1.0);
+                () -> gauge.getValue() < 1.0);
         metricsManager.registerMetric(AdjustableSweepBatchConfigSource.class, "batchSizeMultiplier",
                 gauge);
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/AdjustableSweepBatchConfigSource.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/AdjustableSweepBatchConfigSource.java
@@ -22,8 +22,12 @@ import org.apache.commons.lang3.math.NumberUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.codahale.metrics.Gauge;
+import com.google.common.collect.ImmutableMap;
+import com.palantir.atlasdb.metrics.MetricPublicationFilter;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.logsafe.SafeArg;
+import com.palantir.tritium.metrics.registry.MetricName;
 
 public final class AdjustableSweepBatchConfigSource {
     private static final Logger log = LoggerFactory.getLogger(BackgroundSweeperImpl.class);
@@ -42,8 +46,13 @@ public final class AdjustableSweepBatchConfigSource {
             Supplier<SweepBatchConfig> rawSweepBatchConfig) {
         AdjustableSweepBatchConfigSource configSource = new AdjustableSweepBatchConfigSource(rawSweepBatchConfig);
 
+        Gauge<Double> gauge = AdjustableSweepBatchConfigSource::getBatchSizeMultiplier;
+        metricsManager.addMetricFilter(AdjustableSweepBatchConfigSource.class,
+                "batchSizeMultiplier",
+                ImmutableMap.of(),
+                () -> gauge.getValue() != 1.0);
         metricsManager.registerMetric(AdjustableSweepBatchConfigSource.class, "batchSizeMultiplier",
-                () -> getBatchSizeMultiplier());
+                gauge);
 
         return configSource;
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/InstrumentedTimelockService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/InstrumentedTimelockService.java
@@ -33,7 +33,7 @@ import com.palantir.lock.v2.WaitForLocksResponse;
 import com.palantir.timestamp.TimestampRange;
 import com.palantir.tritium.metrics.registry.MetricName;
 
-public class InstrumentedTimelockService implements TimelockService {
+public final class InstrumentedTimelockService implements TimelockService {
     private static final MetricName SUCCESSFUL_REQUEST_METRIC_NAME = MetricName.builder()
             .safeName(AtlasDbMetricNames.TIMELOCK_SUCCESSFUL_REQUEST)
             .build();

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/InstrumentedTimelockService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/InstrumentedTimelockService.java
@@ -37,30 +37,22 @@ import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 
 public class InstrumentedTimelockService implements TimelockService {
+    public static final MetricName SUCCESSFUL_REQUEST_METRIC_NAME = MetricName.builder().safeName(AtlasDbMetricNames.TIMELOCK_SUCCESSFUL_REQUEST).build();
+    public static final MetricName FAILED_REQUEST_METRIC_NAME = MetricName.builder().safeName(AtlasDbMetricNames.TIMELOCK_FAILED_REQUEST).build();
     private final TimelockService timelockService;
     private final Meter success;
     private final Meter fail;
 
     private InstrumentedTimelockService(TimelockService timelockService, MetricsManager metricsManager) {
         this.timelockService = timelockService;
-        this.success = metricsManager.registerOrGetTaggedMeter(
-                InstrumentedTimelockService.class,
-                AtlasDbMetricNames.TIMELOCK_SUCCESSFUL_REQUEST,
-                ImmutableMap.of());
-        this.fail = metricsManager.registerOrGetTaggedMeter(
-                InstrumentedTimelockService.class,
-                AtlasDbMetricNames.TIMELOCK_FAILED_REQUEST,
-                ImmutableMap.of());
+        this.success = metricsManager.getTaggedRegistry().meter(SUCCESSFUL_REQUEST_METRIC_NAME);
+        this.fail = metricsManager.getTaggedRegistry().meter(FAILED_REQUEST_METRIC_NAME);
     }
 
     public static TimelockService create(TimelockService timelockService, MetricsManager metricsManager) {
         // The instrumentation here is used primarily for the health check, not for external viewing.
-        metricsManager.addMetricFilter(
-                MetricName.builder().safeName(AtlasDbMetricNames.TIMELOCK_SUCCESSFUL_REQUEST).build(),
-                () -> false);
-        metricsManager.addMetricFilter(
-                MetricName.builder().safeName(AtlasDbMetricNames.TIMELOCK_FAILED_REQUEST).build(),
-                () -> false);
+        metricsManager.addMetricFilter(SUCCESSFUL_REQUEST_METRIC_NAME, () -> false);
+        metricsManager.addMetricFilter(FAILED_REQUEST_METRIC_NAME, () -> false);
         return new InstrumentedTimelockService(timelockService, metricsManager);
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/InstrumentedTimelockService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/InstrumentedTimelockService.java
@@ -20,8 +20,6 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 import com.codahale.metrics.Meter;
-import com.codahale.metrics.MetricRegistry;
-import com.google.common.collect.ImmutableMap;
 import com.palantir.atlasdb.AtlasDbMetricNames;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
@@ -34,11 +32,15 @@ import com.palantir.lock.v2.WaitForLocksRequest;
 import com.palantir.lock.v2.WaitForLocksResponse;
 import com.palantir.timestamp.TimestampRange;
 import com.palantir.tritium.metrics.registry.MetricName;
-import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 
 public class InstrumentedTimelockService implements TimelockService {
-    public static final MetricName SUCCESSFUL_REQUEST_METRIC_NAME = MetricName.builder().safeName(AtlasDbMetricNames.TIMELOCK_SUCCESSFUL_REQUEST).build();
-    public static final MetricName FAILED_REQUEST_METRIC_NAME = MetricName.builder().safeName(AtlasDbMetricNames.TIMELOCK_FAILED_REQUEST).build();
+    private static final MetricName SUCCESSFUL_REQUEST_METRIC_NAME = MetricName.builder()
+            .safeName(AtlasDbMetricNames.TIMELOCK_SUCCESSFUL_REQUEST)
+            .build();
+    private static final MetricName FAILED_REQUEST_METRIC_NAME = MetricName.builder()
+            .safeName(AtlasDbMetricNames.TIMELOCK_FAILED_REQUEST)
+            .build();
+
     private final TimelockService timelockService;
     private final Meter success;
     private final Meter fail;
@@ -51,8 +53,8 @@ public class InstrumentedTimelockService implements TimelockService {
 
     public static TimelockService create(TimelockService timelockService, MetricsManager metricsManager) {
         // The instrumentation here is used primarily for the health check, not for external viewing.
-        metricsManager.addMetricFilter(SUCCESSFUL_REQUEST_METRIC_NAME, () -> false);
-        metricsManager.addMetricFilter(FAILED_REQUEST_METRIC_NAME, () -> false);
+        metricsManager.doNotPublish(SUCCESSFUL_REQUEST_METRIC_NAME);
+        metricsManager.doNotPublish(FAILED_REQUEST_METRIC_NAME);
         return new InstrumentedTimelockService(timelockService, metricsManager);
     }
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/health/MetricsBasedTimelockHealthCheckTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/health/MetricsBasedTimelockHealthCheckTest.java
@@ -25,13 +25,15 @@ import org.junit.Test;
 
 import com.codahale.metrics.MetricRegistry;
 import com.palantir.atlasdb.transaction.impl.InstrumentedTimelockService;
+import com.palantir.atlasdb.util.MetricsManager;
+import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.lock.v2.TimelockService;
 
 public class MetricsBasedTimelockHealthCheckTest {
     private static final long METRICS_TICK_INTERVAL = TimeUnit.SECONDS.toMillis(5);
 
-    private final MetricRegistry metricRegistry = new MetricRegistry();
-    private final TimelockHealthCheck timelockHealthCheck = new MetricsBasedTimelockHealthCheck(metricRegistry);
+    private final MetricsManager metricsManager = MetricsManagers.createForTests();
+    private final TimelockHealthCheck timelockHealthCheck = new MetricsBasedTimelockHealthCheck(metricsManager);
     private static TimelockService timelockService = mock(TimelockService.class);
 
     @Test
@@ -80,9 +82,9 @@ public class MetricsBasedTimelockHealthCheckTest {
 
     private TimelockService getFreshInstrumentedTimelockService() {
         timelockService = mock(TimelockService.class);
-        TimelockService instrumentedTimelockService = new InstrumentedTimelockService(
+        TimelockService instrumentedTimelockService = InstrumentedTimelockService.create(
                 timelockService,
-                metricRegistry);
+                metricsManager);
 
         return instrumentedTimelockService;
     }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/health/MetricsBasedTimelockHealthCheckTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/health/MetricsBasedTimelockHealthCheckTest.java
@@ -23,7 +23,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 
-import com.codahale.metrics.MetricRegistry;
 import com.palantir.atlasdb.transaction.impl.InstrumentedTimelockService;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.atlasdb.util.MetricsManagers;

--- a/changelog/@unreleased/pr-4867.v2.yml
+++ b/changelog/@unreleased/pr-4867.v2.yml
@@ -1,0 +1,12 @@
+type: fix
+fix:
+  description: |-
+    Four small metrics cuts:
+    - Only log the background sweep batch multiplier if <1.
+    - Don't instrument `TimestampManagementService` endpoints (used only in timelock migration): saves 10 series.
+    - Don't instrument `CoordinationService` endpoints (used only in transactions2 migration): saves 10 series.
+    - Don't publish `timelockSuccessfulRequest` and `timelockFailedRequest`: saves 4 series.
+
+    Please contact the AtlasDB team if the removal of these series will be an issue.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4867


### PR DESCRIPTION
**Goals (and why)**:
- $$$

**Implementation Description (bullets)**:
This PR contains four small metrics cuts.
- Only log the background sweep batch multiplier if <1. This should save |namespaces| series in atlasdb-proxy.
- Don't instrument `TimestampManagementService` endpoints (used only in timelock migration). This should save 10 * |namespaces| series in atlasdb-proxy.
- Don't instrument `CoordinationService` endpoints (used only in transactions2 migration). This should save 10 * |namespaces| series in atlasdb-proxy.
- Don't publish `timelockSuccessfulRequest` and `timelockFailedRequest` - I'm not aware of anyone who uses these outside of the health check that we have. This should save 4 * |namespaces| series in atlasdb-proxy.

(Note that meters create two series, and timers five.)

**Testing (What was existing testing like?  What have you done to improve it?)**:
Nothing beyond existing tests.

**Concerns (what feedback would you like?)**:
- Are any of these metrics more valuable than what I give them credit for?

**Where should we start reviewing?**: Commit by commit?

**Priority (whenever / two weeks / yesterday)**: this week