### PR TITLE
Add the getRowKeysInRange method to the KVS interface

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -650,11 +650,17 @@ public interface KeyValueService extends AutoCloseable, AsyncKeyValueService {
     /**
      * Returns a sorted list of row keys in the specified range.
      *
+     * This method is not guaranteed to be implemented for all implementations of {@link KeyValueService}. It may be
+     * changed or removed at any time without warning.
+     *
+     * @deprecated if you wish to use this method, contact the atlasdb team for support
+     *
      * @param tableRef table for which the request is made.
      * @param startRow inclusive start of the row key range. Use empty byte array for unbounded.
      * @param endRow inclusive end of the row key range. Use empty byte array for unbounded.
      * @param maxResults the request only returns the first maxResults rows in range.
      */
     @DoDelegate
+    @Deprecated
     List<byte[]> getRowKeysInRange(TableReference tableRef, byte[] startRow, byte[] endRow, int maxResults);
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -646,4 +646,15 @@ public interface KeyValueService extends AutoCloseable, AsyncKeyValueService {
     default boolean shouldTriggerCompactions() {
         return false;
     }
+
+    /**
+     * Returns a sorted list of row keys in the specified range.
+     *
+     * @param tableRef table for which the request is made.
+     * @param startRow inclusive start of the row key range. Use empty byte array for unbounded.
+     * @param endRow inclusive end of the row key range. Use empty byte array for unbounded.
+     * @param maxResults the request only returns the first maxResults rows in range.
+     */
+    @DoDelegate
+    List<byte[]> getRowKeysInRange(TableReference tableRef, byte[] startRow, byte[] endRow, int maxResults);
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -16,9 +16,7 @@
 package com.palantir.atlasdb.keyvalue.cassandra;
 
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
-import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.processors.AutoDelegate;
-import java.util.List;
 
 @AutoDelegate
 public interface CassandraKeyValueService extends KeyValueService {
@@ -30,13 +28,4 @@ public interface CassandraKeyValueService extends KeyValueService {
 
     @Override
     boolean isInitialized();
-    /**
-     * Returns a sorted list of row keys in the specified range.
-     *
-     * @param tableRef table for which the request is made.
-     * @param startRow inclusive start of the row key range. Use empty byte array for unbounded.
-     * @param endRow inclusive end of the row key range. Use empty byte array for unbounded.
-     * @param maxResults the request only returns the first maxResults rows in range.
-     */
-    List<byte[]> getRowKeysInRange(TableReference tableRef, byte[] startRow, byte[] endRow, int maxResults);
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DualWriteKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DualWriteKeyValueService.java
@@ -294,6 +294,11 @@ public class DualWriteKeyValueService implements KeyValueService {
     }
 
     @Override
+    public List<byte[]> getRowKeysInRange(TableReference tableRef, byte[] startRow, byte[] endRow, int maxResults) {
+        return delegate1.getRowKeysInRange(tableRef, startRow, endRow, maxResults);
+    }
+
+    @Override
     public ListenableFuture<Map<Cell, Value>> getAsync(TableReference tableRef, Map<Cell, Long> timestampByCell) {
         return delegate1.getAsync(tableRef, timestampByCell);
     }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
@@ -508,6 +508,13 @@ public final class ProfilingKeyValueService implements KeyValueService {
     }
 
     @Override
+    public List<byte[]> getRowKeysInRange(TableReference tableRef, byte[] startRow, byte[] endRow, int maxResults) {
+        return maybeLog(
+                () -> delegate.getRowKeysInRange(tableRef, startRow, endRow, maxResults),
+                logTimeAndTable("getRowKeysInRange", tableRef));
+    }
+
+    @Override
     public ListenableFuture<Map<Cell, Value>> getAsync(TableReference tableRef, Map<Cell, Long> timestampByCell) {
         long startTime = System.currentTimeMillis();
         return KvsProfilingLogger.maybeLogAsync(

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueService.java
@@ -45,6 +45,8 @@ import com.palantir.atlasdb.tracing.CloseableTrace;
 import com.palantir.common.base.ClosableIterator;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
 import com.palantir.tracing.DetachedSpan;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
 import java.util.Collection;
@@ -425,6 +427,18 @@ public final class TracingKeyValueService extends ForwardingObject implements Ke
     @Override
     public boolean shouldTriggerCompactions() {
         return delegate().shouldTriggerCompactions();
+    }
+
+    @Override
+    public List<byte[]> getRowKeysInRange(TableReference tableRef, byte[] startRow, byte[] endRow, int maxResults) {
+        try (CloseableTrace trace = startLocalTrace(
+                "getRowKeysInRange({}, {}, {}, {})",
+                LoggingArgs.safeTableOrPlaceholder(tableRef),
+                UnsafeArg.of("startRow", startRow),
+                UnsafeArg.of("endRow", endRow),
+                SafeArg.of("maxResults", maxResults))) {
+            return delegate().getRowKeysInRange(tableRef, startRow, endRow, maxResults);
+        }
     }
 
     @Override

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
@@ -1208,6 +1208,11 @@ public final class DbKvs extends AbstractKeyValueService implements DbKeyValueSe
     }
 
     @Override
+    public List<byte[]> getRowKeysInRange(TableReference tableRef, byte[] startRow, byte[] endRow, int maxResults) {
+        throw new UnsupportedOperationException("getRowKeysInRange is only supported for Cassandra.");
+    }
+
+    @Override
     public ListenableFuture<Map<Cell, Value>> getAsync(TableReference tableRef, Map<Cell, Long> timestampByCell) {
         return Futures.immediateFuture(get(tableRef, timestampByCell));
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableRemappingKeyValueService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableRemappingKeyValueService.java
@@ -438,6 +438,15 @@ public final class TableRemappingKeyValueService extends ForwardingObject implem
     }
 
     @Override
+    public List<byte[]> getRowKeysInRange(TableReference tableRef, byte[] startRow, byte[] endRow, int maxResults) {
+        try {
+            return delegate().getRowKeysInRange(tableMapper.getMappedTableName(tableRef), startRow, endRow, maxResults);
+        } catch (TableMappingNotFoundException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    @Override
     public ListenableFuture<Map<Cell, Value>> getAsync(TableReference tableRef, Map<Cell, Long> timestampByCell) {
         try {
             return delegate().getAsync(tableMapper.getMappedTableName(tableRef), timestampByCell);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableSplittingKeyValueService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableSplittingKeyValueService.java
@@ -388,6 +388,11 @@ public final class TableSplittingKeyValueService implements KeyValueService {
     }
 
     @Override
+    public List<byte[]> getRowKeysInRange(TableReference tableRef, byte[] startRow, byte[] endRow, int maxResults) {
+        return getDelegate(tableRef).getRowKeysInRange(tableRef, startRow, endRow, maxResults);
+    }
+
+    @Override
     public ListenableFuture<Map<Cell, Value>> getAsync(TableReference tableRef, Map<Cell, Long> timestampByCell) {
         return getDelegate(tableRef).getAsync(tableRef, timestampByCell);
     }

--- a/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueService.java
+++ b/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueService.java
@@ -1008,6 +1008,11 @@ public final class JdbcKeyValueService implements KeyValueService {
     }
 
     @Override
+    public List<byte[]> getRowKeysInRange(TableReference tableRef, byte[] startRow, byte[] endRow, int maxResults) {
+        throw new UnsupportedOperationException("getRowKeysInRange is only supported for Cassandra.");
+    }
+
+    @Override
     public ListenableFuture<Map<Cell, Value>> getAsync(TableReference tableRef, Map<Cell, Long> timestampByCell) {
         return Futures.immediateFuture(this.get(tableRef, timestampByCell));
     }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTestSetup.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTestSetup.java
@@ -224,7 +224,7 @@ public abstract class TransactionTestSetup {
         return valueBytes != null ? PtBytes.toString(valueBytes) : null;
     }
 
-    void putDirect(String rowName, String columnName, String value, long timestamp) {
+    protected void putDirect(String rowName, String columnName, String value, long timestamp) {
         Cell cell = createCell(rowName, columnName);
         byte[] valueBytes = PtBytes.toBytes(value);
         keyValueService.put(TEST_TABLE, ImmutableMap.of(cell, valueBytes), timestamp);

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/MemoryTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/MemoryTransactionTest.java
@@ -15,15 +15,62 @@
  */
 package com.palantir.atlasdb.keyvalue;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.impl.TestResourceManager;
 import com.palantir.atlasdb.transaction.impl.AbstractTransactionTest;
 import org.junit.ClassRule;
+import org.junit.Test;
 
 public class MemoryTransactionTest extends AbstractTransactionTest {
     @ClassRule
     public static final TestResourceManager TRM = TestResourceManager.inMemory();
 
+    private static final byte[] ROW_1 = PtBytes.toBytes("row1");
+    private static final byte[] ZERO = new byte[0];
+
     public MemoryTransactionTest() {
         super(TRM, TRM);
+    }
+
+    @Test
+    public void testKeyValueRangeColumnSelectionEndInclusive() {
+        setup();
+        assertThat(keyValueService.getRowKeysInRange(TEST_TABLE, ZERO, ROW_1, 9))
+                .containsExactly(ROW_1);
+    }
+
+    @Test
+    public void testKeyValueRangeColumnSelectionEntireTable() {
+        setup();
+        byte[] row1 = PtBytes.toBytes("row1");
+        assertThat(keyValueService.getRowKeysInRange(TEST_TABLE, ZERO, ZERO, 9))
+                .containsExactly(row1, PtBytes.toBytes("row1a"), PtBytes.toBytes("row2"));
+    }
+
+    @Test
+    public void testKeyValueRangeColumnSelectionStartInclusive() {
+        setup();
+        byte[] row1 = PtBytes.toBytes("row1");
+        assertThat(keyValueService.getRowKeysInRange(TEST_TABLE, ROW_1, ZERO, 9))
+                .containsExactly(row1, PtBytes.toBytes("row1a"), PtBytes.toBytes("row2"));
+    }
+
+    @Test
+    public void testKeyValueRangeColumnSelectionMaxResults() {
+        setup();
+        byte[] row1 = PtBytes.toBytes("row1");
+        assertThat(keyValueService.getRowKeysInRange(TEST_TABLE, ZERO, ZERO, 2))
+                .containsExactly(row1, PtBytes.toBytes("row1a"));
+    }
+
+    private void setup() {
+        putDirect("row1", "col1", "v1", 0);
+        putDirect("row1", "col2", "v2", 2);
+        putDirect("row1", "col4", "v5", 3);
+        putDirect("row1a", "col4", "v5", 100);
+        putDirect("row2", "col2", "v3", 1);
+        putDirect("row2", "col4", "v4", 6);
     }
 }

--- a/changelog/@unreleased/pr-5236.v2.yml
+++ b/changelog/@unreleased/pr-5236.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Added the getRowKeysInRange method to the KVS interface, so we can access the Cassandra KVS implementation from a transaction manager. This may be removed at any time, and if you wish to use it, contact the atlasdb team for support.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5236


### PR DESCRIPTION
**Goals (and why)**:
Add the getRowKeysInRange method to the KVS interface, so we can access the Cassandra KVS implementation from a transaction manager. This is probably only temporary and is necessary to address an ongoing issue.

**Implementation Description (bullets)**:
Wiring, hacky in memory implementation

**Testing (What was existing testing like?  What have you done to improve it?)**:
Cassandra impl had tests before, in memory has a few unit tests

**Concerns (what feedback would you like?)**:
bleh

**Where should we start reviewing?**:
anywhere

**Priority (whenever / two weeks / yesterday)**:
yesterday
