### PR TITLE
[LW] Test for lock watch updates that are too far behind

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/ClientLockWatchSnapshot.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/ClientLockWatchSnapshot.java
@@ -82,6 +82,10 @@ final class ClientLockWatchSnapshot {
         locked.clear();
     }
 
+    Optional<IdentifiedVersion> getSnapshotVersion() {
+        return snapshotVersion;
+    }
+
     @VisibleForTesting
     ClientLockWatchSnapshotState getStateForTesting() {
         return ImmutableClientLockWatchSnapshotState.builder()

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLog.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLog.java
@@ -126,7 +126,9 @@ final class LockWatchEventLog {
                 "Must have a snapshot before processing successful updates");
 
         if (success.lastKnownVersion() < snapshotVersion.get().version()) {
-            throw new TransactionLockWatchFailedException("Cannot process events before the oldest event");
+            throw new TransactionLockWatchFailedException(
+                    "Cannot process events before the oldest event. The transaction should be retried, although this"
+                            + " should only happen very rarely.");
         }
 
         if (success.lastKnownVersion() > latestVersion.get().version()) {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheIntegrationTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheIntegrationTest.java
@@ -266,7 +266,8 @@ public class LockWatchEventCacheIntegrationTest {
         assertThatThrownBy(() -> eventCache.processStartTransactionsUpdate(secondTimestamps,
                 LockWatchStateUpdate.success(LEADER, 2L, ImmutableList.of(earlyEvent))))
                 .isExactlyInstanceOf(TransactionLockWatchFailedException.class)
-                .hasMessage("Cannot process events before the oldest event");
+                .hasMessage("Cannot process events before the oldest event. The transaction should be retried, "
+                        + "although this should only happen very rarely.");
     }
 
     @Test


### PR DESCRIPTION
**Goals (and why)**:
Catch a case in the code where the successful update has a version before the snapshot.
Since the start transaction flow is synchronous and batched, it should not be possible to have this case - it would mean that the cache has received some updates, and the transactions that carried those updates have committed, all before the second set of updates comes in. This defends against it anyway.

**Implementation Description (bullets)**:
* Added a test for successful updates that have a version before the snapshot (which essentially represents the earliest version for which we have events).

**Testing (What was existing testing like?  What have you done to improve it?)**:
* Added another test to `LockWatchEventCacheIntegrationTests`.

**Concerns (what feedback would you like?)**:
* Is this change necessary? Note that if the above case were to happen with the current code, the main point of worry is the commit update, and that would end up invalidating all (i.e. causing a conflict, and retrying the transaction anyway).

**Where should we start reviewing?**:
* LockWatchEventLog

**Priority (whenever / two weeks / yesterday)**:
Whenever.
