### PR TITLE
[CCB] | Multi-client getCommitTimestamps endpoint

### DIFF
--- a/changelog/@unreleased/pr-5286.v2.yml
+++ b/changelog/@unreleased/pr-5286.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: TimeLock now has multi-client getCommitTimestamps endpoint.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5286

--- a/timelock-api/src/main/conjure/timelock-api.yml
+++ b/timelock-api/src/main/conjure/timelock-api.yml
@@ -204,3 +204,10 @@ services:
         returns: map<Namespace, ConjureStartTransactionsResponse>
         docs: |
           Version of ConjureTimelockService#startTransactions that starts transactions for multiple namespaces.
+      getCommitTimestamps:
+        http: POST /gcts
+        args:
+          requests: map<Namespace, GetCommitTimestampsRequest>
+        returns: map<Namespace, GetCommitTimestampsResponse>
+        docs: |
+          Version of ConjureTimelockService#getCommitTimestamps for acquiring commit timestamps for multiple namespaces.

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/batch/MultiClientConjureTimelockResourceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/batch/MultiClientConjureTimelockResourceTest.java
@@ -63,6 +63,7 @@ public class MultiClientConjureTimelockResourceTest {
     private static final URL REMOTE = url("https://localhost:" + REMOTE_PORT);
     private static final RedirectRetryTargeter TARGETER =
             RedirectRetryTargeter.create(LOCAL, ImmutableList.of(LOCAL, REMOTE));
+    private static final int DUMMY_COMMIT_TS_COUNT = 5;
 
     private Map<String, AsyncTimelockService> namespaces = new HashMap();
     private Map<String, LeadershipId> namespaceToLeaderMap = new HashMap();
@@ -148,8 +149,9 @@ public class MultiClientConjureTimelockResourceTest {
     private Map<Namespace, GetCommitTimestampsRequest> getGetCommitTimestampsRequests(Set<String> namespaces) {
         return KeyedStream.of(namespaces)
                 .mapKeys(Namespace::of)
-                .map(namespace ->
-                        GetCommitTimestampsRequest.builder().numTimestamps(4).build())
+                .map(namespace -> GetCommitTimestampsRequest.builder()
+                        .numTimestamps(DUMMY_COMMIT_TS_COUNT)
+                        .build())
                 .collectToMap();
     }
 
@@ -187,7 +189,8 @@ public class MultiClientConjureTimelockResourceTest {
 
     private GetCommitTimestampsResponse getCommitTimestampResponse(String namespace) {
         int inclusiveLower = getInclusiveLowerCommitTs(namespace);
-        return GetCommitTimestampsResponse.of(inclusiveLower, inclusiveLower + 5, lockWatchStateUpdate);
+        return GetCommitTimestampsResponse.of(
+                inclusiveLower, inclusiveLower + DUMMY_COMMIT_TS_COUNT, lockWatchStateUpdate);
     }
 
     private Integer getInclusiveLowerCommitTs(String namespace) {

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/batch/MultiClientConjureTimelockResourceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/batch/MultiClientConjureTimelockResourceTest.java
@@ -136,10 +136,10 @@ public class MultiClientConjureTimelockResourceTest {
         Set<String> namespaces = ImmutableSet.of("client1", "client2");
         assertThat(Futures.getUnchecked(
                         resource.getCommitTimestamps(AUTH_HEADER, getGetCommitTimestampsRequests(namespaces))))
-                .isEqualTo(getGetCommitTimestampsResponseList(namespaces));
+                .isEqualTo(getGetCommitTimestampsResponseMap(namespaces));
     }
 
-    private Map<Namespace, GetCommitTimestampsResponse> getGetCommitTimestampsResponseList(Set<String> namespaces) {
+    private Map<Namespace, GetCommitTimestampsResponse> getGetCommitTimestampsResponseMap(Set<String> namespaces) {
         return KeyedStream.of(namespaces)
                 .mapKeys(Namespace::of)
                 .map(this::getCommitTimestampResponse)

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -32,6 +32,8 @@ import com.palantir.atlasdb.timelock.api.ConjureLockToken;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsRequest;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
 import com.palantir.atlasdb.timelock.api.ConjureUnlockRequest;
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampsRequest;
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampsResponse;
 import com.palantir.atlasdb.timelock.api.LeaderTimes;
 import com.palantir.atlasdb.timelock.api.MultiClientConjureTimelockService;
 import com.palantir.atlasdb.timelock.api.Namespace;
@@ -502,7 +504,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
         List<String> expectedNamespaces = ImmutableList.of("alpha", "beta");
         int numTransactions = 7;
         Map<Namespace, ConjureStartTransactionsRequest> namespaceToRequestMap =
-                defaultNamespacedStartTransactionsRequests(expectedNamespaces, numTransactions);
+                defaultNamespaceWiseStartTransactionsRequests(expectedNamespaces, numTransactions);
 
         Map<Namespace, ConjureStartTransactionsResponse> startedTransactions =
                 multiClientConjureTimelockService.startTransactions(AUTH_HEADER, namespaceToRequestMap);
@@ -522,13 +524,75 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
         });
     }
 
+    @Test
+    public void sanityCheckMultiClientGetCommitTimestamps() {
+        MultiClientConjureTimelockService service =
+                cluster.currentLeaderFor(client.namespace()).multiClientService();
+        Set<String> expectedNamespaces = ImmutableSet.of("alpha", "beta");
+        Map<Namespace, GetCommitTimestampsResponse> multiClientResponses = service.getCommitTimestamps(
+                AUTH_HEADER, defaultNamespaceWiseGetCommitTimestampsRequests(expectedNamespaces));
+
+        assertSanityOfNamespacesServed(expectedNamespaces, multiClientResponses);
+
+        Set<UUID> leadershipIds = multiClientResponses.values().stream()
+                .map(GetCommitTimestampsResponse::getLockWatchUpdate)
+                .map(LockWatchStateUpdate::logId)
+                .collect(Collectors.toSet());
+        assertThat(leadershipIds).hasSameSizeAs(expectedNamespaces);
+    }
+
+    @Test
+    public void sanityCheckMultiClientGetCommitTimestampsAgainstConjureTimelockService() {
+        TestableTimelockServer leader = cluster.currentLeaderFor(client.namespace());
+        MultiClientConjureTimelockService service = leader.multiClientService();
+        Set<String> expectedNamespaces = ImmutableSet.of("alpha", "beta");
+        Map<Namespace, GetCommitTimestampsResponse> multiClientResponses = service.getCommitTimestamps(
+                AUTH_HEADER, defaultNamespaceWiseGetCommitTimestampsRequests(expectedNamespaces));
+
+        assertSanityOfNamespacesServed(expectedNamespaces, multiClientResponses);
+
+        // Whether we hit the multi client endpoint or conjureTimelockService endpoint(services one client in one
+        // call), for a namespace, the underlying service to process the request is the same
+        multiClientResponses.forEach((namespace, responseFromBatchedEndpoint) -> {
+            GetCommitTimestampsResponse conjureGetCommitTimestampResponse = leader.client(namespace.get())
+                    .namespacedConjureTimelockService()
+                    .getCommitTimestamps(defaultCommitTimestampRequest());
+            assertThat(conjureGetCommitTimestampResponse.getLockWatchUpdate().logId())
+                    .isEqualTo(responseFromBatchedEndpoint.getLockWatchUpdate().logId());
+            assertThat(conjureGetCommitTimestampResponse.getInclusiveLower())
+                    .as("timestamps should contiguously increase per namespace if there are no elections.")
+                    .isEqualTo(responseFromBatchedEndpoint.getInclusiveUpper() + 1);
+        });
+    }
+
+    private void assertSanityOfNamespacesServed(
+            Set<String> expectedNamespaces, Map<Namespace, GetCommitTimestampsResponse> commitTimestamps) {
+        Set<String> namespaces =
+                commitTimestamps.keySet().stream().map(Namespace::get).collect(Collectors.toSet());
+        assertThat(namespaces).hasSameElementsAs(expectedNamespaces);
+    }
+
+    private Map<Namespace, GetCommitTimestampsRequest> defaultNamespaceWiseGetCommitTimestampsRequests(
+            Set<String> namespaces) {
+        return KeyedStream.of(namespaces)
+                .map(namespace -> GetCommitTimestampsRequest.builder()
+                        .numTimestamps(defaultCommitTimestampRequest().getNumTimestamps())
+                        .build())
+                .mapKeys(Namespace::of)
+                .collectToMap();
+    }
+
+    private GetCommitTimestampsRequest defaultCommitTimestampRequest() {
+        return GetCommitTimestampsRequest.builder().numTimestamps(5).build();
+    }
+
     private Map<Namespace, ConjureStartTransactionsResponse> assertSanityAndStartTransactions(
             TestableTimelockServer leader, List<String> expectedNamespaces) {
         MultiClientConjureTimelockService multiClientConjureTimelockService = leader.multiClientService();
         int numTransactions = 5;
 
         Map<Namespace, ConjureStartTransactionsRequest> namespaceToRequestMap =
-                defaultNamespacedStartTransactionsRequests(expectedNamespaces, numTransactions);
+                defaultNamespaceWiseStartTransactionsRequests(expectedNamespaces, numTransactions);
 
         Map<Namespace, ConjureStartTransactionsResponse> startedTransactions =
                 multiClientConjureTimelockService.startTransactions(AUTH_HEADER, namespaceToRequestMap);
@@ -546,7 +610,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
         return startedTransactions;
     }
 
-    private Map<Namespace, ConjureStartTransactionsRequest> defaultNamespacedStartTransactionsRequests(
+    private Map<Namespace, ConjureStartTransactionsRequest> defaultNamespaceWiseStartTransactionsRequests(
             List<String> namespaces, int numTransactions) {
         return KeyedStream.of(namespaces)
                 .map(namespace -> ConjureStartTransactionsRequest.builder()

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -529,8 +529,8 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
         MultiClientConjureTimelockService service =
                 cluster.currentLeaderFor(client.namespace()).multiClientService();
         Set<String> expectedNamespaces = ImmutableSet.of("alpha", "beta");
-        Map<Namespace, GetCommitTimestampsResponse> multiClientResponses = service.getCommitTimestamps(
-                AUTH_HEADER, defaultNamespaceWiseGetCommitTimestampsRequests(expectedNamespaces));
+        Map<Namespace, GetCommitTimestampsResponse> multiClientResponses =
+                service.getCommitTimestamps(AUTH_HEADER, defaultGetCommitTimestampsRequests(expectedNamespaces));
 
         assertSanityOfNamespacesServed(expectedNamespaces, multiClientResponses);
 
@@ -546,8 +546,8 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
         TestableTimelockServer leader = cluster.currentLeaderFor(client.namespace());
         MultiClientConjureTimelockService service = leader.multiClientService();
         Set<String> expectedNamespaces = ImmutableSet.of("alpha", "beta");
-        Map<Namespace, GetCommitTimestampsResponse> multiClientResponses = service.getCommitTimestamps(
-                AUTH_HEADER, defaultNamespaceWiseGetCommitTimestampsRequests(expectedNamespaces));
+        Map<Namespace, GetCommitTimestampsResponse> multiClientResponses =
+                service.getCommitTimestamps(AUTH_HEADER, defaultGetCommitTimestampsRequests(expectedNamespaces));
 
         assertSanityOfNamespacesServed(expectedNamespaces, multiClientResponses);
 
@@ -572,10 +572,9 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
         assertThat(namespaces).hasSameElementsAs(expectedNamespaces);
     }
 
-    private Map<Namespace, GetCommitTimestampsRequest> defaultNamespaceWiseGetCommitTimestampsRequests(
-            Set<String> namespaces) {
+    private Map<Namespace, GetCommitTimestampsRequest> defaultGetCommitTimestampsRequests(Set<String> namespaces) {
         return KeyedStream.of(namespaces)
-                .map(namespace -> GetCommitTimestampsRequest.builder()
+                .map(_unused -> GetCommitTimestampsRequest.builder()
                         .numTimestamps(defaultCommitTimestampRequest().getNumTimestamps())
                         .build())
                 .mapKeys(Namespace::of)

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -504,7 +504,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
         List<String> expectedNamespaces = ImmutableList.of("alpha", "beta");
         int numTransactions = 7;
         Map<Namespace, ConjureStartTransactionsRequest> namespaceToRequestMap =
-                defaultNamespaceWiseStartTransactionsRequests(expectedNamespaces, numTransactions);
+                defaultStartTransactionsRequests(expectedNamespaces, numTransactions);
 
         Map<Namespace, ConjureStartTransactionsResponse> startedTransactions =
                 multiClientConjureTimelockService.startTransactions(AUTH_HEADER, namespaceToRequestMap);
@@ -594,7 +594,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
         int numTransactions = 5;
 
         Map<Namespace, ConjureStartTransactionsRequest> namespaceToRequestMap =
-                defaultNamespaceWiseStartTransactionsRequests(expectedNamespaces, numTransactions);
+                defaultStartTransactionsRequests(expectedNamespaces, numTransactions);
 
         Map<Namespace, ConjureStartTransactionsResponse> startedTransactions =
                 multiClientConjureTimelockService.startTransactions(AUTH_HEADER, namespaceToRequestMap);
@@ -612,7 +612,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
         return startedTransactions;
     }
 
-    private Map<Namespace, ConjureStartTransactionsRequest> defaultNamespaceWiseStartTransactionsRequests(
+    private Map<Namespace, ConjureStartTransactionsRequest> defaultStartTransactionsRequests(
             List<String> namespaces, int numTransactions) {
         return KeyedStream.of(namespaces)
                 .map(namespace -> ConjureStartTransactionsRequest.builder()

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -528,7 +528,8 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
     public void sanityCheckMultiClientGetCommitTimestamps() {
         MultiClientConjureTimelockService service =
                 cluster.currentLeaderFor(client.namespace()).multiClientService();
-        Set<String> expectedNamespaces = ImmutableSet.of("alpha", "beta");
+
+        Set<String> expectedNamespaces = ImmutableSet.of("cli-1", "cli-2");
         Map<Namespace, GetCommitTimestampsResponse> multiClientResponses =
                 service.getCommitTimestamps(AUTH_HEADER, defaultGetCommitTimestampsRequests(expectedNamespaces));
 
@@ -544,10 +545,12 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
     @Test
     public void sanityCheckMultiClientGetCommitTimestampsAgainstConjureTimelockService() {
         TestableTimelockServer leader = cluster.currentLeaderFor(client.namespace());
-        MultiClientConjureTimelockService service = leader.multiClientService();
-        Set<String> expectedNamespaces = ImmutableSet.of("alpha", "beta");
-        Map<Namespace, GetCommitTimestampsResponse> multiClientResponses =
-                service.getCommitTimestamps(AUTH_HEADER, defaultGetCommitTimestampsRequests(expectedNamespaces));
+        MultiClientConjureTimelockService multiClientService = leader.multiClientService();
+
+        Set<String> expectedNamespaces = ImmutableSet.of("alta", "mp");
+
+        Map<Namespace, GetCommitTimestampsResponse> multiClientResponses = multiClientService.getCommitTimestamps(
+                AUTH_HEADER, defaultGetCommitTimestampsRequests(expectedNamespaces));
 
         assertSanityOfNamespacesServed(expectedNamespaces, multiClientResponses);
 


### PR DESCRIPTION
**Goals (and why)**:
Implement multi-client getCommitTimestamps endpoint

**Implementation Description (bullets)**:

- Adds conjure api definition of cross client batch endpoint for getCommitTimestamps
- The endpoints returns successfully if getCommitTimestamps futures for all queries are successful

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added unit and integration tests

**Concerns (what feedback would you like?)**:
Failure mechanism - fails the requests for all namespaces without retry if any request fails

**Where should we start reviewing?**:
timelock-api.yml, MultiClientConjureTimelockResource.java

**Priority (whenever / two weeks / yesterday)**:
Today would be very very good.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
