### PR TITLE
allow hikari password changes at runtime

### DIFF
--- a/changelog/@unreleased/pr-5308.v2.yml
+++ b/changelog/@unreleased/pr-5308.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: |-
+    The Hikari ConnectionManager now has a setPassword method which allows changing the password at runtime without needing to shutdown and restart services. A future change will add standard runtime configs for this (for now this is only usable by internal products that have their own custom runtime config).
+  links:
+  - https://github.com/palantir/atlasdb/pull/5308

--- a/commons-db/src/main/java/com/palantir/nexus/db/pool/ConnectionManager.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/pool/ConnectionManager.java
@@ -51,4 +51,12 @@ public interface ConnectionManager {
     void initUnchecked();
 
     DBType getDbType();
+
+    /**
+     * Change the password which will be used for new connections. Existing connections are not modified in any way.
+     *
+     * <p>Note that if the password is changed at runtime, there is a slight negative impact on pool performance
+     * because Hikari will copy the JDBC parameters every time a new connection is made.
+     */
+    void setPassword(String newPassword);
 }

--- a/commons-db/src/main/java/com/palantir/nexus/db/pool/ConnectionManager.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/pool/ConnectionManager.java
@@ -57,6 +57,10 @@ public interface ConnectionManager {
      *
      * <p>Note that if the password is changed at runtime, there is a slight negative impact on pool performance
      * because Hikari will copy the JDBC parameters every time a new connection is made.
+     *
+     * <p>Concurrent calls to this method should be avoided since the behavior for concurrent calls is not
+     * deterministic. It is recommended to only call this method from a single runtime config subscription so this is
+     * called when the runtime config changes.
      */
     void setPassword(String newPassword);
 }

--- a/commons-db/src/main/java/com/palantir/nexus/db/pool/ResourceTypes.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/pool/ResourceTypes.java
@@ -59,6 +59,11 @@ public final class ResourceTypes {
                         public DBType getDbType() {
                             return delegate.getDbType();
                         }
+
+                        @Override
+                        public void setPassword(String newPassword) {
+                            delegate.setPassword(newPassword);
+                        }
                     };
                 }
 


### PR DESCRIPTION
**Goals (and why)**: Many customers have password policies that require regular password rotation for Oracle database users (often every 60 days). Currently since the password is in static config, this requires restarting services that use AtlasDB or rely on the Hikari pool. Ideally we should support being able to change user passwords without requiring services restart.

**Implementation Description (bullets)**:
* Hikari internally already supports changing the password of a pool at runtime without needing to shutdown or reinitialize the pool (it also supports changing the username, but we won't allow that for now).
* Adds a setPassword method on the ConnectionManager interface which can be used to change the password of the pool. Note that the implementation here needs to do something different depending on if the pool is already initialized or not. Also note that the way hikari implements this, changing the password (or username) means that it would now copy the JDBC properties object every time a new connection is called. This hurts performance very slightly, but only for new connections (reusing an existing connection is not affected). The way I've implemented it here, you only pay this performance cost if you *actually* call setPassword at runtime (existing consumers will not be affected).
* (NOT YET IMPLEMENTED) A future change can add a runtime config for postgres and oracle so that the hikari pool setPassword method gets called whenever the password changes in runtime config. This is not necessary for many of our internal products though, because internal products often do not use the normal atlas config (they have their own completely independent install/runtime configs).

**Testing (What was existing testing like?  What have you done to improve it?)**: Added tests against postgres. Also fixed the tests (HikariCpConnectionManagerTest was never being run because it was not in a suite, and the setup for that class was broken because it didn't actually wait for the database to be available which meant that even running it manually would have failed).

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**: normal
