### PR TITLE
Add original client namespace while sending adjudication feedback

### DIFF
--- a/changelog/@unreleased/pr-4885.v2.yml
+++ b/changelog/@unreleased/pr-4885.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Include original client namespace while sending adjudication feedback
+    to TimeLock.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4885

--- a/lock-api-objects/build.gradle
+++ b/lock-api-objects/build.gradle
@@ -23,7 +23,6 @@ dependencies {
     compileOnly project(":atlasdb-processors")
 }
 
-
 recommendedProductDependencies {
     productDependency {
         productGroup = 'com.palantir.timelock'

--- a/lock-api-objects/build.gradle
+++ b/lock-api-objects/build.gradle
@@ -23,11 +23,12 @@ dependencies {
     compileOnly project(":atlasdb-processors")
 }
 
+
 recommendedProductDependencies {
     productDependency {
         productGroup = 'com.palantir.timelock'
         productName = 'timelock-server'
-        minimumVersion = '0.200.0'
+        minimumVersion = '0.218.0'
         maximumVersion = '0.x.x'
     }
 }

--- a/lock-api/src/main/java/com/palantir/lock/client/metrics/TimeLockFeedbackBackgroundTask.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/metrics/TimeLockFeedbackBackgroundTask.java
@@ -93,6 +93,7 @@ public final class TimeLockFeedbackBackgroundTask implements AutoCloseable {
                         .atlasVersion(versionSupplier.get())
                         .nodeId(nodeId)
                         .serviceName(serviceName)
+                        .namespace(namespace)
                         .build();
                 timeLockClientFeedbackServices
                         .current()

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/adjudicate/TimeLockClientFeedbackResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/adjudicate/TimeLockClientFeedbackResource.java
@@ -60,7 +60,8 @@ public class TimeLockClientFeedbackResource implements UndertowTimeLockClientFee
     }
     @Override
     public ListenableFuture<Void> reportFeedback(AuthHeader authHeader, ConjureTimeLockClientFeedback feedbackReport) {
-        if (leadershipCheck.test(Client.of(feedbackReport.getServiceName()))) {
+        Client client = Client.of(feedbackReport.getNamespace().orElse(feedbackReport.getServiceName()));
+        if (leadershipCheck.test(client)) {
             feedbackHandler.handle(feedbackReport);
         }
         return Futures.immediateVoidFuture();

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/adjudicate/TimeLockClientFeedbackResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/adjudicate/TimeLockClientFeedbackResource.java
@@ -68,7 +68,7 @@ public class TimeLockClientFeedbackResource implements UndertowTimeLockClientFee
     }
 
     public Client getClient(ConjureTimeLockClientFeedback feedbackReport) {
-        return Client.of(feedbackReport.getNamespace().orElse(feedbackReport.getServiceName()));
+        return Client.of(feedbackReport.getNamespace().orElseGet(() -> feedbackReport.getServiceName()));
     }
 
     public static final class JerseyAdapter implements TimeLockClientFeedbackService {

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/adjudicate/TimeLockClientFeedbackResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/adjudicate/TimeLockClientFeedbackResource.java
@@ -58,13 +58,17 @@ public class TimeLockClientFeedbackResource implements UndertowTimeLockClientFee
             Predicate<Client> leadershipCheck) {
         return new JerseyAdapter(TimeLockClientFeedbackResource.create(feedbackHandler, leadershipCheck));
     }
+
     @Override
     public ListenableFuture<Void> reportFeedback(AuthHeader authHeader, ConjureTimeLockClientFeedback feedbackReport) {
-        Client client = Client.of(feedbackReport.getNamespace().orElse(feedbackReport.getServiceName()));
-        if (leadershipCheck.test(client)) {
+        if (leadershipCheck.test(getClient(feedbackReport))) {
             feedbackHandler.handle(feedbackReport);
         }
         return Futures.immediateVoidFuture();
+    }
+
+    public Client getClient(ConjureTimeLockClientFeedback feedbackReport) {
+        return Client.of(feedbackReport.getNamespace().orElse(feedbackReport.getServiceName()));
     }
 
     public static final class JerseyAdapter implements TimeLockClientFeedbackService {


### PR DESCRIPTION
**Goals (and why)**:
To have original client namespace while sending adjudication feedback. This is required to determine the leader for the client.

**Concerns**:
- Is it safe suppress the case where namespace is not present and fall back quietly to service name? 

**Priority (whenever / two weeks / yesterday)**:
Today

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
