### PR TITLE
Make EC2 Location supplier memoize on failures

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostLocationSupplier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostLocationSupplier.java
@@ -26,14 +26,14 @@ import org.slf4j.LoggerFactory;
 public final class HostLocationSupplier implements Supplier<Optional<HostLocation>> {
 
     private final Supplier<String> snitchSupplier;
-    private final Supplier<HostLocation> ec2Supplier;
+    private final Supplier<Optional<HostLocation>> ec2Supplier;
     private final Optional<HostLocation> overrideLocation;
 
     private static final Logger log = LoggerFactory.getLogger(HostLocationSupplier.class);
 
     public HostLocationSupplier(
             Supplier<String> snitchSupplier,
-            Supplier<HostLocation> ec2Supplier,
+            Supplier<Optional<HostLocation>> ec2Supplier,
             Optional<HostLocation> overrideLocation) {
         this.snitchSupplier = Suppliers.memoize(snitchSupplier::get);
         this.ec2Supplier = Suppliers.memoize(ec2Supplier::get);
@@ -56,7 +56,7 @@ public final class HostLocationSupplier implements Supplier<Optional<HostLocatio
 
             switch (snitch) {
                 case "org.apache.cassandra.locator.Ec2Snitch":
-                    return Optional.of(ec2Supplier.get());
+                    return ec2Supplier.get();
                 default:
                     return Optional.empty();
             }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostLocationSupplierTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostLocationSupplierTest.java
@@ -44,7 +44,7 @@ public class HostLocationSupplierTest {
                 new HostLocationSupplier(ec2SnitchSupplier, ec2LocationSupplier, Optional.empty());
 
         assertThat(hostLocationSupplier.get())
-                .hasValue(ec2LocationSupplier.get().get());
+                .isEqualTo(ec2LocationSupplier.get());
     }
 
     @Test

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostLocationSupplierTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostLocationSupplierTest.java
@@ -43,8 +43,7 @@ public class HostLocationSupplierTest {
         Supplier<Optional<HostLocation>> hostLocationSupplier =
                 new HostLocationSupplier(ec2SnitchSupplier, ec2LocationSupplier, Optional.empty());
 
-        assertThat(hostLocationSupplier.get())
-                .isEqualTo(ec2LocationSupplier.get());
+        assertThat(hostLocationSupplier.get()).isEqualTo(ec2LocationSupplier.get());
     }
 
     @Test

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostLocationSupplierTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostLocationSupplierTest.java
@@ -25,7 +25,8 @@ import org.junit.Test;
 public class HostLocationSupplierTest {
 
     private static final Supplier<String> ec2SnitchSupplier = () -> "org.apache.cassandra.locator.Ec2Snitch";
-    private static final Supplier<HostLocation> ec2LocationSupplier = () -> HostLocation.of("dc2", "rack2");
+    private static final Supplier<Optional<HostLocation>> ec2LocationSupplier =
+            () -> Optional.of(HostLocation.of("dc2", "rack2"));
 
     @Test
     public void shouldReturnOverrideLocation() {
@@ -42,7 +43,8 @@ public class HostLocationSupplierTest {
         Supplier<Optional<HostLocation>> hostLocationSupplier =
                 new HostLocationSupplier(ec2SnitchSupplier, ec2LocationSupplier, Optional.empty());
 
-        assertThat(hostLocationSupplier.get()).hasValue(ec2LocationSupplier.get());
+        assertThat(hostLocationSupplier.get())
+                .hasValue(ec2LocationSupplier.get().get());
     }
 
     @Test
@@ -69,7 +71,7 @@ public class HostLocationSupplierTest {
 
     @Test
     public void shouldReturnEmptyLocationFromEc2Exception() {
-        Supplier<HostLocation> ec2BadLocationSupplier = () -> {
+        Supplier<Optional<HostLocation>> ec2BadLocationSupplier = () -> {
             throw new RuntimeException();
         };
 

--- a/changelog/@unreleased/pr-5149.v2.yml
+++ b/changelog/@unreleased/pr-5149.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Make EC2 Location supplier memoize on failures
+  links:
+  - https://github.com/palantir/atlasdb/pull/5149


### PR DESCRIPTION
**Goals (and why)**:
This stops the constant warn logging from the HostLocationSupplier in environments where services don't get to access the Instance metadata endpoint by default (example, when running on a locked down K8s cluster).

**Implementation Description (bullets)**:
We will now log an warning once if we fail to get location info from the metadata service and then assume we don't have any location info for the lifetime of the process.

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
