### PR TITLE
[LW] Fixes, 6: Don't forget the equals

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLog.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLog.java
@@ -150,7 +150,7 @@ final class LockWatchEventLog {
         if (latestVersion.isPresent()) {
             LockWatchEvent firstEvent = Iterables.getFirst(events, null);
             Preconditions.checkNotNull(firstEvent, "First element not preset in list of events");
-            Preconditions.checkArgument(firstEvent.sequence() < latestVersion.get().version()
+            Preconditions.checkArgument(firstEvent.sequence() <= latestVersion.get().version()
                             || latestVersion.get().version() + 1 == firstEvent.sequence(),
                     "Events missing between last snapshot and this batch of events");
         }

--- a/changelog/@unreleased/pr-4963.v2.yml
+++ b/changelog/@unreleased/pr-4963.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Allow lock watch updates that start on the same version as the locally
+    maintained cache's.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4963


### PR DESCRIPTION
**Goals (and why)**:
* Managed to recreate an issue seen in production where "events were missing". Turns out this is due to the fact that, while we handle the case where the version is earlier (i.e. update took some time to come through), or when a version is new (so first event should be +1 to current), we don't handle an edge case of the former, i.e. when the first version is _the same as_ the current. Which is wrong.

**Implementation Description (bullets)**:
* Don't be out by one.

**Testing (What was existing testing like?  What have you done to improve it?)**:
* Added yet another test, and confirmed it fails without the fix.

**Concerns (what feedback would you like?)**:
* Was there a reason this was omitted before? Am I breaking anything by doing this?

**Where should we start reviewing?**:
`LockWatchEventLog`

**Priority (whenever / two weeks / yesterday)**:
As soon as possible, this is one of the key fixes to get out.