### PR TITLE
Double check that the SQLite migration is consistent with current state

### DIFF
--- a/changelog/@unreleased/pr-5026.v2.yml
+++ b/changelog/@unreleased/pr-5026.v2.yml
@@ -1,0 +1,8 @@
+type: fix
+fix:
+  description: Timelock now verifies consistency of the file based paxos state log
+    with SQLite and fails to start if the check fails. It was previously possible
+    to migrate to SQLite, force a downgrade and use file based log, then upgrade again
+    and skip running the migration again without detecting the inconsistent state.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5026

--- a/leader-election-api/src/main/java/com/palantir/paxos/PaxosValue.java
+++ b/leader-election-api/src/main/java/com/palantir/paxos/PaxosValue.java
@@ -108,6 +108,11 @@ public class PaxosValue implements Persistable, Versionable, Serializable {
     }
 
     @Override
+    public boolean equalsIgnoringVersion(Versionable other) {
+        return equals(other);
+    }
+
+    @Override
     public int hashCode() {
         final int prime = 31;
         int result = 1;

--- a/leader-election-api/src/main/java/com/palantir/paxos/Versionable.java
+++ b/leader-election-api/src/main/java/com/palantir/paxos/Versionable.java
@@ -20,4 +20,6 @@ public interface Versionable {
      * Returns a version number.
      */
     long getVersion();
+
+    boolean equalsIgnoringVersion(Versionable other);
 }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosAcceptorState.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosAcceptorState.java
@@ -16,6 +16,7 @@
 package com.palantir.paxos;
 
 import com.google.common.base.Defaults;
+import com.google.common.base.Objects;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.palantir.common.annotation.Immutable;
 import com.palantir.common.base.Throwables;
@@ -116,5 +117,39 @@ public final class PaxosAcceptorState implements Persistable, Versionable {
 
     public PaxosValue getLastAcceptedValue() {
         return lastAcceptedValue;
+    }
+
+    /**
+     * Standard equals implementation, note that {@link #version} is not persisted and as such is not used in the
+     * calculation.
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        PaxosAcceptorState other = (PaxosAcceptorState) obj;
+        if (!Objects.equal(lastPromisedId, other.lastPromisedId)) {
+            return false;
+        }
+        if (!Objects.equal(lastAcceptedId, other.lastAcceptedId)) {
+            return false;
+        }
+        return Objects.equal(lastAcceptedValue, other.lastAcceptedValue);
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((lastPromisedId == null) ? 0 : lastPromisedId.hashCode());
+        result = prime * result + ((lastAcceptedId == null) ? 0 : lastAcceptedId.hashCode());
+        return prime * result + ((lastAcceptedValue == null) ? 0 : lastAcceptedValue.hashCode());
     }
 }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosAcceptorState.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosAcceptorState.java
@@ -119,12 +119,8 @@ public final class PaxosAcceptorState implements Persistable, Versionable {
         return lastAcceptedValue;
     }
 
-    /**
-     * Standard equals implementation, note that {@link #version} is not persisted and as such is not used in the
-     * calculation.
-     */
     @Override
-    public boolean equals(Object obj) {
+    public boolean equalsIgnoringVersion(Versionable obj) {
         if (this == obj) {
             return true;
         }
@@ -142,14 +138,5 @@ public final class PaxosAcceptorState implements Persistable, Versionable {
             return false;
         }
         return Objects.equal(lastAcceptedValue, other.lastAcceptedValue);
-    }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((lastPromisedId == null) ? 0 : lastPromisedId.hashCode());
-        result = prime * result + ((lastAcceptedId == null) ? 0 : lastAcceptedId.hashCode());
-        return prime * result + ((lastAcceptedValue == null) ? 0 : lastAcceptedValue.hashCode());
     }
 }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogMigrator.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogMigrator.java
@@ -124,10 +124,9 @@ public final class PaxosStateLogMigrator<V extends Persistable & Versionable> {
         long migrationCutoff = calculateCutoff(context);
         long persistedCutoff = context.migrationState().getCutoff();
         long greatestSourceEntry = context.sourceLog().getGreatestLogEntry();
-        long greatestDestinationEntry = context.destinationLog().getGreatestLogEntry();
         Preconditions.checkState(migrationCutoff <= persistedCutoff,
                 "The migration to the destination state log was already performed in the past, but the "
-                        + "persisted cutoff value does not match a freshly calculated one. This indicates the source "
+                        + "persisted cutoff value does not match a newly calculated one. This indicates the source "
                         + "log has advanced since the migration was performed which could lead to data corruption if "
                         + "allowed to continue.",
                 SafeArg.of("fresh cutoff", migrationCutoff),
@@ -150,7 +149,7 @@ public final class PaxosStateLogMigrator<V extends Persistable & Versionable> {
         } catch (IOException e) {
             Preconditions.checkState(false,
                     "Unable to verify consistency between source and destination paxos logs because the "
-                            + "source log seems to be corrupted");
+                            + "source log entry could not be read.");
         }
     }
 

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosAcceptorStateTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosAcceptorStateTest.java
@@ -16,7 +16,8 @@
 
 package com.palantir.paxos;
 
-import org.assertj.core.api.Assertions;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.Test;
 
 public class PaxosAcceptorStateTest {
@@ -31,7 +32,7 @@ public class PaxosAcceptorStateTest {
                 LAST_ACCEPTED,
                 VALUE);
         PaxosAcceptorState hydrated = PaxosAcceptorState.BYTES_HYDRATOR.hydrateFromBytes(state.persistToBytes());
-        Assertions.assertThat(state).isEqualTo(hydrated);
+        assertThat(state.equalsIgnoringVersion(hydrated)).isTrue();
     }
 
     @Test
@@ -41,14 +42,14 @@ public class PaxosAcceptorStateTest {
 
         state = state.withState(LAST_PROMISED, LAST_ACCEPTED, VALUE);
         otherState = otherState.withState(LAST_PROMISED, LAST_ACCEPTED, VALUE);
-        Assertions.assertThat(state).isEqualTo(otherState);
+        assertThat(state.equalsIgnoringVersion(otherState)).isTrue();
     }
 
     @Test
     public void inequalityForPromised() {
         PaxosAcceptorState state = PaxosAcceptorState.newState(LAST_PROMISED);
         PaxosAcceptorState otherState = PaxosAcceptorState.newState(new PaxosProposalId(16, "id"));
-        Assertions.assertThat(state).isNotEqualTo(otherState);
+        assertThat(state.equalsIgnoringVersion(otherState)).isFalse();
     }
 
     @Test
@@ -58,7 +59,7 @@ public class PaxosAcceptorStateTest {
 
         state = state.withState(LAST_PROMISED, LAST_ACCEPTED, VALUE);
         otherState = otherState.withState(LAST_PROMISED, new PaxosProposalId(13, "other"), VALUE);
-        Assertions.assertThat(state).isNotEqualTo(otherState);
+        assertThat(state.equalsIgnoringVersion(otherState)).isFalse();
     }
 
     @Test
@@ -68,6 +69,6 @@ public class PaxosAcceptorStateTest {
 
         state = state.withState(LAST_PROMISED, LAST_ACCEPTED, VALUE);
         otherState = otherState.withState(LAST_PROMISED, LAST_ACCEPTED, PaxosStateLogTestUtils.valueForRound(12));
-        Assertions.assertThat(state).isNotEqualTo(otherState);
+        assertThat(state.equalsIgnoringVersion(otherState)).isFalse();
     }
 }

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosAcceptorStateTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosAcceptorStateTest.java
@@ -1,0 +1,73 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.paxos;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class PaxosAcceptorStateTest {
+    private static final PaxosProposalId LAST_PROMISED = new PaxosProposalId(15, "id");
+    private static final PaxosProposalId LAST_ACCEPTED = new PaxosProposalId(13, "otherId");
+    private static final PaxosValue VALUE = PaxosStateLogTestUtils.valueForRound(13);
+
+    @Test
+    public void hydrationEqualityTest() {
+        PaxosAcceptorState state = PaxosAcceptorState.newState(LAST_PROMISED);
+        state = state.withState(LAST_PROMISED,
+                LAST_ACCEPTED,
+                VALUE);
+        PaxosAcceptorState hydrated = PaxosAcceptorState.BYTES_HYDRATOR.hydrateFromBytes(state.persistToBytes());
+        Assertions.assertThat(state).isEqualTo(hydrated);
+    }
+
+    @Test
+    public void equalityTest() {
+        PaxosAcceptorState state = PaxosAcceptorState.newState(LAST_PROMISED);
+        PaxosAcceptorState otherState = PaxosAcceptorState.newState(LAST_PROMISED);
+
+        state = state.withState(LAST_PROMISED, LAST_ACCEPTED, VALUE);
+        otherState = otherState.withState(LAST_PROMISED, LAST_ACCEPTED, VALUE);
+        Assertions.assertThat(state).isEqualTo(otherState);
+    }
+
+    @Test
+    public void inequalityForPromised() {
+        PaxosAcceptorState state = PaxosAcceptorState.newState(LAST_PROMISED);
+        PaxosAcceptorState otherState = PaxosAcceptorState.newState(new PaxosProposalId(16, "id"));
+        Assertions.assertThat(state).isNotEqualTo(otherState);
+    }
+
+    @Test
+    public void inequalityForAccepted() {
+        PaxosAcceptorState state = PaxosAcceptorState.newState(LAST_PROMISED);
+        PaxosAcceptorState otherState = PaxosAcceptorState.newState(LAST_PROMISED);
+
+        state = state.withState(LAST_PROMISED, LAST_ACCEPTED, VALUE);
+        otherState = otherState.withState(LAST_PROMISED, new PaxosProposalId(13, "other"), VALUE);
+        Assertions.assertThat(state).isNotEqualTo(otherState);
+    }
+
+    @Test
+    public void inequalityForPaxosValue() {
+        PaxosAcceptorState state = PaxosAcceptorState.newState(LAST_PROMISED);
+        PaxosAcceptorState otherState = PaxosAcceptorState.newState(LAST_PROMISED);
+
+        state = state.withState(LAST_PROMISED, LAST_ACCEPTED, VALUE);
+        otherState = otherState.withState(LAST_PROMISED, LAST_ACCEPTED, PaxosStateLogTestUtils.valueForRound(12));
+        Assertions.assertThat(state).isNotEqualTo(otherState);
+    }
+}


### PR DESCRIPTION
**Goals (and why)**:
If we upgraded to version with SQLite paxos log, downgraded to a version before, used timelock for a bit, and then upgraded again, migration would not run because it had already run. Normally, the downgrade itself would have already cause data corruption if allowed, but it is possible to restore from backup to a previous version, and then upgrade after running on the restored version at which point the migration would silently noop and we would start using the pre-restore SQLite paxos state log. This PR verifies the consistency whenever we detect that the migration has already run.

**Implementation Description (bullets)**:
We have imperfect information and do not want to effectively redo the migration on every startup, so we do the following:

1. Verify the cutoff that was persisted matches a newly calculated one. This guarantees the learner has not advanced except in the special case where the greatest log entry is was less than 50 at migration time and then advanced but is still less than 50.
2. Verify that the greatest log entry in the legacy log is not larger than the one in SQLite, and also verify that the entry is present in SQLite and equal. This covers both the special case above and the acceptor as acceptor uses the cutoff from the learner.

Also needed to implement equality for `PaxosAcceptorState.java`, which has to not include the version which is not persisted. Not in love with this, but beats the alternatives.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Unit tests for the migrator and for the PAS equality.

**Concerns (what feedback would you like?)**:
Note that (2) above is not foolproof as it is possible that the legacy log wrote some new entries and then happened to write the latest one to exactly mach one that SQLite wrote after the migration while there are some in between that do not match. I am not aware of a way to do this with more certainty while not also effectively redoing the migration on every startup, which is prohibitively expensive. An alternative approach would be to have a new migration state table where we persist the greatest migrated sequence as well as cutoff, and would then have to migrate all already migrated deployments, but that seems excessive since the chance of (2) failing while also (1) passing is very low.

**Where should we start reviewing?**:
PaxosStateLogMigrator.java

**Priority (whenever / two weeks / yesterday)**:
ASAP