### PR TITLE
Avoid creating thousands of get-ranges threads

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionManager.java
@@ -25,13 +25,14 @@ import com.palantir.atlasdb.transaction.api.TransactionFailedException;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.atlasdb.transaction.api.TransactionTask;
 import com.palantir.atlasdb.util.MetricsManager;
-import com.palantir.common.concurrent.NamedThreadFactory;
+import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.logsafe.Preconditions;
-import java.util.concurrent.BlockingQueue;
+import com.palantir.logsafe.SafeArg;
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,35 +93,59 @@ public abstract class AbstractTransactionManager implements TransactionManager {
 
     @SuppressWarnings("DangerousThreadPoolExecutorUsage")
     ExecutorService createGetRangesExecutor(int numThreads) {
-        BlockingQueue<Runnable> workQueue = new LinkedBlockingQueue<Runnable>() {
+        ExecutorService executor = PTExecutors.newFixedThreadPool(
+                numThreads, AbstractTransactionManager.this.getClass().getSimpleName() + "-get-ranges");
+
+        return new AbstractExecutorService() {
+            private final AtomicInteger queueSizeEstimate = new AtomicInteger();
             private final RateLimiter warningRateLimiter = RateLimiter.create(1);
 
             @Override
-            public boolean offer(Runnable runnable) {
-                sanityCheckQueueSize();
-                return super.offer(runnable);
+            public void shutdown() {
+                executor.shutdown();
             }
 
-            private void sanityCheckQueueSize() {
-                int currentSize = this.size();
+            @Override
+            public List<Runnable> shutdownNow() {
+                return executor.shutdownNow();
+            }
+
+            @Override
+            public boolean isShutdown() {
+                return executor.isShutdown();
+            }
+
+            @Override
+            public boolean isTerminated() {
+                return executor.isTerminated();
+            }
+
+            @Override
+            public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+                return executor.awaitTermination(timeout, unit);
+            }
+
+            @Override
+            public void execute(Runnable command) {
+                sanityCheckAndIncrementQueueSize();
+                executor.execute(() -> {
+                    queueSizeEstimate.getAndDecrement();
+                    command.run();
+                });
+            }
+
+            private void sanityCheckAndIncrementQueueSize() {
+                int currentSize = queueSizeEstimate.getAndIncrement();
                 if (currentSize >= GET_RANGES_QUEUE_SIZE_WARNING_THRESHOLD && warningRateLimiter.tryAcquire()) {
                     log.warn(
                             "You have {} pending getRanges tasks. Please sanity check both your level "
                                     + "of concurrency and size of batched range requests. If necessary you can "
                                     + "increase the value of concurrentGetRangesThreadPoolSize to allow for a larger "
                                     + "thread pool.",
-                            currentSize);
+                            SafeArg.of("currentSize", currentSize));
                 }
             }
         };
-        return new ThreadPoolExecutor(
-                numThreads,
-                numThreads,
-                0L,
-                TimeUnit.MILLISECONDS,
-                workQueue,
-                new NamedThreadFactory(
-                        AbstractTransactionManager.this.getClass().getSimpleName() + "-get-ranges"));
     }
 
     @Override

--- a/changelog/@unreleased/pr-5224.v2.yml
+++ b/changelog/@unreleased/pr-5224.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Avoid creating thousands of `serializabletransactionmanager-get-ranges` threads by using the efficient PTExecutors ExecutorService factory methods.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5224


### PR DESCRIPTION
Our metrics show services with thousands of threads in the
`serializabletransactionmanager-get-ranges` pool, however the
executor was not instrumented with Tritium, so it's not clear
how saturated it is, or if it is used at all. Threads are incredibly
expensive, it's generally a sign of failure when a service reaches
1000 total threads.

Using PTExecutors factories we get tracing and execution metrics
for free, as well as resource utilization improvements to share
a slice of an underlying cached executor so threads are only
used as needed. The provided `numThreads` is still an upper limit
for the ExecutorService instance, however idle threads can be
used elsewhere.

The existing queue size warning logic is preserved using a counter
rather than instrumenting the queue itself in much the same way
tritium estimates ExecutorService queue size.

**Goals (and why)**:

Vastly reduce memory overhead for several services.

**Implementation Description (bullets)**:

Use the standard ptexecutors factory with a wrapper to support queue size warnings. Ideally this would move to Hyperion instead, but that's out of scope here.

**Testing (What was existing testing like?  What have you done to improve it?)**:

No behavior change, only a reduction in resource utilization.

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**: