### PR TITLE
[PDS-125544] Configurable, Instrumented Feedback Sink

### DIFF
--- a/changelog/@unreleased/pr-4900.v2.yml
+++ b/changelog/@unreleased/pr-4900.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Timelock adjudication is now configurable and reports metrics.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4900

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockAdjudicationConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockAdjudicationConfiguration.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 @JsonDeserialize(as = ImmutableTimeLockAdjudicationConfiguration.class)
 @Value.Immutable
 public interface TimeLockAdjudicationConfiguration {
+    @Value.Default
     default boolean enabled() {
         return true;
     }

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockAdjudicationConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockAdjudicationConfiguration.java
@@ -1,0 +1,29 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.timelock.config;
+
+import org.immutables.value.Value;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+@JsonDeserialize(as = ImmutableTimeLockAdjudicationConfiguration.class)
+@Value.Immutable
+public interface TimeLockAdjudicationConfiguration {
+    default boolean enabled() {
+        return true;
+    }
+}

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockRuntimeConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockRuntimeConfiguration.java
@@ -64,6 +64,12 @@ public abstract class TimeLockRuntimeConfiguration {
         return LockWatchTestRuntimeConfig.defaultConfig();
     }
 
+    @JsonProperty("adjudication")
+    @Value.Default
+    public TimeLockAdjudicationConfiguration adjudication() {
+        return ImmutableTimeLockAdjudicationConfiguration.builder().build();
+    }
+
     @Value.Check
     public void check() {
         Preconditions.checkState(maxNumberOfClients() >= 0,

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -180,7 +180,7 @@ public class TimeLockAgent {
         this.noSimultaneousServiceCheck = NoSimultaneousServiceCheck.create(
                 new TimeLockActivityCheckerFactory(install, metricsManager, userAgent).getTimeLockActivityCheckers());
 
-        this.feedbackHandler = new FeedbackHandler(metricsManager);
+        this.feedbackHandler = new FeedbackHandler(metricsManager, () -> runtime.get().adjudication().enabled());
     }
 
     private static ExecutorService createSharedExecutor() {

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -180,7 +180,7 @@ public class TimeLockAgent {
         this.noSimultaneousServiceCheck = NoSimultaneousServiceCheck.create(
                 new TimeLockActivityCheckerFactory(install, metricsManager, userAgent).getTimeLockActivityCheckers());
 
-        this.feedbackHandler = new FeedbackHandler();
+        this.feedbackHandler = new FeedbackHandler(metricsManager);
     }
 
     private static ExecutorService createSharedExecutor() {

--- a/timelock-agent/src/test/java/com/palantir/timelock/config/TimeLockAdjudicationConfigurationTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/config/TimeLockAdjudicationConfigurationTest.java
@@ -1,0 +1,40 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.timelock.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+
+public class TimeLockAdjudicationConfigurationTest {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(new YAMLFactory()
+            .disable(YAMLGenerator.Feature.USE_NATIVE_TYPE_ID)
+            .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER))
+            .registerModule(new GuavaModule());
+
+    @Test
+    public void defaultIsTrue() throws JsonProcessingException {
+        assertThat(OBJECT_MAPPER.readValue("{}", TimeLockAdjudicationConfiguration.class))
+                .satisfies(config -> assertThat(config.enabled()).isTrue());
+    }
+}

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/adjudicate/FeedbackHandler.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/adjudicate/FeedbackHandler.java
@@ -31,6 +31,8 @@ import org.slf4j.LoggerFactory;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
+import com.palantir.atlasdb.util.MetricsManager;
+import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.common.streams.KeyedStream;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.paxos.Client;
@@ -40,11 +42,21 @@ import com.palantir.timelock.feedback.EndpointStatistics;
 public class FeedbackHandler {
     private static final Logger log = LoggerFactory.getLogger(FeedbackHandler.class);
 
-    private final TimeLockClientFeedbackSink timeLockClientFeedbackSink = TimeLockClientFeedbackSink
-            .create(Caffeine
-            .newBuilder()
-            .expireAfterWrite(Constants.HEALTH_FEEDBACK_REPORT_EXPIRATION_MINUTES.toMinutes(), TimeUnit.MINUTES)
-                        .build());
+    private final TimeLockClientFeedbackSink timeLockClientFeedbackSink;
+
+    public FeedbackHandler(MetricsManager metricsManager) {
+        this.timeLockClientFeedbackSink = TimeLockClientFeedbackSink
+                .createAndInstrument(metricsManager,
+                        Caffeine.newBuilder()
+                                .expireAfterWrite(
+                                        Constants.HEALTH_FEEDBACK_REPORT_EXPIRATION_MINUTES.toMinutes(),
+                                        TimeUnit.MINUTES)
+                                .build());
+    }
+
+    public static FeedbackHandler createForTests() {
+        return new FeedbackHandler(MetricsManagers.createForTests());
+    }
 
     public void handle(ConjureTimeLockClientFeedback feedback) {
         timeLockClientFeedbackSink.registerFeedback(feedback);

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/adjudicate/TimeLockClientFeedbackSink.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/adjudicate/TimeLockClientFeedbackSink.java
@@ -21,13 +21,23 @@ import java.util.UUID;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.google.common.collect.ImmutableList;
+import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.timelock.feedback.ConjureTimeLockClientFeedback;
 
 public final class TimeLockClientFeedbackSink {
-    private Cache<UUID, ConjureTimeLockClientFeedback> trackedFeedbackReports;
+    private final Cache<UUID, ConjureTimeLockClientFeedback> trackedFeedbackReports;
 
     private TimeLockClientFeedbackSink(Cache<UUID, ConjureTimeLockClientFeedback> trackedFeedbackReports) {
         this.trackedFeedbackReports = trackedFeedbackReports;
+    }
+
+    static TimeLockClientFeedbackSink createAndInstrument(
+            MetricsManager metricsManager,
+            Cache<UUID, ConjureTimeLockClientFeedback> trackedFeedbackReports) {
+        metricsManager.registerOrGetGauge(TimeLockClientFeedbackSink.class,
+                "estimatedSize",
+                () -> trackedFeedbackReports::estimatedSize);
+        return create(trackedFeedbackReports);
     }
 
     public static TimeLockClientFeedbackSink create(

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/adjudicate/TimeLockClientFeedbackSink.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/adjudicate/TimeLockClientFeedbackSink.java
@@ -35,7 +35,7 @@ public final class TimeLockClientFeedbackSink {
             MetricsManager metricsManager,
             Cache<UUID, ConjureTimeLockClientFeedback> trackedFeedbackReports) {
         metricsManager.registerOrGetGauge(TimeLockClientFeedbackSink.class,
-                "estimatedSize",
+                "numberOfFeedbackReports",
                 () -> trackedFeedbackReports::estimatedSize);
         return create(trackedFeedbackReports);
     }

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/adjudicate/FeedbackAnalysisTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/adjudicate/FeedbackAnalysisTest.java
@@ -55,7 +55,7 @@ public class FeedbackAnalysisTest {
     }
 
     private FeedbackHandler getFeedbackHandlerWithReports(ImmutableList<ConjureTimeLockClientFeedback> reports) {
-        FeedbackHandler feedbackHandler = new FeedbackHandler();
+        FeedbackHandler feedbackHandler = FeedbackHandler.createForTests();
         reports.forEach(feedbackHandler::handle);
         return feedbackHandler;
     }
@@ -91,7 +91,7 @@ public class FeedbackAnalysisTest {
 
     @Test
     public void timeLockIsHealthyIfLessThanSpecifiedRatioOfClientsAreUnhealthy() {
-        FeedbackHandler feedbackHandler = new FeedbackHandler();
+        FeedbackHandler feedbackHandler = FeedbackHandler.createForTests();
         IntStream.range(1, 5).forEach(
                 index -> feedbackHandler
                         .handle(getUnhealthyClientFeedbackReport("Client_" + index, UUID.randomUUID())));
@@ -105,7 +105,7 @@ public class FeedbackAnalysisTest {
 
     @Test
     public void timeLockIsUnhealthyIfMoreThanSpecifiedRatioOfClientsAreUnhealthy() {
-        FeedbackHandler feedbackHandler = new FeedbackHandler();
+        FeedbackHandler feedbackHandler = FeedbackHandler.createForTests();
 
         IntStream.range(1, 10).forEach(
                 index -> feedbackHandler
@@ -199,7 +199,7 @@ public class FeedbackAnalysisTest {
     // point analysis
     @Test
     public void reportIsHealthyIfAllMetricsAreHealthy() {
-        FeedbackHandler feedbackHandler = new FeedbackHandler();
+        FeedbackHandler feedbackHandler = FeedbackHandler.createForTests();
         assertThat(feedbackHandler.pointFeedbackHealthStatus(
                 getHealthyClientFeedbackReport(CLIENT, UUID.randomUUID())))
                 .isEqualTo(HealthStatus.HEALTHY);
@@ -207,7 +207,7 @@ public class FeedbackAnalysisTest {
 
     @Test
     public void reportIsUnknownIfEvenOneMetricIsInUnknownState() {
-        FeedbackHandler feedbackHandler = new FeedbackHandler();
+        FeedbackHandler feedbackHandler = FeedbackHandler.createForTests();
         assertThat(feedbackHandler.pointFeedbackHealthStatus(
                 getReportWithLeaderTimeMetricInUnknownState(CLIENT, UUID.randomUUID())))
                 .isEqualTo(HealthStatus.UNKNOWN);
@@ -219,7 +219,7 @@ public class FeedbackAnalysisTest {
 
     @Test
     public void reportIsUnhealthyIfP99IsOutlier() {
-        FeedbackHandler feedbackHandler = new FeedbackHandler();
+        FeedbackHandler feedbackHandler = FeedbackHandler.createForTests();
         assertThat(feedbackHandler.pointFeedbackHealthStatus(
                 getReportWithStartTxnForVeryHighP99(CLIENT, UUID.randomUUID())))
                 .isEqualTo(HealthStatus.UNHEALTHY);
@@ -227,7 +227,7 @@ public class FeedbackAnalysisTest {
 
     @Test
     public void reportIsUnhealthyIfEvenOneMetricIsInUnhealthy() {
-        FeedbackHandler feedbackHandler = new FeedbackHandler();
+        FeedbackHandler feedbackHandler = FeedbackHandler.createForTests();
         assertThat(feedbackHandler.pointFeedbackHealthStatus(
                 getReportWithLeaderTimeMetricInUnhealthyState(CLIENT, UUID.randomUUID())))
                 .isEqualTo(HealthStatus.UNHEALTHY);
@@ -239,7 +239,7 @@ public class FeedbackAnalysisTest {
 
     @Test
     public void isAbleToHandleReportsWhereLeaderTimeAndStartTransactionAreEqual() {
-        FeedbackHandler feedbackHandler = new FeedbackHandler();
+        FeedbackHandler feedbackHandler = FeedbackHandler.createForTests();
         ConjureTimeLockClientFeedback report = getClientFeedbackReport(CLIENT, UUID.randomUUID(),
                 0, 0, 0, 0);
 

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/adjudicate/FeedbackHandlerTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/adjudicate/FeedbackHandlerTest.java
@@ -1,0 +1,89 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.adjudicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+
+import com.codahale.metrics.Gauge;
+import com.palantir.atlasdb.util.MetricsManager;
+import com.palantir.atlasdb.util.MetricsManagers;
+import com.palantir.timelock.feedback.ConjureTimeLockClientFeedback;
+import com.palantir.tritium.metrics.registry.MetricName;
+
+public class FeedbackHandlerTest {
+    private static final ConjureTimeLockClientFeedback FEEDBACK = ConjureTimeLockClientFeedback.builder()
+            .atlasVersion("1.2.3")
+            .serviceName("tom")
+            .nodeId(UUID.randomUUID())
+            .build();
+    private static final MetricName METRIC_NAME = MetricName.builder()
+            .safeName(TimeLockClientFeedbackSink.class.getName() + ".numberOfFeedbackReports")
+            .build();
+
+    private final TimeLockClientFeedbackSink sink = mock(TimeLockClientFeedbackSink.class);
+
+    @Test
+    public void putsFeedbackInSinkByDefault() {
+        FeedbackHandler handler = new FeedbackHandler(sink, () -> true);
+        handler.handle(FEEDBACK);
+        verify(sink, times(1)).registerFeedback(FEEDBACK);
+    }
+
+    @Test
+    public void doesNotPutFeedbackInSinkIfConfiguredNotTo() {
+        FeedbackHandler handler = new FeedbackHandler(sink, () -> false);
+        handler.handle(FEEDBACK);
+        verify(sink, never()).registerFeedback(FEEDBACK);
+    }
+
+    @Test
+    public void liveReloadsPublicationConfig() {
+        AtomicBoolean atomicBoolean = new AtomicBoolean(true);
+        FeedbackHandler handler = new FeedbackHandler(sink, atomicBoolean::get);
+        handler.handle(FEEDBACK);
+        verify(sink, times(1)).registerFeedback(FEEDBACK);
+
+        atomicBoolean.set(false);
+        handler.handle(FEEDBACK);
+        verify(sink, times(1)).registerFeedback(FEEDBACK);
+
+        atomicBoolean.set(true);
+        handler.handle(FEEDBACK);
+        verify(sink, times(2)).registerFeedback(FEEDBACK);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void publishesSizeMetricToMetricManager() {
+        MetricsManager metricsManager = MetricsManagers.createForTests();
+        FeedbackHandler handler = new FeedbackHandler(metricsManager, () -> true);
+
+        handler.handle(FEEDBACK);
+        assertThat(metricsManager.getPublishableMetrics().getMetrics())
+                .containsKey(METRIC_NAME)
+                .satisfies(map -> assertThat(((Gauge<Long>) map.get(METRIC_NAME)).getValue()).isEqualTo(1L));
+    }
+}

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/adjudicate/PointHealthReportAnalysisTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/adjudicate/PointHealthReportAnalysisTest.java
@@ -37,7 +37,7 @@ public class PointHealthReportAnalysisTest {
 
     @Test
     public void reportIsHealthyWhenEverythingIsRight() {
-        FeedbackHandler feedbackHandler = new FeedbackHandler(metricsManager);
+        FeedbackHandler feedbackHandler = FeedbackHandler.createForTests();
         EndpointStatistics statistics = EndpointStatistics
                 .builder()
                 .p99(P_99 - 1)
@@ -50,7 +50,7 @@ public class PointHealthReportAnalysisTest {
 
     @Test
     public void reportStatusIsUnknownIfReqRateIsBelowThreshold() {
-        FeedbackHandler feedbackHandler = new FeedbackHandler(metricsManager);
+        FeedbackHandler feedbackHandler = FeedbackHandler.createForTests();
         EndpointStatistics statistics = EndpointStatistics
                 .builder()
                 .p99(P_99 + 1)
@@ -63,7 +63,7 @@ public class PointHealthReportAnalysisTest {
 
     @Test
     public void reportStatusIsUnhealthyIfErrProportionIsHigh() {
-        FeedbackHandler feedbackHandler = new FeedbackHandler(metricsManager);
+        FeedbackHandler feedbackHandler = FeedbackHandler.createForTests();
         EndpointStatistics statistics = EndpointStatistics
                 .builder()
                 .p99(P_99 + 1)
@@ -76,7 +76,7 @@ public class PointHealthReportAnalysisTest {
 
     @Test
     public void reportStatusIsUnhealthyIfP99IsAboveThreshold() {
-        FeedbackHandler feedbackHandler = new FeedbackHandler(metricsManager);
+        FeedbackHandler feedbackHandler = FeedbackHandler.createForTests();
         EndpointStatistics statistics = EndpointStatistics
                 .builder()
                 .p99(P_99 + 1)
@@ -89,7 +89,7 @@ public class PointHealthReportAnalysisTest {
 
     @Test
     public void reportStatusIsUnhealthyIfQuietP99IsAboveThreshold() {
-        FeedbackHandler feedbackHandler = new FeedbackHandler(metricsManager);
+        FeedbackHandler feedbackHandler = FeedbackHandler.createForTests();
         EndpointStatistics statistics = EndpointStatistics
                 .builder()
                 .p99(QUIET_P99 + 1)

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/adjudicate/PointHealthReportAnalysisTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/adjudicate/PointHealthReportAnalysisTest.java
@@ -37,7 +37,7 @@ public class PointHealthReportAnalysisTest {
 
     @Test
     public void reportIsHealthyWhenEverythingIsRight() {
-        FeedbackHandler feedbackHandler = new FeedbackHandler();
+        FeedbackHandler feedbackHandler = new FeedbackHandler(metricsManager);
         EndpointStatistics statistics = EndpointStatistics
                 .builder()
                 .p99(P_99 - 1)
@@ -50,7 +50,7 @@ public class PointHealthReportAnalysisTest {
 
     @Test
     public void reportStatusIsUnknownIfReqRateIsBelowThreshold() {
-        FeedbackHandler feedbackHandler = new FeedbackHandler();
+        FeedbackHandler feedbackHandler = new FeedbackHandler(metricsManager);
         EndpointStatistics statistics = EndpointStatistics
                 .builder()
                 .p99(P_99 + 1)
@@ -63,7 +63,7 @@ public class PointHealthReportAnalysisTest {
 
     @Test
     public void reportStatusIsUnhealthyIfErrProportionIsHigh() {
-        FeedbackHandler feedbackHandler = new FeedbackHandler();
+        FeedbackHandler feedbackHandler = new FeedbackHandler(metricsManager);
         EndpointStatistics statistics = EndpointStatistics
                 .builder()
                 .p99(P_99 + 1)
@@ -76,7 +76,7 @@ public class PointHealthReportAnalysisTest {
 
     @Test
     public void reportStatusIsUnhealthyIfP99IsAboveThreshold() {
-        FeedbackHandler feedbackHandler = new FeedbackHandler();
+        FeedbackHandler feedbackHandler = new FeedbackHandler(metricsManager);
         EndpointStatistics statistics = EndpointStatistics
                 .builder()
                 .p99(P_99 + 1)
@@ -89,7 +89,7 @@ public class PointHealthReportAnalysisTest {
 
     @Test
     public void reportStatusIsUnhealthyIfQuietP99IsAboveThreshold() {
-        FeedbackHandler feedbackHandler = new FeedbackHandler();
+        FeedbackHandler feedbackHandler = new FeedbackHandler(metricsManager);
         EndpointStatistics statistics = EndpointStatistics
                 .builder()
                 .p99(QUIET_P99 + 1)

--- a/timelock-impl/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/timelock-impl/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
**Goals (and why)**:
- Attempt to debug inexplicable performance regressions, _even with the same server side code_ on internal timelock.
- Understand the memory footprint of adjudication better.

**Implementation Description (bullets)**:
- Add runtime config to make adjudication configurable

**Testing (What was existing testing like?  What have you done to improve it?)**:
FeedbackHandlerTest should cover most of it.

**Concerns (what feedback would you like?)**:
Nothing in particular. Is there anything actually broken?

**Where should we start reviewing?**: TLAC

**Priority (whenever / two weeks / yesterday)**: this week

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
