### PR TITLE
[Cross Client Batching?] Liveness Checkers for Jepsen

### DIFF
--- a/atlasdb-jepsen-tests/src/jepsen/atlasdb/timestamp.clj
+++ b/atlasdb-jepsen-tests/src/jepsen/atlasdb/timestamp.clj
@@ -16,7 +16,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Defining the set of of operations that you can do with a client
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(defn read-operation [_ _] {:type :invoke, :f :read-operation, :value nil})
+(defn get-timestamp-operation [_ _] {:type :invoke, :f :timestamp, :value nil})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Client creation and invocations (i.e. reading a timestamp)
@@ -37,7 +37,7 @@
       [this test op]
       "Run an operation on our client"
       (case (:f op)
-        :read-operation
+        :timestamp
         (timeout (* 30 1000)
           (assoc op :type :fail :error :timeout)
           (try
@@ -64,7 +64,7 @@
     :os debian/os
     :client (create-client nil)
     :nemesis nem
-    :generator (->> read-operation
+    :generator (->> get-timestamp-operation
                  (gen/stagger 0.05)
                  (gen/nemesis
                    (gen/seq (cycle [(gen/sleep 60)

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/JepsenHistoryCheckers.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/JepsenHistoryCheckers.java
@@ -19,6 +19,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.jepsen.events.Checker;
 import com.palantir.atlasdb.jepsen.lock.IsolatedProcessCorrectnessChecker;
+import com.palantir.atlasdb.jepsen.lock.LockAcquisitionLivenessChecker;
 import com.palantir.atlasdb.jepsen.lock.LockCorrectnessChecker;
 import com.palantir.atlasdb.jepsen.lock.RefreshCorrectnessChecker;
 import com.palantir.atlasdb.jepsen.timestamp.MonotonicChecker;
@@ -43,7 +44,8 @@ public final class JepsenHistoryCheckers {
     static final ImmutableList<Supplier<Checker>> LOCK_CHECKERS = ImmutableList.of(
             () -> new PartitionByInvokeNameCheckerHelper(IsolatedProcessCorrectnessChecker::new),
             () -> new PartitionByInvokeNameCheckerHelper(LockCorrectnessChecker::new),
-            () -> new PartitionByInvokeNameCheckerHelper(RefreshCorrectnessChecker::new));
+            () -> new PartitionByInvokeNameCheckerHelper(RefreshCorrectnessChecker::new),
+            LockAcquisitionLivenessChecker::new);
 
     public static JepsenHistoryChecker createWithTimestampCheckers() {
         return createWithCheckers(TIMESTAMP_CHECKERS);

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/JepsenHistoryCheckers.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/JepsenHistoryCheckers.java
@@ -23,6 +23,7 @@ import com.palantir.atlasdb.jepsen.lock.LockCorrectnessChecker;
 import com.palantir.atlasdb.jepsen.lock.RefreshCorrectnessChecker;
 import com.palantir.atlasdb.jepsen.timestamp.MonotonicChecker;
 import com.palantir.atlasdb.jepsen.timestamp.NonOverlappingReadsMonotonicChecker;
+import com.palantir.atlasdb.jepsen.timestamp.TimestampLivenessChecker;
 import com.palantir.atlasdb.jepsen.timestamp.UniquenessChecker;
 import java.util.List;
 import java.util.function.Supplier;
@@ -35,7 +36,8 @@ public final class JepsenHistoryCheckers {
 
     @VisibleForTesting
     static final ImmutableList<Supplier<Checker>> TIMESTAMP_CHECKERS =
-            ImmutableList.of(MonotonicChecker::new, NonOverlappingReadsMonotonicChecker::new, UniquenessChecker::new);
+            ImmutableList.of(MonotonicChecker::new, NonOverlappingReadsMonotonicChecker::new, UniquenessChecker::new,
+                    TimestampLivenessChecker::new);
 
     @VisibleForTesting
     static final ImmutableList<Supplier<Checker>> LOCK_CHECKERS = ImmutableList.of(

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/JepsenHistoryCheckers.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/JepsenHistoryCheckers.java
@@ -36,9 +36,11 @@ public final class JepsenHistoryCheckers {
     }
 
     @VisibleForTesting
-    static final ImmutableList<Supplier<Checker>> TIMESTAMP_CHECKERS =
-            ImmutableList.of(MonotonicChecker::new, NonOverlappingReadsMonotonicChecker::new, UniquenessChecker::new,
-                    TimestampLivenessChecker::new);
+    static final ImmutableList<Supplier<Checker>> TIMESTAMP_CHECKERS = ImmutableList.of(
+            MonotonicChecker::new,
+            NonOverlappingReadsMonotonicChecker::new,
+            UniquenessChecker::new,
+            TimestampLivenessChecker::new);
 
     @VisibleForTesting
     static final ImmutableList<Supplier<Checker>> LOCK_CHECKERS = ImmutableList.of(

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/NemesisResilienceChecker.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/NemesisResilienceChecker.java
@@ -39,7 +39,7 @@ public class NemesisResilienceChecker implements Checker {
                 .build();
     }
 
-    private static final class Visitor implements EventVisitor {
+    private static final class Visitor implements EventVisitor<Void> {
         private final List<Event> unsurvivedEvents = new ArrayList<>();
         private final Set<Integer> processesPendingReads = new HashSet<>();
 
@@ -47,7 +47,7 @@ public class NemesisResilienceChecker implements Checker {
         private boolean awaitingInvokeOkCycle;
 
         @Override
-        public void visit(InfoEvent event) {
+        public Void visit(InfoEvent event) {
             if (isNemesisEvent(event)) {
                 if (isStartEvent(event)) {
                     startAwaitingInvokeOkCycles(event);
@@ -55,20 +55,23 @@ public class NemesisResilienceChecker implements Checker {
                     addUnsurvivedEvents(event);
                 }
             }
+            return null;
         }
 
         @Override
-        public void visit(InvokeEvent event) {
+        public Void visit(InvokeEvent event) {
             if (awaitingInvokeOkCycle) {
                 processesPendingReads.add(event.process());
             }
+            return null;
         }
 
         @Override
-        public void visit(OkEvent event) {
+        public Void visit(OkEvent event) {
             if (awaitingInvokeOkCycle && processesPendingReads.contains(event.process())) {
                 awaitingInvokeOkCycle = false;
             }
+            return null;
         }
 
         public boolean valid() {

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/events/Event.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/events/Event.java
@@ -61,5 +61,5 @@ public interface Event {
 
     int process();
 
-    void accept(EventVisitor visitor);
+    <T> T accept(EventVisitor<T> visitor);
 }

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/events/EventVisitor.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/events/EventVisitor.java
@@ -15,20 +15,20 @@
  */
 package com.palantir.atlasdb.jepsen.events;
 
-public interface EventVisitor {
-    default void visit(InfoEvent event) {
-        // Do nothing
+public interface EventVisitor<T> {
+    default T visit(InfoEvent event) {
+        return null;
     }
 
-    default void visit(InvokeEvent event) {
-        // Do nothing
+    default T visit(InvokeEvent event) {
+        return null;
     }
 
-    default void visit(OkEvent event) {
-        // Do nothing
+    default T visit(OkEvent event) {
+        return null;
     }
 
-    default void visit(FailEvent event) {
-        // Do nothing
+    default T visit(FailEvent event) {
+        return null;
     }
 }

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/events/FailEvent.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/events/FailEvent.java
@@ -38,7 +38,7 @@ public abstract class FailEvent implements Event {
     public abstract String error();
 
     @Override
-    public void accept(EventVisitor visitor) {
-        visitor.visit(this);
+    public <T> T accept(EventVisitor<T> visitor) {
+        return visitor.visit(this);
     }
 }

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/events/InfoEvent.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/events/InfoEvent.java
@@ -43,7 +43,7 @@ public abstract class InfoEvent implements Event {
     public abstract Optional<Object> value();
 
     @Override
-    public void accept(EventVisitor visitor) {
-        visitor.visit(this);
+    public <T> T accept(EventVisitor<T> visitor) {
+        return visitor.visit(this);
     }
 }

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/events/InvokeEvent.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/events/InvokeEvent.java
@@ -44,7 +44,7 @@ public abstract class InvokeEvent implements Event {
     public abstract String value();
 
     @Override
-    public void accept(EventVisitor visitor) {
-        visitor.visit(this);
+    public <T> T accept(EventVisitor<T> visitor) {
+        return visitor.visit(this);
     }
 }

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/events/OkEvent.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/events/OkEvent.java
@@ -37,7 +37,6 @@ public abstract class OkEvent implements Event {
     public static final String LOCK_FAILURE = "";
     public static final String REFRESH_SUCCESS = "Some Token";
     public static final String REFRESH_FAILURE = "";
-    public static final String TIMESTAMP_SUCCESS = "1337";
     public static final String TIMESTAMP_FAILURE = "";
 
     @Override
@@ -53,7 +52,7 @@ public abstract class OkEvent implements Event {
     public abstract String function();
 
     @Override
-    public void accept(EventVisitor visitor) {
-        visitor.visit(this);
+    public <T> T accept(EventVisitor<T> visitor) {
+        return visitor.visit(this);
     }
 }

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/events/RequestType.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/events/RequestType.java
@@ -16,7 +16,9 @@
 package com.palantir.atlasdb.jepsen.events;
 
 public abstract class RequestType {
-    public static final String TIMESTAMP = "timestamp";
+    // This is the actual type used in Jepsen for timestamp requests.
+    public static final String TIMESTAMP = "read-operation";
+
     public static final String LOCK = "lock";
     public static final String REFRESH = "refresh";
     public static final String UNLOCK = "unlock";

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/events/RequestType.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/events/RequestType.java
@@ -17,7 +17,7 @@ package com.palantir.atlasdb.jepsen.events;
 
 public abstract class RequestType {
     // This is the actual type used in Jepsen for timestamp requests.
-    public static final String TIMESTAMP = "read-operation";
+    public static final String TIMESTAMP = "timestamp";
 
     public static final String LOCK = "lock";
     public static final String REFRESH = "refresh";

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/lock/IsolatedProcessCorrectnessChecker.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/lock/IsolatedProcessCorrectnessChecker.java
@@ -48,7 +48,7 @@ public class IsolatedProcessCorrectnessChecker implements Checker {
                 .build();
     }
 
-    private static final class Visitor implements EventVisitor {
+    private static final class Visitor implements EventVisitor<Void> {
         private final Map<Integer, InvokeEvent> pendingForProcess = new HashMap<>();
         private final Map<Integer, OkEvent> lastOkEvent = new HashMap<>();
         private final Set<Integer> refreshAllowed = new HashSet<>();
@@ -56,8 +56,9 @@ public class IsolatedProcessCorrectnessChecker implements Checker {
         private final List<Event> errors = new ArrayList<>();
 
         @Override
-        public void visit(InvokeEvent event) {
+        public Void visit(InvokeEvent event) {
             pendingForProcess.put(event.process(), event);
+            return null;
         }
 
         /**
@@ -74,7 +75,7 @@ public class IsolatedProcessCorrectnessChecker implements Checker {
          *  - FAILURE: was not holding the lock.
          */
         @Override
-        public void visit(OkEvent event) {
+        public Void visit(OkEvent event) {
             int currentProcess = event.process();
 
             switch (event.function()) {
@@ -99,6 +100,7 @@ public class IsolatedProcessCorrectnessChecker implements Checker {
                     throw new SafeIllegalStateException("Not an OkEvent type supported by this checker!");
             }
             lastOkEvent.put(currentProcess, event);
+            return null;
         }
 
         private void verifyRefreshAllowed(OkEvent event, Integer process) {

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/lock/LockAcquisitionLivenessChecker.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/lock/LockAcquisitionLivenessChecker.java
@@ -19,6 +19,7 @@ package com.palantir.atlasdb.jepsen.lock;
 import com.palantir.atlasdb.jepsen.CheckerResult;
 import com.palantir.atlasdb.jepsen.events.Checker;
 import com.palantir.atlasdb.jepsen.events.Event;
+import com.palantir.atlasdb.jepsen.events.RequestType;
 import com.palantir.atlasdb.jepsen.utils.LivenessChecker;
 import java.util.List;
 import java.util.Objects;
@@ -27,7 +28,7 @@ public class LockAcquisitionLivenessChecker implements Checker {
     private final LivenessChecker delegate;
 
     public LockAcquisitionLivenessChecker() {
-        delegate = new LivenessChecker(okEvent -> okEvent.function().equals("lock")
+        delegate = new LivenessChecker(okEvent -> okEvent.function().equals(RequestType.LOCK)
                 && !Objects.requireNonNull(okEvent.value()).isEmpty());
     }
 

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/lock/LockAcquisitionLivenessChecker.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/lock/LockAcquisitionLivenessChecker.java
@@ -27,9 +27,8 @@ public class LockAcquisitionLivenessChecker implements Checker {
     private final LivenessChecker delegate;
 
     public LockAcquisitionLivenessChecker() {
-        delegate =
-                new LivenessChecker(okEvent -> okEvent.function().equals("lock") && !Objects.requireNonNull(
-                        okEvent.value()).isEmpty());
+        delegate = new LivenessChecker(okEvent -> okEvent.function().equals("lock")
+                && !Objects.requireNonNull(okEvent.value()).isEmpty());
     }
 
     @Override

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/lock/LockAcquisitionLivenessChecker.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/lock/LockAcquisitionLivenessChecker.java
@@ -14,24 +14,22 @@
  * limitations under the License.
  */
 
-package com.palantir.atlasdb.jepsen.timestamp;
+package com.palantir.atlasdb.jepsen.lock;
 
 import com.palantir.atlasdb.jepsen.CheckerResult;
 import com.palantir.atlasdb.jepsen.events.Checker;
 import com.palantir.atlasdb.jepsen.events.Event;
 import com.palantir.atlasdb.jepsen.utils.LivenessChecker;
 import java.util.List;
+import java.util.Objects;
 
-/**
- * Verifies that the number of timestamp requests that succeeded was at least 1.
- */
-public class TimestampLivenessChecker implements Checker {
-    private static final String READ_OPERATION = "read-operation";
-
+public class LockAcquisitionLivenessChecker implements Checker {
     private final LivenessChecker delegate;
 
-    public TimestampLivenessChecker() {
-        this.delegate = new LivenessChecker(okEvent -> okEvent.function().equals(READ_OPERATION));
+    public LockAcquisitionLivenessChecker() {
+        delegate =
+                new LivenessChecker(okEvent -> okEvent.function().equals("lock") && !Objects.requireNonNull(
+                        okEvent.value()).isEmpty());
     }
 
     @Override

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/lock/LockCorrectnessChecker.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/lock/LockCorrectnessChecker.java
@@ -79,7 +79,7 @@ public class LockCorrectnessChecker implements Checker {
                 .build();
     }
 
-    private static final class Visitor implements EventVisitor {
+    private static final class Visitor implements EventVisitor<Void> {
         private final Map<Integer, InvokeEvent> pendingForProcess = new HashMap<>();
         private final Map<Integer, OkEvent> lastHeldLock = new HashMap<>();
 
@@ -91,16 +91,17 @@ public class LockCorrectnessChecker implements Checker {
         private String lockName = null;
 
         @Override
-        public void visit(InvokeEvent event) {
+        public Void visit(InvokeEvent event) {
             int process = event.process();
             pendingForProcess.put(process, event);
             this.lockName = event.value();
+            return null;
         }
 
         @Override
-        public void visit(OkEvent event) {
+        public Void visit(OkEvent event) {
             if (EventUtils.isFailure(event)) {
-                return;
+                return null;
             }
 
             int process = event.process();
@@ -134,6 +135,7 @@ public class LockCorrectnessChecker implements Checker {
                 default:
                     throw new SafeIllegalStateException("Not an OkEvent type supported by this checker!");
             }
+            return null;
         }
 
         private void verifyLockCorrectness() {

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/lock/RefreshCorrectnessChecker.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/lock/RefreshCorrectnessChecker.java
@@ -53,7 +53,7 @@ public class RefreshCorrectnessChecker implements Checker {
                 .build();
     }
 
-    private static final class Visitor implements EventVisitor {
+    private static final class Visitor implements EventVisitor<Void> {
         private final Map<Integer, InvokeEvent> pendingForProcess = new HashMap<>();
         private final Map<Integer, Event> lastHeldLock = new HashMap<>();
 
@@ -62,15 +62,16 @@ public class RefreshCorrectnessChecker implements Checker {
         private final List<Event> errors = new ArrayList<>();
 
         @Override
-        public void visit(InvokeEvent event) {
+        public Void visit(InvokeEvent event) {
             int process = event.process();
             pendingForProcess.put(process, event);
+            return null;
         }
 
         @Override
-        public void visit(OkEvent event) {
+        public Void visit(OkEvent event) {
             if (EventUtils.isFailure(event)) {
-                return;
+                return null;
             }
 
             int process = event.process();
@@ -131,6 +132,7 @@ public class RefreshCorrectnessChecker implements Checker {
                 default:
                     throw new SafeIllegalStateException("Not an OkEvent type supported by this checker!");
             }
+            return null;
         }
 
         public boolean valid() {

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/timestamp/MonotonicChecker.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/timestamp/MonotonicChecker.java
@@ -38,12 +38,12 @@ public class MonotonicChecker implements Checker {
                 .build();
     }
 
-    private static final class Visitor implements EventVisitor {
+    private static final class Visitor implements EventVisitor<Void> {
         private final List<Event> errors = new ArrayList<>();
         private final Map<Integer, OkEvent> latestEventPerProcess = new HashMap<>();
 
         @Override
-        public void visit(OkEvent event) {
+        public Void visit(OkEvent event) {
             int process = event.process();
 
             if (latestEventPerProcess.containsKey(process)) {
@@ -56,6 +56,7 @@ public class MonotonicChecker implements Checker {
                 }
             }
             latestEventPerProcess.put(process, event);
+            return null;
         }
 
         public boolean valid() {

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/timestamp/NonOverlappingReadsMonotonicChecker.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/timestamp/NonOverlappingReadsMonotonicChecker.java
@@ -45,7 +45,7 @@ public class NonOverlappingReadsMonotonicChecker implements Checker {
                 .build();
     }
 
-    private static final class Visitor implements EventVisitor {
+    private static final class Visitor implements EventVisitor<Void> {
         private static final String DUMMY_VALUE = "-1";
         private static final int DUMMY_PROCESS = -1;
 
@@ -56,13 +56,14 @@ public class NonOverlappingReadsMonotonicChecker implements Checker {
         private final List<Event> errors = new ArrayList<>();
 
         @Override
-        public void visit(InvokeEvent event) {
+        public Void visit(InvokeEvent event) {
             Integer process = event.process();
             pendingReadForProcess.put(process, event);
+            return null;
         }
 
         @Override
-        public void visit(OkEvent event) {
+        public Void visit(OkEvent event) {
             int process = event.process();
 
             InvokeEvent invoke = pendingReadForProcess.get(process);
@@ -72,12 +73,14 @@ public class NonOverlappingReadsMonotonicChecker implements Checker {
 
             pendingReadForProcess.remove(process);
             acknowledgedReadsOverTime.add(event);
+            return null;
         }
 
         @Override
-        public void visit(FailEvent event) {
+        public Void visit(FailEvent event) {
             Integer process = event.process();
             pendingReadForProcess.remove(process);
+            return null;
         }
 
         public boolean valid() {

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/timestamp/TimestampLivenessChecker.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/timestamp/TimestampLivenessChecker.java
@@ -1,0 +1,95 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.jepsen.timestamp;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.atlasdb.jepsen.CheckerResult;
+import com.palantir.atlasdb.jepsen.ImmutableCheckerResult;
+import com.palantir.atlasdb.jepsen.events.Checker;
+import com.palantir.atlasdb.jepsen.events.Event;
+import com.palantir.atlasdb.jepsen.events.EventVisitor;
+import com.palantir.atlasdb.jepsen.events.FailEvent;
+import com.palantir.atlasdb.jepsen.events.ImmutableInfoEvent;
+import com.palantir.atlasdb.jepsen.events.InfoEvent;
+import com.palantir.atlasdb.jepsen.events.InvokeEvent;
+import com.palantir.atlasdb.jepsen.events.OkEvent;
+import java.util.List;
+
+/**
+ * Verifies that the number of timestamp requests that succeeded was at least 1.
+ */
+public class TimestampLivenessChecker implements Checker {
+
+    @Override
+    public CheckerResult check(List<Event> events) {
+        Visitor visitor = new Visitor();
+        events.forEach(event -> event.accept(visitor));
+        return ImmutableCheckerResult.builder()
+                .valid(visitor.valid())
+                .errors(visitor.errors())
+                .build();
+    }
+
+    private static final class Visitor implements EventVisitor {
+        private static final int DUMMY_PROCESS_VALUE = 0;
+        private static final String READ_OPERATION = "read-operation";
+
+        private boolean seenOkEvent = false;
+        private long lastSeenTimestamp = Long.MIN_VALUE;
+
+        @Override
+        public void visit(InfoEvent event) {
+            logEventTimestamp(event.time());
+        }
+
+        @Override
+        public void visit(InvokeEvent event) {
+            logEventTimestamp(event.time());
+        }
+
+        @Override
+        public void visit(OkEvent event) {
+            seenOkEvent = true;
+            logEventTimestamp(event.time());
+        }
+
+        @Override
+        public void visit(FailEvent event) {
+            logEventTimestamp(event.time());
+        }
+
+        public boolean valid() {
+            return seenOkEvent;
+        }
+
+        public List<Event> errors() {
+            return valid() ? ImmutableList.of() : ImmutableList.of(
+                    ImmutableInfoEvent.builder()
+                    .time(lastSeenTimestamp)
+                    .value("No timestamps were actually retrieved up to this time, which is worrying as to the "
+                            + "validity of this test.")
+                    .function(READ_OPERATION)
+                    .process(DUMMY_PROCESS_VALUE)
+                    .build()
+            );
+        }
+
+        private void logEventTimestamp(long time) {
+            lastSeenTimestamp = Math.max(lastSeenTimestamp, time);
+        }
+    }
+}

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/timestamp/TimestampLivenessChecker.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/timestamp/TimestampLivenessChecker.java
@@ -19,6 +19,7 @@ package com.palantir.atlasdb.jepsen.timestamp;
 import com.palantir.atlasdb.jepsen.CheckerResult;
 import com.palantir.atlasdb.jepsen.events.Checker;
 import com.palantir.atlasdb.jepsen.events.Event;
+import com.palantir.atlasdb.jepsen.events.RequestType;
 import com.palantir.atlasdb.jepsen.utils.LivenessChecker;
 import java.util.List;
 
@@ -26,12 +27,10 @@ import java.util.List;
  * Verifies that the number of timestamp requests that succeeded was at least 1.
  */
 public class TimestampLivenessChecker implements Checker {
-    private static final String READ_OPERATION = "read-operation";
-
     private final LivenessChecker delegate;
 
     public TimestampLivenessChecker() {
-        this.delegate = new LivenessChecker(okEvent -> okEvent.function().equals(READ_OPERATION));
+        this.delegate = new LivenessChecker(okEvent -> okEvent.function().equals(RequestType.TIMESTAMP));
     }
 
     @Override

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/timestamp/UniquenessChecker.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/timestamp/UniquenessChecker.java
@@ -21,7 +21,6 @@ import com.palantir.atlasdb.jepsen.ImmutableCheckerResult;
 import com.palantir.atlasdb.jepsen.events.Checker;
 import com.palantir.atlasdb.jepsen.events.Event;
 import com.palantir.atlasdb.jepsen.events.EventVisitor;
-import com.palantir.atlasdb.jepsen.events.FailEvent;
 import com.palantir.atlasdb.jepsen.events.OkEvent;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -39,12 +38,12 @@ public class UniquenessChecker implements Checker {
                 .build();
     }
 
-    private static final class Visitor implements EventVisitor {
+    private static final class Visitor implements EventVisitor<Void> {
         private final List<Event> errors = new ArrayList<>();
         private final Map<String, OkEvent> valuesAlreadySeen = new HashMap<>();
 
         @Override
-        public void visit(OkEvent event) {
+        public Void visit(OkEvent event) {
             String value = event.value();
 
             if (valuesAlreadySeen.containsKey(value)) {
@@ -54,10 +53,8 @@ public class UniquenessChecker implements Checker {
             }
 
             valuesAlreadySeen.put(value, event);
+            return null;
         }
-
-        @Override
-        public void visit(FailEvent event) {}
 
         public boolean valid() {
             return errors.isEmpty();

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/utils/LivenessChecker.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/utils/LivenessChecker.java
@@ -1,0 +1,107 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.jepsen.utils;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.atlasdb.jepsen.CheckerResult;
+import com.palantir.atlasdb.jepsen.ImmutableCheckerResult;
+import com.palantir.atlasdb.jepsen.events.Checker;
+import com.palantir.atlasdb.jepsen.events.Event;
+import com.palantir.atlasdb.jepsen.events.EventVisitor;
+import com.palantir.atlasdb.jepsen.events.FailEvent;
+import com.palantir.atlasdb.jepsen.events.ImmutableInfoEvent;
+import com.palantir.atlasdb.jepsen.events.InfoEvent;
+import com.palantir.atlasdb.jepsen.events.InvokeEvent;
+import com.palantir.atlasdb.jepsen.events.OkEvent;
+import java.util.List;
+import java.util.function.Predicate;
+
+public class LivenessChecker implements Checker {
+    private final Predicate<OkEvent> livenessJudgmentHandler;
+
+    public LivenessChecker(Predicate<OkEvent> livenessJudgmentHandler) {
+        this.livenessJudgmentHandler = livenessJudgmentHandler;
+    }
+
+    @Override
+    public CheckerResult check(List<Event> events) {
+        Visitor visitor = new Visitor(livenessJudgmentHandler);
+        events.forEach(event -> event.accept(visitor));
+        return ImmutableCheckerResult.builder()
+                .valid(visitor.valid())
+                .errors(visitor.errors())
+                .build();
+    }
+
+    private static final class Visitor implements EventVisitor {
+        private static final int DUMMY_PROCESS_VALUE = 0;
+        private static final String FUNCTION = "liveness-check";
+
+        private final Predicate<OkEvent> livenessJudgmentHandler;
+
+        private boolean seenLivenessEvidence = false;
+        private long lastSeenEventTimestamp = Long.MIN_VALUE;
+
+        private Visitor(Predicate<OkEvent> livenessJudgmentHandler) {
+            this.livenessJudgmentHandler = livenessJudgmentHandler;
+        }
+
+        @Override
+        public void visit(InfoEvent event) {
+            logEventTimestamp(event.time());
+        }
+
+        @Override
+        public void visit(InvokeEvent event) {
+            logEventTimestamp(event.time());
+        }
+
+        @Override
+        public void visit(OkEvent event) {
+            if (livenessJudgmentHandler.test(event)) {
+                seenLivenessEvidence = true;
+            }
+            logEventTimestamp(event.time());
+        }
+
+        @Override
+        public void visit(FailEvent event) {
+            logEventTimestamp(event.time());
+        }
+
+        public boolean valid() {
+            return seenLivenessEvidence;
+        }
+
+        public List<Event> errors() {
+            return valid() ? ImmutableList.of() : ImmutableList.of(
+                    ImmutableInfoEvent.builder()
+                            .time(lastSeenEventTimestamp)
+                            .value("No live requests were actually observed up to this time, which is worrying as to "
+                                    + "the "
+                                    + "validity of this test.")
+                            .function(FUNCTION)
+                            .process(DUMMY_PROCESS_VALUE)
+                            .build()
+            );
+        }
+
+        private void logEventTimestamp(long time) {
+            lastSeenEventTimestamp = Math.max(lastSeenEventTimestamp, time);
+        }
+    }
+}

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/utils/LivenessChecker.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/utils/LivenessChecker.java
@@ -88,16 +88,16 @@ public class LivenessChecker implements Checker {
         }
 
         public List<Event> errors() {
-            return valid() ? ImmutableList.of() : ImmutableList.of(
-                    ImmutableInfoEvent.builder()
+            return valid()
+                    ? ImmutableList.of()
+                    : ImmutableList.of(ImmutableInfoEvent.builder()
                             .time(lastSeenEventTimestamp)
                             .value("No live requests were actually observed up to this time, which is worrying as to "
                                     + "the "
                                     + "validity of this test.")
                             .function(FUNCTION)
                             .process(DUMMY_PROCESS_VALUE)
-                            .build()
-            );
+                            .build());
         }
 
         private void logEventTimestamp(long time) {

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/lock/LockAcquisitionLivenessCheckerTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/lock/LockAcquisitionLivenessCheckerTest.java
@@ -43,8 +43,7 @@ public class LockAcquisitionLivenessCheckerTest {
 
     @Test
     public void shouldNotSucceedIfWeOnlyInvokedLock() {
-        CheckerResult result = runLockAcquisitionLivenessChecker(
-                TestEventUtils.invokeLock(TIME, 0, "lock"));
+        CheckerResult result = runLockAcquisitionLivenessChecker(TestEventUtils.invokeLock(TIME, 0, "lock"));
 
         assertResultNotValidAndHasOneErrorAtTimestamp(result, TIME);
     }
@@ -52,16 +51,15 @@ public class LockAcquisitionLivenessCheckerTest {
     @Test
     public void shouldNotSucceedIfRefreshOrUnlockWereSuccessful() {
         CheckerResult result = runLockAcquisitionLivenessChecker(
-                TestEventUtils.refreshSuccess(TIME, 0),
-                TestEventUtils.unlockSuccess(TIME + 1, 0));
+                TestEventUtils.refreshSuccess(TIME, 0), TestEventUtils.unlockSuccess(TIME + 1, 0));
 
         assertResultNotValidAndHasOneErrorAtTimestamp(result, TIME + 1);
     }
 
     @Test
     public void shouldNotSucceedOnErrorEvent() {
-        CheckerResult result = runLockAcquisitionLivenessChecker(
-                TestEventUtils.createFailEvent(TIME, 0, "403 403 403 403 403"));
+        CheckerResult result =
+                runLockAcquisitionLivenessChecker(TestEventUtils.createFailEvent(TIME, 0, "403 403 403 403 403"));
 
         assertResultNotValidAndHasOneErrorAtTimestamp(result, TIME);
     }
@@ -69,20 +67,19 @@ public class LockAcquisitionLivenessCheckerTest {
     @Test
     public void shouldSucceedIfLocksWereAcquiredAmongOtherEvents() {
         assertThat(runLockAcquisitionLivenessChecker(
-                TestEventUtils.createFailEvent(TIME, 0, "null"),
-                TestEventUtils.invokeLock(TIME + 1, 0, "lock"),
-                TestEventUtils.createInfoEvent(TIME + 2, 0, "theData"),
-                TestEventUtils.lockSuccess(TIME + 3, 0)))
+                        TestEventUtils.createFailEvent(TIME, 0, "null"),
+                        TestEventUtils.invokeLock(TIME + 1, 0, "lock"),
+                        TestEventUtils.createInfoEvent(TIME + 2, 0, "theData"),
+                        TestEventUtils.lockSuccess(TIME + 3, 0)))
                 .satisfies(LockAcquisitionLivenessCheckerTest::assertResultValidAndErrorFree);
     }
 
     @Test
     public void shouldFailIfNoEventsProvided() {
-        assertThat(runLockAcquisitionLivenessChecker())
-                .satisfies(result -> {
-                    assertThat(result.valid()).isFalse();
-                    assertThat(result.errors()).hasSize(1);
-                });
+        assertThat(runLockAcquisitionLivenessChecker()).satisfies(result -> {
+            assertThat(result.valid()).isFalse();
+            assertThat(result.errors()).hasSize(1);
+        });
     }
 
     @Test

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/lock/LockAcquisitionLivenessCheckerTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/lock/LockAcquisitionLivenessCheckerTest.java
@@ -35,21 +35,21 @@ public class LockAcquisitionLivenessCheckerTest {
     }
 
     @Test
-    public void shouldNotSucceedIfLockWasUnsuccessful() {
+    public void shouldFailIfLockWasUnsuccessful() {
         CheckerResult result = runLockAcquisitionLivenessChecker(TestEventUtils.lockFailure(TIME, 0));
 
         assertResultNotValidAndHasOneErrorAtTimestamp(result, TIME);
     }
 
     @Test
-    public void shouldNotSucceedIfWeOnlyInvokedLock() {
+    public void shouldFailIfWeOnlyInvokedLock() {
         CheckerResult result = runLockAcquisitionLivenessChecker(TestEventUtils.invokeLock(TIME, 0, "lock"));
 
         assertResultNotValidAndHasOneErrorAtTimestamp(result, TIME);
     }
 
     @Test
-    public void shouldNotSucceedIfRefreshOrUnlockWereSuccessful() {
+    public void shouldFailIfRefreshOrUnlockWereSuccessful() {
         CheckerResult result = runLockAcquisitionLivenessChecker(
                 TestEventUtils.refreshSuccess(TIME, 0), TestEventUtils.unlockSuccess(TIME + 1, 0));
 
@@ -57,7 +57,7 @@ public class LockAcquisitionLivenessCheckerTest {
     }
 
     @Test
-    public void shouldNotSucceedOnErrorEvent() {
+    public void shouldFailOnErrorEvent() {
         CheckerResult result =
                 runLockAcquisitionLivenessChecker(TestEventUtils.createFailEvent(TIME, 0, "403 403 403 403 403"));
 

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/lock/LockAcquisitionLivenessCheckerTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/lock/LockAcquisitionLivenessCheckerTest.java
@@ -1,0 +1,120 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.jepsen.lock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.palantir.atlasdb.jepsen.CheckerResult;
+import com.palantir.atlasdb.jepsen.events.Event;
+import com.palantir.atlasdb.jepsen.utils.TestEventUtils;
+import org.junit.Test;
+
+public class LockAcquisitionLivenessCheckerTest {
+    private static final long TIME = 3000L;
+
+    @Test
+    public void shouldSucceedIfLockWasSuccessful() {
+        assertThat(runLockAcquisitionLivenessChecker(TestEventUtils.lockSuccess(TIME, 0)))
+                .satisfies(LockAcquisitionLivenessCheckerTest::assertResultValidAndErrorFree);
+    }
+
+    @Test
+    public void shouldNotSucceedIfLockWasUnsuccessful() {
+        CheckerResult result = runLockAcquisitionLivenessChecker(TestEventUtils.lockFailure(TIME, 0));
+
+        assertResultNotValidAndHasOneErrorAtTimestamp(result, TIME);
+    }
+
+    @Test
+    public void shouldNotSucceedIfWeOnlyInvokedLock() {
+        CheckerResult result = runLockAcquisitionLivenessChecker(
+                TestEventUtils.invokeLock(TIME, 0, "lock"));
+
+        assertResultNotValidAndHasOneErrorAtTimestamp(result, TIME);
+    }
+
+    @Test
+    public void shouldNotSucceedIfRefreshOrUnlockWereSuccessful() {
+        CheckerResult result = runLockAcquisitionLivenessChecker(
+                TestEventUtils.refreshSuccess(TIME, 0),
+                TestEventUtils.unlockSuccess(TIME + 1, 0));
+
+        assertResultNotValidAndHasOneErrorAtTimestamp(result, TIME + 1);
+    }
+
+    @Test
+    public void shouldNotSucceedOnErrorEvent() {
+        CheckerResult result = runLockAcquisitionLivenessChecker(
+                TestEventUtils.createFailEvent(TIME, 0, "403 403 403 403 403"));
+
+        assertResultNotValidAndHasOneErrorAtTimestamp(result, TIME);
+    }
+
+    @Test
+    public void shouldSucceedIfLocksWereAcquiredAmongOtherEvents() {
+        assertThat(runLockAcquisitionLivenessChecker(
+                TestEventUtils.createFailEvent(TIME, 0, "null"),
+                TestEventUtils.invokeLock(TIME + 1, 0, "lock"),
+                TestEventUtils.createInfoEvent(TIME + 2, 0, "theData"),
+                TestEventUtils.lockSuccess(TIME + 3, 0)))
+                .satisfies(LockAcquisitionLivenessCheckerTest::assertResultValidAndErrorFree);
+    }
+
+    @Test
+    public void shouldFailIfNoEventsProvided() {
+        assertThat(runLockAcquisitionLivenessChecker())
+                .satisfies(result -> {
+                    assertThat(result.valid()).isFalse();
+                    assertThat(result.errors()).hasSize(1);
+                });
+    }
+
+    @Test
+    public void shouldFailIfNoLocksWereAcquired() {
+        CheckerResult result = runLockAcquisitionLivenessChecker(
+                TestEventUtils.timestampOk(TIME, 0, "42"),
+                TestEventUtils.createFailEvent(TIME + 1, 0, "insufficient"),
+                TestEventUtils.createFailEvent(TIME + 2, 0, "inadequate"),
+                TestEventUtils.invokeLock(TIME + 3, 0),
+                TestEventUtils.invokeLock(TIME + 4, 0),
+                TestEventUtils.invokeLock(TIME + 5, 0),
+                TestEventUtils.lockFailure(TIME + 6, 0),
+                TestEventUtils.createFailEvent(TIME + 7, 0, "unsuccessful"),
+                TestEventUtils.lockFailure(TIME + 8, 0),
+                TestEventUtils.createFailEvent(TIME + 9, 0, "inferior"),
+                TestEventUtils.lockFailure(TIME + 10, 0));
+
+        assertResultNotValidAndHasOneErrorAtTimestamp(result, TIME + 10);
+    }
+
+    private static void assertResultValidAndErrorFree(CheckerResult result) {
+        assertThat(result.valid()).isTrue();
+        assertThat(result.errors()).isEmpty();
+    }
+
+    private static void assertResultNotValidAndHasOneErrorAtTimestamp(CheckerResult result, long expectedTimestamp) {
+        assertThat(result.valid()).isFalse();
+        assertThat(Iterables.getOnlyElement(result.errors()).time()).isEqualTo(expectedTimestamp);
+    }
+
+    private static CheckerResult runLockAcquisitionLivenessChecker(Event... events) {
+        LockAcquisitionLivenessChecker livenessChecker = new LockAcquisitionLivenessChecker();
+        return livenessChecker.check(ImmutableList.copyOf(events));
+    }
+}

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/timestamp/TimestampLivenessCheckerTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/timestamp/TimestampLivenessCheckerTest.java
@@ -1,0 +1,82 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.jepsen.timestamp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.palantir.atlasdb.jepsen.CheckerResult;
+import com.palantir.atlasdb.jepsen.events.Event;
+import com.palantir.atlasdb.jepsen.utils.TestEventUtils;
+import org.junit.Test;
+
+public class TimestampLivenessCheckerTest {
+    private static final long TIME = 1984L;
+
+    @Test
+    public void shouldSucceedIfATimestampWasReturned() {
+        assertThat(runTimestampLivenessChecker(TestEventUtils.timestampOk(TIME, 0, "4242424")))
+                .satisfies(TimestampLivenessCheckerTest::assertResultValidAndErrorFree);
+    }
+
+    @Test
+    public void shouldSucceedIfTimestampsWereReturnedAmongOtherEvents() {
+        assertThat(runTimestampLivenessChecker(
+                TestEventUtils.createFailEvent(TIME, 0),
+                TestEventUtils.invokeTimestamp(TIME + 1, 0),
+                TestEventUtils.createInfoEvent(TIME + 2, 0, "I come bearing information"),
+                TestEventUtils.timestampOk(TIME + 3, 0, "4242424")))
+                .satisfies(TimestampLivenessCheckerTest::assertResultValidAndErrorFree);
+    }
+
+    @Test
+    public void shouldFailIfNoEventsProvided() {
+        assertThat(runTimestampLivenessChecker())
+                .satisfies(result -> {
+                    assertThat(result.valid()).isFalse();
+                    assertThat(result.errors()).hasSize(1);
+                });
+    }
+
+    @Test
+    public void shouldFailIfNoOkEventsProvided() {
+        assertThat(runTimestampLivenessChecker(
+                TestEventUtils.createFailEvent(TIME, 0, "fail"),
+                TestEventUtils.invokeTimestamp(TIME + 1, 0),
+                TestEventUtils.createInfoEvent(TIME + 2, 0, "abyss"),
+                TestEventUtils.createFailEvent(TIME + 3, 0, "crash"),
+                TestEventUtils.invokeTimestamp(TIME + 4, 0),
+                TestEventUtils.createInfoEvent(TIME + 5, 0, "nadir")))
+                .satisfies(result -> {
+                    assertThat(result.valid()).isFalse();
+
+                    Event errorEvent = Iterables.getOnlyElement(result.errors());
+                    assertThat(errorEvent.time()).isEqualTo(TIME + 5);
+                });
+    }
+
+    private static void assertResultValidAndErrorFree(CheckerResult result) {
+        assertThat(result.valid()).isTrue();
+        assertThat(result.errors()).isEmpty();
+    }
+
+    private static CheckerResult runTimestampLivenessChecker(Event... events) {
+        TimestampLivenessChecker livenessChecker = new TimestampLivenessChecker();
+        return livenessChecker.check(ImmutableList.copyOf(events));
+    }
+}

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/timestamp/TimestampLivenessCheckerTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/timestamp/TimestampLivenessCheckerTest.java
@@ -38,31 +38,30 @@ public class TimestampLivenessCheckerTest {
     @Test
     public void shouldSucceedIfTimestampsWereReturnedAmongOtherEvents() {
         assertThat(runTimestampLivenessChecker(
-                TestEventUtils.createFailEvent(TIME, 0),
-                TestEventUtils.invokeTimestamp(TIME + 1, 0),
-                TestEventUtils.createInfoEvent(TIME + 2, 0, "I come bearing information"),
-                TestEventUtils.timestampOk(TIME + 3, 0, "4242424")))
+                        TestEventUtils.createFailEvent(TIME, 0),
+                        TestEventUtils.invokeTimestamp(TIME + 1, 0),
+                        TestEventUtils.createInfoEvent(TIME + 2, 0, "I come bearing information"),
+                        TestEventUtils.timestampOk(TIME + 3, 0, "4242424")))
                 .satisfies(TimestampLivenessCheckerTest::assertResultValidAndErrorFree);
     }
 
     @Test
     public void shouldFailIfNoEventsProvided() {
-        assertThat(runTimestampLivenessChecker())
-                .satisfies(result -> {
-                    assertThat(result.valid()).isFalse();
-                    assertThat(result.errors()).hasSize(1);
-                });
+        assertThat(runTimestampLivenessChecker()).satisfies(result -> {
+            assertThat(result.valid()).isFalse();
+            assertThat(result.errors()).hasSize(1);
+        });
     }
 
     @Test
     public void shouldFailIfNoOkEventsProvided() {
         assertThat(runTimestampLivenessChecker(
-                TestEventUtils.createFailEvent(TIME, 0, "fail"),
-                TestEventUtils.invokeTimestamp(TIME + 1, 0),
-                TestEventUtils.createInfoEvent(TIME + 2, 0, "abyss"),
-                TestEventUtils.createFailEvent(TIME + 3, 0, "crash"),
-                TestEventUtils.invokeTimestamp(TIME + 4, 0),
-                TestEventUtils.createInfoEvent(TIME + 5, 0, "nadir")))
+                        TestEventUtils.createFailEvent(TIME, 0, "fail"),
+                        TestEventUtils.invokeTimestamp(TIME + 1, 0),
+                        TestEventUtils.createInfoEvent(TIME + 2, 0, "abyss"),
+                        TestEventUtils.createFailEvent(TIME + 3, 0, "crash"),
+                        TestEventUtils.invokeTimestamp(TIME + 4, 0),
+                        TestEventUtils.createInfoEvent(TIME + 5, 0, "nadir")))
                 .satisfies(result -> {
                     assertThat(result.valid()).isFalse();
 
@@ -74,11 +73,11 @@ public class TimestampLivenessCheckerTest {
     @Test
     public void shouldFailIfOkEventsAreNotTimestamps() {
         assertThat(runTimestampLivenessChecker(
-                TestEventUtils.createOkEvent(TIME, 0, "token3141592", RequestType.LOCK),
-                TestEventUtils.createOkEvent(TIME + 1, 0, "token3141592", RequestType.REFRESH),
-                TestEventUtils.createOkEvent(TIME + 2, 0, "true", RequestType.UNLOCK),
-                TestEventUtils.createOkEvent(TIME + 3, 0, "Unserializable?", "curry"),
-                TestEventUtils.createOkEvent(TIME + 4, 0, "42", "foldl1")))
+                        TestEventUtils.createOkEvent(TIME, 0, "token3141592", RequestType.LOCK),
+                        TestEventUtils.createOkEvent(TIME + 1, 0, "token3141592", RequestType.REFRESH),
+                        TestEventUtils.createOkEvent(TIME + 2, 0, "true", RequestType.UNLOCK),
+                        TestEventUtils.createOkEvent(TIME + 3, 0, "Unserializable?", "curry"),
+                        TestEventUtils.createOkEvent(TIME + 4, 0, "42", "foldl1")))
                 .satisfies(result -> {
                     assertThat(result.valid()).isFalse();
 

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/timestamp/TimestampLivenessCheckerTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/timestamp/TimestampLivenessCheckerTest.java
@@ -82,7 +82,7 @@ public class TimestampLivenessCheckerTest {
                     assertThat(result.valid()).isFalse();
 
                     Event errorEvent = Iterables.getOnlyElement(result.errors());
-                    assertThat(errorEvent.time()).isEqualTo(TIME + 2);
+                    assertThat(errorEvent.time()).isEqualTo(TIME + 4);
                 });
     }
 

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/timestamp/UniquenessCheckerTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/timestamp/UniquenessCheckerTest.java
@@ -32,7 +32,7 @@ public class UniquenessCheckerTest {
     private static final String VALUE_B = "1";
 
     @Test
-    public void shouldSuceeedOnNoEvents() {
+    public void shouldSucceedOnNoEvents() {
         CheckerResult result = runUniquenessChecker();
 
         assertThat(result.valid()).isTrue();

--- a/changelog/@unreleased/pr-5261.v2.yml
+++ b/changelog/@unreleased/pr-5261.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Jepsen tests now validate liveness of the cluster to a minimal extent. Previously, they would pass even with 0 successful requests.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5261


### PR DESCRIPTION
**Goals (and why)**:
- returning 0 successful events is by definition not an inconsistent analysis, but is pretty useless in giving confidence that our jepsen tests are verifying anything.

**Implementation Description (bullets)**:
I added Jepsen verifiers that introduce the following rules:
- Timestamps: a timestamp test needs at least 1 timestamp to be returned in order to pass.
- Locks: a lock test needs at least 1 lock request to have a lock token returned in order to pass.

**Testing (What was existing testing like?  What have you done to improve it?)**:
This PR is about testing.

**Concerns (what feedback would you like?)**:
- Is this too heavy-handed?
- Some irritating duplication, though I tried to factor most of it out into a common LivenessChecker.

**Where should we start reviewing?**: LivenessChecker

**Priority (whenever / two weeks / yesterday)**: eh, this week. Not the highest.