### PR TITLE
only log at debug for unused keystore/truststore

### DIFF
--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/OracleConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/OracleConnectionConfig.java
@@ -204,7 +204,7 @@ public abstract class OracleConnectionConfig extends ConnectionConfig {
                     || getTruststorePassword().isPresent()
                     || getKeystorePath().isPresent()
                     || getKeystorePassword().isPresent()) {
-                log.warn("Your Oracle config is not set to use ConnectionProtocol.TCPS, but some security settings"
+                log.debug("Your Oracle config is not set to use ConnectionProtocol.TCPS, but some security settings"
                         + " have been set. These settings are currently being ignored - please verify that you are"
                         + " OK with this.");
             }

--- a/changelog/@unreleased/pr-4994.v2.yml
+++ b/changelog/@unreleased/pr-4994.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: |-
+    Only logs at debug for unused keystore/truststore.
+  links:
+  - https://github.com/palantir/atlasdb/pull/4994


### PR DESCRIPTION
Changes logging to only log at debug instead of warn, since it is normal
for our internal deployment infrastructure to always fill in values.

Using warn here would is generally not useful since if the config is
correct we do not want to confuse people. Either the config will be
correct and connections to the DB will work, or they won't. If someone
made a "mistake" trying to set up TCPS, it would be obvious since
connections would not work at all.