### PR TITLE
Pingv2 fallback

### DIFF
--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/SinglePingableLeaderTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/SinglePingableLeaderTest.java
@@ -91,8 +91,8 @@ public class SinglePingableLeaderTest {
         availableServer.stubFor(PING_V2_MAPPING.willReturn(WireMock.aResponse().withStatus(200)
                 .withBody("{\"isLeader\":false}")));
         pingerWithVersion(OrderableSlsVersion.valueOf("1.1.1")).pingLeaderWithUuid(REMOTE_UUID);
-        assertLegacyPingRequestsMade(1);
-        assertPingV2RequestsMadeAreAtMost(0);
+        assertPingV2RequestsMadeAreExactly(1);
+        assertLegacyPingRequestsMade(0);
     }
 
 
@@ -117,19 +117,22 @@ public class SinglePingableLeaderTest {
     public void verifyPingRequests(int totalNumOfPings, int verifyLegacyPingRequests) {
         LeaderPinger pinger = pingerWithVersion(OrderableSlsVersion.valueOf("1.1.1"));
         IntStream.range(0, totalNumOfPings).forEach(idx -> pinger.pingLeaderWithUuid(REMOTE_UUID));
-
-        List<LoggedRequest> requests = WireMock.findAll(WireMock.getRequestedFor(WireMock.urlMatching(PING_V2)));
-        assertThat(requests.size()).isLessThan(totalNumOfPings);
-        assertPingV2RequestsMadeAreAtMost(verifyLegacyPingRequests);
+        assertPingV2RequestsMadeAreAtMost(totalNumOfPings);
+        assertLegacyPingRequestsMade(verifyLegacyPingRequests);
     }
 
     public void assertPingV2RequestsMadeAreAtMost(int count) {
-        List<LoggedRequest> requests = WireMock.findAll(WireMock.getRequestedFor(WireMock.urlMatching(PING)));
+        List<LoggedRequest> requests = WireMock.findAll(WireMock.getRequestedFor(WireMock.urlMatching(PING_V2)));
+        assertThat(requests.size()).isLessThan(count);
+    }
+
+    public void assertPingV2RequestsMadeAreExactly(int count) {
+        List<LoggedRequest> requests = WireMock.findAll(WireMock.getRequestedFor(WireMock.urlMatching(PING_V2)));
         assertThat(requests.size()).isEqualTo(count);
     }
 
     public void assertLegacyPingRequestsMade(int count) {
-        List<LoggedRequest> requests = WireMock.findAll(WireMock.getRequestedFor(WireMock.urlMatching(PING_V2)));
+        List<LoggedRequest> requests = WireMock.findAll(WireMock.getRequestedFor(WireMock.urlMatching(PING)));
         assertThat(requests.size()).isEqualTo(count);
     }
 

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/SinglePingableLeaderTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/SinglePingableLeaderTest.java
@@ -99,7 +99,7 @@ public class SinglePingableLeaderTest {
     public void fallbackOnPingWhenPingV2DoesNotExist() {
         availableServer.stubFor(PING_V2_MAPPING.willReturn(WireMock.aResponse().withStatus(404)));
         LeaderPinger pinger = getDefaultLeaderPinger();
-        IntStream.range(0, 5).forEach(idx -> pinger.pingLeaderWithUuid(REMOTE_UUID));
+        pingMultipleTimes(pinger, 5);
         assertPingV2RequestsMadeAreLessThan(5);
         assertLegacyPingRequestsMade(5);
     }
@@ -108,7 +108,7 @@ public class SinglePingableLeaderTest {
     public void fallbackOnPingWhenPingV2ThrowsEvenWhenPingV2Exists() {
         availableServer.stubFor(PING_V2_MAPPING.willReturn(WireMock.aResponse().withStatus(500)));
         LeaderPinger pinger = getDefaultLeaderPinger();
-        IntStream.range(0, 5).forEach(idx -> pinger.pingLeaderWithUuid(REMOTE_UUID));
+        pingMultipleTimes(pinger, 5);
         assertPingV2RequestsMadeAreLessThan(5);
         assertLegacyPingRequestsMade(5);
     }
@@ -117,7 +117,7 @@ public class SinglePingableLeaderTest {
     public void samplesRequestsToFailingPing2() {
         availableServer.stubFor(PING_V2_MAPPING.willReturn(WireMock.aResponse().withStatus(500)));
         LeaderPinger pinger = getDefaultLeaderPinger();
-        IntStream.range(0, 100).forEach(idx -> pinger.pingLeaderWithUuid(REMOTE_UUID));
+        pingMultipleTimes(pinger, 100);
         assertPingV2RequestsMadeAreLessThan(100);
         assertLegacyPingRequestsMade(100);
     }
@@ -137,7 +137,11 @@ public class SinglePingableLeaderTest {
         assertThat(requests.size()).isEqualTo(count);
     }
 
-    public LeaderPinger getDefaultLeaderPinger() {
+    private void pingMultipleTimes(LeaderPinger pinger, int pingFrequency) {
+        IntStream.range(0, pingFrequency).forEach(idx -> pinger.pingLeaderWithUuid(REMOTE_UUID));
+    }
+
+    private LeaderPinger getDefaultLeaderPinger() {
         return pingerWithVersion(OrderableSlsVersion.valueOf("1.1.1"));
     }
 

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/SinglePingableLeaderTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/SinglePingableLeaderTest.java
@@ -1,0 +1,131 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.github.tomakehurst.wiremock.client.MappingBuilder;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.palantir.atlasdb.config.RemotingClientConfigs;
+import com.palantir.atlasdb.factory.Leaders;
+import com.palantir.atlasdb.factory.ServiceCreator;
+import com.palantir.common.concurrent.CheckedRejectionExecutorService;
+import com.palantir.conjure.java.api.config.service.UserAgent;
+import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
+import com.palantir.leader.PingableLeader;
+import com.palantir.paxos.LeaderPinger;
+import com.palantir.paxos.LeaderPingerContext;
+import com.palantir.paxos.SingleLeaderPinger;
+import com.palantir.sls.versions.OrderableSlsVersion;
+
+public class SinglePingableLeaderTest {
+    private static final UUID LOCAL_UUID = UUID.randomUUID();
+    private static final UUID REMOTE_UUID = UUID.randomUUID();
+    private static final UserAgent USER_AGENT = UserAgent.of(UserAgent.Agent.of("user-agent", "0.27.1"));
+    private final ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+    private static final String PING = "/leader/ping";
+    private static final String PING_V2 = "/leader/pingV2";
+    private static final String UUID_PATH = "/leader/uuid";
+
+    private static final MappingBuilder PING_MAPPING = WireMock.get(WireMock.urlEqualTo(PING));
+    private static final MappingBuilder PING_V2_MAPPING = WireMock.get(WireMock.urlEqualTo(PING_V2));
+    private static final MappingBuilder UUID_MAPPING = WireMock.get(WireMock.urlEqualTo(UUID_PATH));
+
+    private static final SslConfiguration SSL_CONFIGURATION
+            = SslConfiguration.of(Paths.get("var/security/trustStore.jks"));
+
+    private int availablePort;
+    private String serverUri;
+
+    @Rule
+    public WireMockRule availableServer = new WireMockRule(WireMockConfiguration.wireMockConfig().dynamicPort());
+
+    @Before
+    public void setup() {
+        availableServer.stubFor(UUID_MAPPING.willReturn(aResponse().withStatus(200).withBody(
+                ("\"" + REMOTE_UUID.toString() + "\"").getBytes())));
+
+        availableServer.stubFor(PING_MAPPING.willReturn(WireMock.aResponse().withStatus(204)));
+
+        availablePort = availableServer.port();
+        serverUri = String.format("http://%s:%s", WireMockConfiguration.DEFAULT_BIND_ADDRESS, availablePort);
+    }
+
+    @Test
+    public void doesNotFallbackOnPingWhenPingV2Responds() {
+        availableServer.stubFor(PING_V2_MAPPING.willReturn(WireMock.aResponse().withStatus(200)
+                .withBody("{\"isLeader\":false}")));
+        verifyPingRequests(1, 0);
+    }
+
+    @Test
+    public void fallbackOnPingWhenPingV2DoesNotExist() {
+        availableServer.stubFor(PING_V2_MAPPING.willReturn(WireMock.aResponse().withStatus(404)));
+        verifyPingRequests(1, 1);
+    }
+
+    @Test
+    public void fallbackOnPingWhenPingV2Throws() {
+        availableServer.stubFor(PING_V2_MAPPING.willReturn(WireMock.aResponse().withStatus(500)));
+        verifyPingRequests(1, 1);
+    }
+
+    public void verifyPingRequests(int pingV2RequestCount, int pingRequestCount) {
+        LeaderPinger pinger = pingerWithVersion(OrderableSlsVersion.valueOf("1.1.1"));
+        pinger.pingLeaderWithUuid(REMOTE_UUID);
+        List<LoggedRequest> requests = WireMock.findAll(WireMock.getRequestedFor(WireMock.urlMatching(PING_V2)));
+        assertThat(requests.size()).isEqualTo(pingV2RequestCount);
+        requests = WireMock.findAll(WireMock.getRequestedFor(WireMock.urlMatching(PING)));
+        assertThat(requests.size()).isEqualTo(pingRequestCount);
+    }
+
+    private LeaderPinger pingerWithVersion(OrderableSlsVersion version) {
+        List<LeaderPingerContext<PingableLeader>> otherLeaders = Leaders.generatePingables(
+                ImmutableList.of(serverUri),
+                () -> RemotingClientConfigs.DEFAULT,
+                ServiceCreator.createTrustContext(Optional.of(SSL_CONFIGURATION)),
+                USER_AGENT);
+        return new SingleLeaderPinger(
+                ImmutableMap.of(
+                        otherLeaders.get(0),
+                        new CheckedRejectionExecutorService(executorService)),
+                Duration.ofSeconds(5),
+                LOCAL_UUID,
+                true,
+                Optional.of(version));
+    }
+}

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/SinglePingableLeaderTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/SinglePingableLeaderTest.java
@@ -100,7 +100,7 @@ public class SinglePingableLeaderTest {
     @Test
     public void fallbackOnPingWhenPingV2DoesNotExist() {
         availableServer.stubFor(PING_V2_MAPPING.willReturn(WireMock.aResponse().withStatus(404)));
-        verifyPingRequests( 5, 5);
+        verifyPingRequests(5, 5);
     }
 
     @Test

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/SinglePingableLeaderTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/SinglePingableLeaderTest.java
@@ -110,7 +110,7 @@ public class SinglePingableLeaderTest {
     }
 
     @Test
-    public void blah() {
+    public void samplesRequestsToFailingPing2() {
         availableServer.stubFor(PING_V2_MAPPING.willReturn(WireMock.aResponse().withStatus(500)));
         verifyPingRequests(100, 100);
     }

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/SinglePingableLeaderTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/SinglePingableLeaderTest.java
@@ -104,13 +104,13 @@ public class SinglePingableLeaderTest {
         verifyPingRequests(1, 1);
     }
 
-    public void verifyPingRequests(int pingV2RequestCount, int pingRequestCount) {
+    public void verifyPingRequests(int verifyPingV2Requests, int verifyLegacyPingRequests) {
         LeaderPinger pinger = pingerWithVersion(OrderableSlsVersion.valueOf("1.1.1"));
         pinger.pingLeaderWithUuid(REMOTE_UUID);
         List<LoggedRequest> requests = WireMock.findAll(WireMock.getRequestedFor(WireMock.urlMatching(PING_V2)));
-        assertThat(requests.size()).isEqualTo(pingV2RequestCount);
+        assertThat(requests.size()).isEqualTo(verifyPingV2Requests);
         requests = WireMock.findAll(WireMock.getRequestedFor(WireMock.urlMatching(PING)));
-        assertThat(requests.size()).isEqualTo(pingRequestCount);
+        assertThat(requests.size()).isEqualTo(verifyLegacyPingRequests);
     }
 
     private LeaderPinger pingerWithVersion(OrderableSlsVersion version) {

--- a/changelog/@unreleased/pr-4953.v2.yml
+++ b/changelog/@unreleased/pr-4953.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: |
+    We now fallback on ping endpoint to check if remote server is the leader if pingV2 endpoint throws exception.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4953

--- a/leader-election-impl/src/main/java/com/palantir/paxos/LeaderPingResult.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/LeaderPingResult.java
@@ -55,6 +55,12 @@ public abstract class LeaderPingResult {
                 .otherwise_(false);
     }
 
+    public boolean pingCallFailed() {
+        return LeaderPingResults.caseOf(this)
+                .pingCallFailure_(true)
+                .otherwise_(false);
+    }
+
     private static <R> Supplier<R> wrap(Runnable runnable) {
         return () -> {
             runnable.run();

--- a/leader-election-impl/src/main/java/com/palantir/paxos/LeaderPingResult.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/LeaderPingResult.java
@@ -36,6 +36,7 @@ public abstract class LeaderPingResult {
         R pingReturnedTrueWithOlderVersion(OrderableSlsVersion version);
         R pingReturnedFalse();
         R pingCallFailure(Throwable exception);
+        R pingCallFailedWithExecutionException(Throwable exception);
     }
 
     public abstract <R> R match(Cases<R> cases);
@@ -55,9 +56,17 @@ public abstract class LeaderPingResult {
                 .otherwise_(false);
     }
 
-    public boolean pingCallFailed() {
+    public boolean pingCallFailedDueToExecutionException() {
         return LeaderPingResults.caseOf(this)
-                .pingCallFailure_(true)
+                .pingCallFailedWithExecutionException_(true)
+                .otherwise_(false);
+    }
+
+    public boolean pingCallWasSuccessfullyExecuted() {
+        return LeaderPingResults.caseOf(this)
+                .pingReturnedTrue_(true)
+                .pingReturnedTrueWithOlderVersion_(true)
+                .pingReturnedFalse_(true)
                 .otherwise_(false);
     }
 

--- a/leader-election-impl/src/main/java/com/palantir/paxos/LeaderPingResult.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/LeaderPingResult.java
@@ -47,6 +47,7 @@ public abstract class LeaderPingResult {
                 .pingReturnedTrueWithOlderVersion(wrap(eventRecorder::recordLeaderOnOlderVersion))
                 .pingReturnedFalse(wrap(eventRecorder::recordLeaderPingReturnedFalse))
                 .pingCallFailure(wrap(eventRecorder::recordLeaderPingFailure))
+                .pingCallFailedWithExecutionException(wrap(eventRecorder::recordLeaderPingFailure))
                 .otherwise_(null);
     }
 

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderPinger.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderPinger.java
@@ -118,7 +118,8 @@ public class SingleLeaderPinger implements LeaderPinger {
     }
 
     private LeaderPingResult actuallyPingLeaderWithUuid(
-            MultiplexingCompletionService<LeaderPingerContext<PingableLeader>, PingResult>  multiplexingCompletionService,
+            MultiplexingCompletionService<LeaderPingerContext<PingableLeader>, PingResult>
+                    multiplexingCompletionService,
             UUID uuid,
             LeaderPingerContext<PingableLeader> leader,
             Callable<PingResult> pingEndpoint) throws ExecutionException {

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderPinger.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderPinger.java
@@ -50,8 +50,6 @@ import com.palantir.sls.versions.VersionComparator;
 
 public class SingleLeaderPinger implements LeaderPinger {
     private static final Logger log = LoggerFactory.getLogger(SingleLeaderPinger.class);
-    private static final RateLimiter pingV2RateLimiter = RateLimiter.create(1.0 / (5 * 60));
-
 
     private final ConcurrentMap<UUID, LeaderPingerContext<PingableLeader>> uuidToServiceCache = Maps.newConcurrentMap();
     private final Map<LeaderPingerContext<PingableLeader>, CheckedRejectionExecutorService> leaderPingExecutors;
@@ -59,6 +57,8 @@ public class SingleLeaderPinger implements LeaderPinger {
     private final UUID localUuid;
     private final boolean cancelRemainingCalls;
     private final Optional<OrderableSlsVersion> timeLockVersion;
+    private final RateLimiter pingV2RateLimiter = RateLimiter.create(1.0 / (5 * 60));
+
     private Map<LeaderPingerContext<PingableLeader>, Boolean> pingV2StatusOnRemotes = new HashMap<>();
 
     public SingleLeaderPinger(

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderPinger.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderPinger.java
@@ -124,8 +124,7 @@ public class SingleLeaderPinger implements LeaderPinger {
     }
 
     private PingResult getPingResultFromLegacyEndpoint(LeaderPingerContext<PingableLeader> leader) {
-        boolean isLeader = leader.pinger().ping();
-        return PingResult.builder().isLeader(isLeader).build();
+        return PingResult.builder().isLeader(leader.pinger().ping()).build();
     }
 
     private LeaderPingResult actuallyPingLeaderWithUuid(
@@ -155,18 +154,15 @@ public class SingleLeaderPinger implements LeaderPinger {
         if (pingFuture == null) {
             return LeaderPingResults.pingTimedOut();
         }
-
-        PingResult pingResult = null;
         try {
-            pingResult = Futures.getDone(pingFuture).getValue();
-
+            PingResult pingResult = Futures.getDone(pingFuture).getValue();
             if (!pingResult.isLeader()) {
                 return LeaderPingResults.pingReturnedFalse();
             }
             return isAtLeastOurVersion(pingResult, timeLockVersion)
                     ? LeaderPingResults.pingReturnedTrue(
-                    uuid,
-                    Futures.getDone(pingFuture).getKey().hostAndPort())
+                            uuid,
+                            Futures.getDone(pingFuture).getKey().hostAndPort())
                     : LeaderPingResults.pingReturnedTrueWithOlderVersion(pingResult.timeLockVersion().get());
         } catch (ExecutionException e) {
             return LeaderPingResults.pingCallFailedWithExecutionException(e.getCause());

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderPinger.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderPinger.java
@@ -119,8 +119,7 @@ public class SingleLeaderPinger implements LeaderPinger {
     }
 
     private boolean shouldUsePingV2(LeaderPingerContext<PingableLeader> leader) {
-        return !pingV2StatusOnRemotes.containsKey(leader)
-                || pingV2StatusOnRemotes.get(leader) == true
+        return pingV2StatusOnRemotes.getOrDefault(leader, true)
                 || Math.random() < PING_V2_SAMPLING_RATE;
     }
 

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderPinger.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderPinger.java
@@ -94,18 +94,22 @@ public class SingleLeaderPinger implements LeaderPinger {
         LeaderPingerContext<PingableLeader> leader = suspectedLeader.get();
 
         try {
+            log.info("Blah | Attempting to ping2 leader.");
             return pingLeaderWithUuidNew(uuid,
                     leader,
                     () -> leader.pinger().pingV2());
         } catch (ExecutionException e) {
-            log.warn("failed attempt pingV2");
+            log.info("Blah | failed attempt pingV2");
+//            log.warn("failed attempt pingV2");
         }
 
         try {
+            log.info("Blah | Attempting to ping2 leader.");
             return pingLeaderWithUuidNew(uuid,
                     leader,
                     () -> getPingResultFromLegacyEndpoint(leader));
         } catch (ExecutionException ex) {
+            log.info("Blah | failed attempt ping.");
             return LeaderPingResults.pingCallFailure(ex.getCause());
         }
     }
@@ -126,10 +130,11 @@ public class SingleLeaderPinger implements LeaderPinger {
                     = multiplexingCompletionService.poll(leaderPingResponseWait.toMillis(), TimeUnit.MILLISECONDS);
             return getLeaderPingResult(uuid, pingFuture, timeLockVersion);
         } catch (InterruptedException exc) {
+            log.info("Blah | Interrupted exc.");
             Thread.currentThread().interrupt();
             return LeaderPingResults.pingCallFailure(exc);
         } catch (CheckedRejectedExecutionException e) {
-            log.warn("Could not ping the leader, because the executor used to talk to that node is overloaded", e);
+            log.warn("Blah | Could not ping the leader, because the executor used to talk to that node is overloaded", e);
             return LeaderPingResults.pingCallFailure(e);
         }
     }
@@ -139,11 +144,13 @@ public class SingleLeaderPinger implements LeaderPinger {
             @Nullable Future<Map.Entry<LeaderPingerContext<PingableLeader>, PingResult>> pingFuture,
             Optional<OrderableSlsVersion> timeLockVersion) throws ExecutionException {
         if (pingFuture == null) {
+            log.info("Blah | pingFuture was null");
             return LeaderPingResults.pingTimedOut();
         }
 
         PingResult pingResult = Futures.getDone(pingFuture).getValue();
         if (!pingResult.isLeader()) {
+            log.info("Blah | checking if the leader");
             return LeaderPingResults.pingReturnedFalse();
         }
         return isAtLeastOurVersion(pingResult, timeLockVersion)
@@ -154,6 +161,7 @@ public class SingleLeaderPinger implements LeaderPinger {
     }
 
     private static boolean isAtLeastOurVersion(PingResult pingResult, Optional<OrderableSlsVersion> timeLockVersion) {
+        log.info("Blah | checking atlas version");
         return (pingResult.timeLockVersion().isPresent() && timeLockVersion.isPresent())
                 ? VersionComparator.INSTANCE.compare(pingResult.timeLockVersion().get(), timeLockVersion.get()) >= 0
                 : true;

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderPinger.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderPinger.java
@@ -158,20 +158,18 @@ public class SingleLeaderPinger implements LeaderPinger {
         }
 
         PingResult pingResult = null;
-        LeaderPingResult leaderPingResult = null;
         try {
             pingResult = Futures.getDone(pingFuture).getValue();
 
             if (!pingResult.isLeader()) {
-                leaderPingResult = LeaderPingResults.pingReturnedFalse();
+                return LeaderPingResults.pingReturnedFalse();
             } else {
-                leaderPingResult = isAtLeastOurVersion(pingResult, timeLockVersion)
+                return isAtLeastOurVersion(pingResult, timeLockVersion)
                         ? LeaderPingResults.pingReturnedTrue(
                         uuid,
                         Futures.getDone(pingFuture).getKey().hostAndPort())
                         : LeaderPingResults.pingReturnedTrueWithOlderVersion(pingResult.timeLockVersion().get());
             }
-            return leaderPingResult;
         } catch (ExecutionException e) {
             return LeaderPingResults.pingCallFailedWithExecutionException(e.getCause());
         }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderPinger.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderPinger.java
@@ -163,13 +163,12 @@ public class SingleLeaderPinger implements LeaderPinger {
 
             if (!pingResult.isLeader()) {
                 return LeaderPingResults.pingReturnedFalse();
-            } else {
-                return isAtLeastOurVersion(pingResult, timeLockVersion)
-                        ? LeaderPingResults.pingReturnedTrue(
-                        uuid,
-                        Futures.getDone(pingFuture).getKey().hostAndPort())
-                        : LeaderPingResults.pingReturnedTrueWithOlderVersion(pingResult.timeLockVersion().get());
             }
+            return isAtLeastOurVersion(pingResult, timeLockVersion)
+                    ? LeaderPingResults.pingReturnedTrue(
+                    uuid,
+                    Futures.getDone(pingFuture).getKey().hostAndPort())
+                    : LeaderPingResults.pingReturnedTrueWithOlderVersion(pingResult.timeLockVersion().get());
         } catch (ExecutionException e) {
             return LeaderPingResults.pingCallFailedWithExecutionException(e.getCause());
         }

--- a/leader-election-impl/src/test/java/com/palantir/leader/PaxosLeaderEventsTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/PaxosLeaderEventsTest.java
@@ -60,6 +60,7 @@ public class PaxosLeaderEventsTest {
     public void recordsLeaderPingFailure() {
         RuntimeException error = new RuntimeException("foo");
         when(pingableLeader.pingV2()).thenThrow(error);
+        when(pingableLeader.ping()).thenThrow(error);
         when(pingableLeader.getUUID()).thenReturn(REMOTE_UUID.toString());
 
         LeaderPinger pinger = pingerWithTimeout(Duration.ofSeconds(10));

--- a/leader-election-impl/src/test/java/com/palantir/leader/PaxosLeaderEventsTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/PaxosLeaderEventsTest.java
@@ -65,7 +65,7 @@ public class PaxosLeaderEventsTest {
 
         LeaderPinger pinger = pingerWithTimeout(Duration.ofSeconds(10));
         assertThat(pinger.pingLeaderWithUuid(REMOTE_UUID))
-                .isEqualTo(LeaderPingResults.pingCallFailure(error));
+                .isEqualTo(LeaderPingResults.pingCallFailedWithExecutionException(error));
     }
 
     @Test


### PR DESCRIPTION
**Goals (and why)**:
Fallback to ping if pingV2 throws, this is being done to support services where there is no concept of schema.

**Implementation Description (bullets)**:

- Hit ping if pingV2 throws.

**Testing (What was existing testing like?  What have you done to improve it?)**:

- Added new tests

**Concerns (what feedback would you like?)**:

- Hitting ping when pingV2 throws with status other than 404.

**Where should we start reviewing?**:
Small

**Priority (whenever / two weeks / yesterday)**:
By end of week

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
