### PR TITLE
Much less ram used by disruptors

### DIFF
--- a/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/BatchElement.java
+++ b/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/BatchElement.java
@@ -16,7 +16,17 @@
 
 package com.palantir.atlasdb.autobatch;
 
+import org.immutables.value.Value;
+
+@Value.Immutable
 public interface BatchElement<T, R> {
+    @Value.Parameter
     T argument();
+
+    @Value.Parameter
     DisruptorAutobatcher.DisruptorFuture<R> result();
+
+    static <T, R> BatchElement<T, R> of(T argument, DisruptorAutobatcher.DisruptorFuture<R> result) {
+        return ImmutableBatchElement.of(argument, result);
+    }
 }

--- a/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/BatchElement.java
+++ b/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/BatchElement.java
@@ -16,11 +16,14 @@
 
 package com.palantir.atlasdb.autobatch;
 
+import javax.annotation.Nullable;
+
 import org.immutables.value.Value;
 
 @Value.Immutable
 public interface BatchElement<T, R> {
     @Value.Parameter
+    @Nullable
     T argument();
 
     @Value.Parameter

--- a/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/DisruptorAutobatcher.java
+++ b/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/DisruptorAutobatcher.java
@@ -162,7 +162,8 @@ public final class DisruptorAutobatcher<T, R>
             String safeLoggablePurpose) {
         Disruptor<DisruptorBatchElement<T, R>> disruptor =
                 new Disruptor<>(DisruptorBatchElement::new, bufferSize, threadFactory(safeLoggablePurpose));
-        disruptor.handleEventsWith((event, sequence, endOfBatch) -> eventHandler.onEvent(event.consume(), sequence, endOfBatch));
+        disruptor.handleEventsWith(
+                (event, sequence, endOfBatch) -> eventHandler.onEvent(event.consume(), sequence, endOfBatch));
         disruptor.start();
         return new DisruptorAutobatcher<>(disruptor, disruptor.getRingBuffer(), safeLoggablePurpose);
     }

--- a/changelog/@unreleased/pr-4941.v2.yml
+++ b/changelog/@unreleased/pr-4941.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Much less ram used by disruptors.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4941


### PR DESCRIPTION
Disruptors at the moment hold their arguments and results for potentially far longer
than their expected lifetime. We use large buffers and so likely 16k copies of the arg
and result are held, per autobatcher (internally we might have 300, or 5M copies of the results, spans, etc).