### PR TITLE
reduce log level.

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -1776,7 +1776,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             final String baseMsg = "Locks acquired as part of the transaction protocol are no longer valid. ";
             String expiredLocksErrorString = getExpiredLocksErrorString(commitLocksToken, expiredLocks);
             TransactionLockTimeoutException ex = new TransactionLockTimeoutException(baseMsg + expiredLocksErrorString);
-            log.error(baseMsg + "{}", expiredLocksErrorString, ex);
+            log.warn(baseMsg + "{}", expiredLocksErrorString, ex);
             transactionOutcomeMetrics.markLocksExpired();
             throw ex;
         }

--- a/changelog/@unreleased/pr-5046.v2.yml
+++ b/changelog/@unreleased/pr-5046.v2.yml
@@ -1,31 +1,6 @@
 type: improvement
 improvement:
   description: |-
-    reduce log level.
-
-    **Goals (and why)**:
-    Internal PDS-138463
-
-    This can happen during a timelock leader election, and retrying transaction should work.
-    The log level can be misleading, hence reducing the level to warn.
-
-    **Implementation Description (bullets)**:
-    fairly trivial
-
-    **Testing (What was existing testing like?  What have you done to improve it?)**:
-    none, but again, fairly trivial
-
-    **Concerns (what feedback would you like?)**:
-    none
-
-    **Where should we start reviewing?**:
-
-    **Priority (whenever / two weeks / yesterday)**:
-
-    <!---
-    Please remember to:
-    - Add any necessary release notes (including breaking changes)
-    - Make sure the documentation is up to date for your change
-    --->
+    Reduces logging level for throwIfImmutableTsOrCommitLocksExpired to warn because it usually succeeds on retries, so logging at error level is misleading.
   links:
   - https://github.com/palantir/atlasdb/pull/5046

--- a/changelog/@unreleased/pr-5046.v2.yml
+++ b/changelog/@unreleased/pr-5046.v2.yml
@@ -1,0 +1,31 @@
+type: improvement
+improvement:
+  description: |-
+    reduce log level.
+
+    **Goals (and why)**:
+    Internal PDS-138463
+
+    This can happen during a timelock leader election, and retrying transaction should work.
+    The log level can be misleading, hence reducing the level to warn.
+
+    **Implementation Description (bullets)**:
+    fairly trivial
+
+    **Testing (What was existing testing like?  What have you done to improve it?)**:
+    none, but again, fairly trivial
+
+    **Concerns (what feedback would you like?)**:
+    none
+
+    **Where should we start reviewing?**:
+
+    **Priority (whenever / two weeks / yesterday)**:
+
+    <!---
+    Please remember to:
+    - Add any necessary release notes (including breaking changes)
+    - Make sure the documentation is up to date for your change
+    --->
+  links:
+  - https://github.com/palantir/atlasdb/pull/5046


### PR DESCRIPTION
**Goals (and why)**:
Internal PDS-138463

This can happen during a timelock leader election, and retrying transaction should work.
The log level can be misleading, hence reducing the level to warn.

**Implementation Description (bullets)**:
fairly trivial

**Testing (What was existing testing like?  What have you done to improve it?)**:
none, but again, fairly trivial

**Concerns (what feedback would you like?)**:
none

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
