### PR TITLE
Don't Register Duplicate Metrics

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -1265,10 +1265,12 @@ public abstract class TransactionManagers {
             // remote services are pointed at them anyway.
             LockService dynamicLockService = LocalOrRemoteProxy.newProxyInstance(
                     LockService.class, localLock, remoteLock, useLocalServicesFuture);
+
+            // Use managedTimestampProxy here to avoid local calls going through indirection.
             TimestampService dynamicTimeService = LocalOrRemoteProxy.newProxyInstance(
-                    TimestampService.class, localTime, remoteTime, useLocalServicesFuture);
+                    TimestampService.class, managedTimestampProxy, remoteTime, useLocalServicesFuture);
             TimestampManagementService dynamicManagementService = LocalOrRemoteProxy.newProxyInstance(
-                    TimestampManagementService.class, localManagement, remoteManagement, useLocalServicesFuture);
+                    TimestampManagementService.class, managedTimestampProxy, remoteManagement, useLocalServicesFuture);
             return ImmutableLockAndTimestampServices.builder()
                     .lock(dynamicLockService)
                     .timestamp(dynamicTimeService)

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -188,6 +188,7 @@ import com.palantir.timestamp.DelegatingManagedTimestampService;
 import com.palantir.timestamp.ManagedTimestampService;
 import com.palantir.timestamp.RemoteTimestampManagementAdapter;
 import com.palantir.timestamp.TimestampManagementService;
+import com.palantir.timestamp.TimestampRange;
 import com.palantir.timestamp.TimestampService;
 import com.palantir.timestamp.TimestampStoreInvalidator;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
@@ -1187,23 +1188,16 @@ public abstract class TransactionManagers {
                 leaderConfig,
                 userAgent);
         LeaderElectionService leader = localPaxosServices.leaderElectionService();
-        LockService localLock = ServiceCreator.instrumentService(
-                metricsManager.getRegistry(),
-                AwaitingLeadershipProxy.newProxyInstance(LockService.class, lock::get, leader),
-                LockService.class);
+        LockService localLock = AwaitingLeadershipProxy.newProxyInstance(LockService.class, lock::get, leader);
 
         ManagedTimestampService managedTimestampProxy =
                 AwaitingLeadershipProxy.newProxyInstance(ManagedTimestampService.class, time::get, leader);
 
-        TimestampService localTime = ServiceCreator.instrumentService(
-                metricsManager.getRegistry(),
-                managedTimestampProxy,
-                TimestampService.class);
+        // These facades are necessary because of the semantics of the JAX-RS algorithm (in particular, accepting
+        // just the managed timestamp service will *not* work.
+        TimestampService localTime = getTimestampFacade(managedTimestampProxy);
+        TimestampManagementService localManagement = getTimestampManagementFacade(managedTimestampProxy);
 
-        TimestampManagementService localManagement = ServiceCreator.instrumentService(
-                metricsManager.getRegistry(),
-                managedTimestampProxy,
-                TimestampManagementService.class);
         env.accept(localLock);
         env.accept(localTime);
         env.accept(localManagement);
@@ -1290,6 +1284,35 @@ public abstract class TransactionManagers {
                     .timelock(new LegacyTimelockService(remoteTime, remoteLock, LOCK_CLIENT))
                     .build();
         }
+    }
+
+    private static TimestampService getTimestampFacade(ManagedTimestampService managedTimestampService) {
+        return new TimestampService() {
+            @Override
+            public long getFreshTimestamp() {
+                return managedTimestampService.getFreshTimestamp();
+            }
+
+            @Override
+            public TimestampRange getFreshTimestamps(int numTimestampsRequested) {
+                return managedTimestampService.getFreshTimestamps(numTimestampsRequested);
+            }
+        };
+    }
+
+    private static TimestampManagementService getTimestampManagementFacade(
+            ManagedTimestampService managedTimestampService) {
+        return new TimestampManagementService() {
+            @Override
+            public void fastForwardTimestamp(long currentTimestamp) {
+                managedTimestampService.fastForwardTimestamp(currentTimestamp);
+            }
+
+            @Override
+            public String ping() {
+                return managedTimestampService.ping();
+            }
+        };
     }
 
     private static int logFailureToReadRemoteTimestampServerId(int logAfter, Throwable th) {

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
@@ -613,15 +613,6 @@ public class TransactionManagersTest {
     }
 
     @Test
-    public void metricsAreReportedExactlyOnceWhenUsingLocalService() throws IOException {
-        setUpForLocalServices();
-        setUpLeaderBlockInConfig();
-
-        assertThatTimeAndLockMetricsAreRecorded(TIMESTAMP_SERVICE_FRESH_TIMESTAMP_METRIC,
-                LOCK_SERVICE_CURRENT_TIME_METRIC);
-    }
-
-    @Test
     public void metricsAreReportedExactlyOnceWhenUsingRemoteService() throws IOException {
         setUpForRemoteServices();
         setUpLeaderBlockInConfig();
@@ -776,18 +767,6 @@ public class TransactionManagersTest {
                 GenericTestSchemaTableFactory.of().getRangeScanTestTable(tx).getColumn1s(ImmutableSet.of(testRow)));
 
         assertThat(Iterables.getOnlyElement(result.entrySet()).getValue(), is(12345L));
-    }
-
-    private void assertThatTimeAndLockMetricsAreRecorded(String timestampMetric, String lockMetric) {
-        assertThat(metricsManager.getRegistry().timer(timestampMetric).getCount(), is(equalTo(0L)));
-        assertThat(metricsManager.getRegistry().timer(lockMetric).getCount(), is(equalTo(0L)));
-
-        TransactionManagers.LockAndTimestampServices lockAndTimestamp = getLockAndTimestampServices();
-        lockAndTimestamp.timelock().getFreshTimestamp();
-        lockAndTimestamp.timelock().currentTimeMillis();
-
-        assertThat(metricsManager.getRegistry().timer(timestampMetric).getCount(), is(equalTo(1L)));
-        assertThat(metricsManager.getRegistry().timer(lockMetric).getCount(), is(equalTo(1L)));
     }
 
     private void assertThatTimeAndLockMetricsWithTagsAreRecorded(


### PR DESCRIPTION
Based on @pkoenig10's #4938 but fixed to handle annoying JAX-RS semantics correctly.

**Goals (and why)**:
- See #4938

**Implementation Description (bullets)**:
- Don't wire proxies through ServiceCreator for embedded leader block
- But open TimestampService and TimestampManagementService facades so that registration works properly.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Existing tests should suffice for correctness.
- Removal of metrics is verified by removing the test involved

**Concerns (what feedback would you like?)**:
Nothing in particular

**Where should we start reviewing?**: TransactionManagers

**Priority (whenever / two weeks / yesterday)**: yesterday 🔥 
