### PR TITLE
[Autobatchers] Fix wonky metric name

### DIFF
--- a/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/BatchSizeRecorder.java
+++ b/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/BatchSizeRecorder.java
@@ -24,7 +24,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 
 @NotThreadSafe // Disruptor runs the batching function on just one thread.
 public final class BatchSizeRecorder {
-    static final String AUTOBATCHER_METER = "atlasdb.autobatcherMeter";
+    static final String BATCH_SIZE_METER_NAME = BatchSizeRecorder.class.getName() + ".batchSize";
 
     private final Histogram histogram;
 
@@ -35,7 +35,7 @@ public final class BatchSizeRecorder {
     public static BatchSizeRecorder create(String safeLoggerIdentifier, Map<String, String> tags) {
         Histogram histogram = SharedTaggedMetricRegistries.getSingleton()
                 .histogram(MetricName.builder()
-                        .safeName(AUTOBATCHER_METER)
+                        .safeName(BATCH_SIZE_METER_NAME)
                         .putSafeTags("identifier", safeLoggerIdentifier)
                         .putAllSafeTags(tags)
                         .build());

--- a/atlasdb-autobatch/src/test/java/com/palantir/atlasdb/autobatch/BatchSizeRecorderTest.java
+++ b/atlasdb-autobatch/src/test/java/com/palantir/atlasdb/autobatch/BatchSizeRecorderTest.java
@@ -38,7 +38,7 @@ public class BatchSizeRecorderTest {
         Histogram histogram = (Histogram) SharedTaggedMetricRegistries.getSingleton()
                 .getMetrics()
                 .get(MetricName.builder()
-                        .safeName(BatchSizeRecorder.AUTOBATCHER_METER)
+                        .safeName(BatchSizeRecorder.BATCH_SIZE_METER_NAME)
                         .putSafeTags("identifier", SAFE_IDENTIFIER)
                         .build());
 

--- a/changelog/@unreleased/pr-5192.v2.yml
+++ b/changelog/@unreleased/pr-5192.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: The metric for the batch size of an autobatcher has changed from `atlasdb.autobatcherMeter`
+    to `com.palantir.atlasdb.autobatch.BatchSizeRecorder.batchSize`.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5192


### PR DESCRIPTION
**Goals (and why)**:
- Have meaningful metric names

**Implementation Description (bullets)**:
- `atlasdb.autobatcherMeter` is not meaningful, change to `com.palantir.atlasdb.autobatch.BatchSizeRecorder.batchSize`

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Existing tests should validate this

**Concerns (what feedback would you like?)**:
- Will this break annoy anyone?

**Where should we start reviewing?**: small

**Priority (whenever / two weeks / yesterday)**: whenever
