### PR TITLE
Do not kill timelock for no reason

### DIFF
--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogMigrator.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogMigrator.java
@@ -127,7 +127,7 @@ public final class PaxosStateLogMigrator<V extends Persistable & Versionable> {
         long persistedCutoff = context.migrationState().getCutoff();
         long greatestSourceEntry = context.sourceLog().getGreatestLogEntry();
         Preconditions.checkState(
-                migrationCutoff <= persistedCutoff,
+                migrationCutoff <= persistedCutoff || context.migrateFrom().isPresent(),
                 "The migration to the destination state log was already performed in the past, but the "
                         + "persisted cutoff value does not match a newly calculated one. This indicates the source "
                         + "log has advanced since the migration was performed which could lead to data corruption if "

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosStateLogMigratorTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosStateLogMigratorTest.java
@@ -386,6 +386,17 @@ public class PaxosStateLogMigratorTest {
     }
 
     @Test
+    public void doNotFailWhenAlreadyMigratedAndMigrateFromIncreasesButGreatestEntryIsMigrated() {
+        long lowerBound = 10;
+        long upperBound = 250;
+        insertValuesWithinBounds(lowerBound, upperBound, source);
+
+        migrateFrom(source, OptionalLong.of(220));
+
+        assertThatCode(() -> migrateFrom(source, OptionalLong.of(300))).doesNotThrowAnyException();
+    }
+
+    @Test
     public void doNotFailWhenAlreadyMigratedAndSourceTruncatedFully() {
         long lowerBound = 10;
         long upperBound = 250;


### PR DESCRIPTION
**Goals (and why)**:
Timelock should fail to start if SQLite migration has run, but the state is inconsistent. The way we are checking this is:

1. Verify that the migration cutoff would be the same if we ran the migration now
2. Verify that the greatest entry in the old log is present in the log

These checks are correct for paxos learner, because 1) will fail if old log has advanced and 2) will catch the special case where old learner advanced but is still below 50 so the cutoff matches. However, the calculation of the cutoff for the acceptor is based on the greatest entry observed by the **current learner**. Therefore, after the migration ran and the SQLite learner learned something, the cutoff for the learner is no longer going to match the persisted cutoff.

**Implementation Description (bullets)**:
Ignore the first check when `migrateFrom` is specified, the second check should realistically be good enough to catch any bad cases.
