### PR TITLE
add refresh failure callbacks

### DIFF
--- a/changelog/@unreleased/pr-4879.v2.yml
+++ b/changelog/@unreleased/pr-4879.v2.yml
@@ -1,40 +1,8 @@
 type: improvement
 improvement:
   description: |-
-    add refresh failure callbacks
-
-    **Goals (and why)**:
-
     Adds an option to register callback functions that get called whenever a
     LockRefreshingLockService stops refreshing a lock because it failed to
     refresh.
-
-    This helps with situations where a client intentionally will be holding
-    locks for a long time, and they want to be nofied immediately as soon as
-    refreshing the lock fails. Without this callback, clients would need to
-    implement their own background thread to check if the locks were still
-    valid.
-
-    We have an internal product that would already like to use this feature, and this will save us an additional background task that would currently be used to repeatedly check that locks are still valid.
-
-    **Implementation Description (bullets)**:
-
-    Adds methods to register and remove callbacks from LockRefreshingLockService, and calls the callback when lock tokens fail to refresh. To avoid problems where a callback is very slow, the callbacks are only called on a new thread that is submitted to the same executor that runs refreshes. The executor service already has an unbounded max number of threads so it will create new threads and for these callbacks and then dispose of the threads when not needed.
-
-    **Testing (What was existing testing like?  What have you done to improve it?)**:
-
-    Added a simple test.
-
-    **Concerns (what feedback would you like?)**:
-
-    N/A (simple change)
-
-    **Where should we start reviewing?**:
-
-    simple change
-
-    **Priority (whenever / two weeks / yesterday)**:
-
-    normal
   links:
   - https://github.com/palantir/atlasdb/pull/4879

--- a/changelog/@unreleased/pr-4879.v2.yml
+++ b/changelog/@unreleased/pr-4879.v2.yml
@@ -1,0 +1,40 @@
+type: improvement
+improvement:
+  description: |-
+    add refresh failure callbacks
+
+    **Goals (and why)**:
+
+    Adds an option to register callback functions that get called whenever a
+    LockRefreshingLockService stops refreshing a lock because it failed to
+    refresh.
+
+    This helps with situations where a client intentionally will be holding
+    locks for a long time, and they want to be nofied immediately as soon as
+    refreshing the lock fails. Without this callback, clients would need to
+    implement their own background thread to check if the locks were still
+    valid.
+
+    We have an internal product that would already like to use this feature, and this will save us an additional background task that would currently be used to repeatedly check that locks are still valid.
+
+    **Implementation Description (bullets)**:
+
+    Adds methods to register and remove callbacks from LockRefreshingLockService, and calls the callback when lock tokens fail to refresh. To avoid problems where a callback is very slow, the callbacks are only called on a new thread that is submitted to the same executor that runs refreshes. The executor service already has an unbounded max number of threads so it will create new threads and for these callbacks and then dispose of the threads when not needed.
+
+    **Testing (What was existing testing like?  What have you done to improve it?)**:
+
+    Added a simple test.
+
+    **Concerns (what feedback would you like?)**:
+
+    N/A (simple change)
+
+    **Where should we start reviewing?**:
+
+    simple change
+
+    **Priority (whenever / two weeks / yesterday)**:
+
+    normal
+  links:
+  - https://github.com/palantir/atlasdb/pull/4879

--- a/lock-api/src/main/java/com/palantir/lock/client/LockRefreshingLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockRefreshingLockService.java
@@ -21,9 +21,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
@@ -86,12 +84,7 @@ public final class LockRefreshingLockService extends SimplifyingLockService {
         toRefresh = ConcurrentHashMap.newKeySet();
         failedRefreshCallbacks = ConcurrentHashMap.newKeySet();
         exec = PTExecutors.newScheduledThreadPool(1, PTExecutors.newNamedThreadFactory(true));
-        // the callbackExec must use a SynchronousQueue so it actually creates new threads on demand
-        callbackExec = PTExecutors.newThreadPoolExecutor(0,
-                Integer.MAX_VALUE,
-                0,
-                TimeUnit.NANOSECONDS,
-                new SynchronousQueue<>());
+        callbackExec = PTExecutors.newCachedThreadPool("LockRefreshingLockService callbacks");
     }
 
     @Override

--- a/lock-api/src/main/java/com/palantir/lock/client/LockRefreshingLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockRefreshingLockService.java
@@ -191,6 +191,7 @@ public final class LockRefreshingLockService extends SimplifyingLockService {
 
     public void dispose() {
         exec.shutdown();
+        callbackExec.shutdown();
         isClosed = true;
     }
 

--- a/lock-impl/build.gradle
+++ b/lock-impl/build.gradle
@@ -22,4 +22,5 @@ dependencies {
     exclude group: 'org.hamcrest'
   }
   testCompile group: 'org.mockito', name: 'mockito-core'
+  testCompile group: 'org.awaitility', name: 'awaitility'
 }

--- a/lock-impl/src/test/java/com/palantir/lock/client/LockRefreshingLockServiceTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/client/LockRefreshingLockServiceTest.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -90,8 +91,8 @@ public class LockRefreshingLockServiceTest {
         LockResponse lock = server.lockWithFullLockResponse(LockClient.ANONYMOUS, request);
         // use the internal server to unlock (refreshing service will still try to refresh but fail)
         internalServer.unlock(lock.getToken());
-        Thread.sleep(10000);
-        // this assert implies the callback was called correctly when the lock failed to refresh
+        Awaitility.waitAtMost(20, TimeUnit.SECONDS)
+                .until(() -> failedTokens.get() != null);
         assertThat(failedTokens.get()).containsExactlyInAnyOrder(lock.getLockRefreshToken());
     }
 }


### PR DESCRIPTION
**Goals (and why)**:

Adds an option to register callback functions that get called whenever a
LockRefreshingLockService stops refreshing a lock because it failed to
refresh.

This helps with situations where a client intentionally will be holding
locks for a long time, and they want to be nofied immediately as soon as
refreshing the lock fails. Without this callback, clients would need to
implement their own background thread to check if the locks were still
valid.

We have an internal product that would already like to use this feature, and this will save us an additional background task that would currently be used to repeatedly check that locks are still valid.

**Implementation Description (bullets)**:

Adds methods to register and remove callbacks from LockRefreshingLockService, and calls the callback when lock tokens fail to refresh. To avoid problems where a callback is very slow, the callbacks are only called on a new thread that is submitted to the same executor that runs refreshes. The executor service already has an unbounded max number of threads so it will create new threads and for these callbacks and then dispose of the threads when not needed.

**Testing (What was existing testing like?  What have you done to improve it?)**:

Added a simple test.

**Concerns (what feedback would you like?)**:

N/A (simple change)

**Where should we start reviewing?**:

simple change

**Priority (whenever / two weeks / yesterday)**:

normal
