### PR TITLE
retry socket timeout exception

### DIFF
--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/ConjureResourceExceptionHandler.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/ConjureResourceExceptionHandler.java
@@ -68,8 +68,7 @@ public class ConjureResourceExceptionHandler {
                         SocketTimeoutException.class,
                         timeout -> {
                             throw new TransactionFailedRetriableException(
-                                    "Socket timed out. Rethrowing as retryable exception."
-                            );
+                                    "Socket timed out. Rethrowing as retryable exception.");
                         },
                         MoreExecutors.directExecutor());
     }


### PR DESCRIPTION
**Goals (and why)**:
Currently socket timeout exceptions don't get retried, and can result in spurious 5xxs during host reboots. This change catches socket timeout exceptions, and make them retryable. 

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
