### PR TITLE
[TS] Auto Tune TS Pause Between Iterations

### DIFF
--- a/atlasdb-config/src/test/resources/runtime-config-block.yml
+++ b/atlasdb-config/src/test/resources/runtime-config-block.yml
@@ -29,5 +29,3 @@ internalSchema:
 
 targetedSweep:
   batchShardIterations: false
-
-

--- a/atlasdb-config/src/test/resources/runtime-config-block.yml
+++ b/atlasdb-config/src/test/resources/runtime-config-block.yml
@@ -27,3 +27,7 @@ sweep:
 internalSchema:
   targetTransactionsSchemaVersion: 1
 
+targetedSweep:
+  batchShardIterations: false
+
+

--- a/atlasdb-impl-shared/build.gradle
+++ b/atlasdb-impl-shared/build.gradle
@@ -34,6 +34,8 @@ dependencies {
   compileOnly 'com.google.auto.service:auto-service'
   annotationProcessor project(":atlasdb-processors")
   compileOnly project(":atlasdb-processors")
+  annotationProcessor 'org.derive4j:derive4j'
+  compileOnly 'org.derive4j:derive4j-annotation'
 
   testAnnotationProcessor group: 'org.immutables', name: 'value'
   testCompileOnly 'org.immutables:value::annotations'

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepDelay.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepDelay.java
@@ -19,6 +19,20 @@ package com.palantir.atlasdb.sweep.queue;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicLong;
 
+/**
+ * This class calculates the delay for the next iteration of targeted sweep from the current delay and the outcome
+ * of the last iteration of TS. If the sweep iteration was successful, the next delay will gravitate towards the
+ * target delay using the formula 0.2 * target + 0.8 * current. The target delay is as follows:
+ *
+ *  1. if the sweep iteration processed fewer than {@link #BATCH_CELLS_LOW_THRESHOLD} cells, the target pause is
+ *  {@link #maxPauseMillis} milliseconds.
+ *  2. if the sweep iteration processed a full batch of {@link SweepQueueUtils#SWEEP_BATCH_SIZE} or more cells, the
+ *  target pause is {@link #MIN_PAUSE_MILLIS} milliseconds.
+ *  3. otherwise, the target pause is {@link #initialPause} milliseconds.
+ *
+ *  In case of an unsuccessful iteration, the pause is temporarily set to a constant as determined in
+ *  {@link #getNextPause(SweepIterationResult)}.
+ */
 class SweepDelay {
     static final int BATCH_CELLS_LOW_THRESHOLD = 100;
     static final long MIN_PAUSE_MILLIS = 1;
@@ -29,20 +43,6 @@ class SweepDelay {
     private final long maxPauseMillis;
     private final AtomicLong currentPause;
 
-    /**
-     * This class calculates the delay for the next iteration of targeted sweep from the current delay and the outcome
-     * of the last iteration of TS. If the sweep iteration was successful, the next delay will gravitate towards the
-     * target delay using the formula 0.2 * target + 0.8 * current. The target delay is as follows:
-     *
-     *  1. if the sweep iteration processed fewer than {@link #BATCH_CELLS_LOW_THRESHOLD} cells, the target pause is
-     *  {@link #maxPauseMillis} milliseconds.
-     *  2. if the sweep iteration processed a full batch of {@link SweepQueueUtils#SWEEP_BATCH_SIZE} or more cells, the
-     *  target pause is {@link #MIN_PAUSE_MILLIS} milliseconds.
-     *  3. otherwise, the target pause is {@link #initialPause} milliseconds.
-     *
-     *  In case of an unsuccessful iteration, the pause is temporarily set to a constant as determined in
-     *  {@link #getNextPause(SweepIterationResult)}.
-     */
     SweepDelay(long configPause) {
         this.maxPauseMillis = Math.max(DEFAULT_MAX_PAUSE_MILLIS, configPause);
         this.initialPause = Math.max(MIN_PAUSE_MILLIS, configPause);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepDelay.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepDelay.java
@@ -1,0 +1,58 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.queue;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class SweepDelay {
+    public static final int BATCH_CELLS_LOW_THRESHOLD = 100;
+    public static final long MIN_PAUSE_MILLIS = 1;
+    public static final long MAX_PAUSE_MILLIS = 5000;
+    public static final long BACKOFF = Duration.ofMinutes(2).toMillis();
+
+    private final long initialPause;
+    private final AtomicLong currentPause;
+
+    public SweepDelay(long configPause) {
+        this.initialPause = Math.min(Math.max(MIN_PAUSE_MILLIS, configPause), MAX_PAUSE_MILLIS);
+        this.currentPause = new AtomicLong(initialPause);
+    }
+
+    public long getNextPause(SweepIterationResult result) {
+        return SweepIterationResults.caseOf(result)
+                .success(this::updateCurrentPauseAndGet)
+                .unableToAcquireShard_(MAX_PAUSE_MILLIS)
+                .insufficientConsistency_(BACKOFF)
+                .otherError_(MAX_PAUSE_MILLIS)
+                .disabled_(BACKOFF);
+    }
+
+    private long updateCurrentPauseAndGet(long numSwept) {
+        long target = pauseTarget(numSwept);
+        return currentPause.updateAndGet(oldPause -> (4 * oldPause + target) / 5);
+    }
+
+    private long pauseTarget(long numSwept) {
+        if (numSwept <= BATCH_CELLS_LOW_THRESHOLD) {
+            return MAX_PAUSE_MILLIS;
+        } else if (numSwept >= SweepQueueUtils.SWEEP_BATCH_SIZE) {
+            return MIN_PAUSE_MILLIS;
+        }
+        return initialPause;
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepIterationResult.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepIterationResult.java
@@ -1,0 +1,32 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.queue;
+
+import org.derive4j.Data;
+
+@Data
+public abstract class SweepIterationResult {
+    public interface Cases<R> {
+        R success(long entriesSwept);
+        R unableToAcquireShard();
+        R insufficientConsistency();
+        R otherError();
+        R disabled();
+    }
+
+    public abstract <R> R match(Cases<R> cases);
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/config/TargetedSweepRuntimeConfig.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/config/TargetedSweepRuntimeConfig.java
@@ -17,6 +17,7 @@ package com.palantir.atlasdb.sweep.queue.config;
 
 import org.immutables.value.Value;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Preconditions;
@@ -24,6 +25,7 @@ import com.palantir.atlasdb.AtlasDbConstants;
 
 @JsonDeserialize(as = ImmutableTargetedSweepRuntimeConfig.class)
 @JsonSerialize(as = ImmutableTargetedSweepRuntimeConfig.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
 @Value.Immutable
 public abstract class TargetedSweepRuntimeConfig {
     /**
@@ -43,16 +45,6 @@ public abstract class TargetedSweepRuntimeConfig {
     @Value.Default
     public int shards() {
         return 8;
-    }
-
-    /**
-     * @deprecated This configuration is ignored, use {@link #enableAutoTuning()} or
-     * {@link #maximumPartitionsToBatchInSingleRead()} instead.
-     */
-    @Deprecated
-    @Value.Default
-    public boolean batchShardIterations() {
-        return false;
     }
 
     /**
@@ -88,9 +80,8 @@ public abstract class TargetedSweepRuntimeConfig {
     }
 
     /**
-     * If enabled, the {@link #batchShardIterations()} and {@link #maximumPartitionsToBatchInSingleRead()} parameters
-     * will be ignored. Instead, sweep will read across as many fine partitions as necessary to try assemble a single
-     * full batch of entries to sweep.
+     * If enabled, the {@link #maximumPartitionsToBatchInSingleRead()} parameter will be ignored. Instead, sweep will
+     * read across as many fine partitions as necessary to try assemble a single full batch of entries to sweep.
      *
      * In addition, the pause between iterations of sweep will automatically adjusted depending on previous
      * iterations using {@link #pauseMillis()} as a hint.

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/config/TargetedSweepRuntimeConfig.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/config/TargetedSweepRuntimeConfig.java
@@ -15,17 +15,20 @@
  */
 package com.palantir.atlasdb.sweep.queue.config;
 
+import java.time.Duration;
+
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.google.common.base.Preconditions;
 import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
 
 @JsonDeserialize(as = ImmutableTargetedSweepRuntimeConfig.class)
 @JsonSerialize(as = ImmutableTargetedSweepRuntimeConfig.class)
-@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonIgnoreProperties("batchShardIterations")
 @Value.Immutable
 public abstract class TargetedSweepRuntimeConfig {
     /**
@@ -64,16 +67,20 @@ public abstract class TargetedSweepRuntimeConfig {
     @Value.Check
     void checkPartitionsToBatch() {
         Preconditions.checkArgument(maximumPartitionsToBatchInSingleRead() > 0,
-                "Number of partitions to read in a batch must be positive, but found %s.",
-                maximumPartitionsToBatchInSingleRead());
+                "Number of partitions to read in a batch must be positive.",
+                SafeArg.of("partitions to batch", maximumPartitionsToBatchInSingleRead()));
     }
 
     @Value.Check
     void checkShardSize() {
         Preconditions.checkArgument(shards() >= 1 && shards() <= 256,
-                "Shard number must be between 1 and 256 inclusive, but it is %s.", shards());
+                "Shard number must be between 1 and 256 inclusive.",
+                SafeArg.of("shards", shards()));
     }
 
+    /**
+     * Hint for the duration of pause between iterations of targeted sweep. Must not be longer than a day.
+     */
     @Value.Default
     public long pauseMillis() {
         return 500L;
@@ -89,6 +96,13 @@ public abstract class TargetedSweepRuntimeConfig {
     @Value.Default
     public boolean enableAutoTuning() {
         return false;
+    }
+
+    @Value.Check
+    public void checkPauseDuration() {
+        Preconditions.checkArgument(pauseMillis() <= Duration.ofDays(1).toMillis(),
+                "The pause between iterations of targeted sweep must not be greater than 1 day.",
+                SafeArg.of("pauseMillis", pauseMillis()));
     }
 
     public static TargetedSweepRuntimeConfig defaultTargetedSweepRuntimeConfig() {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/config/TargetedSweepRuntimeConfig.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/config/TargetedSweepRuntimeConfig.java
@@ -46,9 +46,6 @@ public abstract class TargetedSweepRuntimeConfig {
     }
 
     /**
-     * If true, we batch many iterations on each shard and strategy upon obtaining the lock. This should lead to
-     * higher throughput in targeted sweep at the expense of more uneven sweeping across different shards.
-     *
      * @deprecated This configuration is ignored, use {@link #enableAutoTuning()} or
      * {@link #maximumPartitionsToBatchInSingleRead()} instead.
      */

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/config/TargetedSweepRuntimeConfig.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/config/TargetedSweepRuntimeConfig.java
@@ -48,7 +48,11 @@ public abstract class TargetedSweepRuntimeConfig {
     /**
      * If true, we batch many iterations on each shard and strategy upon obtaining the lock. This should lead to
      * higher throughput in targeted sweep at the expense of more uneven sweeping across different shards.
+     *
+     * @deprecated This configuration is ignored, use {@link #enableAutoTuning()} or
+     * {@link #maximumPartitionsToBatchInSingleRead()} instead.
      */
+    @Deprecated
     @Value.Default
     public boolean batchShardIterations() {
         return false;
@@ -84,6 +88,19 @@ public abstract class TargetedSweepRuntimeConfig {
     @Value.Default
     public long pauseMillis() {
         return 500L;
+    }
+
+    /**
+     * If enabled, the {@link #batchShardIterations()} and {@link #maximumPartitionsToBatchInSingleRead()} parameters
+     * will be ignored. Instead, sweep will read across as many fine partitions as necessary to try assemble a single
+     * full batch of entries to sweep.
+     *
+     * In addition, the pause between iterations of sweep will automatically adjusted depending on previous
+     * iterations using {@link #pauseMillis()} as a hint.
+     */
+    @Value.Default
+    public boolean enableAutoTuning() {
+        return false;
     }
 
     public static TargetedSweepRuntimeConfig defaultTargetedSweepRuntimeConfig() {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepDelayTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepDelayTest.java
@@ -1,0 +1,111 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.queue;
+
+
+import static com.palantir.atlasdb.sweep.queue.SweepDelay.BACKOFF;
+import static com.palantir.atlasdb.sweep.queue.SweepDelay.BATCH_CELLS_LOW_THRESHOLD;
+import static com.palantir.atlasdb.sweep.queue.SweepDelay.MAX_PAUSE_MILLIS;
+import static com.palantir.atlasdb.sweep.queue.SweepDelay.MIN_PAUSE_MILLIS;
+import static com.palantir.atlasdb.sweep.queue.SweepQueueUtils.SWEEP_BATCH_SIZE;
+import static com.palantir.logsafe.testing.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class SweepDelayTest {
+    private static final SweepIterationResult SUCCESS_TOO_FAST = SweepIterationResults.success(1L);
+    private static final SweepIterationResult SUCCESS_TOO_SLOW = SweepIterationResults.success(SWEEP_BATCH_SIZE);
+    private static final SweepIterationResult SUCCESS = SweepIterationResults
+            .success((BATCH_CELLS_LOW_THRESHOLD + SWEEP_BATCH_SIZE) / 2);
+    private static final long INITIAL_DELAY = 250L;
+
+    private SweepDelay delay = new SweepDelay(INITIAL_DELAY);
+
+    @Test
+    public void configurationsOutOfBoundsAreSetAtBounds() {
+        SweepDelay negativeDelay = new SweepDelay(-5L);
+        SweepDelay largeDelay = new SweepDelay(10_000_000L);
+
+        assertThat(negativeDelay.getNextPause(SUCCESS)).isEqualTo(MIN_PAUSE_MILLIS);
+        assertThat(largeDelay.getNextPause(SUCCESS)).isEqualTo(MAX_PAUSE_MILLIS);
+    }
+
+    @Test
+    public void unableToAcquireShardReturnsMaxPause() {
+        assertThat(delay.getNextPause(SweepIterationResults.unableToAcquireShard())).isEqualTo(MAX_PAUSE_MILLIS);
+    }
+
+    @Test
+    public void insufficientConsistencyReturnsBackoff() {
+        assertThat(delay.getNextPause(SweepIterationResults.insufficientConsistency())).isEqualTo(BACKOFF);
+    }
+
+    @Test
+    public void otherErrorReturnsMaxPause() {
+        assertThat(delay.getNextPause(SweepIterationResults.otherError())).isEqualTo(MAX_PAUSE_MILLIS);
+    }
+
+    @Test
+    public void disabledReturnsBackoff() {
+        assertThat(delay.getNextPause(SweepIterationResults.disabled())).isEqualTo(BACKOFF);
+    }
+
+    @Test
+    public void iterationWithNormalBatchReturnsInitialPause() {
+        assertThat(delay.getNextPause(SUCCESS)).isEqualTo(INITIAL_DELAY);
+    }
+
+    @Test
+    public void iterationWithSmallBatchIncreasesPause() {
+        assertThat(delay.getNextPause(SUCCESS_TOO_FAST)).isGreaterThan(INITIAL_DELAY);
+    }
+
+    @Test
+    public void iterationWithFullBatchReducesPause() {
+        assertThat(delay.getNextPause(SUCCESS_TOO_SLOW)).isLessThan(INITIAL_DELAY);
+    }
+
+    @Test
+    public void consistentSmallBatchesGravitatesTowardsMaximumPause() {
+        for (int i = 0; i < 20; i++) {
+            delay.getNextPause(SUCCESS_TOO_FAST);
+        }
+        assertThat(delay.getNextPause(SUCCESS_TOO_FAST)).isGreaterThanOrEqualTo((long) (MAX_PAUSE_MILLIS * 0.95));
+    }
+
+    @Test
+    public void consistentFullBatchesGravitatesTowardsMinimumPause() {
+        for (int i = 0; i < 20; i++) {
+            delay.getNextPause(SUCCESS_TOO_SLOW);
+        }
+        assertThat(delay.getNextPause(SUCCESS_TOO_FAST)).isGreaterThanOrEqualTo((long) (MIN_PAUSE_MILLIS * 1.05));
+    }
+
+    @Test
+    public void consistentNormalBatchesAfterFullBatchesGravitatesTowardsInitialPause() {
+        for (int i = 0; i < 20; i++) {
+            delay.getNextPause(SUCCESS_TOO_SLOW);
+        }
+        for (int i = 0; i < 20; i++) {
+            delay.getNextPause(SUCCESS);
+        }
+        long nextPause = delay.getNextPause(SUCCESS);
+        assertThat(nextPause).isGreaterThanOrEqualTo((long) (INITIAL_DELAY * 0.95));
+        assertThat(nextPause).isLessThanOrEqualTo((long) (INITIAL_DELAY * 1.05));
+
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepDelayTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepDelayTest.java
@@ -36,6 +36,11 @@ public class SweepDelayTest {
     private SweepDelay delay = new SweepDelay(INITIAL_DELAY);
 
     @Test
+    public void iterationWithNormalBatchReturnsInitialPause() {
+        assertThat(delay.getNextPause(SUCCESS)).isEqualTo(INITIAL_DELAY);
+    }
+
+    @Test
     public void configurationsOutOfBoundsAreSetAtBounds() {
         SweepDelay negativeDelay = new SweepDelay(-5L);
         SweepDelay largeDelay = new SweepDelay(10_000_000L);
@@ -62,11 +67,6 @@ public class SweepDelayTest {
     @Test
     public void disabledReturnsBackoff() {
         assertThat(delay.getNextPause(SweepIterationResults.disabled())).isEqualTo(BACKOFF);
-    }
-
-    @Test
-    public void iterationWithNormalBatchReturnsInitialPause() {
-        assertThat(delay.getNextPause(SUCCESS)).isEqualTo(INITIAL_DELAY);
     }
 
     @Test

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
@@ -120,7 +120,7 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
     private TimelockService timelockService;
     private PuncherStore puncherStore;
     private boolean enabled = true;
-    private boolean batchShardIterations = false;
+    private boolean enableAutoTuning = false;
 
     public TargetedSweeperTest(int readBatchSize) {
         this.readBatchSize = readBatchSize;
@@ -132,7 +132,7 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
         super.setup();
         Supplier<TargetedSweepRuntimeConfig> runtime = () -> ImmutableTargetedSweepRuntimeConfig.builder()
                 .enabled(enabled)
-                .batchShardIterations(batchShardIterations)
+                .enableAutoTuning(enableAutoTuning)
                 .maximumPartitionsToBatchInSingleRead(readBatchSize)
                 .shards(DEFAULT_SHARDS)
                 .build();
@@ -161,7 +161,7 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
 
     @Test
     public void callingEnqueueAndSweepOnUninitializedSweeperThrows() {
-        TargetedSweeper uninitializedSweeper = TargetedSweeper.createUninitializedForTest(null);
+        TargetedSweeper uninitializedSweeper = TargetedSweeper.createUninitializedForTest(() -> 1);
         assertThatThrownBy(() -> uninitializedSweeper.enqueue(ImmutableList.of()))
                 .isInstanceOf(NotInitializedException.class)
                 .hasMessageContaining("Targeted Sweeper");
@@ -174,7 +174,7 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
     public void initializingWithUninitializedKvsThrows() {
         KeyValueService uninitializedKvs = mock(KeyValueService.class);
         when(uninitializedKvs.isInitialized()).thenReturn(false);
-        TargetedSweeper sweeper = TargetedSweeper.createUninitializedForTest(null);
+        TargetedSweeper sweeper = TargetedSweeper.createUninitializedForTest(() -> 1);
         assertThatThrownBy(() -> sweeper.initializeWithoutRunning(
                 null, mock(TimelockService.class), uninitializedKvs, txnService, mock(TargetedSweepFollower.class)))
                 .isInstanceOf(IllegalStateException.class);
@@ -249,17 +249,6 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
 
         assertThat(metricsManager).hasTargetedOutcomeEqualTo(CONSERVATIVE, SweepOutcome.NOTHING_TO_SWEEP, 1L);
         assertThat(metricsManager).hasNotRegisteredTargetedOutcome(THOROUGH, SweepOutcome.NOTHING_TO_SWEEP);
-    }
-
-    @Test
-    public void sweepNextBatchReturnsFalseWhenAtSweepTimestamp() {
-        enqueueWriteCommitted(TABLE_CONS, getSweepTsCons());
-        boolean continueSweeping = sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
-
-        assertThat(continueSweeping).isTrue();
-
-        continueSweeping = sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
-        assertThat(continueSweeping).isFalse();
     }
 
     @Test
@@ -438,6 +427,23 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
         setTimelockTime(10_000L);
         punchTimeAtTimestamp(5_000L, LOW_TS + 8);
         assertThat(metricsManager).hasMillisSinceLastSweptConservativeEqualTo(10_000L - 5000L);
+    }
+
+    @Test
+    public void enableAutoTuningOverridesEffectivelySetsLargeReadBatchSize() {
+        enableAutoTuning = true;
+
+        for (int partition = 0; partition < readBatchSize * 5; partition++) {
+            enqueueWriteCommitted(TABLE_CONS, minTsForFinePartition(partition + 1));
+        }
+
+        sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
+
+        for (int partition = 0; partition < readBatchSize * 5 - 1; partition++) {
+            assertReadAtTimestampReturnsSentinel(TABLE_CONS, minTsForFinePartition(partition + 1));
+        }
+        assertTestValueEnqueuedAtGivenTimestampStillPresent(TABLE_CONS, minTsForFinePartition(readBatchSize * 5));
+        verify(spiedKvs, times(1)).deleteAllTimestamps(any(), any());
     }
 
     @Test
@@ -1063,8 +1069,8 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
     }
 
     @Test
-    public void batchShardIterationsSweepsMultipleFinePartitions() {
-        batchShardIterations = true;
+    public void enableAutoTuningSweepsMultipleFinePartitions() {
+        enableAutoTuning = true;
 
         enqueueWriteCommitted(TABLE_CONS, LOW_TS);
         enqueueTombstone(TABLE_CONS, LOW_TS + 2);
@@ -1078,45 +1084,6 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
         sweepQueue.processShard(ShardAndStrategy.conservative(CONS_SHARD));
 
         assertReadAtTimestampReturnsSentinel(TABLE_CONS, maxTsForFinePartition(0) + 1);
-    }
-
-    @Test
-    public void sweepNextBatchReturnsFalseWhenEncounteringEntryCommittedAfterSweepTs() {
-        ShardAndStrategy shardStrategy = ShardAndStrategy.conservative(CONS_SHARD);
-        long sweepTimestamp = getSweepTsCons();
-        enqueueWriteCommitted(TABLE_CONS, sweepTimestamp - 10);
-        enqueueWriteCommitedAt(TABLE_CONS, sweepTimestamp - 5, sweepTimestamp + 5);
-
-        assertThat(sweepNextBatch(shardStrategy)).isFalse();
-        assertThat(metricsManager).hasEntriesReadConservativeEqualTo(2L);
-        assertThat(metricsManager).hasTombstonesPutConservativeEqualTo(1L);
-        assertThat(progress.getLastSweptTimestamp(shardStrategy)).isEqualTo(sweepTimestamp - 6);
-
-        assertThat(sweepNextBatch(shardStrategy)).isFalse();
-        assertThat(metricsManager).hasEntriesReadConservativeEqualTo(3L);
-        assertThat(metricsManager).hasTombstonesPutConservativeEqualTo(1L);
-        assertThat(progress.getLastSweptTimestamp(shardStrategy)).isEqualTo(sweepTimestamp - 6);
-    }
-
-    @Test
-    public void sweepNextBatchReturnsTrueWhenThereCouldBeMoreEntries() {
-        ShardAndStrategy shardStrategy = ShardAndStrategy.conservative(CONS_SHARD);
-        long sweepTimestamp = getSweepTsCons();
-        for (int i = 0; i < readBatchSize; i++) {
-            enqueueWriteCommitted(TABLE_CONS, SweepQueueUtils.maxTsForFinePartition(i) - 5);
-        }
-        enqueueWriteCommitedAt(TABLE_CONS, sweepTimestamp - 5, sweepTimestamp + 5);
-
-        assertThat(sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD))).isTrue();
-        assertThat(metricsManager).hasEntriesReadConservativeEqualTo(readBatchSize);
-        assertThat(metricsManager).hasTombstonesPutConservativeEqualTo(1L);
-        assertThat(progress.getLastSweptTimestamp(shardStrategy))
-                .isEqualTo(SweepQueueUtils.maxTsForFinePartition(readBatchSize - 1));
-
-        assertThat(sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD))).isFalse();
-        assertThat(metricsManager).hasEntriesReadConservativeEqualTo(readBatchSize + 1);
-        assertThat(metricsManager).hasTombstonesPutConservativeEqualTo(1L);
-        assertThat(progress.getLastSweptTimestamp(shardStrategy)).isEqualTo(sweepTimestamp - 6);
     }
 
     private void writeValuesAroundSweepTimestampAndSweepAndCheck(long sweepTimestamp, int sweepIterations) {
@@ -1354,12 +1321,12 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
         return writeInfos;
     }
 
-    private boolean sweepNextBatch(ShardAndStrategy shardStrategy) {
-        return sweepNextBatch(sweepQueue, shardStrategy);
+    private void sweepNextBatch(ShardAndStrategy shardStrategy) {
+        sweepNextBatch(sweepQueue, shardStrategy);
     }
 
-    private boolean sweepNextBatch(TargetedSweeper sweeper, ShardAndStrategy shardStrategy) {
-        return sweeper.sweepNextBatch(shardStrategy, Sweeper.of(shardStrategy).getSweepTimestamp(timestampsSupplier));
+    private void sweepNextBatch(TargetedSweeper sweeper, ShardAndStrategy shardStrategy) {
+        sweeper.sweepNextBatch(shardStrategy, Sweeper.of(shardStrategy).getSweepTimestamp(timestampsSupplier));
     }
 
     private void setSweepTimestamp(long timestamp) {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
@@ -864,7 +864,7 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
         enqueueWriteCommitted(TABLE_CONS, 90);
 
         // first iteration reads all before giving up
-        sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
+        assertThat(sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD))).isEqualTo(4 + writesInDedicated);
         assertThat(metricsManager).hasEntriesReadConservativeEqualTo(4 + writesInDedicated);
 
         // we read one entry and give up
@@ -897,17 +897,17 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
         assertThat(writesInOther).isGreaterThan(0);
 
         // first iteration reads all before giving up
-        sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
+        assertThat(sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD))).isEqualTo(writesInDedicated);
         assertThat(metricsManager).hasEntriesReadConservativeEqualTo(writesInDedicated);
 
         // we read a reference to bad entries and give up
-        sweepNextBatch(ShardAndStrategy.conservative(otherShard));
+        assertThat(sweepNextBatch(ShardAndStrategy.conservative(otherShard))).isEqualTo(1);
         assertThat(metricsManager).hasEntriesReadConservativeEqualTo(writesInDedicated + 1);
 
         immutableTs = 250;
 
         // we now read all to the end
-        sweepNextBatch(ShardAndStrategy.conservative(otherShard));
+        assertThat(sweepNextBatch(ShardAndStrategy.conservative(otherShard))).isEqualTo(writesInOther);
         assertThat(metricsManager).hasEntriesReadConservativeEqualTo(writesInDedicated + 1 + writesInOther);
     }
 
@@ -1321,12 +1321,12 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
         return writeInfos;
     }
 
-    private void sweepNextBatch(ShardAndStrategy shardStrategy) {
-        sweepNextBatch(sweepQueue, shardStrategy);
+    private long sweepNextBatch(ShardAndStrategy shardStrategy) {
+        return sweepNextBatch(sweepQueue, shardStrategy);
     }
 
-    private void sweepNextBatch(TargetedSweeper sweeper, ShardAndStrategy shardStrategy) {
-        sweeper.sweepNextBatch(shardStrategy, Sweeper.of(shardStrategy).getSweepTimestamp(timestampsSupplier));
+    private long sweepNextBatch(TargetedSweeper sweeper, ShardAndStrategy shardStrategy) {
+        return sweeper.sweepNextBatch(shardStrategy, Sweeper.of(shardStrategy).getSweepTimestamp(timestampsSupplier));
     }
 
     private void setSweepTimestamp(long timestamp) {

--- a/changelog/@unreleased/pr-4973.v2.yml
+++ b/changelog/@unreleased/pr-4973.v2.yml
@@ -1,8 +1,8 @@
 type: improvement
 improvement:
   description: |-
-    Targeted sweep runtime configuration now has a `enableAutoTuning` parameter. While true, targeted sweep will dynamically adjust the pause between sweep iterations based on the amount of work that was done. It will, furthermore, attempt to read a full batch (100k) of entries to sweep whenever possible.
+    Targeted sweep runtime configuration now has an `enableAutoTuning` parameter. While true, targeted sweep will dynamically adjust the pause between sweep iterations based on the amount of work that was done. It will, furthermore, attempt to read a full batch (100k) of entries to sweep whenever possible. This feature is still experimental and disabled by default. Please contact the AtlasDB team if you wish to use it.
 
-    The `batchShardIterations` parameter has been deprecated and now does nothing, use `maximumPartitionsToBatchInSingleRead` or `enableAutoTuning` instead.
+    The `batchShardIterations` parameter has been removed and if it is specified it will be ignored, use `maximumPartitionsToBatchInSingleRead` or `enableAutoTuning` instead.
   links:
   - https://github.com/palantir/atlasdb/pull/4973


### PR DESCRIPTION
**Goals (and why)**:
Allow TS to change the pause between iterations depending on how much work was done. This serves primarily to slow things down when there are not many entries to sweep and conserve resources, but also to reduce the pause when we detect we are falling behind.

**Implementation Description (bullets)**:
The auto tuning is enabled through a runtime configuration. When true, after each iteration, we will determine the next pause based on the last one and the number of entries swept. Furthermore, we will continue to read from the queue until either a full batch is read or we reach the sweep timestamp.

The `batchShardIterations` runtime config has deprecated and is ignored now. This is because it is better to use `maximumPartitionsToBatchInSingleRead` or the new auto tuning for the purpose, and it was adding unnecessary complexity. 

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added tests for `SweepDelay`, modified some tests in `TargetedSweeperTest`. Do you think we need more?

**Concerns (what feedback would you like?)**:
Generally, I don't think this is too contentious. Mostly interested if there are disagreements on the numbers in `SweepDelay`, and if I missed something.
Is there a better way of doing the recurring task in `TargetedSweeper`, and do we need to be defensive around `executorService.schedule` throwing?

**Where should we start reviewing?**:
`TargetedSweepRuntimeConfig.java`

**Priority (whenever / two weeks / yesterday)**:
Ideally today