### PR TITLE
[PD$-110002] Part 12: Only Publish Top Ten Table Metrics

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -86,6 +86,7 @@ import com.palantir.atlasdb.transaction.api.PreCommitCondition;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
 import com.palantir.atlasdb.transaction.api.TransactionSerializableConflictException;
+import com.palantir.atlasdb.transaction.impl.metrics.TableLevelMetricsController;
 import com.palantir.atlasdb.transaction.service.AsyncTransactionService;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.util.MetricsManager;
@@ -146,7 +147,8 @@ public class SerializableTransaction extends SnapshotTransaction {
                                    ExecutorService deleteExecutor,
                                    boolean validateLocksOnReads,
                                    Supplier<TransactionConfig> transactionConfig,
-                                   ConflictTracer conflictTracer) {
+                                   ConflictTracer conflictTracer,
+                                   TableLevelMetricsController tableLevelMetricsController) {
         super(metricsManager,
               keyValueService,
               timelockService,
@@ -170,7 +172,8 @@ public class SerializableTransaction extends SnapshotTransaction {
               deleteExecutor,
               validateLocksOnReads,
               transactionConfig,
-              conflictTracer);
+              conflictTracer,
+              tableLevelMetricsController);
     }
 
     @Override
@@ -790,7 +793,8 @@ public class SerializableTransaction extends SnapshotTransaction {
                 deleteExecutor,
                 validateLocksOnReads,
                 transactionConfig,
-                conflictTracer) {
+                conflictTracer,
+                tableLevelMetricsController) {
             @Override
             protected ListenableFuture<Map<Long, Long>> getCommitTimestamps(
                     TableReference tableRef,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -547,7 +547,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 deleteExecutor,
                 validateLocksOnReads,
                 transactionConfig,
-                conflictTracer);
+                conflictTracer,
+                tableLevelMetricsController);
     }
 
     @VisibleForTesting

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ShouldNotDeleteAndRollbackTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ShouldNotDeleteAndRollbackTransaction.java
@@ -30,6 +30,7 @@ import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
 import com.palantir.atlasdb.transaction.TransactionConfig;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
+import com.palantir.atlasdb.transaction.impl.metrics.SimpleTableLevelMetricsController;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.util.MetricsManager;
 
@@ -103,7 +104,8 @@ public class ShouldNotDeleteAndRollbackTransaction extends SnapshotTransaction {
                 IGNORING_EXECUTOR,
                 true,
                 transactionConfig,
-                ConflictTracer.NO_OP);
+                ConflictTracer.NO_OP,
+                new SimpleTableLevelMetricsController(metricsManager));
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -247,7 +247,6 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
      * @param immutableTimestamp If we find a row written before the immutableTimestamp we don't need to
      *                           grab a read lock for it because we know that no writers exist.
      * @param preCommitCondition This check must pass for this transaction to commit.
-     * @param tableLevelMetricsController
      */
     /* package */ SnapshotTransaction(
             MetricsManager metricsManager,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -124,6 +124,7 @@ import com.palantir.atlasdb.transaction.api.TransactionFailedRetriableException;
 import com.palantir.atlasdb.transaction.api.TransactionLockAcquisitionTimeoutException;
 import com.palantir.atlasdb.transaction.api.TransactionLockTimeoutException;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
+import com.palantir.atlasdb.transaction.impl.metrics.TableLevelMetricsController;
 import com.palantir.atlasdb.transaction.impl.metrics.TransactionOutcomeMetrics;
 import com.palantir.atlasdb.transaction.service.AsyncTransactionService;
 import com.palantir.atlasdb.transaction.service.TransactionService;
@@ -238,6 +239,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     protected final TransactionOutcomeMetrics transactionOutcomeMetrics;
     protected final boolean validateLocksOnReads;
     protected final Supplier<TransactionConfig> transactionConfig;
+    protected final TableLevelMetricsController tableLevelMetricsController;
 
     protected volatile boolean hasReads;
 
@@ -245,6 +247,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
      * @param immutableTimestamp If we find a row written before the immutableTimestamp we don't need to
      *                           grab a read lock for it because we know that no writers exist.
      * @param preCommitCondition This check must pass for this transaction to commit.
+     * @param tableLevelMetricsController
      */
     /* package */ SnapshotTransaction(
             MetricsManager metricsManager,
@@ -270,7 +273,8 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             ExecutorService deleteExecutor,
             boolean validateLocksOnReads,
             Supplier<TransactionConfig> transactionConfig,
-            ConflictTracer conflictTracer) {
+            ConflictTracer conflictTracer,
+            TableLevelMetricsController tableLevelMetricsController) {
         this.metricsManager = metricsManager;
         this.lockWatchManager = lockWatchManager;
         this.conflictTracer = conflictTracer;
@@ -300,6 +304,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         this.transactionOutcomeMetrics = TransactionOutcomeMetrics.create(metricsManager);
         this.validateLocksOnReads = validateLocksOnReads;
         this.transactionConfig = transactionConfig;
+        this.tableLevelMetricsController = tableLevelMetricsController;
     }
 
     @Override
@@ -2472,9 +2477,9 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     }
 
     private Counter getCounter(String name, TableReference tableRef) {
-        return metricsManager.registerOrGetTaggedCounter(
+        return tableLevelMetricsController.createAndRegisterCounter(
                 SnapshotTransaction.class,
                 name,
-                metricsManager.getTableNameTagFor(tableRef));
+                tableRef);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -59,6 +59,8 @@ import com.palantir.atlasdb.transaction.api.Transaction.TransactionType;
 import com.palantir.atlasdb.transaction.api.TransactionFailedRetriableException;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
 import com.palantir.atlasdb.transaction.api.TransactionTask;
+import com.palantir.atlasdb.transaction.impl.metrics.TableLevelMetricsController;
+import com.palantir.atlasdb.transaction.impl.metrics.ToplistDeltaFilteringTableLevelMetricsController;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.common.base.Throwables;
@@ -99,6 +101,8 @@ import com.palantir.util.SafeShutdownRunner;
     final Supplier<TransactionConfig> transactionConfig;
     final List<Runnable> closingCallbacks;
     final AtomicBoolean isClosed;
+    final TableLevelMetricsController tableLevelMetricsController;
+
     private final ConflictTracer conflictTracer;
 
     protected SnapshotTransactionManager(
@@ -147,6 +151,7 @@ import com.palantir.util.SafeShutdownRunner;
         this.validateLocksOnReads = validateLocksOnReads;
         this.transactionConfig = transactionConfig;
         this.conflictTracer = conflictTracer;
+        this.tableLevelMetricsController = ToplistDeltaFilteringTableLevelMetricsController.create(metricsManager);
     }
 
     @Override
@@ -300,7 +305,8 @@ import com.palantir.util.SafeShutdownRunner;
                 deleteExecutor,
                 validateLocksOnReads,
                 transactionConfig,
-                conflictTracer);
+                conflictTracer,
+                tableLevelMetricsController);
     }
 
     @Override
@@ -341,7 +347,8 @@ import com.palantir.util.SafeShutdownRunner;
                 deleteExecutor,
                 validateLocksOnReads,
                 transactionConfig,
-                conflictTracer);
+                conflictTracer,
+                tableLevelMetricsController);
         try {
             return runTaskThrowOnConflict(txn -> task.execute(txn, condition),
                     new ReadTransaction(transaction, sweepStrategyManager));

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
@@ -65,6 +65,7 @@ import com.palantir.atlasdb.transaction.api.TransactionFailedRetriableException;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
 import com.palantir.atlasdb.transaction.api.TransactionSerializableConflictException;
+import com.palantir.atlasdb.transaction.impl.metrics.SimpleTableLevelMetricsController;
 import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.common.base.BatchingVisitable;
 import com.palantir.common.base.BatchingVisitables;
@@ -132,7 +133,8 @@ public abstract class AbstractSerializableTransactionTest extends AbstractTransa
                 MoreExecutors.newDirectExecutorService(),
                 true,
                 () -> ImmutableTransactionConfig.builder().build(),
-                ConflictTracer.NO_OP) {
+                ConflictTracer.NO_OP,
+                new SimpleTableLevelMetricsController(metricsManager)) {
             @Override
             protected Map<Cell, byte[]> transformGetsForTesting(Map<Cell, byte[]> map) {
                 return Maps.transformValues(map, input -> input.clone());

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -96,6 +96,7 @@ import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionConflictException;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
 import com.palantir.atlasdb.transaction.api.TransactionTask;
+import com.palantir.atlasdb.transaction.impl.metrics.SimpleTableLevelMetricsController;
 import com.palantir.common.base.AbortingVisitors;
 import com.palantir.common.base.BatchingVisitable;
 import com.palantir.common.base.BatchingVisitables;
@@ -155,7 +156,8 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
                 MoreExecutors.newDirectExecutorService(),
                 true,
                 () -> TRANSACTION_CONFIG,
-                ConflictTracer.NO_OP);
+                ConflictTracer.NO_OP,
+                new SimpleTableLevelMetricsController(metricsManager));
     }
 
     @Test

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/CommitLockTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/CommitLockTest.java
@@ -48,6 +48,7 @@ import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import com.palantir.atlasdb.transaction.api.PreCommitCondition;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
+import com.palantir.atlasdb.transaction.impl.metrics.SimpleTableLevelMetricsController;
 import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.lock.AtlasCellLockDescriptor;
 import com.palantir.lock.AtlasRowLockDescriptor;
@@ -184,7 +185,8 @@ public class CommitLockTest extends TransactionTestSetup {
                 MoreExecutors.newDirectExecutorService(),
                 true,
                 () -> TRANSACTION_CONFIG,
-                ConflictTracer.NO_OP) {
+                ConflictTracer.NO_OP,
+                new SimpleTableLevelMetricsController(metricsManager)) {
             @Override
             protected Map<Cell, byte[]> transformGetsForTesting(Map<Cell, byte[]> map) {
                 return Maps.transformValues(map, byte[]::clone);

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -207,7 +207,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                         deleteExecutor,
                         validateLocksOnReads,
                         () -> TRANSACTION_CONFIG,
-                        ConflictTracer.NO_OP),
+                        ConflictTracer.NO_OP,
+                        tableLevelMetricsController),
                 pathTypeTracker);
     }
 
@@ -243,7 +244,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                         deleteExecutor,
                         validateLocksOnReads,
                         transactionConfig,
-                        ConflictTracer.NO_OP),
+                        ConflictTracer.NO_OP,
+                        tableLevelMetricsController),
                 pathTypeTracker);
     }
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -131,6 +131,8 @@ import com.palantir.atlasdb.transaction.api.TransactionFailedRetriableException;
 import com.palantir.atlasdb.transaction.api.TransactionLockTimeoutException;
 import com.palantir.atlasdb.transaction.api.TransactionLockTimeoutNonRetriableException;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
+import com.palantir.atlasdb.transaction.impl.metrics.TableLevelMetricsController;
+import com.palantir.atlasdb.transaction.impl.metrics.ToplistDeltaFilteringTableLevelMetricsController;
 import com.palantir.atlasdb.transaction.impl.metrics.TransactionOutcomeMetrics;
 import com.palantir.atlasdb.transaction.impl.metrics.TransactionOutcomeMetricsAssert;
 import com.palantir.common.base.AbortingVisitor;
@@ -193,6 +195,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
     private final int defaultGetRangesConcurrency = 2;
     private final TransactionOutcomeMetrics transactionOutcomeMetrics
             = TransactionOutcomeMetrics.create(metricsManager);
+    private final TableLevelMetricsController tableLevelMetricsController
+            = ToplistDeltaFilteringTableLevelMetricsController.create(metricsManager);
 
     private TransactionConfig transactionConfig;
 
@@ -424,7 +428,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                         MoreExecutors.newDirectExecutorService(),
                         true,
                         () -> transactionConfig,
-                        ConflictTracer.NO_OP),
+                        ConflictTracer.NO_OP,
+                        tableLevelMetricsController),
                 pathTypeTracker);
         try {
             snapshot.get(TABLE, ImmutableSet.of(cell));
@@ -496,7 +501,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                         MoreExecutors.newDirectExecutorService(),
                         true,
                         () -> transactionConfig,
-                        ConflictTracer.NO_OP),
+                        ConflictTracer.NO_OP,
+                        tableLevelMetricsController),
                 pathTypeTracker);
         snapshot.delete(TABLE, ImmutableSet.of(cell));
         snapshot.commit();
@@ -1548,7 +1554,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                         MoreExecutors.newDirectExecutorService(),
                         validateLocksOnReads,
                         () -> transactionConfig,
-                        ConflictTracer.NO_OP),
+                        ConflictTracer.NO_OP, tableLevelMetricsController),
                 pathTypeTracker);
     }
 

--- a/changelog/@unreleased/pr-4920.v2.yml
+++ b/changelog/@unreleased/pr-4920.v2.yml
@@ -1,0 +1,9 @@
+type: improvement
+improvement:
+  description: AtlasDB now publishes only the counter metrics for the top 10 tables
+    by delta relative to the last measurement for `SnapshotTransaction` (`cellsRead,
+    cellsReturned, emptyValue, invalidStartTs, invalidCommitTs, commitTsGreaterThanTransactionTs`).
+    This should detect spikes as well as by default track the busiest tables, while
+    making savings on metrics cost.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4920


### PR DESCRIPTION
**Goals (and why)**:
- Save money on metrics.

**Implementation Description (bullets)**:
- Only publish the top ten metrics, by delta relative since the last measurement. This should detect spikes as well as by default track the busiest tables.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Most of the individual testing was done in Parts 10 and 11

**Concerns (what feedback would you like?)**:
- Nothing additional

**Where should we start reviewing?**: SnapshotTransaction

**Priority (whenever / two weeks / yesterday)**: this week?
