### PR TITLE
add initializeAsync for Db implementations

### DIFF
--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbKvsPostgresInvalidationRunnerTest.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbKvsPostgresInvalidationRunnerTest.java
@@ -95,7 +95,7 @@ public class DbKvsPostgresInvalidationRunnerTest {
         assertBoundNotReadableAfterBeingPoisoned();
     }
 
-    public InDbTimestampBoundStore getStore() {
+    public TimestampBoundStore getStore() {
         return InDbTimestampBoundStore.create(
                 kvs.getConnectionManager(),
                 AtlasDbConstants.TIMESTAMP_TABLE,

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbTimestampStoreInvalidatorCreationTest.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbTimestampStoreInvalidatorCreationTest.java
@@ -92,7 +92,7 @@ public class DbTimestampStoreInvalidatorCreationTest {
     }
 
     // utils
-    private InDbTimestampBoundStore getStore(TableReference tableReference, String tablePrefix) {
+    private TimestampBoundStore getStore(TableReference tableReference, String tablePrefix) {
         return InDbTimestampBoundStore.create(kvs.getConnectionManager(), tableReference, tablePrefix);
     }
 

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/PostgresMultiSequenceTimestampSeriesProviderTest.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/PostgresMultiSequenceTimestampSeriesProviderTest.java
@@ -74,7 +74,7 @@ public class PostgresMultiSequenceTimestampSeriesProviderTest {
         assertThat(clients).isSubsetOf(knownSeries);
     }
 
-    private static InDbTimestampBoundStore createDbTimestampBoundStore(
+    private static TimestampBoundStore createDbTimestampBoundStore(
             ConnectionManagerAwareDbKvs keyValueService, TimestampSeries series) {
         return InDbTimestampBoundStore.createForMultiSeries(
                 keyValueService.getConnectionManager(), AtlasDbConstants.DB_TIMELOCK_TIMESTAMP_TABLE, series);

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/PostgresMultiSeriesDbTimestampBoundStoreTest.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/PostgresMultiSeriesDbTimestampBoundStoreTest.java
@@ -82,7 +82,7 @@ public class PostgresMultiSeriesDbTimestampBoundStoreTest extends AbstractDbTime
         assertThat(store.getUpperLimit()).isEqualTo(ONE_BILLION);
     }
 
-    private InDbTimestampBoundStore createDbTimestampBoundStore(TimestampSeries series) {
+    private TimestampBoundStore createDbTimestampBoundStore(TimestampSeries series) {
         return InDbTimestampBoundStore.createForMultiSeries(
                 kvs.getConnectionManager(), AtlasDbConstants.DB_TIMELOCK_TIMESTAMP_TABLE, series);
     }

--- a/atlasdb-dbkvs/build.gradle
+++ b/atlasdb-dbkvs/build.gradle
@@ -22,4 +22,6 @@ dependencies {
   compileOnly 'org.immutables:value::annotations'
   annotationProcessor 'com.google.auto.service:auto-service'
   compileOnly 'com.google.auto.service:auto-service'
+  annotationProcessor project(":atlasdb-processors")
+  compileOnly project(":atlasdb-processors")
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/DbAtlasDbFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/DbAtlasDbFactory.java
@@ -53,7 +53,7 @@ public class DbAtlasDbFactory implements AtlasDbFactory {
      * @param leaderConfig unused.
      * @param namespace unused.
      * @param unusedLongSupplier unused.
-     * @param initializeAsync
+     * @param initializeAsync initialize asynchronously
      * @return The requested KeyValueService instance
      */
     @Override

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/ConnectionManagerAwareDbKvs.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/ConnectionManagerAwareDbKvs.java
@@ -33,15 +33,20 @@ import java.util.function.Supplier;
 
 // This class should be removed and replaced by DbKvs when InDbTimestampStore depends directly on DbKvs
 public final class ConnectionManagerAwareDbKvs extends ForwardingKeyValueService {
-    private final DbKvs kvs;
+    private final DbKeyValueService kvs;
     private final ConnectionManager connManager;
     private final SqlConnectionSupplier sqlConnectionSupplier;
 
     public static ConnectionManagerAwareDbKvs create(DbKeyValueServiceConfig config) {
+        return create(config, false);
+    }
+
+    public static ConnectionManagerAwareDbKvs create(DbKeyValueServiceConfig config, boolean initializeAsync) {
         HikariCPConnectionManager connManager = new HikariCPConnectionManager(config.connection());
         ReentrantManagedConnectionSupplier connSupplier = new ReentrantManagedConnectionSupplier(connManager);
         SqlConnectionSupplier sqlConnSupplier = getSimpleTimedSqlConnectionSupplier(connSupplier);
-        return new ConnectionManagerAwareDbKvs(DbKvs.create(config, sqlConnSupplier), connManager, sqlConnSupplier);
+        return new ConnectionManagerAwareDbKvs(
+                DbKvs.create(config, sqlConnSupplier, initializeAsync), connManager, sqlConnSupplier);
     }
 
     private static SqlConnectionSupplier getSimpleTimedSqlConnectionSupplier(
@@ -88,7 +93,7 @@ public final class ConnectionManagerAwareDbKvs extends ForwardingKeyValueService
     }
 
     private ConnectionManagerAwareDbKvs(
-            DbKvs kvs, ConnectionManager connManager, SqlConnectionSupplier sqlConnectionSupplier) {
+            DbKeyValueService kvs, ConnectionManager connManager, SqlConnectionSupplier sqlConnectionSupplier) {
         this.kvs = kvs;
         this.connManager = connManager;
         this.sqlConnectionSupplier = sqlConnectionSupplier;

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/ConnectionManagerAwareDbKvs.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/ConnectionManagerAwareDbKvs.java
@@ -16,6 +16,7 @@
 package com.palantir.atlasdb.keyvalue.dbkvs.impl;
 
 import com.google.common.collect.ImmutableList;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.dbkvs.DbKeyValueServiceConfig;
 import com.palantir.atlasdb.keyvalue.impl.ForwardingKeyValueService;
@@ -38,7 +39,7 @@ public final class ConnectionManagerAwareDbKvs extends ForwardingKeyValueService
     private final SqlConnectionSupplier sqlConnectionSupplier;
 
     public static ConnectionManagerAwareDbKvs create(DbKeyValueServiceConfig config) {
-        return create(config, false);
+        return create(config, AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
     }
 
     public static ConnectionManagerAwareDbKvs create(DbKeyValueServiceConfig config, boolean initializeAsync) {

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKeyValueService.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKeyValueService.java
@@ -1,0 +1,26 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.dbkvs.impl;
+
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.processors.AutoDelegate;
+
+@AutoDelegate
+public interface DbKeyValueService extends KeyValueService {
+
+    String getTablePrefix();
+}

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKeyValueService.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKeyValueService.java
@@ -21,6 +21,5 @@ import com.palantir.processors.AutoDelegate;
 
 @AutoDelegate
 public interface DbKeyValueService extends KeyValueService {
-
     String getTablePrefix();
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
@@ -36,17 +36,20 @@ import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Atomics;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.async.initializer.AsyncInitializer;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.CandidateCellForSweeping;
 import com.palantir.atlasdb.keyvalue.api.CandidateCellForSweepingRequest;
 import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.CheckAndSetCompatibility;
 import com.palantir.atlasdb.keyvalue.api.CheckAndSetException;
 import com.palantir.atlasdb.keyvalue.api.CheckAndSetRequest;
 import com.palantir.atlasdb.keyvalue.api.ClusterAvailabilityStatus;
 import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
 import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.RangeRequests;
 import com.palantir.atlasdb.keyvalue.api.RowColumnRangeIterator;
@@ -128,7 +131,7 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public final class DbKvs extends AbstractKeyValueService {
+public final class DbKvs extends AbstractKeyValueService implements DbKeyValueService {
     private static final Logger log = LoggerFactory.getLogger(DbKvs.class);
 
     public static final String ROW = "row_name";
@@ -146,11 +149,17 @@ public final class DbKvs extends AbstractKeyValueService {
     private final OverflowValueLoader overflowValueLoader;
     private final DbKvsGetRange getRangeStrategy;
     private final DbKvsGetCandidateCellsForSweeping getCandidateCellsForSweepingStrategy;
+    private final InitializingWrapper wrapper = new InitializingWrapper();
 
-    public static DbKvs create(DbKeyValueServiceConfig config, SqlConnectionSupplier sqlConnSupplier) {
+    public static DbKeyValueService create(DbKeyValueServiceConfig config, SqlConnectionSupplier sqlConnSupplier) {
+        return create(config, sqlConnSupplier, false);
+    }
+
+    public static DbKeyValueService create(
+            DbKeyValueServiceConfig config, SqlConnectionSupplier sqlConnSupplier, boolean initializeAsync) {
         DbKvs dbKvs = createNoInit(config.ddl(), sqlConnSupplier);
-        dbKvs.init();
-        return dbKvs;
+        dbKvs.wrapper.initialize(initializeAsync);
+        return dbKvs.wrapper.isInitialized() ? dbKvs : dbKvs.wrapper;
     }
 
     /**
@@ -1235,6 +1244,7 @@ public final class DbKvs extends AbstractKeyValueService {
         });
     }
 
+    @Override
     public String getTablePrefix() {
         return config.tablePrefix();
     }
@@ -1367,5 +1377,53 @@ public final class DbKvs extends AbstractKeyValueService {
 
     private interface ReadWriteTask<T> {
         T run(DbReadTable readTable, DbWriteTable writeTable);
+    }
+
+    class InitializingWrapper extends AsyncInitializer implements AutoDelegate_DbKeyValueService {
+        @Override
+        public DbKeyValueService delegate() {
+            checkInitialized();
+            return DbKvs.this;
+        }
+
+        @Override
+        public Collection<? extends KeyValueService> getDelegates() {
+            return ImmutableList.of(delegate());
+        }
+
+        @Override
+        protected void tryInitialize() {
+            DbKvs.this.init();
+        }
+
+        @Override
+        public boolean supportsCheckAndSet() {
+            return DbKvs.this.supportsCheckAndSet();
+        }
+
+        @Override
+        public CheckAndSetCompatibility getCheckAndSetCompatibility() {
+            return DbKvs.this.getCheckAndSetCompatibility();
+        }
+
+        @Override
+        public boolean shouldTriggerCompactions() {
+            return DbKvs.this.shouldTriggerCompactions();
+        }
+
+        @Override
+        protected String getInitializingClassName() {
+            return "DbKvs";
+        }
+
+        @Override
+        public void close() {
+            cancelInitialization(DbKvs.this::close);
+        }
+
+        @Override
+        public String getTablePrefix() {
+            return DbKvs.this.getTablePrefix();
+        }
     }
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
@@ -152,7 +152,7 @@ public final class DbKvs extends AbstractKeyValueService implements DbKeyValueSe
     private final InitializingWrapper wrapper = new InitializingWrapper();
 
     public static DbKeyValueService create(DbKeyValueServiceConfig config, SqlConnectionSupplier sqlConnSupplier) {
-        return create(config, sqlConnSupplier, false);
+        return create(config, sqlConnSupplier, AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
     }
 
     public static DbKeyValueService create(

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/timestamp/InDbTimestampBoundStore.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/timestamp/InDbTimestampBoundStore.java
@@ -87,7 +87,9 @@ public class InDbTimestampBoundStore implements TimestampBoundStore {
     public static TimestampBoundStore create(
             ConnectionManager connManager, TableReference timestampTable, String tablePrefixString) {
         return createWithStrategy(
-                connManager, new LegacyPhysicalBoundStoreStrategy(timestampTable, tablePrefixString), AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
+                connManager,
+                new LegacyPhysicalBoundStoreStrategy(timestampTable, tablePrefixString),
+                AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
     }
 
     public static TimestampBoundStore create(
@@ -102,7 +104,9 @@ public class InDbTimestampBoundStore implements TimestampBoundStore {
     public static TimestampBoundStore createForMultiSeries(
             ConnectionManager connManager, TableReference timestampTable, TimestampSeries series) {
         return createWithStrategy(
-                connManager, new MultiSequencePhysicalBoundStoreStrategy(timestampTable, series), AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
+                connManager,
+                new MultiSequencePhysicalBoundStoreStrategy(timestampTable, series),
+                AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
     }
 
     public static TimestampBoundStore createForMultiSeries(

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/timestamp/InDbTimestampBoundStore.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/timestamp/InDbTimestampBoundStore.java
@@ -16,6 +16,7 @@
 package com.palantir.atlasdb.keyvalue.dbkvs.timestamp;
 
 import com.palantir.async.initializer.AsyncInitializer;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.TimestampSeries;
 import com.palantir.common.base.Throwables;
@@ -86,7 +87,7 @@ public class InDbTimestampBoundStore implements TimestampBoundStore {
     public static TimestampBoundStore create(
             ConnectionManager connManager, TableReference timestampTable, String tablePrefixString) {
         return createWithStrategy(
-                connManager, new LegacyPhysicalBoundStoreStrategy(timestampTable, tablePrefixString), false);
+                connManager, new LegacyPhysicalBoundStoreStrategy(timestampTable, tablePrefixString), AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
     }
 
     public static TimestampBoundStore create(
@@ -101,7 +102,7 @@ public class InDbTimestampBoundStore implements TimestampBoundStore {
     public static TimestampBoundStore createForMultiSeries(
             ConnectionManager connManager, TableReference timestampTable, TimestampSeries series) {
         return createWithStrategy(
-                connManager, new MultiSequencePhysicalBoundStoreStrategy(timestampTable, series), false);
+                connManager, new MultiSequencePhysicalBoundStoreStrategy(timestampTable, series), AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
     }
 
     public static TimestampBoundStore createForMultiSeries(

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/timestamp/InDbTimestampBoundStore.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/timestamp/InDbTimestampBoundStore.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.keyvalue.dbkvs.timestamp;
 
+import com.palantir.async.initializer.AsyncInitializer;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.TimestampSeries;
 import com.palantir.common.base.Throwables;
@@ -26,6 +27,7 @@ import com.palantir.nexus.db.pool.ConnectionManager;
 import com.palantir.nexus.db.pool.RetriableTransactions;
 import com.palantir.nexus.db.pool.RetriableTransactions.TransactionResult;
 import com.palantir.nexus.db.pool.RetriableWriteTransaction;
+import com.palantir.timestamp.AutoDelegate_TimestampBoundStore;
 import com.palantir.timestamp.MultipleRunningTimestampServiceError;
 import com.palantir.timestamp.TimestampBoundStore;
 import java.sql.Connection;
@@ -35,10 +37,29 @@ import javax.annotation.concurrent.GuardedBy;
 
 // TODO(hsaraogi): switch to using ptdatabase sql running, which more gracefully supports multiple db types.
 public class InDbTimestampBoundStore implements TimestampBoundStore {
+    private final class InitializingWrapper extends AsyncInitializer implements AutoDelegate_TimestampBoundStore {
+        @Override
+        public TimestampBoundStore delegate() {
+            checkInitialized();
+            return InDbTimestampBoundStore.this;
+        }
+
+        @Override
+        protected void tryInitialize() {
+            InDbTimestampBoundStore.this.init();
+        }
+
+        @Override
+        protected String getInitializingClassName() {
+            return "InDbTimestampBoundStore";
+        }
+    }
+
     private static final String EMPTY_TABLE_PREFIX = "";
 
     private final ConnectionManager connManager;
     private final PhysicalBoundStoreStrategy physicalBoundStoreStrategy;
+    private final InitializingWrapper wrapper = new InitializingWrapper();
 
     @GuardedBy("this") // lazy init to avoid db connections in constructors
     private DBType dbType;
@@ -53,25 +74,50 @@ public class InDbTimestampBoundStore implements TimestampBoundStore {
         this(connManager, new LegacyPhysicalBoundStoreStrategy(timestampTable, EMPTY_TABLE_PREFIX));
     }
 
-    public static InDbTimestampBoundStore create(ConnectionManager connManager, TableReference timestampTable) {
+    public static TimestampBoundStore create(ConnectionManager connManager, TableReference timestampTable) {
         return InDbTimestampBoundStore.create(connManager, timestampTable, EMPTY_TABLE_PREFIX);
     }
 
-    public static InDbTimestampBoundStore create(
+    public static TimestampBoundStore create(
+            ConnectionManager connManager, TableReference timestampTable, boolean initializeAsync) {
+        return InDbTimestampBoundStore.create(connManager, timestampTable, EMPTY_TABLE_PREFIX, initializeAsync);
+    }
+
+    public static TimestampBoundStore create(
             ConnectionManager connManager, TableReference timestampTable, String tablePrefixString) {
-        return createWithStrategy(connManager, new LegacyPhysicalBoundStoreStrategy(timestampTable, tablePrefixString));
+        return createWithStrategy(
+                connManager, new LegacyPhysicalBoundStoreStrategy(timestampTable, tablePrefixString), false);
     }
 
-    public static InDbTimestampBoundStore createForMultiSeries(
+    public static TimestampBoundStore create(
+            ConnectionManager connManager,
+            TableReference timestampTable,
+            String tablePrefixString,
+            boolean initializeAsync) {
+        return createWithStrategy(
+                connManager, new LegacyPhysicalBoundStoreStrategy(timestampTable, tablePrefixString), initializeAsync);
+    }
+
+    public static TimestampBoundStore createForMultiSeries(
             ConnectionManager connManager, TableReference timestampTable, TimestampSeries series) {
-        return createWithStrategy(connManager, new MultiSequencePhysicalBoundStoreStrategy(timestampTable, series));
+        return createWithStrategy(
+                connManager, new MultiSequencePhysicalBoundStoreStrategy(timestampTable, series), false);
     }
 
-    private static InDbTimestampBoundStore createWithStrategy(
-            ConnectionManager connManager, PhysicalBoundStoreStrategy strategy) {
-        InDbTimestampBoundStore inDbTimestampBoundStore = new InDbTimestampBoundStore(connManager, strategy);
-        inDbTimestampBoundStore.init();
-        return inDbTimestampBoundStore;
+    public static TimestampBoundStore createForMultiSeries(
+            ConnectionManager connManager,
+            TableReference timestampTable,
+            TimestampSeries series,
+            boolean initializeAsync) {
+        return createWithStrategy(
+                connManager, new MultiSequencePhysicalBoundStoreStrategy(timestampTable, series), initializeAsync);
+    }
+
+    private static TimestampBoundStore createWithStrategy(
+            ConnectionManager connManager, PhysicalBoundStoreStrategy strategy, boolean initializeAsync) {
+        InDbTimestampBoundStore store = new InDbTimestampBoundStore(connManager, strategy);
+        store.wrapper.initialize(initializeAsync);
+        return store.wrapper.isInitialized() ? store : store.wrapper;
     }
 
     private InDbTimestampBoundStore(

--- a/changelog/@unreleased/pr-5093.v2.yml
+++ b/changelog/@unreleased/pr-5093.v2.yml
@@ -1,6 +1,6 @@
 type: feature
 feature:
-  description: DbKvs can now be initialized asynchrnously. Earlier, a service depending
+  description: DbKvs can now be initialized asynchronously. Earlier, a service depending
     on it would crash if the Db was not up at initialization time.
   links:
   - https://github.com/palantir/atlasdb/pull/5093

--- a/changelog/@unreleased/pr-5093.v2.yml
+++ b/changelog/@unreleased/pr-5093.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: DbKvs can now be initialized asynchrnously. Earlier, a service depending
+    on it would crash if the Db was not up at initialization time.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5093


### PR DESCRIPTION
**Goals (and why)**:
There is a cassandra impl of initializeAsync, but not one for DbKvs. If a service depends on this, then it will crash if the db is not up at initialization time.

**Implementation Description (bullets)**:
Copied the cassandra pattern into DbKvs and InDbTimestampBoundStore.
Kept all old function signatures intact to prevent api breaks.

**Testing (What was existing testing like?  What have you done to improve it?)**:
I updated an internal service to use this. I started it with the db off. I waited a few minutes, then turned the db on. The service became healthy.

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
