### PR TITLE
[Cross Client Batching - 1d] | Modify leaderTimes api

### DIFF
--- a/timelock-api/src/main/conjure/timelock-api.yml
+++ b/timelock-api/src/main/conjure/timelock-api.yml
@@ -110,21 +110,11 @@ types:
       LockWatchRequest:
         fields:
           references: set<LockWatchReference>
-      NamespacedLeaderTime:
+      Namespace:
+        alias: string
+      LeaderTimes:
         fields:
-          namespace: string
-          leaderTime: LeaderTime
-      NamespacedGetCommitTimestampsRequest:
-        fields:
-          namespace: string
-          numTimestamps: integer
-          lastKnownVersion: optional<ConjureIdentifiedVersion>
-      NamespacedGetCommitTimestampsResponse:
-        fields:
-          namespace: string
-          inclusiveLower: Long
-          inclusiveUpper: Long
-          lockWatchUpdate: LockWatchStateUpdate
+          namespaceWiseLeaderTimes: map<Namespace, LeaderTime>
 
 services:
   ConjureTimelockService:
@@ -203,14 +193,7 @@ services:
       leaderTimes:
         http: POST /lts
         args:
-          namespaces: set<string>
-        returns: list<NamespacedLeaderTime>
+          namespaces: set<Namespace>
+        returns: LeaderTimes
         docs: |
           Version of ConjureTimelockService#leaderTime endpoint for acquiring leaderTimes for a set of namespaces.
-      getCommitTimestamps:
-        http: POST /gcts
-        args:
-          requests: list<NamespacedGetCommitTimestampsRequest>
-        returns: list<NamespacedGetCommitTimestampsResponse>
-        docs: |
-          Version of ConjureTimelockService#getCommitTimestamps for acquiring commit timestamps for multiple namespaces.

--- a/timelock-api/src/main/conjure/timelock-api.yml
+++ b/timelock-api/src/main/conjure/timelock-api.yml
@@ -114,7 +114,7 @@ types:
         alias: string
       LeaderTimes:
         fields:
-          namespaceWiseLeaderTimes: map<Namespace, LeaderTime>
+          leaderTimes: map<Namespace, LeaderTime>
 
 services:
   ConjureTimelockService:

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/batch/MultiClientConjureTimelockResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/batch/MultiClientConjureTimelockResource.java
@@ -17,6 +17,8 @@
 package com.palantir.atlasdb.timelock.batch;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -24,19 +26,17 @@ import com.palantir.atlasdb.futures.AtlasFutures;
 import com.palantir.atlasdb.http.RedirectRetryTargeter;
 import com.palantir.atlasdb.timelock.AsyncTimelockService;
 import com.palantir.atlasdb.timelock.ConjureResourceExceptionHandler;
-import com.palantir.atlasdb.timelock.api.ConjureIdentifiedVersion;
-import com.palantir.atlasdb.timelock.api.GetCommitTimestampsResponse;
+import com.palantir.atlasdb.timelock.api.LeaderTimes;
 import com.palantir.atlasdb.timelock.api.MultiClientConjureTimelockService;
 import com.palantir.atlasdb.timelock.api.MultiClientConjureTimelockServiceEndpoints;
-import com.palantir.atlasdb.timelock.api.NamespacedGetCommitTimestampsRequest;
-import com.palantir.atlasdb.timelock.api.NamespacedGetCommitTimestampsResponse;
-import com.palantir.atlasdb.timelock.api.NamespacedLeaderTime;
+import com.palantir.atlasdb.timelock.api.Namespace;
 import com.palantir.atlasdb.timelock.api.UndertowMultiClientConjureTimelockService;
 import com.palantir.conjure.java.undertow.lib.UndertowService;
 import com.palantir.lock.v2.LeaderTime;
-import com.palantir.lock.watch.LockWatchVersion;
 import com.palantir.tokens.auth.AuthHeader;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -65,47 +65,25 @@ public final class MultiClientConjureTimelockResource implements UndertowMultiCl
     }
 
     @Override
-    public ListenableFuture<List<NamespacedLeaderTime>> leaderTimes(AuthHeader authHeader, Set<String> namespaces) {
-        List<ListenableFuture<NamespacedLeaderTime>> futures = namespaces.stream()
-                .map(this::getNamespacedLeaderTimeListenableFutures)
-                .collect(Collectors.toList());
+    public ListenableFuture<LeaderTimes> leaderTimes(AuthHeader authHeader, Set<Namespace> namespaces) {
+        List<ListenableFuture<Map.Entry<Namespace, LeaderTime>>> futures =
+                namespaces.stream().map(this::getNamespacedLeaderTimes).collect(Collectors.toList());
 
-        return handleExceptions(() -> Futures.allAsList(futures));
+        return handleExceptions(() -> {
+            ListenableFuture<List<Entry<Namespace, LeaderTime>>> listListenableFuture = Futures.allAsList(futures);
+            return Futures.transform(
+                    listListenableFuture,
+                    entryList -> LeaderTimes.of(ImmutableMap.copyOf(entryList)),
+                    MoreExecutors.directExecutor());
+        });
     }
 
-    @Override
-    public ListenableFuture<List<NamespacedGetCommitTimestampsResponse>> getCommitTimestamps(
-            AuthHeader authHeader, List<NamespacedGetCommitTimestampsRequest> requests) {
-        List<ListenableFuture<NamespacedGetCommitTimestampsResponse>> futures = requests.stream()
-                .map(this::getNamespacedGetCommitTimestampsResponseListenableFutures)
-                .collect(Collectors.toList());
-
-        return handleExceptions(() -> Futures.allAsList(futures));
-    }
-
-    private ListenableFuture<NamespacedLeaderTime> getNamespacedLeaderTimeListenableFutures(String namespace) {
+    private ListenableFuture<Map.Entry<Namespace, LeaderTime>> getNamespacedLeaderTimes(Namespace namespace) {
         ListenableFuture<LeaderTime> leaderTimeListenableFuture =
-                getServiceForNamespace(namespace).leaderTime();
+                getServiceForNamespace(namespace.get()).leaderTime();
         return Futures.transform(
                 leaderTimeListenableFuture,
-                leaderTime -> NamespacedLeaderTime.of(namespace, leaderTime),
-                MoreExecutors.directExecutor());
-    }
-
-    private ListenableFuture<NamespacedGetCommitTimestampsResponse>
-            getNamespacedGetCommitTimestampsResponseListenableFutures(NamespacedGetCommitTimestampsRequest request) {
-        ListenableFuture<GetCommitTimestampsResponse> commitTimestamps = getServiceForNamespace(request.getNamespace())
-                .getCommitTimestamps(
-                        request.getNumTimestamps(),
-                        request.getLastKnownVersion().map(this::toIdentifiedVersion));
-        return Futures.transform(
-                commitTimestamps,
-                response -> NamespacedGetCommitTimestampsResponse.builder()
-                        .namespace(request.getNamespace())
-                        .inclusiveLower(response.getInclusiveLower())
-                        .inclusiveUpper(response.getInclusiveUpper())
-                        .lockWatchUpdate(response.getLockWatchUpdate())
-                        .build(),
+                leaderTime -> Maps.immutableEntry(namespace, leaderTime),
                 MoreExecutors.directExecutor());
     }
 
@@ -117,10 +95,6 @@ public final class MultiClientConjureTimelockResource implements UndertowMultiCl
         return exceptionHandler.handleExceptions(supplier);
     }
 
-    private LockWatchVersion toIdentifiedVersion(ConjureIdentifiedVersion conjureIdentifiedVersion) {
-        return LockWatchVersion.of(conjureIdentifiedVersion.getId(), conjureIdentifiedVersion.getVersion());
-    }
-
     public static final class JerseyAdapter implements MultiClientConjureTimelockService {
         private final MultiClientConjureTimelockResource resource;
 
@@ -129,14 +103,8 @@ public final class MultiClientConjureTimelockResource implements UndertowMultiCl
         }
 
         @Override
-        public List<NamespacedLeaderTime> leaderTimes(AuthHeader authHeader, Set<String> namespaces) {
+        public LeaderTimes leaderTimes(AuthHeader authHeader, Set<Namespace> namespaces) {
             return unwrap(resource.leaderTimes(authHeader, namespaces));
-        }
-
-        @Override
-        public List<NamespacedGetCommitTimestampsResponse> getCommitTimestamps(
-                AuthHeader authHeader, List<NamespacedGetCommitTimestampsRequest> requests) {
-            return unwrap(resource.getCommitTimestamps(authHeader, requests));
         }
 
         private static <T> T unwrap(ListenableFuture<T> future) {

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/batch/MultiClientConjureTimelockResourceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/batch/MultiClientConjureTimelockResourceTest.java
@@ -28,12 +28,17 @@ import com.palantir.atlasdb.http.RedirectRetryTargeter;
 import com.palantir.atlasdb.timelock.AsyncTimelockService;
 import com.palantir.atlasdb.timelock.api.LeaderTimes;
 import com.palantir.atlasdb.timelock.api.Namespace;
+import com.palantir.common.time.NanoTime;
 import com.palantir.lock.remoting.BlockingTimeoutException;
 import com.palantir.lock.v2.LeaderTime;
+import com.palantir.lock.v2.LeadershipId;
 import com.palantir.tokens.auth.AuthHeader;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Test;
@@ -46,35 +51,58 @@ public class MultiClientConjureTimelockResourceTest {
     private static final RedirectRetryTargeter TARGETER =
             RedirectRetryTargeter.create(LOCAL, ImmutableList.of(LOCAL, REMOTE));
 
-    private AsyncTimelockService timelockService = mock(AsyncTimelockService.class);
-    private LeaderTime leaderTime = mock(LeaderTime.class);
+    private Map<String, AsyncTimelockService> namespaces = new HashMap();
+    private Map<String, LeadershipId> namespaceToLeaderMap = new HashMap();
+
     private MultiClientConjureTimelockResource resource;
 
     @Before
     public void before() {
-        resource = new MultiClientConjureTimelockResource(TARGETER, unused -> timelockService);
+        resource = new MultiClientConjureTimelockResource(TARGETER, this::getServiceForClient);
     }
 
     @Test
     public void canGetLeaderTimesForMultipleClients() {
-        when(timelockService.leaderTime()).thenReturn(Futures.immediateFuture(leaderTime));
-        Set<Namespace> namespaces = ImmutableSet.of(Namespace.of("client1"), Namespace.of("client2"));
-        assertThat(Futures.getUnchecked(resource.leaderTimes(AUTH_HEADER, namespaces)))
-                .isEqualTo(getLeaderTimesForNamespaces(namespaces));
+        Namespace client1 = Namespace.of("client1");
+        Namespace client2 = Namespace.of("client2");
+        Set<Namespace> namespaces = ImmutableSet.of(client1, client1, client2);
+
+        LeaderTimes leaderTimesResponse = Futures.getUnchecked(resource.leaderTimes(AUTH_HEADER, namespaces));
+        Map<Namespace, LeaderTime> leaderTimes = leaderTimesResponse.getLeaderTimes();
+
+        // leaderTimes for namespaces are computed by their respective underlying AsyncTimelockService instances
+        leaderTimes.forEach((namespace, leaderTime) -> {
+            assertThat(leaderTime.id()).isEqualTo(namespaceToLeaderMap.get(namespace.get()));
+        });
+
+        // there should be as many leaders as there are distinct clients
+        Set<UUID> leaders = leaderTimes.values().stream()
+                .map(LeaderTime::id)
+                .map(LeadershipId::id)
+                .collect(Collectors.toSet());
+        assertThat(leaders).hasSameSizeAs(namespaces);
     }
 
     @Test
     public void requestThrowsIfAnyQueryFails() {
-        when(timelockService.leaderTime())
-                .thenReturn(Futures.immediateFuture(leaderTime))
-                .thenThrow(new BlockingTimeoutException(""));
-        Set<Namespace> namespaces = ImmutableSet.of(Namespace.of("client1"), Namespace.of("client2"));
+        String throwingClient = "alpha";
+        Set<Namespace> namespaces = ImmutableSet.of(Namespace.of(throwingClient), Namespace.of("beta"));
+        when(getServiceForClient(throwingClient).leaderTime()).thenThrow(new BlockingTimeoutException(""));
         assertThatThrownBy(() -> Futures.getUnchecked(resource.leaderTimes(AUTH_HEADER, namespaces)))
                 .isInstanceOf(BlockingTimeoutException.class);
     }
 
-    private LeaderTimes getLeaderTimesForNamespaces(Set<Namespace> namespaces) {
-        return LeaderTimes.of(namespaces.stream().collect(Collectors.toMap(x -> x, x -> leaderTime)));
+    private AsyncTimelockService getServiceForClient(String client) {
+        return namespaces.computeIfAbsent(client, this::createAsyncTimeLockServiceForClient);
+    }
+
+    private AsyncTimelockService createAsyncTimeLockServiceForClient(String client) {
+        AsyncTimelockService timelockService = mock(AsyncTimelockService.class);
+        LeadershipId leadershipId = LeadershipId.random();
+        namespaceToLeaderMap.put(client, leadershipId);
+        when(timelockService.leaderTime())
+                .thenReturn(Futures.immediateFuture(LeaderTime.of(leadershipId, NanoTime.createForTests(1L))));
+        return timelockService;
     }
 
     private static URL url(String url) {

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/batch/MultiClientConjureTimelockResourceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/batch/MultiClientConjureTimelockResourceTest.java
@@ -33,7 +33,6 @@ import com.palantir.lock.v2.LeaderTime;
 import com.palantir.tokens.auth.AuthHeader;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.Before;
@@ -75,8 +74,7 @@ public class MultiClientConjureTimelockResourceTest {
     }
 
     private LeaderTimes getLeaderTimesForNamespaces(Set<Namespace> namespaces) {
-        Map<Namespace, LeaderTime> collect = namespaces.stream().collect(Collectors.toMap(x -> x, x -> leaderTime));
-        return LeaderTimes.of(collect);
+        return LeaderTimes.of(namespaces.stream().collect(Collectors.toMap(x -> x, x -> leaderTime)));
     }
 
     private static URL url(String url) {

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/batch/MultiClientConjureTimelockResourceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/batch/MultiClientConjureTimelockResourceTest.java
@@ -65,7 +65,7 @@ public class MultiClientConjureTimelockResourceTest {
     public void canGetLeaderTimesForMultipleClients() {
         Namespace client1 = Namespace.of("client1");
         Namespace client2 = Namespace.of("client2");
-        Set<Namespace> namespaces = ImmutableSet.of(client1, client1, client2);
+        Set<Namespace> namespaces = ImmutableSet.of(client1, client2);
 
         LeaderTimes leaderTimesResponse = Futures.getUnchecked(resource.leaderTimes(AUTH_HEADER, namespaces));
         Map<Namespace, LeaderTime> leaderTimes = leaderTimesResponse.getLeaderTimes();

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -495,7 +495,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
         LeaderTimes leaderTimes = assertSanityAndGetLeaderTimes(expectedNamespaces);
 
         // leaderTimes for namespaces are computed by their respective underlying AsyncTimelockService instances
-        Set<UUID> leadershipIds = leaderTimes.getNamespaceWiseLeaderTimes().values().stream()
+        Set<UUID> leadershipIds = leaderTimes.getLeaderTimes().values().stream()
                 .map(LeaderTime::id)
                 .map(LeadershipId::id)
                 .collect(Collectors.toSet());
@@ -510,7 +510,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
 
         // Whether we hit the multi client endpoint or conjureTimelockService endpoint(services one client in one
         // call), for a namespace, the underlying service to process the request is the same
-        leaderTimes.getNamespaceWiseLeaderTimes().forEach((namespace, leaderTime) -> {
+        leaderTimes.getLeaderTimes().forEach((namespace, leaderTime) -> {
             LeaderTime conjureTimelockServiceLeaderTime = leader.client(namespace.get())
                     .namespacedConjureTimelockService()
                     .leaderTime();
@@ -523,7 +523,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
         MultiClientConjureTimelockService multiClientConjureTimelockService = leader.multiClientService();
 
         LeaderTimes leaderTimes = multiClientConjureTimelockService.leaderTimes(AUTH_HEADER, expectedNamespaces);
-        Set<Namespace> namespaces = leaderTimes.getNamespaceWiseLeaderTimes().keySet();
+        Set<Namespace> namespaces = leaderTimes.getLeaderTimes().keySet();
         assertThat(namespaces).hasSameElementsAs(expectedNamespaces);
 
         return leaderTimes;

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -31,12 +31,9 @@ import com.palantir.atlasdb.timelock.api.ConjureLockRequest;
 import com.palantir.atlasdb.timelock.api.ConjureLockResponse;
 import com.palantir.atlasdb.timelock.api.ConjureLockToken;
 import com.palantir.atlasdb.timelock.api.ConjureUnlockRequest;
-import com.palantir.atlasdb.timelock.api.GetCommitTimestampsRequest;
-import com.palantir.atlasdb.timelock.api.GetCommitTimestampsResponse;
+import com.palantir.atlasdb.timelock.api.LeaderTimes;
 import com.palantir.atlasdb.timelock.api.MultiClientConjureTimelockService;
-import com.palantir.atlasdb.timelock.api.NamespacedGetCommitTimestampsRequest;
-import com.palantir.atlasdb.timelock.api.NamespacedGetCommitTimestampsResponse;
-import com.palantir.atlasdb.timelock.api.NamespacedLeaderTime;
+import com.palantir.atlasdb.timelock.api.Namespace;
 import com.palantir.atlasdb.timelock.api.SuccessfulLockResponse;
 import com.palantir.atlasdb.timelock.api.UnsuccessfulLockResponse;
 import com.palantir.atlasdb.timelock.suite.DbTimeLockSingleLeaderPaxosSuite;
@@ -60,12 +57,10 @@ import com.palantir.lock.v2.LockResponse;
 import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.WaitForLocksRequest;
 import com.palantir.lock.v2.WaitForLocksResponse;
-import com.palantir.lock.watch.LockWatchStateUpdate;
 import com.palantir.tokens.auth.AuthHeader;
 import java.lang.management.ManagementFactory;
 import java.time.Duration;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -495,18 +490,12 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
     }
 
     @Test
-    public void leaderCanProcessMultiClientLeaderTimeRequest() {
-        TestableTimelockServer leader = cluster.currentLeaderFor(client.namespace());
-        MultiClientConjureTimelockService multiClientConjureTimelockService = leader.multiClientService();
-        Set<String> expectedNamespaces = ImmutableSet.of("alpha", "beta");
-        List<NamespacedLeaderTime> leaderTimes =
-                multiClientConjureTimelockService.leaderTimes(AUTH_HEADER, expectedNamespaces);
-        Set<String> namespaces =
-                leaderTimes.stream().map(NamespacedLeaderTime::getNamespace).collect(Collectors.toSet());
-        assertThat(namespaces).hasSameElementsAs(expectedNamespaces);
+    public void sanityCheckMultiClientLeaderTime() {
+        Set<Namespace> expectedNamespaces = ImmutableSet.of(Namespace.of("client1"), Namespace.of("client2"));
+        LeaderTimes leaderTimes = assertSanityAndGetLeaderTimes(expectedNamespaces);
 
-        Set<UUID> leadershipIds = leaderTimes.stream()
-                .map(NamespacedLeaderTime::getLeaderTime)
+        // leaderTimes for namespaces are computed by their respective underlying AsyncTimelockService instances
+        Set<UUID> leadershipIds = leaderTimes.getNamespaceWiseLeaderTimes().values().stream()
                 .map(LeaderTime::id)
                 .map(LeadershipId::id)
                 .collect(Collectors.toSet());
@@ -514,76 +503,30 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
     }
 
     @Test
-    public void leaderCanProcessMultiClientGetCommitTimestampRequest() {
-        MultiClientConjureTimelockService service =
-                cluster.currentLeaderFor(client.namespace()).multiClientService();
-        Set<String> expectedNamespaces = ImmutableSet.of("alpha", "beta");
-        List<NamespacedGetCommitTimestampsResponse> commitTimestamps = service.getCommitTimestamps(
-                AUTH_HEADER, defaultNamespacedGetCommitTimestampsRequests(expectedNamespaces));
-        Set<String> namespaces = commitTimestamps.stream()
-                .map(NamespacedGetCommitTimestampsResponse::getNamespace)
-                .collect(Collectors.toSet());
-        assertThat(namespaces).hasSameElementsAs(expectedNamespaces);
-
-        Set<UUID> leadershipIds = commitTimestamps.stream()
-                .map(NamespacedGetCommitTimestampsResponse::getLockWatchUpdate)
-                .map(LockWatchStateUpdate::logId)
-                .collect(Collectors.toSet());
-        assertThat(leadershipIds).hasSameSizeAs(expectedNamespaces);
-    }
-
-    @Test
     public void sanityCheckMultiClientLeaderTimeAgainstConjureTimelockService() {
+        Set<Namespace> expectedNamespaces = ImmutableSet.of(Namespace.of("alpha"), Namespace.of("beta"));
         TestableTimelockServer leader = cluster.currentLeaderFor(client.namespace());
-        MultiClientConjureTimelockService multiClientConjureTimelockService = leader.multiClientService();
-        Set<String> expectedNamespaces = ImmutableSet.of("alpha", "beta", "gamma");
-        List<NamespacedLeaderTime> leaderTimeResponses =
-                multiClientConjureTimelockService.leaderTimes(AUTH_HEADER, expectedNamespaces);
-        Set<String> namespacesWithLeaderTime = leaderTimeResponses.stream()
-                .map(NamespacedLeaderTime::getNamespace)
-                .collect(Collectors.toSet());
-        assertThat(namespacesWithLeaderTime).hasSameElementsAs(expectedNamespaces);
+        LeaderTimes leaderTimes = assertSanityAndGetLeaderTimes(expectedNamespaces);
 
         // Whether we hit the multi client endpoint or conjureTimelockService endpoint(services one client in one
         // call), for a namespace, the underlying service to process the request is the same
-        leaderTimeResponses.forEach(namespacedLeaderTime -> {
-            LeaderTime conjureTimelockServiceLeaderTime = leader.client(namespacedLeaderTime.getNamespace())
+        leaderTimes.getNamespaceWiseLeaderTimes().forEach((namespace, leaderTime) -> {
+            LeaderTime conjureTimelockServiceLeaderTime = leader.client(namespace.get())
                     .namespacedConjureTimelockService()
                     .leaderTime();
-            assertThat(conjureTimelockServiceLeaderTime.id())
-                    .isEqualTo(namespacedLeaderTime.getLeaderTime().id());
+            assertThat(conjureTimelockServiceLeaderTime.id()).isEqualTo(leaderTime.id());
         });
     }
 
-    @Test
-    public void sanityCheckMultiClientGetCommitTimestampsAgainstConjureTimelockService() {
+    private LeaderTimes assertSanityAndGetLeaderTimes(Set<Namespace> expectedNamespaces) {
         TestableTimelockServer leader = cluster.currentLeaderFor(client.namespace());
-        MultiClientConjureTimelockService service = leader.multiClientService();
-        Set<String> expectedNamespaces = ImmutableSet.of("alpha", "beta");
-        List<NamespacedGetCommitTimestampsResponse> commitTimestamps = service.getCommitTimestamps(
-                AUTH_HEADER, defaultNamespacedGetCommitTimestampsRequests(expectedNamespaces));
-        Set<String> namespaces = commitTimestamps.stream()
-                .map(NamespacedGetCommitTimestampsResponse::getNamespace)
-                .collect(Collectors.toSet());
+        MultiClientConjureTimelockService multiClientConjureTimelockService = leader.multiClientService();
+
+        LeaderTimes leaderTimes = multiClientConjureTimelockService.leaderTimes(AUTH_HEADER, expectedNamespaces);
+        Set<Namespace> namespaces = leaderTimes.getNamespaceWiseLeaderTimes().keySet();
         assertThat(namespaces).hasSameElementsAs(expectedNamespaces);
 
-        // Whether we hit the multi client endpoint or conjureTimelockService endpoint(services one client in one
-        // call), for a namespace, the underlying service to process the request is the same
-        commitTimestamps.forEach(namespacedGetCommitTimestampsResponse -> {
-            GetCommitTimestampsResponse conjureTimelockServiceGetCommitTimestampResponse = leader.client(
-                            namespacedGetCommitTimestampsResponse.getNamespace())
-                    .namespacedConjureTimelockService()
-                    .getCommitTimestamps(defaultCommitTimestampRequest());
-            assertThat(conjureTimelockServiceGetCommitTimestampResponse
-                            .getLockWatchUpdate()
-                            .logId())
-                    .isEqualTo(namespacedGetCommitTimestampsResponse
-                            .getLockWatchUpdate()
-                            .logId());
-            assertThat(conjureTimelockServiceGetCommitTimestampResponse.getInclusiveLower())
-                    .as("timestamps should contiguously increase per namespace if there are no elections.")
-                    .isEqualTo(namespacedGetCommitTimestampsResponse.getInclusiveUpper() + 1);
-        });
+        return leaderTimes;
     }
 
     private static void assertNumberOfThreadsReasonable(int startingThreads, int threadCount, boolean nonLeaderDown) {
@@ -614,20 +557,6 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
                                 .withFixedDelay(
                                         Ints.checkedCast(Duration.ofSeconds(2).toMillis())))
                         .build());
-    }
-
-    private List<NamespacedGetCommitTimestampsRequest> defaultNamespacedGetCommitTimestampsRequests(
-            Set<String> namespaces) {
-        return namespaces.stream()
-                .map(namespace -> NamespacedGetCommitTimestampsRequest.builder()
-                        .namespace(namespace)
-                        .numTimestamps(defaultCommitTimestampRequest().getNumTimestamps())
-                        .build())
-                .collect(Collectors.toList());
-    }
-
-    private GetCommitTimestampsRequest defaultCommitTimestampRequest() {
-        return GetCommitTimestampsRequest.builder().numTimestamps(5).build();
     }
 
     private enum ToConjureLockTokenVisitor implements ConjureLockResponse.Visitor<Optional<ConjureLockToken>> {


### PR DESCRIPTION
**Goals (and why)**:
Modify signature of leaderTimes api

**Implementation Description (bullets)**:

- Changed signature of leaderTimes to ```Map<Namespace, LeaderTime> leaderTimes(AuthHeader authHeader, Set<Namespace> namespaces)```

- Removing multi getCommitTimestamps endpoint 

**Testing (What was existing testing like?  What have you done to improve it?)**:
Modified existing tests

**Concerns (what feedback would you like?)**:
N/A

**Where should we start reviewing?**:
timelock-api.yml, MultiClientConjureTimelockResource.java

**Priority (whenever / two weeks / yesterday)**:
Tomorrow EOD 
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
