### PR TITLE
[PoC][PD$-110002] Part 10-12: Top N for SnapshotTransaction / Table-Level Metrics

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/MetricsManagers.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/MetricsManagers.java
@@ -38,4 +38,12 @@ public final class MetricsManagers {
     public static MetricsManager createForTests() {
         return MetricsManagers.of(new MetricRegistry(), new DefaultTaggedMetricRegistry());
     }
+
+    public static MetricsManager createAlwaysSafeAndFilteringForTests() {
+        return new MetricsManager(
+                new MetricRegistry(),
+                new DefaultTaggedMetricRegistry(),
+                Refreshable.only(true),
+                tableRef -> true);
+    }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/MetricsManagers.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/MetricsManagers.java
@@ -15,8 +15,6 @@
  */
 package com.palantir.atlasdb.util;
 
-import java.util.function.BooleanSupplier;
-
 import com.codahale.metrics.MetricRegistry;
 import com.palantir.atlasdb.logging.LoggingArgs;
 import com.palantir.refreshable.Refreshable;

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/TopNMetricPublicationController.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/TopNMetricPublicationController.java
@@ -1,0 +1,78 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.util;
+
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import com.codahale.metrics.Gauge;
+import com.google.common.base.Suppliers;
+import com.google.common.collect.Sets;
+import com.palantir.atlasdb.metrics.MetricPublicationFilter;
+
+/**
+ * Given a provided number of metrics, ensures that only the top {@code maxPermittedRank} are published in the steady
+ * state.
+ */
+public final class TopNMetricPublicationController<T extends Comparable> {
+    static final Duration REFRESH_INTERVAL = Duration.ofSeconds(30);
+
+    private final Set<Gauge<T>> gauges;
+    private final Comparator<T> comparator;
+    private final int maxPermittedRank;
+    private final Supplier<Optional<T>> orderStatisticSupplier;
+
+    private TopNMetricPublicationController(Comparator<T> comparator, int maxPermittedRank) {
+        this.comparator = comparator;
+        this.maxPermittedRank = maxPermittedRank;
+        this.gauges = Sets.newConcurrentHashSet();
+        this.orderStatisticSupplier = Suppliers.memoizeWithExpiration(
+                this::calculateOrderStatistic,
+                REFRESH_INTERVAL.toNanos(),
+                TimeUnit.NANOSECONDS);
+    }
+
+    private Optional<T> calculateOrderStatistic() {
+        return gauges.stream()
+                .map(Gauge::getValue)
+                .filter(Objects::nonNull)
+                .sorted(comparator.reversed())
+                .skip(maxPermittedRank - 1)
+                .findFirst();
+    }
+
+    MetricPublicationFilter registerAndCreateFilter(Gauge<T> gauge) {
+        gauges.add(gauge);
+        return () -> shouldPublishIndividualGaugeMetric(gauge);
+    }
+
+    private boolean shouldPublishIndividualGaugeMetric(Gauge<T> constituentGauge) {
+        T value = constituentGauge.getValue();
+        return orderStatisticSupplier.get()
+                .map(orderStatistic -> isAtLeastAsLargeAsOrderStatistic(value, orderStatistic))
+                .orElse(false);
+    }
+
+    private boolean isAtLeastAsLargeAsOrderStatistic(T value, T orderStatistic) {
+        return comparator.compare(value, orderStatistic) >= 0;
+    }
+}

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/TopNMetricPublicationController.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/TopNMetricPublicationController.java
@@ -62,7 +62,7 @@ public final class TopNMetricPublicationController<T> {
         return new TopNMetricPublicationController<T>(Comparator.naturalOrder(), maxPermittedRank);
     }
 
-    MetricPublicationFilter registerAndCreateFilter(Gauge<T> gauge) {
+    public MetricPublicationFilter registerAndCreateFilter(Gauge<T> gauge) {
         gauges.add(gauge);
         return () -> shouldPublishIndividualGaugeMetric(gauge);
     }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/TopNMetricPublicationController.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/TopNMetricPublicationController.java
@@ -38,7 +38,7 @@ import com.palantir.logsafe.SafeArg;
  * state.
  */
 public final class TopNMetricPublicationController<T> {
-    static final Duration REFRESH_INTERVAL = Duration.ofSeconds(30);
+    private static final Duration REFRESH_INTERVAL = Duration.ofSeconds(30);
 
     private final Set<Gauge<T>> gauges;
     private final Comparator<T> comparator;
@@ -57,6 +57,8 @@ public final class TopNMetricPublicationController<T> {
 
     @SuppressWarnings("unchecked") // Guaranteed correct
     public static <T extends Comparable> TopNMetricPublicationController<T> create(int maxPermittedRank) {
+        Preconditions.checkState(maxPermittedRank > 0, "maxPermittedRank must be positive",
+                SafeArg.of("maxPermittedRank", maxPermittedRank));
         return new TopNMetricPublicationController<T>(Comparator.naturalOrder(), maxPermittedRank);
     }
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/TopNMetricPublicationController.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/TopNMetricPublicationController.java
@@ -18,11 +18,13 @@ package com.palantir.atlasdb.util;
 
 import java.time.Duration;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.codahale.metrics.Gauge;

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/util/TopNMetricPublicationControllerTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/util/TopNMetricPublicationControllerTest.java
@@ -161,4 +161,14 @@ public class TopNMetricPublicationControllerTest {
         assertThat(filter1.shouldPublish()).isTrue();
         assertThat(filter2.shouldPublish()).isTrue();
     }
+
+    @Test
+    public void throwsWhenCreatingControllerWithNonPositiveArguments() {
+        assertThatThrownBy(() -> TopNMetricPublicationController.create(0))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("maxPermittedRank must be positive");
+        assertThatThrownBy(() -> TopNMetricPublicationController.create(-29359))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("maxPermittedRank must be positive");
+    }
 }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/util/TopNMetricPublicationControllerTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/util/TopNMetricPublicationControllerTest.java
@@ -145,4 +145,20 @@ public class TopNMetricPublicationControllerTest {
         assertThat(filtersInOrder.get(94).shouldPublish()).isTrue();
         assertThat(filtersInOrder.get(99).shouldPublish()).isTrue();
     }
+
+    @Test
+    public void publishesAllGaugesIfThereAreFewerThanTheThreshold() {
+        AtomicLong value1 = new AtomicLong(42);
+        AtomicLong value2 = new AtomicLong(157);
+
+        Gauge<Long> gauge1 = value1::get;
+        Gauge<Long> gauge2 = value2::get;
+
+        TopNMetricPublicationController<Long> controller = TopNMetricPublicationController.create(50);
+        MetricPublicationFilter filter1 = controller.registerAndCreateFilter(gauge1);
+        MetricPublicationFilter filter2 = controller.registerAndCreateFilter(gauge2);
+
+        assertThat(filter1.shouldPublish()).isTrue();
+        assertThat(filter2.shouldPublish()).isTrue();
+    }
 }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/util/TopNMetricPublicationControllerTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/util/TopNMetricPublicationControllerTest.java
@@ -36,75 +36,54 @@ public class TopNMetricPublicationControllerTest {
     @Test
     public void orderStatisticOfNothingIsAbsent() {
         assertThat(TopNMetricPublicationController.calculateOrderStatistic(
-                Stream.<Integer>of(),
-                Comparator.naturalOrder(),
-                1)).isEmpty();
+                Stream.<Integer>of(), Comparator.naturalOrder(), 1)).isEmpty();
         assertThat(TopNMetricPublicationController.calculateOrderStatistic(
-                Stream.<Integer>of(null, null),
-                Comparator.naturalOrder(),
-                1)).isEmpty();
+                Stream.<Integer>of(null, null), Comparator.naturalOrder(), 1)).isEmpty();
     }
 
     @Test
     public void calculatesSecondElementCorrectly() {
         assertThat(TopNMetricPublicationController.calculateOrderStatistic(
-                IntStream.rangeClosed(1, 50).boxed(),
-                Comparator.naturalOrder(),
-                2)).contains(49);
+                IntStream.rangeClosed(1, 50).boxed(), Comparator.naturalOrder(), 2)).contains(49);
     }
 
     @Test
     public void handlesDuplicates() {
         assertThat(TopNMetricPublicationController.calculateOrderStatistic(
-                Stream.of(8, 8, 8, 8, 8),
-                Comparator.naturalOrder(),
-                2)).contains(8);
+                Stream.of(8, 8, 8, 8, 8), Comparator.naturalOrder(), 2)).contains(8);
     }
 
     @Test
     public void orderStatisticAtEdgesOfStreamCanBeRetrieved() {
         assertThat(TopNMetricPublicationController.calculateOrderStatistic(
-                IntStream.rangeClosed(1, 50).boxed(),
-                Comparator.naturalOrder(),
-                50)).contains(1);
+                IntStream.rangeClosed(1, 50).boxed(), Comparator.naturalOrder(), 50)).contains(1);
         assertThat(TopNMetricPublicationController.calculateOrderStatistic(
-                IntStream.rangeClosed(1, 50).boxed(),
-                Comparator.naturalOrder(),
-                51)).isEmpty();
+                IntStream.rangeClosed(1, 50).boxed(), Comparator.naturalOrder(), 51)).isEmpty();
     }
 
     @Test
     public void skipsNullsInOrderStatisticComputation() {
         assertThat(TopNMetricPublicationController.calculateOrderStatistic(
-                Stream.of(null, null, 3, 7),
-                Comparator.naturalOrder(),
-                2)).contains(3);
+                Stream.of(null, null, 3, 7), Comparator.naturalOrder(), 2)).contains(3);
         assertThat(TopNMetricPublicationController.calculateOrderStatistic(
-                Stream.of(null, null, 3, 7),
-                Comparator.naturalOrder(),
-                3)).isEmpty();
+                Stream.of(null, null, 3, 7), Comparator.naturalOrder(), 3)).isEmpty();
     }
 
     @Test
     public void canSpecifyCustomComparator() {
         assertThat(TopNMetricPublicationController.calculateOrderStatistic(
-                Stream.of("a", "bcd", "efghi", "jk"),
-                Comparator.comparingInt(String::length),
-                1)).contains("efghi");
+                Stream.of("a", "bcd", "efghi", "jk"), Comparator.comparingInt(String::length), 1))
+                .contains("efghi");
     }
 
     @Test
     public void throwsIfAttemptingToRetrieveNonPositiveOrderStatistics() {
         assertThatThrownBy(() -> TopNMetricPublicationController.calculateOrderStatistic(
-                IntStream.rangeClosed(1, 50).boxed(),
-                Comparator.naturalOrder(),
-                0))
+                IntStream.rangeClosed(1, 50).boxed(), Comparator.naturalOrder(), 0))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("The order statistic to be queried for must be positive");
         assertThatThrownBy(() -> TopNMetricPublicationController.calculateOrderStatistic(
-                IntStream.rangeClosed(1, 50).boxed(),
-                Comparator.naturalOrder(),
-                -1))
+                IntStream.rangeClosed(1, 50).boxed(), Comparator.naturalOrder(), -1))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("The order statistic to be queried for must be positive");
     }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/util/TopNMetricPublicationControllerTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/util/TopNMetricPublicationControllerTest.java
@@ -1,0 +1,148 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+
+import com.codahale.metrics.Gauge;
+import com.palantir.atlasdb.metrics.MetricPublicationFilter;
+
+public class TopNMetricPublicationControllerTest {
+    @Test
+    public void orderStatisticOfNothingIsAbsent() {
+        assertThat(TopNMetricPublicationController.calculateOrderStatistic(
+                Stream.<Integer>of(),
+                Comparator.naturalOrder(),
+                1)).isEmpty();
+        assertThat(TopNMetricPublicationController.calculateOrderStatistic(
+                Stream.<Integer>of(null, null),
+                Comparator.naturalOrder(),
+                1)).isEmpty();
+    }
+
+    @Test
+    public void calculatesSecondElementCorrectly() {
+        assertThat(TopNMetricPublicationController.calculateOrderStatistic(
+                IntStream.rangeClosed(1, 50).boxed(),
+                Comparator.naturalOrder(),
+                2)).contains(49);
+    }
+
+    @Test
+    public void handlesDuplicates() {
+        assertThat(TopNMetricPublicationController.calculateOrderStatistic(
+                Stream.of(8, 8, 8, 8, 8),
+                Comparator.naturalOrder(),
+                2)).contains(8);
+    }
+
+    @Test
+    public void orderStatisticAtEdgesOfStreamCanBeRetrieved() {
+        assertThat(TopNMetricPublicationController.calculateOrderStatistic(
+                IntStream.rangeClosed(1, 50).boxed(),
+                Comparator.naturalOrder(),
+                50)).contains(1);
+        assertThat(TopNMetricPublicationController.calculateOrderStatistic(
+                IntStream.rangeClosed(1, 50).boxed(),
+                Comparator.naturalOrder(),
+                51)).isEmpty();
+    }
+
+    @Test
+    public void skipsNullsInOrderStatisticComputation() {
+        assertThat(TopNMetricPublicationController.calculateOrderStatistic(
+                Stream.of(null, null, 3, 7),
+                Comparator.naturalOrder(),
+                2)).contains(3);
+        assertThat(TopNMetricPublicationController.calculateOrderStatistic(
+                Stream.of(null, null, 3, 7),
+                Comparator.naturalOrder(),
+                3)).isEmpty();
+    }
+
+    @Test
+    public void canSpecifyCustomComparator() {
+        assertThat(TopNMetricPublicationController.calculateOrderStatistic(
+                Stream.of("a", "bcd", "efghi", "jk"),
+                Comparator.comparingInt(String::length),
+                1)).contains("efghi");
+    }
+
+    @Test
+    public void throwsIfAttemptingToRetrieveNonPositiveOrderStatistics() {
+        assertThatThrownBy(() -> TopNMetricPublicationController.calculateOrderStatistic(
+                IntStream.rangeClosed(1, 50).boxed(),
+                Comparator.naturalOrder(),
+                0))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("The order statistic to be queried for must be positive");
+        assertThatThrownBy(() -> TopNMetricPublicationController.calculateOrderStatistic(
+                IntStream.rangeClosed(1, 50).boxed(),
+                Comparator.naturalOrder(),
+                -1))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("The order statistic to be queried for must be positive");
+    }
+
+    @Test
+    public void canSelectivelyPublishGaugeResults() {
+        AtomicLong value1 = new AtomicLong(42);
+        AtomicLong value2 = new AtomicLong(157);
+
+        Gauge<Long> gauge1 = value1::get;
+        Gauge<Long> gauge2 = value2::get;
+
+        TopNMetricPublicationController<Long> controller = TopNMetricPublicationController.create(1);
+        MetricPublicationFilter filter1 = controller.registerAndCreateFilter(gauge1);
+        MetricPublicationFilter filter2 = controller.registerAndCreateFilter(gauge2);
+
+        assertThat(filter1.shouldPublish()).isFalse();
+        assertThat(filter2.shouldPublish()).isTrue();
+    }
+
+    @Test
+    public void canSelectivelyPublishMultipleGaugeResults() {
+        List<Gauge<Long>> atomicLongs = LongStream.range(0, 100)
+                .mapToObj(AtomicLong::new)
+                .<Gauge<Long>>map(atomicLong -> atomicLong::get)
+                .collect(Collectors.toList());
+
+        TopNMetricPublicationController<Long> controller = TopNMetricPublicationController.create(7);
+
+        List<MetricPublicationFilter> filtersInOrder = atomicLongs.stream()
+                .map(controller::registerAndCreateFilter)
+                .collect(Collectors.toList());
+
+        assertThat(filtersInOrder.get(0).shouldPublish()).isFalse();
+        assertThat(filtersInOrder.get(50).shouldPublish()).isFalse();
+        assertThat(filtersInOrder.get(92).shouldPublish()).isFalse();
+        assertThat(filtersInOrder.get(93).shouldPublish()).isTrue();
+        assertThat(filtersInOrder.get(94).shouldPublish()).isTrue();
+        assertThat(filtersInOrder.get(99).shouldPublish()).isTrue();
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -86,6 +86,7 @@ import com.palantir.atlasdb.transaction.api.PreCommitCondition;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
 import com.palantir.atlasdb.transaction.api.TransactionSerializableConflictException;
+import com.palantir.atlasdb.transaction.impl.metrics.TableLevelMetricsController;
 import com.palantir.atlasdb.transaction.service.AsyncTransactionService;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.util.MetricsManager;
@@ -146,7 +147,8 @@ public class SerializableTransaction extends SnapshotTransaction {
                                    ExecutorService deleteExecutor,
                                    boolean validateLocksOnReads,
                                    Supplier<TransactionConfig> transactionConfig,
-                                   ConflictTracer conflictTracer) {
+                                   ConflictTracer conflictTracer,
+                                   TableLevelMetricsController tableLevelMetricsController) {
         super(metricsManager,
               keyValueService,
               timelockService,
@@ -170,7 +172,8 @@ public class SerializableTransaction extends SnapshotTransaction {
               deleteExecutor,
               validateLocksOnReads,
               transactionConfig,
-              conflictTracer);
+              conflictTracer,
+              tableLevelMetricsController);
     }
 
     @Override
@@ -790,7 +793,8 @@ public class SerializableTransaction extends SnapshotTransaction {
                 deleteExecutor,
                 validateLocksOnReads,
                 transactionConfig,
-                conflictTracer) {
+                conflictTracer,
+                tableLevelMetricsController) {
             @Override
             protected ListenableFuture<Map<Long, Long>> getCommitTimestamps(
                     TableReference tableRef,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -547,7 +547,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 deleteExecutor,
                 validateLocksOnReads,
                 transactionConfig,
-                conflictTracer);
+                conflictTracer,
+                tableLevelMetricsController);
     }
 
     @VisibleForTesting

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ShouldNotDeleteAndRollbackTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ShouldNotDeleteAndRollbackTransaction.java
@@ -30,6 +30,7 @@ import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
 import com.palantir.atlasdb.transaction.TransactionConfig;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
+import com.palantir.atlasdb.transaction.impl.metrics.SimpleTableLevelMetricsController;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.util.MetricsManager;
 
@@ -103,7 +104,8 @@ public class ShouldNotDeleteAndRollbackTransaction extends SnapshotTransaction {
                 IGNORING_EXECUTOR,
                 true,
                 transactionConfig,
-                ConflictTracer.NO_OP);
+                ConflictTracer.NO_OP,
+                new SimpleTableLevelMetricsController(metricsManager));
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -150,7 +150,7 @@ import com.palantir.util.SafeShutdownRunner;
         this.validateLocksOnReads = validateLocksOnReads;
         this.transactionConfig = transactionConfig;
         this.conflictTracer = conflictTracer;
-        this.tableLevelMetricsController = new FilteringTableLevelMetricsController(metricsManager);
+        this.tableLevelMetricsController = FilteringTableLevelMetricsController.create(metricsManager);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -59,6 +59,8 @@ import com.palantir.atlasdb.transaction.api.Transaction.TransactionType;
 import com.palantir.atlasdb.transaction.api.TransactionFailedRetriableException;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
 import com.palantir.atlasdb.transaction.api.TransactionTask;
+import com.palantir.atlasdb.transaction.impl.metrics.FilteringTableLevelMetricsController;
+import com.palantir.atlasdb.transaction.impl.metrics.TableLevelMetricsController;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.common.base.Throwables;
@@ -100,6 +102,7 @@ import com.palantir.util.SafeShutdownRunner;
     final List<Runnable> closingCallbacks;
     final AtomicBoolean isClosed;
     private final ConflictTracer conflictTracer;
+    final TableLevelMetricsController tableLevelMetricsController;
 
     protected SnapshotTransactionManager(
             MetricsManager metricsManager,
@@ -147,6 +150,7 @@ import com.palantir.util.SafeShutdownRunner;
         this.validateLocksOnReads = validateLocksOnReads;
         this.transactionConfig = transactionConfig;
         this.conflictTracer = conflictTracer;
+        this.tableLevelMetricsController = new FilteringTableLevelMetricsController(metricsManager);
     }
 
     @Override
@@ -300,7 +304,8 @@ import com.palantir.util.SafeShutdownRunner;
                 deleteExecutor,
                 validateLocksOnReads,
                 transactionConfig,
-                conflictTracer);
+                conflictTracer,
+                tableLevelMetricsController);
     }
 
     @Override
@@ -341,7 +346,8 @@ import com.palantir.util.SafeShutdownRunner;
                 deleteExecutor,
                 validateLocksOnReads,
                 transactionConfig,
-                conflictTracer);
+                conflictTracer,
+                tableLevelMetricsController);
         try {
             return runTaskThrowOnConflict(txn -> task.execute(txn, condition),
                     new ReadTransaction(transaction, sweepStrategyManager));

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/metrics/DeltaGauge.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/metrics/DeltaGauge.java
@@ -16,7 +16,6 @@
 
 package com.palantir.atlasdb.transaction.impl.metrics;
 
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongSupplier;
 
 import com.codahale.metrics.Gauge;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/metrics/DeltaGauge.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/metrics/DeltaGauge.java
@@ -1,0 +1,43 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl.metrics;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
+
+import com.codahale.metrics.Gauge;
+
+/**
+ * Reports the difference between measurements of a supplier of long values.
+ */
+public class DeltaGauge implements Gauge<Long> {
+    private final LongSupplier underlying;
+
+    private long previousValue = 0;
+
+    public DeltaGauge(LongSupplier underlying) {
+        this.underlying = underlying;
+    }
+
+    @Override
+    public synchronized Long getValue() {
+        long currentValue = underlying.getAsLong();
+        long previous = previousValue;
+        previousValue = currentValue;
+        return currentValue - previous;
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/metrics/FilteringTableLevelMetricsController.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/metrics/FilteringTableLevelMetricsController.java
@@ -1,0 +1,80 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl.metrics;
+
+import java.util.Map;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.metrics.MetricPublicationFilter;
+import com.palantir.atlasdb.util.MetricsManager;
+import com.palantir.atlasdb.util.TopNMetricPublicationController;
+
+public final class FilteringTableLevelMetricsController implements TableLevelMetricsController {
+    private static final int MAXIMUM_NUMBER_OF_TABLES_TO_PUBLISH_SERIES_FOR = 10;
+    private static final String CONTROLLER_GENERATED = "controllerGenerated";
+    private static final String TRUE = "true";
+
+    private final Map<String, TopNMetricPublicationController<Long>> metricNameToPublicationController;
+    private final MetricsManager metricsManager;
+
+    public FilteringTableLevelMetricsController(
+            MetricsManager metricsManager) {
+        this.metricNameToPublicationController = Maps.newConcurrentMap();
+        this.metricsManager = metricsManager;
+    }
+
+    @Override
+    public <T> Counter createAndRegisterCounter(Class<T> clazz, String metricName, TableReference tableReference) {
+        Counter counter = metricsManager.registerOrGetTaggedCounter(
+                clazz,
+                metricName,
+                getTagsForTableReference(tableReference));
+        metricsManager.addMetricFilter(
+                clazz,
+                metricName,
+                getTagsForTableReference(tableReference),
+                MetricPublicationFilter.NEVER_PUBLISH);
+
+        Gauge<Long> gauge = new DeltaGauge(counter::getCount);
+        MetricPublicationFilter filter = metricNameToPublicationController.computeIfAbsent(metricName,
+                _name -> TopNMetricPublicationController.create(MAXIMUM_NUMBER_OF_TABLES_TO_PUBLISH_SERIES_FOR))
+                .registerAndCreateFilter(gauge);
+        metricsManager.addMetricFilter(
+                clazz,
+                metricName,
+                metricsManager.getTableNameTagFor(tableReference),
+                filter);
+        metricsManager.registerOrGet(
+                clazz,
+                metricName,
+                gauge,
+                metricsManager.getTableNameTagFor(tableReference));
+
+        return counter;
+    }
+
+    private Map<String, String> getTagsForTableReference(TableReference tableReference) {
+        return ImmutableMap.<String, String>builder()
+                .putAll(metricsManager.getTableNameTagFor(tableReference))
+                .put(CONTROLLER_GENERATED, TRUE)
+                .build();
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/metrics/SimpleTableLevelMetricsController.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/metrics/SimpleTableLevelMetricsController.java
@@ -1,0 +1,35 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl.metrics;
+
+import com.codahale.metrics.Counter;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.util.MetricsManager;
+
+public class SimpleTableLevelMetricsController implements TableLevelMetricsController {
+    private final MetricsManager metricsManager;
+
+    public SimpleTableLevelMetricsController(MetricsManager metricsManager) {
+        this.metricsManager = metricsManager;
+    }
+
+    @Override
+    public <T> Counter createAndRegisterCounter(Class<T> clazz, String metricName, TableReference tableReference) {
+        return metricsManager.registerOrGetTaggedCounter(
+                clazz, metricName, metricsManager.getTableNameTagFor(tableReference));
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/metrics/TableLevelMetricsController.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/metrics/TableLevelMetricsController.java
@@ -1,0 +1,24 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl.metrics;
+
+import com.codahale.metrics.Counter;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+
+public interface TableLevelMetricsController {
+    <T> Counter createAndRegisterCounter(Class<T> clazz, String metricName, TableReference tableReference);
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/metrics/ZeroBasedDeltaGauge.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/metrics/ZeroBasedDeltaGauge.java
@@ -22,13 +22,16 @@ import com.codahale.metrics.Gauge;
 
 /**
  * Reports the difference between measurements of a supplier of long values.
+ *
+ * The first value is returned as is. Users of this gauge should be very careful when attempting to evaluate deltas of
+ * sequences that do not start at zero, as they will on their first measurement not give an accurate delta.
  */
-public class DeltaGauge implements Gauge<Long> {
+public class ZeroBasedDeltaGauge implements Gauge<Long> {
     private final LongSupplier underlying;
 
     private long previousValue = 0;
 
-    public DeltaGauge(LongSupplier underlying) {
+    public ZeroBasedDeltaGauge(LongSupplier underlying) {
         this.underlying = underlying;
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/metrics/FilteringTableLevelMetricsControllerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/metrics/FilteringTableLevelMetricsControllerTest.java
@@ -1,0 +1,108 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.codahale.metrics.Clock;
+import com.codahale.metrics.Counter;
+import com.google.common.collect.ImmutableMap;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.util.MetricsManager;
+import com.palantir.atlasdb.util.MetricsManagers;
+import com.palantir.tritium.metrics.registry.MetricName;
+
+public class FilteringTableLevelMetricsControllerTest {
+    private final Clock mockClock = mock(Clock.class);
+    private final MetricsManager metricsManager = MetricsManagers.createAlwaysSafeAndFilteringForTests();
+    private final FilteringTableLevelMetricsController controller = new FilteringTableLevelMetricsController(
+            metricsManager,
+            3,
+            mockClock);
+
+    @Before
+    public void setUpClock() {
+        when(mockClock.getTick()).thenReturn(0L);
+    }
+
+    @Test
+    public void letsSingularMetricsThrough() {
+        Counter counter = controller.createAndRegisterCounter(
+                Class.class,
+                "metricName",
+                TableReference.create(Namespace.create("namespace"), "table"));
+
+        counter.inc();
+        assertThat(metricsManager.getPublishableMetrics().getMetrics())
+                .hasSize(1)
+                .containsKey(getMetricName("table"));
+    }
+
+    @Test
+    public void selectsOnlyHighestMetricsForPublication() {
+        List<Counter> counters = IntStream.range(0, 5)
+                .mapToObj(index -> controller.createAndRegisterCounter(
+                        Class.class,
+                        "metricName",
+                        TableReference.create(Namespace.create("namespace"), "table" + index)))
+                .collect(Collectors.toList());
+
+        IntStream.range(0, 5)
+                .forEach(index -> counters.get(index).inc(index));
+        assertThat(metricsManager.getPublishableMetrics().getMetrics())
+                .containsOnlyKeys(getMetricName("table2"), getMetricName("table3"), getMetricName("table4"));
+    }
+
+    @Test
+    public void detectsSpikeInMetrics() {
+        List<Counter> counters = IntStream.range(0, 5)
+                .mapToObj(index -> controller.createAndRegisterCounter(
+                        Class.class,
+                        "metricName",
+                        TableReference.create(Namespace.create("namespace"), "table" + index)))
+                .collect(Collectors.toList());
+
+        IntStream.range(0, 5)
+                .forEach(index -> counters.get(index).inc(index));
+
+        when(mockClock.getTick()).thenReturn(FilteringTableLevelMetricsController.REFRESH_INTERVAL.toNanos() + 1);
+        counters.get(1).inc(1_000_000L);
+        assertThat(metricsManager.getPublishableMetrics().getMetrics())
+                .containsKey(getMetricName("table1"));
+
+        when(mockClock.getTick()).thenReturn(FilteringTableLevelMetricsController.REFRESH_INTERVAL.toNanos() * 2 + 1);
+        assertThat(metricsManager.getPublishableMetrics().getMetrics())
+                .doesNotContainKey(getMetricName("table1"));
+    }
+
+    private static MetricName getMetricName(String tableName) {
+        return MetricName.builder().safeName(Class.class.getName() + ".metricName")
+                .safeTags(ImmutableMap.of("tableName", tableName))
+                .build();
+    }
+
+}

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
@@ -65,6 +65,7 @@ import com.palantir.atlasdb.transaction.api.TransactionFailedRetriableException;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
 import com.palantir.atlasdb.transaction.api.TransactionSerializableConflictException;
+import com.palantir.atlasdb.transaction.impl.metrics.SimpleTableLevelMetricsController;
 import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.common.base.BatchingVisitable;
 import com.palantir.common.base.BatchingVisitables;
@@ -132,7 +133,8 @@ public abstract class AbstractSerializableTransactionTest extends AbstractTransa
                 MoreExecutors.newDirectExecutorService(),
                 true,
                 () -> ImmutableTransactionConfig.builder().build(),
-                ConflictTracer.NO_OP) {
+                ConflictTracer.NO_OP,
+                new SimpleTableLevelMetricsController(metricsManager)) {
             @Override
             protected Map<Cell, byte[]> transformGetsForTesting(Map<Cell, byte[]> map) {
                 return Maps.transformValues(map, input -> input.clone());

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -96,6 +96,7 @@ import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionConflictException;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
 import com.palantir.atlasdb.transaction.api.TransactionTask;
+import com.palantir.atlasdb.transaction.impl.metrics.SimpleTableLevelMetricsController;
 import com.palantir.common.base.AbortingVisitors;
 import com.palantir.common.base.BatchingVisitable;
 import com.palantir.common.base.BatchingVisitables;
@@ -155,7 +156,8 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
                 MoreExecutors.newDirectExecutorService(),
                 true,
                 () -> TRANSACTION_CONFIG,
-                ConflictTracer.NO_OP);
+                ConflictTracer.NO_OP,
+                new SimpleTableLevelMetricsController(metricsManager));
     }
 
     @Test

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/CommitLockTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/CommitLockTest.java
@@ -48,6 +48,7 @@ import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import com.palantir.atlasdb.transaction.api.PreCommitCondition;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
+import com.palantir.atlasdb.transaction.impl.metrics.SimpleTableLevelMetricsController;
 import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.lock.AtlasCellLockDescriptor;
 import com.palantir.lock.AtlasRowLockDescriptor;
@@ -184,7 +185,8 @@ public class CommitLockTest extends TransactionTestSetup {
                 MoreExecutors.newDirectExecutorService(),
                 true,
                 () -> TRANSACTION_CONFIG,
-                ConflictTracer.NO_OP) {
+                ConflictTracer.NO_OP,
+                new SimpleTableLevelMetricsController(metricsManager)) {
             @Override
             protected Map<Cell, byte[]> transformGetsForTesting(Map<Cell, byte[]> map) {
                 return Maps.transformValues(map, byte[]::clone);

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -209,7 +209,7 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                         validateLocksOnReads,
                         () -> TRANSACTION_CONFIG,
                         ConflictTracer.NO_OP,
-                        new SimpleTableLevelMetricsController(metricsManager)),
+                        tableLevelMetricsController),
                 pathTypeTracker);
     }
 

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -39,6 +39,7 @@ import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import com.palantir.atlasdb.transaction.api.PreCommitCondition;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
+import com.palantir.atlasdb.transaction.impl.metrics.SimpleTableLevelMetricsController;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.lock.LockClient;
@@ -207,7 +208,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                         deleteExecutor,
                         validateLocksOnReads,
                         () -> TRANSACTION_CONFIG,
-                        ConflictTracer.NO_OP),
+                        ConflictTracer.NO_OP,
+                        new SimpleTableLevelMetricsController(metricsManager)),
                 pathTypeTracker);
     }
 
@@ -243,7 +245,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                         deleteExecutor,
                         validateLocksOnReads,
                         transactionConfig,
-                        ConflictTracer.NO_OP),
+                        ConflictTracer.NO_OP,
+                        new SimpleTableLevelMetricsController(metricsManager)),
                 pathTypeTracker);
     }
 

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -39,7 +39,6 @@ import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import com.palantir.atlasdb.transaction.api.PreCommitCondition;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
-import com.palantir.atlasdb.transaction.impl.metrics.SimpleTableLevelMetricsController;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.lock.LockClient;

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -246,7 +246,7 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                         validateLocksOnReads,
                         transactionConfig,
                         ConflictTracer.NO_OP,
-                        new SimpleTableLevelMetricsController(metricsManager)),
+                        tableLevelMetricsController),
                 pathTypeTracker);
     }
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -430,7 +430,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                         true,
                         () -> transactionConfig,
                         ConflictTracer.NO_OP,
-                        new SimpleTableLevelMetricsController(metricsManager)),
+                        tableLevelMetricsController),
                 pathTypeTracker);
         try {
             snapshot.get(TABLE, ImmutableSet.of(cell));
@@ -503,7 +503,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                         true,
                         () -> transactionConfig,
                         ConflictTracer.NO_OP,
-                        new SimpleTableLevelMetricsController(metricsManager)),
+                        tableLevelMetricsController),
                 pathTypeTracker);
         snapshot.delete(TABLE, ImmutableSet.of(cell));
         snapshot.commit();

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -196,7 +196,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
     private final TransactionOutcomeMetrics transactionOutcomeMetrics
             = TransactionOutcomeMetrics.create(metricsManager);
     private final TableLevelMetricsController tableLevelMetricsController
-            = new FilteringTableLevelMetricsController(metricsManager);
+            = FilteringTableLevelMetricsController.create(metricsManager);
 
     private TransactionConfig transactionConfig;
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -132,7 +132,6 @@ import com.palantir.atlasdb.transaction.api.TransactionLockTimeoutException;
 import com.palantir.atlasdb.transaction.api.TransactionLockTimeoutNonRetriableException;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
 import com.palantir.atlasdb.transaction.impl.metrics.FilteringTableLevelMetricsController;
-import com.palantir.atlasdb.transaction.impl.metrics.SimpleTableLevelMetricsController;
 import com.palantir.atlasdb.transaction.impl.metrics.TableLevelMetricsController;
 import com.palantir.atlasdb.transaction.impl.metrics.TransactionOutcomeMetrics;
 import com.palantir.atlasdb.transaction.impl.metrics.TransactionOutcomeMetricsAssert;

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -131,6 +131,7 @@ import com.palantir.atlasdb.transaction.api.TransactionFailedRetriableException;
 import com.palantir.atlasdb.transaction.api.TransactionLockTimeoutException;
 import com.palantir.atlasdb.transaction.api.TransactionLockTimeoutNonRetriableException;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
+import com.palantir.atlasdb.transaction.impl.metrics.SimpleTableLevelMetricsController;
 import com.palantir.atlasdb.transaction.impl.metrics.TransactionOutcomeMetrics;
 import com.palantir.atlasdb.transaction.impl.metrics.TransactionOutcomeMetricsAssert;
 import com.palantir.common.base.AbortingVisitor;
@@ -424,7 +425,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                         MoreExecutors.newDirectExecutorService(),
                         true,
                         () -> transactionConfig,
-                        ConflictTracer.NO_OP),
+                        ConflictTracer.NO_OP,
+                        new SimpleTableLevelMetricsController(metricsManager)),
                 pathTypeTracker);
         try {
             snapshot.get(TABLE, ImmutableSet.of(cell));
@@ -496,7 +498,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                         MoreExecutors.newDirectExecutorService(),
                         true,
                         () -> transactionConfig,
-                        ConflictTracer.NO_OP),
+                        ConflictTracer.NO_OP,
+                        new SimpleTableLevelMetricsController(metricsManager)),
                 pathTypeTracker);
         snapshot.delete(TABLE, ImmutableSet.of(cell));
         snapshot.commit();
@@ -1548,7 +1551,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                         MoreExecutors.newDirectExecutorService(),
                         validateLocksOnReads,
                         () -> transactionConfig,
-                        ConflictTracer.NO_OP),
+                        ConflictTracer.NO_OP,
+                        new SimpleTableLevelMetricsController(metricsManager)),
                 pathTypeTracker);
     }
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -131,7 +131,9 @@ import com.palantir.atlasdb.transaction.api.TransactionFailedRetriableException;
 import com.palantir.atlasdb.transaction.api.TransactionLockTimeoutException;
 import com.palantir.atlasdb.transaction.api.TransactionLockTimeoutNonRetriableException;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
+import com.palantir.atlasdb.transaction.impl.metrics.FilteringTableLevelMetricsController;
 import com.palantir.atlasdb.transaction.impl.metrics.SimpleTableLevelMetricsController;
+import com.palantir.atlasdb.transaction.impl.metrics.TableLevelMetricsController;
 import com.palantir.atlasdb.transaction.impl.metrics.TransactionOutcomeMetrics;
 import com.palantir.atlasdb.transaction.impl.metrics.TransactionOutcomeMetricsAssert;
 import com.palantir.common.base.AbortingVisitor;
@@ -194,6 +196,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
     private final int defaultGetRangesConcurrency = 2;
     private final TransactionOutcomeMetrics transactionOutcomeMetrics
             = TransactionOutcomeMetrics.create(metricsManager);
+    private final TableLevelMetricsController tableLevelMetricsController
+            = new FilteringTableLevelMetricsController(metricsManager);
 
     private TransactionConfig transactionConfig;
 
@@ -1552,7 +1556,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                         validateLocksOnReads,
                         () -> transactionConfig,
                         ConflictTracer.NO_OP,
-                        new SimpleTableLevelMetricsController(metricsManager)),
+                        tableLevelMetricsController),
                 pathTypeTracker);
     }
 


### PR DESCRIPTION
**This PR exists to show how I plan on fitting the pieces together. I will open individual PRs for components for merging.**

**Goals (and why)**:
- $$$
- With many table-level metrics, we are interested in being able to identify which tables are offending. This can be useful when dealing with high-priority issues - we normally want to see if a given table has an unexpectedly large number of reads or writes.
- We are also interested in load spikes.

**Implementation Description (bullets)**:
- Add a controller that publishes the top-N series that are registered to it.
- Instead of publishing the number of cells read / other counters, have a gauge that publishes the number of entries processed in the last 30 seconds.
- Publish counter metrics for the top ten tables, in terms of their change in the last 30 second period, inside SnapshotTransaction.

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:
- Does the idea of looking for _deltas_ and otherwise publishing the busiest tables in the steady state make sense?
- Is the zero based delta gauge a problem?

**Where should we start reviewing?**: TopNMetricPublicationController

**Priority (whenever / two weeks / yesterday)**: this week
