### PR TITLE
Log WARN if some security settings were ignored in an Oracle conn config

### DIFF
--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/OracleConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/OracleConnectionConfig.java
@@ -22,6 +22,8 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import org.immutables.value.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -37,6 +39,7 @@ import com.palantir.nexus.db.DBType;
 @JsonTypeName(OracleConnectionConfig.TYPE)
 @Value.Immutable
 public abstract class OracleConnectionConfig extends ConnectionConfig {
+    private static final Logger log = LoggerFactory.getLogger(OracleConnectionConfig.class);
 
     public static final String TYPE = "oracle";
 
@@ -196,6 +199,15 @@ public abstract class OracleConnectionConfig extends ConnectionConfig {
         } else {
             Preconditions.checkArgument(!getTwoWaySsl(),
                     "two way ssl cannot be enabled without enabling ConnectionProtocol.TCPS");
+            if (getServerDn().isPresent()
+                    || getTruststorePath().isPresent()
+                    || getTruststorePassword().isPresent()
+                    || getKeystorePath().isPresent()
+                    || getKeystorePassword().isPresent()) {
+                log.warn("Your Oracle config is not set to use ConnectionProtocol.TCPS, but some security settings"
+                        + " have been set. These settings are currently being ignored - please verify that you are"
+                        + " OK with this.");
+            }
         }
     }
 

--- a/changelog/@unreleased/pr-4990.v2.yml
+++ b/changelog/@unreleased/pr-4990.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: We now log a WARN log line if both plain TCP is used and security settings
+    are present in an Oracle connection config, but allow the system to proceed. Please
+    verify that this is OK if you see this line.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4990


### PR DESCRIPTION
**Goals (and why)**:
#4988 allows Oracle configs to be created with TCP (not TCPS) and security settings. This is easier for large internal product's automation. I had a suggestion and didn't realise merge-when-ready was there when I approved.

**Implementation Description (bullets)**:
Add a WARN log line if both plain TCP is used and security settings are present, but allow the system to proceed.

**Testing (What was existing testing like?  What have you done to improve it?)**:
None; only logging

**Concerns (what feedback would you like?)**:
Nothing in particular

**Where should we start reviewing?**: the one file

**Priority (whenever / two weeks / yesterday)**: today please, it's small
