### PR TITLE
Don't throw on duplicate metric names

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/metrics/DisjointUnionTaggedMetricSet.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/metrics/DisjointUnionTaggedMetricSet.java
@@ -16,11 +16,12 @@
 
 package com.palantir.atlasdb.metrics;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
 
 import com.codahale.metrics.Metric;
-import com.google.common.collect.ImmutableMap;
 import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricSet;
 
@@ -28,6 +29,7 @@ import com.palantir.tritium.metrics.registry.TaggedMetricSet;
  * Combines two {@link TaggedMetricSet}s. It is expected that the metric names present from the two sets are disjoint.
  */
 public class DisjointUnionTaggedMetricSet implements TaggedMetricSet {
+
     private final TaggedMetricSet first;
     private final TaggedMetricSet second;
 
@@ -38,10 +40,14 @@ public class DisjointUnionTaggedMetricSet implements TaggedMetricSet {
 
     @Override
     public Map<MetricName, Metric> getMetrics() {
-        return ImmutableMap.<MetricName, Metric>builder()
-                .putAll(first.getMetrics())
-                .putAll(second.getMetrics())
-                .build();
+        Map<MetricName, Metric> firstMetrics = first.getMetrics();
+        Map<MetricName, Metric> secondMetrics = second.getMetrics();
+
+        Map<MetricName, Metric> metrics = new HashMap<>(firstMetrics.size() + secondMetrics.size());
+        firstMetrics.forEach(metrics::putIfAbsent);
+        secondMetrics.forEach(metrics::putIfAbsent);
+
+        return Collections.unmodifiableMap(metrics);
     }
 
     @Override

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/util/MetricsManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/util/MetricsManager.java
@@ -93,7 +93,7 @@ public class MetricsManager {
             Refreshable<Boolean> performFiltering) {
         TaggedMetricSet legacyMetricsAsTaggedSet = new DropwizardTaggedMetricSet(metricRegistry);
         TaggedMetricSet unfilteredUnion
-                = new DisjointUnionTaggedMetricSet(legacyMetricsAsTaggedSet, taggedMetricRegistry);
+                = new DisjointUnionTaggedMetricSet(taggedMetricRegistry, legacyMetricsAsTaggedSet);
         return new FilteredTaggedMetricSet(unfilteredUnion, arbiter, performFiltering);
     }
 

--- a/atlasdb-api/src/test/java/com/palantir/atlasdb/metrics/DisjointUnionTaggedMetricSetTest.java
+++ b/atlasdb-api/src/test/java/com/palantir/atlasdb/metrics/DisjointUnionTaggedMetricSetTest.java
@@ -17,7 +17,6 @@
 package com.palantir.atlasdb.metrics;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Map;
 
@@ -76,11 +75,12 @@ public class DisjointUnionTaggedMetricSetTest {
     }
 
     @Test
-    public void throwsIfConflictDetected() {
-        registry1.timer(METRIC_NAME_1);
+    public void doesNotReplaceIfConflictDetected() {
+        Timer timer = registry1.timer(METRIC_NAME_1);
         registry2.timer(METRIC_NAME_1);
 
-        assertThatThrownBy(disjointUnionTaggedMetricSet::getMetrics).isInstanceOf(IllegalArgumentException.class);
+        assertThat(disjointUnionTaggedMetricSet.getMetrics()).containsExactlyInAnyOrderEntriesOf(
+                ImmutableMap.of(METRIC_NAME_1, timer));
     }
 
     @Test

--- a/changelog/@unreleased/pr-4935.v2.yml
+++ b/changelog/@unreleased/pr-4935.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '`DisjointUnionTaggedMetricSet` no longer throws if metric names conflict.'
+  links:
+  - https://github.com/palantir/atlasdb/pull/4935


### PR DESCRIPTION
**Goals (and why)**:
Fixes https://github.com/palantir/atlasdb/issues/4927

**Implementation Description (bullets)**:
Change the implementation of `DisjointUnionTaggedMetricSet#getMetrics` to ignore duplicate metrics instead of throwing. As demonstrated in the issue, it is very easy to accidentally introduce duplicate metrics because Atlas uses both `MetricRegistry` and `TaggedMetricRegistry` extensively to instrument service interfaces.

This matches the behavior of a single `MetricRegistry` or `TaggedMetricRegistry` which simply ignore attempts to register duplicate metrics.

Ultimately, the long-term solution is to:
- Stop using `MetricRegistry` and instead use `TaggedMetricRegistry` everywhere.
- Add tags when instrumenting service interfaces to deconflict multiple instrumentations of the same interface.

**Concerns (what feedback would you like?)**:
- Do we want to log if we are replacing metrics?