### PR TITLE
QueuedViewExecutor concurrency: state is guarded by lock

### DIFF
--- a/changelog/@unreleased/pr-4884.v2.yml
+++ b/changelog/@unreleased/pr-4884.v2.yml
@@ -1,6 +1,7 @@
 type: fix
 fix:
   description: Fixed fixed-size executor view thread safety. State is always updated
-    under a lock.
+    under a lock. Previously this could result in awaitTermination waiting the full
+    duration or tasks failing to be interrupted.
   links:
   - https://github.com/palantir/atlasdb/pull/4884

--- a/changelog/@unreleased/pr-4884.v2.yml
+++ b/changelog/@unreleased/pr-4884.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fixed fixed-size executor view thread safety. State is always updated
+    under a lock.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4884

--- a/commons-executors/src/main/java/com/palantir/common/concurrent/AtlasQueuedViewExecutor.java
+++ b/commons-executors/src/main/java/com/palantir/common/concurrent/AtlasQueuedViewExecutor.java
@@ -165,8 +165,8 @@ final class AtlasQueuedViewExecutor extends AtlasViewExecutor {
                 }
                 runTermination();
             } else {
-                lock.unlock();
                 this.state = ST_SHUTDOWN_INT_REQ;
+                lock.unlock();
                 // interrupt all runners
                 for (TaskWrapper wrapper : allWrappers) {
                     wrapper.interrupt();
@@ -250,18 +250,18 @@ final class AtlasQueuedViewExecutor extends AtlasViewExecutor {
         public void run() {
             boolean resetStateOnCompletion = true;
             thread = Thread.currentThread();
-            // Interruption may be missed between when a TaskWrapper is submitted
-            // to the delegate executor, and when the task begins to execute.
-            // This must execute after thread is set.
-            if (state == ST_SHUTDOWN_INT_REQ) {
-                Thread.currentThread().interrupt();
-            }
             try {
                 for (;;) {
                     lock.lock();
                     try {
                         submittedCount--;
                         runningCount++;
+                        // Interruption may be missed between when a TaskWrapper is submitted
+                        // to the delegate executor, and when the task begins to execute.
+                        // This must execute after thread is set.
+                        if (state == ST_SHUTDOWN_INT_REQ) {
+                            Thread.currentThread().interrupt();
+                        }
                     } finally {
                         lock.unlock();
                     }


### PR DESCRIPTION
see:
https://github.com/jbossas/jboss-threads/pull/93
and
https://github.com/jbossas/jboss-threads/pull/86

**Goals (and why)**:

unsafe access to the state field without locks.