### PR TITLE
[PDS-127999] Improved Corroboration Checker

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/TimestampCorroboratingTimelockService.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/TimestampCorroboratingTimelockService.java
@@ -19,7 +19,6 @@ package com.palantir.atlasdb.factory.timelock;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.LongAccumulator;
 import java.util.function.Supplier;
 import java.util.function.ToLongFunction;
 import java.util.stream.Collectors;

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/TimestampCorroboratingTimelockService.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/TimestampCorroboratingTimelockService.java
@@ -18,25 +18,33 @@ package com.palantir.atlasdb.factory.timelock;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAccumulator;
 import java.util.function.Supplier;
 import java.util.function.ToLongFunction;
 import java.util.stream.Collectors;
 
+import org.immutables.value.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.palantir.lock.v2.AutoDelegate_TimelockService;
 import com.palantir.lock.v2.StartIdentifiedAtlasDbTransactionResponse;
 import com.palantir.lock.v2.TimelockService;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.timestamp.TimestampRange;
 
 /**
  * A timelock service decorator for introducing runtime validity checks on received timestamps.
  */
 public final class TimestampCorroboratingTimelockService implements AutoDelegate_TimelockService {
-    private static final String CLOCKS_WENT_BACKWARDS_MESSAGE =
-            "Expected timestamp to be greater than %s, but a fresh timestamp was %s!";
+    private static final Logger log = LoggerFactory.getLogger(TimestampCorroboratingTimelockService.class);
+    private static final String CLOCKS_WENT_BACKWARDS_MESSAGE = "It appears that clocks went backwards!";
 
     private final TimelockService delegate;
-    private final LongAccumulator lowerBound = new LongAccumulator(Long::max, Long.MIN_VALUE);
+    private final AtomicLong lowerBoundFromTimestamps = new AtomicLong(Long.MIN_VALUE);
+    private final AtomicLong lowerBoundFromTransactions = new AtomicLong(Long.MIN_VALUE);
 
     private TimestampCorroboratingTimelockService(TimelockService delegate) {
         this.delegate = delegate;
@@ -53,21 +61,23 @@ public final class TimestampCorroboratingTimelockService implements AutoDelegate
 
     @Override
     public long getFreshTimestamp() {
-        return checkAndUpdateLowerBound(delegate::getFreshTimestamp, x -> x, x -> x);
+        return checkAndUpdateLowerBound(delegate::getFreshTimestamp, x -> x, x -> x, OperationType.TIMESTAMP);
     }
 
     @Override
     public TimestampRange getFreshTimestamps(int numTimestampsRequested) {
         return checkAndUpdateLowerBound(() -> delegate.getFreshTimestamps(numTimestampsRequested),
                 TimestampRange::getLowerBound,
-                TimestampRange::getUpperBound);
+                TimestampRange::getUpperBound,
+                OperationType.TIMESTAMP);
     }
 
     @Override
     public List<StartIdentifiedAtlasDbTransactionResponse> startIdentifiedAtlasDbTransactionBatch(int count) {
         return checkAndUpdateLowerBound(() -> delegate.startIdentifiedAtlasDbTransactionBatch(count),
                 responses -> Collections.min(getTimestampsFromResponses(responses)),
-                responses -> Collections.max(getTimestampsFromResponses(responses)));
+                responses -> Collections.max(getTimestampsFromResponses(responses)),
+                OperationType.TRANSACTION);
     }
 
     private List<Long> getTimestampsFromResponses(List<StartIdentifiedAtlasDbTransactionResponse> responses) {
@@ -75,28 +85,62 @@ public final class TimestampCorroboratingTimelockService implements AutoDelegate
                 Collectors.toList());
     }
 
-    private <T> T checkAndUpdateLowerBound(Supplier<T> timestampContainerSupplier,
+    private <T> T checkAndUpdateLowerBound(
+            Supplier<T> timestampContainerSupplier,
             ToLongFunction<T> lowerBoundExtractor,
-            ToLongFunction<T> upperBoundExtractor) {
-        long threadLocalLowerBound = lowerBound.get();
+            ToLongFunction<T> upperBoundExtractor,
+            OperationType operationType) {
+        TimestampBounds timestampBounds = getTimestampBounds();
         T timestampContainer = timestampContainerSupplier.get();
 
-        checkTimestamp(threadLocalLowerBound, lowerBoundExtractor.applyAsLong(timestampContainer));
-        updateLowerBound(upperBoundExtractor.applyAsLong(timestampContainer));
+        checkTimestamp(timestampBounds, operationType, lowerBoundExtractor.applyAsLong(timestampContainer));
+        updateLowerBound(operationType, upperBoundExtractor.applyAsLong(timestampContainer));
         return timestampContainer;
     }
 
-    private static void checkTimestamp(long timestampLowerBound, long freshTimestamp) {
-        if (freshTimestamp <= timestampLowerBound) {
-            throw clocksWentBackwards(timestampLowerBound, freshTimestamp);
+    private TimestampBounds getTimestampBounds() {
+        long threadLocalLowerBoundFromTimestamps = lowerBoundFromTimestamps.get();
+        long threadLocalLowerBoundFromTransactions = lowerBoundFromTransactions.get();
+        return ImmutableTimestampBounds.of(
+                threadLocalLowerBoundFromTimestamps,
+                threadLocalLowerBoundFromTransactions);
+    }
+
+    private static void checkTimestamp(TimestampBounds bounds, OperationType type, long freshTimestamp) {
+        if (freshTimestamp <= Math.max(bounds.boundFromTimestamps(), bounds.boundFromTransactions())) {
+            throw clocksWentBackwards(bounds, type, freshTimestamp);
         }
     }
 
-    private void updateLowerBound(long freshTimestamp) {
-        lowerBound.accumulate(freshTimestamp);
+    private static RuntimeException clocksWentBackwards(TimestampBounds bounds,
+            OperationType type, long freshTimestamp) {
+        RuntimeException runtimeException = new SafeRuntimeException(CLOCKS_WENT_BACKWARDS_MESSAGE);
+        log.error(CLOCKS_WENT_BACKWARDS_MESSAGE + ": bounds were {}, operation {}, fresh timestamp of {}.",
+                SafeArg.of("bounds", bounds),
+                SafeArg.of("operationType", type),
+                SafeArg.of("freshTimestamp", freshTimestamp),
+                runtimeException);
+        throw runtimeException;
     }
 
-    private static AssertionError clocksWentBackwards(long timestampLowerBound, long freshTimestamp) {
-        return new AssertionError(String.format(CLOCKS_WENT_BACKWARDS_MESSAGE, timestampLowerBound, freshTimestamp));
+    private void updateLowerBound(OperationType type, long freshTimestamp) {
+        if (type == OperationType.TIMESTAMP) {
+            lowerBoundFromTimestamps.accumulateAndGet(freshTimestamp, Math::max);
+        } else {
+            lowerBoundFromTransactions.accumulateAndGet(freshTimestamp, Math::max);
+        }
+    }
+
+    @Value.Immutable
+    interface TimestampBounds {
+        @Value.Parameter
+        long boundFromTimestamps();
+        @Value.Parameter
+        long boundFromTransactions();
+    }
+
+    private enum OperationType {
+        TIMESTAMP,
+        TRANSACTION;
     }
 }

--- a/changelog/@unreleased/pr-4909.v2.yml
+++ b/changelog/@unreleased/pr-4909.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: Timestamp corroboration checker now throws `SafeIllegalStateException`
+    instead of `AssertionError`, declares some of its parameters to be safe, and logs
+    more noisily. It also gives more nuanced information on whether problems were
+    noted on timestamp or transactional operations.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4909


### PR DESCRIPTION
**Goals (and why)**:
- We've seen some strange-looking corroboration failure messages (even though Jepsen has been green).
- Trying to understand what has been going on and isolate the problem space.

**Implementation Description (bullets)**:
- Log at ERROR every time this occurs (as opposed to throwing an AssertionError, that is often silenced by background tasks and difficult to find).
- Declare parameters (bounds, operationType, freshTimestamp) to be SafeArgs - these are safe and the size of the delta can be meaningful.
- Switch the LongAccumulators for simpler AtomicLongs. Javadoc for get() warns that it isn't an atomic snapshot, and while I _think_ it is fine in that it is an under-approximation, I'm not 100% sure.
- Separate counters for values returned from timestamps and transactions. We'll see, but I expect there to not be TIMESTAMP-TIMESTAMP conflicts.

**Testing (What was existing testing like?  What have you done to improve it?)**: Added one new test now that I'm separating TIMESTAMP and TRANSACTION concerns.

**Concerns (what feedback would you like?)**: Is anything accidentally broken?

**Where should we start reviewing?**: TimestampCorroboratingTimelockService

**Priority (whenever / two weeks / yesterday)**: yesterday 🔥 
