### PR TITLE
[SQLite] Part1: Async/Lazy Migration

### DIFF
--- a/changelog/@unreleased/pr-5327.v2.yml
+++ b/changelog/@unreleased/pr-5327.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: SQLite migration/validation is now done asynchronously at startup instead of synchronously. This is correct because if a paxos component is needed before it is initialised, it will be initialised lazily.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5327

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipContextFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipContextFactory.java
@@ -59,7 +59,7 @@ public abstract class LeadershipContextFactory
     @Override
     @Value.Derived
     public LocalPaxosComponents components() {
-        return LocalPaxosComponents.createWithBlockingMigration(
+        return LocalPaxosComponents.createWithAsyncMigration(
                 metrics(),
                 useCase(),
                 install().dataDirectory(),

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResourcesFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResourcesFactory.java
@@ -170,7 +170,7 @@ public final class PaxosResourcesFactory {
             PaxosRemoteClients remoteClients) {
         TimelockPaxosMetrics timelockMetrics = TimelockPaxosMetrics.of(PaxosUseCase.TIMESTAMP, metrics);
 
-        LocalPaxosComponents paxosComponents = LocalPaxosComponents.createWithBlockingMigration(
+        LocalPaxosComponents paxosComponents = LocalPaxosComponents.createWithAsyncMigration(
                 timelockMetrics,
                 PaxosUseCase.TIMESTAMP,
                 install.dataDirectory(),

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponents.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponents.java
@@ -103,18 +103,20 @@ public class LocalPaxosComponents {
             OrderableSlsVersion timeLockVersion,
             boolean skipConsistencyCheckAndTruncateOldPaxosLog) {
         ExecutorService sqliteAsyncExecutor = PTExecutors.newSingleThreadExecutor(true);
-        LocalPaxosComponents components = createWithAsyncMigration(
-                metrics,
-                paxosUseCase,
-                legacyLogDirectory,
-                sqliteDataSource,
-                leaderUuid,
-                canCreateNewClients,
-                timeLockVersion,
-                skipConsistencyCheckAndTruncateOldPaxosLog,
-                sqliteAsyncExecutor);
-        sqliteAsyncExecutor.shutdown();
-        return components;
+        try {
+            return createWithAsyncMigration(
+                    metrics,
+                    paxosUseCase,
+                    legacyLogDirectory,
+                    sqliteDataSource,
+                    leaderUuid,
+                    canCreateNewClients,
+                    timeLockVersion,
+                    skipConsistencyCheckAndTruncateOldPaxosLog,
+                    sqliteAsyncExecutor);
+        } finally {
+            sqliteAsyncExecutor.shutdown();
+        }
     }
 
     public static LocalPaxosComponents createWithAsyncMigration(

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponentsTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponentsTest.java
@@ -126,7 +126,7 @@ public class LocalPaxosComponentsTest {
 
     // utils
     public LocalPaxosComponents createPaxosComponents(boolean canCreateNewClients) {
-        return LocalPaxosComponents.createWithBlockingMigration(
+        return LocalPaxosComponents.createWithAsyncMigration(
                 TimelockPaxosMetrics.of(PaxosUseCase.TIMESTAMP, MetricsManagers.createForTests()),
                 PaxosUseCase.TIMESTAMP,
                 legacyDirectory,
@@ -139,7 +139,7 @@ public class LocalPaxosComponentsTest {
 
     public LocalPaxosComponents createPaxosComponents(
             boolean canCreateNewClients, OrderableSlsVersion timeLockVersion) {
-        return LocalPaxosComponents.createWithBlockingMigration(
+        return LocalPaxosComponents.createWithAsyncMigration(
                 TimelockPaxosMetrics.of(PaxosUseCase.TIMESTAMP, MetricsManagers.createForTests()),
                 PaxosUseCase.TIMESTAMP,
                 legacyDirectory,

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
@@ -109,7 +109,7 @@ public class PaxosTimestampBoundStoreTest {
 
         for (int i = 0; i < NUM_NODES; i++) {
             String root = temporaryFolder.getRoot().getAbsolutePath();
-            LocalPaxosComponents components = LocalPaxosComponents.createWithBlockingMigration(
+            LocalPaxosComponents components = LocalPaxosComponents.createWithAsyncMigration(
                     TimelockPaxosMetrics.of(PaxosUseCase.TIMESTAMP, MetricsManagers.createForTests()),
                     PaxosUseCase.TIMESTAMP,
                     Paths.get(root, i + "legacy"),


### PR DESCRIPTION
**Goals (and why)**:
We have migrated virtually everywhere, but if validation is slow for any reason, the server will block until we verified all namespaces. This alleviates the issue.

**Implementation Description (bullets)**:
Submit a task to migrate(initialise) all namespaces asynchronously (previously was blocking). This is fine because if we need a component that has not been initialised yet, we will initialise it lazily.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Parameterized existing tests.

**Concerns (what feedback would you like?)**:
None, really. Though flagging that this may result in some initial sluggishness due to lazy initialisation -- mostly relevant if someone actually needs to migrate still. The alternative is that the server would not have started instead.

**Where should we start reviewing?**:
small

**Priority (whenever / two weeks / yesterday)**:
today
