### PR TITLE
Reuse Dialogue Factory in Timelock Adjudication Service

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -572,11 +572,11 @@ public abstract class TransactionManagers {
             Refreshable<AtlasDbRuntimeConfig> runtimeConfig) {
         if (isUsingTimeLock(config, runtimeConfig.current())) {
             Refreshable<List<TimeLockClientFeedbackService>> refreshableTimeLockClientFeedbackServices
-                    = getTimeLockClientFeedbackServices(config, runtimeConfig, userAgent());
+                    = getTimeLockClientFeedbackServices(config, runtimeConfig, userAgent(), reloadingFactory());
             return Optional.of(initializeCloseable(
                     () -> TimeLockFeedbackBackgroundTask.create(
                             globalTaggedMetricRegistry(),
-                            () -> AtlasDbVersion.readVersion(),
+                            AtlasDbVersion::readVersion,
                             serviceName(),
                             refreshableTimeLockClientFeedbackServices,
                             namespace()), closeables));
@@ -587,10 +587,10 @@ public abstract class TransactionManagers {
     @VisibleForTesting
     static Refreshable<List<TimeLockClientFeedbackService>> getTimeLockClientFeedbackServices(AtlasDbConfig config,
             Refreshable<AtlasDbRuntimeConfig> runtimeConfig,
-            UserAgent userAgent) {
+            UserAgent userAgent,
+            DialogueClients.ReloadingFactory reloadingFactory) {
         Refreshable<ServerListConfig> serverListConfigSupplier =
                 getServerListConfigSupplierForTimeLock(config, runtimeConfig);
-        DialogueClients.ReloadingFactory reloadingFactory = newMinimalDialogueFactory();
 
         BroadcastDialogueClientFactory broadcastDialogueClientFactory = BroadcastDialogueClientFactory.create(
                 reloadingFactory,

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
@@ -105,6 +105,7 @@ import com.palantir.atlasdb.transaction.TransactionConfig;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.atlasdb.util.MetricsManagers;
+import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.conjure.java.api.config.service.ServicesConfigBlock;
 import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.api.config.service.UserAgents;
@@ -917,7 +918,11 @@ public class TransactionManagersTest {
                 Refreshable.create(mockAtlasDbRuntimeConfig);
         Refreshable<List<TimeLockClientFeedbackService>> timeLockClientFeedbackServices =
                 TransactionManagers.getTimeLockClientFeedbackServices(
-                        config, refreshableRuntimeConfig, USER_AGENT);
+                        config,
+                        refreshableRuntimeConfig,
+                        USER_AGENT,
+                        DialogueClients.create(Refreshable.only(ServicesConfigBlock.builder().build()))
+                                .withBlockingExecutor(PTExecutors.newCachedThreadPool("atlas-dialogue-blocking")));
         ConjureTimeLockClientFeedback feedbackReport = ConjureTimeLockClientFeedback
                 .builder()
                 .atlasVersion("1.0")

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
@@ -921,8 +921,7 @@ public class TransactionManagersTest {
                         config,
                         refreshableRuntimeConfig,
                         USER_AGENT,
-                        DialogueClients.create(Refreshable.only(ServicesConfigBlock.builder().build()))
-                                .withBlockingExecutor(PTExecutors.newCachedThreadPool()));
+                        DialogueClients.create(Refreshable.only(ServicesConfigBlock.builder().build())));
         ConjureTimeLockClientFeedback feedbackReport = ConjureTimeLockClientFeedback
                 .builder()
                 .atlasVersion("1.0")

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
@@ -922,7 +922,7 @@ public class TransactionManagersTest {
                         refreshableRuntimeConfig,
                         USER_AGENT,
                         DialogueClients.create(Refreshable.only(ServicesConfigBlock.builder().build()))
-                                .withBlockingExecutor(PTExecutors.newCachedThreadPool("atlas-dialogue-blocking")));
+                                .withBlockingExecutor(PTExecutors.newCachedThreadPool()));
         ConjureTimeLockClientFeedback feedbackReport = ConjureTimeLockClientFeedback
                 .builder()
                 .atlasVersion("1.0")

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
@@ -105,7 +105,6 @@ import com.palantir.atlasdb.transaction.TransactionConfig;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.atlasdb.util.MetricsManagers;
-import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.conjure.java.api.config.service.ServicesConfigBlock;
 import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.api.config.service.UserAgents;

--- a/changelog/@unreleased/pr-4937.v2.yml
+++ b/changelog/@unreleased/pr-4937.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: AtlasDB clients now re-use a Dialogue `ReloadingFactory` across standard
+    TimeLock and Adjudication use-cases, and correctly respect user-provided factories
+    for the latter.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4937

--- a/changelog/@unreleased/pr-4937.v2.yml
+++ b/changelog/@unreleased/pr-4937.v2.yml
@@ -1,5 +1,5 @@
-type: improvement
-improvement:
+type: fix
+fix:
   description: AtlasDB clients now re-use a Dialogue `ReloadingFactory` across standard
     TimeLock and Adjudication use-cases, and correctly respect user-provided factories
     for the latter.


### PR DESCRIPTION
**Goals (and why)**:
- Reuse Dialogue clients as much as possible, for performance reasons.

**Implementation Description (bullets)**:
- TimeLock Adjudication created its own ReloadingFactory, but it should use the same base one as the normal TimeLock client, and where it's provided (e.g. in AtlasDB Proxy) we *really* should reuse them.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- None :( Is there a good way to test this?

**Concerns (what feedback would you like?)**:
- Is there a good way to test this?

**Where should we start reviewing?**: small

**Priority (whenever / two weeks / yesterday)**: this week please
