### PR TITLE
Bound lock acquire timeout

### DIFF
--- a/changelog/@unreleased/pr-4933.v2.yml
+++ b/changelog/@unreleased/pr-4933.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Lock acquire timeout is now bounded by client read timeout.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4933

--- a/lock-api/src/main/java/com/palantir/lock/client/BlockEnforcingLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/BlockEnforcingLockService.java
@@ -46,6 +46,13 @@ import com.palantir.logsafe.exceptions.SafeIllegalStateException;
  * Fairness is admittedly compromised, but this is a closer approximation than the previous behaviour.
  */
 final class BlockEnforcingLockService {
+    /**
+     * Bound lock acquire timeout by client read timeout because 1. the async request expires before server cancels
+     * the request thus avoiding {@link java.util.concurrent.CancellationException} and
+     * 2. this ensures locks are not given out to phantom client.
+     */
+    private static final Duration MAX_PERMISSIBLE_LOCK_ACQUIRE_TIMEOUT = Duration.ofSeconds(65);
+
     private final NamespacedConjureTimelockService namespacedConjureTimelockService;
     private final RemoteTimeoutRetryer timeoutRetryer;
 
@@ -81,7 +88,8 @@ final class BlockEnforcingLockService {
     private static ConjureLockRequest clampLockRequestToDeadline(ConjureLockRequest request, Duration remainingTime) {
         return ConjureLockRequest.builder()
                 .from(request)
-                .acquireTimeoutMs(Ints.checkedCast(remainingTime.toMillis()))
+                .acquireTimeoutMs(Math.min(Ints.checkedCast(remainingTime.toMillis()),
+                        Ints.checkedCast(MAX_PERMISSIBLE_LOCK_ACQUIRE_TIMEOUT.toMillis())))
                 .build();
     }
 

--- a/lock-api/src/main/java/com/palantir/lock/client/BlockEnforcingLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/BlockEnforcingLockService.java
@@ -51,7 +51,7 @@ final class BlockEnforcingLockService {
      * the request thus avoiding {@link java.util.concurrent.CancellationException} and
      * 2. this ensures locks are not given out to phantom client.
      */
-    private static final Duration MAX_PERMISSIBLE_LOCK_ACQUIRE_TIMEOUT = Duration.ofSeconds(65);
+    static final Duration MAX_PERMISSIBLE_LOCK_ACQUIRE_TIMEOUT = Duration.ofSeconds(65).minusMillis(100);
 
     private final NamespacedConjureTimelockService namespacedConjureTimelockService;
     private final RemoteTimeoutRetryer timeoutRetryer;

--- a/lock-api/src/test/java/com/palantir/lock/client/LockLeaseServiceTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/LockLeaseServiceTest.java
@@ -155,7 +155,6 @@ public class LockLeaseServiceTest {
                 .thenReturn(ConjureLockResponse.successful(SuccessfulLockResponse.of(LOCK_TOKEN, getLease())));
         LockResponse lockResponse = lockLeaseService.lock(lockRequest);
         assertValid(lockResponse.getToken());
-        verify(timelock, times(1)).lock(any());
         verify(timelock)
                 .lock(argThat(req -> req.getAcquireTimeoutMs()
                         == BlockEnforcingLockService.MAX_PERMISSIBLE_LOCK_ACQUIRE_TIMEOUT.toMillis()));

--- a/lock-api/src/test/java/com/palantir/lock/client/LockLeaseServiceTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/LockLeaseServiceTest.java
@@ -18,10 +18,13 @@ package com.palantir.lock.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.net.SocketTimeoutException;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Set;
@@ -64,9 +67,13 @@ public class LockLeaseServiceTest {
     @Mock private LockRequest lockRequest;
     @Mock private PartitionedTimestamps partitionedTimestamps;
 
+    private static final Duration TIMEOUT_GREATER_THAN_MAX_PERMISSIBLE_TIMEOUT =
+            BlockEnforcingLockService.MAX_PERMISSIBLE_LOCK_ACQUIRE_TIMEOUT.multipliedBy(5);
     private static final Duration LEASE_DURATION = Duration.ofSeconds(1);
     private static final LeadershipId LEADER_ID = LeadershipId.random();
     private static final UUID SERVICE_ID = UUID.randomUUID();
+
+    private static final Exception TIMEOUT_EXCEPTION = new RuntimeException(new SocketTimeoutException("timeout"));
 
     private static final ConjureLockToken LOCK_TOKEN = ConjureLockToken.of(UUID.randomUUID());
 
@@ -140,6 +147,33 @@ public class LockLeaseServiceTest {
         LockResponse lockResponse = lockLeaseService.lock(lockRequest);
         assertValid(lockResponse.getToken());
     }
+
+    @Test
+    public void lockAcquireTimeoutIsBounded() {
+        when(lockRequest.getAcquireTimeoutMs()).thenReturn(TIMEOUT_GREATER_THAN_MAX_PERMISSIBLE_TIMEOUT.toMillis());
+        when(timelock.lock(any()))
+                .thenReturn(ConjureLockResponse.successful(SuccessfulLockResponse.of(LOCK_TOKEN, getLease())));
+        LockResponse lockResponse = lockLeaseService.lock(lockRequest);
+        assertValid(lockResponse.getToken());
+        verify(timelock, times(1)).lock(any());
+        verify(timelock)
+                .lock(argThat(req -> req.getAcquireTimeoutMs()
+                        == BlockEnforcingLockService.MAX_PERMISSIBLE_LOCK_ACQUIRE_TIMEOUT.toMillis()));
+    }
+
+    @Test
+    public void lockAcquireTimeoutIsBoundedAndRequestRetried() {
+        when(lockRequest.getAcquireTimeoutMs()).thenReturn(TIMEOUT_GREATER_THAN_MAX_PERMISSIBLE_TIMEOUT.toMillis());
+        when(timelock.lock(any()))
+                .thenThrow(TIMEOUT_EXCEPTION)
+                .thenReturn(ConjureLockResponse.successful(SuccessfulLockResponse.of(LOCK_TOKEN, getLease())));
+
+        LockResponse lockResponse = lockLeaseService.lock(lockRequest);
+        assertValid(lockResponse.getToken());
+        verify(timelock, times(2)).lock(any());
+    }
+
+
 
     @Test
     public void unlockShouldCallRemoteServer_validLeases() {


### PR DESCRIPTION
**Goals (and why)**:
Bound lock acquire timeout by client read timeout because 1. the async request expires before server cancels the request thus avoiding `java.util.concurrent.CancellationException` and 2. this ensures locks are not given out to phantom client.

**Implementation Description (bullets)**:
BELS limits lock acquire timeout to client read timeout via duration limiter.

**Testing (What was existing testing like?  What have you done to improve it?)**:
TBD

**Concerns (what feedback would you like?)**:

- If extended timeout is not used, the client read timeout will be - `ClientOptionsConstants.SHORT_READ_TIMEOUT` and phantom client problem would not be solved.

- Maintaining two constants is not a good idea. 

**Where should we start reviewing?**:
BlockEnforcingLockService

**Priority (whenever / two weeks / yesterday)**:
Next week

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
