### PR TITLE
[Fix develop] Fix a potential deadlock in SweepQueueReader

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsSerializableTransactionTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsSerializableTransactionTest.java
@@ -21,7 +21,7 @@ import com.palantir.atlasdb.containers.CassandraResource;
 import com.palantir.atlasdb.sweep.metrics.TargetedSweepMetrics;
 import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
 import com.palantir.atlasdb.sweep.queue.SweepQueue;
-import com.palantir.atlasdb.sweep.queue.SweepQueueReader.ReadBatchingRuntimeContext;
+import com.palantir.atlasdb.sweep.queue.SweepQueueReader;
 import com.palantir.atlasdb.sweep.queue.TargetedSweeper;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.impl.AbstractSerializableTransactionTest;
@@ -74,7 +74,7 @@ public class CassandraKvsSerializableTransactionTest extends AbstractSerializabl
                 keyValueService,
                 timelockService,
                 () -> 128,
-                ReadBatchingRuntimeContext.DEFAULT);
+                SweepQueueReader.DEFAULT_READ_BATCHING_RUNTIME_CONTEXT);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueReader.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueReader.java
@@ -53,12 +53,14 @@ public class SweepQueueReader {
         return accumulator.toSweepBatch();
     }
 
+    public static final ReadBatchingRuntimeContext DEFAULT_READ_BATCHING_RUNTIME_CONTEXT =
+            ReadBatchingRuntimeContext.builder()
+                    .maximumPartitions(() -> 1)
+                    .cellsThreshold(() -> SweepQueueUtils.SWEEP_BATCH_SIZE)
+                    .build();
+
     @Immutable
     public interface ReadBatchingRuntimeContext {
-        ReadBatchingRuntimeContext DEFAULT = ReadBatchingRuntimeContext.builder()
-                .maximumPartitions(() -> 1)
-                .cellsThreshold(() -> SweepQueueUtils.SWEEP_BATCH_SIZE)
-                .build();
 
         IntSupplier maximumPartitions();
 

--- a/changelog/@unreleased/pr-5225.v2.yml
+++ b/changelog/@unreleased/pr-5225.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix a potential class initialization deadlock in SweepQueueReader
+  links:
+  - https://github.com/palantir/atlasdb/pull/5225


### PR DESCRIPTION
Unsure how this passed baseline originally, but it's blocking
commits on develop.

I've searched internal sources and don't see any references
to the modified member.
