### PR TITLE
Read from palantir system table to try and use hostnames instead of ips

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraUtils.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraUtils.java
@@ -16,17 +16,36 @@
 package com.palantir.atlasdb.keyvalue.cassandra;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
+import org.apache.cassandra.thrift.Compression;
+import org.apache.cassandra.thrift.ConsistencyLevel;
+import org.apache.cassandra.thrift.CqlRow;
+import org.apache.cassandra.thrift.KsDef;
+import org.apache.cassandra.thrift.NotFoundException;
 import org.apache.cassandra.thrift.TokenRange;
 import org.apache.cassandra.thrift.UnavailableException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
+import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.InsufficientConsistencyException;
 import com.palantir.atlasdb.keyvalue.api.RetryLimitReachedException;
 import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.common.exception.AtlasDbDependencyException;
+import com.palantir.logsafe.SafeArg;
 
 public final class CassandraUtils {
+    private static final Logger logger = LoggerFactory.getLogger(CassandraUtils.class);
+    private static final String SYSTEM_PALANTIR_KEYSPACE = "system_palantir";
+    private static final String HOSTNAMES_BY_IP_TABLE = "hostnames_by_ip";
+    private static final String HOSTNAME_COLUMN = "hostname";
+    private static final String IP_COLUMN = "ip";
+
     private CassandraUtils() {}
 
     public static FunctionCheckedException<CassandraClient, Void, Exception> getValidatePartitioner(
@@ -42,10 +61,46 @@ public final class CassandraUtils {
         return client -> client.describe_ring(config.getKeyspaceOrThrow());
     }
 
+    public static FunctionCheckedException<CassandraClient, Map<String, String>, Exception> getHostnameMappings() {
+        return client -> {
+            try {
+                KsDef systemPalantir = client.describe_keyspace(SYSTEM_PALANTIR_KEYSPACE);
+                if (systemPalantir.getCf_defs().stream().noneMatch(cfDef -> cfDef.name.equals(HOSTNAMES_BY_IP_TABLE))) {
+                    return ImmutableMap.of();
+                }
+                CqlQuery query = CqlQuery.builder()
+                        .safeQueryFormat("SELECT * FROM \"%s\".\"%s\";")
+                        .addArgs(
+                                SafeArg.of("keyspace", SYSTEM_PALANTIR_KEYSPACE),
+                                SafeArg.of("table", HOSTNAMES_BY_IP_TABLE))
+                        .build();
+
+                return client.execute_cql3_query(query, Compression.NONE, ConsistencyLevel.ONE).getRows().stream()
+                        .collect(ImmutableMap.toImmutableMap(
+                                row -> getNamedColumnValue(row, IP_COLUMN),
+                                row -> getNamedColumnValue(row, HOSTNAME_COLUMN)));
+            } catch (NotFoundException e) {
+                logger.debug("Did not find table with hostname mappings, moving on without them");
+                return ImmutableMap.of();
+            } catch (Exception e) {
+                logger.warn("Could not get hostname mappings from Cassandra", e);
+                return ImmutableMap.of();
+            }
+        };
+    }
+
     public static AtlasDbDependencyException wrapInIceForDeleteOrRethrow(RetryLimitReachedException ex) {
         if (ex.suppressed(UnavailableException.class) || ex.suppressed(InsufficientConsistencyException.class)) {
             throw new InsufficientConsistencyException("Deleting requires all Cassandra nodes to be available.", ex);
         }
         throw ex;
+    }
+
+    private static String getNamedColumnValue(CqlRow row, String columnName) {
+        return Iterables.getOnlyElement(
+                row.getColumns().stream()
+                        .filter(col -> PtBytes.toString(col.getName()).equals(columnName))
+                        .map(col -> PtBytes.toString(col.getValue()))
+                        .collect(Collectors.toList()));
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraUtils.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraUtils.java
@@ -16,36 +16,17 @@
 package com.palantir.atlasdb.keyvalue.cassandra;
 
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
-import org.apache.cassandra.thrift.Compression;
-import org.apache.cassandra.thrift.ConsistencyLevel;
-import org.apache.cassandra.thrift.CqlRow;
-import org.apache.cassandra.thrift.KsDef;
-import org.apache.cassandra.thrift.NotFoundException;
 import org.apache.cassandra.thrift.TokenRange;
 import org.apache.cassandra.thrift.UnavailableException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
-import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.InsufficientConsistencyException;
 import com.palantir.atlasdb.keyvalue.api.RetryLimitReachedException;
 import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.common.exception.AtlasDbDependencyException;
-import com.palantir.logsafe.SafeArg;
 
 public final class CassandraUtils {
-    private static final Logger logger = LoggerFactory.getLogger(CassandraUtils.class);
-    private static final String SYSTEM_PALANTIR_KEYSPACE = "system_palantir";
-    private static final String HOSTNAMES_BY_IP_TABLE = "hostnames_by_ip";
-    private static final String HOSTNAME_COLUMN = "hostname";
-    private static final String IP_COLUMN = "ip";
-
     private CassandraUtils() {}
 
     public static FunctionCheckedException<CassandraClient, Void, Exception> getValidatePartitioner(
@@ -61,46 +42,10 @@ public final class CassandraUtils {
         return client -> client.describe_ring(config.getKeyspaceOrThrow());
     }
 
-    public static FunctionCheckedException<CassandraClient, Map<String, String>, Exception> getHostnameMappings() {
-        return client -> {
-            try {
-                KsDef systemPalantir = client.describe_keyspace(SYSTEM_PALANTIR_KEYSPACE);
-                if (systemPalantir.getCf_defs().stream().noneMatch(cfDef -> cfDef.name.equals(HOSTNAMES_BY_IP_TABLE))) {
-                    return ImmutableMap.of();
-                }
-                CqlQuery query = CqlQuery.builder()
-                        .safeQueryFormat("SELECT * FROM \"%s\".\"%s\";")
-                        .addArgs(
-                                SafeArg.of("keyspace", SYSTEM_PALANTIR_KEYSPACE),
-                                SafeArg.of("table", HOSTNAMES_BY_IP_TABLE))
-                        .build();
-
-                return client.execute_cql3_query(query, Compression.NONE, ConsistencyLevel.ONE).getRows().stream()
-                        .collect(ImmutableMap.toImmutableMap(
-                                row -> getNamedColumnValue(row, IP_COLUMN),
-                                row -> getNamedColumnValue(row, HOSTNAME_COLUMN)));
-            } catch (NotFoundException e) {
-                logger.debug("Did not find table with hostname mappings, moving on without them");
-                return ImmutableMap.of();
-            } catch (Exception e) {
-                logger.warn("Could not get hostname mappings from Cassandra", e);
-                return ImmutableMap.of();
-            }
-        };
-    }
-
     public static AtlasDbDependencyException wrapInIceForDeleteOrRethrow(RetryLimitReachedException ex) {
         if (ex.suppressed(UnavailableException.class) || ex.suppressed(InsufficientConsistencyException.class)) {
             throw new InsufficientConsistencyException("Deleting requires all Cassandra nodes to be available.", ex);
         }
         throw ex;
-    }
-
-    private static String getNamedColumnValue(CqlRow row, String columnName) {
-        return Iterables.getOnlyElement(
-                row.getColumns().stream()
-                        .filter(col -> PtBytes.toString(col.getName()).equals(columnName))
-                        .map(col -> PtBytes.toString(col.getValue()))
-                        .collect(Collectors.toList()));
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
@@ -223,13 +223,13 @@ public class CassandraService implements AutoCloseable {
     }
 
     @VisibleForTesting
-    InetSocketAddress getAddressForHost(String host) throws UnknownHostException {
-        if (config.addressTranslation().containsKey(host)) {
-            return config.addressTranslation().get(host);
+    InetSocketAddress getAddressForHost(String inputHost) throws UnknownHostException {
+        if (config.addressTranslation().containsKey(inputHost)) {
+            return config.addressTranslation().get(inputHost);
         }
 
         Map<String, String> hostnamesByIp = hostnameByIpSupplier.get();
-        host = hostnamesByIp.getOrDefault(host, host);
+        String host = hostnamesByIp.getOrDefault(inputHost, inputHost);
 
         InetAddress resolvedHost = InetAddress.getByName(host);
         Set<InetSocketAddress> allKnownHosts = Sets.union(currentPools.keySet(),

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostnamesByIpSupplier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostnamesByIpSupplier.java
@@ -70,7 +70,7 @@ public final class HostnamesByIpSupplier implements Supplier<Map<String, String>
                 logger.debug("Did not find keyspace with hostnames by ip, moving on without them");
                 return ImmutableMap.of();
             }
-            if (systemPalantir.getCf_defs().stream().noneMatch(cfDef -> cfDef.name.equals(HOSTNAMES_BY_IP_TABLE))) {
+            if (isCfNotPresent(systemPalantir, HOSTNAMES_BY_IP_TABLE)) {
                 logger.debug("Did not find table with hostnames by ip, moving on without them");
                 return ImmutableMap.of();
             }
@@ -87,6 +87,10 @@ public final class HostnamesByIpSupplier implements Supplier<Map<String, String>
                             row -> getNamedColumnValue(row, IP_COLUMN),
                             row -> getNamedColumnValue(row, HOSTNAME_COLUMN)));
         };
+    }
+
+    private boolean isCfNotPresent(KsDef ksDef, String cfName) {
+        return ksDef.getCf_defs().stream().noneMatch(cfDef -> cfDef.name.equals(cfName));
     }
 
     private static String getNamedColumnValue(CqlRow row, String columnName) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostnamesByIpSupplier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostnamesByIpSupplier.java
@@ -1,0 +1,99 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra.pool;
+
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.apache.cassandra.thrift.Compression;
+import org.apache.cassandra.thrift.ConsistencyLevel;
+import org.apache.cassandra.thrift.CqlRow;
+import org.apache.cassandra.thrift.KsDef;
+import org.apache.cassandra.thrift.NotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.cassandra.CassandraClient;
+import com.palantir.atlasdb.keyvalue.cassandra.CqlQuery;
+import com.palantir.common.base.FunctionCheckedException;
+import com.palantir.common.pooling.PoolingContainer;
+import com.palantir.logsafe.SafeArg;
+
+public final class HostnamesByIpSupplier implements Supplier<Map<String, String>> {
+    private static final Logger logger = LoggerFactory.getLogger(HostnamesByIpSupplier.class);
+
+    private static final String SYSTEM_PALANTIR_KEYSPACE = "system_palantir";
+    private static final String HOSTNAMES_BY_IP_TABLE = "hostnames_by_ip";
+    private static final String HOSTNAME_COLUMN = "hostname";
+    private static final String IP_COLUMN = "ip";
+
+    private final Supplier<PoolingContainer<CassandraClient>> randomGoodHostSupplier;
+
+    public HostnamesByIpSupplier(Supplier<PoolingContainer<CassandraClient>> randomGoodHostSupplier) {
+        this.randomGoodHostSupplier = randomGoodHostSupplier;
+    }
+
+    @Override
+    public Map<String, String> get() {
+        try {
+            return randomGoodHostSupplier.get().runWithPooledResource(getHostnamesByIp());
+        } catch (Exception e) {
+            logger.warn("Could not get hostnames by ip from Cassandra", e);
+            return ImmutableMap.of();
+        }
+    }
+
+    public FunctionCheckedException<CassandraClient, Map<String, String>, Exception> getHostnamesByIp() {
+        return client -> {
+            KsDef systemPalantir;
+            try {
+                systemPalantir = client.describe_keyspace(SYSTEM_PALANTIR_KEYSPACE);
+            }  catch (NotFoundException e) {
+                logger.debug("Did not find keyspace with hostnames by ip, moving on without them");
+                return ImmutableMap.of();
+            }
+            if (systemPalantir.getCf_defs().stream().noneMatch(cfDef -> cfDef.name.equals(HOSTNAMES_BY_IP_TABLE))) {
+                logger.debug("Did not find table with hostnames by ip, moving on without them");
+                return ImmutableMap.of();
+            }
+
+            CqlQuery query = CqlQuery.builder()
+                    .safeQueryFormat("SELECT * FROM \"%s\".\"%s\";")
+                    .addArgs(
+                            SafeArg.of("keyspace", SYSTEM_PALANTIR_KEYSPACE),
+                            SafeArg.of("table", HOSTNAMES_BY_IP_TABLE))
+                    .build();
+
+            return client.execute_cql3_query(query, Compression.NONE, ConsistencyLevel.LOCAL_ONE).getRows().stream()
+                    .collect(ImmutableMap.toImmutableMap(
+                            row -> getNamedColumnValue(row, IP_COLUMN),
+                            row -> getNamedColumnValue(row, HOSTNAME_COLUMN)));
+        };
+    }
+
+    private static String getNamedColumnValue(CqlRow row, String columnName) {
+        return Iterables.getOnlyElement(
+                row.getColumns().stream()
+                        .filter(col -> PtBytes.toString(col.getName()).equals(columnName))
+                        .map(col -> PtBytes.toString(col.getValue()))
+                        .collect(Collectors.toList()));
+    }
+}

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostnamesByIpSupplierTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostnamesByIpSupplierTest.java
@@ -155,14 +155,14 @@ public class HostnamesByIpSupplierTest {
         }
 
         @Override
-        public <V, K extends Exception> V runWithPooledResource(FunctionCheckedException<CassandraClient, V, K> f)
+        public <V, K extends Exception> V runWithPooledResource(FunctionCheckedException<CassandraClient, V, K> fn)
                 throws K {
-            return f.apply(client);
+            return fn.apply(client);
         }
 
         @Override
-        public <V> V runWithPooledResource(Function<CassandraClient, V> f) {
-            return f.apply(client);
+        public <V> V runWithPooledResource(Function<CassandraClient, V> fn) {
+            return fn.apply(client);
         }
 
         @Override

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostnamesByIpSupplierTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostnamesByIpSupplierTest.java
@@ -1,0 +1,172 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra.pool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.apache.cassandra.thrift.CfDef;
+import org.apache.cassandra.thrift.Column;
+import org.apache.cassandra.thrift.CqlResult;
+import org.apache.cassandra.thrift.CqlRow;
+import org.apache.cassandra.thrift.KsDef;
+import org.apache.cassandra.thrift.NotFoundException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.cassandra.CassandraClient;
+import com.palantir.common.base.FunctionCheckedException;
+import com.palantir.common.pooling.PoolingContainer;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HostnamesByIpSupplierTest {
+    @Mock
+    CassandraClient client;
+
+    @Test
+    public void keyspaceNotAccessibleDoesNotError() throws Exception {
+        when(client.describe_keyspace("system_palantir")).thenThrow(new NotFoundException());
+        DummyClientPool clientPool = new DummyClientPool(client);
+
+        Supplier<Map<String, String>> hostnamesByIpSupplier = new HostnamesByIpSupplier(() -> clientPool);
+        assertThatCode(hostnamesByIpSupplier::get).doesNotThrowAnyException();
+        assertThat(hostnamesByIpSupplier.get()).isEmpty();
+    }
+
+    @Test
+    public void tableNotAccessibleDoesNotError() throws Exception {
+        when(client.describe_keyspace("system_palantir"))
+                .thenReturn(new KsDef("system_palantir", "", ImmutableList.of()));
+        DummyClientPool clientPool = new DummyClientPool(client);
+
+        Supplier<Map<String, String>> hostnamesByIpSupplier = new HostnamesByIpSupplier(() -> clientPool);
+        assertThatCode(hostnamesByIpSupplier::get).doesNotThrowAnyException();
+        assertThat(hostnamesByIpSupplier.get()).isEmpty();
+    }
+
+    @Test
+    public void unexpectedTableFormatDoesNotError() throws Exception {
+        when(client.describe_keyspace("system_palantir"))
+                .thenReturn(new KsDef("system_palantir", "",
+                        ImmutableList.of(new CfDef("system_palantir", "hostnames_by_ip"))));
+        CqlResult cqlResult = createMockCqlResult(ImmutableList.of(
+                ImmutableList.of(
+                        createColumn("unknown_name", PtBytes.toBytes("unknown_value")),
+                        createColumn("another_unknown_name", PtBytes.toBytes("another_unknown_value")))));
+        when(client.execute_cql3_query(any(), any(), any())).thenReturn(cqlResult);
+        DummyClientPool clientPool = new DummyClientPool(client);
+
+        Supplier<Map<String, String>> hostnamesByIpSupplier = new HostnamesByIpSupplier(() -> clientPool);
+        assertThat(hostnamesByIpSupplier.get()).isEmpty();
+        verify(client).execute_cql3_query(any(), any(), any());
+    }
+
+    @Test
+    public void hostnamesByIpAreReturnedWhenPresent() throws Exception {
+        when(client.describe_keyspace("system_palantir"))
+                .thenReturn(new KsDef("system_palantir", "",
+                        ImmutableList.of(new CfDef("system_palantir", "hostnames_by_ip"))));
+        CqlResult cqlResult = createMockCqlResult(ImmutableList.of(
+                ImmutableList.of(
+                        createColumn("ip", PtBytes.toBytes("10.0.0.0")),
+                        createColumn("hostname", PtBytes.toBytes("cassandra-1"))),
+                ImmutableList.of(
+                        createColumn("ip", PtBytes.toBytes("10.0.0.1")),
+                        createColumn("hostname", PtBytes.toBytes("cassandra-2")))));
+        when(client.execute_cql3_query(any(), any(), any())).thenReturn(cqlResult);
+        DummyClientPool clientPool = new DummyClientPool(client);
+
+        Supplier<Map<String, String>> hostnamesByIpSupplier = new HostnamesByIpSupplier(() -> clientPool);
+        Map<String, String> hostnamesByIp = hostnamesByIpSupplier.get();
+        assertThat(hostnamesByIp).containsEntry("10.0.0.0", "cassandra-1");
+        assertThat(hostnamesByIp).containsEntry("10.0.0.1", "cassandra-2");
+    }
+
+    @Test
+    public void unknownColumnsAreIgnored() throws Exception {
+        when(client.describe_keyspace("system_palantir"))
+                .thenReturn(new KsDef("system_palantir", "",
+                        ImmutableList.of(new CfDef("system_palantir", "hostnames_by_ip"))));
+        CqlResult cqlResult = createMockCqlResult(ImmutableList.of(
+                ImmutableList.of(
+                        createColumn("ip", PtBytes.toBytes("10.0.0.0")),
+                        createColumn("hostname", PtBytes.toBytes("cassandra-1")),
+                        createColumn("unknown_column", PtBytes.toBytes("unknown_column_value")))));
+        when(client.execute_cql3_query(any(), any(), any())).thenReturn(cqlResult);
+        DummyClientPool clientPool = new DummyClientPool(client);
+
+        Supplier<Map<String, String>> hostnamesByIpSupplier = new HostnamesByIpSupplier(() -> clientPool);
+        Map<String, String> hostnamesByIp = hostnamesByIpSupplier.get();
+        assertThat(hostnamesByIp).containsEntry("10.0.0.0", "cassandra-1");
+    }
+
+    private static CqlResult createMockCqlResult(List<List<Column>> rowsAndCols) {
+        CqlResult result = mock(CqlResult.class);
+        List<CqlRow> rows = new ArrayList<>();
+        for (List<Column> cols : rowsAndCols) {
+            CqlRow row = mock(CqlRow.class);
+            when(row.getColumns()).thenReturn(cols);
+            rows.add(row);
+        }
+        when(result.getRows()).thenReturn(rows);
+        return result;
+    }
+
+    private static Column createColumn(String name, byte[] value) {
+        Column column = new Column();
+        column.setName(PtBytes.toBytes(name));
+        column.setValue(value);
+        return column;
+    }
+
+    private static class DummyClientPool implements PoolingContainer<CassandraClient> {
+        private final CassandraClient client;
+
+        DummyClientPool(CassandraClient client) {
+            this.client = client;
+        }
+
+        @Override
+        public <V, K extends Exception> V runWithPooledResource(FunctionCheckedException<CassandraClient, V, K> f)
+                throws K {
+            return f.apply(client);
+        }
+
+        @Override
+        public <V> V runWithPooledResource(Function<CassandraClient, V> f) {
+            return f.apply(client);
+        }
+
+        @Override
+        public void shutdownPooling() {
+        }
+    }
+}

--- a/changelog/@unreleased/pr-5045.v2.yml
+++ b/changelog/@unreleased/pr-5045.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Read from palantir system table to try and use hostnames instead of
+    ips when creating connections to Cassandra
+  links:
+  - https://github.com/palantir/atlasdb/pull/5045


### PR DESCRIPTION
**Goals (and why)**:
This allows Atlas services to work in scenarios when Cassandra is running in a different VPC than the Atlas service.
It builds on top of the address translation feature that was added here https://github.com/palantir/atlasdb/pull/3040 by reading the hostname <-> private IP mappings from Cassandra itself. We have added this mapping to all internal Cassandra clusters but for clusters that don't have it, this PR will simply no-op.

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:
Have tested this e2e with the multi VPC scenario internally.

**Concerns (what feedback would you like?)**:
is there a better way to do this?
**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:
ASAP to unblock work on multi VPC setups.
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
