### PR TITLE
Namespace in TM

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -618,7 +618,8 @@ public abstract class TransactionManagers {
         return serviceIdentifierOverride().orElseGet(this::namespace);
     }
 
-    private String namespace() {
+    @Value.Derived
+    String namespace() {
         return Stream.of(config().namespace(),
                 config().timelock().flatMap(TimeLockClientConfig::client),
                 config().keyValueService().namespace())

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -579,7 +579,8 @@ public abstract class TransactionManagers {
                             globalTaggedMetricRegistry(),
                             () -> AtlasDbVersion.readVersion(),
                             serviceName(),
-                            refreshableTimeLockClientFeedbackServices), closeables));
+                            refreshableTimeLockClientFeedbackServices,
+                            namespace()), closeables));
         }
         return Optional.empty();
     }
@@ -614,13 +615,19 @@ public abstract class TransactionManagers {
     @VisibleForTesting
     @Value.Derived
     String serviceName() {
-        return serviceIdentifierOverride().orElseGet(() -> Stream.of(config().namespace(),
+        return serviceIdentifierOverride().orElseGet(this::namespace);
+    }
+
+    // todo sudiksha should namespace be a property?
+    @Value.Default
+    private String namespace() {
+        return Stream.of(config().namespace(),
                 config().timelock().flatMap(TimeLockClientConfig::client),
                 config().keyValueService().namespace())
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .findFirst()
-                .orElse("UNKNOWN"));
+                .orElse("UNKNOWN");
     }
 
     private static Callback<TransactionManager> createClearsTable() {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -618,8 +618,6 @@ public abstract class TransactionManagers {
         return serviceIdentifierOverride().orElseGet(this::namespace);
     }
 
-    // todo sudiksha should namespace be a property?
-    @Value.Default
     private String namespace() {
         return Stream.of(config().namespace(),
                 config().timelock().flatMap(TimeLockClientConfig::client),

--- a/changelog/@unreleased/pr-4869.v2.yml
+++ b/changelog/@unreleased/pr-4869.v2.yml
@@ -1,7 +1,6 @@
 type: improvement
 improvement:
-  description: |2
-
+  description: |
     Client feedback report for TimeLock can now have the original namespace along with the overridden service name.
   links:
   - https://github.com/palantir/atlasdb/pull/4869

--- a/changelog/@unreleased/pr-4869.v2.yml
+++ b/changelog/@unreleased/pr-4869.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: |2
+
+    Client feedback report for TimeLock can now have the original namespace along with the overridden service name.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4869

--- a/lock-api/src/main/java/com/palantir/lock/client/metrics/TimeLockFeedbackBackgroundTask.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/metrics/TimeLockFeedbackBackgroundTask.java
@@ -53,26 +53,31 @@ public final class TimeLockFeedbackBackgroundTask implements AutoCloseable {
     private ConjureTimelockServiceBlockingMetrics conjureTimelockServiceBlockingMetrics;
     private Supplier<String> versionSupplier;
     private String serviceName;
+    private String namespace;
     private Refreshable<List<TimeLockClientFeedbackService>> timeLockClientFeedbackServices;
 
     private TimeLockFeedbackBackgroundTask(TaggedMetricRegistry taggedMetricRegistry,
             Supplier<String> versionSupplier,
             String serviceName,
-            Refreshable<List<TimeLockClientFeedbackService>> timeLockClientFeedbackServices) {
+            Refreshable<List<TimeLockClientFeedbackService>> timeLockClientFeedbackServices,
+            String namespace) {
         this.conjureTimelockServiceBlockingMetrics = ConjureTimelockServiceBlockingMetrics.of(taggedMetricRegistry);
         this.versionSupplier = versionSupplier;
         this.serviceName = serviceName;
         this.timeLockClientFeedbackServices = timeLockClientFeedbackServices;
+        this.namespace = namespace;
     }
 
     public static TimeLockFeedbackBackgroundTask create(TaggedMetricRegistry taggedMetricRegistry,
             Supplier<String> versionSupplier,
             String serviceName,
-            Refreshable<List<TimeLockClientFeedbackService>> timeLockClientFeedbackServices) {
+            Refreshable<List<TimeLockClientFeedbackService>> timeLockClientFeedbackServices,
+            String namespace) {
         TimeLockFeedbackBackgroundTask task = new TimeLockFeedbackBackgroundTask(taggedMetricRegistry,
                 versionSupplier,
                 serviceName,
-                timeLockClientFeedbackServices);
+                timeLockClientFeedbackServices,
+                namespace);
         task.scheduleWithFixedDelay();
         return task;
     }
@@ -88,6 +93,7 @@ public final class TimeLockFeedbackBackgroundTask implements AutoCloseable {
                         .atlasVersion(versionSupplier.get())
                         .nodeId(nodeId)
                         .serviceName(serviceName)
+                        .namespace(namespace)
                         .build();
                 timeLockClientFeedbackServices
                         .current()

--- a/lock-api/src/main/java/com/palantir/lock/client/metrics/TimeLockFeedbackBackgroundTask.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/metrics/TimeLockFeedbackBackgroundTask.java
@@ -93,7 +93,6 @@ public final class TimeLockFeedbackBackgroundTask implements AutoCloseable {
                         .atlasVersion(versionSupplier.get())
                         .nodeId(nodeId)
                         .serviceName(serviceName)
-                        .namespace(namespace)
                         .build();
                 timeLockClientFeedbackServices
                         .current()

--- a/timelock-api/src/main/conjure/timelock-feedback.yml
+++ b/timelock-api/src/main/conjure/timelock-feedback.yml
@@ -9,7 +9,9 @@ types:
           nodeId: uuid
           startTransaction: optional<EndpointStatistics>
           leaderTime: optional<EndpointStatistics>
-          namespace: optional<string>
+          namespace:
+            type: optional<string>
+            docs: The namespace the client uses to make timestamp/lock requests
       EndpointStatistics:
         fields:
           p99: double

--- a/timelock-api/src/main/conjure/timelock-feedback.yml
+++ b/timelock-api/src/main/conjure/timelock-feedback.yml
@@ -9,6 +9,7 @@ types:
           nodeId: uuid
           startTransaction: optional<EndpointStatistics>
           leaderTime: optional<EndpointStatistics>
+          namespace: optional<string>
       EndpointStatistics:
         fields:
           p99: double


### PR DESCRIPTION
**Goals (and why)**:
Client feedback report for TimeLock should include both the original namespace and the overridden service name.

**Implementation Description (bullets)**:

- Optional namespace field is added to ConjureTimeLockClientFeedback

**Testing (What was existing testing like?  What have you done to improve it?)**:
- No new tests added

**Priority (whenever / two weeks / yesterday)**:
Today

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
