### PR TITLE
Atlas dialogue consumption provides a ptexecutor cached pool

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -150,6 +150,7 @@ import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.atlasdb.versions.AtlasDbVersion;
 import com.palantir.common.annotation.Output;
+import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.common.time.Clock;
 import com.palantir.conjure.java.api.config.service.ServicesConfigBlock;
 import com.palantir.conjure.java.api.config.service.UserAgent;
@@ -286,7 +287,7 @@ public abstract class TransactionManagers {
      */
     @Value.Default
     DialogueClients.ReloadingFactory reloadingFactory() {
-        return DialogueClients.create(Refreshable.only(ServicesConfigBlock.builder().build()));
+        return newMinimalDialogueFactory();
     }
 
     public static ImmutableTransactionManagers.ConfigBuildStage builder() {
@@ -590,8 +591,7 @@ public abstract class TransactionManagers {
             UserAgent userAgent) {
         Refreshable<ServerListConfig> serverListConfigSupplier =
                 getServerListConfigSupplierForTimeLock(config, runtimeConfig);
-        DialogueClients.ReloadingFactory reloadingFactory = DialogueClients.create(
-                Refreshable.only(ServicesConfigBlock.builder().build()));
+        DialogueClients.ReloadingFactory reloadingFactory = newMinimalDialogueFactory();
 
         BroadcastDialogueClientFactory broadcastDialogueClientFactory = BroadcastDialogueClientFactory.create(
                 reloadingFactory,
@@ -607,6 +607,11 @@ public abstract class TransactionManagers {
         return broadcastDialogueClientFactory.getSingleNodeProxies(
                 TimeLockClientFeedbackService.class,
                 true);
+    }
+
+    private static DialogueClients.ReloadingFactory newMinimalDialogueFactory() {
+        return DialogueClients.create(Refreshable.only(ServicesConfigBlock.builder().build()))
+                .withBlockingExecutor(PTExecutors.newCachedThreadPool("atlas-dialogue-blocking"));
     }
 
     abstract Optional<String> serviceIdentifierOverride();
@@ -930,7 +935,7 @@ public abstract class TransactionManagers {
                         invalidator,
                         UserAgents.tryParse(userAgent),
                         Optional.empty(),
-                        DialogueClients.create(Refreshable.only(ServicesConfigBlock.builder().build())));
+                        newMinimalDialogueFactory());
         TimeLockClient timeLockClient = TimeLockClient.withSynchronousUnlocker(lockAndTimestampServices.timelock());
         return ImmutableLockAndTimestampServices.builder()
                 .from(lockAndTimestampServices)

--- a/changelog/@unreleased/pr-4883.v2.yml
+++ b/changelog/@unreleased/pr-4883.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: |-
+    Atlas dialogue consumption provides a ptexecutor cached pool. This executor is used heavily, so we're better off reusing threads
+    between dialogue and PTExecutors thread pools.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4883

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -130,7 +130,8 @@ public class TimeLockAgent {
     private static TimeLockDialogueServiceProvider createTimeLockDialogueServiceProvider(
             MetricsManager metricsManager, TimeLockInstallConfiguration install, UserAgent userAgent) {
         DialogueClients.ReloadingFactory baseFactory = DialogueClients.create(
-                Refreshable.only(ServicesConfigBlock.builder().build()));
+                Refreshable.only(ServicesConfigBlock.builder().build()))
+                .withBlockingExecutor(PTExecutors.newCachedThreadPool("atlas-dialogue-blocking"));
         ServerListConfig timeLockServerListConfig = ImmutableServerListConfig.builder()
                 .addAllServers(PaxosRemotingUtils.getRemoteServerPaths(install))
                 .sslConfiguration(install.cluster().cluster().security())


### PR DESCRIPTION
This executor is used heavily, so we're better off reusing threads
between dialogue and PTExecutors thread pools.