### PR TITLE
Fix WeightedHosts concurrency bug

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
@@ -314,8 +314,8 @@ public class CassandraService implements AutoCloseable {
 
         Set<InetSocketAddress> localFilteredHosts = maybeFilterLocalHosts(desiredHosts);
 
-        Map<InetSocketAddress, CassandraClientPoolingContainer> matchingPools =
-                KeyedStream.stream(ImmutableMap.copyOf(currentPools))
+        Map<InetSocketAddress, CassandraClientPoolingContainer> matchingPools = KeyedStream.stream(
+                        ImmutableMap.copyOf(currentPools))
                 .filterKeys(localFilteredHosts::contains)
                 .collectToMap();
         if (matchingPools.isEmpty()) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
@@ -18,12 +18,12 @@ package com.palantir.atlasdb.keyvalue.cassandra.pool;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableRangeMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Interner;
 import com.google.common.collect.Interners;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeMap;
 import com.google.common.collect.Sets;
@@ -40,6 +40,7 @@ import com.palantir.atlasdb.keyvalue.cassandra.LightweightOppToken;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.common.base.Throwables;
+import com.palantir.common.streams.KeyedStream;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.net.InetAddress;
@@ -314,7 +315,9 @@ public class CassandraService implements AutoCloseable {
         Set<InetSocketAddress> localFilteredHosts = maybeFilterLocalHosts(desiredHosts);
 
         Map<InetSocketAddress, CassandraClientPoolingContainer> matchingPools =
-                Maps.filterKeys(currentPools, localFilteredHosts::contains);
+                KeyedStream.stream(ImmutableMap.copyOf(currentPools))
+                .filterKeys(localFilteredHosts::contains)
+                .collectToMap();
         if (matchingPools.isEmpty()) {
             return Optional.empty();
         }

--- a/changelog/@unreleased/pr-5266.v2.yml
+++ b/changelog/@unreleased/pr-5266.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Requests to Cassandra may previously have thrown a `NoSuchElementException` from `WeightedHosts` when attempting to perform a request, if this was concurrent with our view of the Cassandra cluster being refreshed and changing. This has been fixed.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5266


### PR DESCRIPTION
**Goals (and why)**:
- @gsheasby noted that he caught a `NoSuchElementException` in `WeightedHosts`. This should not happen.
- > Jeremy Kong  12 minutes ago
I think there’s a fun race condition here…
so buildHostsWeightedByActiveConnections returns an empty map, and we know pools is nonempty since there’s an assert just before that’s called
the map passed in as an input is a view of a mutable ConcurrentHashMap (CassandraService:316)
this map is updated in the background when we see the cassandra ring change
so if there were some matching pools to the query that were all taken out when we refreshed our view of the cluster, then you could get a NoSuchElementException in WeightedHosts :fire:


**Implementation Description (bullets)**:
- This PR takes a snapshot of the state of the cluster before doing the WeightedHosts computation.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Unfortunately none, we don't have good infra for this right now.

**Concerns (what feedback would you like?)**:
- Is this safe? I argue it is: this method could always already have returned an `Optional.of(x)` where `x` had been removed from the host map.
- Is this too costly? I argue no: a host-map should not have more than O(100) elements even in extreme cases.

**Where should we start reviewing?**: It's really small

**Priority (whenever / two weeks / yesterday)**: Today please
