### PR TITLE
[PDS-156719] | LeaderConfig bug fix

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/config/LeaderConfig.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/config/LeaderConfig.java
@@ -130,7 +130,7 @@ public abstract class LeaderConfig {
     }
 
     private boolean ensureDirectoryExists(File directory) {
-        if (learnerLogDir().exists()) {
+        if (directory.exists()) {
             return true;
         }
         try {

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/config/LeaderConfig.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/config/LeaderConfig.java
@@ -20,25 +20,18 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Preconditions;
 import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
-import com.palantir.logsafe.SafeArg;
 import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.Set;
 import javax.validation.constraints.Size;
 import org.immutables.value.Value;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @JsonDeserialize(as = ImmutableLeaderConfig.class)
 @JsonSerialize(as = ImmutableLeaderConfig.class)
 @Value.Immutable
 @SuppressWarnings("DesignForExtension")
 public abstract class LeaderConfig {
-
-    private static final Logger log = LoggerFactory.getLogger(LeaderConfig.class);
 
     public abstract int quorumSize();
 
@@ -119,26 +112,5 @@ public abstract class LeaderConfig {
                 "The localServer '%s' must included in the leader entries %s.",
                 localServer(),
                 leaders());
-        Preconditions.checkArgument(
-                ensureDirectoryExists(learnerLogDir()),
-                "Learner log directory '%s' does not exist and cannot be created.",
-                learnerLogDir());
-        Preconditions.checkArgument(
-                ensureDirectoryExists(acceptorLogDir()),
-                "Acceptor log directory '%s' does not exist and cannot be created.",
-                acceptorLogDir());
-    }
-
-    private boolean ensureDirectoryExists(File directory) {
-        if (directory.exists()) {
-            return true;
-        }
-        try {
-            Files.createDirectories(Paths.get(directory.getPath()));
-            return true;
-        } catch (Throwable t) {
-            log.error("Could not create the directory {}", SafeArg.of("dirName", directory.getPath()), t);
-            return false;
-        }
     }
 }

--- a/changelog/@unreleased/pr-5240.v2.yml
+++ b/changelog/@unreleased/pr-5240.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Allows overriding of LeaderConfig#learnerLogDir and LeaderConfig#acceptorLogDir while setting up external TL service.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5240

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -78,6 +78,7 @@ import com.palantir.timelock.management.TimestampStorage;
 import com.palantir.timestamp.ManagedTimestampService;
 import com.zaxxer.hikari.HikariDataSource;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -431,11 +432,15 @@ public class TimeLockAgent {
 
     private LeaderConfig createLeaderConfig() {
         List<String> uris = install.cluster().clusterMembers();
+        Path dataDirectory = install.paxos().dataDirectory().toPath();
+
         return ImmutableLeaderConfig.builder()
                 .addLeaders(uris.toArray(new String[0]))
                 .localServer(install.cluster().localServer())
                 .sslConfiguration(PaxosRemotingUtils.getSslConfigurationOptional(install))
                 .quorumSize(PaxosRemotingUtils.getQuorumSize(uris))
+                .learnerLogDir(dataDirectory.resolve("learner").toFile())
+                .acceptorLogDir(dataDirectory.resolve("acceptor").toFile())
                 .build();
     }
 

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -15,6 +15,10 @@
  */
 package com.palantir.timelock.paxos;
 
+import static com.palantir.atlasdb.timelock.paxos.PaxosTimeLockConstants.ACCEPTOR_SUBDIRECTORY_PATH;
+import static com.palantir.atlasdb.timelock.paxos.PaxosTimeLockConstants.LEADER_PAXOS_NAMESPACE;
+import static com.palantir.atlasdb.timelock.paxos.PaxosTimeLockConstants.LEARNER_SUBDIRECTORY_PATH;
+
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.AtlasDbConstants;
@@ -432,15 +436,19 @@ public class TimeLockAgent {
 
     private LeaderConfig createLeaderConfig() {
         List<String> uris = install.cluster().clusterMembers();
-        Path dataDirectory = install.paxos().dataDirectory().toPath();
+        Path leaderPaxosDataDirectory = install.paxos().dataDirectory().toPath().resolve(LEADER_PAXOS_NAMESPACE);
 
         return ImmutableLeaderConfig.builder()
                 .addLeaders(uris.toArray(new String[0]))
                 .localServer(install.cluster().localServer())
                 .sslConfiguration(PaxosRemotingUtils.getSslConfigurationOptional(install))
                 .quorumSize(PaxosRemotingUtils.getQuorumSize(uris))
-                .learnerLogDir(dataDirectory.resolve("learner").toFile())
-                .acceptorLogDir(dataDirectory.resolve("acceptor").toFile())
+                .learnerLogDir(leaderPaxosDataDirectory
+                        .resolve(LEARNER_SUBDIRECTORY_PATH)
+                        .toFile())
+                .acceptorLogDir(leaderPaxosDataDirectory
+                        .resolve(ACCEPTOR_SUBDIRECTORY_PATH)
+                        .toFile())
                 .build();
     }
 

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -336,6 +336,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
 
         Set<String> namespacesAfterRestart = getKnownNamespaces();
         assertThat(namespacesAfterRestart).contains(randomNamespace);
+        assertThat(namespacesAfterRestart).doesNotContain("learner", "acceptor");
         assertThat(Sets.difference(knownNamespaces, namespacesAfterRestart)).isEmpty();
     }
 


### PR DESCRIPTION
**Goals (and why)**:
Minor bug in `ensureDirectoryExists ` - it returns if learnerDir exists, so acceptor dir is never created.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Existing tests should suffice.

**Priority (whenever / two weeks / yesterday)**:
🏃 
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
