### PR TITLE
Prototype of getSortedColumns

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/Cell.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/Cell.java
@@ -27,6 +27,7 @@ import com.palantir.logsafe.UnsafeArg;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Comparator;
 import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,6 +40,9 @@ import org.slf4j.LoggerFactory;
 public final class Cell implements Serializable, Comparable<Cell> {
     private static final long serialVersionUID = 1L;
     private static final Logger log = LoggerFactory.getLogger(Cell.class);
+    private static final Comparator<Cell> columnComparator = PtBytes.BYTES_COMPARATOR.onResultOf(Cell::getColumnName);
+    private static final Comparator<Cell> rowComparator = PtBytes.BYTES_COMPARATOR.onResultOf(Cell::getRowName);
+    public static final Comparator<Cell> columnFirstComparator = columnComparator.thenComparing(rowComparator);
 
     // Oracle has an upper bound on RAW types of 2000.
     public static final int MAX_NAME_LENGTH = 1500;

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
@@ -131,6 +131,21 @@ public interface Transaction {
             TableReference tableRef, Iterable<byte[]> rows, BatchColumnRangeSelection columnRangeSelection);
 
     /**
+     * Returns an iterator over cell-value pairs within {@code tableRef} for the specified {@code rows}, where the
+     * columns fall within the provided {@link BatchColumnRangeSelection}. The single provided {@link BatchColumnRangeSelection}
+     * applies to all of the rows.
+     *
+     * The returned iterator is guaranteed contains cells sorted first in order of column, then in order of row.
+     *
+     * @param tableRef table to load values from
+     * @param rows unique rows to apply column range selection to
+     * @param columnRangeSelection range of columns and batch size to load for all rows provided.
+     * @return iterator of cells matching predicate in rows, following ordering outlined above.
+     */
+    Iterator<Map.Entry<Cell, byte[]>> getSortedColumns(
+            TableReference tableRef, Iterable<byte[]> rows, BatchColumnRangeSelection columnRangeSelection);
+
+    /**
      * Gets the values associated for each cell in {@code cells} from table specified by {@code tableRef}.
      *
      * @param tableRef the table from which to get the values

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransaction.java
@@ -67,6 +67,12 @@ public abstract class ForwardingTransaction extends ForwardingObject implements 
     }
 
     @Override
+    public Iterator<Map.Entry<Cell, byte[]>> getSortedColumns(
+            TableReference tableRef, Iterable<byte[]> rows, BatchColumnRangeSelection columnRangeSelection) {
+        return delegate().getSortedColumns(tableRef, rows, columnRangeSelection);
+    }
+
+    @Override
     public Iterator<Map.Entry<Cell, byte[]>> getRowsColumnRange(
             TableReference tableRef, Iterable<byte[]> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
         return delegate().getRowsColumnRange(tableRef, rows, columnRangeSelection, batchHint);

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ReadTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ReadTransaction.java
@@ -129,6 +129,13 @@ public class ReadTransaction extends ForwardingTransaction {
         return delegate().getRowsColumnRange(tableRef, rows, columnRangeSelection, batchHint);
     }
 
+    @Override
+    public Iterator<Map.Entry<Cell, byte[]>> getSortedColumns(
+            TableReference tableRef, Iterable<byte[]> rows, BatchColumnRangeSelection selection) {
+        checkTableName(tableRef);
+        return delegate().getSortedColumns(tableRef, rows, selection);
+    }
+
     private void checkTableName(TableReference tableRef) {
         SweepStrategy sweepStrategy = sweepStrategies.get(tableRef);
         Preconditions.checkState(


### PR DESCRIPTION
Internally we do a fair amount of merge sorting between rows, and this
is quite inefficient within Atlas. How it goes wrong is related to the
batching - basically each batch is lock checked, timestamp checked
independently, and so you get the nice waterfall in the gantt chart.

Here we add a specific method that does the sorting and merging, giving
the user an iterator which broadly does the right thing.

Skip all the rebatching stuff because sweep works nicely now.

Obviously I have no tests, and there are quite a few that you'd need to
write - especially since I've caught three more bugs in the original
getColumnsRange implementation (unsafe usages of transformEntries).

The other question I have is: most use cases (although not all) for this
actually read a fixed number of things. We could probably simplify the
contract a bit (although the implementation is already very clean) by
returning a Map of the first n or whatever.

Lastly, there is some downside of this. The present approach means that
if you e.g. read _all_ the columns of 1000 rows using distinct getColumnRange
calls, they'll be batched together at conflict checking. This approach
cannot extend in this way, so if you make 1000 calls, you'll do 1000
waterfalls here. That said, based on use cases this is probably fine -
the fanouts we see _should_ be on gets.

It does mean that if one row is requested, we simply delegate to the
present method of read only conflict checking since this will have
more opportunities to be optimized in conflict checking.

I think long term there's some fairly strong argument here that we're
suffering due to our KVS interface. IRL, the mgms implementation if
exposed on KVS would make the conflict checking here be awesome.