### PR TITLE
[LW/AC] Keep events around for active transactions

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheImpl.java
@@ -116,7 +116,7 @@ public final class LockWatchEventCacheImpl implements LockWatchEventCache {
     @Override
     public void removeTransactionStateFromCache(long startTimestamp) {
         timestampStateStore.remove(startTimestamp);
-        eventLog.retentionEvents(timestampStateStore.getEarliestLiveSequence());
+        retentionEvents();
     }
 
     @VisibleForTesting
@@ -144,9 +144,12 @@ public final class LockWatchEventCacheImpl implements LockWatchEventCache {
             timestampStateStore.clear();
         }
 
-        eventLog.retentionEvents(timestampStateStore.getEarliestLiveSequence());
-
+        retentionEvents();
         return cacheUpdate.getVersion();
+    }
+
+    private void retentionEvents() {
+        eventLog.retentionEvents(timestampStateStore.getEarliestLiveSequence());
     }
 
     private static void assertTrue(boolean condition, String message) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheImpl.java
@@ -116,6 +116,7 @@ public final class LockWatchEventCacheImpl implements LockWatchEventCache {
     @Override
     public void removeTransactionStateFromCache(long startTimestamp) {
         timestampStateStore.remove(startTimestamp);
+        eventLog.retentionEvents(timestampStateStore.getEarliestLiveSequence());
     }
 
     @VisibleForTesting

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheImpl.java
@@ -143,7 +143,7 @@ public final class LockWatchEventCacheImpl implements LockWatchEventCache {
             timestampStateStore.clear();
         }
 
-        eventLog.retentionEvents(timestampStateStore.getEarliestLiveTimestamp());
+        eventLog.retentionEvents(timestampStateStore.getEarliestLiveSequence());
 
         return cacheUpdate.getVersion();
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheImpl.java
@@ -36,16 +36,16 @@ import java.util.Set;
  * in concurrency issues and inconsistency in the cache state.
  */
 public final class LockWatchEventCacheImpl implements LockWatchEventCache {
-    // This value should be the same as in TimeLock's LockEventLogImpl. Note that this is not a hard limit - we
-    // instead guarantee that we will not delete events unless they exceed this count.
-    private static final int MAX_EVENTS = 1000;
+    // The minimum number of events should be the same as Timelocks' LockEventLogImpl.
+    private static final int MIN_EVENTS = 1000;
+    private static final int MAX_EVENTS = 10_000;
 
     private final LockWatchEventLog eventLog;
     private final TimestampStateStore timestampStateStore;
 
     public static LockWatchEventCache create(MetricsManager metricsManager) {
         return ResilientLockWatchEventCache.newProxyInstance(
-                new LockWatchEventCacheImpl(LockWatchEventLog.create(MAX_EVENTS)),
+                new LockWatchEventCacheImpl(LockWatchEventLog.create(MIN_EVENTS, MAX_EVENTS)),
                 NoOpLockWatchEventCache.create(),
                 metricsManager);
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheImpl.java
@@ -36,7 +36,8 @@ import java.util.Set;
  * in concurrency issues and inconsistency in the cache state.
  */
 public final class LockWatchEventCacheImpl implements LockWatchEventCache {
-    // This value should be the same as in TimeLock's LockEventLogImpl.
+    // This value should be the same as in TimeLock's LockEventLogImpl. Note that this is not a hard limit - we
+    // instead guarantee that we will not delete events unless they exceed this count.
     private static final int MAX_EVENTS = 1000;
 
     private final LockWatchEventLog eventLog;
@@ -142,7 +143,7 @@ public final class LockWatchEventCacheImpl implements LockWatchEventCache {
             timestampStateStore.clear();
         }
 
-        eventLog.retentionEvents();
+        eventLog.retentionEvents(timestampStateStore.getEarliestLiveTimestamp());
 
         return cacheUpdate.getVersion();
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLog.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLog.java
@@ -97,7 +97,7 @@ final class LockWatchEventLog {
 
     void retentionEvents() {
         getLatestKnownVersion().ifPresent(version -> {
-            LockWatchEvents eventsToBeRemoved = eventStore.retentionEvents();
+            LockWatchEvents eventsToBeRemoved = eventStore.retentionEvents(earliestVersionToKeep);
             snapshot.processEvents(eventsToBeRemoved, version.id());
         });
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLog.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLog.java
@@ -95,9 +95,9 @@ final class LockWatchEventLog {
         }
     }
 
-    void retentionEvents(Optional<Long> earliestTimestamp) {
+    void retentionEvents(Optional<Long> earliestSequence) {
         getLatestKnownVersion().ifPresent(version -> {
-            LockWatchEvents eventsToBeRemoved = eventStore.retentionEvents(earliestTimestamp);
+            LockWatchEvents eventsToBeRemoved = eventStore.retentionEvents(earliestSequence);
             snapshot.processEvents(eventsToBeRemoved, version.id());
         });
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLog.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLog.java
@@ -95,9 +95,9 @@ final class LockWatchEventLog {
         }
     }
 
-    void retentionEvents() {
+    void retentionEvents(Optional<Long> earliestTimestamp) {
         getLatestKnownVersion().ifPresent(version -> {
-            LockWatchEvents eventsToBeRemoved = eventStore.retentionEvents(earliestVersionToKeep);
+            LockWatchEvents eventsToBeRemoved = eventStore.retentionEvents(earliestTimestamp);
             snapshot.processEvents(eventsToBeRemoved, version.id());
         });
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLog.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLog.java
@@ -32,13 +32,13 @@ final class LockWatchEventLog {
     private final VersionedEventStore eventStore;
     private Optional<LockWatchVersion> latestVersion = Optional.empty();
 
-    static LockWatchEventLog create(int maxEvents) {
-        return new LockWatchEventLog(ClientLockWatchSnapshot.create(), maxEvents);
+    static LockWatchEventLog create(int minEvents, int maxEvents) {
+        return new LockWatchEventLog(ClientLockWatchSnapshot.create(), minEvents, maxEvents);
     }
 
-    private LockWatchEventLog(ClientLockWatchSnapshot snapshot, int maxEvents) {
+    private LockWatchEventLog(ClientLockWatchSnapshot snapshot, int minEvents, int maxEvents) {
         this.snapshot = snapshot;
-        this.eventStore = new VersionedEventStore(maxEvents);
+        this.eventStore = new VersionedEventStore(minEvents, maxEvents);
     }
 
     CacheUpdate processUpdate(LockWatchStateUpdate update) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStore.java
@@ -25,13 +25,13 @@ import com.palantir.lock.watch.LockWatchVersion;
 import com.palantir.lock.watch.TransactionUpdate;
 import com.palantir.logsafe.Preconditions;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.NavigableMap;
 import java.util.Optional;
+import java.util.TreeMap;
 import org.immutables.value.Value;
 
 final class TimestampStateStore {
-    private final Map<Long, MapEntry> timestampMap = new HashMap<>();
+    private final NavigableMap<Long, MapEntry> timestampMap = new TreeMap<>();
 
     void putStartTimestamps(Collection<Long> startTimestamps, LockWatchVersion version) {
         startTimestamps.forEach(startTimestamp -> {
@@ -77,6 +77,14 @@ final class TimestampStateStore {
         return ImmutableTimestampStateStoreState.builder()
                 .timestampMap(timestampMap)
                 .build();
+    }
+
+    public Optional<Long> getEarliestLiveTimestamp() {
+        if (timestampMap.isEmpty()) {
+            return Optional.empty();
+        } else {
+            return Optional.of(timestampMap.firstKey());
+        }
     }
 
     @Value.Immutable

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStoreState.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStoreState.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.keyvalue.api.watch;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.collect.SortedSetMultimap;
 import java.util.Map;
 import org.immutables.value.Value;
 
@@ -26,4 +27,6 @@ import org.immutables.value.Value;
 @JsonDeserialize(as = ImmutableTimestampStateStoreState.class)
 interface TimestampStateStoreState {
     Map<Long, TimestampStateStore.MapEntry> timestampMap();
+
+    SortedSetMultimap<Long, Long> livingVersions();
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStore.java
@@ -21,7 +21,7 @@ import com.google.common.collect.ImmutableList;
 import com.palantir.lock.watch.LockWatchEvent;
 import com.palantir.logsafe.Preconditions;
 import java.util.Collection;
-import java.util.Map.Entry;
+import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Optional;
 import java.util.Set;
@@ -58,7 +58,7 @@ final class VersionedEventStore {
         int numToRetention = eventMap.size() - maxEvents;
         ImmutableLockWatchEvents.Builder builder = LockWatchEvents.builder();
 
-        Set<Entry<Long, LockWatchEvent>> eventsToClear = eventMap.entrySet().stream()
+        Set<Map.Entry<Long, LockWatchEvent>> eventsToClear = eventMap.entrySet().stream()
                 .limit(numToRetention)
                 .filter(entry -> entry.getKey() < earliestVersionToKeep.orElse(Long.MAX_VALUE))
                 .collect(Collectors.toSet());

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStore.java
@@ -56,9 +56,9 @@ final class VersionedEventStore {
         }
 
         int numToRetention = eventMap.size() - maxEvents;
-        ImmutableLockWatchEvents.Builder builder = LockWatchEvents.builder();
-
         long earliestVersion = earliestSequenceToKeep.orElse(Long.MAX_VALUE);
+
+        ImmutableLockWatchEvents.Builder builder = LockWatchEvents.builder();
         List<Entry<Long, LockWatchEvent>> eventsToClear = eventMap.entrySet().stream()
                 .limit(numToRetention)
                 .filter(entry -> entry.getKey() < earliestVersion)

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStore.java
@@ -65,7 +65,7 @@ final class VersionedEventStore {
                 .collect(Collectors.toList());
 
         eventsToClear.forEach(entry -> {
-            eventMap.remove(entry.getKey(), entry.getValue());
+            eventMap.remove(entry.getKey());
             builder.addEvents(entry.getValue());
         });
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStore.java
@@ -22,7 +22,7 @@ import com.palantir.lock.watch.LockWatchEvent;
 import com.palantir.logsafe.Preconditions;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map.Entry;
+import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Optional;
 import java.util.TreeMap;
@@ -59,7 +59,7 @@ final class VersionedEventStore {
         long earliestVersion = earliestSequenceToKeep.orElse(Long.MAX_VALUE);
 
         ImmutableLockWatchEvents.Builder builder = LockWatchEvents.builder();
-        List<Entry<Long, LockWatchEvent>> eventsToClear = eventMap.entrySet().stream()
+        List<Map.Entry<Long, LockWatchEvent>> eventsToClear = eventMap.entrySet().stream()
                 .limit(numToRetention)
                 .filter(entry -> entry.getKey() < earliestVersion)
                 .collect(Collectors.toList());

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStore.java
@@ -50,7 +50,7 @@ final class VersionedEventStore {
                 .orElseGet(ImmutableList::of);
     }
 
-    LockWatchEvents retentionEvents(long earliestVersionToKeep) {
+    LockWatchEvents retentionEvents(Optional<Long> earliestVersionToKeep) {
         if (eventMap.size() < maxEvents) {
             return LockWatchEvents.builder().build();
         }
@@ -60,12 +60,12 @@ final class VersionedEventStore {
 
         Set<Entry<Long, LockWatchEvent>> eventsToClear = eventMap.entrySet().stream()
                 .limit(numToRetention)
-                .filter(entry -> entry.getKey() < earliestVersionToKeep)
+                .filter(entry -> entry.getKey() < earliestVersionToKeep.orElse(Long.MAX_VALUE))
                 .collect(Collectors.toSet());
 
-        eventsToClear.forEach(event -> {
-            eventMap.remove(event.getKey(), event.getValue());
-            builder.addEvents(event.getValue());
+        eventsToClear.forEach(entry -> {
+            eventMap.remove(entry.getKey(), entry.getValue());
+            builder.addEvents(entry.getValue());
         });
 
         return builder.build();

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheIntegrationTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheIntegrationTest.java
@@ -584,17 +584,4 @@ public class LockWatchEventCacheIntegrationTest {
             return invalidatedLocks;
         }
     }
-
-    private static final class InvalidatedAllVisitor implements CommitUpdate.Visitor<Boolean> {
-
-        @Override
-        public Boolean invalidateAll() {
-            return true;
-        }
-
-        @Override
-        public Boolean invalidateSome(Set<LockDescriptor> invalidatedLocks) {
-            return false;
-        }
-    }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheIntegrationTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheIntegrationTest.java
@@ -470,20 +470,56 @@ public class LockWatchEventCacheIntegrationTest {
     }
 
     @Test
-    public void eventsExceedingCacheSizeAreNotRetentionedForActiveTransactions() {
+    public void eventsExceedingMinimumCacheSizeAreNotRetentionedForActiveTransactions() {
         createEventCache(1);
         setupInitialState();
         eventCache.processStartTransactionsUpdate(TIMESTAMPS_2, SUCCESS);
 
-        TransactionsLockWatchUpdate update = eventCache.getUpdateForTransactions(TIMESTAMPS_2, Optional.empty());
+        TransactionsLockWatchUpdate update =
+                eventCache.getUpdateForTransactions(TIMESTAMPS_2, Optional.of(LockWatchVersion.of(LEADER, 3L)));
 
-        assertThat(update.clearCache()).isTrue();
+        assertThat(update.clearCache()).as("Verify update is not a snapshot").isFalse();
         assertThat(update.events())
+                .as("Verify events are not condensed into a snapshot")
+                .containsExactly(WATCH_EVENT, UNLOCK_EVENT, LOCK_EVENT);
+        assertThat(update.startTsToSequence())
+                .as("Verify transaction present in timestamp map")
+                .containsExactlyEntriesOf(ImmutableMap.of(START_TS_2, LockWatchVersion.of(LEADER, SUCCESS_VERSION)));
+    }
+
+    @Test
+    public void eventsExceedingMaximumCacheSizeAreRetentionedAnyway() {
+        createEventCache(1, 1);
+        setupInitialState();
+        eventCache.processStartTransactionsUpdate(TIMESTAMPS_2, SUCCESS);
+
+        TransactionsLockWatchUpdate laterUpdate =
+                eventCache.getUpdateForTransactions(TIMESTAMPS_2, Optional.of(LockWatchVersion.of(LEADER, 3L)));
+
+        assertThat(laterUpdate.clearCache()).as("Verify update is a snapshot").isTrue();
+        assertThat(laterUpdate.events())
+                .as("Verify events are not condensed into a snapshot")
                 .containsExactly(LockWatchCreatedEvent.builder(
                                 ImmutableSet.of(REFERENCE), ImmutableSet.of(DESCRIPTOR, DESCRIPTOR_3))
                         .build(6L));
-        assertThat(update.startTsToSequence())
+        assertThat(laterUpdate.startTsToSequence())
+                .as("Verify transaction present in timestamp map")
                 .containsExactlyEntriesOf(ImmutableMap.of(START_TS_2, LockWatchVersion.of(LEADER, SUCCESS_VERSION)));
+    }
+
+    @Test
+    public void timestampEventsRetentionedThrows() {
+        createEventCache(1, 1);
+        setupInitialState();
+        eventCache.processStartTransactionsUpdate(ImmutableSet.of(), SUCCESS);
+
+        assertThatThrownBy(() -> eventCache.getUpdateForTransactions(TIMESTAMPS, Optional.empty()))
+                .isExactlyInstanceOf(TransactionLockWatchFailedException.class)
+                .hasMessage("Events do not enclose the required versions");
+
+        assertThatThrownBy(() -> eventCache.getCommitUpdate(START_TS_1))
+                .isExactlyInstanceOf(TransactionLockWatchFailedException.class)
+                .hasMessage("start or commit info not processed for start timestamp");
     }
 
     @Test
@@ -566,9 +602,13 @@ public class LockWatchEventCacheIntegrationTest {
         eventCache.processStartTransactionsUpdate(TIMESTAMPS, SNAPSHOT);
     }
 
-    private void createEventCache(int maxSize) {
+    private void createEventCache(int minSize) {
+        createEventCache(minSize, 20);
+    }
+
+    private void createEventCache(int minSize, int maxSize) {
         fakeCache = NoOpLockWatchEventCache.create();
-        realEventCache = new LockWatchEventCacheImpl(LockWatchEventLog.create(maxSize));
+        realEventCache = new LockWatchEventCacheImpl(LockWatchEventLog.create(minSize, maxSize));
         eventCache = new DuplicatingLockWatchEventCache(realEventCache, fakeCache);
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheIntegrationTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheIntegrationTest.java
@@ -498,7 +498,7 @@ public class LockWatchEventCacheIntegrationTest {
 
         assertThat(laterUpdate.clearCache()).as("Verify update is a snapshot").isTrue();
         assertThat(laterUpdate.events())
-                .as("Verify events are not condensed into a snapshot")
+                .as("Verify events are condensed into a snapshot")
                 .containsExactly(LockWatchCreatedEvent.builder(
                                 ImmutableSet.of(REFERENCE), ImmutableSet.of(DESCRIPTOR, DESCRIPTOR_3))
                         .build(6L));

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStoreTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStoreTest.java
@@ -44,10 +44,13 @@ public final class VersionedEventStoreTest {
     }
 
     @Test
-    public void getAndRemoveElementsRemovesOldestElements() {
-        eventStore.putAll(makeEvents(EVENT_1, EVENT_2, EVENT_3));
-        eventStore.putAll(makeEvents(EVENT_4));
-        LockWatchEvents events = eventStore.retentionEvents(earliestVersionToKeep);
+    public void retentionEventsDoesNotRetentionAfterEarliestVersion() {
+        eventStore.putAll(makeEvents(EVENT_1, EVENT_2, EVENT_3, EVENT_4));
+        LockWatchEvents emptyEvents = eventStore.retentionEvents(Optional.of(-1L));
+        assertThat(emptyEvents.events()).isEmpty();
+        assertThat(eventStore.getStateForTesting().eventMap().keySet()).containsExactlyInAnyOrder(1L, 2L, 3L, 4L);
+
+        LockWatchEvents events = eventStore.retentionEvents(Optional.empty());
         assertThat(events.events().stream().map(LockWatchEvent::sequence)).containsExactly(1L, 2L);
         assertThat(eventStore.getStateForTesting().eventMap().firstKey()).isEqualTo(3L);
     }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStoreTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStoreTest.java
@@ -47,7 +47,7 @@ public final class VersionedEventStoreTest {
     public void getAndRemoveElementsRemovesOldestElements() {
         eventStore.putAll(makeEvents(EVENT_1, EVENT_2, EVENT_3));
         eventStore.putAll(makeEvents(EVENT_4));
-        LockWatchEvents events = eventStore.retentionEvents();
+        LockWatchEvents events = eventStore.retentionEvents(earliestVersionToKeep);
         assertThat(events.events().stream().map(LockWatchEvent::sequence)).containsExactly(1L, 2L);
         assertThat(eventStore.getStateForTesting().eventMap().firstKey()).isEqualTo(3L);
     }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStoreTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStoreTest.java
@@ -40,7 +40,7 @@ public final class VersionedEventStoreTest {
 
     @Before
     public void before() {
-        eventStore = new VersionedEventStore(2);
+        eventStore = new VersionedEventStore(0, 2);
     }
 
     @Test

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/cacheClearedOnSnapshotUpdate/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/cacheClearedOnSnapshotUpdate/event-cache-1.json
@@ -49,20 +49,24 @@
   },
   "timestampStoreState" : {
     "timestampMap" : {
-      "16" : {
-        "version" : {
-          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
-          "version" : 6
-        },
-        "commitInfo" : null
-      },
       "1" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
         },
         "commitInfo" : null
+      },
+      "16" : {
+        "version" : {
+          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
+          "version" : 6
+        },
+        "commitInfo" : null
       }
+    },
+    "livingVersions" : {
+      "3" : [ 1 ],
+      "6" : [ 16 ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/cacheClearedOnSnapshotUpdate/event-cache-2.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/cacheClearedOnSnapshotUpdate/event-cache-2.json
@@ -20,20 +20,23 @@
   },
   "timestampStoreState" : {
     "timestampMap" : {
-      "1255" : {
-        "version" : {
-          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
-          "version" : 7
-        },
-        "commitInfo" : null
-      },
       "123" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 7
         },
         "commitInfo" : null
+      },
+      "1255" : {
+        "version" : {
+          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
+          "version" : 7
+        },
+        "commitInfo" : null
       }
+    },
+    "livingVersions" : {
+      "7" : [ 123, 1255 ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-1.json
@@ -27,6 +27,9 @@
         },
         "commitInfo" : null
       }
+    },
+    "livingVersions" : {
+      "3" : [ 1 ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-2.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-2.json
@@ -27,6 +27,9 @@
         },
         "commitInfo" : null
       }
+    },
+    "livingVersions" : {
+      "3" : [ 1 ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-3.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-3.json
@@ -34,6 +34,9 @@
         },
         "commitInfo" : null
       }
+    },
+    "livingVersions" : {
+      "3" : [ 1, 2 ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-4.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-4.json
@@ -41,6 +41,9 @@
         },
         "commitInfo" : null
       }
+    },
+    "livingVersions" : {
+      "3" : [ 1, 2, 3 ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-5.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-5.json
@@ -59,6 +59,10 @@
         },
         "commitInfo" : null
       }
+    },
+    "livingVersions" : {
+      "3" : [ 1, 2, 3 ],
+      "4" : [ 99 ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getCommitUpdateIsInvalidateSomeAsEventsAreRetained/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getCommitUpdateIsInvalidateSomeAsEventsAreRetained/event-cache-1.json
@@ -1,22 +1,28 @@
 {
   "logState" : {
     "snapshotState" : {
-      "watches" : [ {
-        "type" : "fullTable",
-        "qualifiedTableRef" : "table"
-      } ],
+      "watches" : [ ],
       "locked" : [ {
-        "bytes" : "dGFibGUAAQ=="
-      }, {
         "bytes" : "dGFibGUAAg=="
       } ],
       "snapshotVersion" : {
         "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
-        "version" : 4
+        "version" : 3
       }
     },
     "eventStoreState" : {
       "eventMap" : {
+        "4" : {
+          "type" : "created",
+          "sequence" : 4,
+          "references" : [ {
+            "type" : "fullTable",
+            "qualifiedTableRef" : "table"
+          } ],
+          "lockDescriptors" : [ {
+            "bytes" : "dGFibGUAAQ=="
+          } ]
+        },
         "5" : {
           "type" : "unlock",
           "sequence" : 5,
@@ -53,20 +59,24 @@
   },
   "timestampStoreState" : {
     "timestampMap" : {
-      "16" : {
-        "version" : {
-          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
-          "version" : 7
-        },
-        "commitInfo" : null
-      },
       "1" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
         },
-        "commitInfo" : null
+        "commitInfo" : {
+          "commitLockToken" : {
+            "requestId" : "203fcd7a-b3d7-4c2a-9d2c-3d61cde1ba59"
+          },
+          "commitVersion" : {
+            "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
+            "version" : 6
+          }
+        }
       }
+    },
+    "livingVersions" : {
+      "3" : [ 1 ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getCommitUpdateIsInvalidateSomeAsEventsAreRetained/event-cache-2.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getCommitUpdateIsInvalidateSomeAsEventsAreRetained/event-cache-2.json
@@ -1,35 +1,20 @@
 {
   "logState" : {
     "snapshotState" : {
-      "watches" : [ ],
+      "watches" : [ {
+        "type" : "fullTable",
+        "qualifiedTableRef" : "table"
+      } ],
       "locked" : [ {
-        "bytes" : "dGFibGUAAg=="
+        "bytes" : "dGFibGUAAQ=="
       } ],
       "snapshotVersion" : {
         "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
-        "version" : 3
+        "version" : 5
       }
     },
     "eventStoreState" : {
       "eventMap" : {
-        "4" : {
-          "type" : "created",
-          "sequence" : 4,
-          "references" : [ {
-            "type" : "fullTable",
-            "qualifiedTableRef" : "table"
-          } ],
-          "lockDescriptors" : [ {
-            "bytes" : "dGFibGUAAQ=="
-          } ]
-        },
-        "5" : {
-          "type" : "unlock",
-          "sequence" : 5,
-          "lockDescriptors" : [ {
-            "bytes" : "dGFibGUAAg=="
-          } ]
-        },
         "6" : {
           "type" : "lock",
           "sequence" : 6,

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getCommitUpdateIsInvalidateSomeAsEventsAreRetained/event-cache-2.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getCommitUpdateIsInvalidateSomeAsEventsAreRetained/event-cache-2.json
@@ -58,54 +58,7 @@
     }
   },
   "timestampStoreState" : {
-    "timestampMap" : {
-      "1" : {
-        "version" : {
-          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
-          "version" : 3
-        },
-        "commitInfo" : null
-      },
-      "11" : {
-        "version" : {
-          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
-          "version" : 5
-        },
-        "commitInfo" : null
-      },
-      "12" : {
-        "version" : {
-          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
-          "version" : 5
-        },
-        "commitInfo" : null
-      },
-      "91" : {
-        "version" : {
-          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
-          "version" : 7
-        },
-        "commitInfo" : null
-      },
-      "92" : {
-        "version" : {
-          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
-          "version" : 7
-        },
-        "commitInfo" : null
-      },
-      "93" : {
-        "version" : {
-          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
-          "version" : 7
-        },
-        "commitInfo" : null
-      }
-    },
-    "livingVersions" : {
-      "3" : [ 1 ],
-      "5" : [ 11, 12 ],
-      "7" : [ 91, 92, 93 ]
-    }
+    "timestampMap" : { },
+    "livingVersions" : { }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getEventsForTransactionsMaxCondensing/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getEventsForTransactionsMaxCondensing/event-cache-1.json
@@ -59,20 +59,24 @@
   },
   "timestampStoreState" : {
     "timestampMap" : {
-      "16" : {
-        "version" : {
-          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
-          "version" : 7
-        },
-        "commitInfo" : null
-      },
       "1" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
         },
         "commitInfo" : null
+      },
+      "16" : {
+        "version" : {
+          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
+          "version" : 7
+        },
+        "commitInfo" : null
       }
+    },
+    "livingVersions" : {
+      "3" : [ 1 ],
+      "7" : [ 16 ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getEventsForTransactionsNoCondensing/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getEventsForTransactionsNoCondensing/event-cache-1.json
@@ -59,20 +59,24 @@
   },
   "timestampStoreState" : {
     "timestampMap" : {
-      "16" : {
-        "version" : {
-          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
-          "version" : 7
-        },
-        "commitInfo" : null
-      },
       "1" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
         },
         "commitInfo" : null
+      },
+      "16" : {
+        "version" : {
+          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
+          "version" : 7
+        },
+        "commitInfo" : null
       }
+    },
+    "livingVersions" : {
+      "3" : [ 1 ],
+      "7" : [ 16 ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getEventsForTransactionsSomeCondensing/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getEventsForTransactionsSomeCondensing/event-cache-1.json
@@ -49,20 +49,24 @@
   },
   "timestampStoreState" : {
     "timestampMap" : {
-      "16" : {
-        "version" : {
-          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
-          "version" : 6
-        },
-        "commitInfo" : null
-      },
       "1" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
         },
         "commitInfo" : null
+      },
+      "16" : {
+        "version" : {
+          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
+          "version" : 6
+        },
+        "commitInfo" : null
       }
+    },
+    "livingVersions" : {
+      "3" : [ 1 ],
+      "6" : [ 16 ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getEventsForTransactionsSomeCondensing/event-cache-2.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getEventsForTransactionsSomeCondensing/event-cache-2.json
@@ -59,17 +59,17 @@
   },
   "timestampStoreState" : {
     "timestampMap" : {
-      "16" : {
-        "version" : {
-          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
-          "version" : 6
-        },
-        "commitInfo" : null
-      },
       "1" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
+        },
+        "commitInfo" : null
+      },
+      "16" : {
+        "version" : {
+          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
+          "version" : 6
         },
         "commitInfo" : null
       },
@@ -80,6 +80,11 @@
         },
         "commitInfo" : null
       }
+    },
+    "livingVersions" : {
+      "3" : [ 1 ],
+      "6" : [ 16 ],
+      "7" : [ 25 ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/largerUpdateAfterSmallUpdateOnlyPicksUpNewEvents/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/largerUpdateAfterSmallUpdateOnlyPicksUpNewEvents/event-cache-1.json
@@ -60,6 +60,10 @@
         },
         "commitInfo" : null
       }
+    },
+    "livingVersions" : {
+      "3" : [ 1 ],
+      "5" : [ 11, 12 ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/leaderChangeClearsCaches/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/leaderChangeClearsCaches/event-cache-1.json
@@ -11,6 +11,7 @@
     "latestVersion" : null
   },
   "timestampStoreState" : {
-    "timestampMap" : { }
+    "timestampMap" : { },
+    "livingVersions" : { }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/newEventsCauseOldEventsToBeDeletedOnceTransactionsRemoved/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/newEventsCauseOldEventsToBeDeletedOnceTransactionsRemoved/event-cache-1.json
@@ -1,20 +1,35 @@
 {
   "logState" : {
     "snapshotState" : {
-      "watches" : [ {
-        "type" : "fullTable",
-        "qualifiedTableRef" : "table"
-      } ],
+      "watches" : [ ],
       "locked" : [ {
-        "bytes" : "dGFibGUAAQ=="
+        "bytes" : "dGFibGUAAg=="
       } ],
       "snapshotVersion" : {
         "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
-        "version" : 5
+        "version" : 3
       }
     },
     "eventStoreState" : {
       "eventMap" : {
+        "4" : {
+          "type" : "created",
+          "sequence" : 4,
+          "references" : [ {
+            "type" : "fullTable",
+            "qualifiedTableRef" : "table"
+          } ],
+          "lockDescriptors" : [ {
+            "bytes" : "dGFibGUAAQ=="
+          } ]
+        },
+        "5" : {
+          "type" : "unlock",
+          "sequence" : 5,
+          "lockDescriptors" : [ {
+            "bytes" : "dGFibGUAAg=="
+          } ]
+        },
         "6" : {
           "type" : "lock",
           "sequence" : 6,
@@ -24,22 +39,12 @@
           "lockToken" : {
             "requestId" : "203fcd7a-b3d7-4c2a-9d2c-3d61cde1ba59"
           }
-        },
-        "7" : {
-          "type" : "lock",
-          "sequence" : 7,
-          "lockDescriptors" : [ {
-            "bytes" : "dGFibGUAAQ=="
-          } ],
-          "lockToken" : {
-            "requestId" : "888fcd7a-b3d7-4d2a-9d2c-3d61cde1ba44"
-          }
         }
       }
     },
     "latestVersion" : {
       "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
-      "version" : 7
+      "version" : 6
     }
   },
   "timestampStoreState" : {
@@ -49,16 +54,11 @@
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
         },
-        "commitInfo" : {
-          "commitLockToken" : {
-            "requestId" : "203fcd7a-b3d7-4c2a-9d2c-3d61cde1ba59"
-          },
-          "commitVersion" : {
-            "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
-            "version" : 6
-          }
-        }
+        "commitInfo" : null
       }
+    },
+    "livingVersions" : {
+      "3" : [ 1 ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/newEventsCauseOldEventsToBeDeletedOnceTransactionsRemoved/event-cache-2.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/newEventsCauseOldEventsToBeDeletedOnceTransactionsRemoved/event-cache-2.json
@@ -39,12 +39,22 @@
           "lockToken" : {
             "requestId" : "203fcd7a-b3d7-4c2a-9d2c-3d61cde1ba59"
           }
+        },
+        "7" : {
+          "type" : "lock",
+          "sequence" : 7,
+          "lockDescriptors" : [ {
+            "bytes" : "dGFibGUAAQ=="
+          } ],
+          "lockToken" : {
+            "requestId" : "888fcd7a-b3d7-4d2a-9d2c-3d61cde1ba44"
+          }
         }
       }
     },
     "latestVersion" : {
       "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
-      "version" : 6
+      "version" : 7
     }
   },
   "timestampStoreState" : {
@@ -55,7 +65,18 @@
           "version" : 3
         },
         "commitInfo" : null
+      },
+      "16" : {
+        "version" : {
+          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
+          "version" : 7
+        },
+        "commitInfo" : null
       }
+    },
+    "livingVersions" : {
+      "3" : [ 1 ],
+      "7" : [ 16 ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/newEventsCauseOldEventsToBeDeletedOnceTransactionsRemoved/event-cache-3.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/newEventsCauseOldEventsToBeDeletedOnceTransactionsRemoved/event-cache-3.json
@@ -1,28 +1,22 @@
 {
   "logState" : {
     "snapshotState" : {
-      "watches" : [ ],
+      "watches" : [ {
+        "type" : "fullTable",
+        "qualifiedTableRef" : "table"
+      } ],
       "locked" : [ {
+        "bytes" : "dGFibGUAAQ=="
+      }, {
         "bytes" : "dGFibGUAAg=="
       } ],
       "snapshotVersion" : {
         "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
-        "version" : 3
+        "version" : 4
       }
     },
     "eventStoreState" : {
       "eventMap" : {
-        "4" : {
-          "type" : "created",
-          "sequence" : 4,
-          "references" : [ {
-            "type" : "fullTable",
-            "qualifiedTableRef" : "table"
-          } ],
-          "lockDescriptors" : [ {
-            "bytes" : "dGFibGUAAQ=="
-          } ]
-        },
         "5" : {
           "type" : "unlock",
           "sequence" : 5,

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/newEventsCauseOldEventsToBeDeletedOnceTransactionsRemoved/event-cache-3.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/newEventsCauseOldEventsToBeDeletedOnceTransactionsRemoved/event-cache-3.json
@@ -58,54 +58,7 @@
     }
   },
   "timestampStoreState" : {
-    "timestampMap" : {
-      "1" : {
-        "version" : {
-          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
-          "version" : 3
-        },
-        "commitInfo" : null
-      },
-      "11" : {
-        "version" : {
-          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
-          "version" : 5
-        },
-        "commitInfo" : null
-      },
-      "12" : {
-        "version" : {
-          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
-          "version" : 5
-        },
-        "commitInfo" : null
-      },
-      "91" : {
-        "version" : {
-          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
-          "version" : 7
-        },
-        "commitInfo" : null
-      },
-      "92" : {
-        "version" : {
-          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
-          "version" : 7
-        },
-        "commitInfo" : null
-      },
-      "93" : {
-        "version" : {
-          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
-          "version" : 7
-        },
-        "commitInfo" : null
-      }
-    },
-    "livingVersions" : {
-      "3" : [ 1 ],
-      "5" : [ 11, 12 ],
-      "7" : [ 91, 92, 93 ]
-    }
+    "timestampMap" : { },
+    "livingVersions" : { }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/processStartTimestampUpdateOnMultipleBatches/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/processStartTimestampUpdateOnMultipleBatches/event-cache-1.json
@@ -27,6 +27,9 @@
         },
         "commitInfo" : null
       }
+    },
+    "livingVersions" : {
+      "3" : [ 1 ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/processStartTimestampUpdateOnMultipleBatches/event-cache-2.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/processStartTimestampUpdateOnMultipleBatches/event-cache-2.json
@@ -70,6 +70,10 @@
         },
         "commitInfo" : null
       }
+    },
+    "livingVersions" : {
+      "3" : [ 1 ],
+      "6" : [ 5, 123 ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/processStartTimestampUpdateOnMultipleBatches/event-cache-3.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/processStartTimestampUpdateOnMultipleBatches/event-cache-3.json
@@ -73,6 +73,13 @@
         },
         "commitInfo" : null
       },
+      "123" : {
+        "version" : {
+          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
+          "version" : 6
+        },
+        "commitInfo" : null
+      },
       "6677" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
@@ -86,14 +93,12 @@
           "version" : 7
         },
         "commitInfo" : null
-      },
-      "123" : {
-        "version" : {
-          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
-          "version" : 6
-        },
-        "commitInfo" : null
       }
+    },
+    "livingVersions" : {
+      "3" : [ 1 ],
+      "6" : [ 5, 123 ],
+      "7" : [ 6677, 8888 ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/removingEntriesDoesNotRetentionVersions/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/removingEntriesDoesNotRetentionVersions/event-cache-1.json
@@ -49,20 +49,24 @@
   },
   "timestampStoreState" : {
     "timestampMap" : {
-      "16" : {
-        "version" : {
-          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
-          "version" : 6
-        },
-        "commitInfo" : null
-      },
       "1" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
         },
         "commitInfo" : null
+      },
+      "16" : {
+        "version" : {
+          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
+          "version" : 6
+        },
+        "commitInfo" : null
       }
+    },
+    "livingVersions" : {
+      "3" : [ 1 ],
+      "6" : [ 16 ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/removingEntriesDoesNotRetentionVersions/event-cache-2.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/removingEntriesDoesNotRetentionVersions/event-cache-2.json
@@ -56,6 +56,9 @@
         },
         "commitInfo" : null
       }
+    },
+    "livingVersions" : {
+      "6" : [ 16 ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/sameUpdateTwiceButDifferentTimestamps/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/sameUpdateTwiceButDifferentTimestamps/event-cache-1.json
@@ -70,6 +70,10 @@
         },
         "commitInfo" : null
       }
+    },
+    "livingVersions" : {
+      "3" : [ 1 ],
+      "6" : [ 11, 12 ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/sameUpdateTwiceButDifferentTimestamps/event-cache-2.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/sameUpdateTwiceButDifferentTimestamps/event-cache-2.json
@@ -63,14 +63,14 @@
         },
         "commitInfo" : null
       },
-      "91" : {
+      "12" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 6
         },
         "commitInfo" : null
       },
-      "12" : {
+      "91" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 6
@@ -91,6 +91,10 @@
         },
         "commitInfo" : null
       }
+    },
+    "livingVersions" : {
+      "3" : [ 1 ],
+      "6" : [ 11, 12, 91, 92, 93 ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/smallerUpdateAfterLargeUpdateDoesNotAffectCache/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/smallerUpdateAfterLargeUpdateDoesNotAffectCache/event-cache-1.json
@@ -80,6 +80,10 @@
         },
         "commitInfo" : null
       }
+    },
+    "livingVersions" : {
+      "3" : [ 1 ],
+      "7" : [ 11, 12 ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/smallerUpdateAfterLargeUpdateDoesNotAffectCache/event-cache-2.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/smallerUpdateAfterLargeUpdateDoesNotAffectCache/event-cache-2.json
@@ -73,17 +73,17 @@
         },
         "commitInfo" : null
       },
-      "91" : {
-        "version" : {
-          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
-          "version" : 5
-        },
-        "commitInfo" : null
-      },
       "12" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 7
+        },
+        "commitInfo" : null
+      },
+      "91" : {
+        "version" : {
+          "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
+          "version" : 5
         },
         "commitInfo" : null
       },
@@ -101,6 +101,11 @@
         },
         "commitInfo" : null
       }
+    },
+    "livingVersions" : {
+      "3" : [ 1 ],
+      "5" : [ 91, 92, 93 ],
+      "7" : [ 11, 12 ]
     }
   }
 }

--- a/changelog/@unreleased/pr-5339.v2.yml
+++ b/changelog/@unreleased/pr-5339.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: LockWatchEventLog now retains events for all open transactions as well as at least 1000 events.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5339


### PR DESCRIPTION
**Goals (and why)**:
Caching will be significantly more complex and less useful if we do not guarantee that we will keep events around for active transactions.

Note that this is a partial reversal of this PR: https://github.com/palantir/atlasdb/pull/5012/

**Implementation Description (bullets)**:
* `retentionEvents` now takes the earliest timestamp to keep, and only retentions events if they are before that (as well as if the size exceeds 1000).
* Changed to a `TreeMap` in `VersionedEventStore` to allow us to get the lowest timestamp.

**Testing (What was existing testing like?  What have you done to improve it?)**:
* Unit tests updated
* LWECIT also updated (and is the reason behind most of the diff).

**Concerns (what feedback would you like?)**:
It's LW, so correctness and performance, of course! Namely:
1. Does this violate any of our correctness guarantees? From what I can understand, we're just being more conservative on the retention side of things, so we're only going to keep more events, and we actually don't make any assumptions on what events exist anyway.
2. Does this cause a regression in terms of speed or memory? TreeMap over HashMap is now a log cost, but I think we use tree maps elsewhere and this is likely negligible. As for memory, we can now technically keep an arbitrary number of events around for long running transactions (at most one hour in AtlasDB). I suppose for _super_ write heavy users of LW, this could be an issue (since before we had certain guarantees that transactions were no more than 5 minutes).

**Where should we start reviewing?**:
* `VersionedEventStore`

**Priority (whenever / two weeks / yesterday)**:
Sooner rather than later, because we need this for other LW/AC stuff.
