### PR TITLE
[pds-164019] expose isNewServiceNode() properly for user health checks

### DIFF
--- a/changelog/@unreleased/pr-5269.v2.yml
+++ b/changelog/@unreleased/pr-5269.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: 'We now expose a proper mechanism for internal services to query TimeLock''s health as opposed to probing deeply into its config. User healthchecks should use `isNewServiceNode()` and not directly e.g. `paxos().isNewService()` which was broken because we added specific exclusion in the CentOS migration CLI last year. '
+  links:
+  - https://github.com/palantir/atlasdb/pull/5269

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockInstallConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockInstallConfiguration.java
@@ -55,11 +55,15 @@ public interface TimeLockInstallConfiguration {
         return ImmutablePaxosTsBoundPersisterConfiguration.builder().build();
     }
 
+    @Value.Derived
+    default boolean isNewServiceNode() {
+        return paxos().isNewService()
+                || cluster().knownNewServers().contains(cluster().localServer());
+    }
+
     @Value.Check
     default void check() {
         TimeLockPersistenceInvariants.checkPersistenceConsistentWithState(
-                paxos().isNewService()
-                        || cluster().knownNewServers().contains(cluster().localServer()),
-                paxos().doDataDirectoriesExist());
+                isNewServiceNode(), paxos().doDataDirectoriesExist());
     }
 }

--- a/timelock-agent/src/test/java/com/palantir/timelock/config/TimeLockInstallConfigurationTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/config/TimeLockInstallConfigurationTest.java
@@ -66,14 +66,7 @@ public class TimeLockInstallConfigurationTest {
     public void newServiceIfNewServiceFlagSetToTrue() {
         assertThat(ImmutableTimeLockInstallConfiguration.builder()
                         .cluster(CLUSTER_CONFIG)
-                        .paxos(ImmutablePaxosInstallConfiguration.builder()
-                                .dataDirectory(newPaxosLogDirectory)
-                                .isNewService(true)
-                                .leaderMode(PaxosLeaderMode.SINGLE_LEADER)
-                                .sqlitePersistence(ImmutableSqlitePaxosPersistenceConfiguration.builder()
-                                        .dataDirectory(newSqliteLogDirectory)
-                                        .build())
-                                .build())
+                        .paxos(createPaxosInstall(true, false))
                         .build()
                         .isNewServiceNode())
                 .isTrue();
@@ -83,14 +76,7 @@ public class TimeLockInstallConfigurationTest {
     public void existingServiceIfNewServiceFlagSetToFalse() {
         assertThat(ImmutableTimeLockInstallConfiguration.builder()
                         .cluster(CLUSTER_CONFIG)
-                        .paxos(ImmutablePaxosInstallConfiguration.builder()
-                                .dataDirectory(extantPaxosLogDirectory)
-                                .isNewService(false)
-                                .leaderMode(PaxosLeaderMode.SINGLE_LEADER)
-                                .sqlitePersistence(ImmutableSqlitePaxosPersistenceConfiguration.builder()
-                                        .dataDirectory(extantSqliteLogDirectory)
-                                        .build())
-                                .build())
+                        .paxos(createPaxosInstall(false, true))
                         .build()
                         .isNewServiceNode())
                 .isFalse();
@@ -106,16 +92,20 @@ public class TimeLockInstallConfigurationTest {
                                         Optional.empty()))
                                 .addKnownNewServers(SERVER_A)
                                 .build())
-                        .paxos(ImmutablePaxosInstallConfiguration.builder()
-                                .dataDirectory(newPaxosLogDirectory)
-                                .isNewService(false)
-                                .leaderMode(PaxosLeaderMode.SINGLE_LEADER)
-                                .sqlitePersistence(ImmutableSqlitePaxosPersistenceConfiguration.builder()
-                                        .dataDirectory(newSqliteLogDirectory)
-                                        .build())
-                                .build())
+                        .paxos(createPaxosInstall(false, false))
                         .build()
                         .isNewServiceNode())
                 .isTrue();
+    }
+
+    private PaxosInstallConfiguration createPaxosInstall(boolean isNewService, boolean shouldDirectoriesExist) {
+        return ImmutablePaxosInstallConfiguration.builder()
+                .dataDirectory(shouldDirectoriesExist ? extantPaxosLogDirectory : newPaxosLogDirectory)
+                .sqlitePersistence(ImmutableSqlitePaxosPersistenceConfiguration.builder()
+                        .dataDirectory(shouldDirectoriesExist ? extantSqliteLogDirectory : extantPaxosLogDirectory)
+                        .build())
+                .isNewService(isNewService)
+                .leaderMode(PaxosLeaderMode.SINGLE_LEADER)
+                .build();
     }
 }

--- a/timelock-agent/src/test/java/com/palantir/timelock/config/TimeLockInstallConfigurationTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/config/TimeLockInstallConfigurationTest.java
@@ -1,0 +1,121 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.timelock.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.conjure.java.api.config.service.PartialServiceConfiguration;
+import com.palantir.timelock.config.PaxosInstallConfiguration.PaxosLeaderMode;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TimeLockInstallConfigurationTest {
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private static final String SERVER_A = "horses-for-courses:1234";
+    public static final String SERVER_B = "paddock-and-chips:2345";
+    private static final ClusterConfiguration CLUSTER_CONFIG = ImmutableDefaultClusterConfiguration.builder()
+            .localServer(SERVER_A)
+            .cluster(PartialServiceConfiguration.of(
+                    ImmutableList.of(SERVER_A, SERVER_B, "the-mane-event:3456"), Optional.empty()))
+            .addKnownNewServers(SERVER_B)
+            .build();
+
+    private File newPaxosLogDirectory;
+    private File newSqliteLogDirectory;
+    private File extantPaxosLogDirectory;
+    private File extantSqliteLogDirectory;
+
+    private PaxosInstallConfiguration newService;
+    private PaxosInstallConfiguration extantService;
+
+    @Before
+    public void setUp() throws IOException {
+        newPaxosLogDirectory = Paths.get(temporaryFolder.getRoot().toString(), "part-time-parliament")
+                .toFile();
+        newSqliteLogDirectory = Paths.get(temporaryFolder.getRoot().toString(), "sqlite-is-cool")
+                .toFile();
+
+        extantPaxosLogDirectory = temporaryFolder.newFolder("lets-do-some-voting");
+        extantSqliteLogDirectory = temporaryFolder.newFolder("whats-a-right-join");
+    }
+
+    @Test
+    public void newServiceIfNewServiceFlagSetToTrue() {
+        assertThat(ImmutableTimeLockInstallConfiguration.builder()
+                        .cluster(CLUSTER_CONFIG)
+                        .paxos(ImmutablePaxosInstallConfiguration.builder()
+                                .dataDirectory(newPaxosLogDirectory)
+                                .isNewService(true)
+                                .leaderMode(PaxosLeaderMode.SINGLE_LEADER)
+                                .sqlitePersistence(ImmutableSqlitePaxosPersistenceConfiguration.builder()
+                                        .dataDirectory(newSqliteLogDirectory)
+                                        .build())
+                                .build())
+                        .build()
+                        .isNewServiceNode())
+                .isTrue();
+    }
+
+    @Test
+    public void existingServiceIfNewServiceFlagSetToFalse() {
+        assertThat(ImmutableTimeLockInstallConfiguration.builder()
+                        .cluster(CLUSTER_CONFIG)
+                        .paxos(ImmutablePaxosInstallConfiguration.builder()
+                                .dataDirectory(extantPaxosLogDirectory)
+                                .isNewService(false)
+                                .leaderMode(PaxosLeaderMode.SINGLE_LEADER)
+                                .sqlitePersistence(ImmutableSqlitePaxosPersistenceConfiguration.builder()
+                                        .dataDirectory(extantSqliteLogDirectory)
+                                        .build())
+                                .build())
+                        .build()
+                        .isNewServiceNode())
+                .isFalse();
+    }
+
+    @Test
+    public void newNodeInExistingServiceRecognisedAsNew() {
+        assertThat(ImmutableTimeLockInstallConfiguration.builder()
+                        .cluster(ImmutableDefaultClusterConfiguration.builder()
+                                .localServer(SERVER_A)
+                                .cluster(PartialServiceConfiguration.of(
+                                        ImmutableList.of(SERVER_A, SERVER_B, "hoof-moved-my-cheese:4567"),
+                                        Optional.empty()))
+                                .addKnownNewServers(SERVER_A)
+                                .build())
+                        .paxos(ImmutablePaxosInstallConfiguration.builder()
+                                .dataDirectory(newPaxosLogDirectory)
+                                .isNewService(false)
+                                .leaderMode(PaxosLeaderMode.SINGLE_LEADER)
+                                .sqlitePersistence(ImmutableSqlitePaxosPersistenceConfiguration.builder()
+                                        .dataDirectory(newSqliteLogDirectory)
+                                        .build())
+                                .build())
+                        .build()
+                        .isNewServiceNode())
+                .isTrue();
+    }
+}


### PR DESCRIPTION
**Goals (and why)**:
- Expose a proper mechanism for internal services to query TimeLock's health as opposed to probing deeply into its config.

**Implementation Description (bullets)**:
- Expose said logic. User healthchecks should use isNewServiceNode() and not directly e.g. paxos().isNewService() which was broken because we added specific exclusion in the CentOS migration CLI last year. *cough* Law of Demeter *cough*

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Added a bunch of tests for the main cases.

**Concerns (what feedback would you like?)**: nothing in particular

**Where should we start reviewing?**: small PR

**Priority (whenever / two weeks / yesterday)**: several months ago 🔥  in any case it's actively blocking the aforementioned ticket, perhaps not at P0 right now but will be in a few days.