### PR TITLE
Fix baseline error prone ExecutorSubmitRunnableFutureIgnored

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/common/concurrent/CoalescingSupplier.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/concurrent/CoalescingSupplier.java
@@ -72,7 +72,7 @@ public class CoalescingSupplier<T> implements Supplier<T> {
         }
         return Futures.transformAsync(present.done(), next -> {
             if (next.isFirstToArrive()) {
-                executor.submit(next::execute);
+                executor.execute(next::execute);
             }
             return next.getResultAsync();
         }, MoreExecutors.directExecutor());

--- a/changelog/@unreleased/pr-4882.v2.yml
+++ b/changelog/@unreleased/pr-4882.v2.yml
@@ -1,5 +1,5 @@
-type: improvement
-improvement:
+type: fix
+fix:
   description: Fix baseline error prone ExecutorSubmitRunnableFutureIgnored
   links:
   - https://github.com/palantir/atlasdb/pull/4882

--- a/changelog/@unreleased/pr-4882.v2.yml
+++ b/changelog/@unreleased/pr-4882.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Fix baseline error prone ExecutorSubmitRunnableFutureIgnored
+  links:
+  - https://github.com/palantir/atlasdb/pull/4882

--- a/timelock-agent/src/main/java/com/palantir/timelock/invariants/NoSimultaneousServiceCheck.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/invariants/NoSimultaneousServiceCheck.java
@@ -89,7 +89,7 @@ public final class NoSimultaneousServiceCheck {
     }
 
     private void scheduleCheckOnSpecificClient(Client client) {
-        executorService.submit(() -> {
+        executorService.execute(() -> {
             try {
                 performCheckOnSpecificClientUnsafe(client);
             } catch (Exception e) {


### PR DESCRIPTION
Uncaught exceptions from ExecutorService.submit are not logged by
the uncaught exception handler because it is assumed that the
returned future is used to watch for failures.
When the returned future is ignored, using ExecutorService.execute
is preferred because failures are recorded.