### PR TITLE
[TS] Better shard balancing

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/CellReference.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/CellReference.java
@@ -39,7 +39,7 @@ public abstract class CellReference {
         return hash;
     }
 
-    static CellReference of(TableReference tableRef, Cell cell) {
+    public static CellReference of(TableReference tableRef, Cell cell) {
         return ImmutableCellReference.builder().tableRef(tableRef).cell(cell).build();
     }
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/CellReference.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/CellReference.java
@@ -29,13 +29,14 @@ public abstract class CellReference {
      * the column name match. We did not want to change it to keep backwards compatibility, but we need a uniform
      * distribution here for all reasonable patterns.
      */
+    @SuppressWarnings("EqualsHashCode") // this replaces the immutable generated code, which has equality defined
     @Override
     public int hashCode() {
-        int h = 5381;
-        h += (h << 5) + tableRef().hashCode();
-        h += (h << 5) + Arrays.hashCode(cell().getRowName());
-        h += (h << 5) + Arrays.hashCode(cell().getColumnName());
-        return h;
+        int hash = 5381;
+        hash += (hash << 5) + tableRef().hashCode();
+        hash += (hash << 5) + Arrays.hashCode(cell().getRowName());
+        hash += (hash << 5) + Arrays.hashCode(cell().getColumnName());
+        return hash;
     }
 
     static CellReference of(TableReference tableRef, Cell cell) {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/AbstractSweepQueueTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/AbstractSweepQueueTest.java
@@ -18,8 +18,10 @@ package com.palantir.atlasdb.sweep.queue;
 import static org.mockito.Mockito.spy;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.math.IntMath;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.CellReference;
 import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
@@ -53,8 +55,11 @@ public abstract class AbstractSweepQueueTest {
     static final long TS_FINE_PARTITION = SweepQueueUtils.tsPartitionFine(TS);
     static final long TS2_FINE_PARTITION = SweepQueueUtils.tsPartitionFine(TS2);
     static final int DEFAULT_SHARDS = 8;
-    static final int FIXED_SHARD =
-            WriteInfo.write(TABLE_CONS, getCellWithFixedHash(0), 0L).toShard(DEFAULT_SHARDS);
+    static final int FIXED_SHARD = WriteInfo.write(
+                    TABLE_CONS,
+                    getCellRefWithFixedShard(0, TABLE_CONS, DEFAULT_SHARDS).cell(),
+                    0L)
+            .toShard(DEFAULT_SHARDS);
     static final int CONS_SHARD =
             WriteInfo.tombstone(TABLE_CONS, DEFAULT_CELL, 0).toShard(DEFAULT_SHARDS);
     static final int THOR_SHARD =
@@ -150,16 +155,24 @@ public abstract class AbstractSweepQueueTest {
     List<WriteInfo> writeToCellsInFixedShard(SweepQueueTable writer, long ts, int number, TableReference tableRef) {
         List<WriteInfo> result = new ArrayList<>();
         for (long i = 0; i < number; i++) {
-            Cell cell = getCellWithFixedHash(i);
-            result.add(WriteInfo.write(tableRef, cell, ts));
+            CellReference cellRef = getCellRefWithFixedShard(i, tableRef, numShards);
+            result.add(WriteInfo.write(tableRef, cellRef.cell(), ts));
         }
         putTimestampIntoTransactionTable(ts, ts);
         writer.enqueue(result);
         return result;
     }
 
-    static Cell getCellWithFixedHash(long seed) {
-        return Cell.create(PtBytes.toBytes(seed), PtBytes.toBytes(seed));
+    static CellReference getCellRefWithFixedShard(long seed, TableReference tableRef, int shards) {
+        byte[] rowName = PtBytes.toBytes(seed);
+        int counter = 0;
+        CellReference cellReference;
+        do {
+            byte[] colName = PtBytes.toBytes(counter);
+            cellReference = CellReference.of(tableRef, Cell.create(rowName, colName));
+            counter++;
+        } while (IntMath.mod(cellReference.hashCode(), shards) != 0);
+        return cellReference;
     }
 
     boolean isTransactionAborted(long txnTimestamp) {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/ShardProgressTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/ShardProgressTest.java
@@ -61,7 +61,7 @@ public class ShardProgressTest {
     @Test
     public void canUpgradeNumberOfShardsIfPersistedDefaultValue() {
         byte[] defaultValue = ShardProgress.createColumnValue(AtlasDbConstants.LEGACY_DEFAULT_TARGETED_SWEEP_SHARDS);
-        CheckAndSetRequest request = progress.createNewCellRequest(ShardProgress.SHARD_COUNT_SAS, defaultValue);
+        CheckAndSetRequest request = ShardProgress.createNewCellRequest(ShardProgress.SHARD_COUNT_SAS, defaultValue);
         kvs.checkAndSet(request);
 
         progress.updateNumberOfShards(128);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepableCellsTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepableCellsTest.java
@@ -209,13 +209,17 @@ public class SweepableCellsTest extends AbstractSweepQueueTest {
 
     @Test
     public void canReadMultipleEntriesInSingleShardDifferentTransactions() {
-        writeToCellCommitted(sweepableCells, TS, getCellWithFixedHash(1), TABLE_CONS);
-        writeToCellCommitted(sweepableCells, TS + 1, getCellWithFixedHash(2), TABLE_CONS);
+        Cell cellInFirstShard =
+                getCellRefWithFixedShard(1, TABLE_CONS, numShards).cell();
+        writeToCellCommitted(sweepableCells, TS, cellInFirstShard, TABLE_CONS);
+        Cell cellInSecondShard =
+                getCellRefWithFixedShard(2, TABLE_CONS, numShards).cell();
+        writeToCellCommitted(sweepableCells, TS + 1, cellInSecondShard, TABLE_CONS);
         SweepBatch conservativeBatch = readConservative(FIXED_SHARD, TS_FINE_PARTITION, TS - 1, TS + 2);
         assertThat(conservativeBatch.writes())
                 .containsExactlyInAnyOrder(
-                        WriteInfo.write(TABLE_CONS, getCellWithFixedHash(1), TS),
-                        WriteInfo.write(TABLE_CONS, getCellWithFixedHash(2), TS + 1));
+                        WriteInfo.write(TABLE_CONS, cellInFirstShard, TS),
+                        WriteInfo.write(TABLE_CONS, cellInSecondShard, TS + 1));
         assertThat(conservativeBatch.lastSweptTimestamp()).isEqualTo(TS + 1);
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/WriteInfoPartitionerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/WriteInfoPartitionerTest.java
@@ -114,10 +114,10 @@ public class WriteInfoPartitionerTest {
 
         assertThat(partitioner.filterOutUnsweepableTables(writes))
                 .containsExactly(
-                        getWriteInfoWithFixedShard(CONSERVATIVE, 0, numShards), getWriteInfoWithFixedShard(CONSERVATIVE, 0,
-                                numShards),
-                        getWriteInfoWithFixedShard(CONSERVATIVE2, 1, numShards), getWriteInfoWithFixedShard(THOROUGH, 2,
-                                numShards));
+                        getWriteInfoWithFixedShard(CONSERVATIVE, 0, numShards),
+                                getWriteInfoWithFixedShard(CONSERVATIVE, 0, numShards),
+                        getWriteInfoWithFixedShard(CONSERVATIVE2, 1, numShards),
+                                getWriteInfoWithFixedShard(THOROUGH, 2, numShards));
     }
 
     @Test

--- a/changelog/@unreleased/pr-5274.v2.yml
+++ b/changelog/@unreleased/pr-5274.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Improved `CellReference.hashCode()` method to use a more standard implementation rather than depend on `Cell.hashCode()`. This fixes imbalance in the targeted sweep queue caused by writes to cells where row and column names match.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5274


### PR DESCRIPTION
**Goals (and why)**:
The existing `Cell` hashCode is always 0 if rowName and colName match. This could be the cause of write->shard assignment imbalances that we've seen in targeted sweep. This should make the distribution more uniform.

**Implementation Description (bullets)**:
Implements hashCode for `CellReference` as if the `Cell` hashCode was generated by immutables, without changing the `Cell.hashCode()` impl.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Some existing tests needed to be changed as they used the hashCode hack. No other tests as this is a super standard implementation, but existing tests don't break

**Concerns (what feedback would you like?)**:
None really, I was considering having a separate method, but this has the added benefit of also working better if we have a `CellReference` keyed HashMap so decided to go with this.

**Where should we start reviewing?**:
small

**Priority (whenever / two weeks / yesterday)**:
soon^{tm}
