### PR TITLE
Add migration mode for RETRY_ON_WRITE_WRITE conflict handlers

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/ConflictHandler.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/ConflictHandler.java
@@ -114,7 +114,8 @@ public enum ConflictHandler {
      * 1. Upgrade product to V1, supporting schema version SV1 (not supporting downgrades to SV0), and now knows
      * about ROWWM (but does *not* use it).
      * 2. Upgrade product to V2, supporting SV2 (supporting downgrades to SV1), and uses ROWWM.
-     * 3. Upgrade product to V3, supporting SV3 (supporting downgrades to SV2), and uses the desired new strategy
+     * 3. Upgrade product to V3, supporting SV3 (supporting downgrades to SV2 but not SV1), and uses the desired new
+     * strategy
      * (for example, now using ROWWC where it was using ROWW in version v0).
      * <p>
      * Failure to adhere to this flow may cause arbitrary data corruption.

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/ConflictHandler.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/ConflictHandler.java
@@ -102,7 +102,13 @@ public enum ConflictHandler {
      * cell then correctness issues may occur as there is no way for t1 to be aware of t2. Locking on both cell and row
      * level prevents this issue.
      */
-    SERIALIZABLE_LOCK_LEVEL_MIGRATION(true, true, true, true);
+    SERIALIZABLE_LOCK_LEVEL_MIGRATION(true, true, true, true),
+
+    /**
+     * This conflict handler is analogous to SERIALIZABLE_LOCK_LEVEL_MIGRATION, but for migrating between
+     * RETRY_ON_WRITE_WRITE and RETRY_ON_WRITE_WRITE_CELL.
+     */
+    RETRY_ON_WRITE_WRITE_MIGRATION(true, true, true, false);
 
     private final boolean lockCellsForConflicts;
     private final boolean lockRowsForConflicts;

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/ConflictHandler.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/ConflictHandler.java
@@ -107,6 +107,18 @@ public enum ConflictHandler {
     /**
      * This conflict handler is analogous to SERIALIZABLE_LOCK_LEVEL_MIGRATION, but for migrating between
      * RETRY_ON_WRITE_WRITE and RETRY_ON_WRITE_WRITE_CELL.
+     * <p>
+     * Migrations between RETRY_ON_WRITE_WRITE (ROWW) and RETRY_ON_WRITE_WRITE_CELL (ROWWC) using
+     * RETRY_ON_WRITE_WRITE_MIGRATION (ROWWM) takes three steps:
+     * 0. Product is on version V0, and schema version SV0, and does not even know about ROWWM.
+     * 1. Upgrade product to V1, supporting schema version SV1 (not supporting downgrades to SV0), and now knows
+     * about ROWWM (but does *not* use it).
+     * 2. Upgrade product to V2, supporting SV2 (supporting downgrades to SV1), and uses ROWWM.
+     * 3. Upgrade product to V3, supporting SV3 (supporting downgrades to SV2), and uses the desired new strategy
+     * (for example, now using ROWWC where it was using ROWW in version v0).
+     * <p>
+     * Failure to adhere to this flow may cause arbitrary data corruption.
+     *
      */
     RETRY_ON_WRITE_WRITE_MIGRATION(true, true, true, false);
 

--- a/atlasdb-client-protobufs/src/main/proto/TableMetadataPersistence.proto
+++ b/atlasdb-client-protobufs/src/main/proto/TableMetadataPersistence.proto
@@ -108,6 +108,7 @@ enum TableConflictHandler {
     SERIALIZABLE_CELL = 6;
     SERIALIZABLE_INDEX = 7;
     SERIALIZABLE_LOCK_LEVEL_MIGRATION = 8;
+    RETRY_ON_WRITE_WRITE_MIGRATION = 9;
 }
 
 enum CachePriority {

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
         classpath 'com.netflix.nebula:gradle-info-plugin:9.3.0'
         classpath 'com.netflix.nebula:nebula-publishing-plugin:17.3.2'
-        classpath 'com.palantir.baseline:gradle-baseline-java:3.68.1'
+        classpath 'com.palantir.baseline:gradle-baseline-java:3.69.0'
         classpath 'com.palantir.gradle.conjure:gradle-conjure:4.22.0'
         classpath 'com.palantir.javaformat:gradle-palantir-java-format:1.0.1'
         classpath 'com.palantir.metricschema:gradle-metric-schema:0.5.5'


### PR DESCRIPTION
**Goals (and why)**:
* Enable migration between `RETRY_ON_WRITE_WRITE` and `RETRY_ON_WRITE_WRITE_CELL` conflict handler modes.

**Implementation Description (bullets)**:
* Added new mode to enum;
* Updated `.proto` file.

**Testing (What was existing testing like?  What have you done to improve it?)**:
* Existing tests tend to parameterise on the enum, so should cover the new value automatically.

**Concerns (what feedback would you like?)**:
* Am I missing any important tests or things to update?

**Where should we start reviewing?**:
`ConflictHandler`

**Priority (whenever / two weeks / yesterday)**:
ASAP.
