### PR TITLE
getSortedColumns bug fix

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -145,6 +145,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.NavigableMap;
 import java.util.Objects;
 import java.util.Optional;
@@ -471,7 +472,8 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         Iterator<Map.Entry<Cell, Value>> postFilterIterator = getRowColumnRangePostFilteredWithoutSorting(
                 tableRef,
                 mergeByComparator(rawResults.values(), cellComparator),
-                batchColumnRangeSelection.getBatchHint());
+                batchColumnRangeSelection.getBatchHint(),
+                cellComparator);
         Iterator<Map.Entry<Cell, byte[]>> remoteWrites = Iterators.transform(
                 postFilterIterator,
                 entry -> Maps.immutableEntry(entry.getKey(), entry.getValue().getContents()));
@@ -623,13 +625,18 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     }
 
     private Iterator<Map.Entry<Cell, Value>> getRowColumnRangePostFilteredWithoutSorting(
-            TableReference tableRef, Iterator<Map.Entry<Cell, Value>> iterator, int batchHint) {
+            TableReference tableRef,
+            Iterator<Entry<Cell, Value>> iterator,
+            int batchHint,
+            Comparator<Cell> cellComparator) {
         return Iterators.concat(Iterators.transform(Iterators.partition(iterator, batchHint), batch -> {
             Map<Cell, Value> raw = validateBatch(tableRef, batch);
             if (raw.isEmpty()) {
                 return Collections.emptyIterator();
             }
-            Map<Cell, Value> postFiltered = ImmutableMap.copyOf(getWithPostFilteringSync(tableRef, raw, x -> x));
+
+            SortedMap<Cell, Value> postFiltered =
+                    ImmutableSortedMap.copyOf(getWithPostFilteringSync(tableRef, raw, x -> x), cellComparator);
             return postFiltered.entrySet().iterator();
         }));
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -626,7 +626,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
 
     private Iterator<Map.Entry<Cell, Value>> getRowColumnRangePostFilteredWithoutSorting(
             TableReference tableRef,
-            Iterator<Entry<Cell, Value>> iterator,
+            Iterator<Map.Entry<Cell, Value>> iterator,
             int batchHint,
             Comparator<Cell> cellComparator) {
         return Iterators.concat(Iterators.transform(Iterators.partition(iterator, batchHint), batch -> {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -145,7 +145,6 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.NavigableMap;
 import java.util.Objects;
 import java.util.Optional;

--- a/changelog/@unreleased/pr-5343.v2.yml
+++ b/changelog/@unreleased/pr-5343.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: getSortedColumns | Sorting order should be maintained after validating batch of merge-sorted entries.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5343


### PR DESCRIPTION
**Goals (and why)**:
The ordering of entries was being lost in the process of running validation checks on bat of merge-sorted entries. This PR fixes the bug. 

**Testing (What was existing testing like?  What have you done to improve it?)**:
TBD - we did validate that after this change wrong ordering is not produced on internal test stack

**Concerns (what feedback would you like?)**:
Cannot write a test

**Priority (whenever / two weeks / yesterday)**:
🔥 
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
