### PR TITLE
Leader Election Metrics 1a: Client Side Wiring

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -147,9 +147,9 @@ import com.palantir.lock.LockServerOptions;
 import com.palantir.lock.LockService;
 import com.palantir.lock.NamespaceAgnosticLockRpcClient;
 import com.palantir.lock.SimpleTimeDuration;
+import com.palantir.lock.client.LeaderElectionReportingTimelockService;
 import com.palantir.lock.client.LockRefreshingLockService;
 import com.palantir.lock.client.NamespacedConjureLockWatchingService;
-import com.palantir.lock.client.NamespacedConjureTimelockService;
 import com.palantir.lock.client.ProfilingTimelockService;
 import com.palantir.lock.client.RemoteLockServiceAdapter;
 import com.palantir.lock.client.RemoteTimelockServiceAdapter;
@@ -407,7 +407,8 @@ public abstract class TransactionManagers {
                 atlasFactory.getTimestampStoreInvalidator(),
                 userAgent(),
                 lockDiagnosticComponents(),
-                reloadingFactory());
+                reloadingFactory(),
+                timeLockFeedbackBackgroundTask);
         adapter.setTimestampService(lockAndTimestampServices.managedTimestampService());
 
         KvsProfilingLogger.setSlowLogThresholdMillis(config().getKvsSlowLogThresholdMillis());
@@ -968,7 +969,8 @@ public abstract class TransactionManagers {
                 invalidator,
                 UserAgents.tryParse(userAgent),
                 Optional.empty(),
-                newMinimalDialogueFactory());
+                newMinimalDialogueFactory(),
+                Optional.empty());
         TimeLockClient timeLockClient = TimeLockClient.withSynchronousUnlocker(lockAndTimestampServices.timelock());
         return ImmutableLockAndTimestampServices.builder()
                 .from(lockAndTimestampServices)
@@ -989,7 +991,8 @@ public abstract class TransactionManagers {
             TimestampStoreInvalidator invalidator,
             UserAgent userAgent,
             Optional<LockDiagnosticComponents> lockDiagnosticComponents,
-            DialogueClients.ReloadingFactory reloadingFactory) {
+            DialogueClients.ReloadingFactory reloadingFactory,
+            Optional<TimeLockFeedbackBackgroundTask> timeLockFeedbackBackgroundTask) {
         LockAndTimestampServices lockAndTimestampServices = createRawInstrumentedServices(
                 metricsManager,
                 config,
@@ -1000,7 +1003,8 @@ public abstract class TransactionManagers {
                 invalidator,
                 userAgent,
                 lockDiagnosticComponents,
-                reloadingFactory);
+                reloadingFactory,
+                timeLockFeedbackBackgroundTask);
         return withMetrics(
                 metricsManager, withCorroboratingTimestampService(withRefreshingLockService(lockAndTimestampServices)));
     }
@@ -1055,7 +1059,8 @@ public abstract class TransactionManagers {
             TimestampStoreInvalidator invalidator,
             UserAgent userAgent,
             Optional<LockDiagnosticComponents> lockDiagnosticComponents,
-            DialogueClients.ReloadingFactory reloadingFactory) {
+            DialogueClients.ReloadingFactory reloadingFactory,
+            Optional<TimeLockFeedbackBackgroundTask> timeLockFeedbackBackgroundTask) {
         AtlasDbRuntimeConfig initialRuntimeConfig = runtimeConfig.get();
         assertNoSpuriousTimeLockBlockInRuntimeConfig(config, initialRuntimeConfig);
         if (config.leader().isPresent()) {
@@ -1070,7 +1075,8 @@ public abstract class TransactionManagers {
                     invalidator,
                     userAgent,
                     lockDiagnosticComponents,
-                    reloadingFactory);
+                    reloadingFactory,
+                    timeLockFeedbackBackgroundTask);
         } else {
             return createRawEmbeddedServices(metricsManager, env, lock, time);
         }
@@ -1101,7 +1107,8 @@ public abstract class TransactionManagers {
             TimestampStoreInvalidator invalidator,
             UserAgent userAgent,
             Optional<LockDiagnosticComponents> lockDiagnosticComponents,
-            DialogueClients.ReloadingFactory reloadingFactory) {
+            DialogueClients.ReloadingFactory reloadingFactory,
+            Optional<TimeLockFeedbackBackgroundTask> timeLockFeedbackBackgroundTask) {
         Refreshable<ServerListConfig> serverListConfigSupplier =
                 getServerListConfigSupplierForTimeLock(config, runtimeConfig);
 
@@ -1113,7 +1120,8 @@ public abstract class TransactionManagers {
                 userAgent,
                 timelockNamespace,
                 lockDiagnosticComponents,
-                reloadingFactory);
+                reloadingFactory,
+                timeLockFeedbackBackgroundTask);
 
         TimeLockMigrator migrator = TimeLockMigrator.create(
                 lockAndTimestampServices.managedTimestampService(), invalidator, config.initializeAsync());
@@ -1140,7 +1148,8 @@ public abstract class TransactionManagers {
             UserAgent userAgent,
             String timelockNamespace,
             Optional<LockDiagnosticComponents> lockDiagnosticComponents,
-            DialogueClients.ReloadingFactory reloadingFactory) {
+            DialogueClients.ReloadingFactory reloadingFactory,
+            Optional<TimeLockFeedbackBackgroundTask> timeLockFeedbackBackgroundTask) {
         AtlasDbDialogueServiceProvider serviceProvider = AtlasDbDialogueServiceProvider.create(
                 timelockServerListConfig, reloadingFactory, userAgent, metricsManager.getTaggedRegistry());
 
@@ -1163,8 +1172,11 @@ public abstract class TransactionManagers {
 
         NamespacedTimelockRpcClient namespacedTimelockRpcClient =
                 new NamespacedTimelockRpcClient(timelockClient, timelockNamespace);
-        NamespacedConjureTimelockService namespacedConjureTimelockService =
-                new NamespacedConjureTimelockService(withDiagnosticsConjureTimelockService, timelockNamespace);
+        LeaderElectionReportingTimelockService namespacedConjureTimelockService =
+                LeaderElectionReportingTimelockService.create(withDiagnosticsConjureTimelockService, timelockNamespace);
+
+        timeLockFeedbackBackgroundTask.ifPresent(
+                task -> task.registerLeaderElectionStatistics(namespacedConjureTimelockService));
 
         LockWatchEventCache lockWatchEventCache = LockWatchEventCacheImpl.create(metricsManager);
         NamespacedConjureLockWatchingService lockWatchingService = new NamespacedConjureLockWatchingService(

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
@@ -345,7 +345,8 @@ public class TransactionManagersTest {
                         invalidator,
                         USER_AGENT,
                         Optional.empty(),
-                        reloadingFactory);
+                        reloadingFactory,
+                        Optional.empty());
 
         LockRequest lockRequest = LockRequest.builder(
                         ImmutableSortedMap.of(StringLockDescriptor.of("foo"), LockMode.WRITE))
@@ -882,7 +883,8 @@ public class TransactionManagersTest {
                 invalidator,
                 USER_AGENT,
                 Optional.empty(),
-                reloadingFactory);
+                reloadingFactory,
+                Optional.empty());
     }
 
     private void verifyUserAgentOnRawTimestampAndLockRequests() {
@@ -902,7 +904,9 @@ public class TransactionManagersTest {
                         invalidator,
                         USER_AGENT,
                         Optional.empty(),
-                        reloadingFactory);
+                        reloadingFactory,
+                        Optional.empty());
+
         lockAndTimestamp.timelock().getFreshTimestamp();
         lockAndTimestamp.timelock().currentTimeMillis();
 

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/AsyncLockClient.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/AsyncLockClient.java
@@ -20,6 +20,7 @@ import com.palantir.atlasdb.timelock.api.ConjureTimelockService;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.lock.StringLockDescriptor;
 import com.palantir.lock.client.NamespacedConjureTimelockService;
+import com.palantir.lock.client.NamespacedConjureTimelockServiceImpl;
 import com.palantir.lock.client.RemoteTimelockServiceAdapter;
 import com.palantir.lock.v2.LockRequest;
 import com.palantir.lock.v2.LockResponse;
@@ -46,7 +47,7 @@ public final class AsyncLockClient implements JepsenLockClient<LockToken> {
         return new AsyncLockClient(
                 new NamespacedTimelockRpcClient(
                         TimelockUtils.createClient(metricsManager, hosts, TimelockRpcClient.class), NAMESPACE),
-                new NamespacedConjureTimelockService(
+                new NamespacedConjureTimelockServiceImpl(
                         TimelockUtils.createClient(metricsManager, hosts, ConjureTimelockService.class), NAMESPACE));
     }
 

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/TimestampClient.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/TimestampClient.java
@@ -18,7 +18,7 @@ package com.palantir.atlasdb.http;
 import com.palantir.atlasdb.timelock.api.ConjureTimelockService;
 import com.palantir.atlasdb.transaction.impl.TimelockTimestampServiceAdapter;
 import com.palantir.atlasdb.util.MetricsManager;
-import com.palantir.lock.client.NamespacedConjureTimelockService;
+import com.palantir.lock.client.NamespacedConjureTimelockServiceImpl;
 import com.palantir.lock.client.RemoteTimelockServiceAdapter;
 import com.palantir.lock.v2.NamespacedTimelockRpcClient;
 import com.palantir.lock.v2.TimelockRpcClient;
@@ -34,7 +34,7 @@ public final class TimestampClient {
                 new NamespacedTimelockRpcClient(
                         TimelockUtils.createClient(metricsManager, hosts, TimelockRpcClient.class),
                         TimelockUtils.NAMESPACE),
-                new NamespacedConjureTimelockService(
+                new NamespacedConjureTimelockServiceImpl(
                         TimelockUtils.createClient(metricsManager, hosts, ConjureTimelockService.class),
                         TimelockUtils.NAMESPACE),
                 NoOpLockWatchEventCache.INSTANCE));

--- a/gradle/shared.gradle
+++ b/gradle/shared.gradle
@@ -53,6 +53,7 @@ license {
     exclude '**/SmoothRateLimiter.java'
     exclude '**/DiscoverableSubtypeResolver.java'
     exclude '**/ConjureTimelockServiceBlockingMetrics.java'
+    exclude '**/LeaderElectionMetrics.java'
 }
 
 ext {

--- a/lock-api/src/main/java/com/palantir/lock/client/LeaderElectionReportingTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LeaderElectionReportingTimelockService.java
@@ -106,7 +106,7 @@ public class LeaderElectionReportingTimelockService implements NamespacedConjure
         T response = method.get();
         Duration timeTaken = stopwatch.elapsed();
         if (updateLeaderIfNew(leaderExtractor, currentLeader, response)) {
-            logMetrics(timeTaken);
+            updateMetrics(timeTaken);
         }
         return response;
     }
@@ -122,7 +122,7 @@ public class LeaderElectionReportingTimelockService implements NamespacedConjure
         return election && (currentLeader != null);
     }
 
-    private void logMetrics(Duration timeTaken) {
+    private void updateMetrics(Duration timeTaken) {
         metrics.observedDuration().update(timeTaken.toNanos(), TimeUnit.NANOSECONDS);
     }
 }

--- a/lock-api/src/main/java/com/palantir/lock/client/LeaderElectionReportingTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LeaderElectionReportingTimelockService.java
@@ -1,0 +1,148 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.client;
+
+import com.codahale.metrics.Snapshot;
+import com.google.common.base.Stopwatch;
+import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsRequest;
+import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponse;
+import com.palantir.atlasdb.timelock.api.ConjureLockRequest;
+import com.palantir.atlasdb.timelock.api.ConjureLockResponse;
+import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksRequest;
+import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksResponse;
+import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsRequest;
+import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
+import com.palantir.atlasdb.timelock.api.ConjureTimelockService;
+import com.palantir.atlasdb.timelock.api.ConjureUnlockRequest;
+import com.palantir.atlasdb.timelock.api.ConjureUnlockResponse;
+import com.palantir.atlasdb.timelock.api.ConjureWaitForLocksResponse;
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampsRequest;
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampsResponse;
+import com.palantir.conjure.java.lib.SafeLong;
+import com.palantir.lock.v2.LeaderTime;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.timelock.feedback.LeaderElectionStatistics;
+import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LeaderElectionReportingTimelockService implements NamespacedConjureTimelockService {
+    private static final Logger log = LoggerFactory.getLogger(LeaderElectionReportingTimelockService.class);
+    private final NamespacedConjureTimelockService delegate;
+    private final LeaderElectionMetrics metrics;
+    private volatile UUID leaderId = null;
+
+    public LeaderElectionReportingTimelockService(
+            NamespacedConjureTimelockService delegate, TaggedMetricRegistry taggedMetricRegistry) {
+        this.delegate = delegate;
+        this.metrics = LeaderElectionMetrics.of(taggedMetricRegistry);
+    }
+
+    public static LeaderElectionReportingTimelockService create(
+            ConjureTimelockService conjureTimelockService, String namespace) {
+        return new LeaderElectionReportingTimelockService(
+                new NamespacedConjureTimelockServiceImpl(conjureTimelockService, namespace),
+                new DefaultTaggedMetricRegistry());
+    }
+
+    @Override
+    public ConjureUnlockResponse unlock(ConjureUnlockRequest request) {
+        return delegate.unlock(request);
+    }
+
+    @Override
+    public ConjureRefreshLocksResponse refreshLocks(ConjureRefreshLocksRequest request) {
+        return delegate.refreshLocks(request);
+    }
+
+    @Override
+    public ConjureWaitForLocksResponse waitForLocks(ConjureLockRequest request) {
+        return delegate.waitForLocks(request);
+    }
+
+    @Override
+    public ConjureLockResponse lock(ConjureLockRequest request) {
+        return delegate.lock(request);
+    }
+
+    @Override
+    public LeaderTime leaderTime() {
+        return delegate.leaderTime();
+    }
+
+    @Override
+    public GetCommitTimestampsResponse getCommitTimestamps(GetCommitTimestampsRequest request) {
+        return runTimed(() -> delegate.getCommitTimestamps(request), response -> response.getLockWatchUpdate()
+                .logId());
+    }
+
+    @Override
+    public ConjureGetFreshTimestampsResponse getFreshTimestamps(ConjureGetFreshTimestampsRequest request) {
+        return delegate.getFreshTimestamps(request);
+    }
+
+    @Override
+    public ConjureStartTransactionsResponse startTransactions(ConjureStartTransactionsRequest request) {
+        return runTimed(() -> delegate.startTransactions(request), response -> response.getLockWatchUpdate()
+                .logId());
+    }
+
+    public LeaderElectionStatistics statistics() {
+        Snapshot metricsSnapshot = metrics.observedDuration().getSnapshot();
+        LeaderElectionStatistics meh = LeaderElectionStatistics.builder()
+                .p99(metricsSnapshot.get99thPercentile())
+                .p95(metricsSnapshot.get95thPercentile())
+                .mean(metricsSnapshot.getMean())
+                .count(SafeLong.of(metrics.observedDuration().getCount()))
+                .build();
+        resetTimer();
+        return meh;
+    }
+
+    private <T> T runTimed(Supplier<T> method, Function<T, UUID> leaderExtractor) {
+        UUID currentLeader = leaderId;
+        Stopwatch stopwatch = Stopwatch.createStarted();
+        T response = method.get();
+        Duration timeTaken = stopwatch.elapsed();
+        if (updateLeaderIfNew(leaderExtractor, currentLeader, response)) {
+            logMetrics(timeTaken);
+        }
+        return response;
+    }
+
+    private <T> boolean updateLeaderIfNew(Function<T, UUID> leaderExtractor, UUID currentLeader, T response) {
+        UUID newLeader = leaderExtractor.apply(response);
+        boolean election = !newLeader.equals(currentLeader);
+
+        if (election) {
+            leaderId = newLeader;
+        }
+
+        return election && (currentLeader != null);
+    }
+
+    private void logMetrics(Duration timeTaken) {
+        metrics.observedDuration().update(timeTaken.toNanos(), TimeUnit.NANOSECONDS);
+        log.info("Leader election duration as observed by call", SafeArg.of("timeTaken", timeTaken));
+    }
+}

--- a/lock-api/src/main/java/com/palantir/lock/client/NamespacedConjureTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/NamespacedConjureTimelockService.java
@@ -24,54 +24,27 @@ import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksRequest;
 import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksResponse;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsRequest;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
-import com.palantir.atlasdb.timelock.api.ConjureTimelockService;
 import com.palantir.atlasdb.timelock.api.ConjureUnlockRequest;
 import com.palantir.atlasdb.timelock.api.ConjureUnlockResponse;
 import com.palantir.atlasdb.timelock.api.ConjureWaitForLocksResponse;
 import com.palantir.atlasdb.timelock.api.GetCommitTimestampsRequest;
 import com.palantir.atlasdb.timelock.api.GetCommitTimestampsResponse;
 import com.palantir.lock.v2.LeaderTime;
-import com.palantir.tokens.auth.AuthHeader;
 
-public class NamespacedConjureTimelockService {
-    private static final AuthHeader AUTH_HEADER = AuthHeader.valueOf("Bearer omitted");
-    private final String namespace;
-    private final ConjureTimelockService conjureTimelockService;
+public interface NamespacedConjureTimelockService {
+    ConjureUnlockResponse unlock(ConjureUnlockRequest request);
 
-    public NamespacedConjureTimelockService(ConjureTimelockService conjureTimelockService, String namespace) {
-        this.namespace = namespace;
-        this.conjureTimelockService = conjureTimelockService;
-    }
+    ConjureRefreshLocksResponse refreshLocks(ConjureRefreshLocksRequest request);
 
-    public ConjureStartTransactionsResponse startTransactions(ConjureStartTransactionsRequest request) {
-        return conjureTimelockService.startTransactions(AUTH_HEADER, namespace, request);
-    }
+    ConjureWaitForLocksResponse waitForLocks(ConjureLockRequest request);
 
-    public ConjureGetFreshTimestampsResponse getFreshTimestamps(ConjureGetFreshTimestampsRequest request) {
-        return conjureTimelockService.getFreshTimestamps(AUTH_HEADER, namespace, request);
-    }
+    ConjureLockResponse lock(ConjureLockRequest request);
 
-    public GetCommitTimestampsResponse getCommitTimestamps(GetCommitTimestampsRequest request) {
-        return conjureTimelockService.getCommitTimestamps(AUTH_HEADER, namespace, request);
-    }
+    LeaderTime leaderTime();
 
-    public LeaderTime leaderTime() {
-        return conjureTimelockService.leaderTime(AUTH_HEADER, namespace);
-    }
+    GetCommitTimestampsResponse getCommitTimestamps(GetCommitTimestampsRequest request);
 
-    public ConjureLockResponse lock(ConjureLockRequest request) {
-        return conjureTimelockService.lock(AUTH_HEADER, namespace, request);
-    }
+    ConjureGetFreshTimestampsResponse getFreshTimestamps(ConjureGetFreshTimestampsRequest request);
 
-    public ConjureWaitForLocksResponse waitForLocks(ConjureLockRequest request) {
-        return conjureTimelockService.waitForLocks(AUTH_HEADER, namespace, request);
-    }
-
-    public ConjureRefreshLocksResponse refreshLocks(ConjureRefreshLocksRequest request) {
-        return conjureTimelockService.refreshLocks(AUTH_HEADER, namespace, request);
-    }
-
-    public ConjureUnlockResponse unlock(ConjureUnlockRequest request) {
-        return conjureTimelockService.unlock(AUTH_HEADER, namespace, request);
-    }
+    ConjureStartTransactionsResponse startTransactions(ConjureStartTransactionsRequest request);
 }

--- a/lock-api/src/main/java/com/palantir/lock/client/NamespacedConjureTimelockServiceImpl.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/NamespacedConjureTimelockServiceImpl.java
@@ -1,0 +1,85 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.client;
+
+import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsRequest;
+import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponse;
+import com.palantir.atlasdb.timelock.api.ConjureLockRequest;
+import com.palantir.atlasdb.timelock.api.ConjureLockResponse;
+import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksRequest;
+import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksResponse;
+import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsRequest;
+import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
+import com.palantir.atlasdb.timelock.api.ConjureTimelockService;
+import com.palantir.atlasdb.timelock.api.ConjureUnlockRequest;
+import com.palantir.atlasdb.timelock.api.ConjureUnlockResponse;
+import com.palantir.atlasdb.timelock.api.ConjureWaitForLocksResponse;
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampsRequest;
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampsResponse;
+import com.palantir.lock.v2.LeaderTime;
+import com.palantir.tokens.auth.AuthHeader;
+
+public class NamespacedConjureTimelockServiceImpl implements NamespacedConjureTimelockService {
+    private static final AuthHeader AUTH_HEADER = AuthHeader.valueOf("Bearer omitted");
+    private final String namespace;
+    private final ConjureTimelockService conjureTimelockService;
+
+    public NamespacedConjureTimelockServiceImpl(ConjureTimelockService conjureTimelockService, String namespace) {
+        this.namespace = namespace;
+        this.conjureTimelockService = conjureTimelockService;
+    }
+
+    @Override
+    public ConjureStartTransactionsResponse startTransactions(ConjureStartTransactionsRequest request) {
+        return conjureTimelockService.startTransactions(AUTH_HEADER, namespace, request);
+    }
+
+    @Override
+    public ConjureGetFreshTimestampsResponse getFreshTimestamps(ConjureGetFreshTimestampsRequest request) {
+        return conjureTimelockService.getFreshTimestamps(AUTH_HEADER, namespace, request);
+    }
+
+    @Override
+    public GetCommitTimestampsResponse getCommitTimestamps(GetCommitTimestampsRequest request) {
+        return conjureTimelockService.getCommitTimestamps(AUTH_HEADER, namespace, request);
+    }
+
+    @Override
+    public LeaderTime leaderTime() {
+        return conjureTimelockService.leaderTime(AUTH_HEADER, namespace);
+    }
+
+    @Override
+    public ConjureLockResponse lock(ConjureLockRequest request) {
+        return conjureTimelockService.lock(AUTH_HEADER, namespace, request);
+    }
+
+    @Override
+    public ConjureWaitForLocksResponse waitForLocks(ConjureLockRequest request) {
+        return conjureTimelockService.waitForLocks(AUTH_HEADER, namespace, request);
+    }
+
+    @Override
+    public ConjureRefreshLocksResponse refreshLocks(ConjureRefreshLocksRequest request) {
+        return conjureTimelockService.refreshLocks(AUTH_HEADER, namespace, request);
+    }
+
+    @Override
+    public ConjureUnlockResponse unlock(ConjureUnlockRequest request) {
+        return conjureTimelockService.unlock(AUTH_HEADER, namespace, request);
+    }
+}

--- a/lock-api/src/main/java/com/palantir/lock/client/RemoteTimelockServiceAdapter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/RemoteTimelockServiceAdapter.java
@@ -18,14 +18,12 @@ package com.palantir.lock.client;
 
 import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsRequest;
 import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponse;
-import com.palantir.atlasdb.timelock.api.ConjureTimelockService;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
 import com.palantir.lock.v2.LockRequest;
 import com.palantir.lock.v2.LockResponse;
 import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.NamespacedTimelockRpcClient;
 import com.palantir.lock.v2.StartIdentifiedAtlasDbTransactionResponse;
-import com.palantir.lock.v2.TimelockRpcClient;
 import com.palantir.lock.v2.TimelockService;
 import com.palantir.lock.v2.WaitForLocksRequest;
 import com.palantir.lock.v2.WaitForLocksResponse;
@@ -57,17 +55,6 @@ public final class RemoteTimelockServiceAdapter implements TimelockService, Auto
             NamespacedConjureTimelockService conjureClient,
             LockWatchEventCache lockWatchEventCache) {
         return new RemoteTimelockServiceAdapter(rpcClient, conjureClient, lockWatchEventCache);
-    }
-
-    public static RemoteTimelockServiceAdapter create(
-            TimelockRpcClient rpcClient,
-            ConjureTimelockService conjureClient,
-            String timelockNamespace,
-            LockWatchEventCache lockWatchEventCache) {
-        return create(
-                new NamespacedTimelockRpcClient(rpcClient, timelockNamespace),
-                new NamespacedConjureTimelockService(conjureClient, timelockNamespace),
-                lockWatchEventCache);
     }
 
     @Override

--- a/lock-api/src/main/java/com/palantir/lock/client/metrics/TimeLockFeedbackBackgroundTask.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/metrics/TimeLockFeedbackBackgroundTask.java
@@ -21,6 +21,7 @@ import com.palantir.atlasdb.timelock.adjudicate.feedback.TimeLockClientFeedbackS
 import com.palantir.common.concurrent.NamedThreadFactory;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.lock.client.ConjureTimelockServiceBlockingMetrics;
+import com.palantir.lock.client.LeaderElectionReportingTimelockService;
 import com.palantir.refreshable.Refreshable;
 import com.palantir.timelock.feedback.ConjureTimeLockClientFeedback;
 import com.palantir.timelock.feedback.EndpointStatistics;
@@ -28,6 +29,7 @@ import com.palantir.tokens.auth.AuthHeader;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -52,6 +54,7 @@ public final class TimeLockFeedbackBackgroundTask implements AutoCloseable {
     private final String serviceName;
     private final String namespace;
     private final Refreshable<List<TimeLockClientFeedbackService>> timeLockClientFeedbackServices;
+    private volatile Optional<LeaderElectionReportingTimelockService> timelock;
 
     private ScheduledFuture<?> task;
 
@@ -102,6 +105,10 @@ public final class TimeLockFeedbackBackgroundTask implements AutoCloseable {
                 TIMELOCK_CLIENT_FEEDBACK_REPORT_INTERVAL.getSeconds(),
                 TIMELOCK_CLIENT_FEEDBACK_REPORT_INTERVAL.getSeconds(),
                 TimeUnit.SECONDS);
+    }
+
+    public void registerLeaderElectionStatistics(LeaderElectionReportingTimelockService conjureTimelock) {
+        this.timelock = Optional.of(conjureTimelock);
     }
 
     private void reportClientFeedbackToService(

--- a/lock-api/src/main/metrics/metric-schema.yml
+++ b/lock-api/src/main/metrics/metric-schema.yml
@@ -17,5 +17,11 @@ namespaces:
       startTransactionErrors:
         type: meter
         docs: error rate for startTransaction api in timelock
+  leaderElection:
+    docs: Metrics for measuring client side impact of timelock leader elections.
+    metrics:
+      observedDuration:
+        type: timer
+        docs: observed call duration during leader election
 
 

--- a/lock-api/src/test/java/com/palantir/lock/client/LeaderElectionReportingTimelockServiceTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/LeaderElectionReportingTimelockServiceTest.java
@@ -1,0 +1,104 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.client;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.codahale.metrics.Timer;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsRequest;
+import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampsRequest;
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampsResponse;
+import com.palantir.lock.watch.LockWatchStateUpdate;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+
+public class LeaderElectionReportingTimelockServiceTest {
+    private static final UUID LEADER_1 = UUID.randomUUID();
+    private static final LockWatchStateUpdate UPDATE = LockWatchStateUpdate.success(LEADER_1, -1L, ImmutableList.of());
+
+    private ConjureStartTransactionsRequest startTransactionsRequest = mock(ConjureStartTransactionsRequest.class);
+    private ConjureStartTransactionsResponse startTransactionsResponse = mock(ConjureStartTransactionsResponse.class);
+    private GetCommitTimestampsRequest commitTimestampsRequest = mock(GetCommitTimestampsRequest.class);
+    private GetCommitTimestampsResponse commitTimestampsResponse = mock(GetCommitTimestampsResponse.class);
+    private NamespacedConjureTimelockService mockedDelegeate = mock(NamespacedConjureTimelockService.class);
+    private TaggedMetricRegistry mockedRegistry = mock(TaggedMetricRegistry.class);
+    private Timer mockedTimer = mock(Timer.class);
+
+    private NamespacedConjureTimelockService timelockService;
+
+    @Before
+    public void before() {
+        timelockService = new LeaderElectionReportingTimelockService(mockedDelegeate, mockedRegistry);
+        when(mockedDelegeate.startTransactions(any())).thenReturn(startTransactionsResponse);
+        when(mockedDelegeate.getCommitTimestamps(any())).thenReturn(commitTimestampsResponse);
+        when(mockedRegistry.timer(any())).thenReturn(mockedTimer);
+
+        when(startTransactionsResponse.getLockWatchUpdate()).thenReturn(UPDATE);
+    }
+
+    @Test
+    public void firstCallDoesNotReportMetrics() {
+        timelockService.startTransactions(startTransactionsRequest);
+        verifyNoInteractions(mockedRegistry);
+    }
+
+    @Test
+    public void sameLeaderDoesNotReportMetrics() {
+        timelockService.startTransactions(startTransactionsRequest);
+        timelockService.startTransactions(startTransactionsRequest);
+        verifyNoInteractions(mockedRegistry);
+    }
+
+    @Test
+    public void reportMetricsOnLeaderElection() {
+        LockWatchStateUpdate.Snapshot secondUpdate =
+                LockWatchStateUpdate.snapshot(UUID.randomUUID(), 1L, ImmutableSet.of(), ImmutableSet.of());
+        when(startTransactionsResponse.getLockWatchUpdate())
+                .thenReturn(UPDATE)
+                .thenReturn(secondUpdate)
+                .thenReturn(secondUpdate)
+                .thenReturn(LockWatchStateUpdate.success(UUID.randomUUID(), 5L, ImmutableList.of()));
+        timelockService.startTransactions(startTransactionsRequest);
+        timelockService.startTransactions(startTransactionsRequest);
+        timelockService.startTransactions(startTransactionsRequest);
+        timelockService.startTransactions(startTransactionsRequest);
+        verify(mockedRegistry, atLeast(1)).timer(any());
+        verify(mockedTimer, times(2)).update(anyLong(), any());
+    }
+
+    @Test
+    public void leaderIsInitialisedForAllMethods() {
+        when(commitTimestampsResponse.getLockWatchUpdate())
+                .thenReturn(LockWatchStateUpdate.success(UUID.randomUUID(), 3L, ImmutableList.of()));
+        timelockService.getCommitTimestamps(commitTimestampsRequest);
+        timelockService.startTransactions(startTransactionsRequest);
+        verify(mockedRegistry).timer(any());
+        verify(mockedTimer).update(anyLong(), any());
+    }
+}

--- a/lock-api/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/lock-api/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/NamespacedClients.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/NamespacedClients.java
@@ -23,6 +23,7 @@ import com.palantir.lock.ConjureLockV1Service;
 import com.palantir.lock.LockRpcClient;
 import com.palantir.lock.LockService;
 import com.palantir.lock.client.NamespacedConjureTimelockService;
+import com.palantir.lock.client.NamespacedConjureTimelockServiceImpl;
 import com.palantir.lock.client.RemoteLockServiceAdapter;
 import com.palantir.lock.client.RemoteTimelockServiceAdapter;
 import com.palantir.lock.v2.LockRequest;
@@ -83,7 +84,7 @@ public interface NamespacedClients {
 
     @Value.Derived
     default NamespacedConjureTimelockService namespacedConjureTimelockService() {
-        return new NamespacedConjureTimelockService(conjureTimelockService(), namespace());
+        return new NamespacedConjureTimelockServiceImpl(conjureTimelockService(), namespace());
     }
 
     @Value.Derived


### PR DESCRIPTION
**Goals (and why)**:
* Add metrics to the client to monitor the perceived impact of leader elections. Note that further metrics on the actual length of leader elections will be introduced in https://github.com/palantir/atlasdb/pull/5069.

**Implementation Description (bullets)**:
* Extracted an interface for `NamespacedConjureTimelockService`, and created another class that delegates to the implementation.
* Monitor startTransactions and getCommitTimestamp requests, and report metrics when these perceive a leader change.

**Testing (What was existing testing like?  What have you done to improve it?)**:
* Added a unit test; intend on adding ETE tests later (in a followup PR).

**Concerns (what feedback would you like?)**:
* Confirm that this won't affect performance

**Where should we start reviewing?**:
* `LeaderElectionReportingTimelockService`

**Priority (whenever / two weeks / yesterday)**:
This week
