### PR TITLE
Make TransactionLockAcquisitionTimeoutException retryable

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionLockAcquisitionTimeoutException.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionLockAcquisitionTimeoutException.java
@@ -18,14 +18,9 @@ package com.palantir.atlasdb.transaction.api;
 /**
  * Indicates that we timed out while trying to obtain necessary locks during a transaction.
  */
-public class TransactionLockAcquisitionTimeoutException extends TransactionFailedException {
+public class TransactionLockAcquisitionTimeoutException extends TransactionFailedRetriableException {
 
     public TransactionLockAcquisitionTimeoutException(String message) {
         super(message);
-    }
-
-    @Override
-    public boolean canTransactionBeRetried() {
-        return false;
     }
 }

--- a/changelog/@unreleased/pr-5154.v2.yml
+++ b/changelog/@unreleased/pr-5154.v2.yml
@@ -1,0 +1,9 @@
+type: improvement
+improvement:
+  description: 'TransactionLockAcquisitionTimeoutExceptions are now retryable. The
+    main implications of this are that clients will attempt to retry when lock acquisition
+    times out, which typically happens due to a leader election. However, this also
+    means that requests will retry in cases where lock acquisition timing out is a
+    non-transient issue. '
+  links:
+  - https://github.com/palantir/atlasdb/pull/5154


### PR DESCRIPTION
**Goals (and why)**:
* Make TLATE retryable - this would likely reduce most of the 500s caused by leader elections.

**Implementation Description (bullets)**:
* Change the exception it extends.

**Testing (What was existing testing like?  What have you done to improve it?)**:
N/A

**Concerns (what feedback would you like?)**:
* If there is a genuine issue with locks timing out, we're now going to retry several times before actually failing. This could be an issue.

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
