### PR TITLE
[getSortedColumns] | snapshot transactions

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/Cell.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/Cell.java
@@ -40,10 +40,10 @@ import org.slf4j.LoggerFactory;
 public final class Cell implements Serializable, Comparable<Cell> {
     private static final long serialVersionUID = 1L;
     private static final Logger log = LoggerFactory.getLogger(Cell.class);
-    public static final Comparator<Cell> columnComparator = PtBytes.BYTES_COMPARATOR.onResultOf(Cell::getColumnName);
 
     // Oracle has an upper bound on RAW types of 2000.
     public static final int MAX_NAME_LENGTH = 1500;
+    public static final Comparator<Cell> COLUMN_COMPARATOR = PtBytes.BYTES_COMPARATOR.onResultOf(Cell::getColumnName);
 
     /**
      * Creates a key. Do not modify the rowName or the columnName arrays after passing them.

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/Cell.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/Cell.java
@@ -27,6 +27,7 @@ import com.palantir.logsafe.UnsafeArg;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Comparator;
 import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,6 +40,7 @@ import org.slf4j.LoggerFactory;
 public final class Cell implements Serializable, Comparable<Cell> {
     private static final long serialVersionUID = 1L;
     private static final Logger log = LoggerFactory.getLogger(Cell.class);
+    public static final Comparator<Cell> columnComparator = PtBytes.BYTES_COMPARATOR.onResultOf(Cell::getColumnName);
 
     // Oracle has an upper bound on RAW types of 2000.
     public static final int MAX_NAME_LENGTH = 1500;

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
@@ -132,8 +132,8 @@ public interface Transaction {
 
     /**
      * Returns an iterator over cell-value pairs within {@code tableRef} for the specified {@code rows}, where the
-     * columns fall within the provided  {@link BatchColumnRangeSelection}. The single provide
-     * {@link BatchColumnRangeSelection} applies to all of the rows.
+     * columns fall within the provided  {@link BatchColumnRangeSelection}.The single provided
+     * {@link ColumnRangeSelection} applies to all of the rows.
      *
      * The returned iterator is guaranteed to contain cells sorted first in order of column, then in order of row,
      * where rows are sorted according to the provided {@code rows} {@link Iterable}. If the {@link Iterable} does not
@@ -142,8 +142,8 @@ public interface Transaction {
      *
      * @param tableRef table to load values from
      * @param rows unique rows to apply column range selection to
-     * @param columnRangeSelection range of columns and batch size to load for all rows provided.
-     * @return iterator of cells matching predicate in rows, following ordering outlined above.
+     * @param columnRangeSelection range of columns and batch size to load for all rows provided
+     * @return an iterator over cell-value pairs, guaranteed to follow the ordering outlined above
      */
     @Idempotent
     Iterator<Map.Entry<Cell, byte[]>> getSortedColumns(

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
@@ -131,6 +131,24 @@ public interface Transaction {
             TableReference tableRef, Iterable<byte[]> rows, BatchColumnRangeSelection columnRangeSelection);
 
     /**
+     * Returns an iterator over cell-value pairs within {@code tableRef} for the specified {@code rows}, where the
+     * columns fall within the provided  {@link BatchColumnRangeSelection}. The single provide
+     * {@link BatchColumnRangeSelection} applies to all of the rows.
+     *
+     * The returned iterator is guaranteed to contain cells sorted first in order of column, then in order of row,
+     * where rows are sorted according to the provided {@code rows} {@link Iterable}. If the {@link Iterable} does not
+     * have a stable ordering (i.e. iteration order can change across iterators returned) then the returned
+     * iterator is sorted lexicographically with columns sorted on byte ordering, but the ordering of rows is undefined.
+     *
+     * @param tableRef table to load values from
+     * @param rows unique rows to apply column range selection to
+     * @param columnRangeSelection range of columns and batch size to load for all rows provided.
+     * @return iterator of cells matching predicate in rows, following ordering outlined above.
+     */
+    @Idempotent
+    Iterator<Map.Entry<Cell, byte[]>> getSortedColumns(
+            TableReference tableRef, Iterable<byte[]> rows, BatchColumnRangeSelection columnRangeSelection);
+    /**
      * Gets the values associated for each cell in {@code cells} from table specified by {@code tableRef}.
      *
      * @param tableRef the table from which to get the values

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
@@ -133,21 +133,25 @@ public interface Transaction {
     /**
      * Returns an iterator over cell-value pairs within {@code tableRef} for the specified {@code rows}, where the
      * columns fall within the provided  {@link BatchColumnRangeSelection}.The single provided
-     * {@link ColumnRangeSelection} applies to all of the rows.
+     * {@link BatchColumnRangeSelection} applies to all of the rows. If the same row is included multiple times,
+     * the cells will appear with only the first occurrence of the row in the stable case.
      *
-     * The returned iterator is guaranteed to contain cells sorted first in order of column, then in order of row,
-     * where rows are sorted according to the provided {@code rows} {@link Iterable}. If the {@link Iterable} does not
-     * have a stable ordering (i.e. iteration order can change across iterators returned) then the returned
-     * iterator is sorted lexicographically with columns sorted on byte ordering, but the ordering of rows is undefined.
+     * The returned iterator is guaranteed to contain cells sorted first in lexicographical order of column on byte
+     * ordering, then in order of row, where rows are sorted according to the provided {@code rows} {@link Iterable}.
+     * If the {@link Iterable} does not have a stable ordering (i.e. iteration order can change across iterators
+     * returned) then the returned iterator is sorted lexicographically with columns sorted on byte ordering, but the
+     * ordering of rows is undefined.
+     *
+     *
      *
      * @param tableRef table to load values from
      * @param rows unique rows to apply column range selection to
-     * @param columnRangeSelection range of columns and batch size to load for all rows provided
+     * @param batchColumnRangeSelection range of columns and batch size to load for all rows provided
      * @return an iterator over cell-value pairs, guaranteed to follow the ordering outlined above
      */
     @Idempotent
     Iterator<Map.Entry<Cell, byte[]>> getSortedColumns(
-            TableReference tableRef, Iterable<byte[]> rows, BatchColumnRangeSelection columnRangeSelection);
+            TableReference tableRef, Iterable<byte[]> rows, BatchColumnRangeSelection batchColumnRangeSelection);
     /**
      * Gets the values associated for each cell in {@code cells} from table specified by {@code tableRef}.
      *

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
@@ -133,16 +133,15 @@ public interface Transaction {
     /**
      * Returns an iterator over cell-value pairs within {@code tableRef} for the specified {@code rows}, where the
      * columns fall within the provided  {@link BatchColumnRangeSelection}.The single provided
-     * {@link BatchColumnRangeSelection} applies to all of the rows. If the same row is included multiple times,
-     * the cells will appear with only the first occurrence of the row in the stable case.
+     * {@link BatchColumnRangeSelection} applies to all of the rows. The cells for a row appear exactly once even if
+     * the same row is included multiple times in {@code rows}.
      *
      * The returned iterator is guaranteed to contain cells sorted first in lexicographical order of column on byte
      * ordering, then in order of row, where rows are sorted according to the provided {@code rows} {@link Iterable}.
      * If the {@link Iterable} does not have a stable ordering (i.e. iteration order can change across iterators
      * returned) then the returned iterator is sorted lexicographically with columns sorted on byte ordering, but the
-     * ordering of rows is undefined.
-     *
-     *
+     * ordering of rows is undefined. In case of duplicate rows, the ordering is based on the first occurrence of
+     * the row.
      *
      * @param tableRef table to load values from
      * @param rows unique rows to apply column range selection to

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransaction.java
@@ -68,8 +68,8 @@ public abstract class ForwardingTransaction extends ForwardingObject implements 
 
     @Override
     public Iterator<Map.Entry<Cell, byte[]>> getSortedColumns(
-            TableReference tableRef, Iterable<byte[]> rows, BatchColumnRangeSelection columnRangeSelection) {
-        return delegate().getSortedColumns(tableRef, rows, columnRangeSelection);
+            TableReference tableRef, Iterable<byte[]> rows, BatchColumnRangeSelection batchColumnRangeSelection) {
+        return delegate().getSortedColumns(tableRef, rows, batchColumnRangeSelection);
     }
 
     @Override

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransaction.java
@@ -67,6 +67,12 @@ public abstract class ForwardingTransaction extends ForwardingObject implements 
     }
 
     @Override
+    public Iterator<Map.Entry<Cell, byte[]>> getSortedColumns(
+            TableReference tableRef, Iterable<byte[]> rows, BatchColumnRangeSelection columnRangeSelection) {
+        return delegate().getSortedColumns(tableRef, rows, columnRangeSelection);
+    }
+
+    @Override
     public Iterator<Map.Entry<Cell, byte[]>> getRowsColumnRange(
             TableReference tableRef, Iterable<byte[]> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
         return delegate().getRowsColumnRange(tableRef, rows, columnRangeSelection, batchHint);

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ReadTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ReadTransaction.java
@@ -123,6 +123,12 @@ public class ReadTransaction extends ForwardingTransaction {
     }
 
     @Override
+    public Iterator<Map.Entry<Cell, byte[]>> getSortedColumns(
+            TableReference tableRef, Iterable<byte[]> rows, BatchColumnRangeSelection columnRangeSelection) {
+        return delegate().getSortedColumns(tableRef, rows, columnRangeSelection);
+    }
+
+    @Override
     public Iterator<Map.Entry<Cell, byte[]>> getRowsColumnRange(
             TableReference tableRef, Iterable<byte[]> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
         checkTableName(tableRef);

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ReadTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ReadTransaction.java
@@ -124,8 +124,9 @@ public class ReadTransaction extends ForwardingTransaction {
 
     @Override
     public Iterator<Map.Entry<Cell, byte[]>> getSortedColumns(
-            TableReference tableRef, Iterable<byte[]> rows, BatchColumnRangeSelection columnRangeSelection) {
-        return delegate().getSortedColumns(tableRef, rows, columnRangeSelection);
+            TableReference tableRef, Iterable<byte[]> rows, BatchColumnRangeSelection batchColumnRangeSelection) {
+        checkTableName(tableRef);
+        return delegate().getSortedColumns(tableRef, rows, batchColumnRangeSelection);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -219,11 +219,11 @@ public class SerializableTransaction extends SnapshotTransaction {
 
     @Override
     public Iterator<Map.Entry<Cell, byte[]>> getSortedColumns(
-            TableReference tableRef, Iterable<byte[]> rows, BatchColumnRangeSelection columnRangeSelection) {
+            TableReference tableRef, Iterable<byte[]> rows, BatchColumnRangeSelection batchColumnRangeSelection) {
         if (isSerializableTable(tableRef)) {
             throw new UnsupportedOperationException("This method does not support serializable conflict handling");
         }
-        return super.getSortedColumns(tableRef, rows, columnRangeSelection);
+        return super.getSortedColumns(tableRef, rows, batchColumnRangeSelection);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -218,6 +218,15 @@ public class SerializableTransaction extends SnapshotTransaction {
     }
 
     @Override
+    public Iterator<Map.Entry<Cell, byte[]>> getSortedColumns(
+            TableReference tableRef, Iterable<byte[]> rows, BatchColumnRangeSelection columnRangeSelection) {
+        if (isSerializableTable(tableRef)) {
+            throw new UnsupportedOperationException("This method does not support serializable conflict handling");
+        }
+        return super.getSortedColumns(tableRef, rows, columnRangeSelection);
+    }
+
+    @Override
     @Idempotent
     public Map<Cell, byte[]> get(TableReference tableRef, Set<Cell> cells) {
         try {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -141,6 +141,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.NavigableMap;
 import java.util.Objects;
 import java.util.Optional;
@@ -432,6 +433,12 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         // validate requirements here as the first batch for each of the above iterators will not check
         validatePreCommitRequirementsOnReadIfNecessary(tableRef, getStartTimestamp());
         return postFilteredResults;
+    }
+
+    @Override
+    public Iterator<Entry<Cell, byte[]>> getSortedColumns(
+            TableReference tableRef, Iterable<byte[]> rows, BatchColumnRangeSelection columnRangeSelection) {
+        throw new UnsupportedOperationException();
     }
 
     private Iterator<Map.Entry<Cell, byte[]>> getPostFilteredColumns(

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -455,7 +455,6 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         Map<byte[], RowColumnRangeIterator> rawResults =
                 keyValueService.getRowsColumnRange(tableRef, distinctRows, perBatchSelection, getStartTimestamp());
 
-        validatePreCommitRequirementsOnReadIfNecessary(tableRef, getStartTimestamp());
         return getPostFilteredSortedColumns(tableRef, columnRangeSelection, distinctRows, rawResults);
     }
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -123,7 +123,6 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Random;
 import java.util.SortedMap;
@@ -1779,7 +1778,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
 
         // lock lost after getting first batch
         timelockService.unlock(ImmutableSet.of(res.getLock()));
-        assertThatThrownBy(() -> sortedColumns.next()).isInstanceOf(TransactionLockTimeoutException.class);
+        assertThatThrownBy(sortedColumns::next).isInstanceOf(TransactionLockTimeoutException.class);
     }
 
     @Test
@@ -1843,7 +1842,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
         Transaction transaction =
                 getSnapshotTransactionWith(timelockService, () -> transactionTs, res, PreCommitConditions.NO_OP, true);
 
-        Iterator<Entry<Cell, byte[]>> sortedColumns = transaction.getSortedColumns(
+        Iterator<Map.Entry<Cell, byte[]>> sortedColumns = transaction.getSortedColumns(
                 TABLE_SWEPT_THOROUGH,
                 rows,
                 BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, batchHint));
@@ -1857,8 +1856,9 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
     private List<Cell> getSortedEntries(
             TableReference table, List<byte[]> rows, BatchColumnRangeSelection batchColumnRangeSelection) {
         return serializableTxManager.runTaskWithRetry(tx -> {
-            Iterator<Entry<Cell, byte[]>> sortedColumns = tx.getSortedColumns(table, rows, batchColumnRangeSelection);
-            return Streams.stream(sortedColumns).map(Entry::getKey).collect(Collectors.toList());
+            Iterator<Map.Entry<Cell, byte[]>> sortedColumns =
+                    tx.getSortedColumns(table, rows, batchColumnRangeSelection);
+            return Streams.stream(sortedColumns).map(Map.Entry::getKey).collect(Collectors.toList());
         });
     }
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -1794,12 +1794,12 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
     @Test
     public void getSortedColumnsObeysColumnRangeSelection() {
         List<byte[]> rows = ImmutableList.of(ROW_FOO, ROW_BAR);
-        List<Cell> col1_cells = ImmutableList.of(Cell.create(ROW_FOO, COL_A), Cell.create(ROW_BAR, COL_A));
+        List<Cell> colA_cells = ImmutableList.of(Cell.create(ROW_FOO, COL_A), Cell.create(ROW_BAR, COL_A));
 
-        putCellsInTable(col1_cells, TABLE);
+        putCellsInTable(colA_cells, TABLE);
         List<Cell> entries =
                 getSortedEntries(TABLE, rows, BatchColumnRangeSelection.create(COL_A, "az".getBytes(), 1000));
-        Assertions.assertThat(entries).containsExactlyElementsOf(col1_cells);
+        Assertions.assertThat(entries).containsExactlyElementsOf(colA_cells);
 
         List<Cell> outOfRangeEntries =
                 getSortedEntries(TABLE, rows, BatchColumnRangeSelection.create("y".getBytes(), "z".getBytes(), 1000));

--- a/changelog/@unreleased/pr-5318.v2.yml
+++ b/changelog/@unreleased/pr-5318.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Adds getSortedColumns endpoint for tables with snapshot-transaction conflict checking.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5318


### PR DESCRIPTION
Ref - #5092
**Goals (and why)**:
Implements getSortedColumns endpoint
- This endpoint returns an iterator over cell-value pairs within specified table for the specified rows, where columns fall within the provided BatchColumnRangeSelection
- The returned iterator is guaranteed to contain cells sorted first in order of column, then in order of input rows

**Implementation Description (bullets)**:

- row wise RowColumnRangeIterator's are fetched and merged - column wise first, then preserving input row order (if stable ordering)

- Lock validations are carried batch-wise on sorted and merged remote entries
- local entries fetched for each row and merged - column wise first, then preserving input row order (if stable ordering)
- iterator over merged remote and local entries is returned

**Testing (What was existing testing like?  What have you done to improve it?)**:
Tests added

**Concerns (what feedback would you like?)**:

- Correctness -> Is the sorting right? Also, are we doing the conflict checking correctly?
- Perf 

**Where should we start reviewing?**:
SnapshotTransaction#getSortedColumns

**Priority (whenever / two weeks / yesterday)**:
Before EOD tomorrow please

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
