### PR TITLE
[DB TimeLock] 3C.2 - Timestamp Storage and Series Extraction Preliminary Wiring

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/TimestampSeriesProvider.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/TimestampSeriesProvider.java
@@ -14,22 +14,10 @@
  * limitations under the License.
  */
 
-package com.palantir.atlasdb.timelock.management;
+package com.palantir.atlasdb.keyvalue.api;
 
-import java.nio.file.Path;
+import java.util.Set;
 
-import javax.sql.DataSource;
-
-import org.derive4j.Data;
-
-import com.palantir.atlasdb.keyvalue.api.TimestampSeriesProvider;
-
-@Data
-public interface PersistentNamespaceContext {
-    interface Cases<R> {
-        R timestampBoundPaxos(Path fileDataDirectory, DataSource sqliteDataSource);
-        R dbBound(TimestampSeriesProvider seriesProvider);
-    }
-
-    <R> R match(PersistentNamespaceContext.Cases<R> cases);
+public interface TimestampSeriesProvider {
+    Set<TimestampSeries> getKnownSeries();
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/timestamp/DbTimeLockFactory.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/timestamp/DbTimeLockFactory.java
@@ -1,0 +1,43 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timestamp;
+
+import java.util.Optional;
+
+import com.palantir.atlasdb.config.DbTimestampCreationSetting;
+import com.palantir.atlasdb.config.LeaderConfig;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.TimestampSeriesProvider;
+import com.palantir.atlasdb.spi.KeyValueServiceConfig;
+import com.palantir.atlasdb.util.MetricsManager;
+import com.palantir.timestamp.ManagedTimestampService;
+
+public interface DbTimeLockFactory {
+    String getType();
+
+    KeyValueService createRawKeyValueService(
+            MetricsManager metricsManager,
+            KeyValueServiceConfig config,
+            LeaderConfig leaderConfig);
+
+    ManagedTimestampService createManagedTimestampService(
+            KeyValueService rawKvs,
+            Optional<DbTimestampCreationSetting> dbTimestampCreationSetting,
+            boolean initializeAsync);
+
+    TimestampSeriesProvider createTimestampSeriesProvider(KeyValueService rawKvs, boolean initializeAsync);
+}

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/timestamp/DbTimeLockFactory.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/timestamp/DbTimeLockFactory.java
@@ -26,6 +26,11 @@ import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.timestamp.ManagedTimestampService;
 
+/**
+ * See {@link com.palantir.atlasdb.spi.AtlasDbFactory}. A {@link DbTimeLockFactory} is an extension of an
+ * AtlasDbFactory that is expected to make suitable decisions around certain parameters to create a raw key-value
+ * service, and it also supports extracting the timestamp series known about by the underlying database.
+ */
 public interface DbTimeLockFactory {
     String getType();
 

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/RelationalDbTimeLockFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/RelationalDbTimeLockFactory.java
@@ -1,0 +1,73 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.dbkvs;
+
+import java.util.Optional;
+
+import com.google.auto.service.AutoService;
+import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.config.DbTimestampCreationSetting;
+import com.palantir.atlasdb.config.LeaderConfig;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.TimestampSeriesProvider;
+import com.palantir.atlasdb.spi.AtlasDbFactory;
+import com.palantir.atlasdb.spi.KeyValueServiceConfig;
+import com.palantir.atlasdb.timestamp.DbTimeLockFactory;
+import com.palantir.atlasdb.util.MetricsManager;
+import com.palantir.timestamp.ManagedTimestampService;
+
+@AutoService(DbTimeLockFactory.class)
+public class RelationalDbTimeLockFactory implements DbTimeLockFactory {
+    public static final String TYPE = "relational";
+
+    private final AtlasDbFactory delegate = new DbAtlasDbFactory();
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    @Override
+    public KeyValueService createRawKeyValueService(
+            MetricsManager metricsManager,
+            KeyValueServiceConfig config,
+            LeaderConfig leaderConfig) {
+        return delegate.createRawKeyValueService(
+                metricsManager,
+                config,
+                Optional::empty,
+                Optional.of(leaderConfig),
+                Optional.empty(), // This refers to an AtlasDB namespace - we use the config to talk to the db
+                AtlasDbFactory.THROWING_FRESH_TIMESTAMP_SOURCE, // This is how we give out timestamps!
+                AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
+    }
+
+    @Override
+    public ManagedTimestampService createManagedTimestampService(
+            KeyValueService rawKvs,
+            Optional<DbTimestampCreationSetting> dbTimestampCreationSetting,
+            boolean initializeAsync) {
+        return delegate.createManagedTimestampService(rawKvs, dbTimestampCreationSetting, initializeAsync);
+    }
+
+    @Override
+    public TimestampSeriesProvider createTimestampSeriesProvider(KeyValueService rawKvs, boolean initializeAsync) {
+        return () -> {
+            throw new UnsupportedOperationException("Not supported yet!");
+        };
+    }
+}

--- a/timelock-agent/src/main/java/com/palantir/timelock/ServiceDiscoveringDatabaseTimeLockSupplier.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/ServiceDiscoveringDatabaseTimeLockSupplier.java
@@ -27,7 +27,6 @@ import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.factory.AtlasDbServiceDiscovery;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TimestampSeriesProvider;
-import com.palantir.atlasdb.spi.AtlasDbFactory;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 import com.palantir.atlasdb.timestamp.DbTimeLockFactory;
 import com.palantir.atlasdb.util.MetricsManager;

--- a/timelock-agent/src/main/java/com/palantir/timelock/ServiceDiscoveringDatabaseTimeLockSupplier.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/ServiceDiscoveringDatabaseTimeLockSupplier.java
@@ -26,8 +26,10 @@ import com.palantir.atlasdb.config.DbTimestampCreationSetting;
 import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.factory.AtlasDbServiceDiscovery;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.TimestampSeriesProvider;
 import com.palantir.atlasdb.spi.AtlasDbFactory;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
+import com.palantir.atlasdb.timestamp.DbTimeLockFactory;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.timestamp.ManagedTimestampService;
 
@@ -38,26 +40,23 @@ import com.palantir.timestamp.ManagedTimestampService;
 public class ServiceDiscoveringDatabaseTimeLockSupplier implements AutoCloseable {
     private final Supplier<KeyValueService> keyValueService;
     private final Function<DbTimestampCreationSetting, ManagedTimestampService> timestampServiceFactory;
+    private final TimestampSeriesProvider timestampSeriesProvider;
 
     public ServiceDiscoveringDatabaseTimeLockSupplier(
             MetricsManager metricsManager,
             KeyValueServiceConfig config,
             LeaderConfig leaderConfig) {
-        AtlasDbFactory atlasFactory = AtlasDbServiceDiscovery.createAtlasFactoryOfCorrectType(config);
+        DbTimeLockFactory dbTimeLockFactory = AtlasDbServiceDiscovery.createDbTimeLockFactoryOfCorrectType(config);
         keyValueService = Suppliers.memoize(
-                () -> atlasFactory.createRawKeyValueService(
-                        metricsManager,
-                        config,
-                        Optional::empty,
-                        Optional.of(leaderConfig),
-                        Optional.empty(), // This refers to an AtlasDB namespace - we use the config to talk to the db
-                        AtlasDbFactory.THROWING_FRESH_TIMESTAMP_SOURCE, // This is how we give out timestamps!
-                        AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC));
+                () -> dbTimeLockFactory.createRawKeyValueService(metricsManager, config, leaderConfig));
         timestampServiceFactory = creationSetting ->
-                atlasFactory.createManagedTimestampService(
+                dbTimeLockFactory.createManagedTimestampService(
                         keyValueService.get(),
                         Optional.of(creationSetting),
                         AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
+        timestampSeriesProvider = dbTimeLockFactory.createTimestampSeriesProvider(
+                keyValueService.get(),
+                AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
     }
 
     @Override
@@ -67,5 +66,9 @@ public class ServiceDiscoveringDatabaseTimeLockSupplier implements AutoCloseable
 
     public synchronized ManagedTimestampService getManagedTimestampService(DbTimestampCreationSetting setting) {
         return timestampServiceFactory.apply(setting);
+    }
+
+    public synchronized TimestampSeriesProvider getTimestampSeriesProvider() {
+        return timestampSeriesProvider;
     }
 }

--- a/timelock-agent/src/main/java/com/palantir/timelock/management/TimestampStorage.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/management/TimestampStorage.java
@@ -14,22 +14,15 @@
  * limitations under the License.
  */
 
-package com.palantir.atlasdb.timelock.management;
+package com.palantir.timelock.management;
 
-import java.nio.file.Path;
+import org.immutables.value.Value;
 
-import javax.sql.DataSource;
+import com.palantir.atlasdb.timelock.management.PersistentNamespaceContext;
+import com.palantir.timelock.paxos.TimestampCreator;
 
-import org.derive4j.Data;
-
-import com.palantir.atlasdb.keyvalue.api.TimestampSeriesProvider;
-
-@Data
-public interface PersistentNamespaceContext {
-    interface Cases<R> {
-        R timestampBoundPaxos(Path fileDataDirectory, DataSource sqliteDataSource);
-        R dbBound(TimestampSeriesProvider seriesProvider);
-    }
-
-    <R> R match(PersistentNamespaceContext.Cases<R> cases);
+@Value.Immutable
+public interface TimestampStorage {
+    TimestampCreator timestampCreator();
+    PersistentNamespaceContext persistentNamespaceContext();
 }

--- a/timelock-agent/src/main/java/com/palantir/timelock/management/TimestampStorage.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/management/TimestampStorage.java
@@ -16,8 +16,6 @@
 
 package com.palantir.timelock.management;
 
-import java.io.Closeable;
-
 import org.immutables.value.Value;
 
 import com.palantir.atlasdb.timelock.management.PersistentNamespaceContext;

--- a/timelock-agent/src/main/java/com/palantir/timelock/management/TimestampStorage.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/management/TimestampStorage.java
@@ -16,13 +16,19 @@
 
 package com.palantir.timelock.management;
 
+import java.io.Closeable;
+
 import org.immutables.value.Value;
 
 import com.palantir.atlasdb.timelock.management.PersistentNamespaceContext;
 import com.palantir.timelock.paxos.TimestampCreator;
 
 @Value.Immutable
-public interface TimestampStorage {
+public interface TimestampStorage extends AutoCloseable {
     TimestampCreator timestampCreator();
     PersistentNamespaceContext persistentNamespaceContext();
+
+    default void close() {
+        timestampCreator().close();
+    }
 }

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/DbBoundTimestampCreator.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/DbBoundTimestampCreator.java
@@ -23,8 +23,6 @@ import com.palantir.atlasdb.config.DbTimestampCreationSetting;
 import com.palantir.atlasdb.config.DbTimestampCreationSettings;
 import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.keyvalue.api.TimestampSeries;
-import com.palantir.atlasdb.spi.KeyValueServiceConfig;
-import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.paxos.Client;
 import com.palantir.timelock.ServiceDiscoveringDatabaseTimeLockSupplier;
 import com.palantir.timestamp.ManagedTimestampService;
@@ -33,17 +31,9 @@ public final class DbBoundTimestampCreator implements TimestampCreator {
 
     private final ServiceDiscoveringDatabaseTimeLockSupplier serviceDiscoveringDatabaseTimeLockSupplier;
 
-    private DbBoundTimestampCreator(
+    public DbBoundTimestampCreator(
             ServiceDiscoveringDatabaseTimeLockSupplier serviceDiscoveringDatabaseTimeLockSupplier) {
         this.serviceDiscoveringDatabaseTimeLockSupplier = serviceDiscoveringDatabaseTimeLockSupplier;
-    }
-
-    public static TimestampCreator create(
-            KeyValueServiceConfig kvsConfig,
-            MetricsManager metricsManager,
-            LeaderConfig leaderConfig) {
-        return new DbBoundTimestampCreator(
-                new ServiceDiscoveringDatabaseTimeLockSupplier(metricsManager, kvsConfig, leaderConfig));
     }
 
     @Override

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -220,11 +220,9 @@ public class TimeLockAgent {
 
     private TimestampStorage createDatabaseTimestampStorage(
             DatabaseTsBoundPersisterConfiguration timestampBoundPersistence) {
-        DatabaseTsBoundPersisterConfiguration persisterConfiguration
-                = timestampBoundPersistence;
         ServiceDiscoveringDatabaseTimeLockSupplier dbTimeLockSupplier =
                 new ServiceDiscoveringDatabaseTimeLockSupplier(
-                        metricsManager, persisterConfiguration.keyValueServiceConfig(), createLeaderConfig());
+                        metricsManager, timestampBoundPersistence.keyValueServiceConfig(), createLeaderConfig());
         return ImmutableTimestampStorage.builder()
                 .timestampCreator(new DbBoundTimestampCreator(dbTimeLockSupplier))
                 .persistentNamespaceContext(PersistentNamespaceContexts.dbBound(
@@ -420,6 +418,6 @@ public class TimeLockAgent {
     public void shutdown() {
         paxosResources.leadershipComponents().shutdown();
         sqliteDataSource.close();
-        timestampStorage.timestampCreator().close();
+        timestampStorage.close();
     }
 }

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -47,7 +47,6 @@ import com.palantir.atlasdb.timelock.adjudicate.HealthStatusReport;
 import com.palantir.atlasdb.timelock.adjudicate.TimeLockClientFeedbackResource;
 import com.palantir.atlasdb.timelock.lock.LockLog;
 import com.palantir.atlasdb.timelock.lock.v1.ConjureLockV1Resource;
-import com.palantir.atlasdb.timelock.management.PersistentNamespaceContext;
 import com.palantir.atlasdb.timelock.management.PersistentNamespaceContexts;
 import com.palantir.atlasdb.timelock.management.TimeLockManagementResource;
 import com.palantir.atlasdb.timelock.paxos.ImmutableTimelockPaxosInstallationContext;

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -48,6 +48,7 @@ import com.palantir.atlasdb.timelock.adjudicate.TimeLockClientFeedbackResource;
 import com.palantir.atlasdb.timelock.lock.LockLog;
 import com.palantir.atlasdb.timelock.lock.v1.ConjureLockV1Resource;
 import com.palantir.atlasdb.timelock.management.PersistentNamespaceContext;
+import com.palantir.atlasdb.timelock.management.PersistentNamespaceContexts;
 import com.palantir.atlasdb.timelock.management.TimeLockManagementResource;
 import com.palantir.atlasdb.timelock.paxos.ImmutableTimelockPaxosInstallationContext;
 import com.palantir.atlasdb.timelock.paxos.PaxosResources;
@@ -64,6 +65,7 @@ import com.palantir.lock.LockService;
 import com.palantir.paxos.Client;
 import com.palantir.refreshable.Refreshable;
 import com.palantir.sls.versions.OrderableSlsVersion;
+import com.palantir.timelock.ServiceDiscoveringDatabaseTimeLockSupplier;
 import com.palantir.timelock.config.DatabaseTsBoundPersisterConfiguration;
 import com.palantir.timelock.config.PaxosTsBoundPersisterConfiguration;
 import com.palantir.timelock.config.TimeLockInstallConfiguration;
@@ -77,6 +79,8 @@ import com.palantir.timelock.history.remote.TimeLockPaxosHistoryProviderResource
 import com.palantir.timelock.history.sqlite.SqlitePaxosStateLogHistory;
 import com.palantir.timelock.invariants.NoSimultaneousServiceCheck;
 import com.palantir.timelock.invariants.TimeLockActivityCheckerFactory;
+import com.palantir.timelock.management.ImmutableTimestampStorage;
+import com.palantir.timelock.management.TimestampStorage;
 import com.palantir.timestamp.ManagedTimestampService;
 import com.zaxxer.hikari.HikariDataSource;
 
@@ -92,7 +96,7 @@ public class TimeLockAgent {
     private final Optional<Consumer<UndertowService>> undertowRegistrar;
     private final PaxosResources paxosResources;
     private final LockCreator lockCreator;
-    private final TimestampCreator timestampCreator;
+    private final TimestampStorage timestampStorage;
     private final TimeLockServicesCreator timelockCreator;
     private final NoSimultaneousServiceCheck noSimultaneousServiceCheck;
     private final HikariDataSource sqliteDataSource;
@@ -175,7 +179,7 @@ public class TimeLockAgent {
         this.paxosResources = paxosResources;
         this.sqliteDataSource = sqliteDataSource;
         this.lockCreator = new LockCreator(runtime, threadPoolSize, blockingTimeoutMs);
-        this.timestampCreator = getTimestampCreator();
+        this.timestampStorage = getTimestampStorage();
         LockLog lockLog = new LockLog(metricsManager.getRegistry(),
                 Suppliers.compose(TimeLockRuntimeConfiguration::slowLockLogTriggerMillis, runtime::get));
 
@@ -193,20 +197,40 @@ public class TimeLockAgent {
         this.corruptionComponents = paxosResources.timeLockCorruptionComponents();
     }
 
-    private TimestampCreator getTimestampCreator() {
+    private TimestampStorage getTimestampStorage() {
         TsBoundPersisterConfiguration timestampBoundPersistence = install.timestampBoundPersistence();
         if (timestampBoundPersistence instanceof PaxosTsBoundPersisterConfiguration) {
-            return new PaxosTimestampCreator(paxosResources.timestampServiceFactory());
+            return createPaxosBasedTimestampStorage();
         } else if (timestampBoundPersistence instanceof DatabaseTsBoundPersisterConfiguration) {
-            DatabaseTsBoundPersisterConfiguration persisterConfiguration
-                    = (DatabaseTsBoundPersisterConfiguration) timestampBoundPersistence;
-            return DbBoundTimestampCreator.create(
-                    persisterConfiguration.keyValueServiceConfig(),
-                    metricsManager,
-                    createLeaderConfig());
+            return createDatabaseTimestampStorage(
+                    (DatabaseTsBoundPersisterConfiguration) timestampBoundPersistence);
         }
         throw new RuntimeException(String.format("Unknown TsBoundPersisterConfiguration found %s",
                 timestampBoundPersistence.getClass()));
+    }
+
+    private TimestampStorage createPaxosBasedTimestampStorage() {
+        return ImmutableTimestampStorage.builder()
+                .timestampCreator(new PaxosTimestampCreator(paxosResources.timestampServiceFactory()))
+                .persistentNamespaceContext(
+                        PersistentNamespaceContexts.timestampBoundPaxos(
+                                install.paxos().dataDirectory().toPath(),
+                                sqliteDataSource))
+                .build();
+    }
+
+    private TimestampStorage createDatabaseTimestampStorage(
+            DatabaseTsBoundPersisterConfiguration timestampBoundPersistence) {
+        DatabaseTsBoundPersisterConfiguration persisterConfiguration
+                = timestampBoundPersistence;
+        ServiceDiscoveringDatabaseTimeLockSupplier dbTimeLockSupplier =
+                new ServiceDiscoveringDatabaseTimeLockSupplier(
+                        metricsManager, persisterConfiguration.keyValueServiceConfig(), createLeaderConfig());
+        return ImmutableTimestampStorage.builder()
+                .timestampCreator(new DbBoundTimestampCreator(dbTimeLockSupplier))
+                .persistentNamespaceContext(PersistentNamespaceContexts.dbBound(
+                        dbTimeLockSupplier.getTimestampSeriesProvider()))
+                .build();
     }
 
     private void createAndRegisterResources() {
@@ -283,21 +307,15 @@ public class TimeLockAgent {
         Path rootDataDirectory = install.paxos().dataDirectory().toPath();
         if (undertowRegistrar.isPresent()) {
             registerCorruptionHandlerWrappedService(undertowRegistrar.get(), TimeLockManagementResource.undertow(
-                    PersistentNamespaceContext.of(
-                            rootDataDirectory, sqliteDataSource, isUsingDatabasePersistence()),
+                    timestampStorage.persistentNamespaceContext(),
                     namespaces,
                     redirectRetryTargeter()));
         } else {
             registrar.accept(TimeLockManagementResource.jersey(
-                    PersistentNamespaceContext.of(
-                            rootDataDirectory, sqliteDataSource, isUsingDatabasePersistence()),
+                    timestampStorage.persistentNamespaceContext(),
                     namespaces,
                     redirectRetryTargeter()));
         }
-    }
-
-    private boolean isUsingDatabasePersistence() {
-        return install.timestampBoundPersistence() instanceof DatabaseTsBoundPersisterConfiguration;
     }
 
     private void registerTimeLockCorruptionJerseyFilter() {
@@ -376,7 +394,7 @@ public class TimeLockAgent {
 
         Client typedClient = Client.of(client);
 
-        Supplier<ManagedTimestampService> rawTimestampServiceSupplier = timestampCreator
+        Supplier<ManagedTimestampService> rawTimestampServiceSupplier = timestampStorage.timestampCreator()
                 .createTimestampService(typedClient, leaderConfig);
         Supplier<LockService> rawLockServiceSupplier = lockCreator::createThreadPoolingLockService;
         return timelockCreator.createTimeLockServices(typedClient, rawTimestampServiceSupplier, rawLockServiceSupplier);
@@ -403,6 +421,6 @@ public class TimeLockAgent {
     public void shutdown() {
         paxosResources.leadershipComponents().shutdown();
         sqliteDataSource.close();
-        timestampCreator.close();
+        timestampStorage.timestampCreator().close();
     }
 }

--- a/timelock-impl/build.gradle
+++ b/timelock-impl/build.gradle
@@ -22,6 +22,8 @@ dependencies {
     compileOnly project(":atlasdb-processors")
     annotationProcessor group: 'org.immutables', name: 'value'
     compileOnly 'org.immutables:value::annotations'
+    annotationProcessor 'org.derive4j:derive4j'
+    compileOnly 'org.derive4j:derive4j-annotation'
 
     testCompile project(path: ":leader-election-impl", configuration: "testArtifacts")
     testCompile project(":atlasdb-tests-shared")

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/management/DiskNamespaceLoaderTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/management/DiskNamespaceLoaderTest.java
@@ -63,10 +63,9 @@ public class DiskNamespaceLoaderTest {
                 .create(testUrl, ImmutableList.of(testUrl));
 
         Path rootFolderPath = tempFolder.getRoot().toPath();
-        PersistentNamespaceContext persistentNamespaceContext = PersistentNamespaceContext.of(
+        PersistentNamespaceContext persistentNamespaceContext = PersistentNamespaceContexts.timestampBoundPaxos(
                 rootFolderPath,
-                SqliteConnections.getPooledDataSource(rootFolderPath),
-                false);
+                SqliteConnections.getPooledDataSource(rootFolderPath));
 
         TimelockNamespaces namespaces = new TimelockNamespaces(metricsManager, serviceFactory, maxNumberOfClientsSupplier);
 


### PR DESCRIPTION
**Goals (and why)**:
- Support getAllNamespaces(), which is used as part of the SQLite and CentOS migrations. While it's debatable whether these will be needed in the short run for users of DB TimeLock, I would strongly prefer for us to not have DB TimeLock behave differently from a standard SQLite TimeLock as far as possible. (e.g. when we want to perform VM migrations, the CLI needs to work, and I wouldn't want it to suddenly implode or fail silently). As of #5027, there is still the test of getAllNamespaces() that is explicitly ignored by DB TimeLock.
- This PR doesn't achieve that yet, but performs a fairly involved refactor that will be needed in the next part of this.

**Implementation Description (bullets)**:
- Migrate `PersistentNamespaceContext` to derive4j which works a lot better IMO
- Define an SPI interface `DbTimeLockFactory` that is an extended version of `AtlasDbFactory` including the ability to extract known timestamp series.

**Testing (What was existing testing like?  What have you done to improve it?)**:
This is atop the branch that supports #5025 so we verify that MNPTLSIT still passes even for db-timelock + postgres.

**Concerns (what feedback would you like?)**:
- Did I break anything badly?

**Where should we start reviewing?**: TimeLockAgent

**Priority (whenever / two weeks / yesterday)**: this week please
