### PR TITLE
Add serialize/deserialize annotations for Oracle service name configuration

### DIFF
--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/OracleConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/OracleConnectionConfig.java
@@ -240,6 +240,8 @@ public abstract class OracleConnectionConfig extends ConnectionConfig {
 
     public static class Builder extends ImmutableOracleConnectionConfig.Builder {}
 
+    @JsonDeserialize(as = ImmutableServiceNameConfiguration.class)
+    @JsonSerialize(as = ImmutableServiceNameConfiguration.class)
     @Value.Immutable
     public interface ServiceNameConfiguration {
         String serviceName();

--- a/changelog/@unreleased/pr-5124.v2.yml
+++ b/changelog/@unreleased/pr-5124.v2.yml
@@ -1,8 +1,7 @@
 type: fix
 fix:
-  description: >
+  description:
     Fixed an issue that caused an exception to be thrown when deserializing
     Oracle service name configuration
   links:
   - https://github.com/palantir/atlasdb/pull/5124
-

--- a/changelog/@unreleased/pr-5124.v2.yml
+++ b/changelog/@unreleased/pr-5124.v2.yml
@@ -1,0 +1,8 @@
+type: fix
+fix:
+  description: >
+    Fixed an issue that caused an exception to be thrown when deserializing
+    Oracle service name configuration
+  links:
+  - https://github.com/palantir/atlasdb/pull/5124
+


### PR DESCRIPTION
**Goals (and why)**:

Enable configuring Oracle service name with YML. Currently the deserialization fails because there's no reference to the concrete immutable class.
