### PR TITLE
"If migration has not run before" is confusing

### DIFF
--- a/changelog/@unreleased/pr-5314.v2.yml
+++ b/changelog/@unreleased/pr-5314.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: TimeLock logs for the splitting paxos state log now indicate which operation is performed as part of startup (migration, validation or truncation).
+  links:
+  - https://github.com/palantir/atlasdb/pull/5314

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogMigrator.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogMigrator.java
@@ -62,7 +62,8 @@ public final class PaxosStateLogMigrator<V extends Persistable & Versionable> {
     public static <V extends Persistable & Versionable> long migrateAndReturnCutoff(MigrationContext<V> context) {
         PaxosStateLogMigrator<V> migrator = new PaxosStateLogMigrator<>(context.sourceLog(), context.destinationLog());
         if (!context.migrationState().isInMigratedState()) {
-            log.info("Now migrating namespace and use case {} to sqlite.",
+            log.info(
+                    "Now migrating namespace and use case {} to sqlite.",
                     SafeArg.of("namespaceAndUseCase", context.namespaceAndUseCase()));
             long cutoff = calculateCutoff(context);
             migrator.runMigration(cutoff, context);
@@ -71,21 +72,26 @@ public final class PaxosStateLogMigrator<V extends Persistable & Versionable> {
             if (context.skipValidationAndTruncateSourceIfMigrated()) {
                 context.sourceLog().truncateAllRounds();
             }
-            log.info("Migrated namespace and use case {} to sqlite.",
+            log.info(
+                    "Migrated namespace and use case {} to sqlite.",
                     SafeArg.of("namespaceAndUseCase", context.namespaceAndUseCase()));
             return cutoff;
         } else {
             if (!context.skipValidationAndTruncateSourceIfMigrated()) {
-                log.info("Now validating the sqlite migration state for namespace and use case {}.",
+                log.info(
+                        "Now validating the sqlite migration state for namespace and use case {}.",
                         SafeArg.of("namespaceAndUseCase", context.namespaceAndUseCase()));
                 validateConsistency(context);
-                log.info("Validated the sqlite migration state for namespace and use case {}.",
+                log.info(
+                        "Validated the sqlite migration state for namespace and use case {}.",
                         SafeArg.of("namespaceAndUseCase", context.namespaceAndUseCase()));
             } else {
-                log.info("Now truncating the sqlite migration state for namespace and use case {}.",
+                log.info(
+                        "Now truncating the sqlite migration state for namespace and use case {}.",
                         SafeArg.of("namespaceAndUseCase", context.namespaceAndUseCase()));
                 context.sourceLog().truncateAllRounds();
-                log.info("Truncated the source log for namespace and use case {}.",
+                log.info(
+                        "Truncated the source log for namespace and use case {}.",
                         SafeArg.of("namespaceAndUseCase", context.namespaceAndUseCase()));
             }
         }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogMigrator.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogMigrator.java
@@ -62,6 +62,8 @@ public final class PaxosStateLogMigrator<V extends Persistable & Versionable> {
     public static <V extends Persistable & Versionable> long migrateAndReturnCutoff(MigrationContext<V> context) {
         PaxosStateLogMigrator<V> migrator = new PaxosStateLogMigrator<>(context.sourceLog(), context.destinationLog());
         if (!context.migrationState().isInMigratedState()) {
+            log.info("Now migrating namespace and use case {} to sqlite.",
+                    SafeArg.of("namespaceAndUseCase", context.namespaceAndUseCase()));
             long cutoff = calculateCutoff(context);
             migrator.runMigration(cutoff, context);
             context.migrationState().setCutoff(cutoff);
@@ -69,12 +71,22 @@ public final class PaxosStateLogMigrator<V extends Persistable & Versionable> {
             if (context.skipValidationAndTruncateSourceIfMigrated()) {
                 context.sourceLog().truncateAllRounds();
             }
+            log.info("Migrated namespace and use case {} to sqlite.",
+                    SafeArg.of("namespaceAndUseCase", context.namespaceAndUseCase()));
             return cutoff;
         } else {
             if (!context.skipValidationAndTruncateSourceIfMigrated()) {
+                log.info("Now validating the sqlite migration state for namespace and use case {}.",
+                        SafeArg.of("namespaceAndUseCase", context.namespaceAndUseCase()));
                 validateConsistency(context);
+                log.info("Validated the sqlite migration state for namespace and use case {}.",
+                        SafeArg.of("namespaceAndUseCase", context.namespaceAndUseCase()));
             } else {
+                log.info("Now truncating the sqlite migration state for namespace and use case {}.",
+                        SafeArg.of("namespaceAndUseCase", context.namespaceAndUseCase()));
                 context.sourceLog().truncateAllRounds();
+                log.info("Truncated the source log for namespace and use case {}.",
+                        SafeArg.of("namespaceAndUseCase", context.namespaceAndUseCase()));
             }
         }
         return context.migrationState().getCutoff();

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SplittingPaxosStateLog.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SplittingPaxosStateLog.java
@@ -18,7 +18,6 @@ package com.palantir.paxos;
 
 import com.palantir.common.persist.Persistable;
 import com.palantir.logsafe.Preconditions;
-import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.io.IOException;
 import java.util.OptionalLong;
@@ -90,9 +89,6 @@ public final class SplittingPaxosStateLog<V extends Persistable & Versionable> i
                 .skipValidationAndTruncateSourceIfMigrated(params.skipConsistencyCheckAndTruncateOldPaxosLog())
                 .build();
 
-        log.info(
-                "Starting migration for namespace and use case {} if migration has not run before.",
-                SafeArg.of("namespaceAndUseCase", params.namespaceAndUseCase()));
         long cutoff = PaxosStateLogMigrator.migrateAndReturnCutoff(migrationContext);
 
         if (params.skipConsistencyCheckAndTruncateOldPaxosLog()) {


### PR DESCRIPTION
**Goals (and why)**:
- Have clear log messages.

**Implementation Description (bullets)**:
- replace "Starting migration for namespace and use case {} if migration has not run before." with log lines chosen to match the context

**Testing (What was existing testing like?  What have you done to improve it?)**:
none 🔥 

**Concerns (what feedback would you like?)**:
- is this too noisy?

**Where should we start reviewing?**: small

**Priority (whenever / two weeks / yesterday)**: today please