### PR TITLE
[TimeLock Adjudication] Handle duplicate case

### DIFF
--- a/changelog/@unreleased/pr-4871.v2.yml
+++ b/changelog/@unreleased/pr-4871.v2.yml
@@ -1,0 +1,8 @@
+type: fix
+fix:
+  description: TimeLock Adjudication now handles cases where the reports for leaderTime
+    and startTransaction were *completely identical*. Previously we would throw an
+    exception when trying to build a KeyedStream - health checks would go red, though
+    users would not be affected.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4871

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/adjudicate/FeedbackHandler.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/adjudicate/FeedbackHandler.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.annotations.VisibleForTesting;
@@ -130,9 +131,10 @@ public class FeedbackHandler {
         }
 
         // considering the worst performing metric only, the health check should fail even if one end-point is unhealthy
-        return KeyedStream.stream(ImmutableMap.of(
-                healthReport.getLeaderTime(), Constants.LEADER_TIME_SERVICE_LEVEL_OBJECTIVES,
-                healthReport.getStartTransaction(), Constants.START_TRANSACTION_SERVICE_LEVEL_OBJECTIVES))
+        return KeyedStream.ofEntries(Stream.of(
+                Maps.immutableEntry(healthReport.getLeaderTime(), Constants.LEADER_TIME_SERVICE_LEVEL_OBJECTIVES),
+                Maps.immutableEntry(healthReport.getStartTransaction(),
+                        Constants.START_TRANSACTION_SERVICE_LEVEL_OBJECTIVES)))
                 .filterKeys(Optional::isPresent)
                 .mapKeys(Optional::get)
                 .map((userStats, sloSpec) -> getHealthStatusForService(userStats,

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/adjudicate/FeedbackAnalysisTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/adjudicate/FeedbackAnalysisTest.java
@@ -225,6 +225,15 @@ public class FeedbackAnalysisTest {
                 .isEqualTo(HealthStatus.UNHEALTHY);
     }
 
+    @Test
+    public void isAbleToHandleReportsWhereLeaderTimeAndStartTransactionAreEqual() {
+        FeedbackHandler feedbackHandler = new FeedbackHandler();
+        ConjureTimeLockClientFeedback report = getClientFeedbackReport(CLIENT, UUID.randomUUID(),
+                0, 0, 0, 0);
+
+        assertThat(feedbackHandler.pointFeedbackHealthStatus(report)).isEqualTo(HealthStatus.UNKNOWN);
+    }
+
     // utils
     private ConjureTimeLockClientFeedback getUnhealthyClientFeedbackReport(String serviceName, UUID nodeId) {
         return getClientFeedbackReport(serviceName,


### PR DESCRIPTION
**Goals (and why)**:
- Make timelock adjudication health checks not explode

**Implementation Description (bullets)**:
- Fix a bug: if the reports for leaderTime and startTransaction were *completely identical* we would throw an exception when trying to build a KeyedStream.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Added a test for the specific edge case.

**Concerns (what feedback would you like?)**:
- Nothing in particular

**Where should we start reviewing?**:
- FeedbackHandler.java

**Priority (whenever / two weeks / yesterday)**: yesterday 🔥 
