### PR TITLE
Better metrics

### DIFF
--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/adjudicate/LeaderElectionMetricAggregator.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/adjudicate/LeaderElectionMetricAggregator.java
@@ -44,9 +44,13 @@ public final class LeaderElectionMetricAggregator {
         Histogram leaderElectionHistogram = new Histogram(new SlidingTimeWindowArrayReservoir(5, TimeUnit.MINUTES));
         leaderElectionDurationAccumulator =
                 new LeaderElectionDurationAccumulator(leaderElectionHistogram::update, CONFIDENCE_THRESHOLD);
-        metricsManager.registerMetric(LeaderElectionMetricAggregator.class, "leaderElectionEstimateMin",
+        metricsManager.registerMetric(
+                LeaderElectionMetricAggregator.class,
+                "leaderElectionEstimateMin",
                 () -> leaderElectionHistogram.getSnapshot().getMin());
-        metricsManager.registerMetric(LeaderElectionMetricAggregator.class, "leaderElectionEstimateMedian",
+        metricsManager.registerMetric(
+                LeaderElectionMetricAggregator.class,
+                "leaderElectionEstimateMedian",
                 () -> leaderElectionHistogram.getSnapshot().getMedian());
     }
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/adjudicate/LeaderElectionMetricAggregator.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/adjudicate/LeaderElectionMetricAggregator.java
@@ -40,12 +40,14 @@ public final class LeaderElectionMetricAggregator {
                 LeaderElectionMetricAggregator.class, "leaderElectionImpactP95", weightedGaugeP95);
         metricsManager.registerMetric(
                 LeaderElectionMetricAggregator.class, "leaderElectionImpactP99", weightedGaugeP99);
-        Histogram leaderElectionHistogram = metricsManager.registerOrGetHistogram(
-                LeaderElectionMetricAggregator.class,
-                "leaderElectionDurationEstimate",
-                () -> new Histogram(new SlidingTimeWindowArrayReservoir(5, TimeUnit.MINUTES)));
+
+        Histogram leaderElectionHistogram = new Histogram(new SlidingTimeWindowArrayReservoir(5, TimeUnit.MINUTES));
         leaderElectionDurationAccumulator =
                 new LeaderElectionDurationAccumulator(leaderElectionHistogram::update, CONFIDENCE_THRESHOLD);
+        metricsManager.registerMetric(LeaderElectionMetricAggregator.class, "leaderElectionEstimateMin",
+                () -> leaderElectionHistogram.getSnapshot().getMin());
+        metricsManager.registerMetric(LeaderElectionMetricAggregator.class, "leaderElectionEstimateMedian",
+                () -> leaderElectionHistogram.getSnapshot().getMedian());
     }
 
     void report(LeaderElectionStatistics statistics) {


### PR DESCRIPTION
**Goals (and why)**:
Current histogram is not very useful because it gives us the worst estimates for leader duration of all the clients. We know that the actual time leader election took is in fact less than the minimum for all the clients, so we now report minimum instead. Added median for good measure, to give us an idea of how accurate the estimate is (the closer the median to the min, the more accurate the estimate should be).