### PR TITLE
[TS] Increase max delay

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepDelay.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepDelay.java
@@ -36,7 +36,7 @@ import java.util.concurrent.atomic.AtomicLong;
 class SweepDelay {
     static final int BATCH_CELLS_LOW_THRESHOLD = 100;
     static final long MIN_PAUSE_MILLIS = 1;
-    static final long DEFAULT_MAX_PAUSE_MILLIS = 5000;
+    static final long DEFAULT_MAX_PAUSE_MILLIS = Duration.ofSeconds(15).toMillis();
     static final long BACKOFF = Duration.ofMinutes(2).toMillis();
 
     private final long initialPause;


### PR DESCRIPTION
**Goals (and why)**:
5 seconds was good, but we can increase it further without falling behind

**Concerns (what feedback would you like?)**:
The default number of shards is 8, so on a service with a single node we should not fall behind by 2 minutes, which is reasonable. In practice, I expect at least 2 nodes, so this number goes down to 1 minute. Do you think we should increase it even further?
