### PR TITLE
[TimeLock] Fix Antiquated cURL Instructions From TimeLock Documentation

### DIFF
--- a/docs/source/configuration/external_timelock_service_configs/timelock_server_config.rst
+++ b/docs/source/configuration/external_timelock_service_configs/timelock_server_config.rst
@@ -27,8 +27,12 @@ path variable. There are no guarantees of relationships between timestamps reque
 
    .. code:: bash
 
-      curl -XPOST localhost:8080/tom/timestamp/fresh-timestamp
-      curl -XPOST localhost:8080/jerry/timestamp/fresh-timestamp # no guarantees of any relationship between the values
+      curl -XPOST https://localhost:8421/timelock/api/tl/ts/tom \
+        --data '{"numTimestamps": 1}' -H "Authorization: Bearer q" -H "Content-Type: application/json"
+
+      # No guarantee of any relationship between the values
+      curl -XPOST https://localhost:8421/timelock/api/tl/ts/jerry \
+        --data '{"numTimestamps": 1}' -H "Authorization: Bearer q" -H "Content-Type: application/json"
 
 This is done for performance reasons: consider that if we maintained a global timestamp across all clients, then
 requests from each of these clients would need to all be synchronized.

--- a/docs/source/services/timelock_service/index.rst
+++ b/docs/source/services/timelock_service/index.rst
@@ -32,3 +32,5 @@ services embedded within one's clients) provides several benefits:
   exists.
 - AtlasDB client services running in HA mode may potentially become stateless, possibly simplifying deployability,
   availability and backup stories. Previously, these services would keep track of Paxos information on the local disk.
+- Upgrades to the timestamp and lock services are generally independent of user versions/upgrades, allowing for easier
+  administration in general.

--- a/docs/source/services/timelock_service/manual-migration.rst
+++ b/docs/source/services/timelock_service/manual-migration.rst
@@ -53,13 +53,19 @@ from here on out, we'll refer to it as ``TS``.
 Step 3: Fast-Forwarding the Timelock Server
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. tip::
+
+   Throughout this document, ``curl`` commands that make requests to TimeLock may receive a 308 indicating the location
+   of the leader, or a 503 indicating that a node is not the leader (and doesn't know this). Commands should be re-run
+   until they succeed on the leader.
+
 The Timelock Server exposes an administrative interface, which features a ``fast-forward`` endpoint. Note that this is
 not typically exposed to AtlasDB clients. One can use it to advance the timestamp on the Timelock Server to ``TS``, as
 follows:
 
    .. code:: bash
 
-      curl -XPOST <protocol>://<host>:<port>/timelock/api/<namespace>/timestamp-management/fast-forward?currentTimestamp=TS \
+      curl -iXPOST <protocol>://<host>:<port>/timelock/api/<namespace>/timestamp-management/fast-forward?currentTimestamp=TS \
         -H "Authorization: Bearer q"
 
 .. danger::
@@ -80,7 +86,7 @@ To verify that this step was completed correctly, you may curl the Timelock Serv
 
    .. code:: bash
 
-      curl -XPOST <protocol>://<host>:<port>/timelock/api/tl/ts/<namespace> \
+      curl -iXPOST <protocol>://<host>:<port>/timelock/api/tl/ts/<namespace> \
         --data '{"numTimestamps": 1}' -H "Authorization: Bearer q" -H "Content-Type: application/json"
 
 The value returned should be (assuming no one else is using the Timelock Server) 1 higher than ``TS``.

--- a/docs/source/services/timelock_service/manual-migration.rst
+++ b/docs/source/services/timelock_service/manual-migration.rst
@@ -55,11 +55,12 @@ Step 3: Fast-Forwarding the Timelock Server
 
 The Timelock Server exposes an administrative interface, which features a ``fast-forward`` endpoint. Note that this is
 not typically exposed to AtlasDB clients. One can use it to advance the timestamp on the Timelock Server to ``TS``, as
-follows (where ``test`` is the namespace you want your client to use).
+follows:
 
    .. code:: bash
 
-      curl -XPOST localhost:8080/test/timestamp-management/fast-forward?currentTimestamp=TS
+      curl -XPOST <protocol>://<host>:<port>/timelock/api/<namespace>/timestamp-management/fast-forward?currentTimestamp=TS \
+        -H "Authorization: Bearer q"
 
 .. danger::
 
@@ -79,7 +80,8 @@ To verify that this step was completed correctly, you may curl the Timelock Serv
 
    .. code:: bash
 
-      curl -XPOST localhost:8080/test/timestamp/fresh-timestamp
+      curl -XPOST <protocol>://<host>:<port>/timelock/api/tl/ts/<namespace> \
+        --data '{"numTimestamps": 1}' -H "Authorization: Bearer q" -H "Content-Type: application/json"
 
 The value returned should be (assuming no one else is using the Timelock Server) 1 higher than ``TS``.
 

--- a/docs/source/services/timelock_service/product-changes.rst
+++ b/docs/source/services/timelock_service/product-changes.rst
@@ -6,17 +6,4 @@ Developing a product to use the timelock service
 All products deploying against the AtlasDB Timelock service should adhere to the following checklist.
 
 1. Ensure that the AtlasDB client config contains the ``timelock`` :ref:`config block <timelock-client-configuration>`.
-2. The `Jetty ALPN agent <https://github.com/jetty-project/jetty-alpn-agent#usage>`__ is added as a javaagent JVM argument.
-   All AtlasDB clients will already have some version of ``jetty-alpn-agent.jar`` in the classpath. This is required to establish
-   HTTP/2 connections, and failure to include this will result in falling back to HTTP/1.1 connections and significant performance degradation. For example,
-
-    .. code-block:: yaml
-
-        java -javaagent:service/lib/jetty-alpn-agent-2.0.6.jar
-
-3. Further to the above, ensure that the Timelock Server is configured to use HTTP/2; see :ref:`Configuring HTTP/2 <timelock-server-config-http2>` for more details.
-4. Ensure that the Timelock server has added the product as a client in its :ref:`client <timelock-server-clients>` block.
-   The client name should be same as the ``client`` field in the :ref:`Timelock client configuration <timelock-client-configuration>`.
-5. All users of the product should :ref:`migrate <timelock-migration>` from embedded timestamp/lock services to the timelock server post-upgrade.
-
-If HTTP/2 is not required, then one may skip steps 2 and 3.
+2. All users of the product should :ref:`migrate <timelock-migration>` from embedded timestamp/lock services to the timelock server post-upgrade.

--- a/docs/source/services/timelock_service/reverse-migration.rst
+++ b/docs/source/services/timelock_service/reverse-migration.rst
@@ -5,7 +5,7 @@ Reverse Migration
 
 .. warning::
 
-   Many Atlas clients switched to using TimeLock by default many versions after it was reasonable to use Atlas with TimeLock.
+   Many Atlas clients switched to using TimeLock by default many versions after it was first reasonable to use Atlas with TimeLock.
    If you are on this page because you were directed to it by an error stating "This can happen if you attempt to run AtlasDB without a timelock block after having previously migrated to the TimeLock server", then please :ref:`configure your service<timelock-client-configuration>` to use TimeLock rather than attempting a reverse migration.
 
 .. danger::
@@ -44,10 +44,10 @@ of timestamps across TimeLock and the key-value service backed services is monot
 This can be obtained using ``curl`` as follows. Note that if you obtain an HTTP 503 error, this is because you curled a
 node that was not the leader; please try the other nodes.
 
-.. code-block:: none
+   .. code:: bash
 
-   $ curl -XPOST https://<timelock-host>:8421/timelock/api/client/timestamp/fresh-timestamp
-   123456789
+      curl -XPOST <protocol>://<host>:<port>/timelock/api/tl/ts/<namespace> \
+        --data '{"numTimestamps": 1}' -H "Authorization: Bearer q" -H "Content-Type: application/json"
 
 Note down the value returned from this call; we'll refer to it as ``TS`` from here on.
 

--- a/docs/source/services/timelock_service/service-management.rst
+++ b/docs/source/services/timelock_service/service-management.rst
@@ -33,7 +33,8 @@ less than the fresh timestamp. This may be obtained through the fresh timestamp 
 
 .. code:: bash
 
-      curl -XPOST localhost:8080/timelock/api/old_namespace/timelock/fresh-timestamp
+    curl -XPOST https://localhost:8421/timelock/api/tl/ts/old_namespace \
+      --data '{"numTimestamps": 1}' -H "Authorization: Bearer q" -H "Content-Type: application/json"
 
 A cluster of TimeLock servers elects a single leader, so if you contact a node that is not the leader you'll receive a
 ``NotCurrentLeaderException`` and an HTTP 503. In this case, try the same request on other nodes until you find the
@@ -49,7 +50,7 @@ on TimeLock.
 
 .. code:: bash
 
-      curl -XPOST localhost:8080/timelock/api/new_namespace/timestamp-management/fast-forward?currentTimestamp=TS
+      curl -XPOST https://localhost:8421/timelock/api/new_namespace/timestamp-management/fast-forward?currentTimestamp=TS
 
 As before, this command needs to be run on the TimeLock leader.
 After performing the fast forward, it may be worth obtaining a fresh timestamp for the new namespace to confirm that

--- a/docs/source/services/timelock_service/service-management.rst
+++ b/docs/source/services/timelock_service/service-management.rst
@@ -33,12 +33,11 @@ less than the fresh timestamp. This may be obtained through the fresh timestamp 
 
 .. code:: bash
 
-    curl -XPOST https://localhost:8421/timelock/api/tl/ts/old_namespace \
+    curl -iXPOST <protocol>://<host>:<port>/timelock/api/tl/ts/old_namespace \
       --data '{"numTimestamps": 1}' -H "Authorization: Bearer q" -H "Content-Type: application/json"
 
-A cluster of TimeLock servers elects a single leader, so if you contact a node that is not the leader you'll receive a
-``NotCurrentLeaderException`` and an HTTP 503. In this case, try the same request on other nodes until you find the
-leader.
+A cluster of TimeLock servers elects a single leader, so if you contact a node that is not the leader you'll receive
+either a HTTP 503 or 308. In this case, try the same request on other nodes until you find the leader.
 
 Note down the value of the timestamp returned. From here on out, we'll refer to this as ``TS``.
 
@@ -50,7 +49,7 @@ on TimeLock.
 
 .. code:: bash
 
-      curl -XPOST https://localhost:8421/timelock/api/new_namespace/timestamp-management/fast-forward?currentTimestamp=TS
+      curl -XPOST <protocol>://<host:<port>/timelock/api/new_namespace/timestamp-management/fast-forward?currentTimestamp=TS
 
 As before, this command needs to be run on the TimeLock leader.
 After performing the fast forward, it may be worth obtaining a fresh timestamp for the new namespace to confirm that


### PR DESCRIPTION
**Goals (and why)**:
- TimeLock docs should allow developers to independently get some understanding of how to talk to timelock. 
- The current docs have a lot of references to paths like `bleh/api/timestamp/fresh-timestamp` when it should be `/api/tl/ts/bleh`, which are outdated and end up requiring us to assist people in `help-atlasdb`.

**Implementation Description (bullets)**:
- Replace uses of TimeLock endpoints _on TimeLock_ with the new Conjure paths. Similarly update related guidance on required headers and wire format changes (e.g. for getFreshTimestamp).

**Testing (What was existing testing like?  What have you done to improve it?)**:
- N/A, docs change.

**Concerns (what feedback would you like?)**:
- Is the Conjure path correctly constructed?
- There are a few places in the docs where I have *deliberately* kept the old notation, generally when we are referring to an embedded service. Have I confused anything (i.e. treated an embedded thing as timelock, or vice versa)?

**Where should we start reviewing?**: wherever

**Priority (whenever / two weeks / yesterday)**: whenever
