### PR TITLE
[CCB] | MultiClientTransactionStarter refactor - part 1

### DIFF
--- a/lock-api/src/main/java/com/palantir/lock/client/BatchingIdentifiedAtlasDbTransactionStarter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/BatchingIdentifiedAtlasDbTransactionStarter.java
@@ -40,21 +40,21 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class BatchingTransactionStarter implements IdentifiedAtlasDbTransactionStarter {
+public class BatchingIdentifiedAtlasDbTransactionStarter implements IdentifiedAtlasDbTransactionStarter {
     private final DisruptorAutobatcher<Integer, List<StartIdentifiedAtlasDbTransactionResponse>> autobatcher;
 
-    public BatchingTransactionStarter(
+    public BatchingIdentifiedAtlasDbTransactionStarter(
             DisruptorAutobatcher<Integer, List<StartIdentifiedAtlasDbTransactionResponse>> autobatcher) {
         this.autobatcher = autobatcher;
     }
 
-    static BatchingTransactionStarter create(
+    static BatchingIdentifiedAtlasDbTransactionStarter create(
             LockLeaseService lockLeaseService, LockWatchEventCache lockWatchEventCache) {
         DisruptorAutobatcher<Integer, List<StartIdentifiedAtlasDbTransactionResponse>> autobatcher =
                 Autobatchers.independent(consumer(lockLeaseService, lockWatchEventCache))
                         .safeLoggablePurpose("transaction-starter")
                         .build();
-        return new BatchingTransactionStarter(autobatcher);
+        return new BatchingIdentifiedAtlasDbTransactionStarter(autobatcher);
     }
 
     @Override

--- a/lock-api/src/main/java/com/palantir/lock/client/BatchingIdentifiedAtlasDbTransactionStarter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/BatchingIdentifiedAtlasDbTransactionStarter.java
@@ -34,10 +34,10 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-public class BatchingIdentifiedAtlasDbTransactionStarter implements IdentifiedAtlasDbTransactionStarter {
+public final class BatchingIdentifiedAtlasDbTransactionStarter implements IdentifiedAtlasDbTransactionStarter {
     private final DisruptorAutobatcher<Integer, List<StartIdentifiedAtlasDbTransactionResponse>> autobatcher;
 
-    public BatchingIdentifiedAtlasDbTransactionStarter(
+    private BatchingIdentifiedAtlasDbTransactionStarter(
             DisruptorAutobatcher<Integer, List<StartIdentifiedAtlasDbTransactionResponse>> autobatcher) {
         this.autobatcher = autobatcher;
     }
@@ -62,7 +62,7 @@ public class BatchingIdentifiedAtlasDbTransactionStarter implements IdentifiedAt
             LockLeaseService lockLeaseService, LockWatchEventCache lockWatchEventCache) {
         return batch -> {
             int numTransactions =
-                    batch.stream().mapToInt(BatchElement::argument).reduce(0, Integer::sum);
+                    batch.stream().mapToInt(BatchElement::argument).sum();
 
             List<StartIdentifiedAtlasDbTransactionResponse> startTransactionResponses =
                     getStartTransactionResponses(lockLeaseService, lockWatchEventCache, numTransactions);

--- a/lock-api/src/main/java/com/palantir/lock/client/BatchingTransactionStarter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/BatchingTransactionStarter.java
@@ -1,0 +1,132 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.client;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Streams;
+import com.palantir.atlasdb.autobatch.Autobatchers;
+import com.palantir.atlasdb.autobatch.BatchElement;
+import com.palantir.atlasdb.autobatch.DisruptorAutobatcher;
+import com.palantir.atlasdb.futures.AtlasFutures;
+import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
+import com.palantir.common.base.Throwables;
+import com.palantir.lock.v2.LockImmutableTimestampResponse;
+import com.palantir.lock.v2.LockToken;
+import com.palantir.lock.v2.PartitionedTimestamps;
+import com.palantir.lock.v2.StartIdentifiedAtlasDbTransactionResponse;
+import com.palantir.lock.v2.TimestampAndPartition;
+import com.palantir.lock.watch.LockWatchEventCache;
+import com.palantir.lock.watch.LockWatchVersion;
+import com.palantir.logsafe.Preconditions;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class BatchingTransactionStarter implements IdentifiedAtlasDbTransactionStarter {
+    private final DisruptorAutobatcher<Integer, List<StartIdentifiedAtlasDbTransactionResponse>> autobatcher;
+
+    public BatchingTransactionStarter(
+            DisruptorAutobatcher<Integer, List<StartIdentifiedAtlasDbTransactionResponse>> autobatcher) {
+        this.autobatcher = autobatcher;
+    }
+
+    static BatchingTransactionStarter create(
+            LockLeaseService lockLeaseService, LockWatchEventCache lockWatchEventCache) {
+        DisruptorAutobatcher<Integer, List<StartIdentifiedAtlasDbTransactionResponse>> autobatcher =
+                Autobatchers.independent(consumer(lockLeaseService, lockWatchEventCache))
+                        .safeLoggablePurpose("transaction-starter")
+                        .build();
+        return new BatchingTransactionStarter(autobatcher);
+    }
+
+    @Override
+    public List<StartIdentifiedAtlasDbTransactionResponse> startIdentifiedAtlasDbTransactionBatch(int count) {
+        Preconditions.checkArgument(count > 0, "Cannot start 0 or fewer transactions");
+        return AtlasFutures.getUnchecked(autobatcher.apply(count));
+    }
+
+    @VisibleForTesting
+    static Consumer<List<BatchElement<Integer, List<StartIdentifiedAtlasDbTransactionResponse>>>> consumer(
+            LockLeaseService lockLeaseService, LockWatchEventCache lockWatchEventCache) {
+        return batch -> {
+            int numTransactions =
+                    batch.stream().mapToInt(BatchElement::argument).reduce(0, Integer::sum);
+
+            List<StartIdentifiedAtlasDbTransactionResponse> startTransactionResponses =
+                    getStartTransactionResponses(lockLeaseService, lockWatchEventCache, numTransactions);
+
+            int start = 0;
+            for (BatchElement<Integer, List<StartIdentifiedAtlasDbTransactionResponse>> batchElement : batch) {
+                int end = start + batchElement.argument();
+                batchElement.result().set(ImmutableList.copyOf(startTransactionResponses.subList(start, end)));
+                start = end;
+            }
+        };
+    }
+
+    private static List<StartIdentifiedAtlasDbTransactionResponse> getStartTransactionResponses(
+            LockLeaseService lockLeaseService, LockWatchEventCache lockWatchEventCache, int numberOfTransactions) {
+        List<StartIdentifiedAtlasDbTransactionResponse> result = new ArrayList<>();
+        while (result.size() < numberOfTransactions) {
+            try {
+                Optional<LockWatchVersion> requestedVersion = lockWatchEventCache.lastKnownVersion();
+                ConjureStartTransactionsResponse response = lockLeaseService.startTransactionsWithWatches(
+                        requestedVersion, numberOfTransactions - result.size());
+                lockWatchEventCache.processStartTransactionsUpdate(
+                        response.getTimestamps().stream().boxed().collect(Collectors.toSet()),
+                        response.getLockWatchUpdate());
+                result.addAll(split(response));
+                LockWatchLogUtility.logTransactionEvents(requestedVersion, response.getLockWatchUpdate());
+            } catch (Throwable t) {
+                TransactionStarterHelper.unlock(
+                        result.stream()
+                                .map(response -> response.immutableTimestamp().getLock())
+                                .collect(Collectors.toSet()),
+                        lockLeaseService);
+                throw Throwables.throwUncheckedException(t);
+            }
+        }
+        return result;
+    }
+
+    private static List<StartIdentifiedAtlasDbTransactionResponse> split(ConjureStartTransactionsResponse response) {
+        PartitionedTimestamps partitionedTimestamps = response.getTimestamps();
+        int partition = partitionedTimestamps.partition();
+
+        LockToken immutableTsLock = response.getImmutableTimestamp().getLock();
+        long immutableTs = response.getImmutableTimestamp().getImmutableTimestamp();
+
+        Stream<LockImmutableTimestampResponse> immutableTsAndLocks = LockTokenShare.share(
+                        immutableTsLock, partitionedTimestamps.count())
+                .map(tokenShare -> LockImmutableTimestampResponse.of(immutableTs, tokenShare));
+
+        Stream<TimestampAndPartition> timestampAndPartitions =
+                partitionedTimestamps.stream().mapToObj(timestamp -> TimestampAndPartition.of(timestamp, partition));
+
+        return Streams.zip(immutableTsAndLocks, timestampAndPartitions, StartIdentifiedAtlasDbTransactionResponse::of)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void close() {
+        autobatcher.close();
+    }
+}

--- a/lock-api/src/main/java/com/palantir/lock/client/IdentifiedAtlasDbTransactionStarter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/IdentifiedAtlasDbTransactionStarter.java
@@ -1,0 +1,24 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.client;
+
+import com.palantir.lock.v2.StartIdentifiedAtlasDbTransactionResponse;
+import java.util.List;
+
+public interface IdentifiedAtlasDbTransactionStarter extends AutoCloseable {
+    List<StartIdentifiedAtlasDbTransactionResponse> startIdentifiedAtlasDbTransactionBatch(int count);
+}

--- a/lock-api/src/main/java/com/palantir/lock/client/IdentifiedAtlasDbTransactionStarter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/IdentifiedAtlasDbTransactionStarter.java
@@ -21,4 +21,7 @@ import java.util.List;
 
 public interface IdentifiedAtlasDbTransactionStarter extends AutoCloseable {
     List<StartIdentifiedAtlasDbTransactionResponse> startIdentifiedAtlasDbTransactionBatch(int count);
+
+    @Override
+    void close();
 }

--- a/lock-api/src/main/java/com/palantir/lock/client/TransactionStarter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/TransactionStarter.java
@@ -16,32 +16,13 @@
 
 package com.palantir.lock.client;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
-import com.google.common.collect.Streams;
-import com.palantir.atlasdb.autobatch.Autobatchers;
-import com.palantir.atlasdb.autobatch.BatchElement;
-import com.palantir.atlasdb.autobatch.DisruptorAutobatcher;
-import com.palantir.atlasdb.futures.AtlasFutures;
-import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
-import com.palantir.common.base.Throwables;
-import com.palantir.lock.v2.LockImmutableTimestampResponse;
 import com.palantir.lock.v2.LockToken;
-import com.palantir.lock.v2.PartitionedTimestamps;
 import com.palantir.lock.v2.StartIdentifiedAtlasDbTransactionResponse;
-import com.palantir.lock.v2.TimestampAndPartition;
 import com.palantir.lock.watch.LockWatchEventCache;
-import com.palantir.lock.watch.LockWatchVersion;
-import com.palantir.logsafe.Preconditions;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * A service responsible for coalescing multiple start transaction calls into a single start transactions call. This
@@ -51,36 +32,29 @@ import java.util.stream.Stream;
  * Callers of this class should use {@link #unlock(Set)} and {@link #refreshLockLeases(Set)} for returned lock tokens,
  * rather than directly calling delegate lock service.
  */
-final class TransactionStarter implements AutoCloseable {
-    private final DisruptorAutobatcher<Integer, List<StartIdentifiedAtlasDbTransactionResponse>> autobatcher;
+class TransactionStarter implements AutoCloseable {
     private final LockLeaseService lockLeaseService;
+    private final BatchingTransactionStarter batchingTransactionStarter;
 
-    private TransactionStarter(
-            DisruptorAutobatcher<Integer, List<StartIdentifiedAtlasDbTransactionResponse>> autobatcher,
-            LockLeaseService lockLeaseService) {
-        this.autobatcher = autobatcher;
+    private TransactionStarter(LockLeaseService lockLeaseService, LockWatchEventCache lockWatchEventCache) {
         this.lockLeaseService = lockLeaseService;
+        this.batchingTransactionStarter = BatchingTransactionStarter.create(lockLeaseService, lockWatchEventCache);
     }
 
     static TransactionStarter create(LockLeaseService lockLeaseService, LockWatchEventCache lockWatchEventCache) {
-        DisruptorAutobatcher<Integer, List<StartIdentifiedAtlasDbTransactionResponse>> autobatcher =
-                Autobatchers.independent(consumer(lockLeaseService, lockWatchEventCache))
-                        .safeLoggablePurpose("transaction-starter")
-                        .build();
-        return new TransactionStarter(autobatcher, lockLeaseService);
+        return new TransactionStarter(lockLeaseService, lockWatchEventCache);
     }
 
     List<StartIdentifiedAtlasDbTransactionResponse> startIdentifiedAtlasDbTransactionBatch(int count) {
-        Preconditions.checkArgument(count > 0, "Cannot start 0 or fewer transactions");
-        return AtlasFutures.getUnchecked(autobatcher.apply(count));
+        return batchingTransactionStarter.startIdentifiedAtlasDbTransactionBatch(count);
     }
 
     Set<LockToken> refreshLockLeases(Set<LockToken> tokens) {
-        Set<LockTokenShare> lockTokenShares = filterLockTokenShares(tokens);
-        Set<LockToken> lockTokens = filterOutTokenShares(tokens);
+        Set<LockTokenShare> lockTokenShares = TransactionStarterHelper.filterLockTokenShares(tokens);
+        Set<LockToken> lockTokens = TransactionStarterHelper.filterOutTokenShares(tokens);
 
-        Set<LockToken> refreshedTokens =
-                lockLeaseService.refreshLockLeases(Sets.union(reduceForRefresh(lockTokenShares), lockTokens));
+        Set<LockToken> refreshedTokens = lockLeaseService.refreshLockLeases(
+                Sets.union(TransactionStarterHelper.reduceForRefresh(lockTokenShares), lockTokens));
 
         Set<LockToken> resultLockTokenShares = lockTokenShares.stream()
                 .filter(t -> refreshedTokens.contains(t.sharedLockToken()))
@@ -92,135 +66,11 @@ final class TransactionStarter implements AutoCloseable {
     }
 
     Set<LockToken> unlock(Set<LockToken> tokens) {
-        return unlock(tokens, lockLeaseService);
-    }
-
-    private static Set<LockToken> unlock(Set<LockToken> tokens, LockLeaseService lockLeaseService) {
-        Set<LockToken> lockTokens = filterOutTokenShares(tokens);
-
-        Set<LockTokenShare> lockTokenShares = filterLockTokenShares(tokens);
-
-        Set<LockToken> toUnlock = reduceForUnlock(lockTokenShares);
-        Set<LockToken> toRefresh = getLockTokensToRefresh(lockTokenShares, toUnlock);
-
-        Set<LockToken> refreshed = lockLeaseService.refreshLockLeases(toRefresh);
-        Set<LockToken> unlocked = lockLeaseService.unlock(Sets.union(toUnlock, lockTokens));
-
-        Set<LockTokenShare> resultLockTokenShares = Sets.filter(
-                lockTokenShares,
-                t -> unlocked.contains(t.sharedLockToken()) || refreshed.contains(t.sharedLockToken()));
-        Set<LockToken> resultLockTokens = Sets.intersection(lockTokens, unlocked);
-
-        return ImmutableSet.copyOf(Sets.union(resultLockTokenShares, resultLockTokens));
-    }
-
-    /**
-     * Calling unlock on a set of LockTokenShares only calls unlock on shared token iff all references to shared token
-     * are unlocked.
-     *
-     * {@link com.palantir.lock.v2.TimelockService#unlock(Set)} has a guarantee that returned tokens were valid until
-     * calling unlock. To keep that guarantee, we need to check if LockTokenShares were valid (by calling refresh with
-     * referenced shared token) even if we don't unlock the underlying shared token.
-     */
-    private static Set<LockToken> getLockTokensToRefresh(
-            Set<LockTokenShare> lockTokenShares, Set<LockToken> sharedTokensToUnlock) {
-        return lockTokenShares.stream()
-                .map(LockTokenShare::sharedLockToken)
-                .filter(token -> !sharedTokensToUnlock.contains(token))
-                .collect(Collectors.toSet());
+        return TransactionStarterHelper.unlock(tokens, lockLeaseService);
     }
 
     @Override
     public void close() {
-        autobatcher.close();
-    }
-
-    @VisibleForTesting
-    static Consumer<List<BatchElement<Integer, List<StartIdentifiedAtlasDbTransactionResponse>>>> consumer(
-            LockLeaseService lockLeaseService, LockWatchEventCache lockWatchEventCache) {
-        return batch -> {
-            int numTransactions =
-                    batch.stream().mapToInt(BatchElement::argument).reduce(0, Integer::sum);
-
-            List<StartIdentifiedAtlasDbTransactionResponse> startTransactionResponses =
-                    getStartTransactionResponses(lockLeaseService, lockWatchEventCache, numTransactions);
-
-            int start = 0;
-            for (BatchElement<Integer, List<StartIdentifiedAtlasDbTransactionResponse>> batchElement : batch) {
-                int end = start + batchElement.argument();
-                batchElement.result().set(ImmutableList.copyOf(startTransactionResponses.subList(start, end)));
-                start = end;
-            }
-        };
-    }
-
-    private static List<StartIdentifiedAtlasDbTransactionResponse> getStartTransactionResponses(
-            LockLeaseService lockLeaseService, LockWatchEventCache lockWatchEventCache, int numberOfTransactions) {
-        List<StartIdentifiedAtlasDbTransactionResponse> result = new ArrayList<>();
-        while (result.size() < numberOfTransactions) {
-            try {
-                Optional<LockWatchVersion> requestedVersion = lockWatchEventCache.lastKnownVersion();
-                ConjureStartTransactionsResponse response = lockLeaseService.startTransactionsWithWatches(
-                        requestedVersion, numberOfTransactions - result.size());
-                lockWatchEventCache.processStartTransactionsUpdate(
-                        response.getTimestamps().stream().boxed().collect(Collectors.toSet()),
-                        response.getLockWatchUpdate());
-                result.addAll(split(response));
-                LockWatchLogUtility.logTransactionEvents(requestedVersion, response.getLockWatchUpdate());
-            } catch (Throwable t) {
-                unlock(
-                        result.stream()
-                                .map(response -> response.immutableTimestamp().getLock())
-                                .collect(Collectors.toSet()),
-                        lockLeaseService);
-                throw Throwables.throwUncheckedException(t);
-            }
-        }
-        return result;
-    }
-
-    private static List<StartIdentifiedAtlasDbTransactionResponse> split(ConjureStartTransactionsResponse response) {
-        PartitionedTimestamps partitionedTimestamps = response.getTimestamps();
-        int partition = partitionedTimestamps.partition();
-
-        LockToken immutableTsLock = response.getImmutableTimestamp().getLock();
-        long immutableTs = response.getImmutableTimestamp().getImmutableTimestamp();
-
-        Stream<LockImmutableTimestampResponse> immutableTsAndLocks = LockTokenShare.share(
-                        immutableTsLock, partitionedTimestamps.count())
-                .map(tokenShare -> LockImmutableTimestampResponse.of(immutableTs, tokenShare));
-
-        Stream<TimestampAndPartition> timestampAndPartitions =
-                partitionedTimestamps.stream().mapToObj(timestamp -> TimestampAndPartition.of(timestamp, partition));
-
-        return Streams.zip(immutableTsAndLocks, timestampAndPartitions, StartIdentifiedAtlasDbTransactionResponse::of)
-                .collect(Collectors.toList());
-    }
-
-    private static Set<LockToken> reduceForRefresh(Set<LockTokenShare> lockTokenShares) {
-        return lockTokenShares.stream().map(LockTokenShare::sharedLockToken).collect(Collectors.toSet());
-    }
-
-    private static Set<LockToken> reduceForUnlock(Set<LockTokenShare> lockTokenShares) {
-        return lockTokenShares.stream()
-                .map(LockTokenShare::unlock)
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .collect(Collectors.toSet());
-    }
-
-    private static Set<LockTokenShare> filterLockTokenShares(Set<LockToken> tokens) {
-        return tokens.stream()
-                .filter(TransactionStarter::isLockTokenShare)
-                .map(LockTokenShare.class::cast)
-                .collect(Collectors.toSet());
-    }
-
-    private static Set<LockToken> filterOutTokenShares(Set<LockToken> tokens) {
-        return tokens.stream().filter(t -> !isLockTokenShare(t)).collect(Collectors.toSet());
-    }
-
-    private static boolean isLockTokenShare(LockToken lockToken) {
-        return lockToken instanceof LockTokenShare;
+        batchingTransactionStarter.close();
     }
 }

--- a/lock-api/src/main/java/com/palantir/lock/client/TransactionStarterHelper.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/TransactionStarterHelper.java
@@ -47,8 +47,15 @@ public final class TransactionStarterHelper {
         return ImmutableSet.copyOf(Sets.union(resultLockTokenShares, resultLockTokens));
     }
 
-    static Set<LockToken> reduceForRefresh(Set<LockTokenShare> lockTokenShares) {
-        return lockTokenShares.stream().map(LockTokenShare::sharedLockToken).collect(Collectors.toSet());
+    static Set<LockTokenShare> filterLockTokenShares(Set<LockToken> tokens) {
+        return tokens.stream()
+                .filter(TransactionStarterHelper::isLockTokenShare)
+                .map(LockTokenShare.class::cast)
+                .collect(Collectors.toSet());
+    }
+
+    static Set<LockToken> filterOutTokenShares(Set<LockToken> tokens) {
+        return tokens.stream().filter(t -> !isLockTokenShare(t)).collect(Collectors.toSet());
     }
 
     /**
@@ -73,17 +80,6 @@ public final class TransactionStarterHelper {
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .collect(Collectors.toSet());
-    }
-
-    static Set<LockTokenShare> filterLockTokenShares(Set<LockToken> tokens) {
-        return tokens.stream()
-                .filter(TransactionStarterHelper::isLockTokenShare)
-                .map(LockTokenShare.class::cast)
-                .collect(Collectors.toSet());
-    }
-
-    static Set<LockToken> filterOutTokenShares(Set<LockToken> tokens) {
-        return tokens.stream().filter(t -> !isLockTokenShare(t)).collect(Collectors.toSet());
     }
 
     private static boolean isLockTokenShare(LockToken lockToken) {

--- a/lock-api/src/main/java/com/palantir/lock/client/TransactionStarterHelper.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/TransactionStarterHelper.java
@@ -18,10 +18,18 @@ package com.palantir.lock.client;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import com.google.common.collect.Streams;
+import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
+import com.palantir.lock.v2.LockImmutableTimestampResponse;
 import com.palantir.lock.v2.LockToken;
+import com.palantir.lock.v2.PartitionedTimestamps;
+import com.palantir.lock.v2.StartIdentifiedAtlasDbTransactionResponse;
+import com.palantir.lock.v2.TimestampAndPartition;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public final class TransactionStarterHelper {
     private TransactionStarterHelper() {
@@ -84,5 +92,23 @@ public final class TransactionStarterHelper {
 
     private static boolean isLockTokenShare(LockToken lockToken) {
         return lockToken instanceof LockTokenShare;
+    }
+
+    static List<StartIdentifiedAtlasDbTransactionResponse> split(ConjureStartTransactionsResponse response) {
+        PartitionedTimestamps partitionedTimestamps = response.getTimestamps();
+        int partition = partitionedTimestamps.partition();
+
+        LockToken immutableTsLock = response.getImmutableTimestamp().getLock();
+        long immutableTs = response.getImmutableTimestamp().getImmutableTimestamp();
+
+        Stream<LockImmutableTimestampResponse> immutableTsAndLocks = LockTokenShare.share(
+                        immutableTsLock, partitionedTimestamps.count())
+                .map(tokenShare -> LockImmutableTimestampResponse.of(immutableTs, tokenShare));
+
+        Stream<TimestampAndPartition> timestampAndPartitions =
+                partitionedTimestamps.stream().mapToObj(timestamp -> TimestampAndPartition.of(timestamp, partition));
+
+        return Streams.zip(immutableTsAndLocks, timestampAndPartitions, StartIdentifiedAtlasDbTransactionResponse::of)
+                .collect(Collectors.toList());
     }
 }

--- a/lock-api/src/main/java/com/palantir/lock/client/TransactionStarterHelper.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/TransactionStarterHelper.java
@@ -1,0 +1,92 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.client;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.palantir.lock.v2.LockToken;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public final class TransactionStarterHelper {
+    private TransactionStarterHelper() {
+        // Do not instantiate helper class
+    }
+
+    static Set<LockToken> unlock(Set<LockToken> tokens, LockLeaseService lockLeaseService) {
+        Set<LockToken> lockTokens = filterOutTokenShares(tokens);
+
+        Set<LockTokenShare> lockTokenShares = filterLockTokenShares(tokens);
+
+        Set<LockToken> toUnlock = reduceForUnlock(lockTokenShares);
+        Set<LockToken> toRefresh = getLockTokensToRefresh(lockTokenShares, toUnlock);
+
+        Set<LockToken> refreshed = lockLeaseService.refreshLockLeases(toRefresh);
+        Set<LockToken> unlocked = lockLeaseService.unlock(Sets.union(toUnlock, lockTokens));
+
+        Set<LockTokenShare> resultLockTokenShares = Sets.filter(
+                lockTokenShares,
+                t -> unlocked.contains(t.sharedLockToken()) || refreshed.contains(t.sharedLockToken()));
+        Set<LockToken> resultLockTokens = Sets.intersection(lockTokens, unlocked);
+
+        return ImmutableSet.copyOf(Sets.union(resultLockTokenShares, resultLockTokens));
+    }
+
+    static Set<LockToken> reduceForRefresh(Set<LockTokenShare> lockTokenShares) {
+        return lockTokenShares.stream().map(LockTokenShare::sharedLockToken).collect(Collectors.toSet());
+    }
+
+    /**
+     * Calling unlock on a set of LockTokenShares only calls unlock on shared token iff all references to shared token
+     * are unlocked.
+     *
+     * {@link com.palantir.lock.v2.TimelockService#unlock(Set)} has a guarantee that returned tokens were valid until
+     * calling unlock. To keep that guarantee, we need to check if LockTokenShares were valid (by calling refresh with
+     * referenced shared token) even if we don't unlock the underlying shared token.
+     */
+    private static Set<LockToken> getLockTokensToRefresh(
+            Set<LockTokenShare> lockTokenShares, Set<LockToken> sharedTokensToUnlock) {
+        return lockTokenShares.stream()
+                .map(LockTokenShare::sharedLockToken)
+                .filter(token -> !sharedTokensToUnlock.contains(token))
+                .collect(Collectors.toSet());
+    }
+
+    private static Set<LockToken> reduceForUnlock(Set<LockTokenShare> lockTokenShares) {
+        return lockTokenShares.stream()
+                .map(LockTokenShare::unlock)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toSet());
+    }
+
+    static Set<LockTokenShare> filterLockTokenShares(Set<LockToken> tokens) {
+        return tokens.stream()
+                .filter(TransactionStarterHelper::isLockTokenShare)
+                .map(LockTokenShare.class::cast)
+                .collect(Collectors.toSet());
+    }
+
+    static Set<LockToken> filterOutTokenShares(Set<LockToken> tokens) {
+        return tokens.stream().filter(t -> !isLockTokenShare(t)).collect(Collectors.toSet());
+    }
+
+    private static boolean isLockTokenShare(LockToken lockToken) {
+        return lockToken instanceof LockTokenShare;
+    }
+}

--- a/lock-api/src/test/java/com/palantir/lock/client/TransactionStarterTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/TransactionStarterTest.java
@@ -173,7 +173,8 @@ public class TransactionStarterTest {
                                 .result(new DisruptorAutobatcher.DisruptorFuture<>("test"))
                                 .build())
                 .collect(toList());
-        BatchingTransactionStarter.consumer(lockLeaseService, lockWatchEventCache).accept(elements);
+        BatchingIdentifiedAtlasDbTransactionStarter.consumer(lockLeaseService, lockWatchEventCache)
+                .accept(elements);
         return Futures.getUnchecked(Futures.allAsList(Lists.transform(elements, BatchElement::result)));
     }
 

--- a/lock-api/src/test/java/com/palantir/lock/client/TransactionStarterTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/TransactionStarterTest.java
@@ -173,7 +173,7 @@ public class TransactionStarterTest {
                                 .result(new DisruptorAutobatcher.DisruptorFuture<>("test"))
                                 .build())
                 .collect(toList());
-        TransactionStarter.consumer(lockLeaseService, lockWatchEventCache).accept(elements);
+        BatchingTransactionStarter.consumer(lockLeaseService, lockWatchEventCache).accept(elements);
         return Futures.getUnchecked(Futures.allAsList(Lists.transform(elements, BatchElement::result)));
     }
 


### PR DESCRIPTION
**Goals (and why)**:
Refactor TransactionStarter to accommodate the flow for batching startTransactions requests across multiple clients.

**Implementation Description (bullets)**:

- Extract out IdentifiedAtlasDbTransactionStarter interface, this will have 2 implementations - 1. batching requests per client, 2. batching startTransactions requests across clients
- TransactionStarter now delegates startTransactions calls to IdentifiedAtlasDbTransactionStarter
- Refactor out startTransactions batching logic from TransactionStarter to BatchingIdentifiedAtlasDbTransactionStarter.java
- Move startTransactions utility methods from TransactionStarter to TransactionStarterHelper

**Testing (What was existing testing like?  What have you done to improve it?)**:
Existing tests should suffice

**Concerns (what feedback would you like?)**:
Does this refactor break something?

**Where should we start reviewing?**:

- BatchingIdentifiedAtlasDbTransactionStarter

**Priority (whenever / two weeks / yesterday)**:
Before EOD tomorrow.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
