### PR TITLE
PTExecutors fixed executor views handle shutdown after termination

### DIFF
--- a/changelog/@unreleased/pr-4887.v2.yml
+++ b/changelog/@unreleased/pr-4887.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: PTExecutors fixed executor views handle shutdown after termination
+  links:
+  - https://github.com/palantir/atlasdb/pull/4887

--- a/commons-executors/src/main/java/com/palantir/common/concurrent/AtlasQueuedViewExecutor.java
+++ b/commons-executors/src/main/java/com/palantir/common/concurrent/AtlasQueuedViewExecutor.java
@@ -131,8 +131,11 @@ final class AtlasQueuedViewExecutor extends AtlasViewExecutor {
                 return;
             }
         }
-        // didn't exit
-        this.state = interrupt ? ST_SHUTDOWN_INT_REQ : ST_SHUTDOWN_REQ;
+        // didn't exit, or already completed
+        int newState = interrupt ? ST_SHUTDOWN_INT_REQ : ST_SHUTDOWN_REQ;
+        if (newState > oldState) {
+            this.state = newState;
+        }
         lock.unlock();
         if (interrupt && oldState < ST_SHUTDOWN_INT_REQ) {
             // interrupt all runners


### PR DESCRIPTION
See https://github.com/jbossas/jboss-threads/pull/94

shutdown on a terminated executor no longer reverts it to a non-terminated state.

Rolling this out through a large internal project exposes all the edge cases :-)