### PR TITLE
[PD$-110002] Part 14: TargetedSweepOutcomes should be protected by the TargetedSweepMetricsPublicationFilter

### DIFF
--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/metrics/SweepOutcomeMetricsTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/metrics/SweepOutcomeMetricsTest.java
@@ -116,20 +116,20 @@ public class SweepOutcomeMetricsTest {
 
     @Test
     public void canFilterOutUninterestingMetrics() {
-        MetricsManager differentManager = MetricsManagers.createAlwaysSafeAndFilteringForTests();
         SweepOutcomeMetrics.registerTargeted(
                 metricsManager,
                 ImmutableMap.of("strategy", "thorough"),
                 () -> false);
         TargetedSweepMetrics targetedMetrics = TargetedSweepMetrics
-                .create(differentManager, mock(TimelockService.class), new InMemoryKeyValueService(true),
+                .create(metricsManager, mock(TimelockService.class), new InMemoryKeyValueService(true),
                         TargetedSweepMetrics.MetricsConfiguration.builder()
                                 .millisBetweenRecomputingMetrics(Long.MAX_VALUE)
                                 .build());
 
         SweepOutcomeMetrics.TARGETED_OUTCOMES.forEach(outcome -> {
             targetedMetrics.registerOccurrenceOf(ShardAndStrategy.thorough(1), outcome);
-            assertThat(metricsManager).hasNotRegisteredTargetedOutcome(THOROUGH, outcome);
         });
+
+        org.assertj.core.api.Assertions.assertThat(metricsManager.getPublishableMetrics().getMetrics()).isEmpty();
     }
 }

--- a/changelog/@unreleased/pr-4936.v2.yml
+++ b/changelog/@unreleased/pr-4936.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Targeted sweep no longer publishes metrics for a given sweep strategy
+    if it is inactive (defined as fewer than 1000 entries written to the queue, 1000
+    entries read, or 4 hours behind).
+  links:
+  - https://github.com/palantir/atlasdb/pull/4936


### PR DESCRIPTION
**Goals (and why)**:
- Save money

**Implementation Description (bullets)**:
- Don't publish targeted sweep metrics if the filter rejects them.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- TargetedSweepMetricsTest should validate I haven't broken anything.

**Concerns (what feedback would you like?)**:
- If targeted sweep is broken and ERRORing then we won't know via metrics until 1,000 writes have been enqueued or we are 4 hours behind. Is this too much of a price to pay? This is still available in logs ("Targeted sweep for {} failed and will be retried later").
- Did I accidentally slip in a memory leak? See #4930 

**Where should we start reviewing?**: SweepOutcomeMetrics

**Priority (whenever / two weeks / yesterday)**: this week: not massively high priority, but would like to close this workstream out.