### PR TITLE
[PSL] Better Logging and Option to Skip Validation + Truncate for PSL Migration

### DIFF
--- a/leader-election-api/src/main/java/com/palantir/paxos/PaxosStateLog.java
+++ b/leader-election-api/src/main/java/com/palantir/paxos/PaxosStateLog.java
@@ -70,4 +70,6 @@ public interface PaxosStateLog<V extends Persistable & Versionable> {
      * @param toDeleteInclusive the upper bound sequence number (inclusive)
      */
     void truncate(long toDeleteInclusive);
+
+    void truncateAllRounds();
 }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosAcceptorState.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosAcceptorState.java
@@ -134,4 +134,17 @@ public final class PaxosAcceptorState implements Persistable, Versionable {
         }
         return Objects.equal(lastAcceptedValue, other.lastAcceptedValue);
     }
+
+    @Override
+    public String toString() {
+        return new StringBuilder("PaxosAcceptorState [")
+                .append("lastPromisedId=")
+                .append(lastPromisedId)
+                .append(", lastAcceptedId=")
+                .append(lastAcceptedId)
+                .append(", lastAcceptedValue=")
+                .append(lastAcceptedValue)
+                .append("]")
+                .toString();
+    }
 }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosAcceptorState.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosAcceptorState.java
@@ -137,14 +137,13 @@ public final class PaxosAcceptorState implements Persistable, Versionable {
 
     @Override
     public String toString() {
-        return new StringBuilder("PaxosAcceptorState [")
-                .append("lastPromisedId=")
-                .append(lastPromisedId)
-                .append(", lastAcceptedId=")
-                .append(lastAcceptedId)
-                .append(", lastAcceptedValue=")
-                .append(lastAcceptedValue)
-                .append("]")
-                .toString();
+        return "PaxosAcceptorState ["
+                + "lastPromisedId="
+                + lastPromisedId
+                + ", lastAcceptedId="
+                + lastAcceptedId
+                + ", lastAcceptedValue="
+                + lastAcceptedValue
+                + "]";
     }
 }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogImpl.java
@@ -212,11 +212,6 @@ public class PaxosStateLogImpl<V extends Persistable & Versionable> implements P
     public void truncate(long toDeleteInclusive) {
         lock.writeLock().lock();
         try {
-            long greatestLogEntry = getGreatestLogEntry();
-            if (greatestLogEntry >= 0) {
-                // We never want to remove our most recent entry
-                toDeleteInclusive = Math.min(greatestLogEntry - 1, toDeleteInclusive);
-            }
             File dir = new File(path);
             List<File> files = getLogEntries(dir);
             files.sort(nameAsLongComparator());

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogImpl.java
@@ -247,7 +247,11 @@ public class PaxosStateLogImpl<V extends Persistable & Versionable> implements P
 
     private static void deleteLogFile(File file) {
         if (!file.delete()) {
-            log.warn("Failed to delete log file {}", SafeArg.of("path", file.getAbsolutePath()));
+            log.warn(
+                    "Failed to delete log file for sequence {}, use case {}, and client {}.",
+                    SafeArg.of("sequence", file.getName()),
+                    SafeArg.of("use case", file.getParentFile().getName()),
+                    SafeArg.of("client", file.getParentFile().getParentFile().getName()));
         }
     }
 

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogMigrator.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogMigrator.java
@@ -34,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import org.immutables.value.Value;
+import org.immutables.value.Value.Default;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,14 +68,14 @@ public final class PaxosStateLogMigrator<V extends Persistable & Versionable> {
             context.migrationState().setCutoff(cutoff);
             context.migrationState().migrateToMigratedState();
             if (context.skipValidationAndTruncateSourceIfMigrated()) {
-                context.sourceLog().truncate(context.sourceLog().getGreatestLogEntry());
+                context.sourceLog().truncateAllRounds();
             }
             return cutoff;
         } else {
             if (!context.skipValidationAndTruncateSourceIfMigrated()) {
                 validateConsistency(context);
             } else {
-                context.sourceLog().truncate(context.sourceLog().getGreatestLogEntry());
+                context.sourceLog().truncateAllRounds();
             }
         }
         return context.migrationState().getCutoff();
@@ -183,7 +184,10 @@ public final class PaxosStateLogMigrator<V extends Persistable & Versionable> {
 
         NamespaceAndUseCase namespaceAndUseCase();
 
-        boolean skipValidationAndTruncateSourceIfMigrated();
+        @Default
+        default boolean skipValidationAndTruncateSourceIfMigrated() {
+            return false;
+        }
     }
 
     private static final class LogReader<V extends Persistable & Versionable> {

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStorageParameters.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStorageParameters.java
@@ -27,4 +27,6 @@ public interface PaxosStorageParameters {
     DataSource sqliteDataSource();
 
     Optional<String> fileBasedLogDirectory();
+
+    boolean skipConsistencyCheckAndTruncateOldPaxosLog();
 }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStorageParameters.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStorageParameters.java
@@ -19,6 +19,7 @@ package com.palantir.paxos;
 import java.util.Optional;
 import javax.sql.DataSource;
 import org.immutables.value.Value;
+import org.immutables.value.Value.Default;
 
 @Value.Immutable
 public interface PaxosStorageParameters {
@@ -28,5 +29,8 @@ public interface PaxosStorageParameters {
 
     Optional<String> fileBasedLogDirectory();
 
-    boolean skipConsistencyCheckAndTruncateOldPaxosLog();
+    @Default
+    default boolean skipConsistencyCheckAndTruncateOldPaxosLog() {
+        return false;
+    }
 }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SplittingPaxosStateLog.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SplittingPaxosStateLog.java
@@ -86,12 +86,18 @@ public final class SplittingPaxosStateLog<V extends Persistable & Versionable> i
                 .hydrator(hydrator)
                 .migrationState(SqlitePaxosStateLogMigrationState.create(namespaceUseCase, params.sqliteDataSource()))
                 .migrateFrom(migrateFrom)
+                .namespaceAndUseCase(namespaceUseCase)
+                .skipValidationAndTruncateSourceIfMigrated(params.skipConsistencyCheckAndTruncateOldPaxosLog())
                 .build();
 
         log.info(
                 "Starting migration for namespace and use case {} if migration has not run before.",
                 SafeArg.of("namespaceAndUseCase", params.namespaceAndUseCase()));
         long cutoff = PaxosStateLogMigrator.migrateAndReturnCutoff(migrationContext);
+
+        if (params.skipConsistencyCheckAndTruncateOldPaxosLog()) {
+            return migrationContext.destinationLog();
+        }
 
         SplittingParameters<V> splittingParameters = ImmutableSplittingParameters.<V>builder()
                 .legacyLog(migrationContext.sourceLog())

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SplittingPaxosStateLog.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SplittingPaxosStateLog.java
@@ -148,6 +148,11 @@ public final class SplittingPaxosStateLog<V extends Persistable & Versionable> i
         log.warn("Tried to truncate paxos state log with an implementation that does not support truncations.");
     }
 
+    @Override
+    public void truncateAllRounds() {
+        log.warn("Tried to truncate paxos state log with an implementation that does not support truncations.");
+    }
+
     @Value.Immutable
     interface SplittingParameters<V extends Persistable & Versionable> {
         PaxosStateLog<V> legacyLog();

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLog.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLog.java
@@ -86,6 +86,15 @@ public class SqlitePaxosStateLog<V extends Persistable & Versionable> implements
         execute(dao -> dao.truncate(namespace, useCase, toDeleteInclusive));
     }
 
+    @Override
+    public void truncateAllRounds() {
+        execute(dao -> {
+            OptionalLong greatestLogEntry = dao.getGreatestLogEntry(namespace, useCase);
+            greatestLogEntry.ifPresent(toDeleteInclusive -> dao.truncate(namespace, useCase, toDeleteInclusive));
+            return null;
+        });
+    }
+
     private <T> T execute(Function<Queries, T> call) {
         return jdbi.withExtension(Queries.class, call::apply);
     }

--- a/leader-election-impl/src/test/java/com/palantir/paxos/FileToSqlitePaxosStateLogIntegrationTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/FileToSqlitePaxosStateLogIntegrationTest.java
@@ -117,6 +117,8 @@ public class FileToSqlitePaxosStateLogIntegrationTest {
                 .destinationLog(target)
                 .hydrator(PaxosValue.BYTES_HYDRATOR)
                 .migrationState(migrationState)
+                .namespaceAndUseCase(ImmutableNamespaceAndUseCase.of(Client.of("client"), "UseCase"))
+                .skipValidationAndTruncateSourceIfMigrated(false)
                 .build());
     }
 

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosStateLogMigratorTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosStateLogMigratorTest.java
@@ -51,6 +51,9 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 public class PaxosStateLogMigratorTest {
+    private static final NamespaceAndUseCase NAMESPACE_AND_USE_CASE =
+            ImmutableNamespaceAndUseCase.of(Client.of("client"), "UseCase");
+
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
 
@@ -127,6 +130,35 @@ public class PaxosStateLogMigratorTest {
                 .mapKeys(PaxosStateLogTestUtils::valueForRound)
                 .entries()
                 .forEach(entry -> assertThat(entry.getKey()).isEqualTo(entry.getValue()));
+        assertThat(source.getGreatestLogEntry()).isEqualTo(upperBound);
+    }
+
+    @Test
+    public void stillMigrateWhenValidationIsSkippedButAlsoTruncateSource() {
+        long lowerBound = 10;
+        long upperBound = 75;
+        insertValuesWithinBounds(lowerBound, upperBound, source);
+
+        long bound = 60;
+        long expectedCutoff = bound - PaxosStateLogMigrator.SAFETY_BUFFER;
+        long cutoff = migrateFrom(source, OptionalLong.of(bound), true);
+
+        assertThat(cutoff).isEqualTo(expectedCutoff);
+        assertThat(migrationState.hasMigratedFromInitialState()).isTrue();
+        assertThat(migrationState.isInMigratedState()).isTrue();
+        assertThat(target.getLeastLogEntry()).isEqualTo(expectedCutoff);
+        assertThat(target.getGreatestLogEntry()).isEqualTo(upperBound);
+
+        LongStream.rangeClosed(lowerBound, expectedCutoff - 1)
+                .mapToObj(sequence -> readRoundUnchecked(target, sequence))
+                .map(Assertions::assertThat)
+                .forEach(AbstractAssert::isNull);
+        KeyedStream.of(LongStream.rangeClosed(expectedCutoff, upperBound).boxed())
+                .map(sequence -> getPaxosValue(target, sequence))
+                .mapKeys(PaxosStateLogTestUtils::valueForRound)
+                .entries()
+                .forEach(entry -> assertThat(entry.getKey()).isEqualTo(entry.getValue()));
+        assertThat(source.getGreatestLogEntry()).isEqualTo(PaxosAcceptor.NO_LOG_ENTRY);
     }
 
     @Test
@@ -281,6 +313,8 @@ public class PaxosStateLogMigratorTest {
                 .hydrator(PaxosValue.BYTES_HYDRATOR)
                 .migrationState(migrationState)
                 .migrateFrom(lowerBound)
+                .namespaceAndUseCase(NAMESPACE_AND_USE_CASE)
+                .skipValidationAndTruncateSourceIfMigrated(false)
                 .build();
 
         assertThatCode(() -> PaxosStateLogMigrator.migrateAndReturnCutoff(context))
@@ -303,6 +337,8 @@ public class PaxosStateLogMigratorTest {
                 .hydrator(PaxosValue.BYTES_HYDRATOR)
                 .migrationState(migrationState)
                 .migrateFrom(lowerBound)
+                .namespaceAndUseCase(NAMESPACE_AND_USE_CASE)
+                .skipValidationAndTruncateSourceIfMigrated(false)
                 .build();
 
         assertThatThrownBy(() -> PaxosStateLogMigrator.migrateAndReturnCutoff(context))
@@ -408,17 +444,92 @@ public class PaxosStateLogMigratorTest {
         assertThatCode(() -> migrateFrom(source, OptionalLong.empty())).doesNotThrowAnyException();
     }
 
+    @Test
+    public void doNotFailWhenSourceAdvancedChangingCutoffOnSkippingValidation() {
+        long lowerBound = 10;
+        long upperBound = 25;
+        insertValuesWithinBounds(lowerBound, upperBound, source);
+
+        migrateFrom(source, OptionalLong.empty());
+
+        insertValuesWithinBounds(upperBound + 50, upperBound + 50, source);
+        insertValuesWithinBounds(upperBound + 50, upperBound + 50, target);
+        assertThatCode(() -> migrateFrom(source, OptionalLong.empty(), true)).doesNotThrowAnyException();
+        assertThat(source.getGreatestLogEntry()).isEqualTo(PaxosAcceptor.NO_LOG_ENTRY);
+    }
+
+    @Test
+    public void doNotFailWhenSourceAdvancedWithoutChangingCutoffAndEntriesDoNotMatchOnSkippingValidation() {
+        long lowerBound = 10;
+        long upperBound = 25;
+        insertValuesWithinBounds(lowerBound, upperBound, source);
+
+        migrateFrom(source, OptionalLong.empty());
+
+        insertValuesWithinBounds(upperBound + 1, upperBound + 1, source);
+        target.writeRound(upperBound + 1, PaxosStateLogTestUtils.valueForRound(upperBound + 2));
+        assertThatCode(() -> migrateFrom(source, OptionalLong.empty(), true)).doesNotThrowAnyException();
+        assertThat(source.getGreatestLogEntry()).isEqualTo(PaxosAcceptor.NO_LOG_ENTRY);
+    }
+
+    @Test
+    public void doNotFailWhenSourceAdvancedWithoutChangingCutoffAndNoEntryInTargetOnSkippingValidation() {
+        long lowerBound = 10;
+        long upperBound = 25;
+        insertValuesWithinBounds(lowerBound, upperBound, source);
+
+        migrateFrom(source, OptionalLong.empty());
+
+        insertValuesWithinBounds(upperBound + 1, upperBound + 1, source);
+        assertThatCode(() -> migrateFrom(source, OptionalLong.empty(), true)).doesNotThrowAnyException();
+        assertThat(source.getGreatestLogEntry()).isEqualTo(PaxosAcceptor.NO_LOG_ENTRY);
+    }
+
+    @Test
+    public void doNotFailWhenSourceAdvancedAndEntriesDoNotMatchWhenSpecifyingLowerBoundOnSkippingValidation() {
+        long lowerBound = 10;
+        long upperBound = 250;
+        insertValuesWithinBounds(lowerBound, upperBound, source);
+
+        migrateFrom(source, OptionalLong.of(150));
+
+        source.writeRound(upperBound + 1, PaxosStateLogTestUtils.valueForRound(upperBound + 2));
+        insertValuesWithinBounds(upperBound + 1, upperBound + 100, target);
+        assertThatCode(() -> migrateFrom(source, OptionalLong.of(150), true)).doesNotThrowAnyException();
+        assertThat(source.getGreatestLogEntry()).isEqualTo(PaxosAcceptor.NO_LOG_ENTRY);
+    }
+
+    @Test
+    public void doNotFailWhenSourceAdvancedAndNoEntryInTargetWhenSpecifyingLowerBoundOnSkippingValidation() {
+        long lowerBound = 10;
+        long upperBound = 250;
+        insertValuesWithinBounds(lowerBound, upperBound, source);
+
+        migrateFrom(source, OptionalLong.of(150));
+
+        source.writeRound(upperBound + 1, PaxosStateLogTestUtils.valueForRound(upperBound + 2));
+        insertValuesWithinBounds(upperBound + 2, upperBound + 100, target);
+        assertThatCode(() -> migrateFrom(source, OptionalLong.of(150), true)).doesNotThrowAnyException();
+        assertThat(source.getGreatestLogEntry()).isEqualTo(PaxosAcceptor.NO_LOG_ENTRY);
+    }
+
     private long migrateFrom(PaxosStateLog<PaxosValue> sourceLog) {
         return migrateFrom(sourceLog, OptionalLong.empty());
     }
 
     private long migrateFrom(PaxosStateLog<PaxosValue> sourceLog, OptionalLong lowerBound) {
+        return migrateFrom(sourceLog, lowerBound, false);
+    }
+
+    private long migrateFrom(PaxosStateLog<PaxosValue> sourceLog, OptionalLong lowerBound, boolean skipValidation) {
         return PaxosStateLogMigrator.migrateAndReturnCutoff(ImmutableMigrationContext.<PaxosValue>builder()
                 .sourceLog(sourceLog)
                 .destinationLog(target)
                 .hydrator(PaxosValue.BYTES_HYDRATOR)
                 .migrationState(migrationState)
                 .migrateFrom(lowerBound)
+                .namespaceAndUseCase(NAMESPACE_AND_USE_CASE)
+                .skipValidationAndTruncateSourceIfMigrated(skipValidation)
                 .build());
     }
 

--- a/leader-election-impl/src/test/java/com/palantir/paxos/SqlitePaxosStateLogTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/SqlitePaxosStateLogTest.java
@@ -168,6 +168,17 @@ public class SqlitePaxosStateLogTest {
     }
 
     @Test
+    public void canTruncateAll() {
+        writeValueForRound(5L);
+        writeValueForRound(7L);
+        writeValueForRound(9L);
+        writeValueForRound(1L);
+
+        stateLog.truncateAllRounds();
+        assertThat(stateLog.getLeastLogEntry()).isEqualTo(PaxosAcceptor.NO_LOG_ENTRY);
+    }
+
+    @Test
     public void valuesAreDistinguishedAcrossLogNamespaces() throws IOException {
         PaxosStateLog<PaxosValue> otherLog = SqlitePaxosStateLog.create(wrap(CLIENT_2, USE_CASE_1), dataSource);
         writeValueForRound(1L);

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipContextFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipContextFactory.java
@@ -65,7 +65,10 @@ public abstract class LeadershipContextFactory
                 install().sqliteDataSource(),
                 leaderUuid(),
                 install().install().paxos().canCreateNewClients(),
-                install().timeLockVersion());
+                install().timeLockVersion(),
+                install()
+                        .install()
+                        .iAmOnThePersistenceTeamAndKnowWhatImDoingSkipSqliteConsistencyCheckAndTruncateFileBasedLog());
     }
 
     @Override

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResourcesFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResourcesFactory.java
@@ -176,7 +176,9 @@ public final class PaxosResourcesFactory {
                 install.sqliteDataSource(),
                 install.nodeUuid(),
                 install.install().paxos().canCreateNewClients(),
-                install.timeLockVersion());
+                install.timeLockVersion(),
+                install.install()
+                        .iAmOnThePersistenceTeamAndKnowWhatImDoingSkipSqliteConsistencyCheckAndTruncateFileBasedLog());
 
         NetworkClientFactories batchClientFactories = ImmutableBatchingNetworkClientFactories.builder()
                 .useCase(PaxosUseCase.TIMESTAMP)

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockInstallConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockInstallConfiguration.java
@@ -37,6 +37,11 @@ public interface TimeLockInstallConfiguration {
 
     ClusterConfiguration cluster();
 
+    @Value.Default
+    default boolean iAmOnThePersistenceTeamAndKnowWhatImDoingSkipSqliteConsistencyCheckAndTruncateFileBasedLog() {
+        return false;
+    }
+
     /**
      * TODO(fdesouza): Remove this once PDS-95791 is resolved.
      * @deprecated Remove this once PDS-95791 is resolved.

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponents.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponents.java
@@ -67,6 +67,7 @@ public class LocalPaxosComponents {
     private final Supplier<BatchPingableLeader> memoizedBatchPingableLeader;
     private final boolean canCreateNewClients;
     private final OrderableSlsVersion timeLockVersion;
+    private final boolean skipConsistencyCheckAndTruncateOldPaxosLog;
 
     private LocalPaxosComponents(
             TimelockPaxosMetrics metrics,
@@ -75,7 +76,8 @@ public class LocalPaxosComponents {
             DataSource sqliteDataSource,
             UUID leaderUuid,
             boolean canCreateNewClients,
-            OrderableSlsVersion timeLockVersion) {
+            OrderableSlsVersion timeLockVersion,
+            boolean skipConsistencyCheckAndTruncateOldPaxosLog) {
         this.metrics = metrics;
         this.paxosUseCase = paxosUseCase;
         this.baseLogDirectory = legacyLogDirectory;
@@ -86,6 +88,7 @@ public class LocalPaxosComponents {
         this.memoizedBatchPingableLeader = Suppliers.memoize(this::createBatchPingableLeader);
         this.canCreateNewClients = canCreateNewClients;
         this.timeLockVersion = timeLockVersion;
+        this.skipConsistencyCheckAndTruncateOldPaxosLog = skipConsistencyCheckAndTruncateOldPaxosLog;
     }
 
     public static LocalPaxosComponents createWithBlockingMigration(
@@ -95,7 +98,8 @@ public class LocalPaxosComponents {
             DataSource sqliteDataSource,
             UUID leaderUuid,
             boolean canCreateNewClients,
-            OrderableSlsVersion timeLockVersion) {
+            OrderableSlsVersion timeLockVersion,
+            boolean skipConsistencyCheckAndTruncateOldPaxosLog) {
         LocalPaxosComponents components = new LocalPaxosComponents(
                 metrics,
                 paxosUseCase,
@@ -103,7 +107,8 @@ public class LocalPaxosComponents {
                 sqliteDataSource,
                 leaderUuid,
                 canCreateNewClients,
-                timeLockVersion);
+                timeLockVersion,
+                skipConsistencyCheckAndTruncateOldPaxosLog);
 
         Path legacyClientDir = paxosUseCase.logDirectoryRelativeToDataDirectory(legacyLogDirectory);
         PersistentNamespaceLoader namespaceLoader = new DiskNamespaceLoader(legacyClientDir);
@@ -202,6 +207,7 @@ public class LocalPaxosComponents {
                 .fileBasedLogDirectory(learnerLogDir.toString())
                 .sqliteDataSource(sqliteDataSource)
                 .namespaceAndUseCase(ImmutableNamespaceAndUseCase.of(client, learnerUseCase))
+                .skipConsistencyCheckAndTruncateOldPaxosLog(skipConsistencyCheckAndTruncateOldPaxosLog)
                 .build();
     }
 
@@ -216,6 +222,7 @@ public class LocalPaxosComponents {
                 .fileBasedLogDirectory(acceptorLogDir.toString())
                 .sqliteDataSource(sqliteDataSource)
                 .namespaceAndUseCase(ImmutableNamespaceAndUseCase.of(client, acceptorUseCase))
+                .skipConsistencyCheckAndTruncateOldPaxosLog(skipConsistencyCheckAndTruncateOldPaxosLog)
                 .build();
     }
 

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponentsTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponentsTest.java
@@ -134,7 +134,8 @@ public class LocalPaxosComponentsTest {
                 sqlite,
                 UUID.randomUUID(),
                 canCreateNewClients,
-                DEFAULT_TIME_LOCK_VERSION);
+                DEFAULT_TIME_LOCK_VERSION,
+                false);
     }
 
     public LocalPaxosComponents createPaxosComponents(
@@ -146,6 +147,7 @@ public class LocalPaxosComponentsTest {
                 sqlite,
                 UUID.randomUUID(),
                 canCreateNewClients,
-                timeLockVersion);
+                timeLockVersion,
+                false);
     }
 }

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
@@ -116,7 +116,8 @@ public class PaxosTimestampBoundStoreTest {
                     SqliteConnections.getPooledDataSource(Paths.get(root, i + "sqlite")),
                     UUID.randomUUID(),
                     true,
-                    OrderableSlsVersion.valueOf("0.0.0"));
+                    OrderableSlsVersion.valueOf("0.0.0"),
+                    false);
 
             AtomicBoolean failureController = new AtomicBoolean(false);
             failureToggles.add(failureController);


### PR DESCRIPTION
**Goals (and why)**:
This PR does two things: improves the logging on the migration and validation tasks, and adds a timelock install config that allows us to skip validation and truncate old logs when we need this to move forward if safe with failing validation

**Implementation Description (bullets)**:

- Added `toString()` to `PaxosAcceptorState`, basically no reason not to do it this way
- Wired in and added client and use case to the logs
- Added a `truncateAllRounds` method to PSL interface
- If the config is set to true, skip validation if migrated, and in any case truncate the file based log
Funnily enough found two bugs in PaxosStateLogImpl so fixed them along the way.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Basically added some new tests that are modified existing tests and verify that the changed behaviour makes sense.

**Concerns (what feedback would you like?)**:
Not the biggest fan of adding more dangerous stuff to the interface, but the alternative was to change the behaviour of `PaxosStateLogImpl` to truncate everything. The JavaDoc implicitly allows this, but in the vein of being more defensive we just don't need this kind of implementation detail change to somehow kick is in the teeth.

**Where should we start reviewing?**:
Tests

**Priority (whenever / two weeks / yesterday)**:
🔥 
