### PR TITLE
[PD$-110002] Part 10: Top-N Tables | Primitives

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/TopNMetricPublicationController.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/TopNMetricPublicationController.java
@@ -1,0 +1,99 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.util;
+
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import com.codahale.metrics.Gauge;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Suppliers;
+import com.google.common.collect.Sets;
+import com.palantir.atlasdb.metrics.MetricPublicationFilter;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+
+/**
+ * Given a provided number of metrics, ensures that only the top {@code maxPermittedRank} are published in the steady
+ * state.
+ */
+public final class TopNMetricPublicationController<T> {
+    private static final Duration REFRESH_INTERVAL = Duration.ofSeconds(30);
+
+    private final Set<Gauge<T>> gauges;
+    private final Comparator<T> comparator;
+    private final int maxPermittedRank;
+    private final Supplier<Optional<T>> lowerBoundSupplier;
+
+    private TopNMetricPublicationController(Comparator<T> comparator, int maxPermittedRank) {
+        this.comparator = comparator;
+        this.maxPermittedRank = maxPermittedRank;
+        this.gauges = Sets.newConcurrentHashSet();
+        this.lowerBoundSupplier = Suppliers.memoizeWithExpiration(
+                this::calculateLowerBound,
+                REFRESH_INTERVAL.toNanos(),
+                TimeUnit.NANOSECONDS);
+    }
+
+    @SuppressWarnings("unchecked") // Guaranteed correct
+    public static <T extends Comparable> TopNMetricPublicationController<T> create(int maxPermittedRank) {
+        Preconditions.checkState(maxPermittedRank > 0, "maxPermittedRank must be positive",
+                SafeArg.of("maxPermittedRank", maxPermittedRank));
+        return new TopNMetricPublicationController<T>(Comparator.naturalOrder(), maxPermittedRank);
+    }
+
+    public MetricPublicationFilter registerAndCreateFilter(Gauge<T> gauge) {
+        gauges.add(gauge);
+        return () -> shouldPublishIndividualGaugeMetric(gauge);
+    }
+
+    private boolean shouldPublishIndividualGaugeMetric(Gauge<T> constituentGauge) {
+        T value = constituentGauge.getValue();
+        return lowerBoundSupplier.get()
+                .map(lowerBound -> isAtLeastLowerBound(value, lowerBound))
+                .orElse(true); // This means there aren't maxPermittedRank series, so we should publish the metric.
+    }
+
+    private boolean isAtLeastLowerBound(T value, T lowerBound) {
+        return comparator.compare(value, lowerBound) >= 0;
+    }
+
+    private Optional<T> calculateLowerBound() {
+        return calculateOrderStatistic(gauges.stream().map(Gauge::getValue), comparator, maxPermittedRank);
+    }
+
+    @VisibleForTesting
+    static <T> Optional<T> calculateOrderStatistic(
+            Stream<T> values, Comparator<T> comparator, int orderStatistic) {
+        Preconditions.checkState(orderStatistic > 0,
+                "The order statistic to be queried for must be positive",
+                SafeArg.of("queriedOrderStatistic", orderStatistic));
+
+        // O(N log N) sorting algorithm. The number of gauges is not expected to be large.
+        // If performance is bad: consider switching to a heap O(n log orderStatistic) or quick-select algorithms.
+        return values.filter(Objects::nonNull)
+                .sorted(comparator.reversed())
+                .skip(orderStatistic - 1)
+                .findFirst();
+    }
+}

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/util/TopNMetricPublicationControllerTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/util/TopNMetricPublicationControllerTest.java
@@ -1,0 +1,153 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+
+import com.codahale.metrics.Gauge;
+import com.palantir.atlasdb.metrics.MetricPublicationFilter;
+
+public class TopNMetricPublicationControllerTest {
+    @Test
+    public void orderStatisticOfNothingIsAbsent() {
+        assertThat(TopNMetricPublicationController.calculateOrderStatistic(
+                Stream.<Integer>of(), Comparator.naturalOrder(), 1)).isEmpty();
+        assertThat(TopNMetricPublicationController.calculateOrderStatistic(
+                Stream.<Integer>of(null, null), Comparator.naturalOrder(), 1)).isEmpty();
+    }
+
+    @Test
+    public void calculatesSecondElementCorrectly() {
+        assertThat(TopNMetricPublicationController.calculateOrderStatistic(
+                IntStream.rangeClosed(1, 50).boxed(), Comparator.naturalOrder(), 2)).contains(49);
+    }
+
+    @Test
+    public void handlesDuplicates() {
+        assertThat(TopNMetricPublicationController.calculateOrderStatistic(
+                Stream.of(8, 8, 8, 8, 8), Comparator.naturalOrder(), 2)).contains(8);
+    }
+
+    @Test
+    public void orderStatisticAtEdgesOfStreamCanBeRetrieved() {
+        assertThat(TopNMetricPublicationController.calculateOrderStatistic(
+                IntStream.rangeClosed(1, 50).boxed(), Comparator.naturalOrder(), 50)).contains(1);
+        assertThat(TopNMetricPublicationController.calculateOrderStatistic(
+                IntStream.rangeClosed(1, 50).boxed(), Comparator.naturalOrder(), 51)).isEmpty();
+    }
+
+    @Test
+    public void skipsNullsInOrderStatisticComputation() {
+        assertThat(TopNMetricPublicationController.calculateOrderStatistic(
+                Stream.of(null, null, 3, 7), Comparator.naturalOrder(), 2)).contains(3);
+        assertThat(TopNMetricPublicationController.calculateOrderStatistic(
+                Stream.of(null, null, 3, 7), Comparator.naturalOrder(), 3)).isEmpty();
+    }
+
+    @Test
+    public void canSpecifyCustomComparator() {
+        assertThat(TopNMetricPublicationController.calculateOrderStatistic(
+                Stream.of("a", "bcd", "efghi", "jk"), Comparator.comparingInt(String::length), 1))
+                .contains("efghi");
+    }
+
+    @Test
+    public void throwsIfAttemptingToRetrieveNonPositiveOrderStatistics() {
+        assertThatThrownBy(() -> TopNMetricPublicationController.calculateOrderStatistic(
+                IntStream.rangeClosed(1, 50).boxed(), Comparator.naturalOrder(), 0))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("The order statistic to be queried for must be positive");
+        assertThatThrownBy(() -> TopNMetricPublicationController.calculateOrderStatistic(
+                IntStream.rangeClosed(1, 50).boxed(), Comparator.naturalOrder(), -1))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("The order statistic to be queried for must be positive");
+    }
+
+    @Test
+    public void canSelectivelyPublishGaugeResults() {
+        AtomicLong value1 = new AtomicLong(42);
+        AtomicLong value2 = new AtomicLong(157);
+
+        Gauge<Long> gauge1 = value1::get;
+        Gauge<Long> gauge2 = value2::get;
+
+        TopNMetricPublicationController<Long> controller = TopNMetricPublicationController.create(1);
+        MetricPublicationFilter filter1 = controller.registerAndCreateFilter(gauge1);
+        MetricPublicationFilter filter2 = controller.registerAndCreateFilter(gauge2);
+
+        assertThat(filter1.shouldPublish()).isFalse();
+        assertThat(filter2.shouldPublish()).isTrue();
+    }
+
+    @Test
+    public void canSelectivelyPublishMultipleGaugeResults() {
+        List<Gauge<Long>> atomicLongs = LongStream.range(0, 100)
+                .mapToObj(AtomicLong::new)
+                .<Gauge<Long>>map(atomicLong -> atomicLong::get)
+                .collect(Collectors.toList());
+
+        TopNMetricPublicationController<Long> controller = TopNMetricPublicationController.create(7);
+
+        List<MetricPublicationFilter> filtersInOrder = atomicLongs.stream()
+                .map(controller::registerAndCreateFilter)
+                .collect(Collectors.toList());
+
+        assertThat(filtersInOrder.get(0).shouldPublish()).isFalse();
+        assertThat(filtersInOrder.get(50).shouldPublish()).isFalse();
+        assertThat(filtersInOrder.get(92).shouldPublish()).isFalse();
+        assertThat(filtersInOrder.get(93).shouldPublish()).isTrue();
+        assertThat(filtersInOrder.get(94).shouldPublish()).isTrue();
+        assertThat(filtersInOrder.get(99).shouldPublish()).isTrue();
+    }
+
+    @Test
+    public void publishesAllGaugesIfThereAreFewerThanTheThreshold() {
+        AtomicLong value1 = new AtomicLong(42);
+        AtomicLong value2 = new AtomicLong(157);
+
+        Gauge<Long> gauge1 = value1::get;
+        Gauge<Long> gauge2 = value2::get;
+
+        TopNMetricPublicationController<Long> controller = TopNMetricPublicationController.create(50);
+        MetricPublicationFilter filter1 = controller.registerAndCreateFilter(gauge1);
+        MetricPublicationFilter filter2 = controller.registerAndCreateFilter(gauge2);
+
+        assertThat(filter1.shouldPublish()).isTrue();
+        assertThat(filter2.shouldPublish()).isTrue();
+    }
+
+    @Test
+    public void throwsWhenCreatingControllerWithNonPositiveArguments() {
+        assertThatThrownBy(() -> TopNMetricPublicationController.create(0))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("maxPermittedRank must be positive");
+        assertThatThrownBy(() -> TopNMetricPublicationController.create(-29359))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("maxPermittedRank must be positive");
+    }
+}

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/util/TopNMetricPublicationControllerTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/util/TopNMetricPublicationControllerTest.java
@@ -19,6 +19,7 @@ package com.palantir.atlasdb.util;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.time.Duration;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
@@ -33,61 +34,6 @@ import com.codahale.metrics.Gauge;
 import com.palantir.atlasdb.metrics.MetricPublicationFilter;
 
 public class TopNMetricPublicationControllerTest {
-    @Test
-    public void orderStatisticOfNothingIsAbsent() {
-        assertThat(TopNMetricPublicationController.calculateOrderStatistic(
-                Stream.<Integer>of(), Comparator.naturalOrder(), 1)).isEmpty();
-        assertThat(TopNMetricPublicationController.calculateOrderStatistic(
-                Stream.<Integer>of(null, null), Comparator.naturalOrder(), 1)).isEmpty();
-    }
-
-    @Test
-    public void calculatesSecondElementCorrectly() {
-        assertThat(TopNMetricPublicationController.calculateOrderStatistic(
-                IntStream.rangeClosed(1, 50).boxed(), Comparator.naturalOrder(), 2)).contains(49);
-    }
-
-    @Test
-    public void handlesDuplicates() {
-        assertThat(TopNMetricPublicationController.calculateOrderStatistic(
-                Stream.of(8, 8, 8, 8, 8), Comparator.naturalOrder(), 2)).contains(8);
-    }
-
-    @Test
-    public void orderStatisticAtEdgesOfStreamCanBeRetrieved() {
-        assertThat(TopNMetricPublicationController.calculateOrderStatistic(
-                IntStream.rangeClosed(1, 50).boxed(), Comparator.naturalOrder(), 50)).contains(1);
-        assertThat(TopNMetricPublicationController.calculateOrderStatistic(
-                IntStream.rangeClosed(1, 50).boxed(), Comparator.naturalOrder(), 51)).isEmpty();
-    }
-
-    @Test
-    public void skipsNullsInOrderStatisticComputation() {
-        assertThat(TopNMetricPublicationController.calculateOrderStatistic(
-                Stream.of(null, null, 3, 7), Comparator.naturalOrder(), 2)).contains(3);
-        assertThat(TopNMetricPublicationController.calculateOrderStatistic(
-                Stream.of(null, null, 3, 7), Comparator.naturalOrder(), 3)).isEmpty();
-    }
-
-    @Test
-    public void canSpecifyCustomComparator() {
-        assertThat(TopNMetricPublicationController.calculateOrderStatistic(
-                Stream.of("a", "bcd", "efghi", "jk"), Comparator.comparingInt(String::length), 1))
-                .contains("efghi");
-    }
-
-    @Test
-    public void throwsIfAttemptingToRetrieveNonPositiveOrderStatistics() {
-        assertThatThrownBy(() -> TopNMetricPublicationController.calculateOrderStatistic(
-                IntStream.rangeClosed(1, 50).boxed(), Comparator.naturalOrder(), 0))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("The order statistic to be queried for must be positive");
-        assertThatThrownBy(() -> TopNMetricPublicationController.calculateOrderStatistic(
-                IntStream.rangeClosed(1, 50).boxed(), Comparator.naturalOrder(), -1))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("The order statistic to be queried for must be positive");
-    }
-
     @Test
     public void canSelectivelyPublishGaugeResults() {
         AtomicLong value1 = new AtomicLong(42);
@@ -126,6 +72,29 @@ public class TopNMetricPublicationControllerTest {
     }
 
     @Test
+    public void eligibleGaugesChangeOverTime() {
+        AtomicLong value1 = new AtomicLong(42);
+        AtomicLong value2 = new AtomicLong(157);
+
+        Gauge<Long> gauge1 = value1::get;
+        Gauge<Long> gauge2 = value2::get;
+
+        TopNMetricPublicationController<Long> controller = new TopNMetricPublicationController<>(
+                Comparator.<Long>naturalOrder(),
+                1,
+                Duration.ofNanos(1));
+        MetricPublicationFilter filter1 = controller.registerAndCreateFilter(gauge1);
+        MetricPublicationFilter filter2 = controller.registerAndCreateFilter(gauge2);
+
+        assertThat(filter1.shouldPublish()).isFalse();
+        assertThat(filter2.shouldPublish()).isTrue();
+
+        value1.set(8888);
+        assertThat(filter1.shouldPublish()).isTrue();
+        assertThat(filter2.shouldPublish()).isFalse();
+    }
+
+    @Test
     public void publishesAllGaugesIfThereAreFewerThanTheThreshold() {
         AtomicLong value1 = new AtomicLong(42);
         AtomicLong value2 = new AtomicLong(157);
@@ -139,6 +108,25 @@ public class TopNMetricPublicationControllerTest {
 
         assertThat(filter1.shouldPublish()).isTrue();
         assertThat(filter2.shouldPublish()).isTrue();
+    }
+
+    @Test
+    public void selectsArbitraryElementFromTies() {
+        AtomicLong value1 = new AtomicLong(42);
+        AtomicLong value2a = new AtomicLong(66);
+        AtomicLong value2b = new AtomicLong(66);
+        AtomicLong value3 = new AtomicLong(89);
+
+        TopNMetricPublicationController<Long> controller = TopNMetricPublicationController.create(2);
+
+        MetricPublicationFilter filter1 = controller.registerAndCreateFilter(value1::get);
+        MetricPublicationFilter filter2a = controller.registerAndCreateFilter(value2a::get);
+        MetricPublicationFilter filter2b = controller.registerAndCreateFilter(value2b::get);
+        MetricPublicationFilter filter3 = controller.registerAndCreateFilter(value3::get);
+
+        assertThat(filter1.shouldPublish()).isFalse();
+        assertThat(filter2a.shouldPublish() ^ filter2b.shouldPublish()).isTrue();
+        assertThat(filter3.shouldPublish()).isTrue();
     }
 
     @Test

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/metrics/ZeroBasedDeltaGauge.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/metrics/ZeroBasedDeltaGauge.java
@@ -1,0 +1,45 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl.metrics;
+
+import java.util.function.LongSupplier;
+
+import com.codahale.metrics.Gauge;
+
+/**
+ * Reports the difference between measurements of a supplier of long values.
+ *
+ * The first value is returned as is. Users of this gauge should be very careful when attempting to evaluate deltas of
+ * sequences that do not start at zero, as they will on their first measurement not give an accurate delta.
+ */
+public class ZeroBasedDeltaGauge implements Gauge<Long> {
+    private final LongSupplier underlying;
+
+    private long previousValue = 0;
+
+    public ZeroBasedDeltaGauge(LongSupplier underlying) {
+        this.underlying = underlying;
+    }
+
+    @Override
+    public synchronized Long getValue() {
+        long currentValue = underlying.getAsLong();
+        long previous = previousValue;
+        previousValue = currentValue;
+        return currentValue - previous;
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/metrics/ZeroBasedDeltaGaugeTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/metrics/ZeroBasedDeltaGaugeTest.java
@@ -1,0 +1,55 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.Test;
+
+import com.codahale.metrics.Gauge;
+
+public class ZeroBasedDeltaGaugeTest {
+    private static final long FIVE = 5L;
+
+    private final AtomicLong value = new AtomicLong(0);
+    private final Gauge<Long> longGauge = new ZeroBasedDeltaGauge(value::get);
+
+    @Test
+    public void initialValueIsReported() {
+        value.set(FIVE);
+        assertThat(longGauge.getValue()).isEqualTo(FIVE);
+    }
+
+    @Test
+    public void reportsDifferencesBetweenValues() {
+        value.set(FIVE);
+        longGauge.getValue();
+        value.addAndGet(FIVE);
+        assertThat(value.get()).isEqualTo(FIVE + FIVE);
+        assertThat(longGauge.getValue()).isEqualTo(FIVE);
+    }
+
+    @Test
+    public void reportsNegativeDifferenceValues() {
+        value.set(FIVE);
+        assertThat(longGauge.getValue()).isEqualTo(FIVE);
+        value.set(2L);
+        assertThat(longGauge.getValue()).isEqualTo(2L - FIVE);
+    }
+}


### PR DESCRIPTION
**Goals (and why)**:
- See #4891 

**Implementation Description (bullets)**:
- TopNMetricPublicationController sets up metrics filters so only the top-N things get published.
- ZeroBasedDeltaGauge reports the delta between measurements (the eventual goal is handling load spikes)

**Testing (What was existing testing like?  What have you done to improve it?)**:
Unit tests for the new things

**Concerns (what feedback would you like?)**:
Nothing much

**Where should we start reviewing?**: TopNMetricPublicationController

**Priority (whenever / two weeks / yesterday)**: this week
