### PR TITLE
Stop spamming logs when local host filtering fails and the weight is 0

### DIFF
--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
@@ -93,7 +93,6 @@ public class CassandraServiceTest {
         CassandraService cassandra = clientPoolWithServersAndParams(hosts, 0.0);
         cassandra.refreshLocalHosts(ImmutableList.of());
 
-        assertThat(cassandra.maybeFilterLocalHosts(hosts)).isEqualTo(hosts);
         verifyNoInteractions(mockedHostLocationSupplier);
     }
 

--- a/changelog/@unreleased/pr-5250.v2.yml
+++ b/changelog/@unreleased/pr-5250.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Stop spamming logs when local host filtering fails and the weight is 0
+  links:
+  - https://github.com/palantir/atlasdb/pull/5250


### PR DESCRIPTION
**Goals (and why)**:
* We attempt to find local hosts even if the weighting is 0; this is a waste of time and spams logs.

**Implementation Description (bullets)**:
* No longer attempt to find local hosts if the local host weighting is 0.

**Testing (What was existing testing like?  What have you done to improve it?)**:
* Had to expose a few things in CassandraService to let me test this via some mocks, but now we can verify that the supplier is or is not called.

**Concerns (what feedback would you like?)**:
* This should not affect the majority of uses that are using this feature. A sanity check is always good here.

**Where should we start reviewing?**:
`CassandraService`

**Priority (whenever / two weeks / yesterday)**:
Sooner rather than later.
