### PR TITLE
[TS] Tune sweepdelay metrics

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepDelay.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepDelay.java
@@ -61,19 +61,19 @@ class SweepDelay {
     }
 
     long getNextPause(SweepIterationResult result) {
-        long lastDelay = SweepIterationResults.caseOf(result)
+        return SweepIterationResults.caseOf(result)
                 .success(this::updateCurrentPauseAndGet)
                 .unableToAcquireShard_(maxPauseMillis)
                 .insufficientConsistency_(BACKOFF)
                 .otherError_(maxPauseMillis)
                 .disabled_(BACKOFF);
-        sweepDelayMetricsUpdater.accept(lastDelay);
-        return lastDelay;
     }
 
     private long updateCurrentPauseAndGet(long numSwept) {
         long target = pauseTarget(numSwept);
-        return currentPause.updateAndGet(oldPause -> (4 * oldPause + target) / 5);
+        long newPause = currentPause.updateAndGet(oldPause -> (4 * oldPause + target) / 5);
+        sweepDelayMetricsUpdater.accept(newPause);
+        return newPause;
     }
 
     private long pauseTarget(long numSwept) {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepDelayTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepDelayTest.java
@@ -60,28 +60,32 @@ public class SweepDelayTest {
 
     @Test
     public void unableToAcquireShardReturnsMaxPause() {
+        delay.getNextPause(SUCCESS);
         assertThat(delay.getNextPause(SweepIterationResults.unableToAcquireShard()))
                 .isEqualTo(DEFAULT_MAX_PAUSE_MILLIS);
-        assertThat(metrics).hasValue(DEFAULT_MAX_PAUSE_MILLIS);
+        assertThat(metrics).hasValue(INITIAL_DELAY);
     }
 
     @Test
     public void insufficientConsistencyReturnsBackoff() {
+        delay.getNextPause(SUCCESS);
         assertThat(delay.getNextPause(SweepIterationResults.insufficientConsistency()))
                 .isEqualTo(BACKOFF);
-        assertThat(metrics).hasValue(BACKOFF);
+        assertThat(metrics).hasValue(INITIAL_DELAY);
     }
 
     @Test
     public void otherErrorReturnsMaxPause() {
+        delay.getNextPause(SUCCESS);
         assertThat(delay.getNextPause(SweepIterationResults.otherError())).isEqualTo(DEFAULT_MAX_PAUSE_MILLIS);
-        assertThat(metrics).hasValue(DEFAULT_MAX_PAUSE_MILLIS);
+        assertThat(metrics).hasValue(INITIAL_DELAY);
     }
 
     @Test
     public void disabledReturnsBackoff() {
+        delay.getNextPause(SUCCESS);
         assertThat(delay.getNextPause(SweepIterationResults.disabled())).isEqualTo(BACKOFF);
-        assertThat(metrics).hasValue(BACKOFF);
+        assertThat(metrics).hasValue(INITIAL_DELAY);
     }
 
     @Test


### PR DESCRIPTION
**Goals (and why)**:
Currently the metric reflects the actual delay of each sweep iteration. The problem with this is that if sweep is set up with more threads * nodes than shards, or we run into errors, this introduces noise into the metric. It was interesting to have this to see that it works, but given that these cases can be detected with the sweep outcomes, there is no need to pollute sweep delay.

**Implementation Description (bullets)**:
Sweep delay now reports the on success delay only

**Testing (What was existing testing like?  What have you done to improve it?)**:
Fixed unit tests

**Concerns (what feedback would you like?)**:
None

**Where should we start reviewing?**:
Tiny

**Priority (whenever / two weeks / yesterday)**:
Not high, but small