### PR TITLE
[CCB] | Multi-client getCommitTimestamps endpoint

### DIFF
--- a/timelock-api/src/main/conjure/timelock-api.yml
+++ b/timelock-api/src/main/conjure/timelock-api.yml
@@ -204,3 +204,10 @@ services:
         returns: map<Namespace, ConjureStartTransactionsResponse>
         docs: |
           Version of ConjureTimelockService#startTransactions that starts transactions for multiple namespaces.
+      getCommitTimestamps:
+        http: POST /gcts
+        args:
+          requests: map<Namespace, GetCommitTimestampsRequest>
+        returns: map<Namespace, GetCommitTimestampsResponse>
+        docs: |
+          Version of ConjureTimelockService#getCommitTimestamps for acquiring commit timestamps for multiple namespaces.

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -32,6 +32,8 @@ import com.palantir.atlasdb.timelock.api.ConjureLockToken;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsRequest;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
 import com.palantir.atlasdb.timelock.api.ConjureUnlockRequest;
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampsRequest;
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampsResponse;
 import com.palantir.atlasdb.timelock.api.LeaderTimes;
 import com.palantir.atlasdb.timelock.api.MultiClientConjureTimelockService;
 import com.palantir.atlasdb.timelock.api.Namespace;
@@ -502,7 +504,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
         List<String> expectedNamespaces = ImmutableList.of("alpha", "beta");
         int numTransactions = 7;
         Map<Namespace, ConjureStartTransactionsRequest> namespaceToRequestMap =
-                defaultNamespacedStartTransactionsRequests(expectedNamespaces, numTransactions);
+                defaultNamespaceWiseStartTransactionsRequests(expectedNamespaces, numTransactions);
 
         Map<Namespace, ConjureStartTransactionsResponse> startedTransactions =
                 multiClientConjureTimelockService.startTransactions(AUTH_HEADER, namespaceToRequestMap);
@@ -522,13 +524,75 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
         });
     }
 
+    @Test
+    public void sanityCheckMultiClientGetCommitTimestamps() {
+        MultiClientConjureTimelockService service =
+                cluster.currentLeaderFor(client.namespace()).multiClientService();
+        Set<String> expectedNamespaces = ImmutableSet.of("alpha", "beta");
+        Map<Namespace, GetCommitTimestampsResponse> multiClientResponses = service.getCommitTimestamps(
+                AUTH_HEADER, defaultNamespaceWiseGetCommitTimestampsRequests(expectedNamespaces));
+
+        assertSanityOfNamespacesServed(expectedNamespaces, multiClientResponses);
+
+        Set<UUID> leadershipIds = multiClientResponses.values().stream()
+                .map(GetCommitTimestampsResponse::getLockWatchUpdate)
+                .map(LockWatchStateUpdate::logId)
+                .collect(Collectors.toSet());
+        assertThat(leadershipIds).hasSameSizeAs(expectedNamespaces);
+    }
+
+    @Test
+    public void sanityCheckMultiClientGetCommitTimestampsAgainstConjureTimelockService() {
+        TestableTimelockServer leader = cluster.currentLeaderFor(client.namespace());
+        MultiClientConjureTimelockService service = leader.multiClientService();
+        Set<String> expectedNamespaces = ImmutableSet.of("alpha", "beta");
+        Map<Namespace, GetCommitTimestampsResponse> multiClientResponses = service.getCommitTimestamps(
+                AUTH_HEADER, defaultNamespaceWiseGetCommitTimestampsRequests(expectedNamespaces));
+
+        assertSanityOfNamespacesServed(expectedNamespaces, multiClientResponses);
+
+        // Whether we hit the multi client endpoint or conjureTimelockService endpoint(services one client in one
+        // call), for a namespace, the underlying service to process the request is the same
+        multiClientResponses.forEach((namespace, responseFromBatchedEndpoint) -> {
+            GetCommitTimestampsResponse conjureGetCommitTimestampResponse = leader.client(namespace.get())
+                    .namespacedConjureTimelockService()
+                    .getCommitTimestamps(defaultCommitTimestampRequest());
+            assertThat(conjureGetCommitTimestampResponse.getLockWatchUpdate().logId())
+                    .isEqualTo(responseFromBatchedEndpoint.getLockWatchUpdate().logId());
+            assertThat(conjureGetCommitTimestampResponse.getInclusiveLower())
+                    .as("timestamps should contiguously increase per namespace if there are no elections.")
+                    .isEqualTo(responseFromBatchedEndpoint.getInclusiveUpper() + 1);
+        });
+    }
+
+    private void assertSanityOfNamespacesServed(
+            Set<String> expectedNamespaces, Map<Namespace, GetCommitTimestampsResponse> commitTimestamps) {
+        Set<String> namespaces =
+                commitTimestamps.keySet().stream().map(Namespace::get).collect(Collectors.toSet());
+        assertThat(namespaces).hasSameElementsAs(expectedNamespaces);
+    }
+
+    private Map<Namespace, GetCommitTimestampsRequest> defaultNamespaceWiseGetCommitTimestampsRequests(
+            Set<String> namespaces) {
+        return KeyedStream.of(namespaces)
+                .map(namespace -> GetCommitTimestampsRequest.builder()
+                        .numTimestamps(defaultCommitTimestampRequest().getNumTimestamps())
+                        .build())
+                .mapKeys(Namespace::of)
+                .collectToMap();
+    }
+
+    private GetCommitTimestampsRequest defaultCommitTimestampRequest() {
+        return GetCommitTimestampsRequest.builder().numTimestamps(5).build();
+    }
+
     private Map<Namespace, ConjureStartTransactionsResponse> assertSanityAndStartTransactions(
             TestableTimelockServer leader, List<String> expectedNamespaces) {
         MultiClientConjureTimelockService multiClientConjureTimelockService = leader.multiClientService();
         int numTransactions = 5;
 
         Map<Namespace, ConjureStartTransactionsRequest> namespaceToRequestMap =
-                defaultNamespacedStartTransactionsRequests(expectedNamespaces, numTransactions);
+                defaultNamespaceWiseStartTransactionsRequests(expectedNamespaces, numTransactions);
 
         Map<Namespace, ConjureStartTransactionsResponse> startedTransactions =
                 multiClientConjureTimelockService.startTransactions(AUTH_HEADER, namespaceToRequestMap);
@@ -546,7 +610,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
         return startedTransactions;
     }
 
-    private Map<Namespace, ConjureStartTransactionsRequest> defaultNamespacedStartTransactionsRequests(
+    private Map<Namespace, ConjureStartTransactionsRequest> defaultNamespaceWiseStartTransactionsRequests(
             List<String> namespaces, int numTransactions) {
         return KeyedStream.of(namespaces)
                 .map(namespace -> ConjureStartTransactionsRequest.builder()


### PR DESCRIPTION
**Goals (and why)**:
Implement multi-client getCommitTimestamps endpoint

**Implementation Description (bullets)**:

- Adds conjure api definition of cross client batch endpoint for getCommitTimestamps
- The endpoints returns successfully if getCommitTimestamps futures for all queries are successful

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added unit and integration tests

**Concerns (what feedback would you like?)**:
Failure mechanism - fails the requests for all namespaces without retry if any request fails

**Where should we start reviewing?**:
timelock-api.yml, MultiClientConjureTimelockResource.java

**Priority (whenever / two weeks / yesterday)**:
Today would be very very good.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
