### PR TITLE
remove moreutils dependency in build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,7 @@ jobs:
           key: gradle-cache-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}
 
       - run: git tag -l | xargs git tag -d && git fetch -t # ensure all tags are fetched and up-to-date
-      - run: ./scripts/circle-ci/download-moreutils.sh
-      - run: ./scripts/time-cmd.sh ./gradlew --profile --parallel --stacktrace classes testClasses
+      - run: ./gradlew --profile --parallel --stacktrace classes testClasses
 
       - save_cache:
           key: gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
@@ -66,11 +65,10 @@ jobs:
               sudo mkdir -p /opt/java && cd /opt/java && sudo chown -R circleci:circleci .
               curl https://cdn.azul.com/zulu/bin/zulu8.38.0.13-ca-jdk8.0.212-linux_x64.tar.gz | tar -xzf - -C /opt/java
               sudo ln -s /opt/java/zulu*/ /opt/java8
-      - run: ./scripts/circle-ci/download-moreutils.sh
       - run:
-          command: ./scripts/time-cmd.sh ./scripts/circle-ci/run-circle-tests.sh
+          command: ./scripts/circle-ci/run-circle-tests.sh
           no_output_timeout: 600
-      - run: ./scripts/time-cmd.sh ./scripts/circle-ci/ensure-repo-clean.sh
+      - run: ./scripts/circle-ci/ensure-repo-clean.sh
       - run: mkdir -p $CIRCLE_TEST_REPORTS/junit/ && mkdir -p $CIRCLE_ARTIFACTS/checkstyle && mkdir -p $CIRCLE_ARTIFACTS/findbugs
       - run:
           command: find . -type f -regex ".*/build/test-results/TEST-.*\.xml" -exec cp {} --parents $CIRCLE_TEST_REPORTS \;

--- a/scripts/circle-ci/download-moreutils.sh
+++ b/scripts/circle-ci/download-moreutils.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-set -x -e
-
-MOREUTILS="moreutils_0.64-1_amd64.deb"
-curl --fail -O "http://http.us.debian.org/debian/pool/main/m/moreutils/$MOREUTILS"
-ar p $MOREUTILS data.tar.xz | sudo tar xJ --strip-components=3 -C /usr/bin/ ./usr/bin/ts
-rm $MOREUTILS

--- a/scripts/time-cmd.sh
+++ b/scripts/time-cmd.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -o pipefail
-
-"$@" 2>&1 | ts -s "[%H:%M:%S]"


### PR DESCRIPTION
**Goals (and why)**:
Make builds more reliable, and remove one of the blockers for re-running much older builds (to allow easier backporting of fixes). It is not sustainable to require regularly updating a url just to keep builds working.

**Implementation Description (bullets)**:
Remove the moreutils dependency completely from builds.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Note that I tried using`sudo apt-get update && sudo apt-get install moreutils` to install moreutils instead (which should be reliable), except that seemed to install a version that is not compatible (it did not have support for the options being used).

**Concerns (what feedback would you like?)**:
If people really worry about the value of timestamps in tests, we should configure slf4j (or whatever we use) logging in tests to output timestamps. I would prefer if this is done in a separate change so that if needed removing the moreutils dependency can be done easily in older versions.

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**: High if reliable builds are important.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
