### PR TITLE
[PD$-110002] Part 13: Filter Resiliency

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/metrics/MetricPublicationArbiter.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/metrics/MetricPublicationArbiter.java
@@ -61,7 +61,7 @@ public class MetricPublicationArbiter implements Predicate<MetricName> {
     private static boolean safeShouldPublish(MetricName metricName, MetricPublicationFilter filter) {
         try {
             return filter.shouldPublish();
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.warn("Exception thrown when attempting to determine whether a metric {} should be published."
                             + " In this case we don't filter out the metric.",
                     SafeArg.of("metricName", metricName),

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/metrics/MetricPublicationArbiter.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/metrics/MetricPublicationArbiter.java
@@ -21,7 +21,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.collect.ImmutableList;
+import com.palantir.logsafe.SafeArg;
 import com.palantir.tritium.metrics.registry.MetricName;
 
 /**
@@ -29,6 +33,8 @@ import com.palantir.tritium.metrics.registry.MetricName;
  * the metric involved SHOULD be published.
  */
 public class MetricPublicationArbiter implements Predicate<MetricName> {
+    private static final Logger log = LoggerFactory.getLogger(MetricPublicationArbiter.class);
+
     private final Map<MetricName, List<MetricPublicationFilter>> singleMetricFilters;
 
     public MetricPublicationArbiter(
@@ -39,7 +45,7 @@ public class MetricPublicationArbiter implements Predicate<MetricName> {
     @Override
     public boolean test(MetricName metricName) {
         return Optional.ofNullable(singleMetricFilters.get(metricName))
-                .map(MetricPublicationArbiter::allFiltersMatch)
+                .map(filters -> allFiltersMatch(metricName, filters))
                 .orElse(true);
     }
 
@@ -48,7 +54,19 @@ public class MetricPublicationArbiter implements Predicate<MetricName> {
                 -> ImmutableList.<MetricPublicationFilter>builder().addAll(oldFilters).addAll(newFilter).build());
     }
 
-    private static boolean allFiltersMatch(List<MetricPublicationFilter> relevantFilters) {
-        return relevantFilters.stream().allMatch(MetricPublicationFilter::shouldPublish);
+    private static boolean allFiltersMatch(MetricName metricName, List<MetricPublicationFilter> relevantFilters) {
+        return relevantFilters.stream().allMatch(filter -> safeShouldPublish(metricName, filter));
+    }
+
+    private static boolean safeShouldPublish(MetricName metricName, MetricPublicationFilter filter) {
+        try {
+            return filter.shouldPublish();
+        } catch (Exception e) {
+            log.warn("Exception thrown when attempting to determine whether a metric {} should be published."
+                            + " In this case we don't filter out the metric.",
+                    SafeArg.of("metricName", metricName),
+                    e);
+            return true;
+        }
     }
 }

--- a/atlasdb-api/src/test/java/com/palantir/atlasdb/metrics/MetricPublicationArbiterTest.java
+++ b/atlasdb-api/src/test/java/com/palantir/atlasdb/metrics/MetricPublicationArbiterTest.java
@@ -83,8 +83,8 @@ public class MetricPublicationArbiterTest {
                 METRIC_NAME_1, ImmutableList.of(() -> {
                     throw new RuntimeException("boo");
                 },
-                () -> true,
-                () -> false)));
+                        () -> true,
+                        () -> false)));
         assertThat(arbiter.test(METRIC_NAME_1)).isFalse();
     }
 }

--- a/atlasdb-api/src/test/java/com/palantir/atlasdb/metrics/MetricPublicationArbiterTest.java
+++ b/atlasdb-api/src/test/java/com/palantir/atlasdb/metrics/MetricPublicationArbiterTest.java
@@ -67,4 +67,24 @@ public class MetricPublicationArbiterTest {
         arbiter.registerMetricsFilter(METRIC_NAME_1, () -> false);
         assertThat(arbiter.test(METRIC_NAME_1)).isFalse();
     }
+
+    @Test
+    public void exceptionTreatedAsNotFiltered() {
+        MetricPublicationArbiter arbiter = new MetricPublicationArbiter(ImmutableMap.of(
+                METRIC_NAME_1, ImmutableList.of(() -> {
+                    throw new RuntimeException("boo");
+                })));
+        assertThat(arbiter.test(METRIC_NAME_1)).isTrue();
+    }
+
+    @Test
+    public void rejectsMetricWithDefinitivelyFalseFilterEvenWithExceptions() {
+        MetricPublicationArbiter arbiter = new MetricPublicationArbiter(ImmutableMap.of(
+                METRIC_NAME_1, ImmutableList.of(() -> {
+                    throw new RuntimeException("boo");
+                },
+                () -> true,
+                () -> false)));
+        assertThat(arbiter.test(METRIC_NAME_1)).isFalse();
+    }
 }

--- a/changelog/@unreleased/pr-4921.v2.yml
+++ b/changelog/@unreleased/pr-4921.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Metrics filters are now resilient to exceptions (e.g. when querying
+    timelock).
+  links:
+  - https://github.com/palantir/atlasdb/pull/4921


### PR DESCRIPTION
**Goals (and why)**:
- Metrics filters shouldn't cause metrics to broadly not be published. This may cause issues when bootstrapping a cluster of leader-block users, and also if timelock is inaccessible (though it may not be the primary concern in that case...)

**Implementation Description (bullets)**:
- If testing a filter throws an exception, treat that as returning true.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Added tests for handling of exceptions

**Concerns (what feedback would you like?)**:
- Will there be log spam?
- Doing an RPC inside getMetrics() is kind of crap, but since it only happens every 5 minutes in practice (see cached composed supplier) I don't see it as an issue.

**Where should we start reviewing?**: MetricPublicationArbiter, or its test

**Priority (whenever / two weeks / yesterday)**: today - internal security product is I think unblocked, but this is a genuine bug.