### PR TITLE
[PDS-146088] Stop! Hammer (the client factory) Time

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -33,6 +33,7 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.net.InetSocketAddress;
 import java.net.SocketTimeoutException;
+import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
@@ -149,6 +150,13 @@ public interface CassandraKeyValueServiceConfig extends KeyValueServiceConfig {
      * Overrides the behaviour of the host location supplier.
      */
     Optional<HostLocation> overrideHostLocation();
+
+    /**
+     * Times out after the provided duration when attempting to close evicted connections from the Cassandra
+     * threadpool. Note that this potentially unsafe in the general case, as unclosed connections can eventually leak
+     * memory.
+     */
+    Optional<Duration> enableTimeoutOnConnectionClose();
 
     @JsonIgnore
     @Value.Lazy

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -153,10 +153,10 @@ public interface CassandraKeyValueServiceConfig extends KeyValueServiceConfig {
 
     /**
      * Times out after the provided duration when attempting to close evicted connections from the Cassandra
-     * threadpool. Note that this potentially unsafe in the general case, as unclosed connections can eventually leak
+     * threadpool. Note that this is potentially unsafe in the general case, as unclosed connections can eventually leak
      * memory.
      */
-    Optional<Duration> enableTimeoutOnConnectionClose();
+    Optional<Duration> timeoutOnConnectionClose();
 
     @JsonIgnore
     @Value.Lazy

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraReloadableKvsConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraReloadableKvsConfig.java
@@ -21,6 +21,7 @@ import com.palantir.atlasdb.keyvalue.cassandra.pool.HostLocation;
 import com.palantir.atlasdb.spi.KeyValueServiceRuntimeConfig;
 import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
 import java.net.InetSocketAddress;
+import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
@@ -102,6 +103,11 @@ public class CassandraReloadableKvsConfig implements CassandraKeyValueServiceCon
     @Override
     public Optional<HostLocation> overrideHostLocation() {
         return config.overrideHostLocation();
+    }
+
+    @Override
+    public Optional<Duration> enableTimeoutOnConnectionClose() {
+        return config.enableTimeoutOnConnectionClose();
     }
 
     @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraReloadableKvsConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraReloadableKvsConfig.java
@@ -106,8 +106,8 @@ public class CassandraReloadableKvsConfig implements CassandraKeyValueServiceCon
     }
 
     @Override
-    public Optional<Duration> enableTimeoutOnConnectionClose() {
-        return config.enableTimeoutOnConnectionClose();
+    public Optional<Duration> timeoutOnConnectionClose() {
+        return config.timeoutOnConnectionClose();
     }
 
     @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
@@ -30,7 +30,6 @@ import com.palantir.util.SafeShutdownRunner;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketException;
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import javax.net.ssl.SSLSocket;
@@ -68,7 +67,7 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
         this.addr = addr;
         this.config = config;
         this.sslSocketFactory = createSslSocketFactory(config);
-        this.safeShutdownRunner = new SafeShutdownRunner(Duration.ofSeconds(30));
+        this.safeShutdownRunner = new SafeShutdownRunner(config.enableTimeoutOnConnectionClose());
     }
 
     @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
@@ -67,7 +67,7 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
         this.addr = addr;
         this.config = config;
         this.sslSocketFactory = createSslSocketFactory(config);
-        this.safeShutdownRunner = new SafeShutdownRunner(config.enableTimeoutOnConnectionClose());
+        this.safeShutdownRunner = new SafeShutdownRunner(config.timeoutOnConnectionClose());
     }
 
     @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
@@ -67,7 +67,7 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
         this.addr = addr;
         this.config = config;
         this.sslSocketFactory = createSslSocketFactory(config);
-        this.safeShutdownRunner = new SafeShutdownRunner(config.timeoutOnConnectionClose());
+        this.safeShutdownRunner = SafeShutdownRunner.createWithSingleThreadpool(config.timeoutOnConnectionClose());
     }
 
     @Override

--- a/atlasdb-commons/src/main/java/com/palantir/util/SafeShutdownRunner.java
+++ b/atlasdb-commons/src/main/java/com/palantir/util/SafeShutdownRunner.java
@@ -28,7 +28,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-public class SafeShutdownRunner implements AutoCloseable {
+public final class SafeShutdownRunner implements AutoCloseable {
     private final List<Throwable> failures = new ArrayList<>();
     private final ExecutorService executor;
     private final Optional<Duration> timeoutDuration;

--- a/atlasdb-commons/src/main/java/com/palantir/util/SafeShutdownRunner.java
+++ b/atlasdb-commons/src/main/java/com/palantir/util/SafeShutdownRunner.java
@@ -29,16 +29,22 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 public class SafeShutdownRunner implements AutoCloseable {
-    private final ExecutorService executor = PTExecutors.newCachedThreadPoolWithMaxThreads(10, "safe-shutdown-runner");
     private final List<Throwable> failures = new ArrayList<>();
+    private final ExecutorService executor;
     private final Optional<Duration> timeoutDuration;
 
-    public SafeShutdownRunner(Duration timeoutDuration) {
-        this.timeoutDuration = Optional.of(timeoutDuration);
+    private SafeShutdownRunner(Optional<Duration> timeoutDuration, ExecutorService executorService) {
+        this.timeoutDuration = timeoutDuration;
+        this.executor = executorService;
     }
 
-    public SafeShutdownRunner(Optional<Duration> timeoutDuration) {
-        this.timeoutDuration = timeoutDuration;
+    public static SafeShutdownRunner createWithCachedThreadpool(Duration timeoutDuration) {
+        return new SafeShutdownRunner(
+                Optional.of(timeoutDuration), PTExecutors.newCachedThreadPool("safe-shutdown-runner"));
+    }
+
+    public static SafeShutdownRunner createWithSingleThreadpool(Optional<Duration> timeoutDuration) {
+        return new SafeShutdownRunner(timeoutDuration, PTExecutors.newSingleThreadExecutor());
     }
 
     public void shutdownSafely(Runnable shutdownCallback) {

--- a/atlasdb-commons/src/test/java/com/palantir/util/SafeShutdownRunnerTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/util/SafeShutdownRunnerTest.java
@@ -58,7 +58,7 @@ public class SafeShutdownRunnerTest {
 
     @Test
     public void runnerRunsOneTask() {
-        SafeShutdownRunner runner = new SafeShutdownRunner(Duration.ofSeconds(1));
+        SafeShutdownRunner runner = SafeShutdownRunner.createWithCachedThreadpool(Duration.ofSeconds(1));
 
         runner.shutdownSafely(mockRunnable);
 
@@ -68,7 +68,7 @@ public class SafeShutdownRunnerTest {
 
     @Test
     public void exceptionsAreSuppressedAndReportedWhenClosing() {
-        SafeShutdownRunner runner = new SafeShutdownRunner(Duration.ofSeconds(1));
+        SafeShutdownRunner runner = SafeShutdownRunner.createWithCachedThreadpool(Duration.ofSeconds(1));
 
         assertThatCode(() -> runner.shutdownSafely(throwingRunnable)).doesNotThrowAnyException();
         assertThatThrownBy(runner::close)
@@ -78,7 +78,7 @@ public class SafeShutdownRunnerTest {
 
     @Test
     public void exceptionsAreThrownWhenRunningSingleton() {
-        SafeShutdownRunner runner = new SafeShutdownRunner(Duration.ofSeconds(1));
+        SafeShutdownRunner runner = SafeShutdownRunner.createWithCachedThreadpool(Duration.ofSeconds(1));
 
         assertThatThrownBy(() -> runner.shutdownSingleton(throwingRunnable))
                 .isInstanceOf(SafeRuntimeException.class)
@@ -89,7 +89,7 @@ public class SafeShutdownRunnerTest {
 
     @Test
     public void slowTasksTimeOutWithoutThrowing() {
-        SafeShutdownRunner runner = new SafeShutdownRunner(Duration.ofMillis(50));
+        SafeShutdownRunner runner = SafeShutdownRunner.createWithCachedThreadpool(Duration.ofMillis(50));
 
         runner.shutdownSafely(blockingUninterruptibleRunnable);
         runner.shutdownSafely(blockingUninterruptibleRunnable);
@@ -101,7 +101,7 @@ public class SafeShutdownRunnerTest {
 
     @Test
     public void otherTasksStillRunInPresenceOfSlowTasksThatTimeOut() {
-        SafeShutdownRunner runner = new SafeShutdownRunner(Duration.ofMillis(50));
+        SafeShutdownRunner runner = SafeShutdownRunner.createWithCachedThreadpool(Duration.ofMillis(50));
 
         runner.shutdownSafely(blockingUninterruptibleRunnable);
         runner.shutdownSafely(blockingUninterruptibleRunnable);
@@ -118,7 +118,7 @@ public class SafeShutdownRunnerTest {
 
     @Test
     public void noDurationSetCausesTasksToBlockForever() {
-        SafeShutdownRunner runner = new SafeShutdownRunner(Optional.empty());
+        SafeShutdownRunner runner = SafeShutdownRunner.createWithSingleThreadpool(Optional.empty());
 
         ExecutorService executorService = Executors.newSingleThreadExecutor();
         executorService.execute(() -> {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -373,7 +373,8 @@ import org.slf4j.LoggerFactory;
             return;
         }
 
-        try (SafeShutdownRunner shutdownRunner = new SafeShutdownRunner(Duration.ofSeconds(20))) {
+        try (SafeShutdownRunner shutdownRunner =
+                SafeShutdownRunner.createWithCachedThreadpool(Duration.ofSeconds(20))) {
             shutdownRunner.shutdownSafely(super::close);
             shutdownRunner.shutdownSafely(cleaner::close);
             shutdownRunner.shutdownSafely(keyValueService::close);

--- a/changelog/@unreleased/pr-5255.v2.yml
+++ b/changelog/@unreleased/pr-5255.v2.yml
@@ -1,5 +1,5 @@
 type: fix
 fix:
-  description: The Cassandra client pool evictor will now give up trying to close a connection after 30 seconds.
+  description: The Cassandra client pool factory can now be configured to give up closing a connection after a provided duration. This should not be set in the general case, as it can potentially leak resources.
   links:
   - https://github.com/palantir/atlasdb/pull/5255

--- a/changelog/@unreleased/pr-5255.v2.yml
+++ b/changelog/@unreleased/pr-5255.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: The Cassandra client pool evictor will now give up trying to close a connection after 30 seconds.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5255


### PR DESCRIPTION
**Goals (and why)**:
* If it takes infinitely long to close a connection, the eviction task for the object pool will never end, and nothing more will be evicted (I think).

**Implementation Description (bullets)**:
* Modify `SafeShutdownRunner` to be able to run singleton tasks - it's not _quite_ its purpose, but I just wanted the ability to run a task for X amount of time, really.
* Make attempting to close a connection fail after 30 seconds.

**Testing (What was existing testing like?  What have you done to improve it?)**:
* Haven't added any yet. I know I should, but will get there if this PR is worth doing.

**Concerns (what feedback would you like?)**:
* If we give up on closing the connection after 30 seconds, I'm a bit concerned that we just leave it and therefore eventually OOM ourselves anyway. Not sure about the best approach here.

**Where should we start reviewing?**:
`CassandraClientFactory`

**Priority (whenever / two weeks / yesterday)**:
Should review ASAP, but may not be right.