### PR TITLE
[CCB] | MultiClient-CommitTimestampGetter refactor - part 1

### DIFF
--- a/lock-api/src/main/java/com/palantir/lock/client/AuthenticatedInternalMultiClientConjureTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/AuthenticatedInternalMultiClientConjureTimelockService.java
@@ -48,6 +48,7 @@ public class AuthenticatedInternalMultiClientConjureTimelockService
         return delegate.getCommitTimestamps(AUTH_HEADER, requests);
     }
 
+    @Override
     public Map<Namespace, ConjureStartTransactionsResponse> startTransactions(
             Map<Namespace, ConjureStartTransactionsRequest> requests) {
         return delegate.startTransactions(AUTH_HEADER, requests);

--- a/lock-api/src/main/java/com/palantir/lock/client/AuthenticatedInternalMultiClientConjureTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/AuthenticatedInternalMultiClientConjureTimelockService.java
@@ -16,10 +16,13 @@
 
 package com.palantir.lock.client;
 
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampsRequest;
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampsResponse;
 import com.palantir.atlasdb.timelock.api.LeaderTimes;
 import com.palantir.atlasdb.timelock.api.MultiClientConjureTimelockServiceBlocking;
 import com.palantir.atlasdb.timelock.api.Namespace;
 import com.palantir.tokens.auth.AuthHeader;
+import java.util.Map;
 import java.util.Set;
 
 public class AuthenticatedInternalMultiClientConjureTimelockService
@@ -35,5 +38,11 @@ public class AuthenticatedInternalMultiClientConjureTimelockService
     @Override
     public LeaderTimes leaderTimes(Set<Namespace> namespaces) {
         return delegate.leaderTimes(AUTH_HEADER, namespaces);
+    }
+
+    @Override
+    public Map<Namespace, GetCommitTimestampsResponse> getCommitTimestamps(
+            Map<Namespace, GetCommitTimestampsRequest> requests) {
+        return delegate.getCommitTimestamps(AUTH_HEADER, requests);
     }
 }

--- a/lock-api/src/main/java/com/palantir/lock/client/AuthenticatedInternalMultiClientConjureTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/AuthenticatedInternalMultiClientConjureTimelockService.java
@@ -16,10 +16,10 @@
 
 package com.palantir.lock.client;
 
-import com.palantir.atlasdb.timelock.api.GetCommitTimestampsRequest;
-import com.palantir.atlasdb.timelock.api.GetCommitTimestampsResponse;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsRequest;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampsRequest;
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampsResponse;
 import com.palantir.atlasdb.timelock.api.LeaderTimes;
 import com.palantir.atlasdb.timelock.api.MultiClientConjureTimelockServiceBlocking;
 import com.palantir.atlasdb.timelock.api.Namespace;
@@ -48,7 +48,7 @@ public class AuthenticatedInternalMultiClientConjureTimelockService
         return delegate.getCommitTimestamps(AUTH_HEADER, requests);
     }
 
-  public Map<Namespace, ConjureStartTransactionsResponse> startTransactions(
+    public Map<Namespace, ConjureStartTransactionsResponse> startTransactions(
             Map<Namespace, ConjureStartTransactionsRequest> requests) {
         return delegate.startTransactions(AUTH_HEADER, requests);
     }

--- a/lock-api/src/main/java/com/palantir/lock/client/BatchingCommitTimestampGetter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/BatchingCommitTimestampGetter.java
@@ -1,0 +1,112 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.client;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Streams;
+import com.palantir.atlasdb.autobatch.Autobatchers;
+import com.palantir.atlasdb.autobatch.BatchElement;
+import com.palantir.atlasdb.autobatch.DisruptorAutobatcher;
+import com.palantir.atlasdb.futures.AtlasFutures;
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampsResponse;
+import com.palantir.lock.v2.LockToken;
+import com.palantir.lock.watch.ImmutableTransactionUpdate;
+import com.palantir.lock.watch.LockWatchEventCache;
+import com.palantir.lock.watch.LockWatchVersion;
+import com.palantir.lock.watch.TransactionUpdate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+import org.immutables.value.Value;
+
+final class BatchingCommitTimestampGetter implements CommitTimestampGetter {
+    private final DisruptorAutobatcher<Request, Long> autobatcher;
+
+    private BatchingCommitTimestampGetter(DisruptorAutobatcher<Request, Long> autobatcher) {
+        this.autobatcher = autobatcher;
+    }
+
+    public static BatchingCommitTimestampGetter create(LockLeaseService leaseService, LockWatchEventCache cache) {
+        DisruptorAutobatcher<Request, Long> autobatcher = Autobatchers.independent(consumer(leaseService, cache))
+                .safeLoggablePurpose("get-commit-timestamp")
+                .build();
+        return new BatchingCommitTimestampGetter(autobatcher);
+    }
+
+    @Override
+    public long getCommitTimestamp(long startTs, LockToken commitLocksToken) {
+        return AtlasFutures.getUnchecked(autobatcher.apply(ImmutableRequest.builder()
+                .startTs(startTs)
+                .commitLocksToken(commitLocksToken)
+                .build()));
+    }
+
+    @VisibleForTesting
+    static Consumer<List<BatchElement<Request, Long>>> consumer(
+            LockLeaseService leaseService, LockWatchEventCache cache) {
+        return batch -> {
+            int count = batch.size();
+            List<Long> commitTimestamps = new ArrayList<>();
+            while (commitTimestamps.size() < count) {
+                Optional<LockWatchVersion> requestedVersion = cache.lastKnownVersion();
+                GetCommitTimestampsResponse response =
+                        leaseService.getCommitTimestamps(requestedVersion, count - commitTimestamps.size());
+                commitTimestamps.addAll(process(batch.subList(commitTimestamps.size(), count), response, cache));
+                LockWatchLogUtility.logTransactionEvents(requestedVersion, response.getLockWatchUpdate());
+            }
+
+            for (int i = 0; i < count; i++) {
+                batch.get(i).result().set(commitTimestamps.get(i));
+            }
+        };
+    }
+
+    private static List<Long> process(
+            List<BatchElement<Request, Long>> requests,
+            GetCommitTimestampsResponse response,
+            LockWatchEventCache cache) {
+        List<Long> timestamps = LongStream.rangeClosed(response.getInclusiveLower(), response.getInclusiveUpper())
+                .boxed()
+                .collect(Collectors.toList());
+        List<TransactionUpdate> transactionUpdates = Streams.zip(
+                        timestamps.stream(),
+                        requests.stream(),
+                        (commitTs, batchElement) -> ImmutableTransactionUpdate.builder()
+                                .startTs(batchElement.argument().startTs())
+                                .commitTs(commitTs)
+                                .writesToken(batchElement.argument().commitLocksToken())
+                                .build())
+                .collect(Collectors.toList());
+        cache.processGetCommitTimestampsUpdate(transactionUpdates, response.getLockWatchUpdate());
+        return timestamps;
+    }
+
+    @Override
+    public void close() {
+        autobatcher.close();
+    }
+
+    @Value.Immutable
+    interface Request {
+        long startTs();
+
+        LockToken commitLocksToken();
+    }
+}

--- a/lock-api/src/main/java/com/palantir/lock/client/BatchingCommitTimestampGetter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/BatchingCommitTimestampGetter.java
@@ -37,8 +37,7 @@ import java.util.stream.LongStream;
 import org.immutables.value.Value;
 
 /**
- * This class batches getCommitTimestamps requests to TimeLock server for a single client/ namespace. In other words,
- * this does NOT batch requests across namespaces.
+ * This class batches getCommitTimestamps requests to TimeLock server for a single client/namespace.
  * */
 final class BatchingCommitTimestampGetter implements CommitTimestampGetter {
     private final DisruptorAutobatcher<Request, Long> autobatcher;

--- a/lock-api/src/main/java/com/palantir/lock/client/BatchingCommitTimestampGetter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/BatchingCommitTimestampGetter.java
@@ -36,6 +36,10 @@ import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import org.immutables.value.Value;
 
+/**
+ * This class batches getCommitTimestamps requests to TimeLock server for a single client/ namespace. In other words,
+ * this does NOT batch requests across namespaces.
+ * */
 final class BatchingCommitTimestampGetter implements CommitTimestampGetter {
     private final DisruptorAutobatcher<Request, Long> autobatcher;
 

--- a/lock-api/src/main/java/com/palantir/lock/client/InternalMultiClientConjureTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/InternalMultiClientConjureTimelockService.java
@@ -16,10 +16,10 @@
 
 package com.palantir.lock.client;
 
-import com.palantir.atlasdb.timelock.api.GetCommitTimestampsRequest;
-import com.palantir.atlasdb.timelock.api.GetCommitTimestampsResponse;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsRequest;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampsRequest;
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampsResponse;
 import com.palantir.atlasdb.timelock.api.LeaderTimes;
 import com.palantir.atlasdb.timelock.api.Namespace;
 import java.util.Map;
@@ -33,5 +33,4 @@ public interface InternalMultiClientConjureTimelockService {
 
     Map<Namespace, ConjureStartTransactionsResponse> startTransactions(
             Map<Namespace, ConjureStartTransactionsRequest> requests);
-
 }

--- a/lock-api/src/main/java/com/palantir/lock/client/InternalMultiClientConjureTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/InternalMultiClientConjureTimelockService.java
@@ -16,10 +16,16 @@
 
 package com.palantir.lock.client;
 
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampsRequest;
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampsResponse;
 import com.palantir.atlasdb.timelock.api.LeaderTimes;
 import com.palantir.atlasdb.timelock.api.Namespace;
+import java.util.Map;
 import java.util.Set;
 
 public interface InternalMultiClientConjureTimelockService {
     LeaderTimes leaderTimes(Set<Namespace> namespaces);
+
+    Map<Namespace, GetCommitTimestampsResponse> getCommitTimestamps(
+            Map<Namespace, GetCommitTimestampsRequest> requests);
 }

--- a/lock-api/src/main/java/com/palantir/lock/client/RemoteTimelockServiceAdapter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/RemoteTimelockServiceAdapter.java
@@ -37,7 +37,7 @@ public final class RemoteTimelockServiceAdapter implements TimelockService, Auto
     private final NamespacedConjureTimelockService conjureTimelockService;
     private final LockLeaseService lockLeaseService;
     private final TransactionStarter transactionStarter;
-    private final BatchingCommitTimestampGetter batchingCommitTimestampGetter;
+    private final CommitTimestampGetter commitTimestampGetter;
 
     private RemoteTimelockServiceAdapter(
             NamespacedTimelockRpcClient rpcClient,
@@ -47,8 +47,7 @@ public final class RemoteTimelockServiceAdapter implements TimelockService, Auto
         this.rpcClient = rpcClient;
         this.lockLeaseService = LockLeaseService.create(conjureTimelockService, leaderTimeGetter);
         this.transactionStarter = TransactionStarter.create(lockLeaseService, lockWatchEventCache);
-        this.batchingCommitTimestampGetter =
-                BatchingCommitTimestampGetter.create(lockLeaseService, lockWatchEventCache);
+        this.commitTimestampGetter = BatchingCommitTimestampGetter.create(lockLeaseService, lockWatchEventCache);
         this.conjureTimelockService = conjureTimelockService;
     }
 
@@ -74,7 +73,7 @@ public final class RemoteTimelockServiceAdapter implements TimelockService, Auto
 
     @Override
     public long getCommitTimestamp(long startTs, LockToken commitLocksToken) {
-        return batchingCommitTimestampGetter.getCommitTimestamp(startTs, commitLocksToken);
+        return commitTimestampGetter.getCommitTimestamp(startTs, commitLocksToken);
     }
 
     @Override
@@ -132,6 +131,6 @@ public final class RemoteTimelockServiceAdapter implements TimelockService, Auto
     @Override
     public void close() {
         transactionStarter.close();
-        batchingCommitTimestampGetter.close();
+        commitTimestampGetter.close();
     }
 }

--- a/lock-api/src/main/java/com/palantir/lock/client/RemoteTimelockServiceAdapter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/RemoteTimelockServiceAdapter.java
@@ -37,7 +37,7 @@ public final class RemoteTimelockServiceAdapter implements TimelockService, Auto
     private final NamespacedConjureTimelockService conjureTimelockService;
     private final LockLeaseService lockLeaseService;
     private final TransactionStarter transactionStarter;
-    private final CommitTimestampGetter commitTimestampGetter;
+    private final BatchingCommitTimestampGetter batchingCommitTimestampGetter;
 
     private RemoteTimelockServiceAdapter(
             NamespacedTimelockRpcClient rpcClient,
@@ -47,7 +47,8 @@ public final class RemoteTimelockServiceAdapter implements TimelockService, Auto
         this.rpcClient = rpcClient;
         this.lockLeaseService = LockLeaseService.create(conjureTimelockService, leaderTimeGetter);
         this.transactionStarter = TransactionStarter.create(lockLeaseService, lockWatchEventCache);
-        this.commitTimestampGetter = CommitTimestampGetter.create(lockLeaseService, lockWatchEventCache);
+        this.batchingCommitTimestampGetter =
+                BatchingCommitTimestampGetter.create(lockLeaseService, lockWatchEventCache);
         this.conjureTimelockService = conjureTimelockService;
     }
 
@@ -73,7 +74,7 @@ public final class RemoteTimelockServiceAdapter implements TimelockService, Auto
 
     @Override
     public long getCommitTimestamp(long startTs, LockToken commitLocksToken) {
-        return commitTimestampGetter.getCommitTimestamp(startTs, commitLocksToken);
+        return batchingCommitTimestampGetter.getCommitTimestamp(startTs, commitLocksToken);
     }
 
     @Override
@@ -131,6 +132,6 @@ public final class RemoteTimelockServiceAdapter implements TimelockService, Auto
     @Override
     public void close() {
         transactionStarter.close();
-        commitTimestampGetter.close();
+        batchingCommitTimestampGetter.close();
     }
 }


### PR DESCRIPTION
**Goals (and why)**:
Refactor CommitTimestampGetter to accommodate the flow for batching getCommitTimestamps requests across multiple clients.

**Implementation Description (bullets)**:

- Extract interface for CommitTimestampGetter - the only implementation right now is the BatchingCommitTimestampGetter which was the default request batching mode per client.
- Does not actually change anything in the current flow.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Existing tests should suffice

**Concerns (what feedback would you like?)**:
Does this refactor break something?

**Where should we start reviewing?**:
CommitTimestampGetter

**Priority (whenever / two weeks / yesterday)**:
EOD today would be great

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
