### PR TITLE
[Cross Client Batching] Autobatchers support configurable wait strats

### DIFF
--- a/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/Autobatchers.java
+++ b/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/Autobatchers.java
@@ -121,8 +121,8 @@ public final class Autobatchers {
             return this;
         }
 
-        public AutobatcherBuilder<I, O> waitStrategy(WaitStrategy waitStrategy) {
-            this.waitStrategy = Optional.of(waitStrategy);
+        public AutobatcherBuilder<I, O> waitStrategy(WaitStrategy waitStrategyParam) {
+            this.waitStrategy = Optional.of(waitStrategyParam);
             return this;
         }
 

--- a/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/DisruptorAutobatcher.java
+++ b/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/DisruptorAutobatcher.java
@@ -20,14 +20,18 @@ import com.google.common.util.concurrent.AbstractFuture;
 import com.google.common.util.concurrent.AsyncFunction;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.lmax.disruptor.BlockingWaitStrategy;
 import com.lmax.disruptor.EventHandler;
 import com.lmax.disruptor.RingBuffer;
 import com.lmax.disruptor.TimeoutException;
+import com.lmax.disruptor.WaitStrategy;
 import com.lmax.disruptor.dsl.Disruptor;
+import com.lmax.disruptor.dsl.ProducerType;
 import com.palantir.common.concurrent.NamedThreadFactory;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.tracing.DetachedSpan;
 import java.io.Closeable;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ThreadFactory;
@@ -158,9 +162,16 @@ public final class DisruptorAutobatcher<T, R>
     }
 
     static <T, R> DisruptorAutobatcher<T, R> create(
-            EventHandler<BatchElement<T, R>> eventHandler, int bufferSize, String safeLoggablePurpose) {
+            EventHandler<BatchElement<T, R>> eventHandler,
+            int bufferSize,
+            String safeLoggablePurpose,
+            Optional<WaitStrategy> waitStrategy) {
         Disruptor<DisruptorBatchElement<T, R>> disruptor =
-                new Disruptor<>(DisruptorBatchElement::new, bufferSize, threadFactory(safeLoggablePurpose));
+                new Disruptor<>(DisruptorBatchElement::new,
+                        bufferSize,
+                        threadFactory(safeLoggablePurpose),
+                        ProducerType.MULTI,
+                        waitStrategy.orElseGet(BlockingWaitStrategy::new));
         disruptor.handleEventsWith(
                 (event, sequence, endOfBatch) -> eventHandler.onEvent(event.consume(), sequence, endOfBatch));
         disruptor.start();

--- a/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/DisruptorAutobatcher.java
+++ b/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/DisruptorAutobatcher.java
@@ -166,12 +166,12 @@ public final class DisruptorAutobatcher<T, R>
             int bufferSize,
             String safeLoggablePurpose,
             Optional<WaitStrategy> waitStrategy) {
-        Disruptor<DisruptorBatchElement<T, R>> disruptor =
-                new Disruptor<>(DisruptorBatchElement::new,
-                        bufferSize,
-                        threadFactory(safeLoggablePurpose),
-                        ProducerType.MULTI,
-                        waitStrategy.orElseGet(BlockingWaitStrategy::new));
+        Disruptor<DisruptorBatchElement<T, R>> disruptor = new Disruptor<>(
+                DisruptorBatchElement::new,
+                bufferSize,
+                threadFactory(safeLoggablePurpose),
+                ProducerType.MULTI,
+                waitStrategy.orElseGet(BlockingWaitStrategy::new));
         disruptor.handleEventsWith(
                 (event, sequence, endOfBatch) -> eventHandler.onEvent(event.consume(), sequence, endOfBatch));
         disruptor.start();

--- a/changelog/@unreleased/pr-5197.v2.yml
+++ b/changelog/@unreleased/pr-5197.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '`AutobatcherBuilder` now supports configurable wait strategies for the underlying Disruptor.'
+  links:
+  - https://github.com/palantir/atlasdb/pull/5197


### PR DESCRIPTION
**Goals (and why)**:
- Minimise the performance overhead imposed by the use of an Autobatcher.

**Implementation Description (bullets)**:
- Expose a way of specifying wait strategy on the builder.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Not much, sadly.

**Concerns (what feedback would you like?)**:
- There's an API break though we explicitly don't guarantee that that API will be preserved
- Are the defaults chosen correctly?

**Where should we start reviewing?**: eh

**Priority (whenever / two weeks / yesterday)**: this week?