### PR TITLE
[LW] Check the correct client versions range

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/ClientLogEvents.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/ClientLogEvents.java
@@ -54,8 +54,9 @@ interface ClientLogEvents {
     default TransactionsLockWatchUpdate toTransactionsLockWatchUpdate(
             TimestampMapping timestampMapping, Optional<LockWatchVersion> lastKnownVersion) {
         /*
-         Case 1: client is behind earliest transaction. Therefore we want to ensure that there are events from
-                 after the client version up to the latest transaction version.
+         Case 1: client is behind earliest transaction. Therefore we want to ensure that there are events present for
+                 each version starting with the client version (exclusive) and ending with latest transaction version
+                 (inclusive).
          Case 2: client is at least as up-to-date as the earliest transaction. The check here is the same as above.
          Case 3: client is completely up-to-date. Here, we don't need to check for any versions.
          Case 4: client has no version. Then we expect that the events returned at least enclose the versions of

--- a/changelog/@unreleased/pr-5106.v2.yml
+++ b/changelog/@unreleased/pr-5106.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fixed a bug which could erroneously throw a bug when getting versions
+    from the lock watch cache.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5106


### PR DESCRIPTION
**Goals (and why)**:
* Turns out that we were checking the wrong version range for validation. We should check that the events returned enclose (userVersion, latestTimestampVersion], but we were actually checking [earliestTimestampVersion, latestTimestampVersion].

**Implementation Description (bullets)**:
* Fixed the bug as listed above.

**Testing (What was existing testing like?  What have you done to improve it?)**:
* Added yet another test. This was caught by the ETE test PR, so that will also help.

**Concerns (what feedback would you like?)**:
* Is this finally right?

**Where should we start reviewing?**:
* `ClientLogEvents`

**Priority (whenever / two weeks / yesterday)**:
This week.
