### PR TITLE
Relieve Flakes - Make Stress Test Run Slightly Longer

### DIFF
--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -455,9 +455,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
     }
 
     private static void assertNumberOfThreadsReasonable(int startingThreads, int threadCount, boolean nonLeaderDown) {
-        // TODO (jkong): Lower the amount over the threshold. This needs to be slightly higher for now because of the
-        // current threading model in batch mode, where separate threads may be spun up on the autobatcher.
-        int threadLimit = startingThreads + 800;
+        int threadLimit = startingThreads + 1000;
         if (nonLeaderDown) {
             if (threadCount > threadLimit) {
                 System.out.println("hello");

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -437,7 +437,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
         int startingNumThreads = ManagementFactory.getThreadMXBean().getThreadCount();
         boolean isNonLeaderTakenOut = false;
         try {
-            for (int i = 0; i < 1_500; i++) { // Needed as it takes a while for the thread buildup to occur
+            for (int i = 0; i < 1_800; i++) { // Needed as it takes a while for the thread buildup to occur
                 assertNumberOfThreadsReasonable(
                         startingNumThreads,
                         ManagementFactory.getThreadMXBean().getThreadCount(),

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -457,9 +457,6 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
     private static void assertNumberOfThreadsReasonable(int startingThreads, int threadCount, boolean nonLeaderDown) {
         int threadLimit = startingThreads + 1000;
         if (nonLeaderDown) {
-            if (threadCount > threadLimit) {
-                System.out.println("hello");
-            }
             assertThat(threadCount)
                     .as("should not additionally spin up too many threads after a non-leader failed")
                     .isLessThanOrEqualTo(threadLimit);


### PR DESCRIPTION
**Goals (and why)**:
- The stress test started flaking a lot more, probably because our containers might be a bit weaker here and the theoretical permitted bound of thread blow-up with a bad node (770 if I'm not mistaken) is very close to our 800 limit.

**Implementation Description (bullets)**:
- Increase the allowance to 1,000.
- Add a few more requests on the tail end of the paxos test, so that an implementation that spins up unbounded threads talking to the bad node will still fail.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- This PR is about tests.

**Concerns (what feedback would you like?)**:
- Please validate the test still retains discriminatory power.

**Where should we start reviewing?**:
- the test

**Priority (whenever / two weeks / yesterday)**: yesterday 🔥  rate of build flakes now is wild