### PR TITLE
[PDS-127121] Log refreshed Cassandra hosts at info level

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -315,7 +315,7 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
         logRefreshedHosts(serversToAdd, serversToRemove);
     }
 
-    private void logRefreshedHosts(Set<InetSocketAddress> serversToAdd, Set<InetSocketAddress> serversToRemove) {
+    private static void logRefreshedHosts(Set<InetSocketAddress> serversToAdd, Set<InetSocketAddress> serversToRemove) {
         if (serversToRemove.isEmpty() && serversToAdd.isEmpty()) {
             log.debug("No hosts added or removed during Cassandra pool refresh");
         } else {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -312,9 +312,17 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
             cassandra.refreshTokenRangesAndGetServers();
         }
 
-        log.info("Cassandra pool refresh added hosts {}, removed hosts {}.",
-                SafeArg.of("serversToAdd", CassandraLogHelper.collectionOfHosts(serversToAdd)),
-                SafeArg.of("serversToRemove", CassandraLogHelper.collectionOfHosts(serversToRemove)));
+        logRefreshedHosts(serversToAdd, serversToRemove);
+    }
+
+    private void logRefreshedHosts(Set<InetSocketAddress> serversToAdd, Set<InetSocketAddress> serversToRemove) {
+        if (serversToRemove.isEmpty() && serversToAdd.isEmpty()) {
+            log.debug("No hosts added or removed during Cassandra pool refresh");
+        } else {
+            log.info("Cassandra pool refresh added hosts {}, removed hosts {}.",
+                    SafeArg.of("serversToAdd", CassandraLogHelper.collectionOfHosts(serversToAdd)),
+                    SafeArg.of("serversToRemove", CassandraLogHelper.collectionOfHosts(serversToRemove)));
+        }
     }
 
     private Set<InetSocketAddress> getCachedServers() {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -312,7 +312,7 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
             cassandra.refreshTokenRangesAndGetServers();
         }
 
-        log.debug("Cassandra pool refresh added hosts {}, removed hosts {}.",
+        log.info("Cassandra pool refresh added hosts {}, removed hosts {}.",
                 SafeArg.of("serversToAdd", CassandraLogHelper.collectionOfHosts(serversToAdd)),
                 SafeArg.of("serversToRemove", CassandraLogHelper.collectionOfHosts(serversToRemove)));
     }

--- a/changelog/@unreleased/pr-4917.v2.yml
+++ b/changelog/@unreleased/pr-4917.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Log refreshed Cassandra hosts at info level instead of debug.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4917


### PR DESCRIPTION
**Goals (and why)**:
Expose more information about the state of the Cassandra pool in logs.

**Implementation Description (bullets)**:
Changed `DEBUG` -> `INFO` on one log line (that details which hosts that have been added and removed).

**Testing (What was existing testing like?  What have you done to improve it?)**:
N/A.

**Concerns (what feedback would you like?)**:
I don't think this introduces much spam - it is unlikely that anyone refreshes their token ranges / servers more than once per 30 seconds (default is once per 120 seconds), so one log line per refresh is minimal.

As for whether this is enough - I believe so, as it would tell us what hosts that are being added/removed at each point so that we can have a reasonable picture of what the pool is. Naturally this doesn't tell us the _actual_ current state of the pool, only the diff - but `debugLogStateOfPool` is a lot more heavy-handed, and possibly not necessary here.

**Where should we start reviewing?**:
`CassandraClientPoolImpl`

**Priority (whenever / two weeks / yesterday)**:
Whenever