### PR TITLE
[TS | LIP-164000] Reset Sweep Progress

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cache.TimestampCache;
@@ -41,9 +40,6 @@ import org.slf4j.LoggerFactory;
 public abstract class AtlasDbConfig {
 
     private static final Logger log = LoggerFactory.getLogger(AtlasDbConfig.class);
-
-    @VisibleForTesting
-    static final String UNSPECIFIED_NAMESPACE = "unspecified";
 
     public abstract KeyValueServiceConfig keyValueService();
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/ShardProgress.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/ShardProgress.java
@@ -144,11 +144,12 @@ public class ShardProgress {
         while (currentValue > SweepQueueUtils.RESET_TIMESTAMP) {
             CheckAndSetRequest casRequest = createRequest(shardAndStrategy, currentValue, colValZero);
             try {
-                log.info("Attempting to reset targeted sweep progress for a shard.",
+                log.info(
+                        "Attempting to reset targeted sweep progress for a shard.",
                         SafeArg.of("shardAndStrategy", shardAndStrategy));
                 kvs.checkAndSet(casRequest);
-                log.info("Reset targeted sweep progress for a shard.",
-                        SafeArg.of("shardAndStrategy", shardAndStrategy));
+                log.info(
+                        "Reset targeted sweep progress for a shard.", SafeArg.of("shardAndStrategy", shardAndStrategy));
             } catch (CheckAndSetException e) {
                 log.info(
                         "Failed to reset targeted sweep progress for a shard; trying again if someone changed it "

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueue.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueue.java
@@ -174,6 +174,7 @@ public final class SweepQueue implements MultiTableSweepQueueWriter {
             progress.resetProgressForShard(ShardAndStrategy.conservative(shard));
             progress.resetProgressForShard(ShardAndStrategy.thorough(shard));
         }
+        log.info("Sweep progress was reset for shards for both strategies.", SafeArg.of("numShards", numShards));
     }
 
     /**

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueue.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueue.java
@@ -167,6 +167,16 @@ public final class SweepQueue implements MultiTableSweepQueueWriter {
         return sweepBatch.entriesRead();
     }
 
+    public void resetSweepProgress() {
+        int numShards = getNumShards();
+        log.info("Now attempting to reset sweep progress for both strategies...",
+                SafeArg.of("numShards", numShards));
+        for (int shard = 0; shard < numShards; shard++) {
+            progress.resetProgressForShard(ShardAndStrategy.conservative(shard));
+            progress.resetProgressForShard(ShardAndStrategy.thorough(shard));
+        }
+    }
+
     /**
      * Returns the most recently known number of shards.
      */

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueue.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueue.java
@@ -174,7 +174,10 @@ public final class SweepQueue implements MultiTableSweepQueueWriter {
             progress.resetProgressForShard(ShardAndStrategy.conservative(shard));
             progress.resetProgressForShard(ShardAndStrategy.thorough(shard));
         }
-        log.info("Sweep progress was reset for shards for both strategies.", SafeArg.of("numShards", shards));
+        log.info("Sweep progress was reset for shards for both strategies. If you are running your service in an HA"
+                        + " configuration, this message by itself does NOT mean that the reset is complete. The reset"
+                        + " is only guaranteed to be complete after this message has been printed by ALL nodes.",
+                SafeArg.of("numShards", shards));
     }
 
     /**

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueue.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueue.java
@@ -168,13 +168,13 @@ public final class SweepQueue implements MultiTableSweepQueueWriter {
     }
 
     public void resetSweepProgress() {
-        int numShards = getNumShards();
-        log.info("Now attempting to reset sweep progress for both strategies...", SafeArg.of("numShards", numShards));
-        for (int shard = 0; shard < numShards; shard++) {
+        int shards = getNumShards();
+        log.info("Now attempting to reset sweep progress for both strategies...", SafeArg.of("numShards", shards));
+        for (int shard = 0; shard < shards; shard++) {
             progress.resetProgressForShard(ShardAndStrategy.conservative(shard));
             progress.resetProgressForShard(ShardAndStrategy.thorough(shard));
         }
-        log.info("Sweep progress was reset for shards for both strategies.", SafeArg.of("numShards", numShards));
+        log.info("Sweep progress was reset for shards for both strategies.", SafeArg.of("numShards", shards));
     }
 
     /**

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueue.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueue.java
@@ -169,8 +169,7 @@ public final class SweepQueue implements MultiTableSweepQueueWriter {
 
     public void resetSweepProgress() {
         int numShards = getNumShards();
-        log.info("Now attempting to reset sweep progress for both strategies...",
-                SafeArg.of("numShards", numShards));
+        log.info("Now attempting to reset sweep progress for both strategies...", SafeArg.of("numShards", numShards));
         for (int shard = 0; shard < numShards; shard++) {
             progress.resetProgressForShard(ShardAndStrategy.conservative(shard));
             progress.resetProgressForShard(ShardAndStrategy.thorough(shard));

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueue.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueue.java
@@ -174,7 +174,8 @@ public final class SweepQueue implements MultiTableSweepQueueWriter {
             progress.resetProgressForShard(ShardAndStrategy.conservative(shard));
             progress.resetProgressForShard(ShardAndStrategy.thorough(shard));
         }
-        log.info("Sweep progress was reset for shards for both strategies. If you are running your service in an HA"
+        log.info(
+                "Sweep progress was reset for shards for both strategies. If you are running your service in an HA"
                         + " configuration, this message by itself does NOT mean that the reset is complete. The reset"
                         + " is only guaranteed to be complete after this message has been printed by ALL nodes.",
                 SafeArg.of("numShards", shards));

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueUtils.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueUtils.java
@@ -43,6 +43,7 @@ public final class SweepQueueUtils {
     public static final int BATCH_SIZE_KVS = 1000;
     public static final long READ_TS = Long.MAX_VALUE;
     public static final long INITIAL_TIMESTAMP = -1L;
+    public static final long RESET_TIMESTAMP = 0L;
     public static final ColumnRangeSelection ALL_COLUMNS = allPossibleColumns();
     public static final int MINIMUM_WRITE_INDEX = -TargetedSweepMetadata.MAX_DEDICATED_ROWS;
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/config/TargetedSweepInstallConfig.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/config/TargetedSweepInstallConfig.java
@@ -92,6 +92,12 @@ public class TargetedSweepInstallConfig {
      * If set to true, resets progress to zero for each shard and strategy on startup. This configuration can also only
      * be safely used if nodes are not actively sweeping, and so if configured to be true will prevent targeted sweep
      * from running.
+     *
+     * The reason for this coupling between resetting progress and not sweeping is that the targeted sweeper retries
+     * CAS operations from the existing bound to where it believes it is, only stopping when the bound is at least
+     * that high. Thus, we need to ensure that no active sweep is running when performing a reset (otherwise said
+     * reset could be lost by a rogue CAS). When operating a cluster, the reset is only definitely complete when
+     * *ALL* nodes have reported that they have completed said reset.
      */
     @Value.Default
     public boolean resetTargetedSweepQueueProgressAndStopSweep() {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/config/TargetedSweepInstallConfig.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/config/TargetedSweepInstallConfig.java
@@ -83,6 +83,21 @@ public class TargetedSweepInstallConfig {
         return TargetedSweepMetricsConfigurations.DEFAULT;
     }
 
+    /**
+     * Specifies whether on startup we should reset progress in the targeted sweep queue. This may be useful to deal
+     * with circumstances where entries are written to the targeted sweep queue after the sweep timestamp has
+     * progressed past it - while the transaction in question will necessarily fail, there may still be cruft in the
+     * targeted sweep queue.
+     *
+     * If set to true, resets progress to zero for each shard and strategy on startup. This configuration can also only
+     * be safely used if nodes are not actively sweeping, and so if configured to be true will prevent targeted sweep
+     * from running.
+     */
+    @Value.Default
+    public boolean resetTargetedSweepQueueProgressAndStopSweep() {
+        return false;
+    }
+
     public static TargetedSweepInstallConfig defaultTargetedSweepConfig() {
         return ImmutableTargetedSweepInstallConfig.builder().build();
     }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/ShardProgressTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/ShardProgressTest.java
@@ -16,6 +16,7 @@
 package com.palantir.atlasdb.sweep.queue;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
@@ -37,6 +38,7 @@ import org.junit.Test;
 
 public class ShardProgressTest {
     private static final long INITIAL_TIMESTAMP = SweepQueueUtils.INITIAL_TIMESTAMP;
+    private static final long RESET_TIMESTAMP = SweepQueueUtils.RESET_TIMESTAMP;
 
     private ShardProgress progress;
     private KeyValueService kvs;
@@ -183,6 +185,46 @@ public class ShardProgressTest {
         ShardProgress instrumentedProgress = new ShardProgress(mockKvs);
 
         assertThatThrownBy(() -> instrumentedProgress.updateLastSweptTimestamp(CONSERVATIVE_TEN, 12L))
+                .isInstanceOf(CheckAndSetException.class);
+    }
+
+    @Test
+    public void canResetProgressForSpecificShards() {
+        progress.updateLastSweptTimestamp(CONSERVATIVE_TEN, 8888L);
+        progress.updateLastSweptTimestamp(CONSERVATIVE_TWENTY, 8888L);
+        assertThat(progress.getLastSweptTimestamp(CONSERVATIVE_TEN)).isEqualTo(8888L);
+        assertThat(progress.getLastSweptTimestamp(CONSERVATIVE_TWENTY)).isEqualTo(8888L);
+
+        progress.resetProgressForShard(CONSERVATIVE_TEN);
+        assertThat(progress.getLastSweptTimestamp(CONSERVATIVE_TEN)).isEqualTo(RESET_TIMESTAMP);
+        assertThat(progress.getLastSweptTimestamp(CONSERVATIVE_TWENTY)).isEqualTo(8888L);
+    }
+
+    @Test
+    public void stopsTryingToResetIfSomeoneElseDid() {
+        KeyValueService mockKvs = mock(KeyValueService.class);
+        when(mockKvs.get(any(), anyMap()))
+                .thenReturn(ImmutableMap.of(DUMMY, createValue(8L)))
+                .thenReturn(ImmutableMap.of(DUMMY, createValue(4L)))
+                .thenReturn(ImmutableMap.of(DUMMY, createValue(RESET_TIMESTAMP)));
+        doThrow(new CheckAndSetException("sadness")).when(mockKvs).checkAndSet(any());
+        ShardProgress instrumentedProgress = new ShardProgress(mockKvs);
+
+        assertThatCode(() -> instrumentedProgress.resetProgressForShard(CONSERVATIVE_TEN))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void repeatedlyFailingCasThrowsForReset() {
+        KeyValueService mockKvs = mock(KeyValueService.class);
+        when(mockKvs.get(any(), anyMap()))
+                .thenReturn(ImmutableMap.of(DUMMY, createValue(8L)))
+                .thenReturn(ImmutableMap.of(DUMMY, createValue(9L)))
+                .thenReturn(ImmutableMap.of(DUMMY, createValue(10L)));
+        doThrow(new CheckAndSetException("sadness")).when(mockKvs).checkAndSet(any());
+        ShardProgress instrumentedProgress = new ShardProgress(mockKvs);
+
+        assertThatCode(() -> instrumentedProgress.resetProgressForShard(CONSERVATIVE_TEN))
                 .isInstanceOf(CheckAndSetException.class);
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/ShardProgressTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/ShardProgressTest.java
@@ -22,6 +22,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
@@ -226,6 +228,7 @@ public class ShardProgressTest {
 
         assertThatCode(() -> instrumentedProgress.resetProgressForShard(CONSERVATIVE_TEN))
                 .isInstanceOf(CheckAndSetException.class);
+        verify(mockKvs, times(3)).checkAndSet(any());
     }
 
     private Value createValue(long num) {

--- a/changelog/@unreleased/pr-5277.v2.yml
+++ b/changelog/@unreleased/pr-5277.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: |-
+    Targeted sweep progress may be reset with the `resetTargetedSweepQueueProgressAndStopSweep` flag in targeted sweep install configuration. This may be useful in cleaning up cruft in the targeted sweep queue that may have been written by failed transactions.
+
+    As the name suggests, this will prevent sweep from cleaning up old cells, so users should not run with this configuration in the steady state. If running your service in HA, once the last node rolls and reports that it has successfully reset the sweep progress table, we can be certain that progress has been reset to zero.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5277


### PR DESCRIPTION
**Goals (and why)**:
- Have the ability to reset sweep progress. This may be useful to deal with circumstances where entries are written to the targeted sweep queue after the sweep timestamp has progressed past it - while the transaction in question will necessarily fail, there may still be cruft in the targeted sweep queue.

**Implementation Description (bullets)**:
- Add a config flag. If set, on startup does a CAS to 0 and doesn't perform targeted sweep. This is needed because a service has multiple nodes, but once the last node rolls, assuming it starts successfully, no one is running sweep and we CAS the progress to 0 -> we have 0 for all shards and strategies.

**Testing (What was existing testing like?  What have you done to improve it?)**: Added some unit tests.

**Concerns (what feedback would you like?)**:
- What happens if the number of shards in the config is not what's actually persisted in the DB? I believe we do this correctly, but worth a check.
- Have I thought through the concurrency model (especially across multiple nodes) correctly? and/or, is this too heavy-handed?

**Where should we start reviewing?**: ShardProgress

**Priority (whenever / two weeks / yesterday)**: this week
