### PR TITLE
Wire paxos history providers

### DIFF
--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipComponents.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipComponents.java
@@ -30,15 +30,11 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.google.common.io.Closer;
-import com.palantir.atlasdb.timelock.corruption.CorruptionHealthCheck;
-import com.palantir.atlasdb.timelock.corruption.LocalCorruptionDetector;
-import com.palantir.atlasdb.timelock.corruption.RemoteCorruptionDetector;
 import com.palantir.atlasdb.timelock.paxos.NetworkClientFactories.Factory;
 import com.palantir.leader.LeaderElectionService;
 import com.palantir.leader.NotCurrentLeaderException;
 import com.palantir.leader.proxy.AwaitingLeadershipProxy;
 import com.palantir.paxos.Client;
-import com.palantir.timelock.corruption.TimeLockCorruptionNotifier;
 import com.palantir.timelock.paxos.HealthCheckPinger;
 import com.palantir.timelock.paxos.LeaderPingHealthCheck;
 import com.palantir.timelock.paxos.NamespaceTracker;
@@ -52,15 +48,12 @@ public class LeadershipComponents {
 
     private final Factory<LeadershipContext> leadershipContextFactory;
     private final LocalAndRemotes<HealthCheckPinger> healthCheckPingers;
-    private final List<TimeLockCorruptionNotifier> corruptionNotifiers;
 
     LeadershipComponents(
             Factory<LeadershipContext> leadershipContextFactory,
-            LocalAndRemotes<HealthCheckPinger> healthCheckPingers,
-            List<TimeLockCorruptionNotifier> corruptionNotifiers) {
+            LocalAndRemotes<HealthCheckPinger> healthCheckPingers) {
         this.leadershipContextFactory = leadershipContextFactory;
         this.healthCheckPingers = healthCheckPingers;
-        this.corruptionNotifiers = corruptionNotifiers;
     }
 
     public <T> T wrapInLeadershipProxy(Client client, Class<T> clazz, Supplier<T> delegateSupplier) {
@@ -88,17 +81,6 @@ public class LeadershipComponents {
 
     public LeaderPingHealthCheck healthCheck(NamespaceTracker namespaceTracker) {
         return new LeaderPingHealthCheck(namespaceTracker, healthCheckPingers.all());
-    }
-
-    public TimeLockCorruptionComponents timeLockCorruptionComponents() {
-        RemoteCorruptionDetector remoteCorruptionDetector = new RemoteCorruptionDetector();
-        CorruptionHealthCheck healthCheck = new CorruptionHealthCheck(ImmutableList.of(
-                LocalCorruptionDetector.create(corruptionNotifiers),
-                remoteCorruptionDetector));
-        return ImmutableTimeLockCorruptionComponents.builder()
-                .timeLockCorruptionHealthCheck(healthCheck)
-                .remoteCorruptionDetector(remoteCorruptionDetector)
-                .build();
     }
 
     public boolean requestHostileTakeover(Client client) {

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipContextFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipContextFactory.java
@@ -33,6 +33,7 @@ import com.palantir.paxos.Client;
 import com.palantir.paxos.LeaderPinger;
 import com.palantir.paxos.PaxosLearner;
 import com.palantir.timelock.corruption.TimeLockCorruptionNotifier;
+import com.palantir.timelock.history.TimeLockPaxosHistoryProvider;
 import com.palantir.timelock.paxos.HealthCheckPinger;
 
 @Value.Immutable
@@ -111,6 +112,11 @@ public abstract class LeadershipContextFactory implements
     @Value.Derived
     List<TimeLockCorruptionNotifier> remoteCorruptionNotifiers() {
         return remoteClients().getRemoteCorruptionNotifiers();
+    }
+
+    @Value.Derived
+    List<TimeLockPaxosHistoryProvider> remoteHistoryProviders() {
+        return remoteClients().getRemoteHistoryProviders();
     }
 
     @Override

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipContextFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipContextFactory.java
@@ -18,7 +18,6 @@ package com.palantir.atlasdb.timelock.paxos;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.List;
 import java.util.UUID;
 
 import org.immutables.value.Value;
@@ -32,8 +31,6 @@ import com.palantir.leader.health.LeaderElectionHealthCheck;
 import com.palantir.paxos.Client;
 import com.palantir.paxos.LeaderPinger;
 import com.palantir.paxos.PaxosLearner;
-import com.palantir.timelock.corruption.TimeLockCorruptionNotifier;
-import com.palantir.timelock.history.TimeLockPaxosHistoryProvider;
 import com.palantir.timelock.paxos.HealthCheckPinger;
 
 @Value.Immutable
@@ -107,16 +104,6 @@ public abstract class LeadershipContextFactory implements
     @Value.Derived
     public LeaderElectionHealthCheck leaderElectionHealthCheck() {
         return new LeaderElectionHealthCheck(Instant::now);
-    }
-
-    @Value.Derived
-    List<TimeLockCorruptionNotifier> remoteCorruptionNotifiers() {
-        return remoteClients().getRemoteCorruptionNotifiers();
-    }
-
-    @Value.Derived
-    List<TimeLockPaxosHistoryProvider> remoteHistoryProviders() {
-        return remoteClients().getRemoteHistoryProviders();
     }
 
     @Override

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClients.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClients.java
@@ -38,6 +38,7 @@ import com.palantir.paxos.LeaderPingerContext;
 import com.palantir.paxos.PaxosAcceptor;
 import com.palantir.paxos.PaxosLearner;
 import com.palantir.timelock.corruption.TimeLockCorruptionNotifier;
+import com.palantir.timelock.history.TimeLockPaxosHistoryProvider;
 import com.palantir.timelock.paxos.TimelockPaxosAcceptorRpcClient;
 import com.palantir.timelock.paxos.TimelockPaxosLearnerRpcClient;
 
@@ -149,6 +150,13 @@ public abstract class PaxosRemoteClients {
     @Value.Derived
     public List<TimeLockCorruptionNotifier> getRemoteCorruptionNotifiers() {
         return createInstrumentedRemoteProxies(TimeLockCorruptionNotifier.class, true)
+                .values()
+                .collect(Collectors.toList());
+    }
+
+    @Value.Derived
+    public List<TimeLockPaxosHistoryProvider> getRemoteHistoryProviders() {
+        return createInstrumentedRemoteProxies(TimeLockPaxosHistoryProvider.class, true)
                 .values()
                 .collect(Collectors.toList());
     }

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/TimeLockCorruptionComponents.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/TimeLockCorruptionComponents.java
@@ -16,13 +16,21 @@
 
 package com.palantir.atlasdb.timelock.paxos;
 
+import java.util.List;
+
 import org.immutables.value.Value;
 
 import com.palantir.atlasdb.timelock.corruption.CorruptionHealthCheck;
 import com.palantir.atlasdb.timelock.corruption.RemoteCorruptionDetector;
+import com.palantir.timelock.history.TimeLockPaxosHistoryProvider;
 
 @Value.Immutable
 public interface TimeLockCorruptionComponents {
     CorruptionHealthCheck timeLockCorruptionHealthCheck();
     RemoteCorruptionDetector remoteCorruptionDetector();
+    List<TimeLockPaxosHistoryProvider> remoteHistoryProviders();
+
+    static ImmutableTimeLockCorruptionComponents.Builder builder() {
+        return ImmutableTimeLockCorruptionComponents.builder();
+    }
 }

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -189,7 +189,7 @@ public class TimeLockAgent {
                 new TimeLockActivityCheckerFactory(install, metricsManager, userAgent).getTimeLockActivityCheckers());
 
         this.feedbackHandler = new FeedbackHandler(metricsManager, () -> runtime.get().adjudication().enabled());
-        this.corruptionComponents = paxosResources.leadershipComponents().timeLockCorruptionComponents();
+        this.corruptionComponents = paxosResources.timeLockCorruptionComponents();
     }
 
     private TimestampCreator getTimestampCreator() {


### PR DESCRIPTION
**Goals (and why)**:
Wire remote Paxos history providing endpoints.

**Implementation Description (bullets)**:

- Added corruption components to PaxosResources

**Testing (What was existing testing like?  What have you done to improve it?)**:
None right now.

**Concerns (what feedback would you like?)**:
Does the wiring make sense?

**Where should we start reviewing?**:
PaxosResources

**Priority (whenever / two weeks / yesterday)**:
As soon as possible 🏃‍♀️ 

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
