### PR TITLE
[RC only] | Suppress 5026

### DIFF
--- a/changelog/0.254.4-rc1/pr-5063.v2.yml
+++ b/changelog/0.254.4-rc1/pr-5063.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: |2
+
+    This is temporary - Suppress invalid log state from throwing, instead log error.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5063

--- a/changelog/0.254.4-rc2/pr-5063.v2.yml
+++ b/changelog/0.254.4-rc2/pr-5063.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: |2
+
+    This is temporary - Suppress invalid log state from throwing, instead log error.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5063

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogMigrator.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogMigrator.java
@@ -138,8 +138,7 @@ public final class PaxosStateLogMigrator<V extends Persistable & Versionable> {
                     SafeArg.of("fresh cutoff", migrationCutoff),
                     SafeArg.of("persisted cutoff", persistedCutoff),
                     SafeArg.of("source greatest entry", greatestSourceEntry),
-                    SafeArg.of("namespace", namespaceAndUseCase.namespace().value()),
-                    SafeArg.of("useCase", namespaceAndUseCase.useCase()));
+                    SafeArg.of("namespaceAndUseCase", namespaceAndUseCase));
         }
         if (greatestSourceEntry == PaxosAcceptor.NO_LOG_ENTRY) {
             return;
@@ -156,8 +155,7 @@ public final class PaxosStateLogMigrator<V extends Persistable & Versionable> {
                                 + "performed which could lead to data corruption if allowed to continue.",
                         SafeArg.of("source entry", source),
                         SafeArg.of("destination entry", dest),
-                        SafeArg.of("namespace", namespaceAndUseCase.namespace().value()),
-                        SafeArg.of("useCase", namespaceAndUseCase.useCase()));
+                        SafeArg.of("namespaceAndUseCase", namespaceAndUseCase));
             }
         } catch (IOException e) {
             throw new SafeIllegalArgumentException("Unable to verify consistency between source and destination paxos "

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogMigrator.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogMigrator.java
@@ -16,14 +16,6 @@
 
 package com.palantir.paxos;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Iterables;
-import com.google.common.util.concurrent.Uninterruptibles;
-import com.palantir.common.base.Throwables;
-import com.palantir.common.persist.Persistable;
-import com.palantir.logsafe.Preconditions;
-import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
@@ -33,9 +25,18 @@ import java.util.OptionalLong;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
+
 import org.immutables.value.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.Uninterruptibles;
+import com.palantir.common.base.Throwables;
+import com.palantir.common.persist.Persistable;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 
 public final class PaxosStateLogMigrator<V extends Persistable & Versionable> {
     private static final Logger log = LoggerFactory.getLogger(PaxosStateLogMigrator.class);
@@ -59,7 +60,8 @@ public final class PaxosStateLogMigrator<V extends Persistable & Versionable> {
      * value of {@link MigrationContext#migrateFrom()}, and the migration is guaranteed to copy at least one entry if
      * sourceLog is not empty. If sourceLog is empty, cutoff will be {@link PaxosAcceptor#NO_LOG_ENTRY}.
      */
-    public static <V extends Persistable & Versionable> long migrateAndReturnCutoff(MigrationContext<V> context) {
+    public static <V extends Persistable & Versionable> long migrateAndReturnCutoff(
+            MigrationContext<V> context, NamespaceAndUseCase namespaceAndUseCase) {
         PaxosStateLogMigrator<V> migrator = new PaxosStateLogMigrator<>(context.sourceLog(), context.destinationLog());
         if (!context.migrationState().isInMigratedState()) {
             long cutoff = calculateCutoff(context);
@@ -68,7 +70,7 @@ public final class PaxosStateLogMigrator<V extends Persistable & Versionable> {
             context.migrationState().migrateToMigratedState();
             return cutoff;
         } else {
-            validateConsistency(context);
+            validateConsistency(context, namespaceAndUseCase);
         }
         return context.migrationState().getCutoff();
     }
@@ -122,19 +124,23 @@ public final class PaxosStateLogMigrator<V extends Persistable & Versionable> {
         target.writeBatchOfRounds(batch);
     }
 
-    private static <V extends Persistable & Versionable> void validateConsistency(MigrationContext<V> context) {
+    private static <V extends Persistable & Versionable> void validateConsistency(
+            MigrationContext<V> context, NamespaceAndUseCase namespaceAndUseCase) {
         long migrationCutoff = calculateCutoff(context);
         long persistedCutoff = context.migrationState().getCutoff();
         long greatestSourceEntry = context.sourceLog().getGreatestLogEntry();
-        Preconditions.checkState(
-                migrationCutoff <= persistedCutoff,
-                "The migration to the destination state log was already performed in the past, but the "
-                        + "persisted cutoff value does not match a newly calculated one. This indicates the source "
-                        + "log has advanced since the migration was performed which could lead to data corruption if "
-                        + "allowed to continue.",
-                SafeArg.of("fresh cutoff", migrationCutoff),
-                SafeArg.of("persisted cutoff", persistedCutoff),
-                SafeArg.of("source greatest entry", greatestSourceEntry));
+
+        if (migrationCutoff > persistedCutoff) {
+            log.error(
+                    "The migration to the destination state log was already performed in the past, but the persisted"
+                        + " cutoff value does not match a newly calculated one. This indicates the source log has"
+                        + " advanced since the migration was performed which could lead to data corruption if allowed"
+                        + " to continue.",
+                    SafeArg.of("fresh cutoff", migrationCutoff),
+                    SafeArg.of("persisted cutoff", persistedCutoff),
+                    SafeArg.of("source greatest entry", greatestSourceEntry),
+                    SafeArg.of("namespaceAndUseCase", namespaceAndUseCase));
+        }
         if (greatestSourceEntry == PaxosAcceptor.NO_LOG_ENTRY) {
             return;
         }
@@ -142,14 +148,17 @@ public final class PaxosStateLogMigrator<V extends Persistable & Versionable> {
             V source = context.hydrator().hydrateFromBytes(context.sourceLog().readRound(greatestSourceEntry));
             byte[] destinationBytes = context.destinationLog().readRound(greatestSourceEntry);
             V dest = destinationBytes != null ? context.hydrator().hydrateFromBytes(destinationBytes) : null;
-            Preconditions.checkState(
-                    source.equalsIgnoringVersion(dest),
-                    "The migration to the destination state log was already performed in the past, but the "
-                            + "entry with the greatest sequence in source log does not match the entry in the "
-                            + "destination log. This indicates the source log has advanced since the migration was "
-                            + "performed which could lead to data corruption if allowed to continue.",
-                    SafeArg.of("source entry", source),
-                    SafeArg.of("destination entry", dest));
+
+            if (!source.equalsIgnoringVersion(dest)) {
+                log.error(
+                        "The migration to the destination state log was already performed in the past, but the "
+                                + "entry with the greatest sequence in source log does not match the entry in the "
+                                + "destination log. This indicates the source log has advanced since the migration was "
+                                + "performed which could lead to data corruption if allowed to continue.",
+                        SafeArg.of("source entry", source),
+                        SafeArg.of("destination entry", dest),
+                        SafeArg.of("namespaceAndUseCase", namespaceAndUseCase));
+            }
         } catch (IOException e) {
             throw new SafeIllegalArgumentException("Unable to verify consistency between source and destination paxos "
                     + "logs because the source log entry could not be read.");

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogMigrator.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogMigrator.java
@@ -16,14 +16,6 @@
 
 package com.palantir.paxos;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Iterables;
-import com.google.common.util.concurrent.Uninterruptibles;
-import com.palantir.common.base.Throwables;
-import com.palantir.common.persist.Persistable;
-import com.palantir.logsafe.Preconditions;
-import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
@@ -33,9 +25,18 @@ import java.util.OptionalLong;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
+
 import org.immutables.value.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.Uninterruptibles;
+import com.palantir.common.base.Throwables;
+import com.palantir.common.persist.Persistable;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 
 public final class PaxosStateLogMigrator<V extends Persistable & Versionable> {
     private static final Logger log = LoggerFactory.getLogger(PaxosStateLogMigrator.class);
@@ -59,7 +60,8 @@ public final class PaxosStateLogMigrator<V extends Persistable & Versionable> {
      * value of {@link MigrationContext#migrateFrom()}, and the migration is guaranteed to copy at least one entry if
      * sourceLog is not empty. If sourceLog is empty, cutoff will be {@link PaxosAcceptor#NO_LOG_ENTRY}.
      */
-    public static <V extends Persistable & Versionable> long migrateAndReturnCutoff(MigrationContext<V> context) {
+    public static <V extends Persistable & Versionable> long migrateAndReturnCutoff(
+            MigrationContext<V> context, NamespaceAndUseCase namespaceAndUseCase) {
         PaxosStateLogMigrator<V> migrator = new PaxosStateLogMigrator<>(context.sourceLog(), context.destinationLog());
         if (!context.migrationState().isInMigratedState()) {
             long cutoff = calculateCutoff(context);
@@ -68,7 +70,7 @@ public final class PaxosStateLogMigrator<V extends Persistable & Versionable> {
             context.migrationState().migrateToMigratedState();
             return cutoff;
         } else {
-            validateConsistency(context);
+            validateConsistency(context, namespaceAndUseCase);
         }
         return context.migrationState().getCutoff();
     }
@@ -122,19 +124,23 @@ public final class PaxosStateLogMigrator<V extends Persistable & Versionable> {
         target.writeBatchOfRounds(batch);
     }
 
-    private static <V extends Persistable & Versionable> void validateConsistency(MigrationContext<V> context) {
+    private static <V extends Persistable & Versionable> void validateConsistency(MigrationContext<V> context,
+            NamespaceAndUseCase namespaceAndUseCase) {
         long migrationCutoff = calculateCutoff(context);
         long persistedCutoff = context.migrationState().getCutoff();
         long greatestSourceEntry = context.sourceLog().getGreatestLogEntry();
-        Preconditions.checkState(
-                migrationCutoff <= persistedCutoff,
-                "The migration to the destination state log was already performed in the past, but the "
-                        + "persisted cutoff value does not match a newly calculated one. This indicates the source "
-                        + "log has advanced since the migration was performed which could lead to data corruption if "
-                        + "allowed to continue.",
-                SafeArg.of("fresh cutoff", migrationCutoff),
-                SafeArg.of("persisted cutoff", persistedCutoff),
-                SafeArg.of("source greatest entry", greatestSourceEntry));
+
+        if (migrationCutoff > persistedCutoff) {
+            log.error("The migration to the destination state log was already performed in the past, but the "
+                            + "persisted cutoff value does not match a newly calculated one. This indicates the source "
+                            + "log has advanced since the migration was performed which could lead to data corruption if "
+                            + "allowed to continue.",
+                    SafeArg.of("fresh cutoff", migrationCutoff),
+                    SafeArg.of("persisted cutoff", persistedCutoff),
+                    SafeArg.of("source greatest entry", greatestSourceEntry),
+                    SafeArg.of("namespace", namespaceAndUseCase.namespace().value()),
+                    SafeArg.of("useCase", namespaceAndUseCase.useCase()));
+        }
         if (greatestSourceEntry == PaxosAcceptor.NO_LOG_ENTRY) {
             return;
         }
@@ -142,14 +148,17 @@ public final class PaxosStateLogMigrator<V extends Persistable & Versionable> {
             V source = context.hydrator().hydrateFromBytes(context.sourceLog().readRound(greatestSourceEntry));
             byte[] destinationBytes = context.destinationLog().readRound(greatestSourceEntry);
             V dest = destinationBytes != null ? context.hydrator().hydrateFromBytes(destinationBytes) : null;
-            Preconditions.checkState(
-                    source.equalsIgnoringVersion(dest),
-                    "The migration to the destination state log was already performed in the past, but the "
-                            + "entry with the greatest sequence in source log does not match the entry in the "
-                            + "destination log. This indicates the source log has advanced since the migration was "
-                            + "performed which could lead to data corruption if allowed to continue.",
-                    SafeArg.of("source entry", source),
-                    SafeArg.of("destination entry", dest));
+
+            if (!source.equalsIgnoringVersion(dest)) {
+                log.error("The migration to the destination state log was already performed in the past, but the "
+                                + "entry with the greatest sequence in source log does not match the entry in the "
+                                + "destination log. This indicates the source log has advanced since the migration was "
+                                + "performed which could lead to data corruption if allowed to continue.",
+                        SafeArg.of("source entry", source),
+                        SafeArg.of("destination entry", dest),
+                        SafeArg.of("namespace", namespaceAndUseCase.namespace().value()),
+                        SafeArg.of("useCase", namespaceAndUseCase.useCase()));
+            }
         } catch (IOException e) {
             throw new SafeIllegalArgumentException("Unable to verify consistency between source and destination paxos "
                     + "logs because the source log entry could not be read.");

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogMigrator.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogMigrator.java
@@ -25,11 +25,9 @@ import java.util.OptionalLong;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
-
 import org.immutables.value.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.Uninterruptibles;
@@ -124,17 +122,18 @@ public final class PaxosStateLogMigrator<V extends Persistable & Versionable> {
         target.writeBatchOfRounds(batch);
     }
 
-    private static <V extends Persistable & Versionable> void validateConsistency(MigrationContext<V> context,
-            NamespaceAndUseCase namespaceAndUseCase) {
+    private static <V extends Persistable & Versionable> void validateConsistency(
+            MigrationContext<V> context, NamespaceAndUseCase namespaceAndUseCase) {
         long migrationCutoff = calculateCutoff(context);
         long persistedCutoff = context.migrationState().getCutoff();
         long greatestSourceEntry = context.sourceLog().getGreatestLogEntry();
 
         if (migrationCutoff > persistedCutoff) {
-            log.error("The migration to the destination state log was already performed in the past, but the "
-                            + "persisted cutoff value does not match a newly calculated one. This indicates the source "
-                            + "log has advanced since the migration was performed which could lead to data corruption if "
-                            + "allowed to continue.",
+            log.error(
+                    "The migration to the destination state log was already performed in the past, but the persisted"
+                        + " cutoff value does not match a newly calculated one. This indicates the source log has"
+                        + " advanced since the migration was performed which could lead to data corruption if allowed"
+                        + " to continue.",
                     SafeArg.of("fresh cutoff", migrationCutoff),
                     SafeArg.of("persisted cutoff", persistedCutoff),
                     SafeArg.of("source greatest entry", greatestSourceEntry),
@@ -149,7 +148,8 @@ public final class PaxosStateLogMigrator<V extends Persistable & Versionable> {
             V dest = destinationBytes != null ? context.hydrator().hydrateFromBytes(destinationBytes) : null;
 
             if (!source.equalsIgnoringVersion(dest)) {
-                log.error("The migration to the destination state log was already performed in the past, but the "
+                log.error(
+                        "The migration to the destination state log was already performed in the past, but the "
                                 + "entry with the greatest sequence in source log does not match the entry in the "
                                 + "destination log. This indicates the source log has advanced since the migration was "
                                 + "performed which could lead to data corruption if allowed to continue.",

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogMigrator.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogMigrator.java
@@ -25,9 +25,11 @@ import java.util.OptionalLong;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
+
 import org.immutables.value.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.Uninterruptibles;

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogMigrator.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogMigrator.java
@@ -16,6 +16,13 @@
 
 package com.palantir.paxos;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.Uninterruptibles;
+import com.palantir.common.base.Throwables;
+import com.palantir.common.persist.Persistable;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
@@ -25,18 +32,9 @@ import java.util.OptionalLong;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
-
 import org.immutables.value.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Iterables;
-import com.google.common.util.concurrent.Uninterruptibles;
-import com.palantir.common.base.Throwables;
-import com.palantir.common.persist.Persistable;
-import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 
 public final class PaxosStateLogMigrator<V extends Persistable & Versionable> {
     private static final Logger log = LoggerFactory.getLogger(PaxosStateLogMigrator.class);

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SplittingPaxosStateLog.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SplittingPaxosStateLog.java
@@ -19,11 +19,9 @@ package com.palantir.paxos;
 import java.io.IOException;
 import java.util.OptionalLong;
 import java.util.concurrent.atomic.AtomicLong;
-
 import org.immutables.value.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.palantir.common.persist.Persistable;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SplittingPaxosStateLog.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SplittingPaxosStateLog.java
@@ -16,16 +16,18 @@
 
 package com.palantir.paxos;
 
+import java.io.IOException;
+import java.util.OptionalLong;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.immutables.value.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.palantir.common.persist.Persistable;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
-import java.io.IOException;
-import java.util.OptionalLong;
-import java.util.concurrent.atomic.AtomicLong;
-import org.immutables.value.Value;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This implementation of {@link PaxosStateLog} delegates all reads and writes of rounds to one of two delegates, as
@@ -91,7 +93,7 @@ public final class SplittingPaxosStateLog<V extends Persistable & Versionable> i
         log.info(
                 "Starting migration for namespace and use case {} if migration has not run before.",
                 SafeArg.of("namespaceAndUseCase", params.namespaceAndUseCase()));
-        long cutoff = PaxosStateLogMigrator.migrateAndReturnCutoff(migrationContext);
+        long cutoff = PaxosStateLogMigrator.migrateAndReturnCutoff(migrationContext, namespaceUseCase);
 
         SplittingParameters<V> splittingParameters = ImmutableSplittingParameters.<V>builder()
                 .legacyLog(migrationContext.sourceLog())

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SplittingPaxosStateLog.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SplittingPaxosStateLog.java
@@ -16,16 +16,16 @@
 
 package com.palantir.paxos;
 
+import com.palantir.common.persist.Persistable;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.io.IOException;
 import java.util.OptionalLong;
 import java.util.concurrent.atomic.AtomicLong;
 import org.immutables.value.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.palantir.common.persist.Persistable;
-import com.palantir.logsafe.Preconditions;
-import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 
 /**
  * This implementation of {@link PaxosStateLog} delegates all reads and writes of rounds to one of two delegates, as

--- a/leader-election-impl/src/test/java/com/palantir/paxos/FileToSqlitePaxosStateLogIntegrationTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/FileToSqlitePaxosStateLogIntegrationTest.java
@@ -16,24 +16,28 @@
 
 package com.palantir.paxos;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import static com.palantir.paxos.PaxosStateLogTestUtils.NAMESPACE;
 import static com.palantir.paxos.PaxosStateLogTestUtils.generateRounds;
 import static com.palantir.paxos.PaxosStateLogTestUtils.readRoundUnchecked;
-import static org.assertj.core.api.Assertions.assertThat;
 
-import com.palantir.common.streams.KeyedStream;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
+
 import javax.sql.DataSource;
+
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+
+import com.palantir.common.streams.KeyedStream;
 
 public class FileToSqlitePaxosStateLogIntegrationTest {
     @Rule
@@ -117,7 +121,7 @@ public class FileToSqlitePaxosStateLogIntegrationTest {
                 .destinationLog(target)
                 .hydrator(PaxosValue.BYTES_HYDRATOR)
                 .migrationState(migrationState)
-                .build());
+                .build(), NAMESPACE);
     }
 
     private Map<Long, byte[]> readMigratedValuesFor(List<PaxosValue> values) {

--- a/leader-election-impl/src/test/java/com/palantir/paxos/FileToSqlitePaxosStateLogIntegrationTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/FileToSqlitePaxosStateLogIntegrationTest.java
@@ -16,28 +16,24 @@
 
 package com.palantir.paxos;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import static com.palantir.paxos.PaxosStateLogTestUtils.NAMESPACE;
 import static com.palantir.paxos.PaxosStateLogTestUtils.generateRounds;
 import static com.palantir.paxos.PaxosStateLogTestUtils.readRoundUnchecked;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import com.palantir.common.streams.KeyedStream;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
-
 import javax.sql.DataSource;
-
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-
-import com.palantir.common.streams.KeyedStream;
 
 public class FileToSqlitePaxosStateLogIntegrationTest {
     @Rule
@@ -116,12 +112,14 @@ public class FileToSqlitePaxosStateLogIntegrationTest {
     }
 
     private void migrate() {
-        PaxosStateLogMigrator.migrateAndReturnCutoff(ImmutableMigrationContext.<PaxosValue>builder()
-                .sourceLog(source)
-                .destinationLog(target)
-                .hydrator(PaxosValue.BYTES_HYDRATOR)
-                .migrationState(migrationState)
-                .build(), NAMESPACE);
+        PaxosStateLogMigrator.migrateAndReturnCutoff(
+                ImmutableMigrationContext.<PaxosValue>builder()
+                        .sourceLog(source)
+                        .destinationLog(target)
+                        .hydrator(PaxosValue.BYTES_HYDRATOR)
+                        .migrationState(migrationState)
+                        .build(),
+                NAMESPACE);
     }
 
     private Map<Long, byte[]> readMigratedValuesFor(List<PaxosValue> values) {

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosStateLogMigratorTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosStateLogMigratorTest.java
@@ -406,13 +406,15 @@ public class PaxosStateLogMigratorTest {
     }
 
     private long migrateFrom(PaxosStateLog<PaxosValue> sourceLog, OptionalLong lowerBound) {
-        return PaxosStateLogMigrator.migrateAndReturnCutoff(ImmutableMigrationContext.<PaxosValue>builder()
-                .sourceLog(sourceLog)
-                .destinationLog(target)
-                .hydrator(PaxosValue.BYTES_HYDRATOR)
-                .migrationState(migrationState)
-                .migrateFrom(lowerBound)
-                .build(), NAMESPACE);
+        return PaxosStateLogMigrator.migrateAndReturnCutoff(
+                ImmutableMigrationContext.<PaxosValue>builder()
+                        .sourceLog(sourceLog)
+                        .destinationLog(target)
+                        .hydrator(PaxosValue.BYTES_HYDRATOR)
+                        .migrationState(migrationState)
+                        .migrateFrom(lowerBound)
+                        .build(),
+                NAMESPACE);
     }
 
     private List<PaxosValue> insertValuesWithinBounds(long from, long to, PaxosStateLog<PaxosValue> targetLog) {

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosStateLogMigratorTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosStateLogMigratorTest.java
@@ -16,6 +16,11 @@
 
 package com.palantir.paxos;
 
+import static com.palantir.paxos.PaxosStateLogMigrator.BATCH_SIZE;
+import static com.palantir.paxos.PaxosStateLogTestUtils.NAMESPACE;
+import static com.palantir.paxos.PaxosStateLogTestUtils.getPaxosValue;
+import static com.palantir.paxos.PaxosStateLogTestUtils.readRoundUnchecked;
+import static com.palantir.paxos.PaxosStateLogTestUtils.valueForRound;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -30,29 +35,20 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import static com.palantir.paxos.PaxosStateLogMigrator.BATCH_SIZE;
-import static com.palantir.paxos.PaxosStateLogTestUtils.NAMESPACE;
-import static com.palantir.paxos.PaxosStateLogTestUtils.getPaxosValue;
-import static com.palantir.paxos.PaxosStateLogTestUtils.readRoundUnchecked;
-import static com.palantir.paxos.PaxosStateLogTestUtils.valueForRound;
-
+import com.palantir.common.streams.KeyedStream;
 import java.io.IOException;
 import java.util.List;
 import java.util.OptionalLong;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
-
 import javax.sql.DataSource;
-
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-
-import com.palantir.common.streams.KeyedStream;
 
 public class PaxosStateLogMigratorTest {
     @Rule

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosStateLogMigrationIntegrationTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosStateLogMigrationIntegrationTest.java
@@ -17,7 +17,18 @@
 package com.palantir.atlasdb.timelock.paxos;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.UUID;
+
+import javax.sql.DataSource;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.common.persist.Persistable;
@@ -34,14 +45,6 @@ import com.palantir.paxos.SqliteConnections;
 import com.palantir.paxos.SqlitePaxosStateLog;
 import com.palantir.paxos.Versionable;
 import com.palantir.sls.versions.OrderableSlsVersion;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.UUID;
-import javax.sql.DataSource;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 public class PaxosStateLogMigrationIntegrationTest {
     private static final Client CLIENT = Client.of("test");
@@ -177,9 +180,7 @@ public class PaxosStateLogMigrationIntegrationTest {
         long newRound = LATEST_ROUND_BEFORE_MIGRATING + 3;
         fileBasedLearnerLog.writeRound(newRound, valueForRound(newRound));
 
-        assertThatThrownBy(this::createPaxosComponents)
-                .as("Written to file based log at greater sequence after migration alredy ran")
-                .isInstanceOf(IllegalStateException.class);
+        assertThatCode(this::createPaxosComponents).doesNotThrowAnyException();
     }
 
     @Test

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosStateLogMigrationIntegrationTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosStateLogMigrationIntegrationTest.java
@@ -19,6 +19,17 @@ package com.palantir.atlasdb.timelock.paxos;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.UUID;
+
+import javax.sql.DataSource;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
 import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.common.persist.Persistable;
 import com.palantir.paxos.Client;
@@ -34,14 +45,6 @@ import com.palantir.paxos.SqliteConnections;
 import com.palantir.paxos.SqlitePaxosStateLog;
 import com.palantir.paxos.Versionable;
 import com.palantir.sls.versions.OrderableSlsVersion;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.UUID;
-import javax.sql.DataSource;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 public class PaxosStateLogMigrationIntegrationTest {
     private static final Client CLIENT = Client.of("test");

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosStateLogMigrationIntegrationTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosStateLogMigrationIntegrationTest.java
@@ -19,17 +19,6 @@ package com.palantir.atlasdb.timelock.paxos;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.UUID;
-
-import javax.sql.DataSource;
-
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-
 import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.common.persist.Persistable;
 import com.palantir.paxos.Client;
@@ -45,6 +34,14 @@ import com.palantir.paxos.SqliteConnections;
 import com.palantir.paxos.SqlitePaxosStateLog;
 import com.palantir.paxos.Versionable;
 import com.palantir.sls.versions.OrderableSlsVersion;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class PaxosStateLogMigrationIntegrationTest {
     private static final Client CLIENT = Client.of("test");


### PR DESCRIPTION
**Goals (and why)**:
This is temporary - Suppress invalid log state from throwing, instead log error.

**Implementation Description (bullets)**:

- Do not throw but log error if migration logs point to a state of corruption

- Also, log namespace and useCase

**Testing (What was existing testing like?  What have you done to improve it?)**:
N/A

**Concerns (what feedback would you like?)**:
Is logging namespace and useCase a prroblem?

**Where should we start reviewing?**:
PaxosStateLogMigrator.java

**Priority (whenever / two weeks / yesterday)**:
🔥 
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
