### PR TITLE
[PDS-130107] Enable Divergent KVS Namespaces and TimeLock Clients

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
@@ -343,10 +343,10 @@ public abstract class AtlasDbConfig {
                             "If present, keyspace/dbName/sid config should be the same as the"
                                     + " atlas root-level namespace config."));
 
-            timelock().ifPresent(timelock -> timelock.client().ifPresent(client ->
+            timelock().flatMap(TimeLockClientConfig::client).ifPresent(client ->
                     Preconditions.checkState(client.equals(presentNamespace),
                             "If present, the TimeLock client config should be the same as the"
-                                    + " atlas root-level namespace config.")));
+                                    + " atlas root-level namespace config."));
             return;
         }
 

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
@@ -372,8 +372,8 @@ public abstract class AtlasDbConfig {
             Preconditions.checkState(timeLockConfig.client().isPresent(),
                     "Either the atlas root-level namespace config or the TimeLock client config should be present.");
 
-            if (keyValueService().type().equals("cassandra") ||
-                    !enableNonstandardAndPossiblyErrorProneTopologyAllowDifferentKvsAndTimelockNamespaces()) {
+            if (keyValueService().type().equals("cassandra")
+                    || !enableNonstandardAndPossiblyErrorProneTopologyAllowDifferentKvsAndTimelockNamespaces()) {
                 Preconditions.checkState(timeLockConfig.client().equals(
                         Optional.of(keyValueServiceNamespace)),
                         "AtlasDB refused to start, in order to avoid potential data corruption."

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
@@ -369,7 +369,7 @@ public abstract class AtlasDbConfig {
         if (timelock().isPresent()) {
             TimeLockClientConfig timeLockConfig = timelock().get();
 
-            com.palantir.logsafe.Preconditions.checkState(timeLockConfig.client().isPresent(),
+            Preconditions.checkState(timeLockConfig.client().isPresent(),
                     "Either the atlas root-level namespace config or the TimeLock client config should be present.");
 
             if (keyValueService().type().equals("cassandra") ||

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbConfigTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbConfigTest.java
@@ -18,7 +18,6 @@ package com.palantir.atlasdb.config;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;

--- a/changelog/@unreleased/pr-4948.v2.yml
+++ b/changelog/@unreleased/pr-4948.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: AtlasDB now allows configuration to accept different KVS namespaces
+    and timelock clients, provided this is explicitly enabled AND the user is not
+    using Cassandra. This was previously banned in all cases.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4948


### PR DESCRIPTION
**Goals (and why)**:
- Used in some DBKVS use cases, where through the use of table mapping it is legitimate to have multiple AtlasDB users interface with the same KVS in the same way.
- Minimise the risk that anyone who does not need this use case actually tries to (this is very error prone).

**Implementation Description (bullets)**:
- Allow the config to accept different KVS namespaces and timelock clients, provided this is explicitly enabled AND the user is not using Cassandra.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Added a few new tests for new cases in the configuration

**Concerns (what feedback would you like?)**:
- Are there correctness issues?

**Where should we start reviewing?**:
paired

**Priority (whenever / two weeks / yesterday)**: this week or early next
