### PR TITLE
Remove local vs remote host selected metric

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
@@ -82,9 +82,6 @@ public class CassandraService implements AutoCloseable {
     private volatile Set<InetSocketAddress> localHosts = ImmutableSet.of();
     private final Supplier<Optional<HostLocation>> myLocationSupplier;
 
-    private final Counter randomHostsSelected;
-    private final Counter localHostsSelected;
-
     private final Random random = new Random();
 
     public CassandraService(
@@ -93,10 +90,6 @@ public class CassandraService implements AutoCloseable {
             Blacklist blacklist,
             CassandraClientPoolMetrics poolMetrics) {
         this.metricsManager = metricsManager;
-        this.randomHostsSelected = metricsManager.getTaggedRegistry().counter(MetricName.builder()
-                .safeName(MetricRegistry.name(CassandraService.class, "randomHostsSelected")).build());
-        this.localHostsSelected = metricsManager.getTaggedRegistry().counter(MetricName.builder()
-                .safeName(MetricRegistry.name(CassandraService.class, "localHostsSelected")).build());
         this.config = config;
         this.myLocationSupplier = new HostLocationSupplier(this::getSnitch, config.overrideHostLocation());
         this.blacklist = blacklist;
@@ -297,12 +290,10 @@ public class CassandraService implements AutoCloseable {
         if (random.nextDouble() < config.localHostWeighting()) {
             Set<InetSocketAddress> localFilteredHosts = Sets.intersection(localHosts, hosts);
             if (!localFilteredHosts.isEmpty()) {
-                localHostsSelected.inc();
                 return localFilteredHosts;
             }
         }
 
-        randomHostsSelected.inc();
         return hosts;
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
@@ -36,8 +36,6 @@ import org.apache.cassandra.thrift.TokenRange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.codahale.metrics.Counter;
-import com.codahale.metrics.MetricRegistry;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableRangeMap;
@@ -63,7 +61,6 @@ import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.common.base.Throwables;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
-import com.palantir.tritium.metrics.registry.MetricName;
 
 public class CassandraService implements AutoCloseable {
     // TODO(tboam): keep logging on old class?

--- a/changelog/@unreleased/pr-4922.v2.yml
+++ b/changelog/@unreleased/pr-4922.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Remove local and remote host metrics.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4922


### PR DESCRIPTION
**Goals (and why)**:
Our internal fleet has long since moved to using the local weighting of 1.0, so this metric generally just shows a straight line all of the time.

**Implementation Description (bullets)**:
Removed counters recording when local or remote host was selected.

**Testing (What was existing testing like?  What have you done to improve it?)**:
N/A.

**Concerns (what feedback would you like?)**:
Does anyone actually look at this metric, and/or is it ever useful?

**Where should we start reviewing?**:
`CassandraService`

**Priority (whenever / two weeks / yesterday)**:
Whenever
