### PR TITLE
[PD$-110002] Part 8: Make Disjoint Metric Set Disjoint

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/InstrumentationUtils.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/InstrumentationUtils.java
@@ -23,11 +23,18 @@ import java.util.function.BooleanSupplier;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.SlidingTimeWindowArrayReservoir;
 import com.codahale.metrics.Timer;
+import com.google.common.collect.ImmutableMap;
 import com.palantir.tritium.event.InstrumentationProperties;
 import com.palantir.tritium.event.InvocationContext;
+import com.palantir.tritium.metrics.registry.MetricName;
 
 final class InstrumentationUtils {
-    static final String FAILURES_METRIC_NAME = "failures";
+    private static final String FAILURES_NAME = "failures";
+
+    static final MetricName FAILURES_METRIC_NAME = MetricName.builder()
+            .safeName(FAILURES_NAME)
+            .safeTags(ImmutableMap.of("serviceUsesTaggedMetrics", "true"))
+            .build();
 
     private InstrumentationUtils() {
         // utility
@@ -50,6 +57,6 @@ final class InstrumentationUtils {
     }
 
     static String getFailuresMetricName(InvocationContext context, String serviceName) {
-        return MetricRegistry.name(getBaseMetricName(context, serviceName), FAILURES_METRIC_NAME);
+        return MetricRegistry.name(getBaseMetricName(context, serviceName), FAILURES_NAME);
     }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/InstrumentationUtils.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/InstrumentationUtils.java
@@ -31,7 +31,7 @@ import com.palantir.tritium.metrics.registry.MetricName;
 final class InstrumentationUtils {
     private static final String FAILURES_NAME = "failures";
 
-    static final MetricName FAILURES_METRIC_NAME = MetricName.builder()
+    static final MetricName TAGGED_FAILURES_METRIC_NAME = MetricName.builder()
             .safeName(FAILURES_NAME)
             .safeTags(ImmutableMap.of("serviceUsesTaggedMetrics", "true"))
             .build();

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/SlidingWindowMetricsInvocationHandler.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/SlidingWindowMetricsInvocationHandler.java
@@ -94,6 +94,6 @@ public final class SlidingWindowMetricsInvocationHandler extends AbstractInvocat
     }
 
     private void markGlobalFailure() {
-        metricRegistry.meter(InstrumentationUtils.FAILURES_METRIC_NAME.safeName()).mark();
+        metricRegistry.meter(InstrumentationUtils.TAGGED_FAILURES_METRIC_NAME.safeName()).mark();
     }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/SlidingWindowMetricsInvocationHandler.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/SlidingWindowMetricsInvocationHandler.java
@@ -94,6 +94,6 @@ public final class SlidingWindowMetricsInvocationHandler extends AbstractInvocat
     }
 
     private void markGlobalFailure() {
-        metricRegistry.meter(InstrumentationUtils.FAILURES_METRIC_NAME).mark();
+        metricRegistry.meter(InstrumentationUtils.FAILURES_METRIC_NAME.safeName()).mark();
     }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/TaggedMetricsInvocationEventHandler.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/TaggedMetricsInvocationEventHandler.java
@@ -183,6 +183,6 @@ public class TaggedMetricsInvocationEventHandler extends AbstractInvocationEvent
     }
 
     private void markGlobalFailure() {
-        taggedMetricRegistry.meter(InstrumentationUtils.FAILURES_METRIC_NAME).mark();
+        taggedMetricRegistry.meter(InstrumentationUtils.TAGGED_FAILURES_METRIC_NAME).mark();
     }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/TaggedMetricsInvocationEventHandler.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/TaggedMetricsInvocationEventHandler.java
@@ -183,9 +183,6 @@ public class TaggedMetricsInvocationEventHandler extends AbstractInvocationEvent
     }
 
     private void markGlobalFailure() {
-        taggedMetricRegistry.meter(MetricName.builder()
-                .safeName(InstrumentationUtils.FAILURES_METRIC_NAME)
-                .build())
-                .mark();
+        taggedMetricRegistry.meter(InstrumentationUtils.FAILURES_METRIC_NAME).mark();
     }
 }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/util/InstrumentationUtilsTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/util/InstrumentationUtilsTest.java
@@ -1,0 +1,68 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.function.LongSupplier;
+
+import org.junit.Test;
+
+import com.palantir.tritium.metrics.registry.MetricName;
+
+public class InstrumentationUtilsTest {
+    private static final RuntimeException EXCEPTION = new RuntimeException();
+    private final MetricsManager metricsManager = MetricsManagers.createForTests();
+    private final LongSupplier mockSupplier = mock(LongSupplier.class);
+
+    @Test
+    public void failureMetricsForTaggedAndUntaggedElementsAreDistinct() {
+        when(mockSupplier.getAsLong()).thenThrow(EXCEPTION);
+        LongSupplier taggedSupplier = AtlasDbMetrics.instrumentWithTaggedMetrics(
+                metricsManager.getTaggedRegistry(),
+                LongSupplier.class,
+                mockSupplier);
+        LongSupplier legacySupplier = AtlasDbMetrics.instrument(
+                metricsManager.getRegistry(),
+                LongSupplier.class,
+                mockSupplier);
+
+        assertThatThrownBy(taggedSupplier::getAsLong).isEqualTo(EXCEPTION);
+        assertThatThrownBy(taggedSupplier::getAsLong).isEqualTo(EXCEPTION);
+        assertThatThrownBy(taggedSupplier::getAsLong).isEqualTo(EXCEPTION);
+        assertThatThrownBy(taggedSupplier::getAsLong).isEqualTo(EXCEPTION);
+        assertThatThrownBy(legacySupplier::getAsLong).isEqualTo(EXCEPTION);
+        assertThatThrownBy(legacySupplier::getAsLong).isEqualTo(EXCEPTION);
+        assertThatThrownBy(legacySupplier::getAsLong).isEqualTo(EXCEPTION);
+
+        assertThat(metricsManager.getTaggedRegistry().meter(InstrumentationUtils.FAILURES_METRIC_NAME).getCount())
+                .isEqualTo(4);
+        assertThat(metricsManager.getRegistry().meter(InstrumentationUtils.FAILURES_METRIC_NAME.safeName()).getCount())
+                .isEqualTo(3);
+    }
+
+    @Test
+    public void untaggedAndTaggedMetricRegistryFailureMetricsHaveDifferentNames() {
+        MetricName legacyFailureMetricName = MetricName.builder()
+                .safeName(InstrumentationUtils.FAILURES_METRIC_NAME.safeName())
+                .build();
+        assertThat(InstrumentationUtils.FAILURES_METRIC_NAME).isNotEqualTo(legacyFailureMetricName);
+    }
+}

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/util/InstrumentationUtilsTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/util/InstrumentationUtilsTest.java
@@ -52,17 +52,19 @@ public class InstrumentationUtilsTest {
         assertThatThrownBy(legacySupplier::getAsLong).isEqualTo(EXCEPTION);
         assertThatThrownBy(legacySupplier::getAsLong).isEqualTo(EXCEPTION);
 
-        assertThat(metricsManager.getTaggedRegistry().meter(InstrumentationUtils.FAILURES_METRIC_NAME).getCount())
+        assertThat(metricsManager.getTaggedRegistry().meter(InstrumentationUtils.TAGGED_FAILURES_METRIC_NAME)
+                .getCount())
                 .isEqualTo(4);
-        assertThat(metricsManager.getRegistry().meter(InstrumentationUtils.FAILURES_METRIC_NAME.safeName()).getCount())
+        assertThat(metricsManager.getRegistry().meter(InstrumentationUtils.TAGGED_FAILURES_METRIC_NAME.safeName())
+                .getCount())
                 .isEqualTo(3);
     }
 
     @Test
     public void untaggedAndTaggedMetricRegistryFailureMetricsHaveDifferentNames() {
         MetricName legacyFailureMetricName = MetricName.builder()
-                .safeName(InstrumentationUtils.FAILURES_METRIC_NAME.safeName())
+                .safeName(InstrumentationUtils.TAGGED_FAILURES_METRIC_NAME.safeName())
                 .build();
-        assertThat(InstrumentationUtils.FAILURES_METRIC_NAME).isNotEqualTo(legacyFailureMetricName);
+        assertThat(InstrumentationUtils.TAGGED_FAILURES_METRIC_NAME).isNotEqualTo(legacyFailureMetricName);
     }
 }

--- a/changelog/@unreleased/pr-4876.v2.yml
+++ b/changelog/@unreleased/pr-4876.v2.yml
@@ -3,7 +3,7 @@ fix:
   description: We now no longer use exactly the same metric name for the tagged and
     legacy invocation handlers. Previously, these used the same metric name, meaning
     that which metric was logged was non-deterministic, and furthermore once an error
-    occurred once on *both* a tagged and legacy-instrumented object, getting metrics
-    from AtlasDB would cause an error.
+    occurred once each on *both* a tagged and legacy-instrumented object, getting
+    metrics from AtlasDB would cause an error.
   links:
   - https://github.com/palantir/atlasdb/pull/4876

--- a/changelog/@unreleased/pr-4876.v2.yml
+++ b/changelog/@unreleased/pr-4876.v2.yml
@@ -1,0 +1,9 @@
+type: fix
+fix:
+  description: We now no longer use exactly the same metric name for the tagged and
+    legacy invocation handlers. Previously, these used the same metric name, meaning
+    that which metric was logged was non-deterministic, and furthermore once an error
+    occurred once on *both* a tagged and legacy-instrumented object, getting metrics
+    from AtlasDB would cause an error.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4876


### PR DESCRIPTION
**Goals (and why)**:
- We shouldn't actually have duplicate metrics in a disjoint metric set

**Implementation Description (bullets)**:
- Add a tag to the failures from a tagged registry. Unfortunately we have places in both the tagged and untagged invocation handlers where these are used, and rewriting the untagged one to use the tagged would be a considerable dev-break

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Added small tests for new behaviour

**Concerns (what feedback would you like?)**:
- nothing in particular

**Where should we start reviewing?**: small

**Priority (whenever / two weeks / yesterday)**: 🔥 yesterday