### PR TITLE
Intern the token map

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
@@ -40,6 +40,8 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableRangeMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Interner;
+import com.google.common.collect.Interners;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
@@ -65,6 +67,8 @@ import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 public class CassandraService implements AutoCloseable {
     // TODO(tboam): keep logging on old class?
     private static final Logger log = LoggerFactory.getLogger(CassandraClientPool.class);
+    private static final Interner<RangeMap<LightweightOppToken, List<InetSocketAddress>>> tokensInterner =
+            Interners.newWeakInterner();
 
     private final MetricsManager metricsManager;
     private final CassandraKeyValueServiceConfig config;
@@ -135,7 +139,7 @@ public class CassandraService implements AutoCloseable {
                     }
                 }
             }
-            tokenMap = newTokenRing.build();
+            tokenMap = tokensInterner.intern(newTokenRing.build());
             return servers;
         } catch (Exception e) {
             log.info("Couldn't grab new token ranges for token aware cassandra mapping. We will retry in {} seconds.",

--- a/changelog/@unreleased/pr-4956.v2.yml
+++ b/changelog/@unreleased/pr-4956.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Intern the token map
+  links:
+  - https://github.com/palantir/atlasdb/pull/4956


### PR DESCRIPTION
This is a very large object and it's duplicated (and computed
separately) per Cassandra keyspace, for a total of
(256 * say 9 hosts * num datastores = O(100k entries) * (size of token = 32 + range map overhead = 8 + 16 + 16 + 16 =
~100) = 16MB heap which is proportional to the number of datastores. Since it's a simple fix, we might as well.