### PR TITLE
[LW] Fixes, 4: Register lockwatches eagerly

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerImpl.java
@@ -72,6 +72,7 @@ public final class LockWatchManagerImpl extends LockWatchManager implements Auto
     @Override
     public void registerWatches(Set<LockWatchReferences.LockWatchReference> newLockWatches) {
         lockWatchReferences.addAll(newLockWatches);
+        registerWatchesWithTimelock();
     }
 
     private void registerWatchesWithTimelock() {


### PR DESCRIPTION
**Goals (and why)**:
* Register locks immediately, _as well as_ periodically. This not only allows the benefits to come through faster, but also makes testing easier.

**Implementation Description (bullets)**:
* Calls the internal register method when the client registers.

**Testing (What was existing testing like?  What have you done to improve it?)**:
N/A

**Concerns (what feedback would you like?)**:
* Any hidden issues here?

**Where should we start reviewing?**:
`LockWatchManagerImpl`

**Priority (whenever / two weeks / yesterday)**:
This week, please