### PR TITLE
Increase gradle build memory to 2 GB

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 enableErrorProne=false
 org.gradle.parallel=true
+org.gradle.jvmargs=-Xmx2g


### PR DESCRIPTION
Full builds of atlasdb sometimes fail due to gradle running out of memory. The gradle wrapper does not allow passing JVM arguments for the build VM on the command-line, so it must be done in gradle.properties instead. Increasing the maximum amount of memory that can be allocated from the default of 512M to 2G.
