### PR TITLE
[PDS-169034] Background Sweep configuration

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
@@ -177,6 +177,21 @@ public abstract class AtlasDbConfig {
     }
 
     /**
+     * Whether to run the background sweeper process at all. Note that this differs from
+     * {@link AtlasDbRuntimeConfig#sweep()} in that configuration there assumes that the background sweeper threads will
+     * still be scheduled, just that they find they do not need to do any work when they wake up. If this flag here
+     * is set to false, this stops us from even running these threads. This saves on thread scheduling overhead,
+     * at the expense of requiring a rolling bounce should one actually decide that one wishes to use Background Sweep.
+     *
+     * The JSON endpoint that may be mounted on a service to run an explicit background sweep is not affected.
+     */
+    @Value.Default
+    public boolean runBackgroundSweepProcess() {
+        // TODO (jkong): Confirm with large internal product owner that this is generally safe to set to false.
+        return true;
+    }
+
+    /**
      * The number of milliseconds to wait between each batch of cells
      * processed by the background sweeper.
      * @deprecated Use {@link AtlasDbRuntimeConfig#sweep()} {@link SweepConfig#pauseMillis()} to make this value

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -698,9 +698,11 @@ public abstract class TransactionManagers {
      *
      * lockImmutableTsOnReadOnlyTransaction flag is used to decide on disabling background sweep, as this flag is used
      * as an intermediate step for migrating to thorough sweep.
+     *
+     * Separately, users may disable the background sweep process entirely in config, which we respect.
      */
     private boolean runBackgroundSweepProcess() {
-        return !lockImmutableTsOnReadOnlyTransactions();
+        return config().runBackgroundSweepProcess() && !lockImmutableTsOnReadOnlyTransactions();
     }
 
     @VisibleForTesting

--- a/changelog/@unreleased/pr-5334.v2.yml
+++ b/changelog/@unreleased/pr-5334.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Users who are confident they do not need Background Sweep (e.g. because they are running Targeted Sweep stably) may turn it off in config. This saves on thread scheduling overheads at the expense of requiring a rolling bounce if it is desired that Background Sweep is turned on again.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5334


### PR DESCRIPTION
**Goals (and why)**:
- Don't waste resources scheduling threads for background sweep when it's disabled and targeted sweep does the work anyway

**Implementation Description (bullets)**:
- Add a config flag for whether to run the process at all. Defaults to true. I need to speak with large internal product team before making it false.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Not much, existing tests should validate I haven't blown anything completely apart
- Will be tested when I turn this on in atlasdb proxy internally.

**Concerns (what feedback would you like?)**:
- Is this overly conservative?

**Where should we start reviewing?**: small

**Priority (whenever / two weeks / yesterday)**: whenever
