### PR TITLE
Fix AsyncInitializerTest message assertion

### DIFF
--- a/atlasdb-commons/src/test/java/com/palantir/async/initializer/AsyncInitializerTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/async/initializer/AsyncInitializerTest.java
@@ -97,7 +97,7 @@ public class AsyncInitializerTest {
 
         assertThatThrownBy(() -> initializer.initialize(false))
                 .isInstanceOf(RuntimeException.class)
-                .withFailMessage("Failed initializing");
+                .hasMessage("Failed initializing");
         assertThatThrownBy(() -> initializer.initialize(false))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Multiple calls tried to initialize the same instance.");


### PR DESCRIPTION
Previously it set the assertion failure message for a nonexistant
next assert rather than making an assertion about the input.