### PR TITLE
Leader election rate

### DIFF
--- a/changelog/@unreleased/pr-4907.v2.yml
+++ b/changelog/@unreleased/pr-4907.v2.yml
@@ -1,11 +1,6 @@
 type: improvement
 improvement:
-  description: |-
-    This change adds a health check to track the leader election rate on TimeLock.
-    <!---
-    Please remember to:
-    - Add any necessary release notes (including breaking changes)
-    - Make sure the documentation is up to date for your change
-    --->
+  description: This change adds a health check to track the leader election rate on
+    TimeLock.
   links:
   - https://github.com/palantir/atlasdb/pull/4907

--- a/changelog/@unreleased/pr-4907.v2.yml
+++ b/changelog/@unreleased/pr-4907.v2.yml
@@ -1,0 +1,11 @@
+type: improvement
+improvement:
+  description: |-
+    This change adds a health check to track the leader election rate on TimeLock.
+    <!---
+    Please remember to:
+    - Add any necessary release notes (including breaking changes)
+    - Make sure the documentation is up to date for your change
+    --->
+  links:
+  - https://github.com/palantir/atlasdb/pull/4907

--- a/leader-election-impl/build.gradle
+++ b/leader-election-impl/build.gradle
@@ -1,6 +1,10 @@
 apply from: "../gradle/shared.gradle"
 apply plugin: 'com.palantir.metric-schema'
 
+license {
+  exclude '**/LeaderElectionServiceMetrics.java'
+}
+
 dependencies {
   compile project(":leader-election-api")
   compile project(":atlasdb-autobatch")

--- a/leader-election-impl/build.gradle
+++ b/leader-election-impl/build.gradle
@@ -1,4 +1,5 @@
 apply from: "../gradle/shared.gradle"
+apply plugin: 'com.palantir.metric-schema'
 
 dependencies {
   compile project(":leader-election-api")

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeadershipEventRecorder.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeadershipEventRecorder.java
@@ -53,7 +53,9 @@ public class PaxosLeadershipEventRecorder implements PaxosKnowledgeEventRecorder
     }
 
     @VisibleForTesting
-    PaxosLeadershipEventRecorder(LeadershipEvents events, String leaderUuid, Optional<LeadershipObserver> observer) {
+    PaxosLeadershipEventRecorder(LeadershipEvents events,
+            String leaderUuid,
+            Optional<LeadershipObserver> observer) {
         this.events = events;
         this.leaderId = leaderUuid;
         this.leadershipObserver = observer;

--- a/leader-election-impl/src/main/java/com/palantir/leader/health/LeaderElectionHealthCheck.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/health/LeaderElectionHealthCheck.java
@@ -1,0 +1,36 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.leader.health;
+
+import com.palantir.leader.LeaderElectionServiceMetrics;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+
+public class LeaderElectionHealthCheck {
+    private static final double MAX_ALLOWED_5_MIN_RATE = 5;
+    private static final double MAX_ALLOWED_15_MIN_RATE = 15;
+
+    private final LeaderElectionServiceMetrics leaderElectionServiceMetrics;
+
+    public LeaderElectionHealthCheck(TaggedMetricRegistry taggedMetricRegistry) {
+        this.leaderElectionServiceMetrics = LeaderElectionServiceMetrics.of(taggedMetricRegistry);
+    }
+
+    public LeaderElectionHealthStatus leaderElectionRateHealthStatus() {
+        return leaderElectionServiceMetrics.proposedLeadership().getFiveMinuteRate() < MAX_ALLOWED_5_MIN_RATE
+                ? LeaderElectionHealthStatus.HEALTHY : LeaderElectionHealthStatus.UNHEALTHY;
+    }
+}

--- a/leader-election-impl/src/main/java/com/palantir/leader/health/LeaderElectionHealthCheck.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/health/LeaderElectionHealthCheck.java
@@ -17,20 +17,18 @@
 package com.palantir.leader.health;
 
 import com.palantir.leader.LeaderElectionServiceMetrics;
-import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 
 public class LeaderElectionHealthCheck {
-    private static final double MAX_ALLOWED_5_MIN_RATE = 5;
-    private static final double MAX_ALLOWED_15_MIN_RATE = 15;
+    private static final double MAX_ALLOWED_LAST_5_MINUTE_RATE = 1;
 
     private final LeaderElectionServiceMetrics leaderElectionServiceMetrics;
 
-    public LeaderElectionHealthCheck(TaggedMetricRegistry taggedMetricRegistry) {
-        this.leaderElectionServiceMetrics = LeaderElectionServiceMetrics.of(taggedMetricRegistry);
+    public LeaderElectionHealthCheck(LeaderElectionServiceMetrics leaderElectionServiceMetrics) {
+        this.leaderElectionServiceMetrics = leaderElectionServiceMetrics;
     }
 
     public LeaderElectionHealthStatus leaderElectionRateHealthStatus() {
-        return leaderElectionServiceMetrics.proposedLeadership().getFiveMinuteRate() < MAX_ALLOWED_5_MIN_RATE
+        return leaderElectionServiceMetrics.proposedLeadership().getFiveMinuteRate() < MAX_ALLOWED_LAST_5_MINUTE_RATE
                 ? LeaderElectionHealthStatus.HEALTHY : LeaderElectionHealthStatus.UNHEALTHY;
     }
 }

--- a/leader-election-impl/src/main/java/com/palantir/leader/health/LeaderElectionHealthCheck.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/health/LeaderElectionHealthCheck.java
@@ -28,7 +28,7 @@ public class LeaderElectionHealthCheck {
     }
 
     public LeaderElectionHealthStatus leaderElectionRateHealthStatus() {
-        return leaderElectionServiceMetrics.proposedLeadership().getFiveMinuteRate() < MAX_ALLOWED_LAST_5_MINUTE_RATE
+        return leaderElectionServiceMetrics.proposedLeadership().getFiveMinuteRate() <= MAX_ALLOWED_LAST_5_MINUTE_RATE
                 ? LeaderElectionHealthStatus.HEALTHY : LeaderElectionHealthStatus.UNHEALTHY;
     }
 }

--- a/leader-election-impl/src/main/java/com/palantir/leader/health/LeaderElectionHealthCheck.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/health/LeaderElectionHealthCheck.java
@@ -19,7 +19,7 @@ package com.palantir.leader.health;
 import com.palantir.leader.LeaderElectionServiceMetrics;
 
 public class LeaderElectionHealthCheck {
-    private static final double MAX_ALLOWED_LAST_5_MINUTE_RATE = 1;
+    private static final double MAX_ALLOWED_LAST_5_MINUTE_RATE = 0.016;
 
     private final LeaderElectionServiceMetrics leaderElectionServiceMetrics;
 

--- a/leader-election-impl/src/main/java/com/palantir/leader/health/LeaderElectionHealthStatus.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/health/LeaderElectionHealthStatus.java
@@ -1,0 +1,22 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.leader.health;
+
+public enum LeaderElectionHealthStatus {
+    HEALTHY,
+    UNHEALTHY
+}

--- a/leader-election-impl/src/main/metrics/leader-election.yml
+++ b/leader-election-impl/src/main/metrics/leader-election.yml
@@ -1,0 +1,31 @@
+options:
+  javaPackage: 'com.palantir.leader'
+
+namespaces:
+  leaderElectionService:
+    docs: Metrics helpful for TimeLock adjudication.
+    metrics:
+      gainedLeadership:
+        type: meter
+        docs: rate of successful leadership gain
+      lostLeadership:
+        type: meter
+        docs: rate of leadership loss
+      noQuorum:
+        type: meter
+        docs: rate of proposals failure due to no quorum
+      proposedLeadership:
+        type: meter
+        docs: rate of leadership proposal
+      proposalFailure:
+        type: meter
+        docs: rate of proposal failure
+      leaderPingFailure:
+        type: meter
+        docs: rate of ping failure
+      leaderPingTimeout:
+        type: meter
+        docs: leader ping timeout rate
+      leaderPingReturnedFalse:
+        type: meter
+        docs: rate of false leader ping

--- a/leader-election-impl/src/main/metrics/leader-election.yml
+++ b/leader-election-impl/src/main/metrics/leader-election.yml
@@ -7,25 +7,25 @@ namespaces:
     metrics:
       gainedLeadership:
         type: meter
-        docs: rate of successful leadership gain
+        docs: Number of times(per second) leadership was gained successully.
       lostLeadership:
         type: meter
-        docs: rate of leadership loss
+        docs: Number of times(per second) leadership was lost.
       noQuorum:
         type: meter
-        docs: rate of proposals failure due to no quorum
+        docs: Number of times(per second) there was no quorum while determining leadership status.
       proposedLeadership:
         type: meter
-        docs: rate of leadership proposal
+        docs: Number of times(per second) leadership was proposed.
       proposalFailure:
         type: meter
-        docs: rate of proposal failure
+        docs: Number of times(per second) leadership could not be gained after proposal.
       leaderPingFailure:
         type: meter
-        docs: rate of ping failure
+        docs: Rate of failure while pinging the leader.
       leaderPingTimeout:
         type: meter
-        docs: leader ping timeout rate
+        docs: Rate of request timeout while pinging the leader.
       leaderPingReturnedFalse:
         type: meter
-        docs: rate of false leader ping
+        docs: Rate of leader pings to a non leader node.

--- a/leader-election-impl/src/main/metrics/leader-election.yml
+++ b/leader-election-impl/src/main/metrics/leader-election.yml
@@ -3,7 +3,7 @@ options:
 
 namespaces:
   leaderElectionService:
-    docs: Metrics helpful for TimeLock adjudication.
+    docs: Metrics for tracking TimeLock leader election events.
     metrics:
       gainedLeadership:
         type: meter
@@ -22,10 +22,10 @@ namespaces:
         docs: Number of times(per second) leadership could not be gained after proposal.
       leaderPingFailure:
         type: meter
-        docs: Rate of failure while pinging the leader.
+        docs: Number of times(per second) pinging the leader failed.
       leaderPingTimeout:
         type: meter
-        docs: Rate of request timeout while pinging the leader.
+        docs: Number of times(per second) requests timed out while pinging the leader.
       leaderPingReturnedFalse:
         type: meter
-        docs: Rate of leader pings to a non leader node.
+        docs: Number of times(per second) leader ping requests were made to a non leader node.

--- a/leader-election-impl/src/test/java/com/palantir/leader/LeadershipElectionCheckTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/LeadershipElectionCheckTest.java
@@ -39,8 +39,8 @@ public class LeadershipElectionCheckTest {
     private final TaggedMetricRegistry registry1 = mock(TaggedMetricRegistry.class);
     private final LeaderElectionServiceMetrics leaderElectionServiceMetrics =
             LeaderElectionServiceMetrics.of(registry1);
-    private final LeaderElectionHealthCheck leaderElectionHealthCheck = new LeaderElectionHealthCheck(
-        leaderElectionServiceMetrics);
+    private final LeaderElectionHealthCheck leaderElectionHealthCheck =
+            new LeaderElectionHealthCheck(leaderElectionServiceMetrics);
 
     @Before
     public void setup() {

--- a/leader-election-impl/src/test/java/com/palantir/leader/LeadershipElectionCheckTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/LeadershipElectionCheckTest.java
@@ -64,7 +64,8 @@ public class LeadershipElectionCheckTest {
     }
 
     private void markLeaderElectionsAtSpecifiedInterval(int leaderElectionCount, Duration timeIntervalInSeconds) {
-        // First tick
+        // The rate is initialized after first tick (5 second interval) of meter with number of marks / interval.
+        // Marking before the first interval has passed sets the rate very high, which should not happen in practice.
         fakeTimeClock.advance(6, TimeUnit.SECONDS);
 
         IntStream.range(0, leaderElectionCount).forEach(idx -> {

--- a/leader-election-impl/src/test/java/com/palantir/leader/LeadershipElectionCheckTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/LeadershipElectionCheckTest.java
@@ -1,0 +1,89 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.leader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.IntStream;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.codahale.metrics.Clock;
+import com.codahale.metrics.Meter;
+import com.palantir.leader.health.LeaderElectionHealthCheck;
+import com.palantir.leader.health.LeaderElectionHealthStatus;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+
+public class LeadershipElectionCheckTest {
+    private final FakeTimeClock fakeTimeClock = new FakeTimeClock();
+    private final TaggedMetricRegistry registry1 = mock(TaggedMetricRegistry.class);
+    private final LeaderElectionServiceMetrics leaderElectionServiceMetrics =
+            LeaderElectionServiceMetrics.of(registry1);
+    private final LeaderElectionHealthCheck leaderElectionHealthCheck = new LeaderElectionHealthCheck(
+        leaderElectionServiceMetrics);
+
+    @Before
+    public void setup() {
+        when(registry1.meter(any())).thenReturn(new Meter(fakeTimeClock));
+    }
+
+    @Test
+    public void shouldBeHealthyForLeaderElectionRateLessThanOne() {
+        markLeaderElections(1);
+        assertThat(leaderElectionHealthCheck.leaderElectionRateHealthStatus())
+                .isEqualTo(LeaderElectionHealthStatus.HEALTHY);
+        assertThat(leaderElectionServiceMetrics.proposedLeadership().getFiveMinuteRate())
+                .isEqualTo(0.2);
+    }
+
+    @Test
+    public void shouldBeUnhealthyForLeaderElectionRateGreaterThanOne() {
+        markLeaderElections(5);
+        assertThat(leaderElectionHealthCheck.leaderElectionRateHealthStatus())
+                .isEqualTo(LeaderElectionHealthStatus.UNHEALTHY);
+        assertThat(leaderElectionServiceMetrics.proposedLeadership().getFiveMinuteRate())
+                .isEqualTo(1.0);
+    }
+
+    public void markLeaderElections(int count) {
+        IntStream.range(0, count).forEach(idx -> leaderElectionServiceMetrics.proposedLeadership().mark());
+
+        // advanceTime has to be strictly greater than com.codahale.metrics.Meter.TICK_INTERVAL
+        fakeTimeClock.advance(6, TimeUnit.SECONDS);
+    }
+
+    public static class FakeTimeClock extends Clock {
+        private final AtomicLong nanos = new AtomicLong();
+
+        public void advance(long time, TimeUnit timeUnit) {
+            nanos.addAndGet(timeUnit.toNanos(time));
+        }
+
+        @Override
+        public long getTick() {
+            return nanos.get();
+        }
+    }
+}
+
+

--- a/leader-election-impl/src/test/java/com/palantir/leader/LeadershipElectionCheckTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/LeadershipElectionCheckTest.java
@@ -49,7 +49,7 @@ public class LeadershipElectionCheckTest {
 
     @Test
     public void shouldBeHealthyForOneLeaderElectionPerMinute() {
-        markLeaderElectionsAtSpecifiedInterval(1, 60);
+        markLeaderElectionsAtSpecifiedInterval(3, 60);
 
         assertThat(leaderElectionHealthCheck.leaderElectionRateHealthStatus())
                 .isEqualTo(LeaderElectionHealthStatus.HEALTHY);

--- a/leader-election-impl/src/test/java/com/palantir/leader/LeadershipElectionCheckTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/LeadershipElectionCheckTest.java
@@ -68,7 +68,8 @@ public class LeadershipElectionCheckTest {
     public void markLeaderElections(int count) {
         IntStream.range(0, count).forEach(idx -> leaderElectionServiceMetrics.proposedLeadership().mark());
 
-        // advanceTime has to be strictly greater than com.codahale.metrics.Meter.TICK_INTERVAL
+        // com.codahale.metrics.Meter.TICK_INTERVAL < advanceTime < com.codahale.metrics.Meter.TICK_INTERVAL * 2
+        // to maintain single tick
         fakeTimeClock.advance(6, TimeUnit.SECONDS);
     }
 

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -57,6 +57,7 @@ import com.palantir.conjure.java.api.config.service.ServicesConfigBlock;
 import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.undertow.lib.UndertowService;
 import com.palantir.dialogue.clients.DialogueClients;
+import com.palantir.leader.LeaderElectionServiceMetrics;
 import com.palantir.leader.health.LeaderElectionHealthCheck;
 import com.palantir.leader.health.LeaderElectionHealthStatus;
 import com.palantir.lock.LockService;
@@ -181,7 +182,8 @@ public class TimeLockAgent {
                 new TimeLockActivityCheckerFactory(install, metricsManager, userAgent).getTimeLockActivityCheckers());
 
         this.feedbackHandler = new FeedbackHandler(metricsManager, () -> runtime.get().adjudication().enabled());
-        this.leaderElectionHealthCheck = new LeaderElectionHealthCheck(metricsManager.getTaggedRegistry());
+        this.leaderElectionHealthCheck = new LeaderElectionHealthCheck(
+                LeaderElectionServiceMetrics.of(metricsManager.getTaggedRegistry()));
     }
 
     private TimestampCreator getTimestampCreator() {

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -57,6 +57,8 @@ import com.palantir.conjure.java.api.config.service.ServicesConfigBlock;
 import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.undertow.lib.UndertowService;
 import com.palantir.dialogue.clients.DialogueClients;
+import com.palantir.leader.health.LeaderElectionHealthCheck;
+import com.palantir.leader.health.LeaderElectionHealthStatus;
 import com.palantir.lock.LockService;
 import com.palantir.paxos.Client;
 import com.palantir.refreshable.Refreshable;
@@ -86,6 +88,7 @@ public class TimeLockAgent {
     private final NoSimultaneousServiceCheck noSimultaneousServiceCheck;
     private final HikariDataSource sqliteDataSource;
     private final FeedbackHandler feedbackHandler;
+    private final LeaderElectionHealthCheck leaderElectionHealthCheck;
 
     private LeaderPingHealthCheck healthCheck;
     private TimelockNamespaces namespaces;
@@ -178,6 +181,7 @@ public class TimeLockAgent {
                 new TimeLockActivityCheckerFactory(install, metricsManager, userAgent).getTimeLockActivityCheckers());
 
         this.feedbackHandler = new FeedbackHandler(metricsManager, () -> runtime.get().adjudication().enabled());
+        this.leaderElectionHealthCheck = new LeaderElectionHealthCheck(metricsManager.getTaggedRegistry());
     }
 
     private TimestampCreator getTimestampCreator() {
@@ -338,6 +342,10 @@ public class TimeLockAgent {
 
     public HealthStatusReport timeLockAdjudicationFeedback() {
         return feedbackHandler.getTimeLockHealthStatus();
+    }
+
+    public LeaderElectionHealthStatus timeLockLeadershipHealthCheck() {
+        return leaderElectionHealthCheck.leaderElectionRateHealthStatus();
     }
 
     public void shutdown() {


### PR DESCRIPTION
**Goals (and why)**:
Add a health check on leader election rate. This will be useful for moving TimeLock to blue-green upgrade model.

**Implementation Description (bullets)**:

- Move LeadershipEvents metrics to metric-schema.

- Add a health check on rate of leader health checks.

**Testing (What was existing testing like?  What have you done to improve it?)**:

- Added a test for leader election health check

**Concerns (what feedback would you like?)**:

- Is the HealthCheck threshold estimate reasonable? 

**Where should we start reviewing?**:

- LeaderElectionHealthCheck, LeadershipEvents

**Priority (whenever / two weeks / yesterday)**:

- Before end of week

> 

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
