### PR TITLE
Bump ping rate

### DIFF
--- a/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosRuntimeConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosRuntimeConfiguration.java
@@ -32,7 +32,7 @@ public interface PaxosRuntimeConfiguration {
     @JsonProperty("ping-rate-in-ms")
     @Value.Default
     default long pingRateMs() {
-        return 50L;
+        return 500L;
     }
 
     @JsonIgnore
@@ -45,7 +45,7 @@ public interface PaxosRuntimeConfiguration {
     @JsonProperty("maximum-wait-before-proposal-in-ms")
     @Value.Default
     default long maximumWaitBeforeProposalMs() {
-        return 300L;
+        return 1000L;
     }
 
     @JsonIgnore


### PR DESCRIPTION
**Goals (and why)**:
[PDS-125305] We are bumping the pingRateMs and maximumWaitBeforeProposalMs so that Leader elections are more stable.

**Testing (What was existing testing like?  What have you done to improve it?)**:
None

**Priority (whenever / two weeks / yesterday)**:
Today 🔥 

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
