### PR TITLE
[LW] Filter out locks using the serverToken, not the fake token in LeasedLockToken

### DIFF
--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheIntegrationTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheIntegrationTest.java
@@ -212,16 +212,6 @@ public class LockWatchEventCacheIntegrationTest {
     }
 
     @Test
-    public void getCommitUpdateDoesNotContainCommitLocks() {
-        setupInitialState();
-        eventCache.processGetCommitTimestampsUpdate(COMMIT_UPDATE, SUCCESS);
-        verifyStage();
-
-        CommitUpdate commitUpdate = eventCache.getCommitUpdate(START_TS);
-        assertThat(commitUpdate.accept(new CommitUpdateVisitor())).containsExactlyInAnyOrder(DESCRIPTOR);
-    }
-
-    @Test
     public void getCommitUpdateIsInvalidatedAllIfEventsHaveBeenDeleted() {
         eventCache = createEventCache(2);
         setupInitialState();

--- a/atlasdb-impl-shared/src/test/java/com/palantir/lock/client/LeasedLockTokenCreator.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/lock/client/LeasedLockTokenCreator.java
@@ -1,0 +1,34 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.client;
+
+import com.palantir.atlasdb.timelock.api.ConjureLockToken;
+import com.palantir.lock.v2.Lease;
+
+/**
+ * Utility class to expose creator of {@link LeasedLockToken} to the lock watch integration test.
+ */
+public final class LeasedLockTokenCreator {
+
+    private LeasedLockTokenCreator() {
+        // no-op
+    }
+
+    public static LeasedLockToken of(ConjureLockToken serverToken, Lease lease) {
+        return LeasedLockToken.of(serverToken, lease);
+    }
+}

--- a/changelog/@unreleased/pr-5100.v2.yml
+++ b/changelog/@unreleased/pr-5100.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Correctly filter out commit locks from a commit update by using the
+    server token from a leased lock token.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5100

--- a/lock-api/src/main/java/com/palantir/lock/client/LockLeaseService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockLeaseService.java
@@ -43,7 +43,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
-
+//
 class LockLeaseService {
     private final NamespacedConjureTimelockService delegate;
     private final UUID clientId;

--- a/lock-api/src/main/java/com/palantir/lock/client/LockLeaseService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockLeaseService.java
@@ -43,7 +43,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
-//
+
 class LockLeaseService {
     private final NamespacedConjureTimelockService delegate;
     private final UUID clientId;


### PR DESCRIPTION
**Goals (and why)**:
* Using the `requestId` from a lock token is not guaranteed to be the right request id - particularly for the `LeasedLockToken` that we actually receive in the `commitWrites` flow. Therefore we need to cast and filter correctly.

**Implementation Description (bullets)**:
* Check if the lock token is the right type, then cast and retrieve the correct request ID.

**Testing (What was existing testing like?  What have you done to improve it?)**:
* Added a test to the integration tests. However, for best coverage we need ETE tests - these are coming in a subsequent PR.

**Concerns (what feedback would you like?)**:
* Just to make sure that this won't break anything.
* Is there a better way to test this without creating a really hacky `LeasedLockTokenCreator` test class?

**Where should we start reviewing?**:
* `ClientLogEvents`

**Priority (whenever / two weeks / yesterday)**:
ASAP