### PR TITLE
Set dclocal_read_repair chance to 0

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
@@ -580,7 +580,7 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
                         .build())
                 .setBloom_filter_fp_chance(0.1)
                 .setCaching("KEYS_ONLY")
-                .setDclocal_read_repair_chance(0.1)
+                .setDclocal_read_repair_chance(0.0)
                 .setMemtable_flush_period_in_ms(0)
                 .setDefault_time_to_live(0)
                 .setSpeculative_retry("NONE")

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTableCreator.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTableCreator.java
@@ -84,7 +84,7 @@ class CassandraTableCreator {
                 .compactionOptions(getCompaction(appendHeavyReadLight))
                 .compactStorage()
                 .compressionOptions(getCompression(tableMetadata.getExplicitCompressionBlockSizeKB()))
-                .dcLocalReadRepairChance(0.1)
+                .dcLocalReadRepairChance(0.0)
                 .gcGraceSeconds(config.gcGraceSeconds())
                 .minIndexInterval(CassandraTableOptions.minIndexInterval(tableMetadata))
                 .maxIndexInterval(CassandraTableOptions.maxIndexInterval(tableMetadata))

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ColumnFamilyDefinitions.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ColumnFamilyDefinitions.java
@@ -110,7 +110,7 @@ final class ColumnFamilyDefinitions {
 
         // explicitly set fields to default values
         cf.setCaching("KEYS_ONLY");
-        cf.setDclocal_read_repair_chance(0.1);
+        cf.setDclocal_read_repair_chance(0.0);
         cf.setTriggers(ImmutableList.of());
         cf.setCells_per_row_to_cache("0");
         cf.setMin_index_interval(CassandraConstants.DEFAULT_MIN_INDEX_INTERVAL);

--- a/changelog/@unreleased/pr-5139.v2.yml
+++ b/changelog/@unreleased/pr-5139.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: AtlasDB now sets dclocal_read_repair_chance chance to 0
+  links:
+    - https://github.com/palantir/atlasdb/pull/5139


### PR DESCRIPTION
**Goals (and why)**:
Currently, all tables in AtlasDB (for Cassandra) have a read repair chance of 0.1 (10%). This is largely un-needed, and will be deprecated in future versions of Cassandra (see https://issues.apache.org/jira/browse/CASSANDRA-13910). This also causes a lot of issues with regards to single node degradation, as it _could_ make 10% of queries slower. 

**Implementation Description (bullets)**:
- Set dclocal_read_repair to 0.0

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:
This should update a services AtlasDB table definition once merged/released, correct? 

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
