### PR TITLE
Don't try to publish internal docs from external CircleCI!

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,8 @@ jobs:
             if [ $CIRCLE_PROJECT_USERNAME = 'atlasdb' ] && [ -z $CIRCLE_PR_NUMBER ]; then
               if [[ "${CIRCLE_BRANCH}" =~ develop ]]; then
                 ./scripts/circle-ci/publish-github-page.sh
-                curl -s --fail $DOCS_URL | bash -s -- -r docs/requirements.txt $CIRCLE_BRANCH
+                # Internal publishing from an external CircleCI is... not a thing.
+                # curl -s --fail $DOCS_URL | bash -s -- -r docs/requirements.txt $CIRCLE_BRANCH
               else
                 echo "Internal and external docs are typically published from develop, not ${CIRCLE_BRANCH}."
               fi


### PR DESCRIPTION
**Goals (and why)**:
- Have a green develop

**Implementation Description (bullets)**: Don't attempt an internal publish

**Testing (What was existing testing like?  What have you done to improve it?)**: Not much testing. Tests on the previous PR only checked that the publish script worked.

**Concerns (what feedback would you like?)**: 
- Is there anything else broken?
- This means internal docs will drift out of date. I've added a task on internal task-tracking service for early 2021.

**Where should we start reviewing?**: +2 -1

**Priority (whenever / two weeks / yesterday)**: yesterday