### PR TITLE
Clean naked sentinels in thoroughly swept tables

### DIFF
--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
@@ -91,6 +91,7 @@ public class TransactionManagerModule {
             ConflictDetectionManager conflictManager,
             SweepStrategyManager sweepStrategyManager,
             Cleaner cleaner) {
+        // todo(gmaretic): should this be using a real sweep queue?
         return new SerializableTransactionManager(
                 metricsManager,
                 kvs,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/MultiTableSweepQueueWriter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/MultiTableSweepQueueWriter.java
@@ -18,9 +18,11 @@ package com.palantir.atlasdb.sweep.queue;
 import com.palantir.async.initializer.CallbackInitializable;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.table.description.SweepStrategy.SweeperStrategy;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -62,5 +64,9 @@ public interface MultiTableSweepQueueWriter extends AutoCloseable, CallbackIniti
     @Override
     default void close() {
         // noop
+    }
+
+    default Optional<SweeperStrategy> getSweepStrategy(TableReference tableReference) {
+        return Optional.empty();
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueWriter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueWriter.java
@@ -15,8 +15,11 @@
  */
 package com.palantir.atlasdb.sweep.queue;
 
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.table.description.SweepStrategy.SweeperStrategy;
 import com.palantir.logsafe.SafeArg;
 import java.util.List;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,10 +28,13 @@ class SweepQueueWriter implements MultiTableSweepQueueWriter {
 
     private final SweepableTimestamps sweepableTimestamps;
     private final SweepableCells sweepableCells;
+    private final WriteInfoPartitioner partitioner;
 
-    SweepQueueWriter(SweepableTimestamps sweepableTimestamps, SweepableCells sweepableCells) {
+    SweepQueueWriter(
+            SweepableTimestamps sweepableTimestamps, SweepableCells sweepableCells, WriteInfoPartitioner partitioner) {
         this.sweepableTimestamps = sweepableTimestamps;
         this.sweepableCells = sweepableCells;
+        this.partitioner = partitioner;
     }
 
     @Override
@@ -36,5 +42,10 @@ class SweepQueueWriter implements MultiTableSweepQueueWriter {
         sweepableTimestamps.enqueue(writes);
         sweepableCells.enqueue(writes);
         log.debug("Enqueued {} writes into the sweep queue.", SafeArg.of("writes", writes.size()));
+    }
+
+    @Override
+    public Optional<SweeperStrategy> getSweepStrategy(TableReference tableReference) {
+        return partitioner.getStrategyForTable(tableReference);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/TargetedSweeper.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/TargetedSweeper.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.cleaner.Follower;
 import com.palantir.atlasdb.keyvalue.api.InsufficientConsistencyException;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.sweep.BackgroundSweeper;
 import com.palantir.atlasdb.sweep.Sweeper;
 import com.palantir.atlasdb.sweep.metrics.SweepOutcome;
@@ -203,6 +204,11 @@ public class TargetedSweeper implements MultiTableSweepQueueWriter, BackgroundSw
     public void close() {
         conservativeScheduler.close();
         thoroughScheduler.close();
+    }
+
+    @Override
+    public Optional<SweeperStrategy> getSweepStrategy(TableReference tableReference) {
+        return queue.getSweepStrategy(tableReference);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/WriteInfoPartitioner.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/WriteInfoPartitioner.java
@@ -88,7 +88,11 @@ public class WriteInfoPartitioner {
 
     @VisibleForTesting
     Optional<SweeperStrategy> getStrategy(WriteInfo writeInfo) {
-        return cache.getUnchecked(writeInfo.tableRef());
+        return getStrategyForTable(writeInfo.tableRef());
+    }
+
+    Optional<SweeperStrategy> getStrategyForTable(TableReference tableRef) {
+        return cache.getUnchecked(tableRef);
     }
 
     private Optional<SweeperStrategy> getStrategyFromKvs(TableReference tableRef) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -728,7 +728,7 @@ public class SerializableTransaction extends SnapshotTransaction {
                 timestampValidationReadCache,
                 getRangesExecutor,
                 defaultGetRangesConcurrency,
-                MultiTableSweepQueueWriter.NO_OP,
+                sweepQueue,
                 deleteExecutor,
                 validateLocksOnReads,
                 transactionConfig,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -207,7 +207,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     protected final MetricsManager metricsManager;
     protected final ConflictTracer conflictTracer;
 
-    private final MultiTableSweepQueueWriter sweepQueue;
+    protected final MultiTableSweepQueueWriter sweepQueue;
 
     protected final long immutableTimestamp;
     protected final Optional<LockToken> immutableTimestampLock;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -18,7 +18,6 @@ package com.palantir.atlasdb.transaction.impl;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Timer;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
 import com.google.common.base.MoreObjects;
@@ -39,6 +38,7 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.PeekingIterator;
+import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
 import com.google.common.primitives.UnsignedBytes;
 import com.google.common.util.concurrent.Futures;
@@ -72,6 +72,7 @@ import com.palantir.atlasdb.keyvalue.impl.LocalRowColumnRangeIterator;
 import com.palantir.atlasdb.keyvalue.impl.RowResults;
 import com.palantir.atlasdb.logging.LoggingArgs;
 import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
+import com.palantir.atlasdb.table.description.SweepStrategy.SweeperStrategy;
 import com.palantir.atlasdb.table.description.exceptions.AtlasDbConstraintException;
 import com.palantir.atlasdb.transaction.TransactionConfig;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
@@ -169,17 +170,14 @@ import org.slf4j.LoggerFactory;
 /**
  * This implements snapshot isolation for transactions.
  * <p>
- * This object is thread safe and you may do reads and writes from multiple threads.
- * You may not continue reading or writing after {@link #commit()} or {@link #abort()}
- * is called.
+ * This object is thread safe and you may do reads and writes from multiple threads. You may not continue reading or
+ * writing after {@link #commit()} or {@link #abort()} is called.
  * <p>
- * Things to keep in mind when dealing with snapshot transactions:
- * 1. Transactions that do writes should be short lived.
- * 1a. Read only transactions can be long lived (within reason).
- * 2. Do not write too much data in one transaction (this relates back to #1)
- * 3. A row should be able to fit in memory without any trouble.  This includes
- *    all columns of the row.  If you are thinking about making your row bigger than like 10MB, you
- *    should think about breaking these up into different rows and using range scans.
+ * Things to keep in mind when dealing with snapshot transactions: 1. Transactions that do writes should be short lived.
+ * 1a. Read only transactions can be long lived (within reason). 2. Do not write too much data in one transaction (this
+ * relates back to #1) 3. A row should be able to fit in memory without any trouble.  This includes all columns of the
+ * row.  If you are thinking about making your row bigger than like 10MB, you should think about breaking these up into
+ * different rows and using range scans.
  */
 public class SnapshotTransaction extends AbstractTransaction implements ConstraintCheckingTransaction {
     private static final Logger log = LoggerFactory.getLogger(SnapshotTransaction.class);
@@ -247,8 +245,8 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     protected volatile boolean hasReads;
 
     /**
-     * @param immutableTimestamp If we find a row written before the immutableTimestamp we don't need to
-     *                           grab a read lock for it because we know that no writers exist.
+     * @param immutableTimestamp If we find a row written before the immutableTimestamp we don't need to grab a read
+     *                           lock for it because we know that no writers exist.
      * @param preCommitCondition This check must pass for this transaction to commit.
      */
     /* package */ SnapshotTransaction(
@@ -543,10 +541,10 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     }
 
     /**
-     * Partitions a {@link RowColumnRangeIterator} into contiguous blocks that share the same row name.
-     * {@link KeyValueService#getRowsColumnRange(TableReference, Iterable, ColumnRangeSelection, int, long)} guarantees
-     * that all columns for a single row are adjacent, so this method will return an {@link Iterator} with exactly one
-     * entry per non-empty row.
+     * Partitions a {@link RowColumnRangeIterator} into contiguous blocks that share the same row name. {@link
+     * KeyValueService#getRowsColumnRange(TableReference, Iterable, ColumnRangeSelection, int, long)} guarantees that
+     * all columns for a single row are adjacent, so this method will return an {@link Iterator} with exactly one entry
+     * per non-empty row.
      */
     private Iterator<Map.Entry<byte[], RowColumnRangeIterator>> partitionByRow(
             Iterator<Map.Entry<Cell, Value>> rawResults) {
@@ -728,9 +726,9 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     }
 
     /**
-     * This will load the given keys from the underlying key value service and apply postFiltering
-     * so we have snapshot isolation.  If the value in the key value service is the empty array
-     * this will be included here and needs to be filtered out.
+     * This will load the given keys from the underlying key value service and apply postFiltering so we have snapshot
+     * isolation.  If the value in the key value service is the empty array this will be included here and needs to be
+     * filtered out.
      */
     private ListenableFuture<Map<Cell, byte[]>> getFromKeyValueService(
             TableReference tableRef,
@@ -1254,12 +1252,11 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     }
 
     /**
-     * A sentinel becomes orphaned if the table has been truncated between the time where the write occurred
-     * and where it was truncated. In this case, there is a chance that we end up with a sentinel with no
-     * valid AtlasDB cell covering it. In this case, we ignore it.
+     * A sentinel becomes orphaned if the table has been truncated between the time where the write occurred and where
+     * it was truncated. In this case, there is a chance that we end up with a sentinel with no valid AtlasDB cell
+     * covering it. In this case, we ignore it.
      */
-    @VisibleForTesting
-    Set<Cell> findOrphanedSweepSentinels(TableReference table, Map<Cell, Value> rawResults) {
+    private Set<Cell> findOrphanedSweepSentinels(TableReference table, Map<Cell, Value> rawResults) {
         Set<Cell> sweepSentinels = Maps.filterValues(rawResults, SnapshotTransaction::isSweepSentinel)
                 .keySet();
         if (sweepSentinels.isEmpty()) {
@@ -1302,7 +1299,24 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             timestampCandidates = keyValueService.getLatestTimestamps(table, nextTimestampCandidates);
         }
 
+        deleteOrphanedSentinelsAsync(table, actualOrphanedSentinels);
+
         return actualOrphanedSentinels;
+    }
+
+    private void deleteOrphanedSentinelsAsync(TableReference table, Set<Cell> actualOrphanedSentinels) {
+        sweepQueue.getSweepStrategy(table).ifPresent(strategy -> {
+            if (strategy == SweeperStrategy.THOROUGH) {
+                SetMultimap<Cell, Long> sentinels = KeyedStream.of(actualOrphanedSentinels)
+                        .map(_ignore -> Value.INVALID_VALUE_TIMESTAMP)
+                        .collectToSetMultimap();
+                try {
+                    deleteExecutor.execute(() -> keyValueService.delete(table, sentinels));
+                } catch (Throwable th) {
+                    // best effort
+                }
+            }
+        });
     }
 
     private static boolean isSweepSentinel(Value value) {
@@ -1310,8 +1324,8 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     }
 
     /**
-     * This will return all the key-value pairs that still need to be postFiltered.  It will output properly
-     * post filtered keys to the {@code resultsCollector} output param.
+     * This will return all the key-value pairs that still need to be postFiltered.  It will output properly post
+     * filtered keys to the {@code resultsCollector} output param.
      */
     private <T> ListenableFuture<Map<Cell, Value>> getWithPostFilteringInternal(
             TableReference tableRef,
@@ -1767,6 +1781,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
 
     /**
      * Refreshes external and commit locks.
+     *
      * @return set of locks that could not be refreshed
      */
     private Set<LockToken> refreshCommitAndImmutableTsLocks(@Nullable LockToken commitLocksToken) {
@@ -1830,9 +1845,9 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     }
 
     /**
-     * This will throw if we have a value changed conflict.  This means that either we changed the
-     * value and anyone did a write after our start timestamp, or we just touched the value (put the
-     * same value as before) and a changed value was written after our start time.
+     * This will throw if we have a value changed conflict.  This means that either we changed the value and anyone did
+     * a write after our start timestamp, or we just touched the value (put the same value as before) and a changed
+     * value was written after our start time.
      */
     private void throwIfValueChangedConflict(
             TableReference table,
@@ -1900,8 +1915,8 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     }
 
     /**
-     * This will return the set of keys that need to be retried.  It will output any conflicts
-     * it finds into the output params.
+     * This will return the set of keys that need to be retried.  It will output any conflicts it finds into the output
+     * params.
      */
     protected Map<Cell, Long> detectWriteAlreadyCommittedInternal(
             TableReference tableRef,
@@ -1954,8 +1969,9 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     }
 
     /**
-     * This will attempt to rollback the passed transactions.  If all are rolled back correctly this
-     * method will also delete the values for the transactions that have been rolled back.
+     * This will attempt to rollback the passed transactions.  If all are rolled back correctly this method will also
+     * delete the values for the transactions that have been rolled back.
+     *
      * @return false if we cannot roll back the failed transactions because someone beat us to it
      */
     private boolean rollbackFailedTransactions(
@@ -1988,8 +2004,8 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     }
 
     /**
-     * This method is made static so it loses reference to the SnapshotTransaction reference
-     * when passed to deleteExecutor::execute in a lambda reducing its retained memory size.
+     * This method is made static so it loses reference to the SnapshotTransaction reference when passed to
+     * deleteExecutor::execute in a lambda reducing its retained memory size.
      */
     private static void deleteCells(
             KeyValueService keyValueService, TableReference tableRef, Map<Cell, Long> keysToDelete) {
@@ -2018,6 +2034,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
 
     /**
      * Rollback a someone else's transaction.
+     *
      * @return true if the other transaction was rolled back
      */
     private boolean rollbackOtherTransaction(long startTs, TransactionService transactionService) {
@@ -2093,9 +2110,8 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     }
 
     /**
-     * We will block here until the passed transactions have released their lock.  This means that
-     * the committing transaction is either complete or it has failed and we are allowed to roll
-     * it back.
+     * We will block here until the passed transactions have released their lock.  This means that the committing
+     * transaction is either complete or it has failed and we are allowed to roll it back.
      */
     private void waitForCommitToComplete(Iterable<Long> startTimestamps) {
         Set<LockDescriptor> lockDescriptors = new HashSet<>();
@@ -2137,6 +2153,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
 
     /**
      * TODO(fdesouza): Remove this once PDS-95791 is resolved.
+     *
      * @deprecated Remove this once PDS-95791 is resolved.
      */
     @Deprecated
@@ -2166,9 +2183,8 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     }
 
     /**
-     * Returns a map from start timestamp to commit timestamp.  If a start timestamp wasn't
-     * committed, then it will be missing from the map.  This method will block until the
-     * transactions for these start timestamps are complete.
+     * Returns a map from start timestamp to commit timestamp.  If a start timestamp wasn't committed, then it will be
+     * missing from the map.  This method will block until the transactions for these start timestamps are complete.
      */
     protected ListenableFuture<Map<Long, Long>> getCommitTimestamps(
             @Nullable TableReference tableRef,
@@ -2272,7 +2288,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     /**
      * This will attempt to put the commitTimestamp into the DB.
      *
-     * @throws TransactionLockTimeoutException If our locks timed out while trying to commit.
+     * @throws TransactionLockTimeoutException  If our locks timed out while trying to commit.
      * @throws TransactionCommitFailedException failed when committing in a way that isn't retriable
      */
     private void putCommitTimestamp(long commitTimestamp, LockToken locksToken, TransactionService transactionService)
@@ -2347,10 +2363,11 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         constraintsByTableName.put(tableRef, table);
     }
 
-    /** The similarly-named-and-intentioned useTable method is only called on writes.
-     *  This one is more comprehensive and covers read paths as well
-     * (necessary because we wish to get the sweep strategies of tables in read-only transactions)
-     *
+    /**
+     * The similarly-named-and-intentioned useTable method is only called on writes. This one is more comprehensive and
+     * covers read paths as well (necessary because we wish to get the sweep strategies of tables in read-only
+     * transactions)
+     * <p>
      * A table can be involved in a transaction, even if there were no reads done on it, see #markTableInvolved.
      */
     private void markTableAsInvolvedInThisTransaction(TableReference tableRef) {

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -1446,7 +1446,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
     @Test
     public void getOrphanedSweepSentinelDoesNotThrow() {
         Transaction t1 = txManager.createNewTransaction();
-        writeSentinelToTestTable(TEST_CELL);
+        writeSentinelToTestTable(TABLE_SWEPT_CONSERVATIVE, TEST_CELL);
         assertThatCode(() -> t1.get(TABLE_SWEPT_CONSERVATIVE, ImmutableSet.of(TEST_CELL)))
                 .doesNotThrowAnyException();
     }
@@ -1454,11 +1454,9 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
     @Test
     public void getSweepSentinelUnderCommittedWriteThrowsAndCanBeRetried() {
         Transaction t1 = txManager.createNewTransaction();
-        writeSentinelToTestTable(TEST_CELL);
+        writeSentinelToTestTable(TABLE_SWEPT_CONSERVATIVE, TEST_CELL);
 
-        Transaction t2 = txManager.createNewTransaction();
-        t2.put(TABLE_SWEPT_CONSERVATIVE, ImmutableMap.of(TEST_CELL, PtBytes.toBytes("blablabla")));
-        t2.commit();
+        commitWrite(TABLE_SWEPT_CONSERVATIVE, TEST_CELL);
 
         assertThatThrownBy(() -> t1.get(TABLE_SWEPT_CONSERVATIVE, ImmutableSet.of(TEST_CELL)))
                 .isInstanceOf(TransactionFailedRetriableException.class)
@@ -1472,8 +1470,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
     @Test
     public void getSweepSentinelUnderLateUncommittedWriteDoesNotThrow() {
         Transaction t1 = txManager.createNewTransaction();
-        writeSentinelToTestTable(TEST_CELL);
-        putUncommittedAtFreshTimestamp(TEST_CELL);
+        writeSentinelToTestTable(TABLE_SWEPT_CONSERVATIVE, TEST_CELL);
+        putUncommittedAtFreshTimestamp(TABLE_SWEPT_CONSERVATIVE, TEST_CELL);
 
         assertThatCode(() -> t1.get(TABLE_SWEPT_CONSERVATIVE, ImmutableSet.of(TEST_CELL)))
                 .doesNotThrowAnyException();
@@ -1481,8 +1479,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
 
     @Test
     public void getSweepSentinelUnderEarlyUncommittedWriteDoesNotThrow() {
-        writeSentinelToTestTable(TEST_CELL);
-        putUncommittedAtFreshTimestamp(TEST_CELL);
+        writeSentinelToTestTable(TABLE_SWEPT_CONSERVATIVE, TEST_CELL);
+        putUncommittedAtFreshTimestamp(TABLE_SWEPT_CONSERVATIVE, TEST_CELL);
         Transaction t1 = txManager.createNewTransaction();
 
         assertThatCode(() -> t1.get(TABLE_SWEPT_CONSERVATIVE, ImmutableSet.of(TEST_CELL)))
@@ -1492,10 +1490,10 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
     @Test
     public void getSweepSentinelUnderMultipleUncommittedWritesDoesNotThrow() {
         Transaction t1 = txManager.createNewTransaction();
-        writeSentinelToTestTable(TEST_CELL);
+        writeSentinelToTestTable(TABLE_SWEPT_CONSERVATIVE, TEST_CELL);
 
         for (int transaction = 1; transaction <= 10; transaction++) {
-            putUncommittedAtFreshTimestamp(TEST_CELL);
+            putUncommittedAtFreshTimestamp(TABLE_SWEPT_CONSERVATIVE, TEST_CELL);
         }
 
         assertThatCode(() -> t1.get(TABLE_SWEPT_CONSERVATIVE, ImmutableSet.of(TEST_CELL)))
@@ -1505,14 +1503,12 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
     @Test
     public void getSweepSentinelUnderHiddenCommittedWriteThrows() {
         Transaction t1 = txManager.createNewTransaction();
-        writeSentinelToTestTable(TEST_CELL);
+        writeSentinelToTestTable(TABLE_SWEPT_CONSERVATIVE, TEST_CELL);
 
-        Transaction t2 = txManager.createNewTransaction();
-        t2.put(TABLE_SWEPT_CONSERVATIVE, ImmutableMap.of(TEST_CELL, PtBytes.toBytes("blablabla")));
-        t2.commit();
+        commitWrite(TABLE_SWEPT_CONSERVATIVE, TEST_CELL);
 
         for (int transaction = 1; transaction <= 10; transaction++) {
-            putUncommittedAtFreshTimestamp(TEST_CELL);
+            putUncommittedAtFreshTimestamp(TABLE_SWEPT_CONSERVATIVE, TEST_CELL);
         }
 
         assertThatThrownBy(() -> t1.get(TABLE_SWEPT_CONSERVATIVE, ImmutableSet.of(TEST_CELL)))
@@ -1523,9 +1519,9 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
     @Test
     public void getOrphanedSentinelAndSentinelUnderUncommittedWriteDoesNotThrow() {
         Transaction t1 = txManager.createNewTransaction();
-        writeSentinelToTestTable(TEST_CELL);
-        writeSentinelToTestTable(TEST_CELL_2);
-        putUncommittedAtFreshTimestamp(TEST_CELL_2);
+        writeSentinelToTestTable(TABLE_SWEPT_CONSERVATIVE, TEST_CELL);
+        writeSentinelToTestTable(TABLE_SWEPT_CONSERVATIVE, TEST_CELL_2);
+        putUncommittedAtFreshTimestamp(TABLE_SWEPT_CONSERVATIVE, TEST_CELL_2);
 
         assertThatCode(() -> t1.get(TABLE_SWEPT_CONSERVATIVE, ImmutableSet.of(TEST_CELL, TEST_CELL_2)))
                 .doesNotThrowAnyException();
@@ -1534,11 +1530,9 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
     @Test
     public void getOrphanedSentinelAndSentinelUnderCommittedWriteThrows() {
         Transaction t1 = txManager.createNewTransaction();
-        writeSentinelToTestTable(TEST_CELL);
-        writeSentinelToTestTable(TEST_CELL_2);
-        Transaction t2 = txManager.createNewTransaction();
-        t2.put(TABLE_SWEPT_CONSERVATIVE, ImmutableMap.of(TEST_CELL_2, PtBytes.toBytes("covering")));
-        t2.commit();
+        writeSentinelToTestTable(TABLE_SWEPT_CONSERVATIVE, TEST_CELL);
+        writeSentinelToTestTable(TABLE_SWEPT_CONSERVATIVE, TEST_CELL_2);
+        commitWrite(TABLE_SWEPT_CONSERVATIVE, TEST_CELL_2);
 
         assertThatThrownBy(() -> t1.get(TABLE_SWEPT_CONSERVATIVE, ImmutableSet.of(TEST_CELL, TEST_CELL_2)))
                 .isInstanceOf(TransactionFailedRetriableException.class)
@@ -1548,12 +1542,10 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
     @Test
     public void getSentinelUnderCommittedAndSentinelUnderUncommittedWriteThrows() {
         Transaction t1 = txManager.createNewTransaction();
-        writeSentinelToTestTable(TEST_CELL);
-        writeSentinelToTestTable(TEST_CELL_2);
-        putUncommittedAtFreshTimestamp(TEST_CELL);
-        Transaction t2 = txManager.createNewTransaction();
-        t2.put(TABLE_SWEPT_CONSERVATIVE, ImmutableMap.of(TEST_CELL_2, PtBytes.toBytes("covering")));
-        t2.commit();
+        writeSentinelToTestTable(TABLE_SWEPT_CONSERVATIVE, TEST_CELL);
+        writeSentinelToTestTable(TABLE_SWEPT_CONSERVATIVE, TEST_CELL_2);
+        putUncommittedAtFreshTimestamp(TABLE_SWEPT_CONSERVATIVE, TEST_CELL);
+        commitWrite(TABLE_SWEPT_CONSERVATIVE, TEST_CELL_2);
 
         assertThatThrownBy(() -> t1.get(TABLE_SWEPT_CONSERVATIVE, ImmutableSet.of(TEST_CELL, TEST_CELL_2)))
                 .isInstanceOf(TransactionFailedRetriableException.class)
@@ -1576,20 +1568,18 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
 
         for (int index = 0; index < cellsUnderUncommittedWrites.size(); index++) {
             Cell cell = cellsUnderUncommittedWrites.get(index);
-            writeSentinelToTestTable(cell);
+            writeSentinelToTestTable(TABLE_SWEPT_CONSERVATIVE, cell);
             for (int uncommittedValue = 0; uncommittedValue <= index; uncommittedValue++) {
-                putUncommittedAtFreshTimestamp(cell);
+                putUncommittedAtFreshTimestamp(TABLE_SWEPT_CONSERVATIVE, cell);
             }
         }
 
         for (int index = 0; index < cellsUnderHiddenCommittedWrites.size(); index++) {
             Cell cell = cellsUnderHiddenCommittedWrites.get(index);
-            writeSentinelToTestTable(cell);
-            Transaction txn = txManager.createNewTransaction();
-            txn.put(TABLE_SWEPT_CONSERVATIVE, ImmutableMap.of(cell, PtBytes.toBytes("i'm in a transaction")));
-            txn.commit();
+            writeSentinelToTestTable(TABLE_SWEPT_CONSERVATIVE, cell);
+            commitWrite(TABLE_SWEPT_CONSERVATIVE, cell);
             for (int uncommittedValue = 0; uncommittedValue < index; uncommittedValue++) {
-                putUncommittedAtFreshTimestamp(cell);
+                putUncommittedAtFreshTimestamp(TABLE_SWEPT_CONSERVATIVE, cell);
             }
         }
 
@@ -1617,16 +1607,98 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
         assertThatCode(() -> retryTxn.get(TABLE_SWEPT_CONSERVATIVE, cells)).doesNotThrowAnyException();
     }
 
-    private void putUncommittedAtFreshTimestamp(Cell cell) {
+    @Test
+    public void orphanedSentinelsGetDeletedAfterDetectionInThoroughlySweptTable() {
         keyValueService.put(
-                TABLE_SWEPT_CONSERVATIVE,
+                TABLE_SWEPT_THOROUGH, ImmutableMap.of(TEST_CELL, new byte[0]), Value.INVALID_VALUE_TIMESTAMP);
+
+        assertThat(keyValueService.get(TABLE_SWEPT_THOROUGH, ImmutableMap.of(TEST_CELL, 0L)))
+                .isNotEmpty();
+
+        Transaction t1 = txManager.createNewTransaction();
+        assertThatCode(() -> t1.get(TABLE_SWEPT_THOROUGH, ImmutableSet.of(TEST_CELL)))
+                .doesNotThrowAnyException();
+
+        assertThat(keyValueService.get(TABLE_SWEPT_THOROUGH, ImmutableMap.of(TEST_CELL, 0L)))
+                .isEmpty();
+    }
+
+    @Test
+    public void orphanedSentinelsCoveredWithUncommitedGetDeletedAfterDetectionInThoroughlySweptTable() {
+        writeSentinelToTestTable(TABLE_SWEPT_THOROUGH, TEST_CELL);
+        putUncommittedAtFreshTimestamp(TABLE_SWEPT_THOROUGH, TEST_CELL);
+
+        Transaction t1 = txManager.createNewTransaction();
+        assertThatCode(() -> t1.get(TABLE_SWEPT_THOROUGH, ImmutableSet.of(TEST_CELL)))
+                .doesNotThrowAnyException();
+
+        assertThat(keyValueService.get(TABLE_SWEPT_THOROUGH, ImmutableMap.of(TEST_CELL, 0L)))
+                .isEmpty();
+    }
+
+    @Test
+    public void nonOrphanedSentinelsDoNotGetDeletedAfterDetectionInThoroughlySweptTable() {
+        Transaction t1 = txManager.createNewTransaction();
+        writeSentinelToTestTable(TABLE_SWEPT_THOROUGH, TEST_CELL);
+
+        commitWrite(TABLE_SWEPT_THOROUGH, TEST_CELL);
+
+        assertThatThrownBy(() -> t1.get(TABLE_SWEPT_THOROUGH, ImmutableSet.of(TEST_CELL)))
+                .isInstanceOf(TransactionFailedRetriableException.class)
+                .hasMessageContaining("Tried to read a value that has been deleted.");
+
+        assertThat(keyValueService.get(TABLE_SWEPT_THOROUGH, ImmutableMap.of(TEST_CELL, 0L)))
+                .isNotEmpty();
+    }
+
+    @Test
+    public void testSentinelsDeletionForDifferentCasesInThoroughTable() {
+        Transaction t1 = txManager.createNewTransaction();
+
+        Cell testCell3 = Cell.create(PtBytes.toBytes("super"), PtBytes.toBytes("ez"));
+
+        writeSentinelToTestTable(TABLE_SWEPT_THOROUGH, TEST_CELL);
+        writeSentinelToTestTable(TABLE_SWEPT_THOROUGH, TEST_CELL_2);
+        writeSentinelToTestTable(TABLE_SWEPT_THOROUGH, testCell3);
+
+        commitWrite(TABLE_SWEPT_THOROUGH, TEST_CELL);
+        putUncommittedAtFreshTimestamp(TABLE_SWEPT_THOROUGH, TEST_CELL_2);
+
+        assertThatThrownBy(() -> t1.get(TABLE_SWEPT_THOROUGH, ImmutableSet.of(TEST_CELL)))
+                .isInstanceOf(TransactionFailedRetriableException.class)
+                .hasMessageContaining("Tried to read a value that has been deleted.");
+
+        assertThat(keyValueService.get(TABLE_SWEPT_THOROUGH, ImmutableMap.of(TEST_CELL, 0L)))
+                .containsExactlyEntriesOf(
+                        ImmutableMap.of(TEST_CELL, Value.create(new byte[0], Value.INVALID_VALUE_TIMESTAMP)));
+    }
+
+    @Test
+    public void orphanedSentinelsDoNotGetDeletedAfterDetectionInConservativelySweptTable() {
+        writeSentinelToTestTable(TABLE_SWEPT_CONSERVATIVE, TEST_CELL);
+        Transaction t1 = txManager.createNewTransaction();
+        assertThatCode(() -> t1.get(TABLE_SWEPT_CONSERVATIVE, ImmutableSet.of(TEST_CELL)))
+                .doesNotThrowAnyException();
+
+        assertThat(keyValueService.get(TABLE_SWEPT_CONSERVATIVE, ImmutableMap.of(TEST_CELL, 0L)))
+                .isNotEmpty();
+    }
+
+    private void putUncommittedAtFreshTimestamp(TableReference tableRef, Cell cell) {
+        keyValueService.put(
+                tableRef,
                 ImmutableMap.of(cell, PtBytes.toBytes("i am uncommitted")),
                 txManager.createNewTransaction().getTimestamp());
     }
 
-    private void writeSentinelToTestTable(Cell cell) {
-        keyValueService.put(
-                TABLE_SWEPT_CONSERVATIVE, ImmutableMap.of(cell, new byte[0]), Value.INVALID_VALUE_TIMESTAMP);
+    private void writeSentinelToTestTable(TableReference tableRef, Cell cell) {
+        keyValueService.put(tableRef, ImmutableMap.of(cell, new byte[0]), Value.INVALID_VALUE_TIMESTAMP);
+    }
+
+    private void commitWrite(TableReference tableSweptThorough, Cell testCell) {
+        Transaction t2 = txManager.createNewTransaction();
+        t2.put(tableSweptThorough, ImmutableMap.of(testCell, PtBytes.toBytes("something")));
+        t2.commit();
     }
 
     private void setTransactionConfig(TransactionConfig config) {

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -1668,8 +1668,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 .hasMessageContaining("Tried to read a value that has been deleted.");
 
         assertThat(keyValueService.get(
-                TABLE_SWEPT_THOROUGH,
-                ImmutableMap.of(TEST_CELL, 0L, TEST_CELL_2, 0L, testCell3, 0L)))
+                        TABLE_SWEPT_THOROUGH, ImmutableMap.of(TEST_CELL, 0L, TEST_CELL_2, 0L, testCell3, 0L)))
                 .containsExactlyEntriesOf(
                         ImmutableMap.of(TEST_CELL, Value.create(new byte[0], Value.INVALID_VALUE_TIMESTAMP)));
     }

--- a/changelog/@unreleased/pr-5232.v2.yml
+++ b/changelog/@unreleased/pr-5232.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Transactions encountering naked sweep sentinels in thoroughly swept tables will now submit a task to clean them up.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5232


### PR DESCRIPTION
**Goals (and why)**:
Clean up some trash in a way that doesn't impact the currently running transaction

**Implementation Description (bullets)**:
We use the sweep queue's cache to determine if the table is thoroughly swept and submit the deletes to the delete executor

**Testing (What was existing testing like?  What have you done to improve it?)**:
some integration tests

**Concerns (what feedback would you like?)**:
none

