### PR TITLE
[Cross Client Batching] Broadside LeaderTimeGetter

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/TimeLockRequestBatcherProviders.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/TimeLockRequestBatcherProviders.java
@@ -16,10 +16,10 @@
 
 package com.palantir.atlasdb.config;
 
-import com.palantir.lock.client.LeaderTimeCoalescingBatcher;
+import com.palantir.lock.client.BroadsideLeaderPoller;
 import org.immutables.value.Value;
 
 @Value.Immutable
 public interface TimeLockRequestBatcherProviders {
-    TimeLockRequestBatcherProvider<LeaderTimeCoalescingBatcher> leaderTimeBatcherProvider();
+    TimeLockRequestBatcherProvider<BroadsideLeaderPoller> leaderTimeBatcherProvider();
 }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -1206,8 +1206,8 @@ public abstract class TransactionManagers {
                 serviceProvider.getConjureLockWatchingService(), timelockNamespace);
         LockWatchManagerImpl lockWatchManager = new LockWatchManagerImpl(lockWatchEventCache, lockWatchingService);
 
-        LeaderTimeGetter leaderTimeGetter = getLeaderTimeGetter(
-                timelockNamespace, timelockRequestBatcherProviders, serviceProvider);
+        LeaderTimeGetter leaderTimeGetter =
+                getLeaderTimeGetter(timelockNamespace, timelockRequestBatcherProviders, serviceProvider);
 
         RemoteTimelockServiceAdapter remoteTimelockServiceAdapter = RemoteTimelockServiceAdapter.create(
                 namespacedTimelockRpcClient, namespacedConjureTimelockService, lockWatchEventCache, leaderTimeGetter);
@@ -1233,9 +1233,9 @@ public abstract class TransactionManagers {
 
         if (!timelockRequestBatcherProviders.isPresent()) {
             return new BroadsideLeaderTimeGetter(
-                    BroadsideLeaderPoller.create(getMultiClientTimelockServiceSupplier(serviceProvider).get()),
-                    com.palantir.atlasdb.timelock.api.Namespace.of(timelockNamespace)
-            );
+                    BroadsideLeaderPoller.create(getMultiClientTimelockServiceSupplier(serviceProvider)
+                            .get()),
+                    com.palantir.atlasdb.timelock.api.Namespace.of(timelockNamespace));
         }
 
         LeaderTimeCoalescingBatcher batcher = timelockRequestBatcherProviders

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -1205,8 +1205,8 @@ public abstract class TransactionManagers {
                 serviceProvider.getConjureLockWatchingService(), timelockNamespace);
         LockWatchManagerImpl lockWatchManager = new LockWatchManagerImpl(lockWatchEventCache, lockWatchingService);
 
-        LeaderTimeGetter leaderTimeGetter =
-                getLeaderTimeGetter(timelockNamespace, timelockRequestBatcherProviders, serviceProvider);
+        LeaderTimeGetter leaderTimeGetter = getLeaderTimeGetter(
+                namespacedConjureTimelockService, timelockNamespace, timelockRequestBatcherProviders, serviceProvider);
 
         RemoteTimelockServiceAdapter remoteTimelockServiceAdapter = RemoteTimelockServiceAdapter.create(
                 namespacedTimelockRpcClient, namespacedConjureTimelockService, lockWatchEventCache, leaderTimeGetter);

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -1206,7 +1206,7 @@ public abstract class TransactionManagers {
         LockWatchManagerImpl lockWatchManager = new LockWatchManagerImpl(lockWatchEventCache, lockWatchingService);
 
         LeaderTimeGetter leaderTimeGetter = getLeaderTimeGetter(
-                namespacedConjureTimelockService, timelockNamespace, timelockRequestBatcherProviders, serviceProvider);
+                timelockNamespace, timelockRequestBatcherProviders, serviceProvider, namespacedConjureTimelockService);
 
         RemoteTimelockServiceAdapter remoteTimelockServiceAdapter = RemoteTimelockServiceAdapter.create(
                 namespacedTimelockRpcClient, namespacedConjureTimelockService, lockWatchEventCache, leaderTimeGetter);
@@ -1226,10 +1226,10 @@ public abstract class TransactionManagers {
     }
 
     private static LeaderTimeGetter getLeaderTimeGetter(
-            LeaderElectionReportingTimelockService namespacedConjureTimelockService,
             String timelockNamespace,
             Optional<TimeLockRequestBatcherProviders> timelockRequestBatcherProviders,
-            AtlasDbDialogueServiceProvider serviceProvider) {
+            AtlasDbDialogueServiceProvider serviceProvider,
+            LeaderElectionReportingTimelockService namespacedConjureTimelockService) {
 
         if (!timelockRequestBatcherProviders.isPresent()) {
             return new LegacyLeaderTimeGetter(namespacedConjureTimelockService);

--- a/changelog/0.285.3-rc2/pr-5202.v2.yml
+++ b/changelog/0.285.3-rc2/pr-5202.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Implemented `BroadsideLeaderTimeGetter`, which makes requests to TimeLock for multiple leader times, based on the entire history of namespaces known to this instance of this class. The idea here is that on a stable, busy stack, the overhead of doing this is near zero (since all namespaces have requests), and we can simply re-use the existing set that was used to send the request.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5202

--- a/lock-api/src/main/java/com/palantir/lock/client/BroadsideLeaderPoller.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/BroadsideLeaderPoller.java
@@ -45,7 +45,7 @@ public final class BroadsideLeaderPoller {
         this.namespaces = namespaces;
     }
 
-    public static BroadsideLeaderPoller create(AuthenticatedInternalMultiClientConjureTimelockService timelockService) {
+    public static BroadsideLeaderPoller create(InternalMultiClientConjureTimelockService timelockService) {
         Set<Namespace> namespaces = Sets.newConcurrentHashSet();
         return new BroadsideLeaderPoller(
                 new CoalescingSupplier<>(() -> timelockService.leaderTimes(namespaces)), namespaces);

--- a/lock-api/src/main/java/com/palantir/lock/client/BroadsideLeaderPoller.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/BroadsideLeaderPoller.java
@@ -17,7 +17,6 @@
 package com.palantir.lock.client;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Sets;
 import com.palantir.atlasdb.timelock.api.LeaderTimes;
 import com.palantir.atlasdb.timelock.api.Namespace;
 import com.palantir.common.concurrent.CoalescingSupplier;
@@ -26,6 +25,7 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,7 +44,7 @@ public final class BroadsideLeaderPoller {
     }
 
     public static BroadsideLeaderPoller create(InternalMultiClientConjureTimelockService timelockService) {
-        Set<Namespace> namespaces = Sets.newConcurrentHashSet();
+        Set<Namespace> namespaces = ConcurrentHashMap.newKeySet();
         return new BroadsideLeaderPoller(
                 new CoalescingSupplier<>(() -> timelockService.leaderTimes(namespaces)), namespaces);
     }

--- a/lock-api/src/main/java/com/palantir/lock/client/BroadsideLeaderPoller.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/BroadsideLeaderPoller.java
@@ -57,8 +57,9 @@ public final class BroadsideLeaderPoller {
             if (leaderTime != null) {
                 return leaderTime;
             }
-            log.info("Failed to get leader time for a namespace. This is unexpected and probably indicates an"
-                    + " AtlasDB bug, but we will try again as this is likely to be transient.",
+            log.info(
+                    "Failed to get leader time for a namespace. This is unexpected and probably indicates an"
+                            + " AtlasDB bug, but we will try again as this is likely to be transient.",
                     SafeArg.of("namespace", namespace));
         }
         log.warn(

--- a/lock-api/src/main/java/com/palantir/lock/client/BroadsideLeaderPoller.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/BroadsideLeaderPoller.java
@@ -57,6 +57,9 @@ public final class BroadsideLeaderPoller {
             if (leaderTime != null) {
                 return leaderTime;
             }
+            log.info("Failed to get leader time for a namespace. This is unexpected and probably indicates an"
+                    + " AtlasDB bug, but we will try again as this is likely to be transient.",
+                    SafeArg.of("namespace", namespace));
         }
         log.warn(
                 "Failed to get leader time for a namespace, despite multiple attempts!",

--- a/lock-api/src/main/java/com/palantir/lock/client/BroadsideLeaderPoller.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/BroadsideLeaderPoller.java
@@ -30,6 +30,11 @@ import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Makes requests to TimeLock for multiple leader times, based on the entire history of namespaces known to this
+ * instance of this class. The idea here is that on a stable, busy stack, the overhead of doing this is near zero
+ * (since all namespaces have requests), and we can simply re-use the existing set that was used to send the request.
+ */
 public final class BroadsideLeaderPoller {
     private static final Logger log = LoggerFactory.getLogger(BroadsideLeaderPoller.class);
     private static final int MAXIMUM_ATTEMPTS = 5;

--- a/lock-api/src/main/java/com/palantir/lock/client/BroadsideLeaderPoller.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/BroadsideLeaderPoller.java
@@ -1,0 +1,68 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.client;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Sets;
+import com.palantir.atlasdb.timelock.api.LeaderTimes;
+import com.palantir.atlasdb.timelock.api.Namespace;
+import com.palantir.common.concurrent.CoalescingSupplier;
+import com.palantir.lock.v2.LeaderTime;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class BroadsideLeaderPoller {
+    private static final Logger log = LoggerFactory.getLogger(BroadsideLeaderPoller.class);
+    private static final int MAXIMUM_ATTEMPTS = 5;
+
+    private final Supplier<LeaderTimes> leaderTimesSupplier;
+    private final Set<Namespace> namespaces;
+
+    @VisibleForTesting
+    BroadsideLeaderPoller(
+            Supplier<LeaderTimes> leaderTimesSupplier,
+            Set<Namespace> namespaces) {
+        this.leaderTimesSupplier = leaderTimesSupplier;
+        this.namespaces = namespaces;
+    }
+
+    public static BroadsideLeaderPoller create(AuthenticatedInternalMultiClientConjureTimelockService timelockService) {
+        Set<Namespace> namespaces = Sets.newConcurrentHashSet();
+        return new BroadsideLeaderPoller(
+                new CoalescingSupplier<>(() -> timelockService.leaderTimes(namespaces)), namespaces);
+    }
+
+    public LeaderTime get(Namespace namespace) {
+        namespaces.add(namespace);
+        for (int attempt = 1; attempt <= MAXIMUM_ATTEMPTS; attempt++) {
+            Map<Namespace, LeaderTime> leaderTimes = leaderTimesSupplier.get().getLeaderTimes();
+            LeaderTime leaderTime = leaderTimes.get(namespace);
+            if (leaderTime != null) {
+                return leaderTime;
+            }
+        }
+        log.warn("Failed to get leader time for a namespace, despite multiple attempts!",
+                SafeArg.of("namespace", namespace));
+        throw new SafeIllegalStateException("Failed to get leader time for a namespace",
+                SafeArg.of("namespace", namespace));
+    }
+}

--- a/lock-api/src/main/java/com/palantir/lock/client/BroadsideLeaderPoller.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/BroadsideLeaderPoller.java
@@ -38,9 +38,7 @@ public final class BroadsideLeaderPoller {
     private final Set<Namespace> namespaces;
 
     @VisibleForTesting
-    BroadsideLeaderPoller(
-            Supplier<LeaderTimes> leaderTimesSupplier,
-            Set<Namespace> namespaces) {
+    BroadsideLeaderPoller(Supplier<LeaderTimes> leaderTimesSupplier, Set<Namespace> namespaces) {
         this.leaderTimesSupplier = leaderTimesSupplier;
         this.namespaces = namespaces;
     }
@@ -60,9 +58,10 @@ public final class BroadsideLeaderPoller {
                 return leaderTime;
             }
         }
-        log.warn("Failed to get leader time for a namespace, despite multiple attempts!",
+        log.warn(
+                "Failed to get leader time for a namespace, despite multiple attempts!",
                 SafeArg.of("namespace", namespace));
-        throw new SafeIllegalStateException("Failed to get leader time for a namespace",
-                SafeArg.of("namespace", namespace));
+        throw new SafeIllegalStateException(
+                "Failed to get leader time for a namespace", SafeArg.of("namespace", namespace));
     }
 }

--- a/lock-api/src/main/java/com/palantir/lock/client/BroadsideLeaderTimeGetter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/BroadsideLeaderTimeGetter.java
@@ -1,0 +1,42 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.client;
+
+import com.palantir.atlasdb.timelock.api.Namespace;
+import com.palantir.lock.v2.LeaderTime;
+
+public class BroadsideLeaderTimeGetter implements LeaderTimeGetter {
+    private final BroadsideLeaderPoller broadsideLeaderPoller;
+    private final Namespace namespace;
+
+    public BroadsideLeaderTimeGetter(
+            BroadsideLeaderPoller broadsideLeaderPoller,
+            Namespace namespace) {
+        this.broadsideLeaderPoller = broadsideLeaderPoller;
+        this.namespace = namespace;
+    }
+
+    @Override
+    public LeaderTime leaderTime() {
+        return broadsideLeaderPoller.get(namespace);
+    }
+
+    @Override
+    public void close() {
+        // No op
+    }
+}

--- a/lock-api/src/main/java/com/palantir/lock/client/BroadsideLeaderTimeGetter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/BroadsideLeaderTimeGetter.java
@@ -23,9 +23,7 @@ public class BroadsideLeaderTimeGetter implements LeaderTimeGetter {
     private final BroadsideLeaderPoller broadsideLeaderPoller;
     private final Namespace namespace;
 
-    public BroadsideLeaderTimeGetter(
-            BroadsideLeaderPoller broadsideLeaderPoller,
-            Namespace namespace) {
+    public BroadsideLeaderTimeGetter(BroadsideLeaderPoller broadsideLeaderPoller, Namespace namespace) {
         this.broadsideLeaderPoller = broadsideLeaderPoller;
         this.namespace = namespace;
     }

--- a/lock-api/src/test/java/com/palantir/lock/client/BroadsideLeaderPollerTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/BroadsideLeaderPollerTest.java
@@ -27,21 +27,27 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.MultimapBuilder;
 import com.google.common.util.concurrent.Futures;
 import com.palantir.atlasdb.timelock.api.LeaderTimes;
 import com.palantir.atlasdb.timelock.api.Namespace;
 import com.palantir.common.concurrent.PTExecutors;
+import com.palantir.common.streams.KeyedStream;
 import com.palantir.common.time.NanoTime;
 import com.palantir.lock.v2.LeaderTime;
 import com.palantir.lock.v2.LeadershipId;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.junit.Test;
 
-@SuppressWarnings("unchecked") // Mocked generics
 public class BroadsideLeaderPollerTest {
     private static final Namespace NAMESPACE_1 = Namespace.of("tom");
     private static final Namespace NAMESPACE_2 = Namespace.of("jeremy");
@@ -72,7 +78,7 @@ public class BroadsideLeaderPollerTest {
     }
 
     @Test
-    public void buildsRequests() {
+    public void constructsUnionOfRequestHistory() {
         when(authenticatedService.leaderTimes(any()))
                 .thenReturn(LeaderTimes.builder()
                         .leaderTimes(NAMESPACE_1, LEADER_TIME_1)
@@ -102,6 +108,19 @@ public class BroadsideLeaderPollerTest {
     }
 
     @Test
+    public void recoversIfResponseAddsNamespaceOnLaterAttempt() {
+        when(authenticatedService.leaderTimes(any()))
+                .thenReturn(LeaderTimes.builder()
+                        .leaderTimes(NAMESPACE_3, LEADER_TIME_3)
+                        .build())
+                .thenReturn(LeaderTimes.builder()
+                        .leaderTimes(NAMESPACE_1, LEADER_TIME_1)
+                        .build());
+
+        assertThat(serviceBackedPoller.get(NAMESPACE_1)).isEqualTo(LEADER_TIME_1);
+    }
+
+    @Test
     public void simulation() {
         when(authenticatedService.leaderTimes(any()))
                 .thenReturn(LeaderTimes.builder()
@@ -119,6 +138,37 @@ public class BroadsideLeaderPollerTest {
         assertThat(mockingDetails(authenticatedService).getInvocations().size())
                 .as("some requests were autobatched")
                 .isLessThan(512)
+                .isGreaterThanOrEqualTo(1);
+    }
+
+    @Test
+    public void multiClientSimulation() {
+        Map<Namespace, LeaderTime> canonicalTimes = KeyedStream.of(
+                IntStream.range(0, 256).boxed().collect(Collectors.toList()))
+                .mapKeys(index -> Namespace.of("n" + index))
+                .map(unused -> LeaderTime.of(LeadershipId.random(), NanoTime.now()))
+                .collectToMap();
+
+        when(authenticatedService.leaderTimes(any())).thenAnswer(invocationOnMock -> {
+            Set<Namespace> namespaces = invocationOnMock.getArgument(0);
+            return LeaderTimes.of(KeyedStream.of(namespaces.stream())
+                    .map(canonicalTimes::get)
+                    .collectToMap());
+        });
+
+        ExecutorService executorService = PTExecutors.newFixedThreadPool(16);
+        Multimap<Namespace, Future<LeaderTime>> leaderTimeFutures = MultimapBuilder.hashKeys().arrayListValues().build();
+        for (int request = 0; request < 1024; request++) {
+            Namespace namespace = Namespace.of("n" + (request % 256));
+            leaderTimeFutures.put(namespace, executorService.submit(() -> serviceBackedPoller.get(namespace)));
+        }
+
+        leaderTimeFutures.forEach(
+                (namespace, future) -> assertThat(Futures.getUnchecked(future)).isEqualTo(canonicalTimes.get(namespace)));
+
+        assertThat(mockingDetails(authenticatedService).getInvocations().size())
+                .as("some requests were autobatched")
+                .isLessThan(1024)
                 .isGreaterThanOrEqualTo(1);
     }
 }

--- a/lock-api/src/test/java/com/palantir/lock/client/BroadsideLeaderPollerTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/BroadsideLeaderPollerTest.java
@@ -57,11 +57,12 @@ public class BroadsideLeaderPollerTest {
 
     @Test
     public void routesRequestsCorrectly() {
-        when(authenticatedService.leaderTimes(any())).thenReturn(LeaderTimes.builder()
-                .leaderTimes(NAMESPACE_1, LEADER_TIME_1)
-                .leaderTimes(NAMESPACE_2, LEADER_TIME_2)
-                .leaderTimes(NAMESPACE_3, LEADER_TIME_3)
-                .build());
+        when(authenticatedService.leaderTimes(any()))
+                .thenReturn(LeaderTimes.builder()
+                        .leaderTimes(NAMESPACE_1, LEADER_TIME_1)
+                        .leaderTimes(NAMESPACE_2, LEADER_TIME_2)
+                        .leaderTimes(NAMESPACE_3, LEADER_TIME_3)
+                        .build());
 
         assertThat(serviceBackedPoller.get(NAMESPACE_1)).isEqualTo(LEADER_TIME_1);
         assertThat(serviceBackedPoller.get(NAMESPACE_2)).isEqualTo(LEADER_TIME_2);
@@ -72,11 +73,12 @@ public class BroadsideLeaderPollerTest {
 
     @Test
     public void buildsRequests() {
-        when(authenticatedService.leaderTimes(any())).thenReturn(LeaderTimes.builder()
-                .leaderTimes(NAMESPACE_1, LEADER_TIME_1)
-                .leaderTimes(NAMESPACE_2, LEADER_TIME_2)
-                .leaderTimes(NAMESPACE_3, LEADER_TIME_3)
-                .build());
+        when(authenticatedService.leaderTimes(any()))
+                .thenReturn(LeaderTimes.builder()
+                        .leaderTimes(NAMESPACE_1, LEADER_TIME_1)
+                        .leaderTimes(NAMESPACE_2, LEADER_TIME_2)
+                        .leaderTimes(NAMESPACE_3, LEADER_TIME_3)
+                        .build());
 
         assertThat(serviceBackedPoller.get(NAMESPACE_1)).isEqualTo(LEADER_TIME_1);
         assertThat(serviceBackedPoller.get(NAMESPACE_2)).isEqualTo(LEADER_TIME_2);
@@ -87,9 +89,10 @@ public class BroadsideLeaderPollerTest {
 
     @Test
     public void throwsIfResponseRepeatedlyDoesNotContainNamespace() {
-        when(authenticatedService.leaderTimes(any())).thenReturn(LeaderTimes.builder()
-                .leaderTimes(NAMESPACE_3, LEADER_TIME_3)
-                .build());
+        when(authenticatedService.leaderTimes(any()))
+                .thenReturn(LeaderTimes.builder()
+                        .leaderTimes(NAMESPACE_3, LEADER_TIME_3)
+                        .build());
 
         assertThatThrownBy(() -> serviceBackedPoller.get(NAMESPACE_1))
                 .isInstanceOf(SafeIllegalStateException.class)
@@ -100,16 +103,18 @@ public class BroadsideLeaderPollerTest {
 
     @Test
     public void simulation() {
-        when(authenticatedService.leaderTimes(any())).thenReturn(LeaderTimes.builder()
-                .leaderTimes(NAMESPACE_1, LEADER_TIME_1)
-                .build());
+        when(authenticatedService.leaderTimes(any()))
+                .thenReturn(LeaderTimes.builder()
+                        .leaderTimes(NAMESPACE_1, LEADER_TIME_1)
+                        .build());
 
         ExecutorService executorService = PTExecutors.newFixedThreadPool(16);
         List<Future<LeaderTime>> leaderTimeFutures = Lists.newArrayList();
         for (int request = 0; request < 512; request++) {
             leaderTimeFutures.add(executorService.submit(() -> serviceBackedPoller.get(NAMESPACE_1)));
         }
-        leaderTimeFutures.forEach(future -> assertThat(Futures.getUnchecked(future)).isEqualTo(LEADER_TIME_1));
+        leaderTimeFutures.forEach(
+                future -> assertThat(Futures.getUnchecked(future)).isEqualTo(LEADER_TIME_1));
 
         assertThat(mockingDetails(authenticatedService).getInvocations().size())
                 .as("some requests were autobatched")

--- a/lock-api/src/test/java/com/palantir/lock/client/BroadsideLeaderPollerTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/BroadsideLeaderPollerTest.java
@@ -27,7 +27,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Futures;
 import com.palantir.atlasdb.timelock.api.LeaderTimes;
 import com.palantir.atlasdb.timelock.api.Namespace;
@@ -36,6 +35,7 @@ import com.palantir.common.time.NanoTime;
 import com.palantir.lock.v2.LeaderTime;
 import com.palantir.lock.v2.LeadershipId;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -109,7 +109,7 @@ public class BroadsideLeaderPollerTest {
                         .build());
 
         ExecutorService executorService = PTExecutors.newFixedThreadPool(16);
-        List<Future<LeaderTime>> leaderTimeFutures = Lists.newArrayList();
+        List<Future<LeaderTime>> leaderTimeFutures = new ArrayList<>();
         for (int request = 0; request < 512; request++) {
             leaderTimeFutures.add(executorService.submit(() -> serviceBackedPoller.get(NAMESPACE_1)));
         }

--- a/lock-api/src/test/java/com/palantir/lock/client/BroadsideLeaderPollerTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/BroadsideLeaderPollerTest.java
@@ -1,0 +1,119 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockingDetails;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.Futures;
+import com.palantir.atlasdb.timelock.api.LeaderTimes;
+import com.palantir.atlasdb.timelock.api.Namespace;
+import com.palantir.common.concurrent.PTExecutors;
+import com.palantir.common.time.NanoTime;
+import com.palantir.lock.v2.LeaderTime;
+import com.palantir.lock.v2.LeadershipId;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import org.junit.Test;
+
+@SuppressWarnings("unchecked") // Mocked generics
+public class BroadsideLeaderPollerTest {
+    private static final Namespace NAMESPACE_1 = Namespace.of("tom");
+    private static final Namespace NAMESPACE_2 = Namespace.of("jeremy");
+    private static final Namespace NAMESPACE_3 = Namespace.of("james");
+
+    private static final LeaderTime LEADER_TIME_1 = LeaderTime.of(LeadershipId.random(), NanoTime.now());
+    private static final LeaderTime LEADER_TIME_2 = LeaderTime.of(LeadershipId.random(), NanoTime.now());
+    private static final LeaderTime LEADER_TIME_3 = LeaderTime.of(LeadershipId.random(), NanoTime.now());
+
+    private final AuthenticatedInternalMultiClientConjureTimelockService authenticatedService =
+            mock(AuthenticatedInternalMultiClientConjureTimelockService.class);
+    private final BroadsideLeaderPoller serviceBackedPoller = BroadsideLeaderPoller.create(authenticatedService);
+
+    @Test
+    public void routesRequestsCorrectly() {
+        when(authenticatedService.leaderTimes(any())).thenReturn(LeaderTimes.builder()
+                .leaderTimes(NAMESPACE_1, LEADER_TIME_1)
+                .leaderTimes(NAMESPACE_2, LEADER_TIME_2)
+                .leaderTimes(NAMESPACE_3, LEADER_TIME_3)
+                .build());
+
+        assertThat(serviceBackedPoller.get(NAMESPACE_1)).isEqualTo(LEADER_TIME_1);
+        assertThat(serviceBackedPoller.get(NAMESPACE_2)).isEqualTo(LEADER_TIME_2);
+        assertThat(serviceBackedPoller.get(NAMESPACE_3)).isEqualTo(LEADER_TIME_3);
+
+        verify(authenticatedService, times(3)).leaderTimes(any());
+    }
+
+    @Test
+    public void buildsRequests() {
+        when(authenticatedService.leaderTimes(any())).thenReturn(LeaderTimes.builder()
+                .leaderTimes(NAMESPACE_1, LEADER_TIME_1)
+                .leaderTimes(NAMESPACE_2, LEADER_TIME_2)
+                .leaderTimes(NAMESPACE_3, LEADER_TIME_3)
+                .build());
+
+        assertThat(serviceBackedPoller.get(NAMESPACE_1)).isEqualTo(LEADER_TIME_1);
+        assertThat(serviceBackedPoller.get(NAMESPACE_2)).isEqualTo(LEADER_TIME_2);
+        assertThat(serviceBackedPoller.get(NAMESPACE_3)).isEqualTo(LEADER_TIME_3);
+
+        verify(authenticatedService, atLeastOnce()).leaderTimes(ImmutableSet.of(NAMESPACE_1, NAMESPACE_2, NAMESPACE_3));
+    }
+
+    @Test
+    public void throwsIfResponseRepeatedlyDoesNotContainNamespace() {
+        when(authenticatedService.leaderTimes(any())).thenReturn(LeaderTimes.builder()
+                .leaderTimes(NAMESPACE_3, LEADER_TIME_3)
+                .build());
+
+        assertThatThrownBy(() -> serviceBackedPoller.get(NAMESPACE_1))
+                .isInstanceOf(SafeIllegalStateException.class)
+                .hasMessageContaining("Failed to get leader time for a namespace")
+                .hasMessageContaining(NAMESPACE_1.toString());
+        verify(authenticatedService, times(5)).leaderTimes(ImmutableSet.of(NAMESPACE_1));
+    }
+
+    @Test
+    public void simulation() {
+        when(authenticatedService.leaderTimes(any())).thenReturn(LeaderTimes.builder()
+                .leaderTimes(NAMESPACE_1, LEADER_TIME_1)
+                .build());
+
+        ExecutorService executorService = PTExecutors.newFixedThreadPool(16);
+        List<Future<LeaderTime>> leaderTimeFutures = Lists.newArrayList();
+        for (int request = 0; request < 512; request++) {
+            leaderTimeFutures.add(executorService.submit(() -> serviceBackedPoller.get(NAMESPACE_1)));
+        }
+        leaderTimeFutures.forEach(future -> assertThat(Futures.getUnchecked(future)).isEqualTo(LEADER_TIME_1));
+
+        assertThat(mockingDetails(authenticatedService).getInvocations().size())
+                .as("some requests were autobatched")
+                .isLessThan(512)
+                .isGreaterThanOrEqualTo(1);
+    }
+}


### PR DESCRIPTION
**Goals (and why)**:
- Make requests to timelock efficiently

**Implementation Description (bullets)**:
- Makes requests to TimeLock for multiple leader times, based on the entire history of namespaces known to this instance of this class. The idea here is that on a stable, busy stack, the overhead of doing this is near zero (since all namespaces have requests), and we can simply re-use the existing set that was used to send the request.

**Testing (What was existing testing like?  What have you done to improve it?)**: Added a couple of tests, including simulations. Also ran the integration tests using Broadside instead of the Legacy LeaderTimeGetter and tests passed (see `arraylist` commit)

**Concerns (what feedback would you like?)**:
- Is the overhead going to be a problem?

**Where should we start reviewing?**: BLPTests

**Priority (whenever / two weeks / yesterday)**: this week
