### PR TITLE
[DB TimeLock] 2D - Documentation of DB-TimeLock Considerations

### DIFF
--- a/docs/source/services/timelock_service/manual-migration.rst
+++ b/docs/source/services/timelock_service/manual-migration.rst
@@ -5,8 +5,11 @@ Manual Migration to Timelock Server
 
 .. warning::
 
-   This is not a recommended way to migrate to external timelock server. We have **automatic** migrations for Cassandra KVS in place.
-   Please contact the AtlasDB team before attempting the manual migration.
+   This is not a recommended way to migrate to external timelock server.
+   We now have automated migrations for both Cassandra and DbKVS in place that will run when a node is started with
+   the configuration to use TimeLock on versions of AtlasDB from 0.253.2 onwards. Please note that these automated
+   migrations still require the cluster to be brought to a complete shutdown before any nodes switch to using TimeLock.
+   If you are attempting a manual migration, please contact the AtlasDB team.
 
 This migration process must be run offline (that is, with no AtlasDB clients running during migration) and basically
 consists of the following steps:

--- a/docs/source/services/timelock_service/migration.rst
+++ b/docs/source/services/timelock_service/migration.rst
@@ -3,6 +3,11 @@
 Migration to Timelock Server
 ============================
 
+.. warning::
+    The scope of this document covers migrations of AtlasDB-using services from using an embedded timestamp and lock
+    service to using TimeLock. In particular, migrations of the timestamp bound persistence method are NOT covered
+    here, and attempting to do this procedure incorrectly runs a risk of **SEVERE DATA CORRUPTION**.
+
 Why Migration?
 --------------
 
@@ -19,10 +24,11 @@ Automated Migration
     nodes in step 4. Otherwise, there is a risk of **SEVERE DATA CORRUPTION** as timestamps may be given out of order.
 
 .. warning::
-    Automated migrations are only implemented for Cassandra. If you are using any other KVS, please follow the
-    instructions at :ref:`manual-timelock-migration`.
+    Automated migrations are only implemented for Cassandra, and from AtlasDB 0.253.2 onwards DbKVS.
+    If you are using any other KVS, please follow the instructions at :ref:`manual-timelock-migration`.
 
-1. Confirm that your AtlasDB installation is backed by Cassandra KVS.
+1. Confirm that your AtlasDB installation is backed by Cassandra KVS, or you are using DbKVS and your version of AtlasDB
+   is at least 0.253.2.
 2. (Optional) Take a fresh timestamp from your AtlasDB services, using the fresh timestamp CLI or the
    ``/timestamp/fresh-timestamp`` endpoint. This step is not strictly required, but may be useful for verification.
 3. Add the :ref:`Timelock client configuration <timelock-client-configuration>` to your service.

--- a/docs/source/services/timelock_service/paxos.rst
+++ b/docs/source/services/timelock_service/paxos.rst
@@ -33,13 +33,13 @@ This can be (and is in AtlasDB) mitigated by having a random backoff between pro
 How we use Paxos
 ================
 
-The Timelock servers uses a Paxos based algorithm for two purposes:
+The TimeLock servers may use a Paxos based algorithm for two purposes:
 
-#. **Leadership election:** We choose who will be the leader in the Timelock cluster. The leader is the only server capable
+#. **Leadership election:** We choose who will be the leader in the TimeLock cluster. The leader is the only server capable
    of responding to lock and timestamp requests. Leader election is often preferable for performance reasons confirming
    you are the leader is more efficient than choosing the value to respond with.
-#. **Timestamp bound:** Timelock has an asynchronous process to increase the upper bound of timestamps that the leader is
-   allowed to hand out, and we choose this bound via Paxos.
+#. **Timestamp bound:** TimeLock needs to store upper bounds on timestamps that the leader is allowed to hand out.
+   If configured to use Paxos timestamp persistence, TimeLock chooses this bound via Paxos.
 
 It is worth noting that the Paxos implementations differ slightly for choosing a leader and choosing a timestamp bound.
 When choosing a leader, all servers can propose leadership and have the potential to be elected. However, once a leader

--- a/docs/source/services/timelock_service/service-management.rst
+++ b/docs/source/services/timelock_service/service-management.rst
@@ -62,6 +62,9 @@ of the timestamp service as far as clients are concerned have been preserved.
 Step 4 (Optional): Cleanup on TimeLock
 --------------------------------------
 
+.. warning::
+    This section is written under the assumption you are using Paxos for timestamp bound persistence.
+
 TimeLock will continue to hold references to the old client in memory until it is next bounced, and the logs for
 previous rounds of the Paxos protocol will be preserved. Generally, these have a very small footprint and it's thus
 okay to leave them around.


### PR DESCRIPTION
**Goals (and why)**:
- Don't confuse readers of the atlasdb docs

**Implementation Description (bullets)**:
- Replace references to migrations only existing for Cassandra to add DbKVS
- Place warnings around sections of the TimeLock docs that only apply to TimeLocks that run with Paxos persistence.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Docs change only

**Concerns (what feedback would you like?)**:
- Did I miss any references?

**Where should we start reviewing?**: migration.rst?

**Priority (whenever / two weeks / yesterday)**: I'd say this blocks announcement, so Thursday would be good.
