### PR TITLE
TimeLock Product dependency upgrade

### DIFF
--- a/lock-api-objects/build.gradle
+++ b/lock-api-objects/build.gradle
@@ -27,7 +27,7 @@ recommendedProductDependencies {
     productDependency {
         productGroup = 'com.palantir.timelock'
         productName = 'timelock-server'
-        minimumVersion = '0.445.0'
+        minimumVersion = '0.455.0'
         maximumVersion = '0.x.x'
     }
 }


### PR DESCRIPTION
**Goals (and why)**:
Required for internal Atlas Proxy to enable use of multi-client getCommitTimestamps

**Priority (whenever / two weeks / yesterday)**:
🏃‍♂️ 
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
