### PR TITLE
[PDS-146088] Log and metrics for a few more edge cases

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraClientPoolHostLevelMetric.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraClientPoolHostLevelMetric.java
@@ -22,7 +22,7 @@ public enum CassandraClientPoolHostLevelMetric {
     NUM_ACTIVE("numActive", 0.1, 2.0),
     CREATED("created", 0.01, 2.0),
     DESTROYED_BY_EVICTOR("destroyedByEvictor", 0.01, 2.0),
-    EVICTOR_TASK_SIZE("evictorTaskSize", 0.0, 2.0);
+    EVICTOR_TASK_SIZE("evictorTaskSize", 0.0, 100.0);
 
     public final String metricName;
     public final double minimumMeanThreshold;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraClientPoolHostLevelMetric.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraClientPoolHostLevelMetric.java
@@ -21,7 +21,8 @@ public enum CassandraClientPoolHostLevelMetric {
     NUM_IDLE("numIdle", 0.1, 2.0),
     NUM_ACTIVE("numActive", 0.1, 2.0),
     CREATED("created", 0.01, 2.0),
-    DESTROYED_BY_EVICTOR("destroyedByEvictor", 0.01, 2.0);
+    DESTROYED_BY_EVICTOR("destroyedByEvictor", 0.01, 2.0),
+    EVICTOR_TASK_SIZE("evictorTaskSize", 0.0, 2.0);
 
     public final String metricName;
     public final double minimumMeanThreshold;

--- a/atlasdb-cassandra/src/main/java/org/apache/commons/pool2/impl/ExposedEvictionTimer.java
+++ b/atlasdb-cassandra/src/main/java/org/apache/commons/pool2/impl/ExposedEvictionTimer.java
@@ -1,0 +1,31 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.pool2.impl;
+
+/**
+ * This class exists solely to expose package-private methods on {@link EvictionTimer}; this should be removed once
+ * the internal investigation into the missing eviction problem is resolved.
+ */
+public final class ExposedEvictionTimer {
+    private ExposedEvictionTimer() {
+        // no-op
+    }
+
+    public static long getNumTasks() {
+        return EvictionTimer.getNumTasks();
+    }
+}

--- a/changelog/@unreleased/pr-5247.v2.yml
+++ b/changelog/@unreleased/pr-5247.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Added further logging around possible edge cases when evicting objects from the Cassandra client pooling containers. Also added a metric that tracks the number of active eviction tasks.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5247


### PR DESCRIPTION
**Goals (and why)**:
* We log when the evictor is considering but _not_ evicting, but it could actually be trying but failing to evict.
* `EvictionTimer` has a static, singleton executor service. If this dies somehow, then no eviction tasks will be run.

**Implementation Description (bullets)**:
* Log even more on all the edge cases
* Added a metric for the number of tasks in the eviction executor.

**Testing (What was existing testing like?  What have you done to improve it?)**:
N/A

**Concerns (what feedback would you like?)**:
* Is this metric expensive?
* Is there a better way of exposing the method from `EvictionTimer`?
* Does this approach of exposing the method require us to include a license / documentation?

**Where should we start reviewing?**:
`CassandraClientPoolingContainer`

**Priority (whenever / two weeks / yesterday)**:
Sooner is better.

