### PR TITLE
LockServiceImpl should ThreadInterrupt all Blocked threads

### DIFF
--- a/changelog/@unreleased/pr-5117.v2.yml
+++ b/changelog/@unreleased/pr-5117.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: LockServiceImpl now interrupts all blocked threads upon closing.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5117

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
@@ -495,8 +495,10 @@ public final class LockServiceImpl
             case BLOCK_INDEFINITELY:
             case BLOCK_INDEFINITELY_THEN_RELEASE:
                 return true;
+            default:
+                throw new SafeIllegalStateException(
+                        "Unrecognized blockingMode", SafeArg.of("blockingMode", blockingMode));
         }
-        throw new SafeIllegalStateException("Unhandled BlockingMode", SafeArg.of("blockingMode", blockingMode))
     }
 
     private void tryLocks(
@@ -590,7 +592,8 @@ public final class LockServiceImpl
                 lock.lockInterruptibly();
                 return null;
             default:
-                throw new IllegalArgumentException("blockingMode = " + blockingMode);
+                throw new SafeIllegalStateException(
+                        "Unrecognized blockingMode", SafeArg.of("blockingMode", blockingMode));
         }
     }
 

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
@@ -71,6 +71,7 @@ import com.palantir.lock.logger.LockServiceStateLogger;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.util.JMXUtils;
 import com.palantir.util.Ownable;
 import java.io.IOException;
@@ -213,7 +214,7 @@ public final class LockServiceImpl
     private final SetMultimap<LockClient, LockRequest> outstandingLockRequestMultimap =
             Multimaps.synchronizedSetMultimap(HashMultimap.<LockClient, LockRequest>create());
 
-    private final Set<Thread> indefinitelyBlockingThreads = ConcurrentHashMap.newKeySet();
+    private final Set<Thread> blockingThreads = ConcurrentHashMap.newKeySet();
 
     private final Multimap<LockClient, Long> versionIdMap = Multimaps.synchronizedMultimap(
             Multimaps.newMultimap(new HashMap<LockClient, Collection<Long>>(), TreeMultiset::create));
@@ -356,9 +357,9 @@ public final class LockServiceImpl
             throw new ServiceNotAvailableException("This lock server is shut down.");
         }
         try {
-            boolean indefinitelyBlocking = isIndefinitelyBlocking(request.getBlockingMode());
-            if (indefinitelyBlocking) {
-                indefinitelyBlockingThreads.add(Thread.currentThread());
+            boolean isBlocking = isBlocking(request.getBlockingMode());
+            if (isBlocking) {
+                blockingThreads.add(Thread.currentThread());
             }
             outstandingLockRequestMultimap.put(client, request);
             Map<LockDescriptor, LockClient> failedLocks = new HashMap<>();
@@ -444,7 +445,7 @@ public final class LockServiceImpl
             return new LockResponse(token, failedLocks);
         } finally {
             outstandingLockRequestMultimap.remove(client, request);
-            indefinitelyBlockingThreads.remove(Thread.currentThread());
+            blockingThreads.remove(Thread.currentThread());
             try {
                 for (Map.Entry<ClientAwareReadWriteLock, LockMode> entry : locks.entrySet()) {
                     entry.getKey().get(client, entry.getValue()).unlock();
@@ -486,9 +487,16 @@ public final class LockServiceImpl
                 UnsafeArg.of("lockDescriptions", lockDescriptions));
     }
 
-    private boolean isIndefinitelyBlocking(BlockingMode blockingMode) {
-        return BlockingMode.BLOCK_INDEFINITELY.equals(blockingMode)
-                || BlockingMode.BLOCK_INDEFINITELY_THEN_RELEASE.equals(blockingMode);
+    private boolean isBlocking(BlockingMode blockingMode) {
+        switch (blockingMode) {
+            case DO_NOT_BLOCK:
+                return false;
+            case BLOCK_UNTIL_TIMEOUT:
+            case BLOCK_INDEFINITELY:
+            case BLOCK_INDEFINITELY_THEN_RELEASE:
+                return true;
+        }
+        throw new SafeIllegalStateException("Unhandled BlockingMode", SafeArg.of("blockingMode", blockingMode))
     }
 
     private void tryLocks(
@@ -1191,7 +1199,7 @@ public final class LockServiceImpl
     public void close() {
         if (isShutDown.compareAndSet(false, true)) {
             lockReapRunner.close();
-            indefinitelyBlockingThreads.forEach(Thread::interrupt);
+            blockingThreads.forEach(Thread::interrupt);
             callOnClose.run();
         }
     }


### PR DESCRIPTION
**Goals (and why)**:

I'm trying to figure out why leader election changes tend to line up to ~40 seconds of no progress on an internal product that loves to make WRITE_LOCK LockRequests with `TxManager#runTaskWithLocksWithRetry`

I believe that there are still requests that are parked while trying to `tryAcquireNanos` on the old node which sit there and causes things to fail slowly. I would like recovery from these situations to be a lot quicker to drive down our P99's.

**Implementation Description (bullets)**:

Instead of tracking just `indefinitelyBlockingThreads`, track all threads that are blocking. Upon `close()` which I think also executes on Leadership changes per `AwaitingLeadershipProxy`, then we should interrupt **all** blocking threads.

~This should trigger `LockServerSync#tryAcquireNanos` to return `false` quickly and subsequently `return new LockResponse(null, failedLocks);` quickly back to the client when it's `LOCK_ALL_OR_NONE` or if all locks failed (what I want)~. The existing behavior is LockServiceImpl throws InterruptedException for callers to handle. Of which it looks like `AwaitingLeadershipProxy#handleDelegateThrewException` will re-throw as `NotCurrentLeaderException`

**Testing (What was existing testing like?  What have you done to improve it?)**:

I couldn't find any tests for the behavior of `close()`, mind pointing them to me if I missed them?

**Concerns (what feedback would you like?)**:

I read the code wrong and this doesn't do what I think it does.

**Where should we start reviewing?**:

LockServiceImpl.java

**Priority (whenever / two weeks / yesterday)**:

Whenever but would appreciate feedback sooner rather than later. 

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
