### PR TITLE
Sanitizing the Git Version for Correct Snapshot Publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,12 +126,7 @@ jobs:
             # hack - notion of "owners" isn't supported in Circle 2
             if [ $CIRCLE_PROJECT_USERNAME = 'palantir' ] && [ -z $CIRCLE_PR_NUMBER ]; then
               git status
-              if [[ $(git describe --tags --always --first-parent) ~= .*-[0-9]*-g.* ]]; then
-                # Publish: this is a snapshot which we need
-                ./gradlew --profile --stacktrace --continue publish;
-              else
-                echo "Won't publish develop because it equals a release tag that should be published by that tag";
-              fi
+              ./gradlew --profile --stacktrace --continue publish
             fi
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,9 @@ jobs:
             # hack - notion of "owners" isn't supported in Circle 2
             if [ $CIRCLE_PROJECT_USERNAME = 'palantir' ] && [ -z $CIRCLE_PR_NUMBER ]; then
               git status
-              ./gradlew --profile --stacktrace --continue publish
+              if [  ]; then
+                ./gradlew --profile --stacktrace --continue publish
+              fi
             fi
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,8 +126,11 @@ jobs:
             # hack - notion of "owners" isn't supported in Circle 2
             if [ $CIRCLE_PROJECT_USERNAME = 'palantir' ] && [ -z $CIRCLE_PR_NUMBER ]; then
               git status
-              if [  ]; then
-                ./gradlew --profile --stacktrace --continue publish
+              if [[ $(git describe --tags --always --first-parent) ~= .*-[0-9]*-g.* ]]; then
+                # Publish: this is a snapshot which we need
+                ./gradlew --profile --stacktrace --continue publish;
+              else
+                echo "Won't publish develop because it equals a release tag that should be published by that tag";
               fi
             fi
 

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ version = System.env.CIRCLE_TAG ?: sanitizeVersion()
 description = 'Transactional distributed database layer'
 
 def sanitizeVersion() {
-    def lastTag = "git describe --tags --always --first-parent".execute().text
+    def lastTag = "git describe --tags --always --first-parent".execute().text.trim()
     def isClean = "git status --porcelain".execute().text.isEmpty()
 
     if (isClean) {

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,14 @@ task printLastVersion {
     }
 }
 
+task isClean {
+    doLast {
+        def diff = "git status --porcelain".execute().text
+        println diff
+        println diff.isEmpty()
+    }
+}
+
 allprojects {
     repositories {
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -45,13 +45,13 @@ version = System.env.CIRCLE_TAG ?: sanitizeVersion()
 description = 'Transactional distributed database layer'
 
 def sanitizeVersion() {
-    def lastTag = "git describe --tags --always --first-parent".execute().text.trim()
     def isClean = "git status --porcelain".execute().text.isEmpty()
+    def pluginReportedVersion = gitVersion()
 
-    if (isClean) {
-        return lastTag
+    if (isClean && pluginReportedVersion.endsWith(".dirty")) {
+        return pluginReportedVersion.dropRight(".dirty".length())
     }
-    return lastTag + ".dirty"
+    return pluginReportedVersion
 }
 
 task printLastVersion {

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ apply plugin: 'com.palantir.external-publish'
 apply from: 'gradle/versions.gradle'
 
 group = 'com.palantir.atlasdb'
-version = System.env.CIRCLE_TAG ?: sanitizeVersion()
+version = sanitizeVersion()
 description = 'Transactional distributed database layer'
 
 def sanitizeVersion() {

--- a/build.gradle
+++ b/build.gradle
@@ -41,12 +41,12 @@ apply plugin: 'com.palantir.external-publish'
 apply from: 'gradle/versions.gradle'
 
 group = 'com.palantir.atlasdb'
-version = System.env.CIRCLE_TAG ?: gitVersion()
+version = System.env.CIRCLE_TAG ?: sanitizeVersion()
 description = 'Transactional distributed database layer'
 
 def sanitizeVersion() {
-    def lastTag = "git describe --tags --always --first-parent".execute().text()
-    def isClean = "git status --porcelain".execute().text().isEmpty()
+    def lastTag = "git describe --tags --always --first-parent".execute().text
+    def isClean = "git status --porcelain".execute().text.isEmpty()
 
     if (isClean) {
         return lastTag

--- a/build.gradle
+++ b/build.gradle
@@ -44,18 +44,20 @@ group = 'com.palantir.atlasdb'
 version = System.env.CIRCLE_TAG ?: gitVersion()
 description = 'Transactional distributed database layer'
 
+def sanitizeVersion() {
+    def lastTag = "git describe --tags --always --first-parent".execute().text()
+    def isClean = "git status --porcelain".execute().text().isEmpty()
+
+    if (isClean) {
+        return lastTag
+    }
+    return lastTag + ".dirty"
+}
+
 task printLastVersion {
     doLast {
         def details = versionDetails()
         println details.lastTag
-    }
-}
-
-task isClean {
-    doLast {
-        def diff = "git status --porcelain".execute().text
-        println diff
-        println diff.isEmpty()
     }
 }
 


### PR DESCRIPTION
**Goals (and why)**:
- In #5337, we switched our publishing story to use the gradle publishing plugin among other changes. Unfortunately, JGit has a six-year old bug https://bugs.eclipse.org/bugs/show_bug.cgi?id=452189 that means that we often get erroneous reports of the build being dirty.
- We normally get round this with something like `System.env.CIRCLE_TAG ?: gitVersion()`
- But Atlas does do develop snapshot publishing which that doesn't fix.

**Implementation Description (bullets)**:
- If `git status` reports the build is *clean* BUT the plugin says it is of the form `bleh.dirty`, just return `bleh` as the version.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Did some manual tests. No automated tests, sadly.

**Concerns (what feedback would you like?)**:
- Might this ever be unsafe?

**Where should we start reviewing?**: the one file

**Priority (whenever / two weeks / yesterday)**: yesterday 🔥 

@CRogers for SA / is there any pattern that we might unexpectedly be violating in this way?