### PR TITLE
[PDS-128523] Fewer leader time calls.

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/GetRowsColumnRangeIterator.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/GetRowsColumnRangeIterator.java
@@ -41,7 +41,7 @@ final class GetRowsColumnRangeIterator extends AbstractIterator<Iterator<Map.Ent
     private boolean firstBatchReturned = false;
     private boolean lastBatchReached = false;
 
-    public GetRowsColumnRangeIterator(
+    GetRowsColumnRangeIterator(
             BatchSizeIncreasingIterator<Map.Entry<Cell, Value>> batchIterator,
             Runnable batchValidationStep,
             PostFilterer postFilterer) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/GetRowsColumnRangeIterator.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/GetRowsColumnRangeIterator.java
@@ -1,0 +1,111 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.SortedMap;
+
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.Iterators;
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.RowColumnRangeIterator;
+import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.common.base.ClosableIterators;
+
+final class GetRowsColumnRangeIterator extends AbstractIterator<Iterator<Map.Entry<Cell, byte[]>>> {
+
+    private final BatchSizeIncreasingIterator<Map.Entry<Cell, Value>> batchIterator;
+    private final Runnable batchValidationStep;
+    private final PostFilterer postFilterer;
+
+    private boolean firstBatchReturned = false;
+    private boolean lastBatchReached = false;
+
+    public GetRowsColumnRangeIterator(
+            BatchSizeIncreasingIterator<Map.Entry<Cell, Value>> batchIterator,
+            Runnable batchValidationStep,
+            PostFilterer postFilterer) {
+        this.batchIterator = batchIterator;
+        this.batchValidationStep = batchValidationStep;
+        this.postFilterer = postFilterer;
+    }
+
+    /**
+     * The iterator returned does not invoke the {@code batchValidationStep} for the first batch of calls as it is
+     * assumed to be prefetched from its caller and the {@code batchValidationStep} can run where this is called.
+     * <p>
+     * If a batch returned by the internal iterator is empty or has size smaller than the batch size specified in
+     * {@code columnRangeSelection}, that batch will be considered the last batch, and there will be no further
+     * invocations of {@code batchValidationStep}.
+     * <p>
+     * This <em>may</em> request more elements than the specified batch hint inside {@code columnRangeSelection} if
+     * there is detection of many deleted values.
+     */
+    public static Iterator<Map.Entry<Cell, byte[]>> iterator(
+            BatchProvider<Map.Entry<Cell, Value>> batchProvider,
+            RowColumnRangeIterator rawIterator,
+            BatchColumnRangeSelection columnRangeSelection,
+            Runnable batchValidationStep,
+            PostFilterer postFilterer) {
+        BatchSizeIncreasingIterator<Map.Entry<Cell, Value>> batchIterator = new BatchSizeIncreasingIterator<>(
+                batchProvider, columnRangeSelection.getBatchHint(), ClosableIterators.wrap(rawIterator));
+        GetRowsColumnRangeIterator postFilteredIterator = new GetRowsColumnRangeIterator(batchIterator,
+                batchValidationStep, postFilterer);
+        return Iterators.concat(postFilteredIterator);
+    }
+
+    @Override
+    protected Iterator<Map.Entry<Cell, byte[]>> computeNext() {
+        try {
+            if (lastBatchReached) {
+                return endOfData();
+            }
+
+            BatchSizeIncreasingIterator.BatchResult<Map.Entry<Cell, Value>> batchResult = batchIterator.getBatch();
+            Map<Cell, Value> raw = ImmutableMap.copyOf(batchResult.batch());
+
+            if (firstBatchReturned) {
+                batchValidationStep.run();
+            }
+
+            if (batchResult.isLastBatch()) {
+                lastBatchReached = true;
+            }
+
+            if (raw.isEmpty()) {
+                return Collections.emptyIterator();
+            }
+
+            SortedMap<Cell, byte[]> postFiltered = ImmutableSortedMap.copyOf(postFilterer.postFilter(raw));
+            batchIterator.markNumResultsNotDeleted(postFiltered.size());
+            return postFiltered.entrySet().iterator();
+        } finally {
+            firstBatchReturned = true;
+        }
+    }
+
+    @FunctionalInterface
+    interface PostFilterer {
+        Collection<Map.Entry<Cell, byte[]>> postFilter(Map<Cell, Value> rawResults);
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -412,16 +412,19 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         hasReads = true;
         Map<byte[], RowColumnRangeIterator> rawResults = keyValueService.getRowsColumnRange(tableRef, rows,
                 columnRangeSelection, getStartTimestamp());
-        ImmutableSortedMap.Builder<byte[], Iterator<Map.Entry<Cell, byte[]>>> postFilteredResults =
+        ImmutableSortedMap.Builder<byte[], Iterator<Map.Entry<Cell, byte[]>>> postFilteredResultsBuilder =
                 ImmutableSortedMap.orderedBy(PtBytes.BYTES_COMPARATOR);
         for (Map.Entry<byte[], RowColumnRangeIterator> e : rawResults.entrySet()) {
             byte[] row = e.getKey();
             RowColumnRangeIterator rawIterator = e.getValue();
             Iterator<Map.Entry<Cell, byte[]>> postFilteredIterator =
                     getPostFilteredColumns(tableRef, columnRangeSelection, row, rawIterator);
-            postFilteredResults.put(row, postFilteredIterator);
+            postFilteredResultsBuilder.put(row, postFilteredIterator);
         }
-        return postFilteredResults.build();
+        SortedMap<byte[], Iterator<Map.Entry<Cell, byte[]>>> postFilteredResults = postFilteredResultsBuilder.build();
+        // validate requirements here as the first batch for each of the above iterators will not check
+        validatePreCommitRequirementsOnReadIfNecessary(tableRef, getStartTimestamp());
+        return postFilteredResults;
     }
 
     private Iterator<Map.Entry<Cell, byte[]>> getPostFilteredColumns(
@@ -508,32 +511,12 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             RowColumnRangeIterator rawIterator) {
         ColumnRangeBatchProvider batchProvider = new ColumnRangeBatchProvider(
                 keyValueService, tableRef, row, columnRangeSelection, getStartTimestamp());
-        BatchSizeIncreasingIterator<Map.Entry<Cell, Value>> batchIterator = new BatchSizeIncreasingIterator<>(
-                batchProvider, columnRangeSelection.getBatchHint(), ClosableIterators.wrap(rawIterator));
-        Iterator<Iterator<Map.Entry<Cell, byte[]>>> postFilteredBatches =
-                new AbstractIterator<Iterator<Map.Entry<Cell, byte[]>>>() {
-            @Override
-            protected Iterator<Map.Entry<Cell, byte[]>> computeNext() {
-                ImmutableMap.Builder<Cell, Value> rawBuilder = ImmutableMap.builder();
-                List<Map.Entry<Cell, Value>> batch = batchIterator.getBatch();
-                for (Map.Entry<Cell, Value> result : batch) {
-                    rawBuilder.put(result);
-                }
-                Map<Cell, Value> raw = rawBuilder.build();
-                validatePreCommitRequirementsOnReadIfNecessary(tableRef, getStartTimestamp());
-                if (raw.isEmpty()) {
-                    return endOfData();
-                }
-                SortedMap<Cell, byte[]> postFiltered = ImmutableSortedMap.copyOf(
-                        getWithPostFilteringSync(
-                                tableRef,
-                                raw,
-                                Value.GET_VALUE));
-                batchIterator.markNumResultsNotDeleted(postFiltered.size());
-                return postFiltered.entrySet().iterator();
-            }
-        };
-        return Iterators.concat(postFilteredBatches);
+        return GetRowsColumnRangeIterator.iterator(
+                batchProvider,
+                rawIterator,
+                columnRangeSelection,
+                () -> validatePreCommitRequirementsOnReadIfNecessary(tableRef, getStartTimestamp()),
+                raw -> getWithPostFilteringSync(tableRef, raw, Value.GET_VALUE));
     }
 
     private Comparator<Cell> preserveInputRowOrder(List<Map.Entry<Cell, Value>> inputEntries) {
@@ -1117,7 +1100,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         Iterator<Iterator<RowResult<T>>> batchedPostFiltered = new AbstractIterator<Iterator<RowResult<T>>>() {
             @Override
             protected Iterator<RowResult<T>> computeNext() {
-                List<RowResult<Value>> batch = results.getBatch();
+                List<RowResult<Value>> batch = results.getBatch().batch();
                 validatePreCommitRequirementsOnReadIfNecessary(tableRef, getStartTimestamp());
                 if (batch.isEmpty()) {
                     return endOfData();

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/GetRowsColumnRangeIteratorTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/GetRowsColumnRangeIteratorTest.java
@@ -1,0 +1,156 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Maps;
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.RowColumnRangeIterator;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GetRowsColumnRangeIteratorTest {
+
+    private static final TableReference TABLE_REFERENCE = TableReference.createWithEmptyNamespace("test");
+    private static final byte[] ROW = "row".getBytes(StandardCharsets.UTF_8);
+    private static final int BATCH_SIZE = 10;
+    public static final BatchColumnRangeSelection COLUMN_RANGE_SELECTION = BatchColumnRangeSelection.create(null, null, BATCH_SIZE);
+
+    private final KeyValueService kvs = new InMemoryKeyValueService(true);
+    private final ColumnRangeBatchProvider batchProvider = new ColumnRangeBatchProvider(
+            kvs,
+            TABLE_REFERENCE,
+            ROW,
+            COLUMN_RANGE_SELECTION,
+            Long.MAX_VALUE);
+
+    @Test
+    public void ifBatchIsEmptyNoValidateCallsAreMade() {
+        Runnable validationStep = mock(Runnable.class);
+        Iterator<Map.Entry<Cell, byte[]>> iterator = createIteratorUnderTest(validationStep);
+
+        List<Map.Entry<Cell, byte[]>> entries = ImmutableList.copyOf(iterator);
+
+        assertThat(entries).isEmpty();
+        verifyNoInteractions(validationStep);
+    }
+
+    @Test
+    public void firstBatchHasNoValidation() {
+        Runnable validationStep = mock(Runnable.class);
+        Set<Cell> puts = putColumns(BATCH_SIZE + 5);
+
+        int limit = BATCH_SIZE - 1;
+        Iterator<Map.Entry<Cell, byte[]>> iteratorUnderTest = createIteratorUnderTest(validationStep);
+
+        // still under the first batch size limit
+        List<Map.Entry<Cell, byte[]>> firstBatchBarOne =
+                ImmutableList.copyOf(Iterators.limit(iteratorUnderTest, limit));
+        verifyNoInteractions(validationStep);
+
+        // the last element in the first batch is still on the first batch
+        Map.Entry<Cell, byte[]> lastInFirstBatch = Iterators.getNext(iteratorUnderTest, null);
+        assertThat(lastInFirstBatch).isNotNull();
+        verifyNoInteractions(validationStep);
+
+        // consume one more i.e. batch size amount
+        Map.Entry<Cell, byte[]> firstInSecondBatch = Iterators.getNext(iteratorUnderTest, null);
+        assertThat(firstInSecondBatch).isNotNull();
+        verify(validationStep, times(1)).run();
+
+        // validation step is called per batch
+        ImmutableList<Map.Entry<Cell, byte[]>> restOfSecondBatch = ImmutableList.copyOf(iteratorUnderTest);
+        verifyNoMoreInteractions(validationStep);
+
+        Map<Cell, byte[]> returnedEntries = ImmutableMap.<Cell, byte[]>builder()
+                .putAll(firstBatchBarOne)
+                .put(lastInFirstBatch)
+                .put(firstInSecondBatch)
+                .putAll(restOfSecondBatch)
+                .build();
+
+
+        assertThat(returnedEntries.keySet())
+                .as("we can read all that we wrote")
+                .isEqualTo(puts);
+    }
+
+    @Test
+    public void validationCalledNumberOfBatchesMinusOneTimes() {
+        Runnable validationStep = mock(Runnable.class);
+        putColumns(13 * BATCH_SIZE + 8);
+
+        Iterator<Map.Entry<Cell, byte[]>> iteratorUnderTest = createIteratorUnderTest(validationStep);
+        List<Map.Entry<Cell, byte[]>> consumedEntries = ImmutableList.copyOf(iteratorUnderTest);
+
+        assertThat(consumedEntries)
+                .hasSize(13 * BATCH_SIZE + 8);
+
+        verify(validationStep, times(14 - 1)).run();
+    }
+
+    private Set<Cell> putColumns(int numberOfColumns) {
+        byte[] value = new byte[1];
+        Map<Cell, byte[]> puts = IntStream.range(0, numberOfColumns)
+                .mapToObj(i -> String.format("cell%02d", i).getBytes())
+                .map(column -> Cell.create(ROW, column))
+                .collect(ImmutableMap.toImmutableMap(Function.identity(), _unused -> value));
+        kvs.put(TABLE_REFERENCE, puts, 1L);
+
+        return puts.keySet();
+    }
+
+    private RowColumnRangeIterator getInitialIterator() {
+        return kvs.getRowsColumnRange(TABLE_REFERENCE, ImmutableList.of(ROW), COLUMN_RANGE_SELECTION, Long.MAX_VALUE)
+                .get(ROW);
+    }
+
+    private Iterator<Map.Entry<Cell,byte[]>> createIteratorUnderTest(Runnable validationStep) {
+        return GetRowsColumnRangeIterator.iterator(
+                batchProvider,
+                getInitialIterator(),
+                COLUMN_RANGE_SELECTION,
+                validationStep,
+                results -> Maps.transformValues(results, Value::getContents).entrySet());
+    }
+
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/GetRowsColumnRangeIteratorTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/GetRowsColumnRangeIteratorTest.java
@@ -53,7 +53,8 @@ public class GetRowsColumnRangeIteratorTest {
     private static final TableReference TABLE_REFERENCE = TableReference.createWithEmptyNamespace("test");
     private static final byte[] ROW = "row".getBytes(StandardCharsets.UTF_8);
     private static final int BATCH_SIZE = 10;
-    public static final BatchColumnRangeSelection COLUMN_RANGE_SELECTION = BatchColumnRangeSelection.create(null, null, BATCH_SIZE);
+    public static final BatchColumnRangeSelection COLUMN_RANGE_SELECTION =
+            BatchColumnRangeSelection.create(null, null, BATCH_SIZE);
 
     private final KeyValueService kvs = new InMemoryKeyValueService(true);
     private final ColumnRangeBatchProvider batchProvider = new ColumnRangeBatchProvider(
@@ -144,7 +145,7 @@ public class GetRowsColumnRangeIteratorTest {
                 .get(ROW);
     }
 
-    private Iterator<Map.Entry<Cell,byte[]>> createIteratorUnderTest(Runnable validationStep) {
+    private Iterator<Map.Entry<Cell, byte[]>> createIteratorUnderTest(Runnable validationStep) {
         return GetRowsColumnRangeIterator.iterator(
                 batchProvider,
                 getInitialIterator(),

--- a/changelog/@unreleased/pr-4929.v2.yml
+++ b/changelog/@unreleased/pr-4929.v2.yml
@@ -1,5 +1,6 @@
 type: fix
 fix:
-  description: There are now fewer `getLeaderTime` calls when calling `getRowsColumnRangeIterator`.
+  description: There are now fewer `getLeaderTime` calls when reading the iterator returned by
+    `getRowsColumnRangeIterator`.
   links:
   - https://github.com/palantir/atlasdb/pull/4929

--- a/changelog/@unreleased/pr-4929.v2.yml
+++ b/changelog/@unreleased/pr-4929.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: There are now fewer `getLeaderTime` calls when calling `getRowsColumnRangeIterator`.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4929


### PR DESCRIPTION
**Goals (and why)**:
A different take on #4916. Instead of rate limiting calls everywhere, we're just going to ensure that the first batch is not validated.

Some further thought, I'll make a different issue. But why bother validating at each kvs batch read? Shouldn't we instead validate after every batch that's *actually* returned to the user i.e. after post filtering and filtering deletes? I don't have any metrics on this, but I imagine this will only affect places where TS is slow and deletes aren't removed, or (guessing here) there are a ton of concurrent writes from different transactions that get returned? Rationale being, if we're validating based on when the user read, we're reading from the kvs in multiple batches in one go to make one batch for a single user read, which feels like we should only validate for that single read. Thoughts?

**Implementation Description (bullets)**:
* Extract the existing iterator into its own class so we can test it
* On the first batch (saved to a field) we skip validation
* We also make `BatchSizeIncreasingIterator` return whether or not a batch is the last.
   * Reason being, the previous implementation would take another iteration and another validation step to decide whether or not to terminate. i.e. if you had `n * BATCH_SIZE + k` columns where `k < n`, you would make `n + 1` calls as expected, and then you would make a further call to figure out that it's empty and that would incur a validation step. Rather than try to special case it, just make the page feel more like a batch iterator by giving some sort of `hasNext` functionality.

**Testing (What was existing testing like?  What have you done to improve it?)**:
I've *just* tested this wrapped iterator, do you want something more?

**Concerns (what feedback would you like?)**:
Is coverage sufficient.

**Where should we start reviewing?**:
Anywhere. Half of it is tests however and there is a bit of bloat there.

**Priority (whenever / two weeks / yesterday)**:
ASAP, blocking internal product, and also violating SLOs of internal skiing product.
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
