### PR TITLE
[PDS-146088] Additional logging around Cassandra client pool issues

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -287,7 +287,8 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Cassand
         poolConfig.setEvictionPolicy(new NonEvictionLoggingEvictionPolicy<>(new DefaultEvictionPolicy<>()));
         GenericObjectPool<CassandraClient> pool = new GenericObjectPool<>(cassandraClientFactory, poolConfig);
         registerMetrics(pool);
-        log.info("Creating a Cassandra client pool for {} with the configuration {}",
+        log.info(
+                "Creating a Cassandra client pool for {} with the configuration {}",
                 SafeArg.of("host", host),
                 SafeArg.of("poolConfig", poolConfig));
         return pool;
@@ -336,12 +337,12 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Cassand
         }
 
         @Override
-        public boolean evict(
-                EvictionConfig config, PooledObject<T> underTest, int idleCount) {
+        public boolean evict(EvictionConfig config, PooledObject<T> underTest, int idleCount) {
             boolean delegateResult = delegate.evict(config, underTest, idleCount);
             // PDS-146088: the issue manifests with failures to evict anything
             if (!delegateResult && log.isDebugEnabled()) {
-                log.debug("Attempted to evict an object from the Cassandra client pool",
+                log.debug(
+                        "Attempted to evict an object from the Cassandra client pool",
                         SafeArg.of("underTestState", underTest.getState()),
                         SafeArg.of("idleState", underTest.getIdleTimeMillis()),
                         SafeArg.of("idleCount", idleCount),

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -329,7 +329,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Cassand
         poolMetrics.registerPoolMetric(metric, gauge, poolNumber);
     }
 
-    private static class NonEvictionLoggingEvictionPolicy<T> implements EvictionPolicy<T> {
+    private static final class NonEvictionLoggingEvictionPolicy<T> implements EvictionPolicy<T> {
         private final EvictionPolicy<T> delegate;
 
         private NonEvictionLoggingEvictionPolicy(EvictionPolicy<T> delegate) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -342,12 +342,11 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Cassand
             // PDS-146088: the issue manifests with failures to evict anything
             if (!delegateResult && log.isDebugEnabled()) {
                 log.debug(
-                        "Attempted to evict an object from the Cassandra client pool",
+                        "Considered an object to be evicted from the Cassandra client pool, but did not evict it",
                         SafeArg.of("underTestState", underTest.getState()),
                         SafeArg.of("idleState", underTest.getIdleTimeMillis()),
                         SafeArg.of("idleCount", idleCount),
-                        SafeArg.of("evictionConfig", config),
-                        SafeArg.of("decisionOnEvicting", delegateResult));
+                        SafeArg.of("evictionConfig", config));
             }
             return delegateResult;
         }

--- a/changelog/@unreleased/pr-5174.v2.yml
+++ b/changelog/@unreleased/pr-5174.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: CassandraClientPoolingContainer now supports more detailed debug logging
+    when decisions are made _not_ to evict its clients.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5174


### PR DESCRIPTION
**Goals (and why)**:
- Understand what is happening in PDS-146088. With this PR in, enabling debug logging on the CassandraClientPoolingContainer origin should yield some interesting information.

**Implementation Description (bullets)**:
- Add logging to creation of a Cassandra client pool
- Add more costly debug logging when eviction decisions are made, in particular negatively

**Testing (What was existing testing like?  What have you done to improve it?)**:
Not much :( existing testing was bad too

**Concerns (what feedback would you like?)**:
- Are any of the SafeArg things actually unsafe?

**Where should we start reviewing?**: it's small

**Priority (whenever / two weeks / yesterday)**: today please