### PR TITLE
[LE] Wire in the metrics from client to server

### DIFF
--- a/changelog/@unreleased/pr-5098.v2.yml
+++ b/changelog/@unreleased/pr-5098.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Wire through the leader election metrics to Timelock.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5098

--- a/lock-api-objects/build.gradle
+++ b/lock-api-objects/build.gradle
@@ -27,7 +27,7 @@ recommendedProductDependencies {
     productDependency {
         productGroup = 'com.palantir.timelock'
         productName = 'timelock-server'
-        minimumVersion = '0.218.0'
+        minimumVersion = '0.313.0'
         maximumVersion = '0.x.x'
     }
 }

--- a/lock-api/src/main/java/com/palantir/lock/client/LeaderElectionReportingTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LeaderElectionReportingTimelockService.java
@@ -63,7 +63,8 @@ public class LeaderElectionReportingTimelockService implements NamespacedConjure
     private Map<UUID, Instant> leadershipUpperBound = new ConcurrentHashMap<>();
     private Map<UUID, Instant> leadershipLowerBound = new ConcurrentHashMap<>();
 
-    public LeaderElectionReportingTimelockService(
+    @VisibleForTesting
+    LeaderElectionReportingTimelockService(
             NamespacedConjureTimelockService delegate, TaggedMetricRegistry taggedMetricRegistry, Clock clock) {
         this.delegate = delegate;
         this.metrics = LeaderElectionMetrics.of(taggedMetricRegistry);
@@ -206,7 +207,8 @@ public class LeaderElectionReportingTimelockService implements NamespacedConjure
      * elected while U_A is the earliest moment at which A could have lost leadership. This method will always return
      * the duration of the most recent such interval.
      */
-    public Optional<LeaderElectionDuration> calculateLastLeaderElectionDuration() {
+    @VisibleForTesting
+    Optional<LeaderElectionDuration> calculateLastLeaderElectionDuration() {
         Map<UUID, Instant> lowerBounds = ImmutableMap.copyOf(leadershipLowerBound.entrySet());
         Map<UUID, Instant> upperBounds = ImmutableMap.copyOf(leadershipUpperBound.entrySet());
 
@@ -230,18 +232,6 @@ public class LeaderElectionReportingTimelockService implements NamespacedConjure
         return durationToNextLeader(lowerBounds, upperBounds, leaders, secondToLastLongTermLeader);
     }
 
-    private Set<UUID> leadersWithBothBounds(Map<UUID, Instant> lowerBounds, Map<UUID, Instant> upperBounds) {
-        return upperBounds.keySet().stream().filter(lowerBounds::containsKey).collect(Collectors.toSet());
-    }
-
-    private List<UUID> orderedLongTermLeaders(
-            Map<UUID, Instant> lowerBounds, Map<UUID, Instant> upperBounds, Set<UUID> leadersWithBothBounds) {
-        return leadersWithBothBounds.stream()
-                .filter(id -> upperBounds.get(id).isAfter(lowerBounds.get(id)))
-                .sorted(Comparator.comparing(lowerBounds::get))
-                .collect(Collectors.toList());
-    }
-
     private void clearOldLongTermLeaders(List<UUID> sortedLongTermLeaders) {
         for (int i = 0; i < sortedLongTermLeaders.size() - 2; i++) {
             leadershipLowerBound.remove(sortedLongTermLeaders.get(i));
@@ -249,7 +239,23 @@ public class LeaderElectionReportingTimelockService implements NamespacedConjure
         }
     }
 
-    private Optional<LeaderElectionDuration> durationToNextLeader(
+    private void updateMetrics(Duration timeTaken) {
+        metrics.observedDuration().update(timeTaken.toNanos(), TimeUnit.NANOSECONDS);
+    }
+
+    private static Set<UUID> leadersWithBothBounds(Map<UUID, Instant> lowerBounds, Map<UUID, Instant> upperBounds) {
+        return upperBounds.keySet().stream().filter(lowerBounds::containsKey).collect(Collectors.toSet());
+    }
+
+    private static List<UUID> orderedLongTermLeaders(
+            Map<UUID, Instant> lowerBounds, Map<UUID, Instant> upperBounds, Set<UUID> leadersWithBothBounds) {
+        return leadersWithBothBounds.stream()
+                .filter(id -> upperBounds.get(id).isAfter(lowerBounds.get(id)))
+                .sorted(Comparator.comparing(lowerBounds::get))
+                .collect(Collectors.toList());
+    }
+
+    private static Optional<LeaderElectionDuration> durationToNextLeader(
             Map<UUID, Instant> lowerBounds,
             Map<UUID, Instant> upperBounds,
             Set<UUID> leaders,
@@ -264,7 +270,7 @@ public class LeaderElectionReportingTimelockService implements NamespacedConjure
                 .build());
     }
 
-    private Duration estimateElectionDuration(
+    private static Duration estimateElectionDuration(
             Map<UUID, Instant> lowerBounds, Map<UUID, Instant> upperBounds, UUID previousLeader, UUID nextLeader) {
         return Duration.between(upperBounds.get(previousLeader), lowerBounds.get(nextLeader));
     }
@@ -281,9 +287,5 @@ public class LeaderElectionReportingTimelockService implements NamespacedConjure
             return second;
         }
         return first.isBefore(second) ? first : second;
-    }
-
-    private void updateMetrics(Duration timeTaken) {
-        metrics.observedDuration().update(timeTaken.toNanos(), TimeUnit.NANOSECONDS);
     }
 }

--- a/lock-api/src/main/java/com/palantir/lock/client/metrics/TimeLockFeedbackBackgroundTask.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/metrics/TimeLockFeedbackBackgroundTask.java
@@ -25,6 +25,7 @@ import com.palantir.lock.client.LeaderElectionReportingTimelockService;
 import com.palantir.refreshable.Refreshable;
 import com.palantir.timelock.feedback.ConjureTimeLockClientFeedback;
 import com.palantir.timelock.feedback.EndpointStatistics;
+import com.palantir.timelock.feedback.LeaderElectionStatistics;
 import com.palantir.tokens.auth.AuthHeader;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.time.Duration;
@@ -54,7 +55,7 @@ public final class TimeLockFeedbackBackgroundTask implements AutoCloseable {
     private final String serviceName;
     private final String namespace;
     private final Refreshable<List<TimeLockClientFeedbackService>> timeLockClientFeedbackServices;
-    private volatile Optional<LeaderElectionReportingTimelockService> timelock;
+    private volatile Optional<LeaderElectionReportingTimelockService> leaderElectionReporter;
 
     private ScheduledFuture<?> task;
 
@@ -95,9 +96,12 @@ public final class TimeLockFeedbackBackgroundTask implements AutoCloseable {
                                 .serviceName(serviceName)
                                 .namespace(namespace)
                                 .build();
-                        timeLockClientFeedbackServices
-                                .current()
-                                .forEach(service -> reportClientFeedbackToService(feedbackReport, service));
+                        timeLockClientFeedbackServices.current().forEach(service -> {
+                            reportClientFeedbackToService(feedbackReport, service);
+                            leaderElectionReporter
+                                    .map(LeaderElectionReportingTimelockService::getStatistics)
+                                    .ifPresent(stats -> reportLeaderElectionStatisticsToService(stats, service));
+                        });
                     } catch (Exception e) {
                         log.warn("A problem occurred while reporting client feedback for timeLock adjudication.", e);
                     }
@@ -108,7 +112,7 @@ public final class TimeLockFeedbackBackgroundTask implements AutoCloseable {
     }
 
     public void registerLeaderElectionStatistics(LeaderElectionReportingTimelockService conjureTimelock) {
-        this.timelock = Optional.of(conjureTimelock);
+        this.leaderElectionReporter = Optional.of(conjureTimelock);
     }
 
     private void reportClientFeedbackToService(
@@ -118,6 +122,15 @@ public final class TimeLockFeedbackBackgroundTask implements AutoCloseable {
         } catch (Exception e) {
             // we do not want this exception to bubble up so that feedback can be reported to other hosts
             log.warn("Failed to report feedback to TimeLock host.", e);
+        }
+    }
+
+    private void reportLeaderElectionStatisticsToService(
+            LeaderElectionStatistics electionStatistics, TimeLockClientFeedbackService service) {
+        try {
+            service.reportLeaderMetrics(AUTH_HEADER, electionStatistics);
+        } catch (Exception e) {
+            log.warn("Failed to report leader election statistics to TimeLock host.", e);
         }
     }
 


### PR DESCRIPTION
**Goals (and why)**:
We have implemented the calculation and aggregating of leader election time, but not yet wired it so that the client sends to the server.

**Implementation Description (bullets)**:
Tacked the sending of metrics on to the current timelock feedback background task. 

**Testing (What was existing testing like?  What have you done to improve it?)**:
Didn't add any testing, there was none existing.

**Concerns (what feedback would you like?)**:
I think this was what we intended.

**Where should we start reviewing?**:
`TimeLockFeedbackBackgroundTask`

**Priority (whenever / two weeks / yesterday)**:
Want to get this through quickly.