### PR TITLE
[LW] Fix exception handling in ResilientLockWatchEventCache

### DIFF
--- a/changelog/@unreleased/pr-4908.v2.yml
+++ b/changelog/@unreleased/pr-4908.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: '`ResilientLockWatchEventCache` now does not switch to the backup cache
+    if it encounters a `TransactionLockWatchFailedException` as originally intended.'
+  links:
+  - https://github.com/palantir/atlasdb/pull/4908


### PR DESCRIPTION
**Goals (and why)**:
Fix the exception handling and add a test to verify expected behaviour.

**Implementation Description (bullets)**:
Extract a method to properly handle exceptions.

**Testing (What was existing testing like?  What have you done to improve it?)**:
`ResilientLockWatchEventCacheTests` existed, but did not test the case where the specific class of exception _not_ supposed to switch over was thrown.

**Where should we start reviewing?**:
`ResilientLockWatchEventCache`.

**Priority (whenever / two weeks / yesterday)**:
This week.