### PR TITLE
[LW] Handle Snapshots into Empty Successes Correctly

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLog.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLog.java
@@ -58,8 +58,8 @@ final class LockWatchEventLog {
         Optional<LockWatchVersion> startVersion = lastKnownVersion.map(this::createStartVersion);
         LockWatchVersion currentVersion = getLatestVersionAndVerify(endVersion);
 
-        if (!startVersion.isPresent() || differentLeaderOrTooFarBehind(
-                currentVersion, lastKnownVersion.get(), startVersion.get())) {
+        if (!startVersion.isPresent()
+                || differentLeaderOrTooFarBehind(currentVersion, lastKnownVersion.get(), startVersion.get())) {
             return new ClientLogEvents.Builder()
                     .clearCache(true)
                     .events(new LockWatchEvents.Builder()

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheIntegrationTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheIntegrationTest.java
@@ -171,7 +171,9 @@ public class LockWatchEventCacheIntegrationTest {
         verifyStage();
 
         assertThat(eventCache.getUpdateForTransactions(ImmutableSet.of(1L), Optional.of(LockWatchVersion.of(LEADER,
-                3L))).clearCache()).isTrue();
+                2L))).clearCache()).isTrue();
+        assertThat(eventCache.getUpdateForTransactions(ImmutableSet.of(1L), Optional.of(LockWatchVersion.of(LEADER,
+                3L))).clearCache()).isFalse();
 
         eventCache.processStartTransactionsUpdate(ImmutableSet.of(2L), emptySuccess);
         verifyStage();

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheIntegrationTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheIntegrationTest.java
@@ -107,7 +107,7 @@ public class LockWatchEventCacheIntegrationTest {
     private static final Set<Long> TIMESTAMPS = ImmutableSet.of(START_TS);
     private static final Set<Long> TIMESTAMPS_2 = ImmutableSet.of(16L);
     private static final String BASE = "src/test/resources/lockwatch-event-cache-output/";
-    private static final Mode MODE = Mode.DEV;
+    private static final Mode MODE = Mode.CI;
 
     private enum Mode {
         DEV,

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheIntegrationTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheIntegrationTest.java
@@ -158,11 +158,10 @@ public class LockWatchEventCacheIntegrationTest {
     public void emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance() {
         LockWatchStateUpdate snapshot =
                 LockWatchStateUpdate.snapshot(LEADER, 3L, ImmutableSet.of(DESCRIPTOR_2), ImmutableSet.of());
-        LockWatchStateUpdate emptySuccess =
-                LockWatchStateUpdate.success(LEADER, 3L, ImmutableList.of());
-        LockWatchEvent lockEvent = LockEvent.builder(ImmutableSet.of(DESCRIPTOR_3), COMMIT_TOKEN).build(4L);
-        LockWatchStateUpdate success =
-                LockWatchStateUpdate.success(LEADER, 4L, ImmutableList.of(lockEvent));
+        LockWatchStateUpdate emptySuccess = LockWatchStateUpdate.success(LEADER, 3L, ImmutableList.of());
+        LockWatchEvent lockEvent =
+                LockEvent.builder(ImmutableSet.of(DESCRIPTOR_3), COMMIT_TOKEN).build(4L);
+        LockWatchStateUpdate success = LockWatchStateUpdate.success(LEADER, 4L, ImmutableList.of(lockEvent));
 
         setupInitialState();
         verifyStage();
@@ -170,30 +169,42 @@ public class LockWatchEventCacheIntegrationTest {
         eventCache.processStartTransactionsUpdate(ImmutableSet.of(1L), snapshot);
         verifyStage();
 
-        assertThat(eventCache.getUpdateForTransactions(ImmutableSet.of(1L), Optional.of(LockWatchVersion.of(LEADER,
-                2L))).clearCache()).isTrue();
-        assertThat(eventCache.getUpdateForTransactions(ImmutableSet.of(1L), Optional.of(LockWatchVersion.of(LEADER,
-                3L))).clearCache()).isFalse();
+        assertThat(eventCache
+                        .getUpdateForTransactions(ImmutableSet.of(1L), Optional.of(LockWatchVersion.of(LEADER, 2L)))
+                        .clearCache())
+                .isTrue();
+        assertThat(eventCache
+                        .getUpdateForTransactions(ImmutableSet.of(1L), Optional.of(LockWatchVersion.of(LEADER, 3L)))
+                        .clearCache())
+                .isFalse();
 
         eventCache.processStartTransactionsUpdate(ImmutableSet.of(2L), emptySuccess);
         verifyStage();
 
-        assertThat(eventCache.getUpdateForTransactions(ImmutableSet.of(2L), Optional.of(LockWatchVersion.of(LEADER,
-                3L))).clearCache()).isFalse();
+        assertThat(eventCache
+                        .getUpdateForTransactions(ImmutableSet.of(2L), Optional.of(LockWatchVersion.of(LEADER, 3L)))
+                        .clearCache())
+                .isFalse();
 
         eventCache.processStartTransactionsUpdate(ImmutableSet.of(3L), emptySuccess);
         verifyStage();
 
-        assertThat(eventCache.getUpdateForTransactions(ImmutableSet.of(3L), Optional.of(LockWatchVersion.of(LEADER,
-                3L))).clearCache()).isFalse();
+        assertThat(eventCache
+                        .getUpdateForTransactions(ImmutableSet.of(3L), Optional.of(LockWatchVersion.of(LEADER, 3L)))
+                        .clearCache())
+                .isFalse();
 
         eventCache.processStartTransactionsUpdate(ImmutableSet.of(99L), success);
         verifyStage();
 
-        assertThat(eventCache.getUpdateForTransactions(ImmutableSet.of(99L), Optional.of(LockWatchVersion.of(LEADER,
-                3L))).events()).containsExactly(lockEvent);
-        assertThat(eventCache.getUpdateForTransactions(ImmutableSet.of(99L), Optional.of(LockWatchVersion.of(LEADER,
-                4L))).events()).isEmpty();
+        assertThat(eventCache
+                        .getUpdateForTransactions(ImmutableSet.of(99L), Optional.of(LockWatchVersion.of(LEADER, 3L)))
+                        .events())
+                .containsExactly(lockEvent);
+        assertThat(eventCache
+                        .getUpdateForTransactions(ImmutableSet.of(99L), Optional.of(LockWatchVersion.of(LEADER, 4L)))
+                        .events())
+                .isEmpty();
     }
 
     @Test

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-1.json
@@ -1,0 +1,32 @@
+{
+  "logState" : {
+    "snapshotState" : {
+      "watches" : [ ],
+      "locked" : [ {
+        "bytes" : "dGFibGUAAg=="
+      } ],
+      "snapshotVersion" : {
+        "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
+        "version" : 3
+      }
+    },
+    "eventStoreState" : {
+      "eventMap" : { }
+    },
+    "latestVersion" : {
+      "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
+      "version" : 3
+    }
+  },
+  "timestampStoreState" : {
+    "timestampMap" : {
+      "1" : {
+        "version" : {
+          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
+          "version" : 3
+        },
+        "commitInfo" : null
+      }
+    }
+  }
+}

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-2.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-2.json
@@ -1,0 +1,32 @@
+{
+  "logState" : {
+    "snapshotState" : {
+      "watches" : [ ],
+      "locked" : [ {
+        "bytes" : "dGFibGUAAg=="
+      } ],
+      "snapshotVersion" : {
+        "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
+        "version" : 3
+      }
+    },
+    "eventStoreState" : {
+      "eventMap" : { }
+    },
+    "latestVersion" : {
+      "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
+      "version" : 3
+    }
+  },
+  "timestampStoreState" : {
+    "timestampMap" : {
+      "1" : {
+        "version" : {
+          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
+          "version" : 3
+        },
+        "commitInfo" : null
+      }
+    }
+  }
+}

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-3.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-3.json
@@ -1,0 +1,39 @@
+{
+  "logState" : {
+    "snapshotState" : {
+      "watches" : [ ],
+      "locked" : [ {
+        "bytes" : "dGFibGUAAg=="
+      } ],
+      "snapshotVersion" : {
+        "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
+        "version" : 3
+      }
+    },
+    "eventStoreState" : {
+      "eventMap" : { }
+    },
+    "latestVersion" : {
+      "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
+      "version" : 3
+    }
+  },
+  "timestampStoreState" : {
+    "timestampMap" : {
+      "1" : {
+        "version" : {
+          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
+          "version" : 3
+        },
+        "commitInfo" : null
+      },
+      "2" : {
+        "version" : {
+          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
+          "version" : 3
+        },
+        "commitInfo" : null
+      }
+    }
+  }
+}

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-4.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-4.json
@@ -1,0 +1,46 @@
+{
+  "logState" : {
+    "snapshotState" : {
+      "watches" : [ ],
+      "locked" : [ {
+        "bytes" : "dGFibGUAAg=="
+      } ],
+      "snapshotVersion" : {
+        "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
+        "version" : 3
+      }
+    },
+    "eventStoreState" : {
+      "eventMap" : { }
+    },
+    "latestVersion" : {
+      "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
+      "version" : 3
+    }
+  },
+  "timestampStoreState" : {
+    "timestampMap" : {
+      "1" : {
+        "version" : {
+          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
+          "version" : 3
+        },
+        "commitInfo" : null
+      },
+      "2" : {
+        "version" : {
+          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
+          "version" : 3
+        },
+        "commitInfo" : null
+      },
+      "3" : {
+        "version" : {
+          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
+          "version" : 3
+        },
+        "commitInfo" : null
+      }
+    }
+  }
+}

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-5.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-5.json
@@ -1,0 +1,64 @@
+{
+  "logState" : {
+    "snapshotState" : {
+      "watches" : [ ],
+      "locked" : [ {
+        "bytes" : "dGFibGUAAg=="
+      } ],
+      "snapshotVersion" : {
+        "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
+        "version" : 3
+      }
+    },
+    "eventStoreState" : {
+      "eventMap" : {
+        "4" : {
+          "type" : "lock",
+          "sequence" : 4,
+          "lockDescriptors" : [ {
+            "bytes" : "dGFibGUAAw=="
+          } ],
+          "lockToken" : {
+            "requestId" : "203fcd7a-b3d7-4c2a-9d2c-3d61cde1ba59"
+          }
+        }
+      }
+    },
+    "latestVersion" : {
+      "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
+      "version" : 4
+    }
+  },
+  "timestampStoreState" : {
+    "timestampMap" : {
+      "1" : {
+        "version" : {
+          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
+          "version" : 3
+        },
+        "commitInfo" : null
+      },
+      "2" : {
+        "version" : {
+          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
+          "version" : 3
+        },
+        "commitInfo" : null
+      },
+      "3" : {
+        "version" : {
+          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
+          "version" : 3
+        },
+        "commitInfo" : null
+      },
+      "99" : {
+        "version" : {
+          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
+          "version" : 4
+        },
+        "commitInfo" : null
+      }
+    }
+  }
+}

--- a/changelog/@unreleased/pr-5167.v2.yml
+++ b/changelog/@unreleased/pr-5167.v2.yml
@@ -2,8 +2,8 @@ type: fix
 fix:
   description: Lock Watches no longer generate client updates instructing users to
     clear their caches after a snapshot if they indicate that their last known version
-    _is_ the version of the snapshot, provided that AtlasDB has seen a success since.
-    Previously, whenever a snapshot was taken, we would insist that clients always
-    clear their cache while no actual lock/unlock/creation event happened.
+    _is_ the version of the snapshot. Previously, whenever a snapshot was taken, we
+    would insist that clients always clear their cache, even after they have demonstrated
+    that they knew about the snapshot.
   links:
   - https://github.com/palantir/atlasdb/pull/5167


### PR DESCRIPTION
**Goals (and why)**:
- Fix a bug in lock watches that caused unnecessary snapshots and, worse, monitor false-positives.

**Implementation Description (bullets)**:
- Suppose a Lock Watch Event Cache gets a `Snapshot [logID = L1, sequence = 10000, data = {...}]` state update. This can be because TimeLock had a leader election, or just the node running the cache fell behind. The node then flushes its cache and updates itself to be in sync. However, if no further events happen, the cache will receive multiple state updates of the form `Success [logID = L1, lastKnownVersion = 10000, events = []]`. 
- The check that happens when a user calls `getUpdateForTransactions` and wants to get a `ClientLogEvents` for purposes of atlasdb-proxy says that something is a snapshot if there is no previously known version, the leader has changed or the log is too far behind (see `LockWatchEventLog#getEventsBetweenVersions`). The implementation of the last of these is `!eventStore.containsEntryLessThanOrEqualTo(startVersion.version())` where the `startVersion` is `(l1, 10001)`. In any case, the event store is _empty_ because it was reset when the snapshot was taken so no event prior to 10001 exists in the log, so we repeatedly return updates that have clearCache as true, i.e. we see many snapshots downstream.
- A single success after sequence 10000 that has events will make everything work again, but we really should be resilient to this case. If the version provided by the user equals the latest version on TimeLock, then they are not behind and should not need to clear their cache. Given the point of lock-watches is often to be able to cache values that are not read frequently, having to wait for a write for this to unblock itself seems unacceptable.
- At the same time this is relatively benign compared to the problems in e.g. PDS-148088, because although we are returning a lot of snapshots, these snapshots are generally very small (realistically, the snapshots can be big if there are a lot of watched locks being taken out: but in that case usually the rate of events should be high enough to quickly break you out of this state anyway)

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Integration Test added for this specific case.

**Concerns (what feedback would you like?)**:
- Is there some edge case I've missed out? This change did not change the state of any of the lock watch caches other than the added test, so I think we should be fine.

**Where should we start reviewing?**:
- LockWatchEventLog.java

**Priority (whenever / two weeks / yesterday)**: this week