### PR TITLE
Revert revert 5131

### DIFF
--- a/changelog/@unreleased/pr-5182.v2.yml
+++ b/changelog/@unreleased/pr-5182.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: TimeLock now validates the expected invariant for its timestamp bounds
+    i.e. the timestamp bound must not decrease with increasing sequence numbers.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5182

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResourcesFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResourcesFactory.java
@@ -36,6 +36,7 @@ import com.palantir.timelock.config.PaxosRuntimeConfiguration;
 import com.palantir.timelock.config.TimeLockInstallConfiguration;
 import com.palantir.timelock.corruption.detection.CorruptionHealthCheck;
 import com.palantir.timelock.corruption.detection.LocalCorruptionDetector;
+import com.palantir.timelock.corruption.detection.LocalTimestampInvariantsVerifier;
 import com.palantir.timelock.corruption.detection.RemoteCorruptionDetector;
 import com.palantir.timelock.history.LocalHistoryLoader;
 import com.palantir.timelock.history.PaxosLogHistoryProvider;
@@ -253,8 +254,10 @@ public final class PaxosResourcesFactory {
         PaxosLogHistoryProvider historyProvider =
                 new PaxosLogHistoryProvider(dataSource, remoteClients.getRemoteHistoryProviders());
 
-        LocalCorruptionDetector localCorruptionDetector =
-                LocalCorruptionDetector.create(historyProvider, remoteClients.getRemoteCorruptionNotifiers());
+        LocalTimestampInvariantsVerifier timestampInvariantsVerifier = new LocalTimestampInvariantsVerifier(dataSource);
+
+        LocalCorruptionDetector localCorruptionDetector = LocalCorruptionDetector.create(
+                historyProvider, remoteClients.getRemoteCorruptionNotifiers(), timestampInvariantsVerifier);
 
         CorruptionHealthCheck healthCheck =
                 new CorruptionHealthCheck(localCorruptionDetector, remoteCorruptionDetector);

--- a/timelock-corruption-detection/build.gradle
+++ b/timelock-corruption-detection/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     compile group: 'com.google.guava', name: 'guava'
     compile group: 'com.github.rholder', name: 'guava-retrying'
     compile group: 'com.palantir.conjure.java.api', name: 'service-config'
+    compile group: 'one.util', name: 'streamex'
 
     annotationProcessor group: 'org.immutables', name: 'value'
     compileOnly 'org.immutables:value::annotations'

--- a/timelock-corruption-detection/src/main/java/com/palantir/timelock/corruption/detection/LocalCorruptionDetector.java
+++ b/timelock-corruption-detection/src/main/java/com/palantir/timelock/corruption/detection/LocalCorruptionDetector.java
@@ -34,30 +34,43 @@ public final class LocalCorruptionDetector implements CorruptionDetector {
             new NamedThreadFactory(CORRUPTION_DETECTOR_THREAD_PREFIX, true));
     private final LocalCorruptionHandler corruptionHandler;
     private final PaxosLogHistoryProvider historyProvider;
+    private final LocalTimestampInvariantsVerifier timestampInvariantsVerifier;
 
     private volatile CorruptionStatus localCorruptionState = CorruptionStatus.HEALTHY;
     private volatile CorruptionHealthReport localCorruptionReport = CorruptionHealthReport.defaultHealthyReport();
 
     public static LocalCorruptionDetector create(
-            PaxosLogHistoryProvider historyProvider, List<TimeLockCorruptionNotifier> corruptionNotifiers) {
+            PaxosLogHistoryProvider historyProvider,
+            List<TimeLockCorruptionNotifier> corruptionNotifiers,
+            LocalTimestampInvariantsVerifier timestampInvariants) {
         LocalCorruptionDetector localCorruptionDetector =
-                new LocalCorruptionDetector(historyProvider, corruptionNotifiers);
+                new LocalCorruptionDetector(historyProvider, corruptionNotifiers, timestampInvariants);
 
         localCorruptionDetector.scheduleWithFixedDelay();
         return localCorruptionDetector;
     }
 
     private LocalCorruptionDetector(
-            PaxosLogHistoryProvider historyProvider, List<TimeLockCorruptionNotifier> corruptionNotifiers) {
+            PaxosLogHistoryProvider historyProvider,
+            List<TimeLockCorruptionNotifier> corruptionNotifiers,
+            LocalTimestampInvariantsVerifier timestampInvariantsVerifier) {
 
         this.historyProvider = historyProvider;
+        this.timestampInvariantsVerifier = timestampInvariantsVerifier;
         this.corruptionHandler = new LocalCorruptionHandler(corruptionNotifiers);
     }
 
     private void scheduleWithFixedDelay() {
         executor.scheduleWithFixedDelay(
                 () -> {
-                    localCorruptionReport = analyzeHistoryAndBuildCorruptionHealthReport();
+                    CorruptionHealthReport paxosRoundCorruptionReport = analyzeHistoryAndBuildCorruptionHealthReport();
+                    CorruptionHealthReport timestampInvariantsReport =
+                            timestampInvariantsVerifier.timestampInvariantsHealthReport();
+                    localCorruptionReport = ImmutableCorruptionHealthReport.builder()
+                            .from(paxosRoundCorruptionReport)
+                            .putAllViolatingStatusesToNamespaceAndUseCase(
+                                    timestampInvariantsReport.violatingStatusesToNamespaceAndUseCase())
+                            .build();
                     processLocalHealthReport();
                 },
                 TIMELOCK_CORRUPTION_ANALYSIS_INTERVAL.getSeconds(),

--- a/timelock-corruption-detection/src/main/java/com/palantir/timelock/corruption/detection/LocalTimestampInvariantsVerifier.java
+++ b/timelock-corruption-detection/src/main/java/com/palantir/timelock/corruption/detection/LocalTimestampInvariantsVerifier.java
@@ -78,7 +78,7 @@ public class LocalTimestampInvariantsVerifier {
                 .sorted(Comparator.comparingLong(Map.Entry::getKey))
                 .map(Map.Entry::getValue);
         return StreamEx.of(expectedSortedTimestamps)
-                        .pairMap((first, second) -> first >= second)
+                        .pairMap((first, second) -> first > second)
                         .anyMatch(x -> x)
                 ? CorruptionCheckViolation.CLOCK_WENT_BACKWARDS
                 : CorruptionCheckViolation.NONE;

--- a/timelock-corruption-detection/src/main/java/com/palantir/timelock/corruption/detection/LocalTimestampInvariantsVerifier.java
+++ b/timelock-corruption-detection/src/main/java/com/palantir/timelock/corruption/detection/LocalTimestampInvariantsVerifier.java
@@ -1,0 +1,129 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.timelock.corruption.detection;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Maps;
+import com.google.common.collect.SetMultimap;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.common.streams.KeyedStream;
+import com.palantir.paxos.ImmutableNamespaceAndUseCase;
+import com.palantir.paxos.NamespaceAndUseCase;
+import com.palantir.paxos.PaxosValue;
+import com.palantir.timelock.history.models.LearnerUseCase;
+import com.palantir.timelock.history.sqlite.SqlitePaxosStateLogHistory;
+import com.palantir.timelock.history.util.UseCaseUtils;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.sql.DataSource;
+import one.util.streamex.StreamEx;
+
+/**
+ * This class validates that timestamp bounds increase with increasing sequence numbers.
+ *
+ * The validation is done batch wise, e.g. [1, n], [n, 2 * n - 1] and so on. Two consecutive batches share
+ * boundaries, this is expected and is done to catch inversion at batch end.
+ * */
+public class LocalTimestampInvariantsVerifier {
+    @VisibleForTesting
+    public static final int LEARNER_LOG_BATCH_SIZE_LIMIT = 250;
+
+    public static final long MIN_SEQUENCE_TO_BE_VERIFIED = Long.MIN_VALUE;
+
+    private final SqlitePaxosStateLogHistory sqlitePaxosStateLogHistory;
+    private Map<NamespaceAndUseCase, Long> minInclusiveSeqBoundsToBeVerified = new ConcurrentHashMap<>();
+
+    public LocalTimestampInvariantsVerifier(DataSource dataSource) {
+        this.sqlitePaxosStateLogHistory = SqlitePaxosStateLogHistory.create(dataSource);
+    }
+
+    public CorruptionHealthReport timestampInvariantsHealthReport() {
+        SetMultimap<CorruptionCheckViolation, NamespaceAndUseCase> namespacesExhibitingViolations = KeyedStream.of(
+                        getNamespaceAndUseCaseTuples())
+                .map(this::timestampInvariantsViolationLevel)
+                .filter(CorruptionCheckViolation::raiseErrorAlert)
+                .mapEntries((k, v) -> Maps.immutableEntry(v, k))
+                .collectToSetMultimap();
+        return ImmutableCorruptionHealthReport.builder()
+                .violatingStatusesToNamespaceAndUseCase(namespacesExhibitingViolations)
+                .build();
+    }
+
+    private CorruptionCheckViolation timestampInvariantsViolationLevel(NamespaceAndUseCase namespaceAndUseCase) {
+        Stream<Long> expectedSortedTimestamps = KeyedStream.stream(getLearnerLogs(namespaceAndUseCase))
+                .map(PaxosValue::getData)
+                .filter(Objects::nonNull)
+                .mapEntries((sequence, timestamp) -> Maps.immutableEntry(sequence, PtBytes.toLong(timestamp)))
+                .entries()
+                .sorted(Comparator.comparingLong(Map.Entry::getKey))
+                .map(Map.Entry::getValue);
+        return StreamEx.of(expectedSortedTimestamps)
+                        .pairMap((first, second) -> first >= second)
+                        .anyMatch(x -> x)
+                ? CorruptionCheckViolation.CLOCK_WENT_BACKWARDS
+                : CorruptionCheckViolation.NONE;
+    }
+
+    private Map<Long, PaxosValue> getLearnerLogs(NamespaceAndUseCase namespaceAndUseCase) {
+        long minSeqToBeVerified = getMinSeqToBeVerified(namespaceAndUseCase);
+        LearnerUseCase useCase = LearnerUseCase.createLearnerUseCase(namespaceAndUseCase.useCase());
+
+        Map<Long, PaxosValue> learnerLogsSince = sqlitePaxosStateLogHistory.getLearnerLogsSince(
+                namespaceAndUseCase.namespace(), useCase, minSeqToBeVerified, LEARNER_LOG_BATCH_SIZE_LIMIT);
+
+        if (notEnoughLogsForVerification(learnerLogsSince)) {
+            resetMinSequenceToBeVerified(namespaceAndUseCase);
+        } else {
+            updateMinSeqToBeVerified(namespaceAndUseCase, learnerLogsSince);
+        }
+        return learnerLogsSince;
+    }
+
+    private boolean notEnoughLogsForVerification(Map<Long, PaxosValue> learnerLogsSince) {
+        return learnerLogsSince.size() <= 1;
+    }
+
+    private void updateMinSeqToBeVerified(NamespaceAndUseCase namespaceAndUseCase, Map<Long, PaxosValue> minSeq) {
+        minInclusiveSeqBoundsToBeVerified.put(namespaceAndUseCase, Collections.max(minSeq.keySet()));
+    }
+
+    private long getMinSeqToBeVerified(NamespaceAndUseCase namespaceAndUseCase) {
+        return minInclusiveSeqBoundsToBeVerified.computeIfAbsent(
+                namespaceAndUseCase, _u -> MIN_SEQUENCE_TO_BE_VERIFIED);
+    }
+
+    private void resetMinSequenceToBeVerified(NamespaceAndUseCase namespaceAndUseCase) {
+        minInclusiveSeqBoundsToBeVerified.put(namespaceAndUseCase, MIN_SEQUENCE_TO_BE_VERIFIED);
+    }
+
+    private ImmutableNamespaceAndUseCase getNamespaceAndUseCasePrefix(NamespaceAndUseCase namespaceAndUseCase) {
+        return ImmutableNamespaceAndUseCase.of(
+                namespaceAndUseCase.namespace(), UseCaseUtils.getPaxosUseCasePrefix(namespaceAndUseCase.useCase()));
+    }
+
+    private Set<NamespaceAndUseCase> getNamespaceAndUseCaseTuples() {
+        return sqlitePaxosStateLogHistory.getAllNamespaceAndUseCaseTuples().stream()
+                .map(this::getNamespaceAndUseCasePrefix)
+                .collect(Collectors.toSet());
+    }
+}

--- a/timelock-corruption-detection/src/main/java/com/palantir/timelock/history/sqlite/SqlitePaxosStateLogHistory.java
+++ b/timelock-corruption-detection/src/main/java/com/palantir/timelock/history/sqlite/SqlitePaxosStateLogHistory.java
@@ -82,6 +82,12 @@ public final class SqlitePaxosStateLogHistory {
                         querySequenceBounds.getUpperBoundInclusive())));
     }
 
+    public Map<Long, PaxosValue> getLearnerLogsSince(
+            Client namespace, LearnerUseCase learnerUseCase, long lowerBoundInclusive, int learnerLogBatchSizeLimit) {
+        return execute(dao -> dao.getLearnerLogsSince(
+                namespace, learnerUseCase.value(), lowerBoundInclusive, learnerLogBatchSizeLimit));
+    }
+
     public long getGreatestLogEntry(Client client, LearnerUseCase useCase) {
         return executeSqlitePaxosStateLogQuery(dao -> dao.getGreatestLogEntry(client, useCase.value()))
                 .orElse(PaxosAcceptor.NO_LOG_ENTRY);
@@ -99,11 +105,6 @@ public final class SqlitePaxosStateLogHistory {
         @SqlQuery("SELECT DISTINCT namespace, useCase FROM paxosLog")
         Set<NamespaceAndUseCase> getAllNamespaceAndUseCaseTuples();
 
-        //        TODO(snanda): For now, limit is based on approximation and has not been tested with remotes. We need
-        // to
-        //         revisit this once we have the remote history providers set up. Also, we may have to make it
-        // configurable to
-        //         accommodate the rate at which logs are being published.
         @SqlQuery("SELECT seq, val FROM paxosLog WHERE namespace = :namespace.value AND useCase = :useCase AND seq >="
                 + " :lowerBoundInclusive AND seq <= :upperBoundInclusive")
         Map<Long, PaxosValue> getLearnerLogsInRange(
@@ -119,5 +120,13 @@ public final class SqlitePaxosStateLogHistory {
                 @Bind("useCase") String useCase,
                 @Bind("lowerBoundInclusive") long lowerBoundInclusive,
                 @Bind("upperBoundInclusive") long upperBoundInclusive);
+
+        @SqlQuery("SELECT seq, val FROM paxosLog WHERE namespace = :namespace.value AND useCase = :useCase AND seq >="
+                + " :lowerBoundInclusive ORDER BY seq ASC LIMIT :limit")
+        Map<Long, PaxosValue> getLearnerLogsSince(
+                @BindPojo("namespace") Client namespace,
+                @Bind("useCase") String useCase,
+                @Bind("lowerBoundInclusive") long lowerBoundInclusive,
+                @Bind("limit") long learnerLogBatchSizeLimit);
     }
 }

--- a/timelock-corruption-detection/src/test/java/com/palantir/timelock/corruption/detection/LocalTimestampInvariantsVerifierTest.java
+++ b/timelock-corruption-detection/src/test/java/com/palantir/timelock/corruption/detection/LocalTimestampInvariantsVerifierTest.java
@@ -1,0 +1,94 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.timelock.corruption.detection;
+
+import static com.palantir.timelock.corruption.detection.LocalTimestampInvariantsVerifier.LEARNER_LOG_BATCH_SIZE_LIMIT;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+public class LocalTimestampInvariantsVerifierTest {
+    @Rule
+    public TimeLockCorruptionDetectionHelper helper = new TimeLockCorruptionDetectionHelper();
+
+    @Test
+    public void detectsClockWentBackwardsOnNode() {
+        helper.writeLogsOnDefaultLocalServer(1, LEARNER_LOG_BATCH_SIZE_LIMIT - 1);
+        helper.createTimestampInversion(5);
+        helper.assertClockGoesBackwardsInNextBatch();
+    }
+
+    @Test
+    public void detectsClockWentBackwardsForDiscontinuousLogs() {
+        helper.writeLogsOnDefaultLocalServer(1, 27);
+        helper.writeLogsOnDefaultLocalServer(LEARNER_LOG_BATCH_SIZE_LIMIT, LEARNER_LOG_BATCH_SIZE_LIMIT + 97);
+
+        helper.createTimestampInversion(72);
+        helper.assertClockGoesBackwardsInNextBatch();
+    }
+
+    @Test
+    public void detectsClockWentBackwardsAtBatchStart() {
+        helper.writeLogsOnDefaultLocalServer(1, LEARNER_LOG_BATCH_SIZE_LIMIT);
+        helper.createTimestampInversion(1);
+        helper.assertClockGoesBackwardsInNextBatch();
+    }
+
+    @Test
+    public void detectsClockWentBackwardsAtBatchEnd() {
+        helper.writeLogsOnDefaultLocalServer(1, LEARNER_LOG_BATCH_SIZE_LIMIT);
+        helper.createTimestampInversion(LEARNER_LOG_BATCH_SIZE_LIMIT - 1);
+        helper.assertClockGoesBackwardsInNextBatch();
+    }
+
+    @Test
+    public void detectsClockWentBackwardsStartOfNextBatch() {
+        helper.writeLogsOnDefaultLocalServer(1, 2 * LEARNER_LOG_BATCH_SIZE_LIMIT);
+        helper.createTimestampInversion(LEARNER_LOG_BATCH_SIZE_LIMIT);
+
+        // No signs of corruption in the first batch
+        helper.assertLocalTimestampInvariantsStandInNextBatch();
+
+        // Detects signs of corruption in the second batch
+        helper.assertClockGoesBackwardsInNextBatch();
+    }
+
+    @Test
+    public void detectsClockWentBackwardsInLaterBatch() {
+        helper.writeLogsOnDefaultLocalAndRemote(1, 2 * LEARNER_LOG_BATCH_SIZE_LIMIT);
+        helper.createTimestampInversion(3 * LEARNER_LOG_BATCH_SIZE_LIMIT / 2);
+
+        // No signs of corruption in the first batch
+        helper.assertLocalTimestampInvariantsStandInNextBatch();
+
+        // Detects signs of corruption in the second batch
+        helper.assertClockGoesBackwardsInNextBatch();
+    }
+
+    @Test
+    public void resetsProgressIfNotEnoughLogsForVerification() {
+        helper.createTimestampInversion(1);
+
+        // No signs of corruption since there aren't enough logs
+        helper.assertLocalTimestampInvariantsStandInNextBatch();
+
+        helper.writeLogsOnDefaultLocalServer(2, LEARNER_LOG_BATCH_SIZE_LIMIT);
+
+        // Detects signs of corruption in the now corrupt first batch of logs
+        helper.assertClockGoesBackwardsInNextBatch();
+    }
+}

--- a/timelock-corruption-detection/src/test/java/com/palantir/timelock/corruption/detection/TimeLockCorruptionDetectionHelper.java
+++ b/timelock-corruption-detection/src/test/java/com/palantir/timelock/corruption/detection/TimeLockCorruptionDetectionHelper.java
@@ -105,6 +105,31 @@ public final class TimeLockCorruptionDetectionHelper implements TestRule {
         return timeLockCorruptionTestSetup.createStatLogForNamespaceAndUseCase(namespaceAndUseCase);
     }
 
+    void assertClockGoesBackwardsInNextBatch() {
+        assertLocalTimestampInvariants(ImmutableSet.of(CorruptionCheckViolation.CLOCK_WENT_BACKWARDS));
+    }
+
+    void assertLocalTimestampInvariantsStandInNextBatch() {
+        assertLocalTimestampInvariants(ImmutableSet.of());
+    }
+
+    void createTimestampInversion(int round) {
+        PaxosSerializationTestUtils.writePaxosValue(
+                getDefaultLocalServer().learnerLog(),
+                round,
+                PaxosSerializationTestUtils.createPaxosValueForRoundAndData(round, round * 100));
+    }
+
+    private void assertLocalTimestampInvariants(Set<CorruptionCheckViolation> violations) {
+        CorruptionHealthReport corruptionHealthReport = timeLockCorruptionTestSetup
+                .getLocalTimestampInvariantsVerifier()
+                .timestampInvariantsHealthReport();
+        assertThat(corruptionHealthReport
+                        .violatingStatusesToNamespaceAndUseCase()
+                        .keySet())
+                .hasSameElementsAs(violations);
+    }
+
     private static void writeLogsOnServer(StateLogComponents server, int startInclusive, int endInclusive) {
         PaxosSerializationTestUtils.writeToLogs(
                 server.acceptorLog(), server.learnerLog(), startInclusive, endInclusive);

--- a/timelock-corruption-detection/src/test/java/com/palantir/timelock/corruption/detection/TimeLockCorruptionTestSetup.java
+++ b/timelock-corruption-detection/src/test/java/com/palantir/timelock/corruption/detection/TimeLockCorruptionTestSetup.java
@@ -50,6 +50,7 @@ public final class TimeLockCorruptionTestSetup implements TestRule {
     private DataSource remoteDataSource1;
     private DataSource remoteDataSource2;
     private PaxosLogHistoryProvider paxosLogHistoryProvider;
+    private LocalTimestampInvariantsVerifier localTimestampInvariantsVerifier;
 
     private StateLogComponents defaultLocalServer;
     private List<StateLogComponents> defaultRemoteServerList;
@@ -87,6 +88,7 @@ public final class TimeLockCorruptionTestSetup implements TestRule {
         defaultRemoteServerList = ImmutableList.of(
                 createLogComponentsForServer(remoteDataSource1), createLogComponentsForServer(remoteDataSource2));
         paxosLogHistoryProvider = paxosLogHistoryProvider();
+        localTimestampInvariantsVerifier = new LocalTimestampInvariantsVerifier(localDataSource);
     }
 
     private PaxosLogHistoryProvider paxosLogHistoryProvider() {
@@ -122,6 +124,10 @@ public final class TimeLockCorruptionTestSetup implements TestRule {
 
     List<StateLogComponents> getDefaultRemoteServerList() {
         return defaultRemoteServerList;
+    }
+
+    public LocalTimestampInvariantsVerifier getLocalTimestampInvariantsVerifier() {
+        return localTimestampInvariantsVerifier;
     }
 
     private static StateLogComponents createLogComponentsForServer(DataSource dataSource) {


### PR DESCRIPTION
**Goals (and why)**:
#5131 was reverted in #5181 as there were false positives. in #5131, it was (incorrectly) assumed the timestamps are strictly increasing with increasing sequence numbers. There is a possibility where consecutive seq numbers have the same timestamp. This is possible when a node gains leadership and does not know the value for latest sequence number - n . In this case, it forces agreement for nth sequence on the same value as that of (n-1)th or (n-2)th round (if value for n-1 is not known).
See PaxosTimestampBoundStore#getAgreedState for reference. 

**Implementation Description (bullets)**:
The invariant is now modified to - timestamps should not decrease with increasing sequence numbers.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added unit tests.
Also, I have validated the invariant on paxos logs from internal dev stack

**Concerns (what feedback would you like?)**:
Corner cases I might have missed?

**Where should we start reviewing?**:
All of the code is same as in #5131 except the inequality check in LocalTimestampInvariantsVerifier#timestampInvariantsViolationLevel

**Priority (whenever / two weeks / yesterday)**:
EOD tomorrow

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
