### PR TITLE
[LE] Add logging to debug metrics + fix bug

### DIFF
--- a/lock-api/src/main/java/com/palantir/lock/client/LeaderElectionReportingTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LeaderElectionReportingTimelockService.java
@@ -170,8 +170,9 @@ public class LeaderElectionReportingTimelockService implements NamespacedConjure
         boolean election = !newLeader.equals(currentLeader);
 
         if (election) {
-            if (leaderId != newLeader) {
-                log.info("Apparent leader change from {} to {}.",
+            if (!leaderId.equals(newLeader)) {
+                log.info(
+                        "Apparent leader change from {} to {}.",
                         SafeArg.of("old leader", leaderId),
                         SafeArg.of("new leader", newLeader));
             }
@@ -244,7 +245,8 @@ public class LeaderElectionReportingTimelockService implements NamespacedConjure
                 durationToNextLeader(lowerBounds, upperBounds, leaders, secondToLastLongTermLeader);
         if (leaderElectionDuration.isPresent() && !leaderElectionDuration.get().equals(lastComputedDuration)) {
             lastComputedDuration = leaderElectionDuration.get();
-            log.info("Computed new leader election duration estimate {}.",
+            log.info(
+                    "Computed new leader election duration estimate {}.",
                     SafeArg.of("leader election duration", leaderElectionDuration.get()));
         }
         return leaderElectionDuration;

--- a/lock-api/src/main/java/com/palantir/lock/client/LeaderElectionReportingTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LeaderElectionReportingTimelockService.java
@@ -36,6 +36,7 @@ import com.palantir.atlasdb.timelock.api.GetCommitTimestampsResponse;
 import com.palantir.common.time.Clock;
 import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.lock.v2.LeaderTime;
+import com.palantir.logsafe.SafeArg;
 import com.palantir.timelock.feedback.LeaderElectionDuration;
 import com.palantir.timelock.feedback.LeaderElectionStatistics;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
@@ -54,12 +55,17 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class LeaderElectionReportingTimelockService implements NamespacedConjureTimelockService {
+    private static final Logger log = LoggerFactory.getLogger(LeaderElectionReportingTimelockService.class);
+
     private final NamespacedConjureTimelockService delegate;
     private volatile LeaderElectionMetrics metrics;
     private final Clock clock;
     private volatile UUID leaderId = null;
+    private volatile LeaderElectionDuration lastComputedDuration = null;
     private Map<UUID, Instant> leadershipUpperBound = new ConcurrentHashMap<>();
     private Map<UUID, Instant> leadershipLowerBound = new ConcurrentHashMap<>();
 
@@ -164,6 +170,11 @@ public class LeaderElectionReportingTimelockService implements NamespacedConjure
         boolean election = !newLeader.equals(currentLeader);
 
         if (election) {
+            if (leaderId != newLeader) {
+                log.info("Apparent leader change from {} to {}.",
+                        SafeArg.of("old leader", leaderId),
+                        SafeArg.of("new leader", newLeader));
+            }
             leaderId = newLeader;
         }
 
@@ -229,13 +240,21 @@ public class LeaderElectionReportingTimelockService implements NamespacedConjure
         }
 
         UUID secondToLastLongTermLeader = sortedLongTermLeaders.get(sortedLongTermLeaders.size() - 2);
-        return durationToNextLeader(lowerBounds, upperBounds, leaders, secondToLastLongTermLeader);
+        Optional<LeaderElectionDuration> leaderElectionDuration =
+                durationToNextLeader(lowerBounds, upperBounds, leaders, secondToLastLongTermLeader);
+        if (leaderElectionDuration.isPresent() && !leaderElectionDuration.get().equals(lastComputedDuration)) {
+            lastComputedDuration = leaderElectionDuration.get();
+            log.info("Computed new leader election duration estimate {}.",
+                    SafeArg.of("leader election duration", leaderElectionDuration.get()));
+        }
+        return leaderElectionDuration;
     }
 
     private void clearOldLongTermLeaders(List<UUID> sortedLongTermLeaders) {
         for (int i = 0; i < sortedLongTermLeaders.size() - 2; i++) {
             leadershipLowerBound.remove(sortedLongTermLeaders.get(i));
             leadershipUpperBound.remove(sortedLongTermLeaders.get(i));
+            log.info("Cleared old long term leader {}.", SafeArg.of("id", sortedLongTermLeaders.get(i)));
         }
     }
 

--- a/lock-api/src/main/java/com/palantir/lock/client/LeaderElectionReportingTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LeaderElectionReportingTimelockService.java
@@ -170,7 +170,7 @@ public class LeaderElectionReportingTimelockService implements NamespacedConjure
         boolean election = !newLeader.equals(currentLeader);
 
         if (election) {
-            if (!leaderId.equals(newLeader)) {
+            if (!newLeader.equals(leaderId)) {
                 log.info(
                         "Apparent leader change from {} to {}.",
                         SafeArg.of("old leader", leaderId),

--- a/lock-api/src/main/java/com/palantir/lock/client/metrics/TimeLockFeedbackBackgroundTask.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/metrics/TimeLockFeedbackBackgroundTask.java
@@ -96,11 +96,11 @@ public final class TimeLockFeedbackBackgroundTask implements AutoCloseable {
                                 .serviceName(serviceName)
                                 .namespace(namespace)
                                 .build();
+                        Optional<LeaderElectionStatistics> maybeStatistics =
+                                leaderElectionReporter.map(LeaderElectionReportingTimelockService::getStatistics);
                         timeLockClientFeedbackServices.current().forEach(service -> {
                             reportClientFeedbackToService(feedbackReport, service);
-                            leaderElectionReporter
-                                    .map(LeaderElectionReportingTimelockService::getStatistics)
-                                    .ifPresent(stats -> reportLeaderElectionStatisticsToService(stats, service));
+                            maybeStatistics.ifPresent(stats -> reportLeaderElectionStatisticsToService(stats, service));
                         });
                     } catch (Exception e) {
                         log.warn("A problem occurred while reporting client feedback for timeLock adjudication.", e);


### PR DESCRIPTION
**Goals (and why)**:
The leader election duration estimates can be drastically longer than the observed impact. Furthermore, sometimes there is a leader election duration estimate when impact is 0 and the leader has not apparently changed. These logs should help us gain more insight into what's happening.

Also fix a bug with reporting the metrics.

**Concerns (what feedback would you like?)**:
Is this enough? I know it's a bit aggressive, but hopefully it's not excessive.

**Priority (whenever / two weeks / yesterday)**:
New rules say the clock is ticking