### PR TITLE
[Cross client Batching - 1c] |  Implement multi-client startTransactions endpoint

### DIFF
--- a/timelock-api/src/main/conjure/timelock-api.yml
+++ b/timelock-api/src/main/conjure/timelock-api.yml
@@ -125,6 +125,20 @@ types:
           inclusiveLower: Long
           inclusiveUpper: Long
           lockWatchUpdate: LockWatchStateUpdate
+      NamespacedStartTransactionsRequest:
+        fields:
+          namespace: string
+          requestId: uuid
+          requestorId: uuid
+          numTransactions: integer
+          lastKnownVersion: optional<ConjureIdentifiedVersion>
+      NamespacedStartTransactionsResponse:
+        fields:
+          namespace: string
+          immutableTimestamp: LockImmutableTimestampResponse
+          timestamps: PartitionedTimestamps
+          lease: Lease
+          lockWatchUpdate: LockWatchStateUpdate
 
 services:
   ConjureTimelockService:
@@ -206,11 +220,18 @@ services:
           namespaces: set<string>
         returns: list<NamespacedLeaderTime>
         docs: |
-          Version of ConjureTimelockService#leaderTime endpoint for acquiring leaderTimes for a set of namespaces.
+          Version of ConjureTimelockService#leaderTime endpoint that acquires leaderTimes for a set of namespaces.
       getCommitTimestamps:
         http: POST /gcts
         args:
           requests: list<NamespacedGetCommitTimestampsRequest>
         returns: list<NamespacedGetCommitTimestampsResponse>
         docs: |
-          Version of ConjureTimelockService#getCommitTimestamps for acquiring commit timestamps for multiple namespaces.
+          Version of ConjureTimelockService#getCommitTimestamps that acquires commit timestamps for multiple namespaces.
+      startTransactions:
+        http: POST /sts
+        args:
+          requests: list<NamespacedStartTransactionsRequest>
+        returns: list<NamespacedStartTransactionsResponse>
+        docs: |
+          Version of ConjureTimelockService#startTransactions that starts transactions for multiple namespaces.

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/batch/MultiClientConjureTimelockResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/batch/MultiClientConjureTimelockResource.java
@@ -40,8 +40,8 @@ import com.palantir.common.streams.KeyedStream;
 import com.palantir.conjure.java.undertow.lib.UndertowService;
 import com.palantir.lock.v2.LeaderTime;
 import com.palantir.lock.watch.LockWatchVersion;
+import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.tokens.auth.AuthHeader;
 import java.util.List;
 import java.util.Map;
@@ -116,13 +116,12 @@ public final class MultiClientConjureTimelockResource implements UndertowMultiCl
                 .filter(requestors -> requestors.size() > 1)
                 .keys()
                 .collect(Collectors.toList());
-        if (!namespacesWithMoreThanOneTimeLockClient.isEmpty()) {
-            log.error(
-                    "More than one TimeLock client is requesting to start transactions for each of the following"
-                            + " namespaces - {}. This is not allowed. Contact support immediately!",
-                    SafeArg.of("namespaces", namespacesWithMoreThanOneTimeLockClient));
-            throw new SafeIllegalStateException("Multiple clients configured for single namespace.");
-        }
+        Preconditions.checkState(
+                namespacesWithMoreThanOneTimeLockClient.isEmpty(),
+                "More than one TimeLock client is "
+                        + "requesting to start transactions for each of the following"
+                        + " namespaces - {}. This is not allowed. Contact support immediately!",
+                SafeArg.of("namespaces", namespacesWithMoreThanOneTimeLockClient));
     }
 
     private ListenableFuture<NamespacedLeaderTime> getNamespacedLeaderTimeListenableFutures(String namespace) {

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/batch/MultiClientConjureTimelockResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/batch/MultiClientConjureTimelockResource.java
@@ -50,12 +50,8 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public final class MultiClientConjureTimelockResource implements UndertowMultiClientConjureTimelockService {
-    private static final Logger log = LoggerFactory.getLogger(MultiClientConjureTimelockResource.class);
-
     private final ConjureResourceExceptionHandler exceptionHandler;
     private final Function<String, AsyncTimelockService> timelockServices;
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/batch/MultiClientConjureTimelockResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/batch/MultiClientConjureTimelockResource.java
@@ -115,7 +115,7 @@ public final class MultiClientConjureTimelockResource implements UndertowMultiCl
                 .collect(Collectors.toList());
         if (!namespacesWithMoreThanOneTimeLockClient.isEmpty()) {
             throw new SafeIllegalStateException(
-                    "More than one TimeLock clients are requesting to start transactions for each of the following"
+                    "More than one TimeLock client is requesting to start transactions for each of the following"
                             + " namespaces - {}. This is not allowed. Contact support immediately!",
                     SafeArg.of("namespaces", namespacesWithMoreThanOneTimeLockClient));
         }
@@ -149,8 +149,7 @@ public final class MultiClientConjureTimelockResource implements UndertowMultiCl
 
     private ListenableFuture<NamespacedStartTransactionsResponse>
             getNamespacedStartTransactionsResponseListenableFutures(NamespacedStartTransactionsRequest request) {
-        ListenableFuture<ConjureStartTransactionsResponse> commitTimestamps = getServiceForNamespace(
-                        request.getNamespace())
+        ListenableFuture<ConjureStartTransactionsResponse> transactions = getServiceForNamespace(request.getNamespace())
                 .startTransactionsWithWatches(ConjureStartTransactionsRequest.builder()
                         .requestId(request.getRequestId())
                         .requestorId(request.getRequestorId())
@@ -158,7 +157,7 @@ public final class MultiClientConjureTimelockResource implements UndertowMultiCl
                         .numTransactions(request.getNumTransactions())
                         .build());
         return Futures.transform(
-                commitTimestamps,
+                transactions,
                 response -> NamespacedStartTransactionsResponse.builder()
                         .namespace(request.getNamespace())
                         .immutableTimestamp(response.getImmutableTimestamp())

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/batch/MultiClientConjureTimelockResourceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/batch/MultiClientConjureTimelockResourceTest.java
@@ -174,7 +174,7 @@ public class MultiClientConjureTimelockResourceTest {
                 .collect(Collectors.toList());
     }
 
-    public void configureStartTransactionsEndPoint() {
+    private void configureStartTransactionsEndPoint() {
         ConjureStartTransactionsResponse startTransactionsResponse = ConjureStartTransactionsResponse.builder()
                 .immutableTimestamp(lockImmutableTimestampResponse)
                 .lease(lease)


### PR DESCRIPTION
**Goals (and why)**:
Implement multi-client startTransactions endpoint

**Implementation Description (bullets)**:

- Adds conjure api definition of cross client batch endpoint for startTransactions

- The endpoints returns successfully if startTransactions futures for **_all_** queries are successful

- There is additional defense mechanism against more than one requestors querying for same namespace.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added unit and integration tests

**Concerns (what feedback would you like?)**:

1. Failure mechanism - fails the request for all queries without retry in case there is sanity check failure
2. Should the sanity check be moved to the client side? 
3. Should optimize the sanity check to avoid multiple iterations on input query list?

**Where should we start reviewing?**:
timelock-api.yml, MultiClientConjureTimelockResource.java

**Priority (whenever / two weeks / yesterday)**:
Today would be great
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
