### PR TITLE
[PDS-146501] Cast DEFAULT_TARGETED_SWEEP_SHARDS=1 down into the briny deeps

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -150,7 +150,8 @@ public final class AtlasDbConstants {
 
     public static final boolean DEFAULT_ENABLE_SWEEP_QUEUE_WRITES = true;
     public static final boolean DEFAULT_ENABLE_TARGETED_SWEEP = true;
-    public static final int DEFAULT_SWEEP_QUEUE_SHARDS = 1;
+    public static final int LEGACY_DEFAULT_TARGETED_SWEEP_SHARDS = 1;
+    public static final int DEFAULT_TARGETED_SWEEP_SHARDS = 8;
     public static final int DEFAULT_TARGETED_SWEEP_THREADS = 1;
     public static final int MAX_SWEEP_QUEUE_SHARDS = TargetedSweepMetadata.MAX_SHARDS;
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -151,7 +151,7 @@ public final class AtlasDbConstants {
     public static final boolean DEFAULT_ENABLE_SWEEP_QUEUE_WRITES = true;
     public static final boolean DEFAULT_ENABLE_TARGETED_SWEEP = true;
     public static final int LEGACY_DEFAULT_TARGETED_SWEEP_SHARDS = 1;
-    public static final int DEFAULT_TARGETED_SWEEP_SHARDS = 8;
+    public static final int DEFAULT_TARGETED_SWEEP_SHARDS = 16;
     public static final int DEFAULT_TARGETED_SWEEP_THREADS = 1;
     public static final int MAX_SWEEP_QUEUE_SHARDS = TargetedSweepMetadata.MAX_SHARDS;
 

--- a/atlasdb-ete-tests/docker/conf/atlasdb-ete.no-leader.cassandra.yml
+++ b/atlasdb-ete-tests/docker/conf/atlasdb-ete.no-leader.cassandra.yml
@@ -33,3 +33,4 @@ atlasDbRuntime:
     enabled: false
   targetedSweep:
     enabled: true
+    shards: 1 # required for CassandraTimestampsEteTest

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/CassandraTimestampsEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/CassandraTimestampsEteTest.java
@@ -88,7 +88,7 @@ public class CassandraTimestampsEteTest {
             throws IOException, InterruptedException {
         long firstWriteTimestamp = todoClient.addNamespacedTodoWithIdAndReturnTimestamp(ID, NAMESPACE, TODO);
         todoClient.addNamespacedTodoWithIdAndReturnTimestamp(ID, NAMESPACE, TODO_2);
-        sweepuntilNoValueExistsForNamespaceAtTimestamp(ID, firstWriteTimestamp, NAMESPACE);
+        sweepUntilNoValueExistsForNamespaceAtTimestamp(ID, firstWriteTimestamp, NAMESPACE);
 
         CassandraCommands.nodetoolFlush(CASSANDRA_CONTAINER_NAME);
 
@@ -116,7 +116,7 @@ public class CassandraTimestampsEteTest {
         sweepUntilConditionSatisfied(() -> todoClient.doesNotExistBeforeTimestamp(id, timestamp));
     }
 
-    private void sweepuntilNoValueExistsForNamespaceAtTimestamp(long id, long timestamp, String namespace) {
+    private void sweepUntilNoValueExistsForNamespaceAtTimestamp(long id, long timestamp, String namespace) {
         sweepUntilConditionSatisfied(
                 () -> todoClient.namespacedTodoDoesNotExistBeforeTimestamp(id, timestamp, namespace));
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/ShardProgress.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/ShardProgress.java
@@ -52,7 +52,9 @@ public class ShardProgress {
      * Returns the persisted number of shards for the sweep queue.
      */
     public int getNumberOfShards() {
-        return maybeGet(SHARD_COUNT_SAS).map(Long::intValue).orElse(AtlasDbConstants.DEFAULT_SWEEP_QUEUE_SHARDS);
+        return maybeGet(SHARD_COUNT_SAS)
+                .map(Long::intValue)
+                .orElse(AtlasDbConstants.LEGACY_DEFAULT_TARGETED_SWEEP_SHARDS);
     }
 
     /**
@@ -157,7 +159,8 @@ public class ShardProgress {
 
     private static boolean isDefaultValue(ShardAndStrategy shardAndStrategy, long oldVal) {
         return SweepQueueUtils.firstSweep(oldVal)
-                || (shardAndStrategy == SHARD_COUNT_SAS && oldVal == AtlasDbConstants.DEFAULT_SWEEP_QUEUE_SHARDS);
+                || (shardAndStrategy == SHARD_COUNT_SAS
+                        && oldVal == AtlasDbConstants.LEGACY_DEFAULT_TARGETED_SWEEP_SHARDS);
     }
 
     static CheckAndSetRequest createNewCellRequest(ShardAndStrategy shardAndStrategy, byte[] colValNew) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/config/TargetedSweepRuntimeConfig.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/config/TargetedSweepRuntimeConfig.java
@@ -45,7 +45,7 @@ public abstract class TargetedSweepRuntimeConfig {
      */
     @Value.Default
     public int shards() {
-        return 8;
+        return AtlasDbConstants.DEFAULT_TARGETED_SWEEP_SHARDS;
     }
 
     /**

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/ShardProgressTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/ShardProgressTest.java
@@ -55,12 +55,12 @@ public class ShardProgressTest {
 
     @Test
     public void canReadInitialNumberOfShards() {
-        assertThat(progress.getNumberOfShards()).isEqualTo(AtlasDbConstants.DEFAULT_SWEEP_QUEUE_SHARDS);
+        assertThat(progress.getNumberOfShards()).isEqualTo(AtlasDbConstants.LEGACY_DEFAULT_TARGETED_SWEEP_SHARDS);
     }
 
     @Test
     public void canUpgradeNumberOfShardsIfPersistedDefaultValue() {
-        byte[] defaultValue = ShardProgress.createColumnValue(AtlasDbConstants.DEFAULT_SWEEP_QUEUE_SHARDS);
+        byte[] defaultValue = ShardProgress.createColumnValue(AtlasDbConstants.LEGACY_DEFAULT_TARGETED_SWEEP_SHARDS);
         CheckAndSetRequest request = progress.createNewCellRequest(ShardProgress.SHARD_COUNT_SAS, defaultValue);
         kvs.checkAndSet(request);
 
@@ -77,7 +77,7 @@ public class ShardProgressTest {
     @Test
     public void cannotUpdateNumberOfShardsToZero() {
         progress.updateNumberOfShards(0);
-        assertThat(progress.getNumberOfShards()).isEqualTo(AtlasDbConstants.DEFAULT_SWEEP_QUEUE_SHARDS);
+        assertThat(progress.getNumberOfShards()).isEqualTo(AtlasDbConstants.LEGACY_DEFAULT_TARGETED_SWEEP_SHARDS);
     }
 
     @Test
@@ -143,7 +143,7 @@ public class ShardProgressTest {
 
     @Test
     public void updatingTimestampsDoesNotAffectShardsAndViceVersa() {
-        assertThat(progress.getNumberOfShards()).isEqualTo(AtlasDbConstants.DEFAULT_SWEEP_QUEUE_SHARDS);
+        assertThat(progress.getNumberOfShards()).isEqualTo(AtlasDbConstants.LEGACY_DEFAULT_TARGETED_SWEEP_SHARDS);
         assertThat(progress.getLastSweptTimestamp(CONSERVATIVE_TEN)).isEqualTo(INITIAL_TIMESTAMP);
         assertThat(progress.getLastSweptTimestamp(THOROUGH_TEN)).isEqualTo(INITIAL_TIMESTAMP);
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperNumShardSupplierTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperNumShardSupplierTest.java
@@ -45,8 +45,8 @@ public class TargetedSweeperNumShardSupplierTest {
 
     @Test
     public void testDefaultValue() {
-        assertThat(setRuntimeAndGetNumShards(AtlasDbConstants.DEFAULT_SWEEP_QUEUE_SHARDS))
-                .isEqualTo(AtlasDbConstants.DEFAULT_SWEEP_QUEUE_SHARDS);
+        assertThat(setRuntimeAndGetNumShards(AtlasDbConstants.LEGACY_DEFAULT_TARGETED_SWEEP_SHARDS))
+                .isEqualTo(AtlasDbConstants.LEGACY_DEFAULT_TARGETED_SWEEP_SHARDS);
     }
 
     @Test
@@ -57,7 +57,7 @@ public class TargetedSweeperNumShardSupplierTest {
 
     @Test
     public void testProgressHigherValue() {
-        when(runtimeConfigSupplier.get()).thenReturn(AtlasDbConstants.DEFAULT_SWEEP_QUEUE_SHARDS);
+        when(runtimeConfigSupplier.get()).thenReturn(AtlasDbConstants.LEGACY_DEFAULT_TARGETED_SWEEP_SHARDS);
         progress.updateNumberOfShards(25);
         assertThat(numShardSupplier.get()).isEqualTo(25);
     }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
@@ -182,8 +182,8 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
 
     @Test
     public void enqueueUpdatesNumberOfShards() {
-        assertThat(AtlasDbConstants.DEFAULT_SWEEP_QUEUE_SHARDS).isLessThan(DEFAULT_SHARDS);
-        assertThat(progress.getNumberOfShards()).isEqualTo(AtlasDbConstants.DEFAULT_SWEEP_QUEUE_SHARDS);
+        assertThat(AtlasDbConstants.LEGACY_DEFAULT_TARGETED_SWEEP_SHARDS).isLessThan(DEFAULT_SHARDS);
+        assertThat(progress.getNumberOfShards()).isEqualTo(AtlasDbConstants.LEGACY_DEFAULT_TARGETED_SWEEP_SHARDS);
         enqueueWriteCommitted(TABLE_CONS, LOW_TS);
         assertThat(progress.getNumberOfShards()).isEqualTo(DEFAULT_SHARDS);
     }

--- a/changelog/@unreleased/pr-5123.v2.yml
+++ b/changelog/@unreleased/pr-5123.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Targeted sweep now uses 16 _shards_ by default. The default number
+    of _threads_ is unaffected.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5123


### PR DESCRIPTION
**Goals (and why)**:
- Avoid tech debt that led to much (probably unnecessary) angst in a P0

**Implementation Description (bullets)**:
- Don't have misleading constants: rename the old `DEFAULT_TARGETED_SWEEP_SHARDS = 1` to `LEGACY_DEFAULT_TARGETED_SWEEP_SHARDS`, and set `DEFAULT_TARGETED_SWEEP_SHARDS = 8`
- There are likely to be substantially more complex semantics involved with just changing the number.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Not much.

**Concerns (what feedback would you like?)**:
- Nothing in particular.

**Where should we start reviewing?**: AtlasDbConstants

**Priority (whenever / two weeks / yesterday)**: Yesterday. The assumption drawn from this constant caused a lot of angst in a P0 yesterday.