### PR TITLE
Disable local host weighting after failing 5 times

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
@@ -94,7 +94,7 @@ public class CassandraService implements AutoCloseable {
             CassandraClientPoolMetrics poolMetrics) {
         this.metricsManager = metricsManager;
         this.config = config;
-        this.myLocationSupplier = new HostLocationSupplier(this::getSnitch, config.overrideHostLocation());
+        this.myLocationSupplier = HostLocationSupplier.create(this::getSnitch, config.overrideHostLocation());
         this.blacklist = blacklist;
         this.poolMetrics = poolMetrics;
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/ExceptionHandlingSupplier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/ExceptionHandlingSupplier.java
@@ -40,7 +40,7 @@ final class ExceptionHandlingSupplier<T> implements Supplier<Optional<T>> {
 
     @Override
     public Optional<T> get() {
-        if (numFailures.get() >= numRetries) {
+        if (numFailures.get() > numRetries) {
             return Optional.empty();
         }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/ExceptionHandlingSupplier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/ExceptionHandlingSupplier.java
@@ -1,0 +1,56 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra.pool;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+/**
+ * A supplier wrapper that stops calling the delegate supplier after failing some number of times in a row.
+ */
+final class ExceptionHandlingSupplier<T> implements Supplier<Optional<T>> {
+    private final Supplier<T> delegate;
+    private final int numRetries;
+    private final AtomicInteger numFailures;
+
+    private ExceptionHandlingSupplier(Supplier<T> delegate, int numRetries) {
+        this.delegate = delegate;
+        this.numRetries = numRetries;
+        numFailures = new AtomicInteger(0);
+    }
+
+    public static <T> ExceptionHandlingSupplier<T> create(Supplier<T> delegate, int numRetries) {
+        return new ExceptionHandlingSupplier<>(delegate, numRetries);
+    }
+
+    @Override
+    public Optional<T> get() {
+        if (numFailures.get() >= numRetries) {
+            return Optional.empty();
+        }
+
+        try {
+            T value = delegate.get();
+            numFailures.set(0);
+            return Optional.of(value);
+        } catch (Throwable t) {
+            numFailures.incrementAndGet();
+            return Optional.empty();
+        }
+    }
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostLocationSupplier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostLocationSupplier.java
@@ -54,9 +54,7 @@ final class HostLocationSupplier implements Supplier<Optional<HostLocation>> {
             return overrideLocation;
         }
 
-        Optional<String> maybeSnitch = snitchSupplier.get();
-
-        return maybeSnitch.flatMap(snitch -> {
+        return snitchSupplier.get().flatMap(snitch -> {
             switch (snitch) {
                 case EC2_SNITCH:
                     return ec2Supplier.get();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostLocationSupplier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostLocationSupplier.java
@@ -16,23 +16,24 @@
 
 package com.palantir.atlasdb.keyvalue.cassandra.pool;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
-import com.palantir.logsafe.SafeArg;
 import java.util.Optional;
 import java.util.function.Supplier;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public final class HostLocationSupplier implements Supplier<Optional<HostLocation>> {
+final class HostLocationSupplier implements Supplier<Optional<HostLocation>> {
+    private static final int NUM_RETRIES = 5;
 
-    private final Supplier<String> snitchSupplier;
+    @VisibleForTesting
+    static final String EC2_SNITCH = "org.apache.cassandra.locator.Ec2Snitch";
+
+    private final Supplier<Optional<String>> snitchSupplier;
     private final Supplier<Optional<HostLocation>> ec2Supplier;
     private final Optional<HostLocation> overrideLocation;
 
-    private static final Logger log = LoggerFactory.getLogger(HostLocationSupplier.class);
-
-    public HostLocationSupplier(
-            Supplier<String> snitchSupplier,
+    @VisibleForTesting
+    HostLocationSupplier(
+            Supplier<Optional<String>> snitchSupplier,
             Supplier<Optional<HostLocation>> ec2Supplier,
             Optional<HostLocation> overrideLocation) {
         this.snitchSupplier = Suppliers.memoize(snitchSupplier::get);
@@ -40,29 +41,28 @@ public final class HostLocationSupplier implements Supplier<Optional<HostLocatio
         this.overrideLocation = overrideLocation;
     }
 
-    public HostLocationSupplier(Supplier<String> snitchSupplier, Optional<HostLocation> overrideLocation) {
-        this(snitchSupplier, new Ec2HostLocationSupplier(), overrideLocation);
+    static HostLocationSupplier create(Supplier<String> snitchSupplier, Optional<HostLocation> overrideLocation) {
+        return new HostLocationSupplier(
+                ExceptionHandlingSupplier.create(snitchSupplier, NUM_RETRIES),
+                ExceptionHandlingSupplier.create(new Ec2HostLocationSupplier(), NUM_RETRIES),
+                overrideLocation);
     }
 
     @Override
     public Optional<HostLocation> get() {
-        try {
-            if (overrideLocation.isPresent()) {
-                return overrideLocation;
-            }
+        if (overrideLocation.isPresent()) {
+            return overrideLocation;
+        }
 
-            String snitch = snitchSupplier.get();
-            log.debug("Snitch successfully detected", SafeArg.of("snitch", snitch));
+        Optional<String> maybeSnitch = snitchSupplier.get();
 
+        return maybeSnitch.flatMap(snitch -> {
             switch (snitch) {
-                case "org.apache.cassandra.locator.Ec2Snitch":
+                case EC2_SNITCH:
                     return ec2Supplier.get();
                 default:
                     return Optional.empty();
             }
-        } catch (RuntimeException e) {
-            log.warn("Host location supplier failed to retrieve the host location", e);
-            return Optional.empty();
-        }
+        });
     }
 }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/ExceptionHandlingSupplierTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/ExceptionHandlingSupplierTest.java
@@ -48,7 +48,7 @@ public final class ExceptionHandlingSupplierTest {
                 .thenThrow(new RuntimeException())
                 .thenThrow(new RuntimeException())
                 .thenReturn(VALUE);
-        Supplier<Optional<String>> exceptionHandlingSupplier = ExceptionHandlingSupplier.create(supplier, 2);
+        Supplier<Optional<String>> exceptionHandlingSupplier = ExceptionHandlingSupplier.create(supplier, 1);
 
         assertThat(exceptionHandlingSupplier.get()).isEmpty();
         assertThat(exceptionHandlingSupplier.get()).isEmpty();

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/ExceptionHandlingSupplierTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/ExceptionHandlingSupplierTest.java
@@ -1,0 +1,76 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra.pool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+import org.junit.Test;
+
+public final class ExceptionHandlingSupplierTest {
+    private static final String VALUE = "value";
+
+    private Supplier<String> supplier = mock(Supplier.class);
+
+    @Test
+    public void supplierCatchesExceptions() {
+        when(supplier.get()).thenThrow(new RuntimeException()).thenReturn(VALUE);
+        Supplier<Optional<String>> exceptionHandlingSupplier = ExceptionHandlingSupplier.create(supplier, 5);
+
+        assertThat(exceptionHandlingSupplier.get()).isEmpty();
+        assertThat(exceptionHandlingSupplier.get()).hasValue(VALUE);
+
+        verify(supplier, times(2)).get();
+    }
+
+    @Test
+    public void underlyingSupplierNoLongerCalledAfterExceptions() {
+        when(supplier.get())
+                .thenThrow(new RuntimeException())
+                .thenThrow(new RuntimeException())
+                .thenReturn(VALUE);
+        Supplier<Optional<String>> exceptionHandlingSupplier = ExceptionHandlingSupplier.create(supplier, 2);
+
+        assertThat(exceptionHandlingSupplier.get()).isEmpty();
+        assertThat(exceptionHandlingSupplier.get()).isEmpty();
+        assertThat(exceptionHandlingSupplier.get()).isEmpty();
+
+        verify(supplier, times(2)).get();
+    }
+
+    @Test
+    public void successfulSupplierCallsResetExceptionCounter() {
+        when(supplier.get())
+                .thenThrow(new RuntimeException())
+                .thenReturn(VALUE)
+                .thenThrow(new RuntimeException())
+                .thenReturn(VALUE);
+        Supplier<Optional<String>> exceptionHandlingSupplier = ExceptionHandlingSupplier.create(supplier, 2);
+
+        assertThat(exceptionHandlingSupplier.get()).isEmpty();
+        assertThat(exceptionHandlingSupplier.get()).hasValue(VALUE);
+        assertThat(exceptionHandlingSupplier.get()).isEmpty();
+        assertThat(exceptionHandlingSupplier.get()).hasValue(VALUE);
+
+        verify(supplier, times(4)).get();
+    }
+}

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostLocationSupplierTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostLocationSupplierTest.java
@@ -23,9 +23,9 @@ import java.util.function.Supplier;
 import org.junit.Test;
 
 public class HostLocationSupplierTest {
-
-    private static final Supplier<String> ec2SnitchSupplier = () -> "org.apache.cassandra.locator.Ec2Snitch";
-    private static final Supplier<Optional<HostLocation>> ec2LocationSupplier =
+    private static final Supplier<Optional<String>> EC2_SNITCH_SUPPLIER =
+            () -> Optional.of(HostLocationSupplier.EC2_SNITCH);
+    private static final Supplier<Optional<HostLocation>> EC2_LOCATION_SUPPLIER =
             () -> Optional.of(HostLocation.of("dc2", "rack2"));
 
     @Test
@@ -33,7 +33,7 @@ public class HostLocationSupplierTest {
         Optional<HostLocation> overrideLocation = Optional.of(HostLocation.of("dc1", "rack1"));
 
         Supplier<Optional<HostLocation>> hostLocationSupplier =
-                new HostLocationSupplier(ec2SnitchSupplier, ec2LocationSupplier, overrideLocation);
+                new HostLocationSupplier(EC2_SNITCH_SUPPLIER, EC2_LOCATION_SUPPLIER, overrideLocation);
 
         assertThat(hostLocationSupplier.get()).isEqualTo(overrideLocation);
     }
@@ -41,19 +41,41 @@ public class HostLocationSupplierTest {
     @Test
     public void shouldReturnEc2Location() {
         Supplier<Optional<HostLocation>> hostLocationSupplier =
-                new HostLocationSupplier(ec2SnitchSupplier, ec2LocationSupplier, Optional.empty());
+                new HostLocationSupplier(EC2_SNITCH_SUPPLIER, EC2_LOCATION_SUPPLIER, Optional.empty());
 
-        assertThat(hostLocationSupplier.get()).isEqualTo(ec2LocationSupplier.get());
+        assertThat(hostLocationSupplier.get()).isEqualTo(EC2_LOCATION_SUPPLIER.get());
     }
 
     @Test
     public void shouldReturnEmptyLocationFromUnexpectedSnitch() {
-        Supplier<String> unexpectedSnitchSupplier = () -> "unexpected snitch";
+        Supplier<Optional<String>> unexpectedSnitchSupplier = () -> Optional.of("unexpected snitch");
 
         Supplier<Optional<HostLocation>> hostLocationSupplier =
-                new HostLocationSupplier(unexpectedSnitchSupplier, ec2LocationSupplier, Optional.empty());
+                new HostLocationSupplier(unexpectedSnitchSupplier, EC2_LOCATION_SUPPLIER, Optional.empty());
 
-        assertThat(hostLocationSupplier.get()).isNotPresent();
+        assertThat(hostLocationSupplier.get()).isEmpty();
+    }
+
+    @Test
+    public void shouldReturnEmptyLocationFromEmptySnitch() {
+        Supplier<Optional<String>> failedSnitchSupplier = Optional::empty;
+
+        Supplier<Optional<HostLocation>> hostLocationSupplier =
+                new HostLocationSupplier(failedSnitchSupplier, EC2_LOCATION_SUPPLIER, Optional.empty());
+
+        assertThat(hostLocationSupplier.get()).isEmpty();
+    }
+
+    @Test
+    public void shouldReturnEmptyLocationFromEC2LocationSupplierException() {
+        Supplier<HostLocation> badEc2Supplier = () -> {
+            throw new RuntimeException();
+        };
+
+        Supplier<Optional<HostLocation>> hostLocationSupplier = new HostLocationSupplier(
+                EC2_SNITCH_SUPPLIER, ExceptionHandlingSupplier.create(badEc2Supplier, 5), Optional.empty());
+
+        assertThat(hostLocationSupplier.get()).isEmpty();
     }
 
     @Test
@@ -62,22 +84,27 @@ public class HostLocationSupplierTest {
             throw new RuntimeException();
         };
 
-        Supplier<Optional<HostLocation>> hostLocationSupplier =
-                new HostLocationSupplier(badSnitchSupplier, ec2LocationSupplier, Optional.empty());
+        Supplier<Optional<HostLocation>> hostLocationSupplier = new HostLocationSupplier(
+                ExceptionHandlingSupplier.create(badSnitchSupplier, 5), EC2_LOCATION_SUPPLIER, Optional.empty());
 
-        assertThat(hostLocationSupplier.get()).isNotPresent();
+        assertThat(hostLocationSupplier.get()).isEmpty();
     }
 
     @Test
-    public void shouldReturnEmptyLocationFromEc2Exception() {
-        Supplier<Optional<HostLocation>> ec2BadLocationSupplier = () -> {
+    public void shouldReturnEmptyLocationWhenEverythingFails() {
+        Supplier<String> badSnitchSupplier = () -> {
+            throw new RuntimeException();
+        };
+        Supplier<HostLocation> badEc2Supplier = () -> {
             throw new RuntimeException();
         };
 
-        Supplier<Optional<HostLocation>> hostLocationSupplier =
-                new HostLocationSupplier(ec2SnitchSupplier, ec2BadLocationSupplier, Optional.empty());
+        Supplier<Optional<HostLocation>> hostLocationSupplier = new HostLocationSupplier(
+                ExceptionHandlingSupplier.create(badSnitchSupplier, 5),
+                ExceptionHandlingSupplier.create(badEc2Supplier, 5),
+                Optional.empty());
 
-        assertThat(hostLocationSupplier.get()).isNotPresent();
+        assertThat(hostLocationSupplier.get()).isEmpty();
     }
 
     @Test

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostLocationSupplierTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostLocationSupplierTest.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import org.junit.Test;
 
-public class HostLocationSupplierTest {
+public final class HostLocationSupplierTest {
     private static final Supplier<Optional<String>> EC2_SNITCH_SUPPLIER =
             () -> Optional.of(HostLocationSupplier.EC2_SNITCH);
     private static final Supplier<Optional<HostLocation>> EC2_LOCATION_SUPPLIER =

--- a/docs/source/cluster_management/kvs-migration.rst
+++ b/docs/source/cluster_management/kvs-migration.rst
@@ -88,8 +88,9 @@ Migration CLI
 
 .. tip::
 
-    If you are migrating to/from Oracle KVS, the standard AtlasDB CLI distribution will not work as it does not
-    contain the requisite Oracle drivers. Please contact the AtlasDB team for assistance.
+    If you are migrating to/from Oracle KVS and are using a version of AtlasDB before 0.240.10, the standard AtlasDB
+    CLI distribution will not work as it does not contain the requisite Oracle drivers. Please contact the AtlasDB team
+    for assistance.
 
 Migration of all transactional data from one KVS to another can be performed using the :ref:`AtlasDB CLI<clis>`.
 


### PR DESCRIPTION
An improved version of https://github.com/palantir/atlasdb/pull/5250.

**Goals (and why)**:
* Stop spamming logs when attempting but failing to get the local hosts.

**Implementation Description (bullets)**:
* Implemented a wrapper around supplier that stops calling the delegate after receiving N exceptions in a row.

**Testing (What was existing testing like?  What have you done to improve it?)**:
* Added some tests to `HostLocationSupplierTest`, added some new tests for the new class.

**Concerns (what feedback would you like?)**:
* I assume that 5 logs being logged is acceptable?
* Perhaps I was trigger happy with using `create` over a constructor - not sure on thoughts here.

**Where should we start reviewing?**:
ExceptionHandlingSupplier

**Priority (whenever / two weeks / yesterday)**:
Sooner is better, but Monday is probably acceptable too.
