### PR TITLE
[Tl Corruption Checks] | Bump down the limit for rows verified per iteration

### DIFF
--- a/changelog/@unreleased/pr-5112.v2.yml
+++ b/changelog/@unreleased/pr-5112.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Bump down the limit on number of rows to be read per iteration for
+    validation against corruption checks. Earlier, the limit was 500 and could cause
+    TimeLock performance degradation.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5112

--- a/timelock-corruption-detection/src/main/java/com/palantir/timelock/history/PaxosLogHistoryProgressTracker.java
+++ b/timelock-corruption-detection/src/main/java/com/palantir/timelock/history/PaxosLogHistoryProgressTracker.java
@@ -28,7 +28,7 @@ import javax.sql.DataSource;
 
 public class PaxosLogHistoryProgressTracker {
     @VisibleForTesting
-    static final int MAX_ROWS_ALLOWED = 500;
+    static final int MAX_ROWS_ALLOWED = 250;
 
     private final LogVerificationProgressState logVerificationProgressState;
     private final SqlitePaxosStateLogHistory sqlitePaxosStateLogHistory;

--- a/timelock-corruption-detection/src/main/java/com/palantir/timelock/history/PaxosLogHistoryProgressTracker.java
+++ b/timelock-corruption-detection/src/main/java/com/palantir/timelock/history/PaxosLogHistoryProgressTracker.java
@@ -28,7 +28,7 @@ import javax.sql.DataSource;
 
 public class PaxosLogHistoryProgressTracker {
     @VisibleForTesting
-    static final int MAX_ROWS_ALLOWED = 250;
+    public static final int MAX_ROWS_ALLOWED = 250;
 
     private final LogVerificationProgressState logVerificationProgressState;
     private final SqlitePaxosStateLogHistory sqlitePaxosStateLogHistory;

--- a/timelock-corruption-detection/src/test/java/com/palantir/timelock/corruption/detection/HistoryAnalyzerTest.java
+++ b/timelock-corruption-detection/src/test/java/com/palantir/timelock/corruption/detection/HistoryAnalyzerTest.java
@@ -16,6 +16,7 @@
 
 package com.palantir.timelock.corruption.detection;
 
+import static com.palantir.timelock.history.PaxosLogHistoryProgressTracker.MAX_ROWS_ALLOWED;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Iterables;
@@ -60,7 +61,7 @@ public final class HistoryAnalyzerTest {
 
     @Test
     public void detectCorruptionIfLearnedValueIsNotAcceptedByQuorum() {
-        helper.writeLogsOnDefaultLocalServer(5, 500);
+        helper.writeLogsOnDefaultLocalServer(5, MAX_ROWS_ALLOWED);
 
         List<CompletePaxosHistoryForNamespaceAndUseCase> historyForAll = helper.getHistory();
         assertThat(HistoryAnalyzer.divergedLearners(Iterables.getOnlyElement(historyForAll)))
@@ -73,8 +74,8 @@ public final class HistoryAnalyzerTest {
 
     @Test
     public void detectCorruptionIfLearnedValueIsNotTheGreatestAcceptedValue() {
-        helper.writeLogsOnDefaultLocalAndRemote(9, 453);
-        helper.induceGreaterAcceptedValueCorruptionOnDefaultLocalServer(432);
+        helper.writeLogsOnDefaultLocalAndRemote(9, MAX_ROWS_ALLOWED - 1);
+        helper.induceGreaterAcceptedValueCorruptionOnDefaultLocalServer(MAX_ROWS_ALLOWED / 2);
 
         List<CompletePaxosHistoryForNamespaceAndUseCase> historyForAll = helper.getHistory();
         assertThat(HistoryAnalyzer.divergedLearners(Iterables.getOnlyElement(historyForAll)))

--- a/timelock-corruption-detection/src/test/java/com/palantir/timelock/history/PaxosLogHistoryProgressTrackerTest.java
+++ b/timelock-corruption-detection/src/test/java/com/palantir/timelock/history/PaxosLogHistoryProgressTrackerTest.java
@@ -57,7 +57,7 @@ public class PaxosLogHistoryProgressTrackerTest {
 
     @Test
     public void getsInitialStateBoundsWhenNoDataInDB() {
-        assertSanityOfFetchedHistoryQuerySeqBounds(0, 499);
+        assertSanityOfFetchedHistoryQuerySeqBounds(0, MAX_ROWS_ALLOWED - 1);
     }
 
     @Test
@@ -99,7 +99,7 @@ public class PaxosLogHistoryProgressTrackerTest {
                 .build();
 
         progressTracker.updateProgressStateForNamespaceAndUseCase(NAMESPACE_AND_USE_CASE, bounds);
-        assertSanityOfFetchedHistoryQuerySeqBounds(0, 499);
+        assertSanityOfFetchedHistoryQuerySeqBounds(0, MAX_ROWS_ALLOWED - 1);
     }
 
     public void assertSanityOfFetchedHistoryQuerySeqBounds(long lowerBoundInclusive, long upperBoundInclusive) {


### PR DESCRIPTION
**Goals (and why)**:
Bump down the limit on number of rows to be read per iteration for verification. The high number of rows read per iteration for verification leads to performance degradation in TimeLock.
The rate at which rows are read for corruption checks is still higher than the max rate at which rows are written on internal stack.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
