### PR TITLE
Fix and enforce ByteBufferBackingArray

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
@@ -262,7 +262,7 @@ public final class CassandraKeyValueServices {
         // Be careful *NOT* to perform anything that will modify the buffer's position or limit
         byte[] bytes = new byte[buffer.limit() - buffer.position()];
         if (buffer.hasArray()) {
-            System.arraycopy(buffer.array(), buffer.position(), bytes, 0, bytes.length);
+            System.arraycopy(buffer.array(), buffer.arrayOffset() + buffer.position(), bytes, 0, bytes.length);
         } else {
             buffer.duplicate().get(bytes, buffer.position(), bytes.length);
         }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/HostPartitioner.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/HostPartitioner.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimaps;
 import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.logsafe.Preconditions;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
@@ -59,6 +60,9 @@ final class HostPartitioner {
         }
         ListMultimap<InetSocketAddress, V> valuesByHost = ArrayListMultimap.create();
         for (ByteBuffer key : partitionedByKey.keySet()) {
+            Preconditions.checkState(key.hasArray(), "Expected an array backed buffer");
+            Preconditions.checkState(key.arrayOffset() == 0, "Buffer array must have no offset");
+            Preconditions.checkState(key.limit() == key.array().length, "Array length must match the limit");
             InetSocketAddress host = clientPool.getRandomHostForKey(key.array());
             valuesByHost.putAll(host, partitionedByKey.get(key));
         }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/sweep/GetCandidateRowsForSweeping.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/sweep/GetCandidateRowsForSweeping.java
@@ -22,6 +22,7 @@ import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.cassandra.CqlExecutor;
 import com.palantir.atlasdb.keyvalue.cassandra.paging.RowGetter;
+import com.palantir.logsafe.Preconditions;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -104,6 +105,9 @@ public class GetCandidateRowsForSweeping {
 
         List<CandidateRowForSweeping> candidates = new ArrayList<>();
         cellsByRow.forEach((row, cells) -> {
+            Preconditions.checkState(row.hasArray(), "Expected an array backed buffer");
+            Preconditions.checkState(row.arrayOffset() == 0, "Buffer array must have no offset");
+            Preconditions.checkState(row.limit() == row.array().length, "Array length must match the limit");
             candidates.add(CandidateRowForSweeping.of(
                     row.array(),
                     cells.stream()

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutorTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutorTest.java
@@ -100,7 +100,11 @@ public class CqlExecutorTest {
                 return false;
             }
 
-            String actualQuery = PtBytes.toString(argument.array());
+            int position = argument.position();
+            byte[] data = new byte[argument.remaining()];
+            argument.get(data);
+            argument.position(position);
+            String actualQuery = PtBytes.toString(data);
             return expected.equals(actualQuery);
         };
     }

--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,6 @@ allprojects {
                 'AnnotateFormatMethod',
                 'ArrayAsKeyOfSetOrMap',
                 'AssertionFailureIgnored',
-                'ByteBufferBackingArray',
                 'CacheLoaderNull',
                 'CatchBlockLogException',
                 'CatchFail',


### PR DESCRIPTION
**Goals (and why)**:
ByteBufferBackingArray failures can result in data corruption. There's no guarantee that an arbitrary heap buffer uses offset zero.
