### PR TITLE
[DB TimeLock] 3B.2 - DbTimeLockSingleLeaderPaxosSuite

### DIFF
--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -78,7 +78,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
 
     @ClassRule
     public static ParameterInjector<TestableTimelockCluster> injector =
-            ParameterInjector.withFallBackConfiguration(() -> DbTimeLockSingleLeaderPaxosSuite.DB_TIMELOCK_CLUSTER);
+            ParameterInjector.withFallBackConfiguration(() -> SingleLeaderPaxosSuite.BATCHED_TIMESTAMP_PAXOS);
 
     @Parameterized.Parameter
     public TestableTimelockCluster cluster;

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -50,7 +50,6 @@ import com.palantir.atlasdb.timelock.api.ConjureLockToken;
 import com.palantir.atlasdb.timelock.api.ConjureUnlockRequest;
 import com.palantir.atlasdb.timelock.api.SuccessfulLockResponse;
 import com.palantir.atlasdb.timelock.api.UnsuccessfulLockResponse;
-import com.palantir.atlasdb.timelock.suite.DbTimeLockSingleLeaderPaxosSuite;
 import com.palantir.atlasdb.timelock.suite.SingleLeaderPaxosSuite;
 import com.palantir.atlasdb.timelock.util.ExceptionMatchers;
 import com.palantir.atlasdb.timelock.util.ParameterInjector;

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -50,6 +50,7 @@ import com.palantir.atlasdb.timelock.api.ConjureLockToken;
 import com.palantir.atlasdb.timelock.api.ConjureUnlockRequest;
 import com.palantir.atlasdb.timelock.api.SuccessfulLockResponse;
 import com.palantir.atlasdb.timelock.api.UnsuccessfulLockResponse;
+import com.palantir.atlasdb.timelock.suite.DbTimeLockSingleLeaderPaxosSuite;
 import com.palantir.atlasdb.timelock.suite.SingleLeaderPaxosSuite;
 import com.palantir.atlasdb.timelock.util.ExceptionMatchers;
 import com.palantir.atlasdb.timelock.util.ParameterInjector;
@@ -77,7 +78,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
 
     @ClassRule
     public static ParameterInjector<TestableTimelockCluster> injector =
-            ParameterInjector.withFallBackConfiguration(() -> SingleLeaderPaxosSuite.BATCHED_PAXOS);
+            ParameterInjector.withFallBackConfiguration(() -> DbTimeLockSingleLeaderPaxosSuite.DB_TIMELOCK_CLUSTER);
 
     @Parameterized.Parameter
     public TestableTimelockCluster cluster;
@@ -306,6 +307,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
 
     @Test
     public void canGetAllNamespaces() {
+        Assume.assumeFalse("DB Timelock currently doesn't support getAllNamespaces().", cluster.isDbTimelock());
         String randomNamespace = UUID.randomUUID().toString();
         cluster.client(randomNamespace).throughWireMockProxy().getFreshTimestamp();
 
@@ -469,6 +471,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
 
     private void abandonLeadershipPaxosModeAgnosticTestIfRunElsewhere() {
         Assume.assumeTrue(cluster == FIRST_CLUSTER);
+        Assume.assumeFalse(cluster.isDbTimelock()); // We will never test only DB timelock when releasing.
     }
 
     private void makeServerWaitTwoSecondsAndThenReturn503s(TestableTimelockServer nonLeader) {

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -78,7 +78,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
 
     @ClassRule
     public static ParameterInjector<TestableTimelockCluster> injector =
-            ParameterInjector.withFallBackConfiguration(() -> SingleLeaderPaxosSuite.BATCHED_TIMESTAMP_PAXOS);
+            ParameterInjector.withFallBackConfiguration(() -> SingleLeaderPaxosSuite.BATCHED_PAXOS);
 
     @Parameterized.Parameter
     public TestableTimelockCluster cluster;

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/suite/DbTimeLockSingleLeaderPaxosSuite.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/suite/DbTimeLockSingleLeaderPaxosSuite.java
@@ -38,9 +38,7 @@ import com.palantir.atlasdb.timelock.TestableTimelockServerConfiguration;
 import com.palantir.timelock.config.PaxosInstallConfiguration;
 
 @RunWith(ParameterizedSuite.class)
-@Suite.SuiteClasses({
-        MultiNodePaxosTimeLockServerIntegrationTest.class
-})
+@Suite.SuiteClasses(MultiNodePaxosTimeLockServerIntegrationTest.class)
 public class DbTimeLockSingleLeaderPaxosSuite {
     private static final Iterable<TemplateVariables> TEMPLATE_VARIABLES = generateThreeNodeTimelockCluster(
             9086,

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/suite/DbTimeLockSingleLeaderPaxosSuite.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/suite/DbTimeLockSingleLeaderPaxosSuite.java
@@ -1,0 +1,72 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.suite;
+
+import static com.palantir.atlasdb.timelock.TemplateVariables.generateThreeNodeTimelockCluster;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Suite;
+
+import com.github.peterwippermann.junit4.parameterizedsuite.ParameterizedSuite;
+import com.google.common.collect.ImmutableSet;
+import com.palantir.atlasdb.timelock.ImmutableTestableTimelockServerConfiguration;
+import com.palantir.atlasdb.timelock.MultiNodePaxosTimeLockServerIntegrationTest;
+import com.palantir.atlasdb.timelock.TemplateVariables;
+import com.palantir.atlasdb.timelock.TestableTimelockCluster;
+import com.palantir.atlasdb.timelock.TestableTimelockServerConfiguration;
+import com.palantir.timelock.config.PaxosInstallConfiguration;
+
+@RunWith(ParameterizedSuite.class)
+@Suite.SuiteClasses({
+        MultiNodePaxosTimeLockServerIntegrationTest.class
+})
+public class DbTimeLockSingleLeaderPaxosSuite {
+    private static final Iterable<TemplateVariables> TEMPLATE_VARIABLES = generateThreeNodeTimelockCluster(
+            9086,
+            builder -> builder.clientPaxosBuilder(builder.clientPaxosBuilder()
+                    .isUseBatchPaxosTimestamp(false)
+                    .isBatchSingleLeader(true))
+                    .leaderMode(PaxosInstallConfiguration.PaxosLeaderMode.SINGLE_LEADER));
+    private static final List<TestableTimelockServerConfiguration> TESTABLE_CONFIGURATIONS = StreamSupport.stream(
+            TEMPLATE_VARIABLES.spliterator(), false)
+            .map(variables -> ImmutableTestableTimelockServerConfiguration.builder()
+                    .templateVariables(variables)
+                    .needsPostgresDatabase(true)
+                    .build())
+            .collect(Collectors.toList());
+
+    public static final TestableTimelockCluster DB_TIMELOCK_CLUSTER = new TestableTimelockCluster(
+            "db-timelock; batched single leader",
+            "dbTimeLockPaxosMultiServer.ftl",
+            TESTABLE_CONFIGURATIONS);
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<TestableTimelockCluster> params() {
+        return ImmutableSet.of(DB_TIMELOCK_CLUSTER);
+    }
+
+    @Rule
+    @Parameterized.Parameter
+    public TestableTimelockCluster cluster;
+}

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/suite/DbTimeLockSingleLeaderPaxosSuite.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/suite/DbTimeLockSingleLeaderPaxosSuite.java
@@ -48,10 +48,7 @@ public class DbTimeLockSingleLeaderPaxosSuite {
                     .leaderMode(PaxosInstallConfiguration.PaxosLeaderMode.SINGLE_LEADER));
     private static final List<TestableTimelockServerConfiguration> TESTABLE_CONFIGURATIONS = StreamSupport.stream(
             TEMPLATE_VARIABLES.spliterator(), false)
-            .map(variables -> ImmutableTestableTimelockServerConfiguration.builder()
-                    .templateVariables(variables)
-                    .needsPostgresDatabase(true)
-                    .build())
+            .map(variables -> TestableTimelockServerConfiguration.of(variables, true))
             .collect(Collectors.toList());
 
     public static final TestableTimelockCluster DB_TIMELOCK_CLUSTER = new TestableTimelockCluster(

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/suite/DbTimeLockSingleLeaderPaxosSuite.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/suite/DbTimeLockSingleLeaderPaxosSuite.java
@@ -30,7 +30,6 @@ import org.junit.runners.Suite;
 
 import com.github.peterwippermann.junit4.parameterizedsuite.ParameterizedSuite;
 import com.google.common.collect.ImmutableSet;
-import com.palantir.atlasdb.timelock.ImmutableTestableTimelockServerConfiguration;
 import com.palantir.atlasdb.timelock.MultiNodePaxosTimeLockServerIntegrationTest;
 import com.palantir.atlasdb.timelock.TemplateVariables;
 import com.palantir.atlasdb.timelock.TestableTimelockCluster;

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockServerConfiguration.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockServerConfiguration.java
@@ -26,4 +26,11 @@ public interface TestableTimelockServerConfiguration {
     default boolean needsPostgresDatabase() {
         return false;
     }
+
+    static TestableTimelockServerConfiguration of(TemplateVariables templateVariables, boolean needsPostgresDatabase) {
+        return ImmutableTestableTimelockServerConfiguration.builder()
+                .templateVariables(templateVariables)
+                .needsPostgresDatabase(needsPostgresDatabase)
+                .build();
+    }
 }

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockServerConfiguration.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockServerConfiguration.java
@@ -1,0 +1,29 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface TestableTimelockServerConfiguration {
+    TemplateVariables templateVariables();
+
+    @Value.Default
+    default boolean needsPostgresDatabase() {
+        return false;
+    }
+}

--- a/timelock-server/src/testCommon/resources/dbTimeLockPaxosMultiServer.ftl
+++ b/timelock-server/src/testCommon/resources/dbTimeLockPaxosMultiServer.ftl
@@ -1,0 +1,76 @@
+install:
+  paxos:
+    data-directory: "${dataDirectory}"
+    sqlite-persistence:
+      data-directory: "${sqliteDataDirectory}"
+    is-new-service: false
+    leader-mode: ${leaderMode}
+  cluster:
+    cluster:
+      security:
+        trustStorePath: "var/security/trustStore.jks"
+        trustStoreType: "JKS"
+        keyStorePath: "var/security/keyStore.jks"
+        keyStorePassword: "keystore"
+        keyStoreType: "JKS"
+      uris:
+<#list serverProxyPorts as serverProxyPort>
+      - "localhost:${serverProxyPort?c}"
+</#list>
+    local-server: "localhost:${localProxyPort?c}"
+  timestampBoundPersistence:
+    type: database
+    key-value-service:
+      type: "relational"
+      ddl:
+        type: "postgres"
+      connection:
+        type: "postgres"
+        host: "localhost"
+        port: 5432
+        dbName: "atlas"
+        dbLogin: "palantir"
+        dbPassword: "palantir"
+
+runtime:
+  paxos:
+    leader-ping-response-wait-in-ms: 1000
+    timestamp-paxos:
+      use-batch-paxos: ${clientPaxos.useBatchPaxosTimestamp?c}
+    enable-batching-for-single-leader: ${clientPaxos.batchSingleLeader?c}
+
+logging:
+  appenders:
+    - type: console
+      logFormat: "server-${localServerPort?c} %-5p [%d{ISO8601,UTC}] %c: %m%n%rEx"
+
+server:
+  requestLog:
+    appenders:
+      - type: console
+        logFormat: 'server-${localServerPort?c}       [%t{ISO8601,UTC}] %s %localPort %r %b "%i{User-Agent}" %D'
+
+  applicationConnectors:
+  - type: h2
+    port: ${localServerPort?c}
+    keyStorePath: var/security/keyStore.jks
+    keyStorePassword: keystore
+    trustStorePath: var/security/trustStore.jks
+    validateCerts: false
+    supportedCipherSuites:
+      - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+      - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
+      - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+      - TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384
+      - TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256
+      - TLS_RSA_WITH_AES_128_CBC_SHA256
+      - TLS_RSA_WITH_AES_256_CBC_SHA256
+      - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+      - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+      - TLS_ECDH_RSA_WITH_AES_256_CBC_SHA
+      - TLS_ECDH_RSA_WITH_AES_128_CBC_SHA
+      - TLS_RSA_WITH_AES_256_CBC_SHA
+      - TLS_RSA_WITH_AES_128_CBC_SHA
+      - TLS_EMPTY_RENEGOTIATION_INFO_SCSV
+  adminConnectors: []


### PR DESCRIPTION
**Goals (and why)**:
- Gather confidence that db timelock works well.

**Implementation Description (bullets)**:
- Wire up DB TimeLock to MNPTLSIT which we consider to be our benchmark for basic timelock correctness.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- This PR is about tests!

**Concerns (what feedback would you like?)**:
- This reruns a bunch of tests that are quite pointless because they test leadership code. I excluded the most egregious exceptions.
- I assumeFalse()d the namespace loader since it really doesn't make any sense until #5014 

**Where should we start reviewing?**: DbTimelockSingleLeaderPaxosSuite

**Priority (whenever / two weeks / yesterday)**: this week
