### PR TITLE
[CCB] | Fix endpoint names

### DIFF
--- a/changelog/@unreleased/pr-5316.v2.yml
+++ b/changelog/@unreleased/pr-5316.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Adds startTransactionsForClients and getCommitTimestampsForClients endpoints on TimeLock for multi client batched requests.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5316

--- a/timelock-api/src/main/conjure/timelock-api.yml
+++ b/timelock-api/src/main/conjure/timelock-api.yml
@@ -199,6 +199,8 @@ services:
           Version of ConjureTimelockService#leaderTime endpoint for acquiring leaderTimes for a set of namespaces.
       startTransactions:
         http: POST /sts
+        deprecated: |
+          This endpoint is deprecated. Please use {@link #startTransactionsForClients} to start transactions for multiple clients.
         args:
           requests: map<Namespace, ConjureStartTransactionsRequest>
         returns: map<Namespace, ConjureStartTransactionsResponse>
@@ -206,6 +208,22 @@ services:
           Version of ConjureTimelockService#startTransactions that starts transactions for multiple namespaces.
       getCommitTimestamps:
         http: POST /gcts
+        deprecated: |
+          This endpoint is deprecated. Please use {@link #getCommitTimestampsForClients} to get commitTimestamps for multiple clients.
+        args:
+          requests: map<Namespace, GetCommitTimestampsRequest>
+        returns: map<Namespace, GetCommitTimestampsResponse>
+        docs: |
+          Version of ConjureTimelockService#getCommitTimestamps for acquiring commit timestamps for multiple namespaces.
+      startTransactionsForClients:
+        http: POST /msts
+        args:
+          requests: map<Namespace, ConjureStartTransactionsRequest>
+        returns: map<Namespace, ConjureStartTransactionsResponse>
+        docs: |
+          Version of ConjureTimelockService#startTransactions that starts transactions for multiple namespaces.
+      getCommitTimestampsForClients:
+        http: POST /mgcts
         args:
           requests: map<Namespace, GetCommitTimestampsRequest>
         returns: map<Namespace, GetCommitTimestampsResponse>

--- a/timelock-api/src/main/conjure/timelock-api.yml
+++ b/timelock-api/src/main/conjure/timelock-api.yml
@@ -209,21 +209,21 @@ services:
       getCommitTimestamps:
         http: POST /gcts
         deprecated: |
-          This endpoint is deprecated. Please use {@link #getCommitTimestampsForClients} to get commitTimestamps for multiple clients.
+          This endpoint is deprecated. Please use {@link #getCommitTimestampsForClients} to get commit timestamps for multiple clients.
         args:
           requests: map<Namespace, GetCommitTimestampsRequest>
         returns: map<Namespace, GetCommitTimestampsResponse>
         docs: |
           Version of ConjureTimelockService#getCommitTimestamps for acquiring commit timestamps for multiple namespaces.
       startTransactionsForClients:
-        http: POST /msts
+        http: POST /stsfc
         args:
           requests: map<Namespace, ConjureStartTransactionsRequest>
         returns: map<Namespace, ConjureStartTransactionsResponse>
         docs: |
           Version of ConjureTimelockService#startTransactions that starts transactions for multiple namespaces.
       getCommitTimestampsForClients:
-        http: POST /mgcts
+        http: POST /gctsfc
         args:
           requests: map<Namespace, GetCommitTimestampsRequest>
         returns: map<Namespace, GetCommitTimestampsResponse>

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/batch/MultiClientConjureTimelockResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/batch/MultiClientConjureTimelockResource.java
@@ -88,6 +88,18 @@ public final class MultiClientConjureTimelockResource implements UndertowMultiCl
     @Override
     public ListenableFuture<Map<Namespace, ConjureStartTransactionsResponse>> startTransactions(
             AuthHeader authHeader, Map<Namespace, ConjureStartTransactionsRequest> requests) {
+        return startTransactionsForClients(authHeader, requests);
+    }
+
+    @Override
+    public ListenableFuture<Map<Namespace, GetCommitTimestampsResponse>> getCommitTimestamps(
+            AuthHeader authHeader, Map<Namespace, GetCommitTimestampsRequest> requests) {
+        return getCommitTimestampsForClients(authHeader, requests);
+    }
+
+    @Override
+    public ListenableFuture<Map<Namespace, ConjureStartTransactionsResponse>> startTransactionsForClients(
+            AuthHeader authHeader, Map<Namespace, ConjureStartTransactionsRequest> requests) {
         return handleExceptions(() -> {
             List<ListenableFuture<Map.Entry<Namespace, ConjureStartTransactionsResponse>>> futures = KeyedStream.stream(
                             requests)
@@ -99,7 +111,7 @@ public final class MultiClientConjureTimelockResource implements UndertowMultiCl
     }
 
     @Override
-    public ListenableFuture<Map<Namespace, GetCommitTimestampsResponse>> getCommitTimestamps(
+    public ListenableFuture<Map<Namespace, GetCommitTimestampsResponse>> getCommitTimestampsForClients(
             AuthHeader authHeader, Map<Namespace, GetCommitTimestampsRequest> requests) {
         return handleExceptions(() -> {
             List<ListenableFuture<Map.Entry<Namespace, GetCommitTimestampsResponse>>> futures = KeyedStream.stream(
@@ -168,15 +180,29 @@ public final class MultiClientConjureTimelockResource implements UndertowMultiCl
         }
 
         @Override
+        @Deprecated
         public Map<Namespace, ConjureStartTransactionsResponse> startTransactions(
                 AuthHeader authHeader, Map<Namespace, ConjureStartTransactionsRequest> requests) {
             return unwrap(resource.startTransactions(authHeader, requests));
         }
 
         @Override
+        @Deprecated
         public Map<Namespace, GetCommitTimestampsResponse> getCommitTimestamps(
                 AuthHeader authHeader, Map<Namespace, GetCommitTimestampsRequest> requests) {
             return unwrap(resource.getCommitTimestamps(authHeader, requests));
+        }
+
+        @Override
+        public Map<Namespace, ConjureStartTransactionsResponse> startTransactionsForClients(
+                AuthHeader authHeader, Map<Namespace, ConjureStartTransactionsRequest> requests) {
+            return unwrap(resource.startTransactionsForClients(authHeader, requests));
+        }
+
+        @Override
+        public Map<Namespace, GetCommitTimestampsResponse> getCommitTimestampsForClients(
+                AuthHeader authHeader, Map<Namespace, GetCommitTimestampsRequest> requests) {
+            return unwrap(resource.getCommitTimestampsForClients(authHeader, requests));
         }
 
         private static <T> T unwrap(ListenableFuture<T> future) {

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/batch/MultiClientConjureTimelockResourceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/batch/MultiClientConjureTimelockResourceTest.java
@@ -130,8 +130,8 @@ public class MultiClientConjureTimelockResourceTest {
     @Test
     public void canStartTransactionsForMultipleClients() {
         List<String> namespaces = ImmutableList.of("client1", "client2");
-        Map<Namespace, ConjureStartTransactionsResponse> startTransactionsResponseMap =
-                Futures.getUnchecked(resource.startTransactions(AUTH_HEADER, getStartTransactionsRequests(namespaces)));
+        Map<Namespace, ConjureStartTransactionsResponse> startTransactionsResponseMap = Futures.getUnchecked(
+                resource.startTransactionsForClients(AUTH_HEADER, getStartTransactionsRequests(namespaces)));
 
         startTransactionsResponseMap.forEach((namespace, response) -> {
             assertThat(response.getLease().leaderTime().id()).isEqualTo(namespaceToLeaderMap.get(namespace.get()));
@@ -148,8 +148,8 @@ public class MultiClientConjureTimelockResourceTest {
     @Test
     public void canGetCommitTimestampsForMultipleClients() {
         Set<String> namespaces = ImmutableSet.of("client1", "client2");
-        assertThat(Futures.getUnchecked(
-                        resource.getCommitTimestamps(AUTH_HEADER, getGetCommitTimestampsRequests(namespaces))))
+        assertThat(Futures.getUnchecked(resource.getCommitTimestampsForClients(
+                        AUTH_HEADER, getGetCommitTimestampsRequests(namespaces))))
                 .isEqualTo(getGetCommitTimestampsResponseMap(namespaces));
     }
 

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -520,7 +520,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
                 defaultStartTransactionsRequests(expectedNamespaces, numTransactions);
 
         Map<Namespace, ConjureStartTransactionsResponse> startedTransactions =
-                multiClientConjureTimelockService.startTransactions(AUTH_HEADER, namespaceToRequestMap);
+                multiClientConjureTimelockService.startTransactionsForClients(AUTH_HEADER, namespaceToRequestMap);
 
         // Whether we hit the multi client endpoint or conjureTimelockService endpoint, for a namespace, the underlying
         // service to process the request is the same
@@ -575,8 +575,8 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
         MultiClientConjureTimelockService service = leader.multiClientService();
 
         Set<String> expectedNamespaces = ImmutableSet.of("cli-1", "cli-2");
-        Map<Namespace, GetCommitTimestampsResponse> multiClientResponses =
-                service.getCommitTimestamps(AUTH_HEADER, defaultGetCommitTimestampsRequests(expectedNamespaces));
+        Map<Namespace, GetCommitTimestampsResponse> multiClientResponses = service.getCommitTimestampsForClients(
+                AUTH_HEADER, defaultGetCommitTimestampsRequests(expectedNamespaces));
 
         assertSanityOfNamespacesServed(expectedNamespaces, multiClientResponses);
 
@@ -597,8 +597,9 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
 
         Set<String> expectedNamespaces = ImmutableSet.of("alta", "mp");
 
-        Map<Namespace, GetCommitTimestampsResponse> multiClientResponses = multiClientService.getCommitTimestamps(
-                AUTH_HEADER, defaultGetCommitTimestampsRequests(expectedNamespaces));
+        Map<Namespace, GetCommitTimestampsResponse> multiClientResponses =
+                multiClientService.getCommitTimestampsForClients(
+                        AUTH_HEADER, defaultGetCommitTimestampsRequests(expectedNamespaces));
 
         assertSanityOfNamespacesServed(expectedNamespaces, multiClientResponses);
 
@@ -645,7 +646,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
                 defaultStartTransactionsRequests(expectedNamespaces, numTransactions);
 
         Map<Namespace, ConjureStartTransactionsResponse> startedTransactions =
-                multiClientConjureTimelockService.startTransactions(AUTH_HEADER, namespaceToRequestMap);
+                multiClientConjureTimelockService.startTransactionsForClients(AUTH_HEADER, namespaceToRequestMap);
 
         Set<String> namespaces =
                 startedTransactions.keySet().stream().map(Namespace::get).collect(Collectors.toSet());


### PR DESCRIPTION
**Goals (and why)**:
We introduced multi client endpoints with the same name as single namespace TimeLock endpoints - getCommitTimestamps, startTransactions.
This has caused metrics published for the two different endpoints to be mixed up.

**Where should we start reviewing?**:
timelock-api

**Priority (whenever / two weeks / yesterday)**:
yesterday 🔥 

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
