### PR TITLE
add a fake client on startup to fix healthcheck getting stuck 

### DIFF
--- a/changelog/@unreleased/pr-5110.v2.yml
+++ b/changelog/@unreleased/pr-5110.v2.yml
@@ -1,0 +1,15 @@
+type: improvement
+improvement:
+  description: "add a fake client on startup to fix healthcheck getting stuck \n\n**Goals
+    (and why)**:\nCurrently a non-leader timelock node gets stuck in REPAIRING healthstate
+    upon restart. This happens because of two things -- (1) we don't create the timelock
+    services until an endpoint is hit (2) The clients are sticky, and stick to a node.
+    \n\n**Implementation Description (bullets)**:\n- Create a fake client on startup
+    to populate something in the database and clear the healthcheck\n\n**Testing (What
+    was existing testing like?  What have you done to improve it?)**:\n- Testing with
+    an RC on dev stack\n\n**Concerns (what feedback would you like?)**:\nOverhead
+    of creating a fake client.\n\nOther edge cases I may have missed\n\n**Where should
+    we start reviewing?**:\n\n**Priority (whenever / two weeks / yesterday)**:\nThis
+    week"
+  links:
+  - https://github.com/palantir/atlasdb/pull/5110

--- a/changelog/@unreleased/pr-5110.v2.yml
+++ b/changelog/@unreleased/pr-5110.v2.yml
@@ -1,15 +1,5 @@
 type: improvement
 improvement:
-  description: "add a fake client on startup to fix healthcheck getting stuck \n\n**Goals
-    (and why)**:\nCurrently a non-leader timelock node gets stuck in REPAIRING healthstate
-    upon restart. This happens because of two things -- (1) we don't create the timelock
-    services until an endpoint is hit (2) The clients are sticky, and stick to a node.
-    \n\n**Implementation Description (bullets)**:\n- Create a fake client on startup
-    to populate something in the database and clear the healthcheck\n\n**Testing (What
-    was existing testing like?  What have you done to improve it?)**:\n- Testing with
-    an RC on dev stack\n\n**Concerns (what feedback would you like?)**:\nOverhead
-    of creating a fake client.\n\nOther edge cases I may have missed\n\n**Where should
-    we start reviewing?**:\n\n**Priority (whenever / two weeks / yesterday)**:\nThis
-    week"
+  description: "Adds a fake client on startup so that non-leader nodes are not stuck in repairing on startup"
   links:
   - https://github.com/palantir/atlasdb/pull/5110

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -15,14 +15,6 @@
  */
 package com.palantir.timelock.paxos;
 
-import java.net.URL;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.Supplier;
-
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.AtlasDbConstants;
@@ -84,6 +76,14 @@ import com.palantir.timelock.management.ImmutableTimestampStorage;
 import com.palantir.timelock.management.TimestampStorage;
 import com.palantir.timestamp.ManagedTimestampService;
 import com.zaxxer.hikari.HikariDataSource;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
 
 @SuppressWarnings("checkstyle:FinalClass") // This is mocked internally
 public class TimeLockAgent {

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -84,7 +84,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-
 @SuppressWarnings("checkstyle:FinalClass") // This is mocked internally
 public class TimeLockAgent {
     // Schema version from 2 onwards are on SQLite


### PR DESCRIPTION
**Goals (and why)**:
Currently a non-leader timelock node gets stuck in REPAIRING healthstate upon restart. This happens because of two things -- (1) we don't create the timelock services until an endpoint is hit (2) The clients are sticky, and stick to a node. 

**Implementation Description (bullets)**:
- Create a fake client on startup to populate something in the database and clear the healthcheck

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Testing with an RC on dev stack

**Concerns (what feedback would you like?)**:
Overhead of creating a fake client.

Other edge cases I may have missed

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:
This week