### PR TITLE
Config checks 1

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
@@ -362,7 +362,12 @@ public abstract class AtlasDbConfig {
                     keyValueService().getClass());
 
             if (namespace().isPresent()) {
-                return namespace().get();
+                String atlasNamespace = namespace().get();
+                timelock().ifPresent(timelock -> timelock.client().ifPresent(client ->
+                        Preconditions.checkState(client.equals(atlasNamespace),
+                                "If present, the TimeLock client config should be the same as the"
+                                        + " atlas root-level namespace config.")));
+                return atlasNamespace;
             }
 
             if (timelock().isPresent()) {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
@@ -334,7 +334,7 @@ public abstract class AtlasDbConfig {
                 TimeLockClientConfig timeLockConfig = timelock().get();
 
                 com.palantir.logsafe.Preconditions.checkState(timeLockConfig.client().isPresent(),
-                        "Client must be explicitly specified if using TimeLock.");
+                        "TimeLock client config should be present if kvs namespace is explicitly specified.");
 
                 // In this case, we need to change the TimeLock client name to be equal to the KVS namespace
                 // (C* keyspace / Postgres dbName / Oracle sid). But changing the name of the TimeLock client
@@ -349,7 +349,7 @@ public abstract class AtlasDbConfig {
             return keyValueServiceNamespace;
         } else if (!(keyValueService() instanceof InMemoryAtlasDbConfig)) {
             Preconditions.checkState(!(keyValueService().type().equals("cassandra")),
-                    "Keyspace must be explicitly specified if using Cassandra.");
+                    "The keyspace config needs to be set if using Cassandra.");
 
             Preconditions.checkState(namespace().isPresent(),
                     "Either the atlas root-level namespace"

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
@@ -360,6 +360,11 @@ public abstract class AtlasDbConfig {
             Preconditions.checkState(keyValueService() instanceof InMemoryAtlasDbConfig,
                     "Expecting KeyValueServiceConfig to be instance of InMemoryAtlasDbConfig, found %s",
                     keyValueService().getClass());
+
+            if (namespace().isPresent()) {
+                return namespace().get();
+            }
+
             if (timelock().isPresent()) {
                 return timelock().get().client().orElseThrow(() -> new SafeIllegalStateException(
                         "For InMemoryKVS, the TimeLock client should not be empty"));

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/debug/TransactionPostMortemRunner.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/debug/TransactionPostMortemRunner.java
@@ -200,7 +200,7 @@ public class TransactionPostMortemRunner {
     }
 
     private static String timelockNamespace(AtlasDbConfig config) {
-        return config.timelock().flatMap(TimeLockClientConfig::client).orElse(config.namespace().get());
+        return config.timelock().flatMap(TimeLockClientConfig::client).orElseGet(config.namespace()::get);
     }
 
     private static Supplier<ServerListConfig> getServerListConfigSupplierForTimeLock(

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/debug/TransactionPostMortemRunner.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/debug/TransactionPostMortemRunner.java
@@ -51,7 +51,6 @@ import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.refreshable.Refreshable;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
-import com.palantir.util.OptionalResolver;
 
 /**
  * TODO(fdesouza): Remove this once PDS-95791 is resolved.
@@ -201,8 +200,7 @@ public class TransactionPostMortemRunner {
     }
 
     private static String timelockNamespace(AtlasDbConfig config) {
-        return OptionalResolver.resolve(
-                config.timelock().flatMap(TimeLockClientConfig::client), config.namespace());
+        return config.timelock().flatMap(TimeLockClientConfig::client).orElse(config.namespace().get());
     }
 
     private static Supplier<ServerListConfig> getServerListConfigSupplierForTimeLock(

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -192,7 +192,6 @@ import com.palantir.timestamp.TimestampService;
 import com.palantir.timestamp.TimestampStoreInvalidator;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
-import com.palantir.util.OptionalResolver;
 
 @Value.Immutable
 @Value.Style(stagedBuilder = true)
@@ -623,8 +622,8 @@ public abstract class TransactionManagers {
 
     @Value.Derived
     String namespace() {
-        return Stream.of(config().namespace(),
-                config().timelock().flatMap(TimeLockClientConfig::client),
+        return Stream.of(config().timelock().flatMap(TimeLockClientConfig::client),
+                config().namespace(),
                 config().keyValueService().namespace())
                 .filter(Optional::isPresent)
                 .map(Optional::get)
@@ -1086,8 +1085,7 @@ public abstract class TransactionManagers {
         Refreshable<ServerListConfig> serverListConfigSupplier =
                 getServerListConfigSupplierForTimeLock(config, runtimeConfig);
 
-        String timelockNamespace = OptionalResolver.resolve(
-                config.timelock().flatMap(TimeLockClientConfig::client), config.namespace());
+        String timelockNamespace = config.timelock().flatMap(TimeLockClientConfig::client).orElse(config.namespace().get());
         LockAndTimestampServices lockAndTimestampServices =
                 getLockAndTimestampServices(
                         metricsManager,

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -1085,7 +1085,8 @@ public abstract class TransactionManagers {
         Refreshable<ServerListConfig> serverListConfigSupplier =
                 getServerListConfigSupplierForTimeLock(config, runtimeConfig);
 
-        String timelockNamespace = config.timelock().flatMap(TimeLockClientConfig::client).orElse(config.namespace().get());
+        String timelockNamespace = config.timelock().flatMap(TimeLockClientConfig::client)
+                .orElseGet(config.namespace()::get);
         LockAndTimestampServices lockAndTimestampServices =
                 getLockAndTimestampServices(
                         metricsManager,


### PR DESCRIPTION
**Goals (and why)**:
Add support for additional namespaces i.e. it should be possible to use different namespaces when oracle DB is shared by multiple services. 

**Implementation Description (bullets)**:

Modified AtlasDBConfig validation checks - 

- For Cassandra Kvs, keyspace must be specified otherwise we throw

- For Cassandra Kvs, if timeLock is used, namespace must be specified and should be equal to keyspace

- It is allowed to have timeLock namespace != atlas namespace if kvs namespace is not specified


**Testing (What was existing testing like?  What have you done to improve it?)**:
Modified existing tests

**Concerns (what feedback would you like?)**:
Are the relaxed rules invitation for data corruption tickets?

**Where should we start reviewing?**:
AtlasDBConfig

**Priority (whenever / two weeks / yesterday)**:
As soon as possible
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
