### PR TITLE
Remove duplicate metrics from TimelockAgent.createSharedExecutor

### DIFF
--- a/changelog/@unreleased/pr-4875.v2.yml
+++ b/changelog/@unreleased/pr-4875.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: |-
+    Remove duplicate metrics from TimelockAgent.createSharedExecutor. Removes the untagged variants of instrumentation, but leaves the tagged executor and thread-factory instrumentation provided by PTExecutors.
+    The tagged metrics are useful more broadly because they can be used with general purpose dashboards and alerts.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4875


### PR DESCRIPTION
This removes the untagged variants of instrumentation, but leaves
the tagged executor and thread-factory instrumentation provided
by PTExecutors.
The tagged metrics are useful more broadly because they can be
used with general purpose dashboards and alerts.

I'm unsure if y'all alert on these, so I defer to your judgement whether or not to merge this change.