### PR TITLE
ALP Hotfix

### DIFF
--- a/changelog/@unreleased/pr-5268.v2.yml
+++ b/changelog/@unreleased/pr-5268.v2.yml
@@ -1,15 +1,5 @@
 type: fix
 fix:
-  description: |-
-    ALP Hotfix
-
-    **Goals (and why)**:
-    `LeadershipStateManager#getLeadershipState` will not throw NullPointerExceptions when the delegateRef has been cleared.
-
-    <!---
-    Please remember to:
-    - Add any necessary release notes (including breaking changes)
-    - Make sure the documentation is up to date for your change
-    --->
+  description: '`LeadershipStateManager#getLeadershipState` will not throw NullPointerExceptions when the delegateRef has been cleared.'
   links:
   - https://github.com/palantir/atlasdb/pull/5268

--- a/changelog/@unreleased/pr-5268.v2.yml
+++ b/changelog/@unreleased/pr-5268.v2.yml
@@ -1,0 +1,15 @@
+type: fix
+fix:
+  description: |-
+    ALP Hotfix
+
+    **Goals (and why)**:
+    `LeadershipStateManager#getLeadershipState` will not throw NullPointerExceptions when the delegateRef has been cleared.
+
+    <!---
+    Please remember to:
+    - Add any necessary release notes (including breaking changes)
+    - Make sure the documentation is up to date for your change
+    --->
+  links:
+  - https://github.com/palantir/atlasdb/pull/5268

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/LeadershipStateManager.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/LeadershipStateManager.java
@@ -160,6 +160,9 @@ public class LeadershipStateManager<T> {
     interface LeadershipState<T> {
         LeadershipToken leadershipToken();
 
+        // Making this nullable instead of optional as this object will be called by 1000s of threads and we want to
+        // avoid the cost of setting an getting the optional.
+        @Nullable
         T delegate();
     }
 }

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/LeadershipStateManager.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/LeadershipStateManager.java
@@ -160,6 +160,9 @@ public class LeadershipStateManager<T> {
     interface LeadershipState<T> {
         LeadershipToken leadershipToken();
 
+        // It is legal to have delegate set to null while the leadershipTokenRef has not been cleared i.e. when the
+        // proxy is closed.
+        //
         // Making this nullable instead of optional as this object will be called by 1000s of threads and we want to
         // avoid the cost of setting an getting the optional.
         @Nullable

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/LeadershipStateManager.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/LeadershipStateManager.java
@@ -164,7 +164,7 @@ public class LeadershipStateManager<T> {
         // proxy is closed.
         //
         // Making this nullable instead of optional as this object will be called by 1000s of threads and we want to
-        // avoid the cost of setting an getting the optional.
+        // avoid the cost of setting and getting the optional.
         @Nullable
         T delegate();
     }


### PR DESCRIPTION
**Goals (and why)**:
Fixes NullPointerExceptions in LeadershipState.
It is legal to have delegate set to null while the leadershipTokenRef still exists i.e. when the proxy is closed.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
