### PR TITLE
[CCB] | MultiClientCommitTimestampGetter refactor - part 2

### DIFF
--- a/changelog/@unreleased/pr-5294.v2.yml
+++ b/changelog/@unreleased/pr-5294.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: AtlasDb client can now batch getCommitTimestamps requests across namespaces.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5294

--- a/lock-api/build.gradle
+++ b/lock-api/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     compile group: 'com.palantir.safe-logging', name: 'safe-logging'
     compile group: 'com.palantir.safe-logging', name: 'preconditions'
     compile group: 'com.palantir.refreshable', name: 'refreshable'
+    compile group: 'one.util', name: 'streamex'
 
     annotationProcessor project(":atlasdb-processors")
     compileOnly project(":atlasdb-processors")

--- a/lock-api/src/main/java/com/palantir/lock/client/MultiClientCommitTimestampGetter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/MultiClientCommitTimestampGetter.java
@@ -50,7 +50,7 @@ public class MultiClientCommitTimestampGetter implements AutoCloseable {
         this.autobatcher = autobatcher;
     }
 
-    static MultiClientCommitTimestampGetter create(InternalMultiClientConjureTimelockService delegate) {
+    public static MultiClientCommitTimestampGetter create(InternalMultiClientConjureTimelockService delegate) {
         DisruptorAutobatcher<NamespacedRequest, Long> autobatcher = Autobatchers.independent(consumer(delegate))
                 .safeLoggablePurpose("multi-client-get-commit-timestamp")
                 .build();
@@ -152,7 +152,6 @@ public class MultiClientCommitTimestampGetter implements AutoCloseable {
             }
         }
 
-        // Todo snanda this is duplicated
         private List<Long> process(
                 List<BatchElement<NamespacedRequest, Long>> requests, GetCommitTimestampsResponse response) {
             List<Long> timestamps = LongStream.rangeClosed(response.getInclusiveLower(), response.getInclusiveUpper())

--- a/lock-api/src/main/java/com/palantir/lock/client/MultiClientCommitTimestampGetter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/MultiClientCommitTimestampGetter.java
@@ -92,7 +92,7 @@ public final class MultiClientCommitTimestampGetter implements AutoCloseable {
         return requestMap;
     }
 
-    private static class BatchStateManager {
+    private static final class BatchStateManager {
         private final Map<Namespace, NamespacedBatchStateManager> requestMap;
 
         private BatchStateManager(Map<Namespace, NamespacedBatchStateManager> requestMap) {
@@ -117,7 +117,7 @@ public final class MultiClientCommitTimestampGetter implements AutoCloseable {
         }
     }
 
-    private static class NamespacedBatchStateManager {
+    private static final class NamespacedBatchStateManager {
         private final Queue<BatchElement<NamespacedRequest, Long>> pendingRequestQueue;
         private final LockWatchEventCache cache;
         private Optional<LockWatchVersion> lastKnownVersion;

--- a/lock-api/src/main/java/com/palantir/lock/client/MultiClientCommitTimestampGetter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/MultiClientCommitTimestampGetter.java
@@ -1,0 +1,188 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.client;
+
+import static com.palantir.lock.client.ConjureLockRequests.toConjure;
+
+import com.google.common.collect.Streams;
+import com.palantir.atlasdb.autobatch.Autobatchers;
+import com.palantir.atlasdb.autobatch.BatchElement;
+import com.palantir.atlasdb.autobatch.DisruptorAutobatcher;
+import com.palantir.atlasdb.futures.AtlasFutures;
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampsRequest;
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampsResponse;
+import com.palantir.atlasdb.timelock.api.Namespace;
+import com.palantir.common.streams.KeyedStream;
+import com.palantir.lock.v2.LockToken;
+import com.palantir.lock.watch.ImmutableTransactionUpdate;
+import com.palantir.lock.watch.LockWatchEventCache;
+import com.palantir.lock.watch.TransactionUpdate;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+import org.immutables.value.Value;
+
+public class MultiClientCommitTimestampGetter implements AutoCloseable {
+    private final DisruptorAutobatcher<NamespacedRequest, Long> autobatcher;
+
+    private MultiClientCommitTimestampGetter(DisruptorAutobatcher<NamespacedRequest, Long> autobatcher) {
+        this.autobatcher = autobatcher;
+    }
+
+    static MultiClientCommitTimestampGetter create(InternalMultiClientConjureTimelockService delegate) {
+        DisruptorAutobatcher<NamespacedRequest, Long> autobatcher = Autobatchers.independent(consumer(delegate))
+                .safeLoggablePurpose("multi-client-transaction-starter")
+                .build();
+        return new MultiClientCommitTimestampGetter(autobatcher);
+    }
+
+    public long getCommitTimestamp(Namespace namespace, long startTs, LockToken commitLocksToken) {
+        return AtlasFutures.getUnchecked(autobatcher.apply(ImmutableNamespacedRequest.builder()
+                .namespace(namespace)
+                .startTs(startTs)
+                .commitLocksToken(commitLocksToken)
+                .build()));
+    }
+
+    private static Consumer<List<BatchElement<NamespacedRequest, Long>>> consumer(
+            InternalMultiClientConjureTimelockService delegate) {
+        return batch -> processBatch(delegate, batch);
+    }
+
+    private static void processBatch(
+            InternalMultiClientConjureTimelockService delegate, List<BatchElement<NamespacedRequest, Long>> batch) {
+        BatchStateManager batchStateManager = new BatchStateManager(getNamespaceWiseRequestHandler(batch));
+        while (batchStateManager.hasPendingRequests()) {
+            batchStateManager.processResponse(delegate.getCommitTimestamps(batchStateManager.getRequests()));
+        }
+    }
+
+    private static Map<Namespace, RequestAndResponseHandler> getNamespaceWiseRequestHandler(
+            List<BatchElement<NamespacedRequest, Long>> batch) {
+        Map<Namespace, RequestAndResponseHandler> requestMap = new HashMap<>();
+
+        for (BatchElement<NamespacedRequest, Long> elem : batch) {
+            NamespacedRequest argument = elem.argument();
+            Namespace namespace = argument.namespace();
+            RequestAndResponseHandler requestAndResponseHandler =
+                    requestMap.computeIfAbsent(namespace, _n -> new RequestAndResponseHandler(argument.cache()));
+            requestAndResponseHandler.addRequest(elem);
+        }
+
+        return requestMap;
+    }
+
+    private static class BatchStateManager {
+        private final Map<Namespace, RequestAndResponseHandler> requestMap;
+
+        private BatchStateManager(Map<Namespace, RequestAndResponseHandler> requestMap) {
+            this.requestMap = requestMap;
+        }
+
+        boolean hasPendingRequests() {
+            return requestMap.values().stream().anyMatch(RequestAndResponseHandler::hasPendingRequests);
+        }
+
+        Map<Namespace, GetCommitTimestampsRequest> getRequests() {
+            return KeyedStream.stream(requestMap)
+                    .filter(RequestAndResponseHandler::hasPendingRequests)
+                    .map(RequestAndResponseHandler::getPendingRequest)
+                    .collectToMap();
+        }
+
+        void processResponse(Map<Namespace, GetCommitTimestampsResponse> namespaceWiseResponse) {
+            KeyedStream.stream(namespaceWiseResponse)
+                    .forEach((namespace, getCommitTimestampsResponse) ->
+                            requestMap.get(namespace).serviceRequests(getCommitTimestampsResponse));
+        }
+    }
+
+    private static class RequestAndResponseHandler {
+        private final Queue<BatchElement<NamespacedRequest, Long>> pendingRequestQueue;
+        private final LockWatchEventCache cache;
+
+        private RequestAndResponseHandler(LockWatchEventCache cache) {
+            this.pendingRequestQueue = new LinkedList();
+            this.cache = cache;
+        }
+
+        boolean hasPendingRequests() {
+            return !pendingRequestQueue.isEmpty();
+        }
+
+        void addRequest(BatchElement<NamespacedRequest, Long> elem) {
+            pendingRequestQueue.add(elem);
+        }
+
+        GetCommitTimestampsRequest getPendingRequest() {
+            return GetCommitTimestampsRequest.builder()
+                    .numTimestamps(pendingRequestQueue.size())
+                    .lastKnownVersion(toConjure(cache.lastKnownVersion()))
+                    .build();
+        }
+
+        void serviceRequests(GetCommitTimestampsResponse commitTimestampsResponse) {
+            List<Long> commitTimestamps = process(
+                    (List<BatchElement<NamespacedRequest, Long>>) pendingRequestQueue, commitTimestampsResponse);
+            Iterator<Long> iterator = commitTimestamps.iterator();
+            while (iterator.hasNext()) {
+                pendingRequestQueue.poll().result().set(iterator.next());
+            }
+        }
+
+        // Todo snanda this is duplicated
+        private List<Long> process(
+                List<BatchElement<NamespacedRequest, Long>> requests, GetCommitTimestampsResponse response) {
+            List<Long> timestamps = LongStream.rangeClosed(response.getInclusiveLower(), response.getInclusiveUpper())
+                    .boxed()
+                    .collect(Collectors.toList());
+            List<TransactionUpdate> transactionUpdates = Streams.zip(
+                            timestamps.stream(),
+                            requests.stream(),
+                            (commitTs, batchElement) -> ImmutableTransactionUpdate.builder()
+                                    .startTs(batchElement.argument().startTs())
+                                    .commitTs(commitTs)
+                                    .writesToken(batchElement.argument().commitLocksToken())
+                                    .build())
+                    .collect(Collectors.toList());
+            cache.processGetCommitTimestampsUpdate(transactionUpdates, response.getLockWatchUpdate());
+            return timestamps;
+        }
+    }
+
+    @Override
+    public void close() {
+        autobatcher.close();
+    }
+
+    @Value.Immutable
+    interface NamespacedRequest {
+        Namespace namespace();
+
+        long startTs();
+
+        LockToken commitLocksToken();
+
+        LockWatchEventCache cache();
+    }
+}

--- a/lock-api/src/main/java/com/palantir/lock/client/MultiClientTransactionStarter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/MultiClientTransactionStarter.java
@@ -33,8 +33,8 @@ import com.palantir.atlasdb.timelock.api.Namespace;
 import com.palantir.common.streams.KeyedStream;
 import com.palantir.lock.v2.StartIdentifiedAtlasDbTransactionResponse;
 import com.palantir.lock.watch.StartTransactionsLockWatchEventCache;
+import java.util.ArrayDeque;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -278,8 +278,8 @@ public final class MultiClientTransactionStarter implements AutoCloseable {
         private final LockCleanupService lockCleanupService;
 
         ResponseHandler(LockCleanupService lockCleanupService) {
-            this.pendingFutures = new LinkedList<>();
-            this.transientResponseList = new LinkedList<>();
+            this.pendingFutures = new ArrayDeque<>();
+            this.transientResponseList = new ArrayDeque<>();
             this.lockCleanupService = lockCleanupService;
         }
 

--- a/lock-api/src/main/java/com/palantir/lock/client/NamespacedCommitTimestampGetter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/NamespacedCommitTimestampGetter.java
@@ -1,0 +1,40 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.client;
+
+import com.palantir.atlasdb.timelock.api.Namespace;
+import com.palantir.lock.v2.LockToken;
+
+public class NamespacedCommitTimestampGetter implements CommitTimestampGetter {
+    private final Namespace namespace;
+    private final MultiClientCommitTimestampGetter batcher;
+
+    public NamespacedCommitTimestampGetter(Namespace namespace, MultiClientCommitTimestampGetter batcher) {
+        this.namespace = namespace;
+        this.batcher = batcher;
+    }
+
+    @Override
+    public long getCommitTimestamp(long startTs, LockToken commitLocksToken) {
+        return 0;
+    }
+
+    @Override
+    public void close() {
+        batcher.close();
+    }
+}

--- a/lock-api/src/main/java/com/palantir/lock/client/NamespacedCommitTimestampGetter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/NamespacedCommitTimestampGetter.java
@@ -30,7 +30,7 @@ public class NamespacedCommitTimestampGetter implements CommitTimestampGetter {
 
     @Override
     public long getCommitTimestamp(long startTs, LockToken commitLocksToken) {
-        return 0;
+        return batcher.getCommitTimestamp(namespace, startTs, commitLocksToken);
     }
 
     @Override

--- a/lock-api/src/test/java/com/palantir/lock/client/MultiClientCommitTimestampGetterTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/MultiClientCommitTimestampGetterTest.java
@@ -1,0 +1,251 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.client;
+
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.Futures;
+import com.palantir.atlasdb.autobatch.BatchElement;
+import com.palantir.atlasdb.autobatch.DisruptorAutobatcher.DisruptorFuture;
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampsRequest;
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampsResponse;
+import com.palantir.atlasdb.timelock.api.Namespace;
+import com.palantir.common.streams.KeyedStream;
+import com.palantir.lock.client.MultiClientCommitTimestampGetter.NamespacedRequest;
+import com.palantir.lock.v2.LockToken;
+import com.palantir.lock.watch.LockWatchEventCache;
+import com.palantir.lock.watch.LockWatchStateUpdate;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import one.util.streamex.StreamEx;
+import org.junit.Test;
+
+public class MultiClientCommitTimestampGetterTest {
+    private static final Map<Namespace, Long> LOWEST_START_TS_MAP = new HashMap<>();
+    private static final int COMMIT_TS_LIMIT_PER_REQUEST = 5;
+    private static final SafeIllegalStateException EXCEPTION = new SafeIllegalStateException("Something went wrong!");
+    private static final Map<Namespace, LockWatchEventCache> LOCK_WATCH_EVENT_CACHE_MAP_MAP = new HashMap<>();
+
+    private final LockToken lockToken = mock(LockToken.class);
+    private final InternalMultiClientConjureTimelockService timelockService =
+            mock(InternalMultiClientConjureTimelockService.class);
+    private final LockWatchStateUpdate lockWatchStateUpdate = mock(LockWatchStateUpdate.class);
+
+    private final Consumer<List<BatchElement<NamespacedRequest, Long>>> consumer =
+            MultiClientCommitTimestampGetter.consumer(timelockService);
+
+    @Test
+    public void canServiceOneClient() {
+        setupServiceAndAssertSanityOfResponse(getCommitTimestampRequestsForClients(1, COMMIT_TS_LIMIT_PER_REQUEST - 1));
+    }
+
+    @Test
+    public void canServiceOneClientInMultipleRequests() {
+        setupServiceAndAssertSanityOfResponse(getCommitTimestampRequestsForClients(1, COMMIT_TS_LIMIT_PER_REQUEST * 5));
+    }
+
+    @Test
+    public void canServiceMultipleClients() {
+        int clientCount = 50;
+        setupServiceAndAssertSanityOfResponse(
+                getCommitTimestampRequestsForClients(clientCount, (COMMIT_TS_LIMIT_PER_REQUEST - 1) * clientCount));
+    }
+
+    @Test
+    public void canServiceMultipleClientsWithMultipleServerCalls() {
+        int clientCount = 5;
+        setupServiceAndAssertSanityOfResponse(
+                getCommitTimestampRequestsForClients(clientCount, (COMMIT_TS_LIMIT_PER_REQUEST + 1) * clientCount));
+    }
+
+    @Test
+    public void updatesCacheWhileProcessingResponse() {
+        Namespace client = Namespace.of("Kitty");
+        List<BatchElement<NamespacedRequest, Long>> batchElements = IntStream.range(0, COMMIT_TS_LIMIT_PER_REQUEST * 2)
+                .mapToObj(ind -> batchElementForNamespace(client))
+                .collect(toList());
+        setupServiceAndAssertSanityOfResponse(batchElements);
+
+        LockWatchEventCache cache = LOCK_WATCH_EVENT_CACHE_MAP_MAP.get(client);
+        verify(cache, times(2)).lastKnownVersion();
+        verify(cache, times(2)).processGetCommitTimestampsUpdate(any(), any());
+    }
+
+    @Test
+    public void doesNotUpdateCacheIfClientNotServed() {
+        Namespace alpha = Namespace.of("alpha" + UUID.randomUUID());
+        Namespace beta = Namespace.of("beta" + UUID.randomUUID());
+
+        BatchElement<NamespacedRequest, Long> requestForAlpha = batchElementForNamespace(alpha);
+        BatchElement<NamespacedRequest, Long> requestForBeta = batchElementForNamespace(beta);
+
+        List<BatchElement<NamespacedRequest, Long>> allRequests = ImmutableList.of(requestForAlpha, requestForBeta);
+        List<BatchElement<NamespacedRequest, Long>> alphaRequestList = ImmutableList.of(requestForAlpha);
+        Map<Namespace, GetCommitTimestampsResponse> responseMap = getCommitTimestamps(alphaRequestList);
+
+        when(timelockService.getCommitTimestamps(any())).thenReturn(responseMap).thenThrow(EXCEPTION);
+
+        assertThatThrownBy(() -> consumer.accept(allRequests)).isEqualTo(EXCEPTION);
+
+        // assert requests made by client alpha are served
+        assertSanityOfResponse(alphaRequestList, ImmutableMap.of(alpha, ImmutableList.of(responseMap.get(alpha))));
+
+        LockWatchEventCache alphaCache = LOCK_WATCH_EVENT_CACHE_MAP_MAP.get(alpha);
+        verify(alphaCache).lastKnownVersion();
+        verify(alphaCache).processGetCommitTimestampsUpdate(any(), any());
+
+        // assert unsuccessful requests were made by client beta
+        assertThat(requestForBeta.result().isDone()).isFalse();
+
+        LockWatchEventCache betaCache = LOCK_WATCH_EVENT_CACHE_MAP_MAP.get(beta);
+        verify(betaCache, times(2)).lastKnownVersion();
+        verify(betaCache, never()).processGetCommitTimestampsUpdate(any(), any());
+    }
+
+    private void setupServiceAndAssertSanityOfResponse(List<BatchElement<NamespacedRequest, Long>> batch) {
+        Map<Namespace, List<GetCommitTimestampsResponse>> expectedResponseMap = new HashMap<>();
+
+        when(timelockService.getCommitTimestamps(any())).thenAnswer(invocation -> {
+            Map<Namespace, GetCommitTimestampsResponse> commitTimestamps =
+                    getCommitTimestampResponse(invocation.getArgument(0));
+            commitTimestamps.forEach((namespace, response) -> {
+                expectedResponseMap
+                        .computeIfAbsent(namespace, _u -> new ArrayList())
+                        .add(response);
+            });
+            return commitTimestamps;
+        });
+
+        consumer.accept(batch);
+        assertSanityOfResponse(batch, expectedResponseMap);
+    }
+
+    private void assertSanityOfResponse(
+            List<BatchElement<NamespacedRequest, Long>> batch,
+            Map<Namespace, List<GetCommitTimestampsResponse>> expectedResponseMap) {
+        // all requests should be served
+        assertThat(batch.stream().filter(elem -> !elem.result().isDone()).collect(Collectors.toSet()))
+                .isEmpty();
+
+        Map<Namespace, List<Long>> partitionedResponseMap = batch.stream()
+                .collect(groupingBy(
+                        elem -> elem.argument().namespace(),
+                        Collectors.mapping(elem -> Futures.getUnchecked(elem.result()), toList())));
+
+        assertThat(partitionedResponseMap.keySet()).isEqualTo(expectedResponseMap.keySet());
+        assertCorrectnessOfCompletedRequests(expectedResponseMap, partitionedResponseMap);
+    }
+
+    private static void assertCorrectnessOfCompletedRequests(
+            Map<Namespace, List<GetCommitTimestampsResponse>> expectedResponseMap,
+            Map<Namespace, List<Long>> partitionedResponseMap) {
+        KeyedStream.stream(partitionedResponseMap)
+                .forEach(((namespace, commitTsList) ->
+                        assertSanityOfServedTimestamps(commitTsList, expectedResponseMap.get(namespace))));
+    }
+
+    private static void assertSanityOfServedTimestamps(
+            List<Long> commitTsList, List<GetCommitTimestampsResponse> commitTimestampsResponses) {
+        long requestedCommitTsCount = commitTimestampsResponses.stream()
+                .mapToLong(resp -> resp.getInclusiveUpper() - resp.getInclusiveLower() + 1)
+                .sum();
+        assertThat(requestedCommitTsCount).isEqualTo(commitTsList.size());
+        assertThat(ImmutableSet.copyOf(commitTsList)).hasSameSizeAs(commitTsList);
+        assertThat(StreamEx.of(commitTsList)
+                        .pairMap((first, second) -> first > second)
+                        .anyMatch(x -> x))
+                .isFalse();
+    }
+
+    private Map<Namespace, GetCommitTimestampsResponse> getCommitTimestamps(
+            List<BatchElement<NamespacedRequest, Long>> batch) {
+        Map<Namespace, List<BatchElement<NamespacedRequest, Long>>> partitionedRequests =
+                batch.stream().collect(groupingBy(elem -> elem.argument().namespace(), toList()));
+        return getCommitTimestampResponse(KeyedStream.stream(partitionedRequests)
+                .map(requestList -> GetCommitTimestampsRequest.builder()
+                        .numTimestamps(requestList.size())
+                        .build())
+                .collectToMap());
+    }
+
+    private Map<Namespace, GetCommitTimestampsResponse> getCommitTimestampResponse(
+            Map<Namespace, GetCommitTimestampsRequest> requestMap) {
+        return KeyedStream.stream(requestMap)
+                .mapEntries((namespace, request) -> {
+                    long inclusiveLower = getLowerBound(namespace);
+                    long exclusiveUpper =
+                            inclusiveLower + Math.min(request.getNumTimestamps(), COMMIT_TS_LIMIT_PER_REQUEST);
+                    updateLowerBound(namespace, exclusiveUpper);
+                    return Maps.immutableEntry(
+                            namespace,
+                            GetCommitTimestampsResponse.builder()
+                                    .inclusiveLower(inclusiveLower)
+                                    .inclusiveUpper(exclusiveUpper - 1)
+                                    .lockWatchUpdate(lockWatchStateUpdate)
+                                    .build());
+                })
+                .collectToMap();
+    }
+
+    private long getLowerBound(Namespace namespace) {
+        return LOWEST_START_TS_MAP.getOrDefault(namespace, 1L);
+    }
+
+    private void updateLowerBound(Namespace namespace, long numTimestamps) {
+        LOWEST_START_TS_MAP.put(namespace, LOWEST_START_TS_MAP.getOrDefault(namespace, 1L) + numTimestamps);
+    }
+
+    private List<BatchElement<NamespacedRequest, Long>> getCommitTimestampRequestsForClients(
+            int clientCount, int requestCount) {
+        List<BatchElement<NamespacedRequest, Long>> test = IntStream.range(0, requestCount)
+                .mapToObj(ind -> batchElementForNamespace(Namespace.of("Test_" + (ind % clientCount))))
+                .collect(Collectors.toList());
+        return test;
+    }
+
+    private BatchElement<NamespacedRequest, Long> batchElementForNamespace(Namespace namespace) {
+        return BatchElement.of(
+                ImmutableNamespacedRequest.builder()
+                        .namespace(namespace)
+                        .startTs(1)
+                        .cache(LOCK_WATCH_EVENT_CACHE_MAP_MAP.computeIfAbsent(namespace,
+                                _u -> mock(LockWatchEventCache.class)))
+                        .commitLocksToken(lockToken)
+                        .build(),
+                new DisruptorFuture<Long>("test"));
+    }
+}

--- a/lock-api/src/test/java/com/palantir/lock/client/MultiClientCommitTimestampGetterTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/MultiClientCommitTimestampGetterTest.java
@@ -144,7 +144,7 @@ public class MultiClientCommitTimestampGetterTest {
                     getCommitTimestampResponse(invocation.getArgument(0));
             commitTimestamps.forEach((namespace, response) -> {
                 expectedResponseMap
-                        .computeIfAbsent(namespace, _u -> new ArrayList())
+                        .computeIfAbsent(namespace, _unused -> new ArrayList())
                         .add(response);
             });
             return commitTimestamps;
@@ -242,8 +242,8 @@ public class MultiClientCommitTimestampGetterTest {
                 ImmutableNamespacedRequest.builder()
                         .namespace(namespace)
                         .startTs(1)
-                        .cache(LOCK_WATCH_EVENT_CACHE_MAP_MAP.computeIfAbsent(namespace,
-                                _u -> mock(LockWatchEventCache.class)))
+                        .cache(LOCK_WATCH_EVENT_CACHE_MAP_MAP.computeIfAbsent(
+                                namespace, _unused -> mock(LockWatchEventCache.class)))
                         .commitLocksToken(lockToken)
                         .build(),
                 new DisruptorFuture<Long>("test"));

--- a/lock-api/src/test/java/com/palantir/lock/client/MultiClientCommitTimestampGetterTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/MultiClientCommitTimestampGetterTest.java
@@ -174,8 +174,8 @@ public class MultiClientCommitTimestampGetterTest {
             Map<Namespace, List<GetCommitTimestampsResponse>> expectedResponseMap,
             Map<Namespace, List<Long>> partitionedResponseMap) {
         KeyedStream.stream(partitionedResponseMap)
-                .forEach(((namespace, commitTsList) ->
-                        assertSanityOfServedTimestamps(commitTsList, expectedResponseMap.get(namespace))));
+                .forEach((namespace, commitTsList) ->
+                        assertSanityOfServedTimestamps(commitTsList, expectedResponseMap.get(namespace)));
     }
 
     private static void assertSanityOfServedTimestamps(


### PR DESCRIPTION
**Goals (and why)**:
Atlas should be able to accept a common batcher for getCommitTimestamps requests for multiple clients.

**Implementation Description (bullets)**:
- Implements AutoBatcher capable of handling getCommitTimestamps requests for multiple clients
- The model is very close to the origin model - for each namespace, while all requests cannot be served, we batch all the requests together, try to do getCommitTimestamps in one call to the server & update the cache after receiving the response.
- The LockWatchEventCache#lastKnownVersion is fetched before making request to TimeLock and LockWatchEventCache#processGetCommitTimestampsUpdate is invoked as response is received. 
- We try to serve requests as responses become available instead of waiting for all responses to serve all requests in one go.
- In case of exception, all pending requests are cancelled.
- This PR actually does not change the current flow
- I haven't done the wiring yet as the PR is pretty big already

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added tests

**Concerns (what feedback would you like?)**:

- There is code duplication b/w NamespacedBatchStateManager#process and BatchingCommitTimestampGetter#process but I could not think of a way of refactoring without 1. adding another iteration over request list 2. creating new instances of a suitable DS
- Did I miss/ break something horribly?

**Where should we start reviewing?**:
MultiClientCommitTimestampGetter

**Priority (whenever / two weeks / yesterday)**:
Before EOD tomorrow is the dream

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
