### PR TITLE
Match dialogue read/write timeout

### DIFF
--- a/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/DialogueClientOptions.java
+++ b/atlasdb-conjure/src/main/java/com/palantir/atlasdb/http/v2/DialogueClientOptions.java
@@ -19,6 +19,7 @@ package com.palantir.atlasdb.http.v2;
 import com.palantir.atlasdb.config.AuxiliaryRemotingParameters;
 import com.palantir.atlasdb.config.ServerListConfig;
 import com.palantir.common.streams.KeyedStream;
+import com.palantir.conjure.java.api.config.service.HumanReadableDuration;
 import com.palantir.conjure.java.api.config.service.PartialServiceConfiguration;
 import com.palantir.conjure.java.api.config.service.ServicesConfigBlock;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
@@ -40,6 +41,9 @@ public final class DialogueClientOptions {
 
     private static PartialServiceConfiguration toPartialServiceConfiguration(
             ServerListConfig serverListConfig, AuxiliaryRemotingParameters remotingParameters) {
+        HumanReadableDuration clientTimeout = remotingParameters.shouldUseExtendedTimeout()
+                ? ClientOptionsConstants.LONG_READ_TIMEOUT
+                : ClientOptionsConstants.SHORT_READ_TIMEOUT;
         return populateConfigurationWithAtlasDbDefaults()
                 .addAllUris(serverListConfig.servers())
                 .proxyConfiguration(serverListConfig.proxyConfiguration())
@@ -50,10 +54,8 @@ public final class DialogueClientOptions {
                         remotingParameters.definitiveRetryIndication()
                                 ? ClientOptionsConstants.STANDARD_MAX_RETRIES
                                 : ClientOptionsConstants.NO_RETRIES)
-                .readTimeout(
-                        remotingParameters.shouldUseExtendedTimeout()
-                                ? ClientOptionsConstants.LONG_READ_TIMEOUT
-                                : ClientOptionsConstants.SHORT_READ_TIMEOUT)
+                .readTimeout(clientTimeout)
+                .writeTimeout(clientTimeout)
                 .build();
     }
 

--- a/atlasdb-conjure/src/test/java/com/palantir/atlasdb/http/v2/DialogueClientOptionsTest.java
+++ b/atlasdb-conjure/src/test/java/com/palantir/atlasdb/http/v2/DialogueClientOptionsTest.java
@@ -99,9 +99,11 @@ public class DialogueClientOptionsTest {
         PartialServiceConfiguration partialServiceConfiguration =
                 servicesConfigBlock.services().get(SERVICE_NAME);
         assertThat(partialServiceConfiguration.readTimeout()).contains(ClientOptionsConstants.LONG_READ_TIMEOUT);
+        assertThat(partialServiceConfiguration.writeTimeout()).contains(ClientOptionsConstants.LONG_READ_TIMEOUT);
 
         PartialServiceConfiguration otherPartialServiceConfiguration =
                 servicesConfigBlock.services().get(otherServiceName);
         assertThat(otherPartialServiceConfiguration.readTimeout()).contains(ClientOptionsConstants.SHORT_READ_TIMEOUT);
+        assertThat(otherPartialServiceConfiguration.writeTimeout()).contains(ClientOptionsConstants.SHORT_READ_TIMEOUT);
     }
 }

--- a/changelog/@unreleased/pr-5060.v2.yml
+++ b/changelog/@unreleased/pr-5060.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Match dialogue read/write timeout.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5060


### PR DESCRIPTION
**Goals (and why)**:

Read and write timeouts for Dialogue clients must be the same.

Currently logs:
```
Read and write timeouts do not match, The value of the readTimeout {} will be used and write timeout {} will be ignored.
readTimeout
"PT1M5S"
writeTimeout
"PT5M"
```

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:
