### PR TITLE
[LW] Fixes, 5: Throw underlying exception if already on fallback cache

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/ResilientLockWatchEventCache.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/ResilientLockWatchEventCache.java
@@ -74,7 +74,7 @@ final class ResilientLockWatchEventCache extends AbstractInvocationHandler {
         } catch (TransactionLockWatchFailedException e) {
             throw e;
         } catch (Throwable t) {
-            if (delegate.equals(fallbackCache)) {
+            if (delegate == fallbackCache) {
                 throw new RuntimeException(t);
             } else {
                 log.warn("Unexpected failure occurred when trying to use the default cache. "

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/ResilientLockWatchEventCache.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/ResilientLockWatchEventCache.java
@@ -74,11 +74,15 @@ final class ResilientLockWatchEventCache extends AbstractInvocationHandler {
         } catch (TransactionLockWatchFailedException e) {
             throw e;
         } catch (Throwable t) {
-            log.warn("Unexpected failure occurred when trying to use the default cache. Switching to the fallback "
-                    + "implementation", t);
-            fallbackCacheSelectedCounter.inc();
-            delegate = fallbackCache;
-            throw new TransactionLockWatchFailedException("Unexpected failure in the lock watch cache", t);
+            if (delegate.equals(fallbackCache)) {
+                throw new RuntimeException(t);
+            } else {
+                log.warn("Unexpected failure occurred when trying to use the default cache. "
+                        + "Switching to the fallback implementation", t);
+                fallbackCacheSelectedCounter.inc();
+                delegate = fallbackCache;
+                throw new TransactionLockWatchFailedException("Unexpected failure in the default lock watch cache", t);
+            }
         }
     }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/ResilientLockWatchEventCacheTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/ResilientLockWatchEventCacheTest.java
@@ -75,4 +75,17 @@ public final class ResilientLockWatchEventCacheTest {
         verify(defaultCache).lastKnownVersion();
         verify(fallbackCache, never()).lastKnownVersion();
     }
+
+    @Test
+    public void alreadyOnFallbackCausesExceptionToBeRethrown() {
+        RuntimeException runtimeException = new RuntimeException();
+        when(defaultCache.getCommitUpdate(anyLong())).thenThrow(runtimeException);
+        when(fallbackCache.getCommitUpdate(anyLong())).thenThrow(runtimeException);
+        assertThatThrownBy(() -> proxyCache.getCommitUpdate(0L))
+                .isExactlyInstanceOf(TransactionLockWatchFailedException.class)
+                .hasCause(runtimeException);
+        assertThatThrownBy(() -> proxyCache.getCommitUpdate(0L))
+                .isExactlyInstanceOf(RuntimeException.class)
+                .hasCause(runtimeException);
+    }
 }

--- a/changelog/@unreleased/pr-4962.v2.yml
+++ b/changelog/@unreleased/pr-4962.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Lock watch event cache will no longer retry on exceptions thrown by
+    the fallback cache.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4962


### PR DESCRIPTION
**Goals (and why)**:
* We don't want to throw retryable exceptions if the fallback cache is throwing.

**Implementation Description (bullets)**:
* Add check that fallback is equal to delegate.

**Testing (What was existing testing like?  What have you done to improve it?)**:
* Added new test

**Concerns (what feedback would you like?)**:
* This shouldn't really happen since the fallback is no op, but I think this is correct anyway (saw this on a test in atlasdb-proxy on that one and wanted to replicate here).

**Where should we start reviewing?**:
`ResilientLockWatchEventCache`

**Priority (whenever / two weeks / yesterday)**:
This week