### PR TITLE
make oracle protocol case insensitive

### DIFF
--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionProtocol.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionProtocol.java
@@ -15,6 +15,8 @@
  */
 package com.palantir.nexus.db.pool.config;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 public enum ConnectionProtocol {
     TCP("tcp"), TCPS("tcps");
 
@@ -28,9 +30,10 @@ public enum ConnectionProtocol {
         return urlStr;
     }
 
+    @JsonCreator
     public static ConnectionProtocol fromUrlString(String val) {
         for (ConnectionProtocol cp : ConnectionProtocol.values()) {
-            if (cp.getUrlString().toLowerCase().equals(val.toLowerCase())) {
+            if (cp.getUrlString().equalsIgnoreCase(val)) {
                 return cp;
             }
         }

--- a/atlasdb-dbkvs-hikari/src/test/java/com/palantir/nexus/db/pool/config/OracleConnectionConfigTest.java
+++ b/atlasdb-dbkvs-hikari/src/test/java/com/palantir/nexus/db/pool/config/OracleConnectionConfigTest.java
@@ -185,4 +185,13 @@ public class OracleConnectionConfigTest {
         }
     }
 
+    @Test
+    public void invalidProtocolTest() {
+        ObjectMapper mapper = new ObjectMapper();
+
+        assertThatThrownBy(() -> mapper.readValue("\"invalid\"", ConnectionProtocol.class))
+                .hasCauseInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("invalid does not correspond to a known ConnectionProtocol");
+    }
+
 }

--- a/changelog/@unreleased/pr-5038.v2.yml
+++ b/changelog/@unreleased/pr-5038.v2.yml
@@ -1,29 +1,6 @@
 type: improvement
 improvement:
   description: |-
-    make oracle protocol case insensitive
-
-    **Goals (and why)**:
-
-    Makes the protocol (tcp/tcps) case insensitive in oracle configs.
-    Previously oracle connection configs required the protocol to be
-    upper-case. Most of our other internal products allow any case
-    on the oracle protocol, so the requirement here for it to be
-    upper-case in config results in some errors when people try to
-    configure oracle.
-
-    **Implementation Description (bullets)**:
-
-    Adds jackson annotations to the ConnectionProtocol enum.
-
-    **Testing (What was existing testing like?  What have you done to improve it?)**:
-
-    Added a unit test.
-
-    **Concerns (what feedback would you like?)**: N/A
-
-    **Where should we start reviewing?**: N/A
-
-    **Priority (whenever / two weeks / yesterday)**: high - allowing this to be case insensitive avoids configuration errors and helps with interoperability with other products that don't enforce case sensitivity on the oracle protocol.
+    The protocol (TCP/TCPS) is now case insensitive in oracle configs.
   links:
   - https://github.com/palantir/atlasdb/pull/5038

--- a/changelog/@unreleased/pr-5038.v2.yml
+++ b/changelog/@unreleased/pr-5038.v2.yml
@@ -1,0 +1,29 @@
+type: improvement
+improvement:
+  description: |-
+    make oracle protocol case insensitive
+
+    **Goals (and why)**:
+
+    Makes the protocol (tcp/tcps) case insensitive in oracle configs.
+    Previously oracle connection configs required the protocol to be
+    upper-case. Most of our other internal products allow any case
+    on the oracle protocol, so the requirement here for it to be
+    upper-case in config results in some errors when people try to
+    configure oracle.
+
+    **Implementation Description (bullets)**:
+
+    Adds jackson annotations to the ConnectionProtocol enum.
+
+    **Testing (What was existing testing like?  What have you done to improve it?)**:
+
+    Added a unit test.
+
+    **Concerns (what feedback would you like?)**: N/A
+
+    **Where should we start reviewing?**: N/A
+
+    **Priority (whenever / two weeks / yesterday)**: high - allowing this to be case insensitive avoids configuration errors and helps with interoperability with other products that don't enforce case sensitivity on the oracle protocol.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5038


### PR DESCRIPTION
**Goals (and why)**:

Makes the protocol (tcp/tcps) case insensitive in oracle configs.
Previously oracle connection configs required the protocol to be
upper-case. Most of our other internal products allow any case
on the oracle protocol, so the requirement here for it to be
upper-case in config results in some errors when people try to
configure oracle.

**Implementation Description (bullets)**:

Adds jackson annotations to the ConnectionProtocol enum.

**Testing (What was existing testing like?  What have you done to improve it?)**:

Added a unit test.

**Concerns (what feedback would you like?)**: N/A

**Where should we start reviewing?**: N/A

**Priority (whenever / two weeks / yesterday)**: high - allowing this to be case insensitive avoids configuration errors and helps with interoperability with other products that don't enforce case sensitivity on the oracle protocol.