### PR TITLE
Suppress deprecation warnings in generated code

### DIFF
--- a/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/AllValueTypesTestTable.java
+++ b/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/AllValueTypesTestTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class AllValueTypesTestTable implements
         AtlasDbMutablePersistentTable<AllValueTypesTestTable.AllValueTypesTestRow,
                                          AllValueTypesTestTable.AllValueTypesTestNamedColumnValue<?>,

--- a/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/HashComponentsTestTable.java
+++ b/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/HashComponentsTestTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class HashComponentsTestTable implements
         AtlasDbMutablePersistentTable<HashComponentsTestTable.HashComponentsTestRow,
                                          HashComponentsTestTable.HashComponentsTestNamedColumnValue<?>,

--- a/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/SchemaApiTestTable.java
+++ b/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/SchemaApiTestTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class SchemaApiTestTable implements
         AtlasDbMutablePersistentTable<SchemaApiTestTable.SchemaApiTestRow,
                                          SchemaApiTestTable.SchemaApiTestNamedColumnValue<?>,

--- a/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/SchemaApiTestV2Table.java
+++ b/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/SchemaApiTestV2Table.java
@@ -34,7 +34,10 @@ import java.util.stream.Collectors;
 import javax.annotation.Generated;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRendererV2")
-@SuppressWarnings("all")
+@SuppressWarnings({
+        "all",
+        "deprecation"
+})
 public class SchemaApiTestV2Table {
     private static final String rawTableName = "SchemaApiTest";
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
@@ -152,7 +152,7 @@ public class StreamStoreRenderer {
                 line();
                 importRenderer.renderImports();
                 line("@Generated(\"", StreamStoreRenderer.class.getName(), "\")");
-                line("@SuppressWarnings(\"all\")");
+                line("@SuppressWarnings({\"all\", \"deprecation\"})");
                 line("public final class ", StreamStore, " extends AbstractPersistentStreamStore", " {");
                 {
                     fields();

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/TableClassRendererV2.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/TableClassRendererV2.java
@@ -122,6 +122,7 @@ public class TableClassRendererV2 {
                         .build())
                 .addAnnotation(AnnotationSpec.builder(SuppressWarnings.class)
                         .addMember("value", "$S", "all")
+                        .addMember("value", "$S", "deprecation")
                         .build())
                 .addModifiers(Modifier.PUBLIC);
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/TableRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/TableRenderer.java
@@ -195,7 +195,7 @@ public class TableRenderer {
                 importRenderer.renderImports();
             }
             line("@Generated(\"", TableRenderer.class.getName(), "\")");
-            line("@SuppressWarnings(\"all\")");
+            line("@SuppressWarnings({\"all\", \"deprecation\"})");
             line("public ", isNestedIndex ? "static " : "", "final class ", Table, " implements");
             if (isNamedSet(table)) {
                 line("        AtlasDbNamedPersistentSet<", Table, ".", Row, ">,");

--- a/changelog/@unreleased/pr-5229.v2.yml
+++ b/changelog/@unreleased/pr-5229.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Deprecation warnings are now suppressed in generated code.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5229


### PR DESCRIPTION
https://github.com/palantir/atlasdb/pull/5169 deprecated some constants that were used in generated classes. While these generated classes do include `@SuppressWarnings("all")`, that does not suppress javac lints such as `-Xlint:deprecation`. Those warnings need to be suppressed explicitly. For example, see https://github.com/jOOQ/jOOQ/issues/2413.

I've verified locally that this resolves the compilation issues with generated code.