### PR TITLE
further isolate dbkvs tests

### DIFF
--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbkvsPostgresTestSuite.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbkvsPostgresTestSuite.java
@@ -63,7 +63,7 @@ public final class DbkvsPostgresTestSuite {
     @ClassRule
     public static final DockerComposeRule docker = DockerComposeRule.builder()
             .file("src/test/resources/docker-compose.yml")
-            .waitingForService("postgres", Container::areAllPortsOpen)
+            .waitingForService("postgres-dbkvs", Container::areAllPortsOpen)
             .saveLogsTo(LogDirectory.circleAwareLogDirectory(DbkvsPostgresTestSuite.class))
             .shutdownStrategy(ShutdownStrategy.AGGRESSIVE_WITH_NETWORK_CLEANUP)
             .build();
@@ -77,7 +77,7 @@ public final class DbkvsPostgresTestSuite {
     }
 
     public static PostgresConnectionConfig getConnectionConfig() {
-        DockerPort port = docker.containers().container("postgres").port(POSTGRES_PORT_NUMBER);
+        DockerPort port = docker.containers().container("postgres-dbkvs").port(POSTGRES_PORT_NUMBER);
         InetSocketAddress postgresAddress = new InetSocketAddress(port.getIp(), port.getExternalPort());
         return ImmutablePostgresConnectionConfig.builder()
                 .dbName("atlas")

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/nexus/db/pool/HikariCpConnectionManagerTest.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/nexus/db/pool/HikariCpConnectionManagerTest.java
@@ -208,11 +208,11 @@ public class HikariCpConnectionManagerTest {
     private static void assertPasswordWrong(ConnectionManager testManager) {
         // This is needed because it appears that sometimes postgres password changes do not take effect immediately.
         // If the password change happens too late, we end up with a connection in the pool that we did not expect.
-        // In that case we need to wait the configured time (1 second) for hikari to remove the idle connection from
+        // In that case we need to wait the configured time (30 seconds) for hikari to remove the idle connection from
         // the pool before we can detect that the password is wrong. Note that I cannot reproduce this case locally,
         // but it appears to almost always happen on circle.
         Awaitility.await("assertPasswordWrong")
-                .atMost(Duration.ofSeconds(60))
+                .atMost(Duration.ofMinutes(2))
                 .pollInterval(Duration.ofSeconds(2))
                 .pollDelay(Duration.ofMillis(100))
                 .until(() -> isPasswordWrong(testManager));
@@ -260,8 +260,8 @@ public class HikariCpConnectionManagerTest {
                 .minConnections(minConnections)
                 .maxConnections(maxConnections)
                 .checkoutTimeout(2000)
-                // if this is set too high, testRuntimePasswordChange will be unreliable (and will take longer)
-                .maxConnectionAge(1)
+                // hikari doesn't allow this to be lower than 30 seconds
+                .maxConnectionAge(30)
                 .build();
     }
 }

--- a/atlasdb-dbkvs-tests/src/test/resources/docker-compose.yml
+++ b/atlasdb-dbkvs-tests/src/test/resources/docker-compose.yml
@@ -1,11 +1,11 @@
 version: '2'
 
 services:
-  postgres:
+  postgres-dbkvs:
     image: postgres:9.6-alpine
     environment:
        POSTGRES_PASSWORD: palantir
        POSTGRES_USER: palantir
        POSTGRES_DB: atlas
     ports:
-      - "5432:5432"
+      - "5432"


### PR DESCRIPTION
**Goals (and why)**: Tests are still flaking. Changing the postgres docker to try to make sure that no other ete tests accidentally interacted with it due to it binding the default postgres port on the host.

**Implementation Description (bullets)**:
* changes the dbkvs test postgres docker container to use a random port on the host (in case something else was trying to interact with it)
* fixes the test hikari config to set the max age to 30 seconds (hikari doesn't respect values lower than that), and increases the awaitility timeout to 2 minutes

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
