### PR TITLE
Fix MaskedValue Jackson 2.12 compatibility

### DIFF
--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/MaskedValue.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/MaskedValue.java
@@ -15,11 +15,10 @@
  */
 package com.palantir.nexus.db.pool.config;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 
-@JsonDeserialize(as = ImmutableMaskedValue.class)
 @JsonSerialize(as = ImmutableMaskedValue.class)
 @Value.Immutable(builder = false)
 public abstract class MaskedValue {
@@ -33,5 +32,15 @@ public abstract class MaskedValue {
 
     public String unmasked() {
         return value();
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    static MaskedValue fromJson(String stringValue) {
+        return ImmutableMaskedValue.of(stringValue);
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    static MaskedValue fromJson(ImmutableMaskedValue jsonValue) {
+        return jsonValue;
     }
 }

--- a/atlasdb-dbkvs-hikari/src/test/java/com/palantir/nexus/db/pool/config/MaskedValueTest.java
+++ b/atlasdb-dbkvs-hikari/src/test/java/com/palantir/nexus/db/pool/config/MaskedValueTest.java
@@ -1,0 +1,40 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.nexus.db.pool.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import org.junit.Test;
+
+public class MaskedValueTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    public void deserializeFromString() throws IOException {
+        MaskedValue value = MAPPER.readValue("\"abc\"", MaskedValue.class);
+        assertThat(value).isEqualTo(ImmutableMaskedValue.of("abc"));
+    }
+
+    @Test
+    public void deserializeFromObject() throws IOException {
+        MaskedValue value = MAPPER.readValue("{\"value\":\"abc\"}", MaskedValue.class);
+        assertThat(value).isEqualTo(ImmutableMaskedValue.of("abc"));
+    }
+}

--- a/changelog/@unreleased/pr-5108.v2.yml
+++ b/changelog/@unreleased/pr-5108.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Fix MaskedValue Jackson 2.12-snapshot compatibility
+  links:
+  - https://github.com/palantir/atlasdb/pull/5108


### PR DESCRIPTION
**Goals (and why)**:

Previously we relied on Jackson magically deserializing a string
value into a MaskedValue. This no longer works in Jackson 2.12
snapshots, and I'm not convinced it ever should have worked. Other
proejcts represent MaskedValue as a string in configuration, so we
must add explicit handling and test coverage.

**Implementation Description (bullets)**:

Explicit `@JsonCreator` annotations.
