### PR TITLE
[LW] Fixes, 1: DoNotDoNotDelegate

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
@@ -320,10 +320,7 @@ public interface TransactionManager extends AutoCloseable {
      */
     TimelockService getTimelockService();
 
-    @DoNotDelegate
-    default LockWatchManager getLockWatchManager() {
-        return NoOpLockWatchManager.INSTANCE;
-    }
+    LockWatchManager getLockWatchManager();
 
     /**
      * Returns the timestamp service used by this transaction manager.


### PR DESCRIPTION
**Goals (and why)**:
* Turns out that the `@DoNotDelegate` annotation was causing atlasdb-proxy to always get the NoOp lock watch manager, thus failing to register any locks.

**Implementation Description (bullets)**:
* Remove `@DoNotDelegate`

**Testing (What was existing testing like?  What have you done to improve it?)**:
* Haven't changed any testing - is there a way that I can test this inside Atlas?

**Concerns (what feedback would you like?)**:
* Does this break anything anywhere else? I've removed the default value too (I'd expect it to be always set, even if it is set to be the no op manager), but does that break anything?

**Where should we start reviewing?**:
* `TransactionManager`

**Priority (whenever / two weeks / yesterday)**:
Today, preferably