### PR TITLE
[PDS-127937] Distinct Executors for Pinging as Opposed to Paxos

### DIFF
--- a/changelog/@unreleased/pr-4914.v2.yml
+++ b/changelog/@unreleased/pr-4914.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: 'TimeLock Server now uses distinct thread pools for pinging the leader and for getting Paxos quorums.
+    This should make it more resilient to leadership storms when a cluster node is slow.'
+  links:
+  - https://github.com/palantir/atlasdb/pull/4914

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClients.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClients.java
@@ -83,37 +83,40 @@ public abstract class PaxosRemoteClients {
 
     @Value.Derived
     public List<WithDedicatedExecutor<TimelockPaxosAcceptorRpcClient>> nonBatchTimestampAcceptor() {
-        return createInstrumentedRemoteProxiesAndAssignDedicatedExecutors(TimelockPaxosAcceptorRpcClient.class, true);
+        return createInstrumentedRemoteProxiesAndAssignDedicatedPaxosExecutors(
+                TimelockPaxosAcceptorRpcClient.class, true);
     }
 
     @Value.Derived
     public List<WithDedicatedExecutor<TimelockPaxosLearnerRpcClient>> nonBatchTimestampLearner() {
-        return createInstrumentedRemoteProxiesAndAssignDedicatedExecutors(TimelockPaxosLearnerRpcClient.class, true);
+        return createInstrumentedRemoteProxiesAndAssignDedicatedPaxosExecutors(
+                TimelockPaxosLearnerRpcClient.class, true);
     }
 
     @Value.Derived
     public List<WithDedicatedExecutor<TimelockSingleLeaderPaxosAcceptorRpcClient>>
             singleLeaderAcceptorsWithExecutors() {
         // Retries should be performed at a higher level, in AwaitingLeadershipProxy.
-        return createInstrumentedRemoteProxiesAndAssignDedicatedExecutors(
+        return createInstrumentedRemoteProxiesAndAssignDedicatedPaxosExecutors(
                 TimelockSingleLeaderPaxosAcceptorRpcClient.class, false);
     }
 
     @Value.Derived
     public List<WithDedicatedExecutor<TimelockSingleLeaderPaxosLearnerRpcClient>> singleLeaderLearner() {
-        return createInstrumentedRemoteProxiesAndAssignDedicatedExecutors(
+        return createInstrumentedRemoteProxiesAndAssignDedicatedPaxosExecutors(
                 TimelockSingleLeaderPaxosLearnerRpcClient.class, true);
     }
 
     @Value.Derived
     public List<WithDedicatedExecutor<BatchPaxosAcceptorRpcClient>> batchAcceptorsWithExecutors() {
-        return createInstrumentedRemoteProxiesAndAssignDedicatedExecutors(
+        return createInstrumentedRemoteProxiesAndAssignDedicatedPaxosExecutors(
                 BatchPaxosAcceptorRpcClient.class, false);
     }
 
     @Value.Derived
     public List<WithDedicatedExecutor<BatchPaxosLearnerRpcClient>> batchLearner() {
-        return createInstrumentedRemoteProxiesAndAssignDedicatedExecutors(BatchPaxosLearnerRpcClient.class, true);
+        return createInstrumentedRemoteProxiesAndAssignDedicatedPaxosExecutors(
+                BatchPaxosLearnerRpcClient.class, true);
     }
 
     @Value.Derived
@@ -153,13 +156,13 @@ public abstract class PaxosRemoteClients {
                 .collect(Collectors.toList());
     }
 
-    private <T> List<WithDedicatedExecutor<T>> createInstrumentedRemoteProxiesAndAssignDedicatedExecutors(
+    private <T> List<WithDedicatedExecutor<T>> createInstrumentedRemoteProxiesAndAssignDedicatedPaxosExecutors(
             Class<T> clazz,
             boolean shouldRetry) {
-        return assignDedicatedExecutors(createInstrumentedRemoteProxies(clazz, shouldRetry));
+        return assignDedicatedRemotePaxosExecutors(createInstrumentedRemoteProxies(clazz, shouldRetry));
     }
 
-    private <T> List<WithDedicatedExecutor<T>> assignDedicatedExecutors(
+    private <T> List<WithDedicatedExecutor<T>> assignDedicatedRemotePaxosExecutors(
             KeyedStream<String, T> remotes) {
         return remotes.mapKeys(uri -> paxosExecutors().get(uri))
                 .entries()

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/TimeLockPaxosExecutors.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/TimeLockPaxosExecutors.java
@@ -35,7 +35,6 @@ final class TimeLockPaxosExecutors {
      * Choosing too large of a value leads to an unnecessary build up of threads when an individual node is slow;
      * choosing too small of a value may lead to unnecessary leader elections or add overhead to the Paxos protocol.
      */
-    @VisibleForTesting
     static final int MAXIMUM_POOL_SIZE = 384;
 
     private TimeLockPaxosExecutors() {
@@ -49,12 +48,12 @@ final class TimeLockPaxosExecutors {
      * It is assumed that tasks run on the local node will return quickly (hence the use of the direct executor).
      */
     static <T> Map<T, ExecutorService> createBoundedExecutors(
-            MetricRegistry metricRegistry, LocalAndRemotes<T> localAndRemotes, String useCase) {
+            int poolSize, LocalAndRemotes<T> localAndRemotes, String useCase) {
         int numRemotes = localAndRemotes.remotes().size();
         ImmutableMap.Builder<T, ExecutorService> remoteExecutors = ImmutableMap.builderWithExpectedSize(numRemotes);
         for (int index = 0; index < numRemotes; index++) {
             T remote = localAndRemotes.remotes().get(index);
-            remoteExecutors.put(remote, createBoundedExecutor(metricRegistry, useCase, index));
+            remoteExecutors.put(remote, createBoundedExecutor(poolSize, useCase, index));
         }
         remoteExecutors.put(localAndRemotes.local(), MoreExecutors.newDirectExecutorService());
         return remoteExecutors.build();
@@ -69,7 +68,7 @@ final class TimeLockPaxosExecutors {
      *
      * Users of such an executor should be prepared to handle {@link java.util.concurrent.RejectedExecutionException}.
      */
-    static ExecutorService createBoundedExecutor(MetricRegistry metricRegistry, String useCase, int index) {
+    static ExecutorService createBoundedExecutor(int poolSize, String useCase, int index) {
         // metricRegistry is ignored because TExecutors.newCachedThreadPoolWithMaxThreads provides instrumentation.
         return PTExecutors.newCachedThreadPoolWithMaxThreads(
                 MAXIMUM_POOL_SIZE, "timelock-executors-" + useCase + "-" + index);

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/TimeLockPaxosExecutors.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/TimeLockPaxosExecutors.java
@@ -19,8 +19,6 @@ package com.palantir.atlasdb.timelock.paxos;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
-import com.codahale.metrics.MetricRegistry;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.common.concurrent.PTExecutors;

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/TimeLockPaxosExecutors.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/TimeLockPaxosExecutors.java
@@ -71,6 +71,6 @@ final class TimeLockPaxosExecutors {
     static ExecutorService createBoundedExecutor(int poolSize, String useCase, int index) {
         // metricRegistry is ignored because TExecutors.newCachedThreadPoolWithMaxThreads provides instrumentation.
         return PTExecutors.newCachedThreadPoolWithMaxThreads(
-                MAXIMUM_POOL_SIZE, "timelock-executors-" + useCase + "-" + index);
+                poolSize, "timelock-executors-" + useCase + "-" + index);
     }
 }

--- a/timelock-agent/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClientsTest.java
+++ b/timelock-agent/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClientsTest.java
@@ -34,15 +34,9 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import com.google.common.collect.ImmutableList;
-import com.palantir.atlasdb.config.AuxiliaryRemotingParameters;
-import com.palantir.atlasdb.config.ImmutableServerListConfig;
-import com.palantir.atlasdb.factory.AtlasDbDialogueServiceProvider;
 import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.conjure.java.api.config.service.PartialServiceConfiguration;
-import com.palantir.conjure.java.api.config.service.ServicesConfigBlock;
 import com.palantir.conjure.java.api.config.service.UserAgent;
-import com.palantir.dialogue.clients.DialogueClients;
-import com.palantir.refreshable.Refreshable;
 import com.palantir.timelock.config.ImmutableDefaultClusterConfiguration;
 import com.palantir.timelock.config.ImmutablePaxosInstallConfiguration;
 import com.palantir.timelock.config.ImmutablePaxosTsBoundPersisterConfiguration;
@@ -56,7 +50,7 @@ public class PaxosRemoteClientsTest {
     @Rule
     public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-    private PaxosInstallConfiguration paxosInstallConfiguration ;
+    private PaxosInstallConfiguration paxosInstallConfiguration;
     private TimeLockInstallConfiguration installConfiguration;
     private PaxosResourcesFactory.TimelockPaxosInstallationContext context;
 

--- a/timelock-agent/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClientsTest.java
+++ b/timelock-agent/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClientsTest.java
@@ -1,0 +1,104 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.atlasdb.config.AuxiliaryRemotingParameters;
+import com.palantir.atlasdb.config.ImmutableServerListConfig;
+import com.palantir.atlasdb.factory.AtlasDbDialogueServiceProvider;
+import com.palantir.atlasdb.util.MetricsManagers;
+import com.palantir.conjure.java.api.config.service.PartialServiceConfiguration;
+import com.palantir.conjure.java.api.config.service.ServicesConfigBlock;
+import com.palantir.conjure.java.api.config.service.UserAgent;
+import com.palantir.dialogue.clients.DialogueClients;
+import com.palantir.refreshable.Refreshable;
+import com.palantir.timelock.config.ImmutableDefaultClusterConfiguration;
+import com.palantir.timelock.config.ImmutablePaxosInstallConfiguration;
+import com.palantir.timelock.config.ImmutablePaxosTsBoundPersisterConfiguration;
+import com.palantir.timelock.config.ImmutableTimeLockInstallConfiguration;
+import com.palantir.timelock.config.PaxosInstallConfiguration;
+import com.palantir.timelock.config.SqlitePaxosPersistenceConfiguration;
+import com.palantir.timelock.config.TimeLockInstallConfiguration;
+import com.palantir.timelock.paxos.TimeLockDialogueServiceProvider;
+
+public class PaxosRemoteClientsTest {
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private PaxosInstallConfiguration paxosInstallConfiguration ;
+    private TimeLockInstallConfiguration installConfiguration;
+    private PaxosResourcesFactory.TimelockPaxosInstallationContext context;
+
+    @Before
+    public void setUp() {
+        paxosInstallConfiguration = ImmutablePaxosInstallConfiguration.builder()
+                .isNewService(false)
+                .dataDirectory(temporaryFolder.getRoot())
+                .sqlitePersistence(SqlitePaxosPersistenceConfiguration.DEFAULT)
+                .leaderMode(PaxosInstallConfiguration.PaxosLeaderMode.SINGLE_LEADER)
+                .build();
+        installConfiguration = ImmutableTimeLockInstallConfiguration.builder()
+                .cluster(ImmutableDefaultClusterConfiguration.builder()
+                        .localServer("a:1")
+                        .cluster(PartialServiceConfiguration.of(
+                                ImmutableList.of("a:1", "b:2", "c:3"),
+                                Optional.empty()))
+                        .build())
+                .paxos(paxosInstallConfiguration) // Normally awful, but too onerous to set up
+                .timestampBoundPersistence(ImmutablePaxosTsBoundPersisterConfiguration.builder().build())
+                .build();
+        TimeLockDialogueServiceProvider dialogueServiceProvider = mock(TimeLockDialogueServiceProvider.class);
+        when(dialogueServiceProvider.createSingleNodeInstrumentedProxy(anyString(), any(), anyBoolean()))
+                .thenAnswer(invocation -> mock(invocation.getArgument(1)));
+        context = ImmutableTimelockPaxosInstallationContext.builder().install(installConfiguration)
+                .dialogueServiceProvider(dialogueServiceProvider)
+                .userAgent(UserAgent.of(UserAgent.Agent.of("aaa", "1.2.3")))
+                .build();
+    }
+
+    @Test
+    public void pingAndPaxosHaveDistinctExecutors() {
+        PaxosRemoteClients remoteClients = ImmutablePaxosRemoteClients.builder()
+                .context(context)
+                .metrics(MetricsManagers.createForTests())
+                .build();
+        Set<ExecutorService> leaderPingExecutors = remoteClients.batchPingableLeadersWithContext().stream()
+                .map(WithDedicatedExecutor::executor)
+                .collect(Collectors.toSet());
+        Set<ExecutorService> paxosExecutionExecutors = remoteClients.nonBatchTimestampAcceptor().stream()
+                .map(WithDedicatedExecutor::executor)
+                .collect(Collectors.toSet());
+        assertThat(leaderPingExecutors).doesNotContainAnyElementsOf(paxosExecutionExecutors);
+    }
+}

--- a/timelock-agent/src/test/java/com/palantir/atlasdb/timelock/paxos/TimeLockPaxosExecutorsTest.java
+++ b/timelock-agent/src/test/java/com/palantir/atlasdb/timelock/paxos/TimeLockPaxosExecutorsTest.java
@@ -53,7 +53,7 @@ public class TimeLockPaxosExecutorsTest {
     private final LocalAndRemotes<Object> localAndRemotes = LocalAndRemotes.of(local, remotes);
 
     private final Map<Object, ExecutorService> executors = TimeLockPaxosExecutors.createBoundedExecutors(
-            MetricsManagers.createForTests().getRegistry(),
+            TimeLockPaxosExecutors.MAXIMUM_POOL_SIZE,
             localAndRemotes,
             TEST);
 

--- a/timelock-agent/src/test/java/com/palantir/atlasdb/timelock/paxos/TimeLockPaxosExecutorsTest.java
+++ b/timelock-agent/src/test/java/com/palantir/atlasdb/timelock/paxos/TimeLockPaxosExecutorsTest.java
@@ -35,7 +35,6 @@ import org.junit.Test;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.palantir.atlasdb.futures.AtlasFutures;
-import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.common.concurrent.PTExecutors;
 
 public class TimeLockPaxosExecutorsTest {

--- a/timelock-agent/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/timelock-agent/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
**Goals (and why)**:
- Still allow pinging a node that has a lot of ongoing Paxos computations.

**Implementation Description (bullets)**:
- Use a separate thread pool.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Added a test that verifies the creation paths are distinct.

**Concerns (what feedback would you like?)**:
- Potential load of 8*2 more threads when a node is really bad. I think it is actually just 1*2 because of autobatching, but went with 8 in case I misunderstood the code.

**Where should we start reviewing?**: PaxosRemoteClients

**Priority (whenever / two weeks / yesterday)**: this week