### PR TITLE
Simplify protobuf configuration

### DIFF
--- a/atlasdb-client-protobufs/build.gradle
+++ b/atlasdb-client-protobufs/build.gradle
@@ -6,7 +6,6 @@ protobuf {
   protoc {
     artifact = "com.google.protobuf:protoc:${libVersions.protoc}"
   }
-  generatedFilesBaseDir = "$projectDir/src"
 }
 
 dependencies {
@@ -14,8 +13,3 @@ dependencies {
 }
 
 project.tasks.idea.dependsOn('generateProto')
-
-// Avoid flagging generated code
-tasks.withType(JavaCompile) {
-    options.errorprone.enabled = false
-}

--- a/examples/profile-client-protobufs/build.gradle
+++ b/examples/profile-client-protobufs/build.gradle
@@ -8,7 +8,6 @@ protobuf {
   protoc {
     artifact = "com.google.protobuf:protoc:${libVersions.protoc}"
   }
-  generatedFilesBaseDir = "$projectDir/src"
 }
 
 dependencies {
@@ -16,8 +15,3 @@ dependencies {
 }
 
 project.tasks.idea.dependsOn('generateProto')
-
-// Avoid flagging generated code
-tasks.withType(JavaCompile) {
-    options.errorprone.enabled = false
-}

--- a/leader-election-api-protobufs/build.gradle
+++ b/leader-election-api-protobufs/build.gradle
@@ -6,7 +6,6 @@ protobuf {
   protoc {
     artifact = "com.google.protobuf:protoc:${libVersions.protoc}"
   }
-  generatedFilesBaseDir = "$projectDir/src"
 }
 
 dependencies {
@@ -14,8 +13,3 @@ dependencies {
 }
 
 project.tasks.idea.dependsOn('generateProto')
-
-// Avoid flagging generated code
-tasks.withType(JavaCompile) {
-    options.errorprone.enabled = false
-}


### PR DESCRIPTION
**Goals (and why)**:
Simplify Gradle configuration

**Implementation Description (bullets)**:
Use the default generated protobuf directory. The protobuf plugin [integrates with the `idea` plugin](https://github.com/google/protobuf-gradle-plugin#intellij-idea) and marks the generated directories as a source directories.

![Screen Shot 2020-10-27 at 3 08 04 PM](https://user-images.githubusercontent.com/5273164/97367401-3e8b9d00-1866-11eb-94ad-e0cca8c01644.png)

This change means we no longer need to disable error-prone in these projects.