### PR TITLE
memoize ssl socket factory creation

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -22,6 +22,8 @@ import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
 
+import javax.net.ssl.SSLSocketFactory;
+
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -186,6 +188,11 @@ public interface CassandraKeyValueServiceConfig extends KeyValueServiceConfig {
      * The existence of this object overrides any configuration made via the ssl config value.
      */
     Optional<SslConfiguration> sslConfiguration();
+
+    @Value.Lazy
+    default SSLSocketFactory sslSocketFactory() {
+        return sslSocketFactory()
+    }
 
     /**
      * An object which implements the logic behind CQL communication resource management. Default factory object creates

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -22,8 +22,6 @@ import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
 
-import javax.net.ssl.SSLSocketFactory;
-
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -188,11 +186,6 @@ public interface CassandraKeyValueServiceConfig extends KeyValueServiceConfig {
      * The existence of this object overrides any configuration made via the ssl config value.
      */
     Optional<SslConfiguration> sslConfiguration();
-
-    @Value.Lazy
-    default SSLSocketFactory sslSocketFactory() {
-        return sslSocketFactory()
-    }
 
     /**
      * An object which implements the logic behind CQL communication resource management. Default factory object creates

--- a/changelog/@unreleased/pr-4955.v2.yml
+++ b/changelog/@unreleased/pr-4955.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: memoize ssl socket factory creation
+  links:
+  - https://github.com/palantir/atlasdb/pull/4955


### PR DESCRIPTION
each ssl socket factory holds a presized 16k entry ssl session cache.
At present AtlasDB-proxy creates a new ssl socket factory per-host,
per-namespace. These really should all be the same ssl socket factory,
since the ssl configuration is the same.

We now memoize these. The config point is not the right place to do
this, since internally we mutate the configs to add extra options in a
few places - can't work via config equality.