### PR TITLE
[PD$-110002] Part 7: Cassandra Client Pool

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -311,7 +311,6 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Cassand
         registerPoolMetric("numActive", pool::getNumActive);
         registerPoolMetric("created", pool::getCreatedCount);
         registerPoolMetric("destroyedByEvictor", pool::getDestroyedByEvictorCount);
-        registerPoolMetric("destroyedByBorrower", pool::getDestroyedByBorrowValidationCount);
     }
 
     private void registerPoolMetric(String metricName, Gauge gauge) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -309,14 +309,9 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Cassand
         registerPoolMetric("meanBorrowWaitTimeMillis", pool::getMeanBorrowWaitTimeMillis);
         registerPoolMetric("numIdle", pool::getNumIdle);
         registerPoolMetric("numActive", pool::getNumActive);
-        registerPoolMetric("approximatePoolSize", () -> pool.getNumIdle() + pool.getNumActive());
         registerPoolMetric("created", pool::getCreatedCount);
         registerPoolMetric("destroyedByEvictor", pool::getDestroyedByEvictorCount);
         registerPoolMetric("destroyedByBorrower", pool::getDestroyedByBorrowValidationCount);
-        registerPoolMetric("proportionDestroyedByEvictor",
-                () -> ((double) pool.getDestroyedByEvictorCount()) / ((double) pool.getCreatedCount()));
-        registerPoolMetric("proportionDestroyedByBorrower",
-                () -> ((double) pool.getDestroyedByBorrowValidationCount()) / ((double) pool.getCreatedCount()));
     }
 
     private void registerPoolMetric(String metricName, Gauge gauge) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -305,8 +305,6 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Cassand
 
     private void registerMetrics(GenericObjectPool<CassandraClient> pool) {
         registerPoolMetric("meanActiveTimeMillis", pool::getMeanActiveTimeMillis);
-        registerPoolMetric("meanIdleTimeMillis", pool::getMeanIdleTimeMillis);
-        registerPoolMetric("meanBorrowWaitTimeMillis", pool::getMeanBorrowWaitTimeMillis);
         registerPoolMetric("numIdle", pool::getNumIdle);
         registerPoolMetric("numActive", pool::getNumActive);
         registerPoolMetric("created", pool::getCreatedCount);

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
@@ -115,7 +115,7 @@ public class CassandraClientPoolTest {
 
     private MetricName getPoolMetricName(String poolName) {
         return MetricName.builder()
-                .safeName(MetricRegistry.name(CassandraClientPoolingContainer.class, "proportionDestroyedByBorrower"))
+                .safeName(MetricRegistry.name(CassandraClientPoolingContainer.class, "created"))
                 .safeTags(ImmutableMap.of("pool", poolName))
                 .build();
     }

--- a/changelog/@unreleased/pr-4873.v2.yml
+++ b/changelog/@unreleased/pr-4873.v2.yml
@@ -1,0 +1,9 @@
+type: improvement
+improvement:
+  description: |-
+    Some Cassandra client pool metrics have been removed, to save costs:
+    - `approximatePoolSize`: please use `numIdle + numActive` instead.
+    - `proportionDestroyedByEvictor`: please use `destroyedByEvictor / created` instead.
+    - `destroyedByBorrower` and `proportionDestroyedByBorrower`: these have been 0 everywhere in production for the past year, because we do not do any validation on objects returned from the pool (at least, within the object pooling framework).
+  links:
+  - https://github.com/palantir/atlasdb/pull/4873


### PR DESCRIPTION
**Goals (and why)**:
- $$$

**Implementation Description (bullets)**:
- Remove four gauge metrics from the CassandraClientPoolingContainer. These are registered once for each Cassandra node, meaning that we would save 4 * |Cassandra cluster| * |namespaces| time series per period on AtlasDb-Proxy.
- Three of these are derived metrics: the aggregation should be done using tools rather than also reporting.
- One more has always been zero **everywhere** in prod for the past **year** (I'm not sure that we do any meaningful validation on borrowing).

**Testing (What was existing testing like?  What have you done to improve it?)**: None

**Concerns (what feedback would you like?)**:
- Are the other metrics actually useful for debugging? I could see edge cases where they might be useful, but not wholly convinced.

**Where should we start reviewing?**: CassandraClientPoolingContainer.java

**Priority (whenever / two weeks / yesterday)**: this week
