### PR TITLE
More errorprone checks enabled

### DIFF
--- a/atlasdb-api/src/test/java/com/palantir/atlasdb/config/LeaderConfigTest.java
+++ b/atlasdb-api/src/test/java/com/palantir/atlasdb/config/LeaderConfigTest.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.config;
 import java.util.Collections;
 import org.junit.Test;
 
+@SuppressWarnings("CheckReturnValue")
 public class LeaderConfigTest {
     @Test(expected = IllegalStateException.class)
     public void cannotCreateALeaderConfigWithNoLeaders() {

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTableManipulationIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTableManipulationIntegrationTest.java
@@ -30,7 +30,6 @@ import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.RetryLimitReachedException;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
-import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.After;
 import org.junit.ClassRule;
@@ -40,7 +39,7 @@ public class CassandraKeyValueServiceTableManipulationIntegrationTest {
     private static final TableReference UPPER_UPPER = TableReference.createFromFullyQualifiedName("TEST.TABLE");
     private static final TableReference LOWER_UPPER = TableReference.createFromFullyQualifiedName("test.TABLE");
     private static final TableReference LOWER_LOWER = TableReference.createFromFullyQualifiedName("test.table");
-    private static final List<TableReference> TABLES = ImmutableList.of(UPPER_UPPER, LOWER_UPPER, LOWER_LOWER);
+    private static final ImmutableList<TableReference> TABLES = ImmutableList.of(UPPER_UPPER, LOWER_UPPER, LOWER_LOWER);
     private static final byte[] BYTE_ARRAY = new byte[] {1};
     private static final byte[] SECOND_BYTE_ARRAY = new byte[] {2};
     private static final Cell CELL = Cell.create(BYTE_ARRAY, BYTE_ARRAY);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientImpl.java
@@ -24,7 +24,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import org.apache.cassandra.thrift.CASResult;
@@ -62,7 +61,7 @@ public class CassandraClientImpl implements CassandraClient {
     private volatile AtomicReference<Throwable> invalidated = new AtomicReference<>();
 
     // Client is considered to be invalid if a blacklisted exception is thrown.
-    private static final Set<Class> BLACKLISTED_EXCEPTIONS =
+    private static final ImmutableSet<Class> BLACKLISTED_EXCEPTIONS =
             ImmutableSet.of(TTransportException.class, TProtocolException.class, NoSuchElementException.class);
 
     public CassandraClientImpl(Cassandra.Client client) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConstants.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConstants.java
@@ -16,7 +16,6 @@
 package com.palantir.atlasdb.keyvalue.cassandra;
 
 import com.google.common.collect.ImmutableSet;
-import java.util.Set;
 
 public final class CassandraConstants {
     static final String DEFAULT_COMPRESSION_TYPE = "LZ4Compressor";
@@ -29,7 +28,7 @@ public final class CassandraConstants {
     static final String NETWORK_STRATEGY = "org.apache.cassandra.locator.NetworkTopologyStrategy";
 
     // They're both ordered, we just had to change the name to accommodate datastax client-side driver handling
-    static final Set<String> ALLOWED_PARTITIONERS = ImmutableSet.of(
+    static final ImmutableSet<String> ALLOWED_PARTITIONERS = ImmutableSet.of(
             "com.palantir.atlasdb.keyvalue.cassandra.dht.AtlasDbPartitioner",
             "com.palantir.atlasdb.keyvalue.cassandra.dht.AtlasDbOrderedPartitioner",
             "org.apache.cassandra.dht.ByteOrderedPartitioner");

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/HiddenTables.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/HiddenTables.java
@@ -18,14 +18,13 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
-import java.util.Set;
 
 public final class HiddenTables {
     private HiddenTables() {
         // utility
     }
 
-    private static final Set<TableReference> CASSANDRA_TABLES = ImmutableSet.of(
+    private static final ImmutableSet<TableReference> CASSANDRA_TABLES = ImmutableSet.of(
             AtlasDbConstants.TIMESTAMP_TABLE,
             AtlasDbConstants.DEFAULT_METADATA_TABLE,
             AtlasDbConstants.PERSISTED_LOCKS_TABLE);

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/QosCassandraClientTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/QosCassandraClientTest.java
@@ -67,7 +67,7 @@ public class QosCassandraClientTest {
     private static final TableReference TEST_TABLE = TableReference.createFromFullyQualifiedName("foo.bar");
     private static final SlicePredicate SLICE_PREDICATE =
             SlicePredicates.create(SlicePredicates.Range.ALL, SlicePredicates.Limit.ONE);
-    private static final Map<ByteBuffer, List<ColumnOrSuperColumn>> MULTIGET_RESULT =
+    private static final ImmutableMap<ByteBuffer, List<ColumnOrSuperColumn>> MULTIGET_RESULT =
             ImmutableMap.of(ROW_KEY, ImmutableList.of(new ColumnOrSuperColumn()));
     private static final ImmutableMap<ByteBuffer, Map<String, List<Mutation>>> BATCH_MUTATE_ARG =
             ImmutableMap.of(ROW_KEY, ImmutableMap.of());

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServicesSchemaConsensusTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServicesSchemaConsensusTest.java
@@ -27,8 +27,6 @@ import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.ImmutableDefaultConfig;
 import java.net.InetSocketAddress;
-import java.util.List;
-import java.util.Set;
 import org.apache.thrift.TException;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -38,7 +36,7 @@ public class CassandraKeyValueServicesSchemaConsensusTest {
     private static CassandraKeyValueServiceConfig waitingConfig = mock(CassandraKeyValueServiceConfig.class);
     private static CassandraClient client = mock(CassandraClient.class);
 
-    private static final Set<InetSocketAddress> FIVE_SERVERS = ImmutableSet.of(
+    private static final ImmutableSet<InetSocketAddress> FIVE_SERVERS = ImmutableSet.of(
             new InetSocketAddress("1", 1),
             new InetSocketAddress("2", 1),
             new InetSocketAddress("3", 1),
@@ -48,9 +46,9 @@ public class CassandraKeyValueServicesSchemaConsensusTest {
     private static final String VERSION_1 = "v1";
     private static final String VERSION_2 = "v2";
     private static final String VERSION_UNREACHABLE = "UNREACHABLE";
-    private static final List<String> QUORUM_OF_NODES = ImmutableList.of("1", "2", "3");
-    private static final List<String> REST_OF_NODES = ImmutableList.of("4", "5");
-    private static final List<String> ALL_NODES = ImmutableList.of("1", "2", "3", "4", "5");
+    private static final ImmutableList<String> QUORUM_OF_NODES = ImmutableList.of("1", "2", "3");
+    private static final ImmutableList<String> REST_OF_NODES = ImmutableList.of("4", "5");
+    private static final ImmutableList<String> ALL_NODES = ImmutableList.of("1", "2", "3", "4", "5");
 
     @BeforeClass
     public static void initializeMocks() {

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandlerTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandlerTest.java
@@ -25,8 +25,6 @@ import com.palantir.atlasdb.keyvalue.api.InsufficientConsistencyException;
 import java.net.SocketTimeoutException;
 import java.util.Collection;
 import java.util.NoSuchElementException;
-import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.cassandra.thrift.InvalidRequestException;
 import org.apache.cassandra.thrift.TimedOutException;
@@ -42,25 +40,26 @@ public class CassandraRequestExceptionHandlerTest {
     private static final int MAX_RETRIES_PER_HOST = 3;
     private static final int MAX_RETRIES_TOTAL = 6;
 
-    private static final Set<Exception> CONNECTION_EXCEPTIONS = ImmutableSet.of(
+    private static final ImmutableSet<Exception> CONNECTION_EXCEPTIONS = ImmutableSet.of(
             new SocketTimeoutException(MESSAGE),
             new CassandraClientFactory.ClientCreationFailedException(MESSAGE, CAUSE));
-    private static final Set<Exception> TRANSIENT_EXCEPTIONS = ImmutableSet.of(new TTransportException());
-    private static final Set<Exception> INDICATIVE_OF_CASSANDRA_LOAD_EXCEPTIONS = ImmutableSet.of(
+    private static final ImmutableSet<Exception> TRANSIENT_EXCEPTIONS = ImmutableSet.of(new TTransportException());
+    private static final ImmutableSet<Exception> INDICATIVE_OF_CASSANDRA_LOAD_EXCEPTIONS = ImmutableSet.of(
             new NoSuchElementException(),
             new TimedOutException(),
             new UnavailableException(),
             new InsufficientConsistencyException(MESSAGE));
-    private static final Set<Exception> FAST_FAILOVER_EXCEPTIONS = ImmutableSet.of(new InvalidRequestException());
-    private static final Set<Exception> ALL_EXCEPTIONS = Stream.of(
+    private static final ImmutableSet<Exception> FAST_FAILOVER_EXCEPTIONS =
+            ImmutableSet.of(new InvalidRequestException());
+    private static final ImmutableSet<Exception> ALL_EXCEPTIONS = Stream.of(
                     CONNECTION_EXCEPTIONS,
                     TRANSIENT_EXCEPTIONS,
                     INDICATIVE_OF_CASSANDRA_LOAD_EXCEPTIONS,
                     FAST_FAILOVER_EXCEPTIONS)
             .flatMap(Collection::stream)
-            .collect(Collectors.toSet());
+            .collect(ImmutableSet.toImmutableSet());
 
-    private static final Set<Exception> NOT_IMPLICATING_NODES_EXCEPTIONS =
+    private static final ImmutableSet<Exception> NOT_IMPLICATING_NODES_EXCEPTIONS =
             ImmutableSet.of(new InsufficientConsistencyException(MESSAGE), new NoSuchElementException());
 
     private boolean currentMode = true;

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtilsTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtilsTest.java
@@ -25,7 +25,6 @@ import com.google.common.collect.ImmutableMap;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.util.Pair;
 import java.util.List;
-import java.util.Map;
 import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.CqlResult;
 import org.apache.cassandra.thrift.CqlRow;
@@ -47,7 +46,7 @@ public class CassandraTimestampUtilsTest {
     private static final byte[] CQL_FAILURE = {0};
     private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
 
-    private static final Map<String, Pair<byte[], byte[]>> CAS_MAP_TWO_COLUMNS =
+    private static final ImmutableMap<String, Pair<byte[], byte[]>> CAS_MAP_TWO_COLUMNS =
             ImmutableMap.<String, Pair<byte[], byte[]>>builder()
                     .put(COLUMN_NAME_1, Pair.create(EMPTY_BYTE_ARRAY, VALUE_1))
                     .put(COLUMN_NAME_2, Pair.create(EMPTY_BYTE_ARRAY, VALUE_2))

--- a/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestKvsMigrationCommand.java
+++ b/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestKvsMigrationCommand.java
@@ -18,7 +18,6 @@ package com.palantir.atlasdb.cli.command;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ObjectArrays;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cli.runner.AbstractTestRunner;
@@ -132,11 +131,9 @@ public class TestKvsMigrationCommand {
         for (int i = 0; i < numTables; i++) {
             TableReference table = getTableRef(i);
             services.getTransactionManager().runTaskThrowOnConflict(t -> {
-                ImmutableSet.Builder<Cell> toRead = ImmutableSet.builder();
                 ImmutableMap.Builder<Cell, byte[]> expectedBuilder = ImmutableMap.builder();
                 for (int j = 0; j < numEntriesPerTable; j++) {
                     Cell cell = Cell.create(PtBytes.toBytes("row" + j), PtBytes.toBytes("col"));
-                    toRead.add(cell);
                     expectedBuilder.put(cell, PtBytes.toBytes("val" + j));
                 }
                 Map<Cell, byte[]> expected = expectedBuilder.build();

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -23,7 +23,6 @@ import com.palantir.atlasdb.protos.generated.TableMetadataPersistence.LogSafety;
 import com.palantir.atlasdb.spi.AtlasDbFactory;
 import com.palantir.atlasdb.table.description.TableMetadata;
 import com.palantir.atlasdb.transaction.impl.TransactionConstants;
-import java.util.Set;
 
 public final class AtlasDbConstants {
     private AtlasDbConstants() {
@@ -98,7 +97,7 @@ public final class AtlasDbConstants {
     public static final long DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS = 60_000;
     public static final int THRESHOLD_FOR_LOGGING_LARGE_NUMBER_OF_TRANSACTION_LOOKUPS = 10_000_000;
 
-    public static final Set<TableReference> HIDDEN_TABLES = ImmutableSet.of(
+    public static final ImmutableSet<TableReference> HIDDEN_TABLES = ImmutableSet.of(
             TransactionConstants.TRANSACTION_TABLE,
             TransactionConstants.TRANSACTIONS2_TABLE,
             PUNCH_TABLE,
@@ -116,14 +115,14 @@ public final class AtlasDbConstants {
     /**
      * Tables that must always be on a KVS that supports an atomic putUnlessExists operation.
      */
-    public static final Set<TableReference> ATOMIC_TABLES = ImmutableSet.of(
+    public static final ImmutableSet<TableReference> ATOMIC_TABLES = ImmutableSet.of(
             TransactionConstants.TRANSACTION_TABLE,
             TransactionConstants.TRANSACTIONS2_TABLE,
             NAMESPACE_TABLE,
             PERSISTED_LOCKS_TABLE,
             COORDINATION_TABLE);
 
-    public static final Set<TableReference> TABLES_KNOWN_TO_BE_POORLY_DESIGNED =
+    public static final ImmutableSet<TableReference> TABLES_KNOWN_TO_BE_POORLY_DESIGNED =
             ImmutableSet.of(TableReference.createWithEmptyNamespace("resync_object"));
 
     public static final long DEFAULT_TRANSACTION_READ_TIMEOUT = 60 * 60 * 1000; // one hour

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbMetricNames.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbMetricNames.java
@@ -16,7 +16,6 @@
 package com.palantir.atlasdb;
 
 import com.google.common.collect.ImmutableSet;
-import java.util.Set;
 
 public final class AtlasDbMetricNames {
 
@@ -65,7 +64,7 @@ public final class AtlasDbMetricNames {
     public static final String LAG_MILLIS = "millisSinceLastSweptTs";
     public static final String BATCH_SIZE_MEAN = "batchSizeMean";
     public static final String SWEEP_DELAY = "sweepDelay";
-    public static final Set<String> TARGETED_SWEEP_PROGRESS_METRIC_NAMES = ImmutableSet.of(
+    public static final ImmutableSet<String> TARGETED_SWEEP_PROGRESS_METRIC_NAMES = ImmutableSet.of(
             ENQUEUED_WRITES,
             ENTRIES_READ,
             TOMBSTONES_PUT,

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/ImportRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/ImportRenderer.java
@@ -23,7 +23,8 @@ import java.util.SortedSet;
 import java.util.stream.Collectors;
 
 public class ImportRenderer extends Renderer {
-    private static final List<String> IMPORT_PREFIXES = ImmutableList.of("java.", "javax.", "org.", "com.", "net.");
+    private static final ImmutableList<String> IMPORT_PREFIXES =
+            ImmutableList.of("java.", "javax.", "org.", "com.", "net.");
     private final Collection<Class<?>> imports;
 
     public ImportRenderer(Renderer parent, Collection<Class<?>> imports) {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionConstants.java
@@ -22,7 +22,6 @@ import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
 import com.palantir.atlasdb.ptobject.EncodingUtils;
 import com.palantir.atlasdb.table.description.TableMetadata;
 import com.palantir.atlasdb.table.description.ValueType;
-import java.util.Set;
 
 public final class TransactionConstants {
     private TransactionConstants() {
@@ -45,7 +44,7 @@ public final class TransactionConstants {
 
     public static final int DIRECT_ENCODING_TRANSACTIONS_SCHEMA_VERSION = 1;
     public static final int TICKETS_ENCODING_TRANSACTIONS_SCHEMA_VERSION = 2;
-    public static final Set<Integer> SUPPORTED_TRANSACTIONS_SCHEMA_VERSIONS =
+    public static final ImmutableSet<Integer> SUPPORTED_TRANSACTIONS_SCHEMA_VERSIONS =
             ImmutableSet.of(DIRECT_ENCODING_TRANSACTIONS_SCHEMA_VERSION, TICKETS_ENCODING_TRANSACTIONS_SCHEMA_VERSION);
 
     public static byte[] getValueForTimestamp(long transactionTimestamp) {

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/logging/LoggingArgsTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/logging/LoggingArgsTest.java
@@ -35,7 +35,6 @@ import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import java.util.List;
-import java.util.Map;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -45,14 +44,14 @@ public class LoggingArgsTest {
     private static final String ARG_NAME = "argName";
     private static final TableReference SAFE_TABLE_REFERENCE = TableReference.createFromFullyQualifiedName("foo.safe");
     private static final TableReference UNSAFE_TABLE_REFERENCE = TableReference.createFromFullyQualifiedName("foo.bar");
-    private static final List<TableReference> LIST_OF_SAFE_AND_UNSAFE_TABLE_REFERENCES =
-            Lists.newArrayList(SAFE_TABLE_REFERENCE, UNSAFE_TABLE_REFERENCE);
+    private static final ImmutableList<TableReference> LIST_OF_SAFE_AND_UNSAFE_TABLE_REFERENCES =
+            ImmutableList.of(SAFE_TABLE_REFERENCE, UNSAFE_TABLE_REFERENCE);
     private static final byte[] SAFE_TABLE_METADATA = AtlasDbConstants.GENERIC_TABLE_METADATA;
     private static final byte[] UNSAFE_TABLE_METADATA = TableMetadata.builder()
             .nameLogSafety(TableMetadataPersistence.LogSafety.UNSAFE)
             .build()
             .persistToBytes();
-    private static final Map<TableReference, byte[]> TABLE_REF_TO_METADATA = ImmutableMap.of(
+    private static final ImmutableMap<TableReference, byte[]> TABLE_REF_TO_METADATA = ImmutableMap.of(
             SAFE_TABLE_REFERENCE, SAFE_TABLE_METADATA,
             UNSAFE_TABLE_REFERENCE, UNSAFE_TABLE_METADATA);
 

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/tracing/CloseableTraceTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/tracing/CloseableTraceTest.java
@@ -42,7 +42,7 @@ public class CloseableTraceTest {
     public void after() throws Exception {
         Tracer.unsubscribe(NAME);
         Tracer.setSampler(AlwaysSampler.INSTANCE);
-        Tracer.completeSpan();
+        Tracer.fastCompleteSpan();
     }
 
     @Test

--- a/atlasdb-commons/src/test/java/com/palantir/remoting/HeaderAccessUtilsTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/remoting/HeaderAccessUtilsTest.java
@@ -34,11 +34,12 @@ public class HeaderAccessUtilsTest {
     private static final ImmutableList<String> VALUE_2 = ImmutableList.of("ls", "du", "cut");
     private static final ImmutableList<String> VALUE_3 = ImmutableList.of();
 
-    private static final Map<String, Collection<String>> HEADERS = ImmutableMap.<String, Collection<String>>builder()
-            .put(KEY_1, VALUE_1)
-            .put(KEY_2, VALUE_2)
-            .put(KEY_3, VALUE_3)
-            .build();
+    private static final ImmutableMap<String, Collection<String>> HEADERS =
+            ImmutableMap.<String, Collection<String>>builder()
+                    .put(KEY_1, VALUE_1)
+                    .put(KEY_2, VALUE_2)
+                    .put(KEY_3, VALUE_3)
+                    .build();
 
     @Test
     public void caseInsensitiveContainsEntryIgnoresCaseOnKeys() {

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbConfigTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbConfigTest.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+@SuppressWarnings("CheckReturnValue")
 public class AtlasDbConfigTest {
     private static final KeyValueServiceConfig KVS_CONFIG_WITHOUT_NAMESPACE = mock(KeyValueServiceConfig.class);
     private static final KeyValueServiceConfig KVS_CONFIG_WITH_OTHER_NAMESPACE = mock(KeyValueServiceConfig.class);

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/PersistentStorageConfigTests.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/PersistentStorageConfigTests.java
@@ -29,6 +29,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+@SuppressWarnings("CheckReturnValue")
 public final class PersistentStorageConfigTests {
     private static final File CURRENT_WORKING_DIR = Files.currentFolder();
 

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/TimeLockClientConfigTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/TimeLockClientConfigTest.java
@@ -64,11 +64,13 @@ public class TimeLockClientConfigTest {
     }
 
     @Test
+    @SuppressWarnings("CheckReturnValue")
     public void canCreateWithoutClientSpecified() {
         ImmutableTimeLockClientConfig.builder().serversList(SERVERS_LIST).build();
     }
 
     @Test
+    @SuppressWarnings("CheckReturnValue")
     public void tmelockClientCannotBeAnEmptyString() {
         assertThatThrownBy(() -> ImmutableTimeLockClientConfig.builder()
                         .client("")

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/LeadersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/LeadersTest.java
@@ -35,7 +35,6 @@ import com.palantir.paxos.PaxosValue;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Supplier;
 import org.junit.Test;
 
@@ -44,7 +43,8 @@ public class LeadersTest {
     private static final SslConfiguration SSL_CONFIGURATION =
             SslConfiguration.of(Paths.get("var/security/trustStore.jks"));
     private static final TrustContext TRUST_CONTEXT = SslSocketFactories.createTrustContext(SSL_CONFIGURATION);
-    private static final Set<String> REMOTE_SERVICE_ADDRESSES = ImmutableSet.of("https://foo:1234", "https://bar:5678");
+    private static final ImmutableSet<String> REMOTE_SERVICE_ADDRESSES =
+            ImmutableSet.of("https://foo:1234", "https://bar:5678");
     private static final Supplier<RemotingClientConfig> REMOTING_CLIENT_CONFIG = () -> RemotingClientConfigs.DEFAULT;
 
     @Test

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
@@ -367,7 +367,7 @@ public class TransactionManagersTest {
                 .keyValueService(new InMemoryAtlasDbConfig())
                 .defaultLockTimeoutSeconds((int) expectedTimeout.getTime())
                 .build();
-        TransactionManagers.builder()
+        TransactionManager tm = TransactionManagers.builder()
                 .config(atlasDbConfig)
                 .userAgent(USER_AGENT)
                 .globalMetricsRegistry(new MetricRegistry())
@@ -382,6 +382,7 @@ public class TransactionManagersTest {
                         ImmutableSortedMap.of(StringLockDescriptor.of("foo"), LockMode.WRITE))
                 .build();
         assertThat(lockRequest.getLockTimeout()).isEqualTo(expectedTimeout);
+        tm.close();
     }
 
     @Test
@@ -449,7 +450,7 @@ public class TransactionManagersTest {
                 .build();
 
         MetricRegistry metrics = new MetricRegistry();
-        TransactionManagers.builder()
+        TransactionManager tm = TransactionManagers.builder()
                 .config(atlasDbConfig)
                 .userAgent(USER_AGENT)
                 .globalMetricsRegistry(metrics)
@@ -459,6 +460,7 @@ public class TransactionManagersTest {
                 .serializable();
         assertThat(metrics.getNames().stream().anyMatch(metricName -> metricName.contains(USER_AGENT_NAME)))
                 .isFalse();
+        tm.close();
     }
 
     @Test
@@ -561,7 +563,7 @@ public class TransactionManagersTest {
             assertThatCode(localOrRemoteLock::currentTimeMillis)
                     .as("proxy correctly handles interrupts")
                     .isInstanceOf(SafeIllegalStateException.class);
-            assertThat(Thread.currentThread().isInterrupted());
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
         } finally {
             // clear the interrupt flag to avoid affecting future tests
             Thread.interrupted();

--- a/atlasdb-conjure/src/test/java/com/palantir/atlasdb/http/v2/DialogueClientOptionsTest.java
+++ b/atlasdb-conjure/src/test/java/com/palantir/atlasdb/http/v2/DialogueClientOptionsTest.java
@@ -28,13 +28,12 @@ import com.palantir.conjure.java.api.config.service.ServicesConfigBlock;
 import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
 import java.nio.file.Paths;
-import java.util.List;
 import org.junit.Test;
 
 public class DialogueClientOptionsTest {
     private static final String SERVICE_NAME = "service";
     private static final UserAgent USER_AGENT = UserAgent.of(UserAgent.Agent.of(SERVICE_NAME, "1.2.3"));
-    private static final List<String> SERVERS = ImmutableList.of("apple", "banana", "cherry", "dewberry");
+    private static final ImmutableList<String> SERVERS = ImmutableList.of("apple", "banana", "cherry", "dewberry");
     private static final SslConfiguration SSL_CONFIGURATION = SslConfiguration.of(Paths.get("a", "b"));
 
     private static final AuxiliaryRemotingParameters REMOTING_PARAMETERS_EXTENDED_TIMEOUT =

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/InterceptorConnection.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/InterceptorConnection.java
@@ -26,7 +26,6 @@ import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.Statement;
-import java.util.Map;
 
 /**
  * Allows you to intercept and override methods in {@link Connection}.
@@ -34,7 +33,7 @@ import java.util.Map;
 public final class InterceptorConnection extends AbstractInvocationHandler implements InvocationHandler {
     private final Connection delegate;
 
-    private static final Map<String, Class<? extends Statement>> INTERCEPT_METHODS =
+    private static final ImmutableMap<String, Class<? extends Statement>> INTERCEPT_METHODS =
             ImmutableMap.<String, Class<? extends Statement>>builder()
                     .put("createStatement", Statement.class)
                     .put("prepareCall", CallableStatement.class)

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
@@ -63,7 +63,6 @@ import io.dropwizard.jersey.optional.EmptyOptionalException;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
@@ -76,7 +75,8 @@ public class AtlasDbEteServer extends Application<AtlasDbEteConfiguration> {
     private static final Logger log = LoggerFactory.getLogger(AtlasDbEteServer.class);
     private static final long CREATE_TRANSACTION_MANAGER_MAX_WAIT_TIME_SECS = 60;
     private static final long CREATE_TRANSACTION_MANAGER_POLL_INTERVAL_SECS = 5;
-    private static final Set<Schema> ETE_SCHEMAS = ImmutableSet.of(TodoSchema.getSchema(), BlobSchema.getSchema());
+    private static final ImmutableSet<Schema> ETE_SCHEMAS =
+            ImmutableSet.of(TodoSchema.getSchema(), BlobSchema.getSchema());
     private static final Follower FOLLOWER = CleanupFollower.create(ETE_SCHEMAS);
 
     public static void main(String[] args) throws Exception {

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/CassandraMultinodeTestSuite.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/CassandraMultinodeTestSuite.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.containers.CassandraEnvironment;
 import com.palantir.atlasdb.ete.coordination.CoordinationEteTest;
 import com.palantir.atlasdb.ete.coordination.MultipleSchemaVersionsCoordinationEteTest;
-import java.util.List;
 import org.junit.ClassRule;
 import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
@@ -34,7 +33,7 @@ import org.junit.runners.Suite;
     MultipleSchemaVersionsCoordinationEteTest.class
 })
 public class CassandraMultinodeTestSuite extends EteSetup {
-    private static final List<String> CLIENTS = ImmutableList.of("ete1", "ete2", "ete3");
+    private static final ImmutableList<String> CLIENTS = ImmutableList.of("ete1", "ete2", "ete3");
 
     @ClassRule
     public static final RuleChain COMPOSITION_SETUP = EteSetup.setupComposition(

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/CassandraNoLeaderTestSuite.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/CassandraNoLeaderTestSuite.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.containers.CassandraEnvironment;
 import com.palantir.atlasdb.ete.coordination.CoordinationEteTest;
 import com.palantir.atlasdb.ete.coordination.MultipleSchemaVersionsCoordinationEteTest;
-import java.util.List;
 import org.junit.ClassRule;
 import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
@@ -36,7 +35,7 @@ import org.junit.runners.Suite;
     LockWithoutTimelockEteTest.class
 })
 public class CassandraNoLeaderTestSuite extends EteSetup {
-    private static final List<String> CLIENTS = ImmutableList.of("ete1");
+    private static final ImmutableList<String> CLIENTS = ImmutableList.of("ete1");
 
     @ClassRule
     public static final RuleChain COMPOSITION_SETUP = EteSetup.setupComposition(

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/CassandraTimeLockTestSuite.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/CassandraTimeLockTestSuite.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.containers.CassandraEnvironment;
 import com.palantir.atlasdb.ete.coordination.CoordinationEteTest;
 import com.palantir.atlasdb.ete.coordination.MultipleSchemaVersionsCoordinationEteTest;
-import java.util.List;
 import org.junit.ClassRule;
 import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
@@ -37,7 +36,7 @@ import org.junit.runners.Suite;
     LockWatchEteTest.class
 })
 public class CassandraTimeLockTestSuite extends EteSetup {
-    private static final List<String> CLIENTS = ImmutableList.of("ete1");
+    private static final ImmutableList<String> CLIENTS = ImmutableList.of("ete1");
 
     @ClassRule
     public static final RuleChain COMPOSITION_SETUP = EteSetup.setupCompositionWithTimelock(

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/DbKvsTestSuite.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/DbKvsTestSuite.java
@@ -17,7 +17,6 @@ package com.palantir.atlasdb.ete;
 
 import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.ete.coordination.CoordinationEteTest;
-import java.util.List;
 import org.junit.ClassRule;
 import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
@@ -31,7 +30,7 @@ import org.junit.runners.Suite;
     LockWithoutTimelockEteTest.class
 })
 public class DbKvsTestSuite extends EteSetup {
-    private static final List<String> CLIENTS = ImmutableList.of("ete1", "ete2", "ete3");
+    private static final ImmutableList<String> CLIENTS = ImmutableList.of("ete1", "ete2", "ete3");
 
     @ClassRule
     public static final RuleChain COMPOSITION_SETUP =

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/MultiCassandraDoubleNodeDownEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/MultiCassandraDoubleNodeDownEteTest.java
@@ -20,16 +20,15 @@ import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.todo.ImmutableTodo;
 import com.palantir.atlasdb.todo.Todo;
 import com.palantir.atlasdb.todo.TodoResource;
-import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class MultiCassandraDoubleNodeDownEteTest {
-    private static final Set<String> ALL_CASSANDRA_NODES = ImmutableSet.of("cassandra1", "cassandra2", "cassandra3");
-    private static final List<String> CASSANDRA_NODES_TO_KILL = ImmutableList.of("cassandra1", "cassandra2");
+    private static final ImmutableSet<String> ALL_CASSANDRA_NODES =
+            ImmutableSet.of("cassandra1", "cassandra2", "cassandra3");
+    private static final ImmutableList<String> CASSANDRA_NODES_TO_KILL = ImmutableList.of("cassandra1", "cassandra2");
 
     @BeforeClass
     public static void shutdownCassandraNode() {

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/MultiCassandraSingleNodeDownEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/MultiCassandraSingleNodeDownEteTest.java
@@ -23,7 +23,6 @@ import com.palantir.atlasdb.todo.Todo;
 import com.palantir.atlasdb.todo.TodoResource;
 import com.palantir.flake.FlakeRetryingRule;
 import com.palantir.flake.ShouldRetry;
-import java.util.Set;
 import java.util.UUID;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -33,7 +32,8 @@ import org.junit.rules.TestRule;
 
 @ShouldRetry // In some cases we obtain a TTransportException from Cassandra, probably because we don't wait enough?
 public class MultiCassandraSingleNodeDownEteTest {
-    private static final Set<String> ALL_CASSANDRA_NODES = ImmutableSet.of("cassandra1", "cassandra2", "cassandra3");
+    private static final ImmutableSet<String> ALL_CASSANDRA_NODES =
+            ImmutableSet.of("cassandra1", "cassandra2", "cassandra3");
     private static final String CASSANDRA_NODE_TO_KILL = "cassandra1";
 
     @Rule

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/MultiCassandraTestSuite.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/MultiCassandraTestSuite.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.containers.CassandraEnvironment;
 import com.palantir.atlasdb.ete.coordination.CoordinationEteTest;
 import com.palantir.atlasdb.ete.coordination.MultipleSchemaVersionsCoordinationEteTest;
-import java.util.List;
 import org.junit.ClassRule;
 import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
@@ -37,7 +36,7 @@ import org.junit.runners.Suite;
     LockWithoutTimelockEteTest.class
 })
 public class MultiCassandraTestSuite extends EteSetup {
-    private static final List<String> CLIENTS = ImmutableList.of("ete1");
+    private static final ImmutableList<String> CLIENTS = ImmutableList.of("ete1");
 
     @ClassRule
     public static final RuleChain COMPOSITION_SETUP = EteSetup.setupComposition(

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/PostgresDbPersistenceTimeLockTestSuite.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/PostgresDbPersistenceTimeLockTestSuite.java
@@ -18,7 +18,6 @@ package com.palantir.atlasdb.ete;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.atlasdb.ete.coordination.CoordinationEteTest;
-import java.util.List;
 import org.junit.ClassRule;
 import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
@@ -33,7 +32,7 @@ import org.junit.runners.Suite;
     LockWatchEteTest.class
 })
 public class PostgresDbPersistenceTimeLockTestSuite extends EteSetup {
-    private static final List<String> CLIENTS = ImmutableList.of("ete1");
+    private static final ImmutableList<String> CLIENTS = ImmutableList.of("ete1");
 
     @ClassRule
     public static final RuleChain COMPOSITION_SETUP = EteSetup.setupCompositionWithTimelock(

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/persistence/InternalSchemaMetadataPayloadCodec.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/persistence/InternalSchemaMetadataPayloadCodec.java
@@ -24,7 +24,6 @@ import com.palantir.conjure.java.serialization.ObjectMappers;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.io.IOException;
-import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -40,7 +39,7 @@ public final class InternalSchemaMetadataPayloadCodec {
      * Mapping of supported schema versions to transforms that are able to deserialize serialized representations of
      * the metadata object associated with that version to a common {@link InternalSchemaMetadata} object.
      */
-    private static final Map<Integer, Function<byte[], InternalSchemaMetadata>> SUPPORTED_DECODERS =
+    private static final ImmutableMap<Integer, Function<byte[], InternalSchemaMetadata>> SUPPORTED_DECODERS =
             ImmutableMap.of(LATEST_VERSION, InternalSchemaMetadataPayloadCodec::decodeViaJson);
 
     private static final ObjectMapper OBJECT_MAPPER = ObjectMappers.newServerObjectMapper();

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/metrics/SweepOutcomeMetrics.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/metrics/SweepOutcomeMetrics.java
@@ -35,8 +35,8 @@ import org.immutables.value.Value;
 
 @Value.Enclosing
 public final class SweepOutcomeMetrics {
-    public static final List<SweepOutcome> LEGACY_OUTCOMES = Arrays.asList(SweepOutcome.values());
-    public static final List<SweepOutcome> TARGETED_OUTCOMES = ImmutableList.of(
+    public static final ImmutableList<SweepOutcome> LEGACY_OUTCOMES = ImmutableList.copyOf(SweepOutcome.values());
+    public static final ImmutableList<SweepOutcome> TARGETED_OUTCOMES = ImmutableList.of(
             SweepOutcome.NOT_ENOUGH_DB_NODES_ONLINE,
             SweepOutcome.SUCCESS,
             SweepOutcome.ERROR,

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheIntegrationTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheIntegrationTest.java
@@ -99,13 +99,14 @@ public class LockWatchEventCacheIntegrationTest {
     private static final LockWatchStateUpdate SUCCESS = LockWatchStateUpdate.success(
             LEADER, SUCCESS_VERSION, ImmutableList.of(WATCH_EVENT, UNLOCK_EVENT, LOCK_EVENT));
     private static final long START_TS = 1L;
-    private static final Set<TransactionUpdate> COMMIT_UPDATE = ImmutableSet.of(ImmutableTransactionUpdate.builder()
-            .startTs(START_TS)
-            .commitTs(5L)
-            .writesToken(COMMIT_TOKEN)
-            .build());
-    private static final Set<Long> TIMESTAMPS = ImmutableSet.of(START_TS);
-    private static final Set<Long> TIMESTAMPS_2 = ImmutableSet.of(16L);
+    private static final ImmutableSet<TransactionUpdate> COMMIT_UPDATE =
+            ImmutableSet.of(ImmutableTransactionUpdate.builder()
+                    .startTs(START_TS)
+                    .commitTs(5L)
+                    .writesToken(COMMIT_TOKEN)
+                    .build());
+    private static final ImmutableSet<Long> TIMESTAMPS = ImmutableSet.of(START_TS);
+    private static final ImmutableSet<Long> TIMESTAMPS_2 = ImmutableSet.of(16L);
     private static final String BASE = "src/test/resources/lockwatch-event-cache-output/";
     private static final Mode MODE = Mode.CI;
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/CellsSweeperShould.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/CellsSweeperShould.java
@@ -29,7 +29,6 @@ import static org.mockito.Mockito.verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Multimap;
 import com.palantir.atlasdb.cleaner.Follower;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
@@ -37,7 +36,6 @@ import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import java.nio.charset.StandardCharsets;
-import java.util.Set;
 import org.junit.Test;
 import org.mockito.InOrder;
 
@@ -46,8 +44,8 @@ public class CellsSweeperShould {
     private static final Cell SINGLE_CELL =
             Cell.create("cellRow".getBytes(StandardCharsets.UTF_8), "cellCol".getBytes(StandardCharsets.UTF_8));
 
-    private static final Set<Cell> SINGLE_CELL_SET = ImmutableSet.of(SINGLE_CELL);
-    private static final Multimap<Cell, Long> SINGLE_CELL_TS_PAIR = ImmutableMultimap.<Cell, Long>builder()
+    private static final ImmutableSet<Cell> SINGLE_CELL_SET = ImmutableSet.of(SINGLE_CELL);
+    private static final ImmutableMultimap<Cell, Long> SINGLE_CELL_TS_PAIR = ImmutableMultimap.<Cell, Long>builder()
             .putAll(
                     Cell.create(
                             "cellPairRow".getBytes(StandardCharsets.UTF_8),

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweepBatchConfigTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweepBatchConfigTest.java
@@ -19,6 +19,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+@SuppressWarnings("CheckReturnValue")
 public class SweepBatchConfigTest {
     @Rule
     public ExpectedException exception = ExpectedException.none();

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweepableCellFilterParametrizedTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweepableCellFilterParametrizedTest.java
@@ -35,7 +35,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,13 +43,13 @@ import org.junit.runners.Parameterized;
 
 @RunWith(Parameterized.class)
 public class SweepableCellFilterParametrizedTest {
-    private static final Set<Boolean> BOOLEANS = ImmutableSet.of(true, false);
+    private static final ImmutableSet<Boolean> BOOLEANS = ImmutableSet.of(true, false);
 
     private static final Cell SINGLE_CELL =
             Cell.create("cellRow".getBytes(StandardCharsets.UTF_8), "cellCol".getBytes(StandardCharsets.UTF_8));
-    private static final List<Long> COMMITTED_BEFORE = ImmutableList.of(10L, 20L, 30L, 40L);
-    private static final List<Long> COMMITTED_AFTER = ImmutableList.of(13L, 23L, 33L);
-    private static final List<Long> ABORTED_TS = ImmutableList.of(16L, 26L, 36L);
+    private static final ImmutableList<Long> COMMITTED_BEFORE = ImmutableList.of(10L, 20L, 30L, 40L);
+    private static final ImmutableList<Long> COMMITTED_AFTER = ImmutableList.of(13L, 23L, 33L);
+    private static final ImmutableList<Long> ABORTED_TS = ImmutableList.of(16L, 26L, 36L);
     private static final long SWEEP_TS = 50L;
     private static final long LAST_TS = SWEEP_TS - 5;
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/metrics/LegacySweepMetricsTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/metrics/LegacySweepMetricsTest.java
@@ -42,7 +42,7 @@ public class LegacySweepMetricsTest {
     private static final String CELLS_SWEPT = AtlasDbMetricNames.CELLS_SWEPT;
     private static final String TIME_SPENT_SWEEPING = AtlasDbMetricNames.TIME_SPENT_SWEEPING;
 
-    private static final List<String> CURRENT_VALUE_LONG_METRIC_NAMES =
+    private static final ImmutableList<String> CURRENT_VALUE_LONG_METRIC_NAMES =
             ImmutableList.of(CELLS_EXAMINED, CELLS_SWEPT, TIME_SPENT_SWEEPING);
 
     private static final SweepResults SWEEP_RESULTS = SweepResults.builder()

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepableCellsTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepableCellsTest.java
@@ -109,10 +109,10 @@ public class SweepableCellsTest extends AbstractSweepQueueTest {
     @Test
     public void readDoesNotReturnValuesFromUncommittedTransactionsAndAbortsThem() {
         writeToDefaultCellUncommitted(sweepableCells, TS + 1, TABLE_CONS);
-        assertThat(!isTransactionAborted(TS + 1));
+        assertThat(isTransactionAborted(TS + 1)).isFalse();
 
         SweepBatch conservativeBatch = readConservative(shardCons, TS_FINE_PARTITION, TS - 1, SMALL_SWEEP_TS);
-        assertThat(isTransactionAborted(TS + 1));
+        assertThat(isTransactionAborted(TS + 1)).isTrue();
         assertThat(conservativeBatch.writes()).containsExactly(WriteInfo.write(TABLE_CONS, DEFAULT_CELL, TS));
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/WriteInfoPartitionerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/WriteInfoPartitionerTest.java
@@ -47,7 +47,7 @@ public class WriteInfoPartitionerTest {
     private static final TableReference CONSERVATIVE = getTableRef("conservative");
     private static final TableReference CONSERVATIVE2 = getTableRef("conservative2");
     private static final TableReference THOROUGH = getTableRef("thorough");
-    private static final Map<TableReference, byte[]> METADATA_MAP = ImmutableMap.of(
+    private static final ImmutableMap<TableReference, byte[]> METADATA_MAP = ImmutableMap.of(
             NOTHING, metadataBytes(TableMetadataPersistence.SweepStrategy.NOTHING),
             CONSERVATIVE, metadataBytes(TableMetadataPersistence.SweepStrategy.CONSERVATIVE),
             CONSERVATIVE2, metadataBytes(TableMetadataPersistence.SweepStrategy.CONSERVATIVE),

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/PreStartHandlingTransactionServiceTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/service/PreStartHandlingTransactionServiceTest.java
@@ -32,7 +32,6 @@ import com.google.common.collect.Maps;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
-import java.util.List;
 import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
@@ -49,10 +48,12 @@ public class PreStartHandlingTransactionServiceTest {
     private static final long NEGATIVE_TIMESTAMP = -125L;
     private static final long BEFORE_TIME_TIMESTAMP = AtlasDbConstants.STARTING_TS - 1;
 
-    private static final List<Long> TWO_VALID_TIMESTAMPS =
+    private static final ImmutableList<Long> TWO_VALID_TIMESTAMPS =
             ImmutableList.of(START_TIMESTAMP, UNCOMMITTED_START_TIMESTAMP);
-    private static final List<Long> ONE_VALID_ONE_INVALID_TIMESTAMP = ImmutableList.of(START_TIMESTAMP, ZERO_TIMESTAMP);
-    private static final List<Long> TWO_INVALID_TIMESTAMPS = ImmutableList.of(ZERO_TIMESTAMP, NEGATIVE_TIMESTAMP);
+    private static final ImmutableList<Long> ONE_VALID_ONE_INVALID_TIMESTAMP =
+            ImmutableList.of(START_TIMESTAMP, ZERO_TIMESTAMP);
+    private static final ImmutableList<Long> TWO_INVALID_TIMESTAMPS =
+            ImmutableList.of(ZERO_TIMESTAMP, NEGATIVE_TIMESTAMP);
 
     @Before
     public void setUpMocks() {

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/JepsenHistoryCheckers.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/JepsenHistoryCheckers.java
@@ -34,11 +34,11 @@ public final class JepsenHistoryCheckers {
     }
 
     @VisibleForTesting
-    static final List<Supplier<Checker>> TIMESTAMP_CHECKERS =
+    static final ImmutableList<Supplier<Checker>> TIMESTAMP_CHECKERS =
             ImmutableList.of(MonotonicChecker::new, NonOverlappingReadsMonotonicChecker::new, UniquenessChecker::new);
 
     @VisibleForTesting
-    static final List<Supplier<Checker>> LOCK_CHECKERS = ImmutableList.of(
+    static final ImmutableList<Supplier<Checker>> LOCK_CHECKERS = ImmutableList.of(
             () -> new PartitionByInvokeNameCheckerHelper(IsolatedProcessCorrectnessChecker::new),
             () -> new PartitionByInvokeNameCheckerHelper(LockCorrectnessChecker::new),
             () -> new PartitionByInvokeNameCheckerHelper(RefreshCorrectnessChecker::new));

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/JepsenHistoryCheckerTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/JepsenHistoryCheckerTest.java
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
 import org.junit.Test;
 
 public class JepsenHistoryCheckerTest {
-    private static final Map<Keyword, ?> INFO_EVENT = ImmutableMap.of(
+    private static final ImmutableMap<Keyword, ?> INFO_EVENT = ImmutableMap.of(
             Keyword.intern("type"),
             "info",
             Keyword.intern("process"),
@@ -41,7 +41,7 @@ public class JepsenHistoryCheckerTest {
             "function",
             Keyword.intern("time"),
             12345L);
-    private static final Map<Keyword, ?> INVOKE_EVENT = ImmutableMap.of(
+    private static final ImmutableMap<Keyword, ?> INVOKE_EVENT = ImmutableMap.of(
             Keyword.intern("type"),
             "invoke",
             Keyword.intern("process"),
@@ -50,7 +50,7 @@ public class JepsenHistoryCheckerTest {
             "function",
             Keyword.intern("time"),
             0L);
-    private static final Map<Keyword, ?> UNRECOGNISED_EVENT = ImmutableMap.of(Keyword.intern("foo"), "bar");
+    private static final ImmutableMap<Keyword, ?> UNRECOGNISED_EVENT = ImmutableMap.of(Keyword.intern("foo"), "bar");
 
     @Test
     public void correctHistoryShouldReturnValidAndNoErrors() {

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/HttpBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/HttpBenchmarks.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HttpHeaders;
 import com.palantir.common.remoting.HeaderAccessUtils;
 import java.util.Collection;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.ws.rs.core.MediaType;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -36,16 +35,17 @@ public class HttpBenchmarks {
     private static final String LOWERCASE_CONTENT_TYPE = HttpHeaders.CONTENT_TYPE.toLowerCase();
 
     // The headers here are all in lowercase, following OkHttp3.3.0+
-    private static final Map<String, Collection<String>> HEADERS = ImmutableMap.<String, Collection<String>>builder()
-            .put(HttpHeaders.ACCEPT.toLowerCase(), ImmutableList.of(MediaType.APPLICATION_JSON))
-            .put(HttpHeaders.ACCEPT_ENCODING.toLowerCase(), ImmutableList.of("UTF-8"))
-            .put(HttpHeaders.CACHE_CONTROL.toLowerCase(), ImmutableList.of("no cache"))
-            .put(HttpHeaders.CONTENT_TYPE.toLowerCase(), ImmutableList.of(MediaType.TEXT_PLAIN))
-            .put(HttpHeaders.FROM.toLowerCase(), ImmutableList.of("TimeLock"))
-            .put(HttpHeaders.USER_AGENT.toLowerCase(), ImmutableList.of("atlasdb/atlasdb-atlasdb"))
-            .put(HttpHeaders.SET_COOKIE.toLowerCase(), ImmutableList.of("cookie"))
-            .put(HttpHeaders.EXPECT.toLowerCase(), ImmutableList.of("12391572384129734"))
-            .build();
+    private static final ImmutableMap<String, Collection<String>> HEADERS =
+            ImmutableMap.<String, Collection<String>>builder()
+                    .put(HttpHeaders.ACCEPT.toLowerCase(), ImmutableList.of(MediaType.APPLICATION_JSON))
+                    .put(HttpHeaders.ACCEPT_ENCODING.toLowerCase(), ImmutableList.of("UTF-8"))
+                    .put(HttpHeaders.CACHE_CONTROL.toLowerCase(), ImmutableList.of("no cache"))
+                    .put(HttpHeaders.CONTENT_TYPE.toLowerCase(), ImmutableList.of(MediaType.TEXT_PLAIN))
+                    .put(HttpHeaders.FROM.toLowerCase(), ImmutableList.of("TimeLock"))
+                    .put(HttpHeaders.USER_AGENT.toLowerCase(), ImmutableList.of("atlasdb/atlasdb-atlasdb"))
+                    .put(HttpHeaders.SET_COOKIE.toLowerCase(), ImmutableList.of("cookie"))
+                    .put(HttpHeaders.EXPECT.toLowerCase(), ImmutableList.of("12391572384129734"))
+                    .build();
 
     @Benchmark
     @Threads(1)

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/cleaner/PuncherTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/cleaner/PuncherTest.java
@@ -57,13 +57,6 @@ public class PuncherTest {
     private final PuncherStore puncherStore;
     private final KeyValueService kvs;
 
-    private final Clock clock = new Clock() {
-        @Override
-        public long getTimeMillis() {
-            return timeMillis;
-        }
-    };
-
     public PuncherTest(PuncherStore puncherStore, KeyValueService kvs) {
         this.puncherStore = puncherStore;
         this.kvs = kvs;
@@ -77,6 +70,8 @@ public class PuncherTest {
     }
 
     long timeMillis = 0;
+
+    private final Clock clock = () -> timeMillis;
 
     final long firstPunchTimestamp = 33L;
     final long secondPunchTimestamp = 35L;

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/TableTasksTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/TableTasksTest.java
@@ -18,7 +18,6 @@ package com.palantir.atlasdb.keyvalue.impl;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterators;
 import com.google.common.collect.Multimap;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.atlasdb.AtlasDbConstants;
@@ -153,7 +152,7 @@ public class TableTasksTest {
                 10,
                 1,
                 stats,
-                (transaction, partialDiff) -> Iterators.size(partialDiff));
+                (transaction, partialDiff) -> partialDiff.forEachRemaining(_unused -> {}));
         long sourceOnlyCells = 0;
         long commonCells = 0;
         for (Map.Entry<Integer, Integer> cell : keys1.entries()) {

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/TracingKvsTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/TracingKvsTest.java
@@ -47,7 +47,7 @@ public class TracingKvsTest extends AbstractKeyValueServiceTest {
     public void setUp() throws Exception {
         Tracer.initTrace(Optional.of(true), getClass().getSimpleName() + "." + Math.random());
         Tracer.subscribe(TEST_OBSERVER_NAME, new TestSpanObserver());
-        Tracer.startSpan("test", SpanType.LOCAL);
+        Tracer.fastStartSpan("test", SpanType.LOCAL);
         super.setUp();
     }
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/metrics/TransactionOutcomeMetricsTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/metrics/TransactionOutcomeMetricsTest.java
@@ -26,7 +26,6 @@ import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.IntStream;
 import org.junit.Test;
 
@@ -35,7 +34,8 @@ public class TransactionOutcomeMetricsTest {
 
     private static final TableReference SAFE_REFERENCE_1 = TableReference.create(NAMESPACE, "safe1");
     private static final TableReference SAFE_REFERENCE_2 = TableReference.create(NAMESPACE, "safe2");
-    private static final Set<TableReference> SAFE_REFERENCES = ImmutableSet.of(SAFE_REFERENCE_1, SAFE_REFERENCE_2);
+    private static final ImmutableSet<TableReference> SAFE_REFERENCES =
+            ImmutableSet.of(SAFE_REFERENCE_1, SAFE_REFERENCE_2);
 
     private static final TableReference UNSAFE_REFERENCE_1 = TableReference.create(NAMESPACE, "PII");
     private static final TableReference UNSAFE_REFERENCE_2 = TableReference.create(NAMESPACE, "topSecret");

--- a/build.gradle
+++ b/build.gradle
@@ -149,7 +149,6 @@ allprojects {
                 'MockitoInternalUsage',
                 'ModifiedButNotUsed',
                 'ModifyCollectionInEnhancedForLoop',
-                'MutableConstantField',
                 'NarrowingCompoundAssignment',
                 'NonAtomicVolatileUpdate',
                 'NullOptional',

--- a/build.gradle
+++ b/build.gradle
@@ -176,7 +176,6 @@ allprojects {
                 'TooManyArguments',
                 'TypeParameterUnusedInFormals',
                 'UndefinedEquals',
-                'UnnecessaryAnonymousClass',
                 'UnnecessaryLambda',
                 'UseCorrectAssertInTests',
                 'ValidateConstantMessage',

--- a/build.gradle
+++ b/build.gradle
@@ -147,7 +147,6 @@ allprojects {
                 'MissingSummary',
                 'MixedMutabilityReturnType',
                 'MockitoInternalUsage',
-                'ModifiedButNotUsed',
                 'ModifyCollectionInEnhancedForLoop',
                 'NarrowingCompoundAssignment',
                 'NonAtomicVolatileUpdate',

--- a/build.gradle
+++ b/build.gradle
@@ -116,7 +116,6 @@ allprojects {
                 'CacheLoaderNull',
                 'CatchBlockLogException',
                 'CatchFail',
-                'CheckReturnValue',
                 'ClassNewInstance',
                 'CloseableProvides',
                 'DangerousCompletableFutureUsage',

--- a/commons-executors/src/test/java/com/palantir/common/concurrent/ExecutorInheritableThreadLocalTest.java
+++ b/commons-executors/src/test/java/com/palantir/common/concurrent/ExecutorInheritableThreadLocalTest.java
@@ -123,6 +123,7 @@ public class ExecutorInheritableThreadLocalTest {
     }
 
     @Test
+    @SuppressWarnings("CheckReturnValue")
     public void testSameThread() {
         local.set("whatup");
         ListeningExecutorService sameThreadExecutor = MoreExecutors.newDirectExecutorService();

--- a/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
@@ -115,7 +115,7 @@ public class AwaitingLeadershipProxyTest {
         ListenableFuture<?> future = proxy.future();
         assertThat(future).isNotDone();
         inProgressCheck.set(StillLeadingStatus.NOT_LEADING);
-        assertThat(future.isDone());
+        assertThat(future).isDone();
         expect.expectCause(isA(NotCurrentLeaderException.class));
         future.get();
     }

--- a/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
@@ -115,7 +115,6 @@ public class AwaitingLeadershipProxyTest {
         ListenableFuture<?> future = proxy.future();
         assertThat(future).isNotDone();
         inProgressCheck.set(StillLeadingStatus.NOT_LEADING);
-        assertThat(future).isDone();
         expect.expectCause(isA(NotCurrentLeaderException.class));
         future.get();
     }

--- a/timelock-agent/src/test/java/com/palantir/timelock/config/ClusterConfigurationDeserializationTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/config/ClusterConfigurationDeserializationTest.java
@@ -26,14 +26,13 @@ import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.google.common.collect.ImmutableSet;
 import java.io.File;
 import java.io.IOException;
-import java.util.Set;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
 public class ClusterConfigurationDeserializationTest {
     private static final String LOCAL_SERVER = "https://server-2:8421";
-    private static final Set<String> SERVERS =
+    private static final ImmutableSet<String> SERVERS =
             ImmutableSet.of("https://server-1:8421", LOCAL_SERVER, "https://server-3:8421");
 
     private static final File CLUSTER_CONFIG_NO_TYPE_INFO = getClusterConfigFile("no-type-info");

--- a/timelock-agent/src/test/java/com/palantir/timelock/config/PaxosInstallConfigurationIntegrationTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/config/PaxosInstallConfigurationIntegrationTest.java
@@ -165,6 +165,7 @@ public class PaxosInstallConfigurationIntegrationTest {
         throw new RuntimeException("Unexpected error when creating a subdirectory");
     }
 
+    @SuppressWarnings("CheckReturnValue")
     private static void attemptConstructTopLevelConfigWithoutOverrides(
             PaxosInstallConfiguration paxosInstallConfiguration) {
         ImmutableTimeLockInstallConfiguration.builder()

--- a/timelock-agent/src/test/java/com/palantir/timelock/config/PaxosRuntimeConfigurationTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/config/PaxosRuntimeConfigurationTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Test;
 
+@SuppressWarnings("CheckReturnValue")
 public class PaxosRuntimeConfigurationTest {
     private static final long POSITIVE_LONG = 1L;
     private static final long NEGATIVE_LONG = -1L;

--- a/timelock-agent/src/test/java/com/palantir/timelock/config/TimeLockPersistenceInvariantsTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/config/TimeLockPersistenceInvariantsTest.java
@@ -125,6 +125,7 @@ public class TimeLockPersistenceInvariantsTest {
         return mockFile;
     }
 
+    @SuppressWarnings("CheckReturnValue")
     private void assertCanBuildConfiguration(ImmutablePaxosInstallConfiguration.Builder configBuilder) {
         PaxosInstallConfiguration installConfiguration = configBuilder.build();
         ImmutableTimeLockInstallConfiguration.builder()

--- a/timelock-agent/src/test/java/com/palantir/timelock/config/TimeLockRuntimeConfigurationTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/config/TimeLockRuntimeConfigurationTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Test;
 
+@SuppressWarnings("CheckReturnValue")
 public class TimeLockRuntimeConfigurationTest {
     @Test
     public void canCreateWithZeroClients() {

--- a/timelock-agent/src/test/java/com/palantir/timelock/paxos/LeaderPingHealthCheckTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/paxos/LeaderPingHealthCheckTest.java
@@ -36,7 +36,7 @@ public class LeaderPingHealthCheckTest {
     private static final Client CLIENT1 = Client.of("client-1");
     private static final Client CLIENT2 = Client.of("client-2");
     private static final Client CLIENT3 = Client.of("client-3");
-    private static final Set<Client> ALL_CLIENTS = ImmutableSet.of(CLIENT1, CLIENT2, CLIENT3);
+    private static final ImmutableSet<Client> ALL_CLIENTS = ImmutableSet.of(CLIENT1, CLIENT2, CLIENT3);
     private static final NamespaceTracker TRACKER = () -> ALL_CLIENTS;
 
     @Test

--- a/timelock-agent/src/test/java/com/palantir/timelock/paxos/PaxosRemotingUtilsTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/paxos/PaxosRemotingUtilsTest.java
@@ -38,7 +38,7 @@ import java.util.Optional;
 import org.junit.Test;
 
 public class PaxosRemotingUtilsTest {
-    private static final List<String> CLUSTER_URIS = ImmutableList.of("foo:1", "bar:2", "baz:3");
+    private static final ImmutableList<String> CLUSTER_URIS = ImmutableList.of("foo:1", "bar:2", "baz:3");
 
     private static final ClusterConfiguration NO_SSL_CLUSTER = ImmutableDefaultClusterConfiguration.builder()
             .localServer("foo:1")

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimelockNamespaces.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimelockNamespaces.java
@@ -43,7 +43,7 @@ public final class TimelockNamespaces {
     @VisibleForTesting
     static final String MAX_CLIENTS = "maxClients";
 
-    private static final Set<String> BANNED_CLIENTS = ImmutableSet.of("tl", "lw");
+    private static final ImmutableSet<String> BANNED_CLIENTS = ImmutableSet.of("tl", "lw");
     private static final String PATH_REGEX =
             String.format("^(?!((%s)$))[a-zA-Z0-9_-]+$", String.join("|", BANNED_CLIENTS));
 

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosLatestSequenceCacheTests.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/BatchingPaxosLatestSequenceCacheTests.java
@@ -43,7 +43,7 @@ public class BatchingPaxosLatestSequenceCacheTests {
     private static final Client CLIENT_1 = Client.of("client-1");
     private static final Client CLIENT_2 = Client.of("client-2");
     private static final Client CLIENT_3 = Client.of("client-3");
-    private static final Map<Client, PaxosLong> INITIAL_UPDATES = ImmutableMap.<Client, PaxosLong>builder()
+    private static final ImmutableMap<Client, PaxosLong> INITIAL_UPDATES = ImmutableMap.<Client, PaxosLong>builder()
             .put(CLIENT_1, PaxosLong.of(5L))
             .put(CLIENT_2, PaxosLong.of(10L))
             .put(CLIENT_3, PaxosLong.of(15L))

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimeLockUriUtilsTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimeLockUriUtilsTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 public class PaxosTimeLockUriUtilsTest {
     private static final String ADDRESS_1 = "foo:1234";
     private static final String ADDRESS_2 = "bar:5678";
-    private static final Set<String> ADDRESSES = ImmutableSet.of(ADDRESS_1, ADDRESS_2);
+    private static final ImmutableSet<String> ADDRESSES = ImmutableSet.of(ADDRESS_1, ADDRESS_2);
 
     private static final String CLIENT = "testClient";
 

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/transaction/timestamp/DelegatingClientAwareManagedTimestampServiceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/transaction/timestamp/DelegatingClientAwareManagedTimestampServiceTest.java
@@ -30,15 +30,14 @@ import com.palantir.atlasdb.timelock.transaction.client.NumericPartitionAllocato
 import com.palantir.lock.v2.TimestampAndPartition;
 import com.palantir.timestamp.ManagedTimestampService;
 import com.palantir.timestamp.TimestampRange;
-import java.util.List;
 import java.util.UUID;
 import org.junit.After;
 import org.junit.Test;
 
 @SuppressWarnings("unchecked") // Mocks of parameterised types
 public class DelegatingClientAwareManagedTimestampServiceTest {
-    private static final List<Integer> RESIDUE_ONE = ImmutableList.of(1);
-    private static final List<Integer> RESIDUE_TWO = ImmutableList.of(2);
+    private static final ImmutableList<Integer> RESIDUE_ONE = ImmutableList.of(1);
+    private static final ImmutableList<Integer> RESIDUE_TWO = ImmutableList.of(2);
 
     private static final UUID UUID_ONE = UUID.randomUUID();
     private static final UUID UUID_TWO = UUID.randomUUID();

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
@@ -32,8 +32,6 @@ import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.TimelockService;
 import com.palantir.timestamp.TimestampManagementService;
 import java.time.Duration;
-import java.util.List;
-import java.util.SortedMap;
 import org.awaitility.Awaitility;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -52,7 +50,8 @@ public class PaxosTimeLockServerIntegrationTest {
     private static final String CLIENT_3 = "test3";
     private static final String LEARNER = "learner";
     private static final String ACCEPTOR = "acceptor";
-    private static final List<String> NAMESPACES = ImmutableList.of(CLIENT_1, CLIENT_2, CLIENT_3, LEARNER, ACCEPTOR);
+    private static final ImmutableList<String> NAMESPACES =
+            ImmutableList.of(CLIENT_1, CLIENT_2, CLIENT_3, LEARNER, ACCEPTOR);
     private static final String INVALID_CLIENT = "test2\b";
 
     private static final long ONE_MILLION = 1000000;
@@ -61,7 +60,8 @@ public class PaxosTimeLockServerIntegrationTest {
 
     private static final String LOCK_CLIENT_NAME = "remoteLock-client-name";
     private static final LockDescriptor LOCK_1 = StringLockDescriptor.of("lock1");
-    private static final SortedMap<LockDescriptor, LockMode> LOCK_MAP = ImmutableSortedMap.of(LOCK_1, LockMode.WRITE);
+    private static final ImmutableSortedMap<LockDescriptor, LockMode> LOCK_MAP =
+            ImmutableSortedMap.of(LOCK_1, LockMode.WRITE);
 
     private static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
     private static final TemporaryConfigurationHolder TEMPORARY_CONFIG_HOLDER =

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -93,7 +93,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
             params().iterator().next();
 
     private static final LockDescriptor LOCK = StringLockDescriptor.of("foo");
-    private static final Set<LockDescriptor> LOCKS = ImmutableSet.of(LOCK);
+    private static final ImmutableSet<LockDescriptor> LOCKS = ImmutableSet.of(LOCK);
 
     private static final int DEFAULT_LOCK_TIMEOUT_MS = 10_000;
     private static final int LONGER_THAN_READ_TIMEOUT_LOCK_TIMEOUT_MS =

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceEteTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceEteTest.java
@@ -322,7 +322,7 @@ public class AsyncLockServiceEteTest {
     public void leaderIdFromLockWatchingServiceIsSameAsLeaderClock() {
         LeaderTime leaderTime = service.leaderTime();
         LockWatchStateUpdate lockWatchUpdate = lockWatchingService.getWatchStateUpdate(Optional.empty());
-        assertThat(leaderTime.id().id().equals(lockWatchUpdate.logId()));
+        assertThat(leaderTime.id().id()).isEqualTo(lockWatchUpdate.logId());
     }
 
     private static void waitForTimeout(TimeLimit timeout) {

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
@@ -51,7 +51,7 @@ import java.util.stream.Stream;
 
 public class TestableTimelockServer {
 
-    private static final Set<Client> PSEUDO_LEADERSHIP_CLIENT_SET =
+    private static final ImmutableSet<Client> PSEUDO_LEADERSHIP_CLIENT_SET =
             ImmutableSet.of(PaxosUseCase.PSEUDO_LEADERSHIP_CLIENT);
     private final TimeLockServerHolder serverHolder;
     private final TestProxies proxies;


### PR DESCRIPTION
Un-suppress CheckReturnValue, ModifiedButNotUsed, MutableConstantField and UnnecessaryAnonymousClass, making suitable changes in relevant places.

There are some actual bugs here that I've fixed, e.g. assertThat(foo.equals(bar)) -> assertThat(foo).isEqualTo(bar).