### PR TITLE
add dbkvs runtime password config

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/timestamp/DbTimeLockFactory.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/timestamp/DbTimeLockFactory.java
@@ -22,8 +22,11 @@ import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.TimestampSeriesProvider;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
+import com.palantir.atlasdb.spi.KeyValueServiceRuntimeConfig;
 import com.palantir.atlasdb.util.MetricsManager;
+import com.palantir.refreshable.Refreshable;
 import com.palantir.timestamp.ManagedTimestampService;
+import java.util.Optional;
 
 /**
  * See {@link com.palantir.atlasdb.spi.AtlasDbFactory}. A {@link DbTimeLockFactory} is an extension of an
@@ -33,8 +36,21 @@ import com.palantir.timestamp.ManagedTimestampService;
 public interface DbTimeLockFactory {
     String getType();
 
+    /**
+     * @deprecated Creating a DbKeyValueService with this method will not support live reloading the DB password. Use
+     * {@link #createRawKeyValueService(MetricsManager, KeyValueServiceConfig, Refreshable, LeaderConfig)} instead.
+     */
+    @Deprecated
+    default KeyValueService createRawKeyValueService(
+            MetricsManager metricsManager, KeyValueServiceConfig config, LeaderConfig leaderConfig) {
+        return createRawKeyValueService(metricsManager, config, Refreshable.only(Optional.empty()), leaderConfig);
+    }
+
     KeyValueService createRawKeyValueService(
-            MetricsManager metricsManager, KeyValueServiceConfig config, LeaderConfig leaderConfig);
+            MetricsManager metricManager,
+            KeyValueServiceConfig config,
+            Refreshable<Optional<KeyValueServiceRuntimeConfig>> runtimeConfig,
+            LeaderConfig leaderConfig);
 
     ManagedTimestampService createManagedTimestampService(
             KeyValueService rawKvs, DbTimestampCreationSetting dbTimestampCreationSetting, boolean initializeAsync);

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
@@ -44,7 +44,14 @@ public abstract class ConnectionConfig {
 
     public abstract String getDbLogin();
 
-    public abstract MaskedValue getDbPassword();
+    /**
+     * If a runtime config is present, this does not need to be set and will not be used. A default value is provided
+     * so that the config will parse when this field is missing.
+     */
+    @Value.Default
+    public MaskedValue getDbPassword() {
+        return ImmutableMaskedValue.of("");
+    }
 
     public abstract String getUrl();
 

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/DbAtlasDbFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/DbAtlasDbFactory.java
@@ -69,7 +69,7 @@ public class DbAtlasDbFactory implements AtlasDbFactory<KeyValueServiceConfig> {
                 config instanceof DbKeyValueServiceConfig,
                 "DbAtlasDbFactory expects a configuration of type DbKeyValueServiceConfiguration, found %s",
                 config.getClass());
-        return ConnectionManagerAwareDbKvs.create((DbKeyValueServiceConfig) config, initializeAsync);
+        return ConnectionManagerAwareDbKvs.create((DbKeyValueServiceConfig) config, runtimeConfig, initializeAsync);
     }
 
     @Override

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/DbKeyValueServiceRuntimeConfig.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/DbKeyValueServiceRuntimeConfig.java
@@ -1,0 +1,38 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.dbkvs;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.auto.service.AutoService;
+import com.palantir.atlasdb.spi.KeyValueServiceRuntimeConfig;
+import com.palantir.nexus.db.pool.config.MaskedValue;
+import org.immutables.value.Value;
+
+@AutoService(KeyValueServiceRuntimeConfig.class)
+@JsonSerialize(as = ImmutableDbKeyValueServiceRuntimeConfig.class)
+@JsonDeserialize(as = ImmutableDbKeyValueServiceRuntimeConfig.class)
+@Value.Immutable
+public abstract class DbKeyValueServiceRuntimeConfig implements KeyValueServiceRuntimeConfig {
+
+    @Override
+    public String type() {
+        return DbAtlasDbFactory.TYPE;
+    }
+
+    public abstract MaskedValue getDbPassword();
+}

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/RelationalDbTimeLockFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/RelationalDbTimeLockFactory.java
@@ -30,6 +30,7 @@ import com.palantir.atlasdb.keyvalue.dbkvs.timestamp.InDbTimestampBoundStore;
 import com.palantir.atlasdb.keyvalue.dbkvs.timestamp.MultiSequenceTimestampSeriesProvider;
 import com.palantir.atlasdb.spi.AtlasDbFactory;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
+import com.palantir.atlasdb.spi.KeyValueServiceRuntimeConfig;
 import com.palantir.atlasdb.timestamp.DbTimeLockFactory;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.refreshable.Refreshable;
@@ -51,11 +52,14 @@ public class RelationalDbTimeLockFactory implements DbTimeLockFactory {
 
     @Override
     public KeyValueService createRawKeyValueService(
-            MetricsManager metricsManager, KeyValueServiceConfig config, LeaderConfig leaderConfig) {
+            MetricsManager metricsManager,
+            KeyValueServiceConfig config,
+            Refreshable<Optional<KeyValueServiceRuntimeConfig>> runtimeConfig,
+            LeaderConfig leaderConfig) {
         return delegate.createRawKeyValueService(
                 metricsManager,
                 config,
-                Refreshable.only(Optional.empty()),
+                runtimeConfig,
                 Optional.of(leaderConfig),
                 Optional.empty(), // This refers to an AtlasDB namespace - we use the config to talk to the db
                 AtlasDbFactory.THROWING_FRESH_TIMESTAMP_SOURCE, // This is how we give out timestamps!

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryDbTimeLockFactory.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryDbTimeLockFactory.java
@@ -25,12 +25,15 @@ import com.palantir.atlasdb.keyvalue.api.TimestampSeries;
 import com.palantir.atlasdb.keyvalue.api.TimestampSeriesProvider;
 import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
+import com.palantir.atlasdb.spi.KeyValueServiceRuntimeConfig;
 import com.palantir.atlasdb.timestamp.DbTimeLockFactory;
 import com.palantir.atlasdb.util.MetricsManager;
+import com.palantir.refreshable.Refreshable;
 import com.palantir.timestamp.InMemoryTimestampService;
 import com.palantir.timestamp.ManagedTimestampService;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 @AutoService(DbTimeLockFactory.class)
 public class InMemoryDbTimeLockFactory implements DbTimeLockFactory {
@@ -43,7 +46,10 @@ public class InMemoryDbTimeLockFactory implements DbTimeLockFactory {
 
     @Override
     public KeyValueService createRawKeyValueService(
-            MetricsManager metricsManager, KeyValueServiceConfig config, LeaderConfig leaderConfig) {
+            MetricsManager metricManager,
+            KeyValueServiceConfig config,
+            Refreshable<Optional<KeyValueServiceRuntimeConfig>> runtimeConfig,
+            LeaderConfig leaderConfig) {
         return new InMemoryKeyValueService(true);
     }
 

--- a/changelog/@unreleased/pr-5365.v2.yml
+++ b/changelog/@unreleased/pr-5365.v2.yml
@@ -1,0 +1,21 @@
+type: improvement
+improvement:
+  description: |-
+    add dbkvs runtime password config
+
+    **Goals (and why)**: Supports live password changes for products that use the standard atlas install and runtime config. Previously only products that had their own custom config and managed their own hikari pool could update the password at runtime. No behavior is changed when the new dbkvs runtime config is absent.
+
+    **Implementation Description (bullets)**:
+    * adds a new dbkvs runtime config
+    * when the dbkvs runtime config is absent, behavior is the same as before
+    * subscribes to the runtime config so that the hikari pool is updated any time the config changes
+
+    **Testing (What was existing testing like?  What have you done to improve it?)**:
+
+    **Concerns (what feedback would you like?)**:
+
+    **Where should we start reviewing?**:
+
+    **Priority (whenever / two weeks / yesterday)**: normal
+  links:
+  - https://github.com/palantir/atlasdb/pull/5365

--- a/changelog/@unreleased/pr-5365.v2.yml
+++ b/changelog/@unreleased/pr-5365.v2.yml
@@ -1,21 +1,6 @@
 type: improvement
 improvement:
   description: |-
-    add dbkvs runtime password config
-
-    **Goals (and why)**: Supports live password changes for products that use the standard atlas install and runtime config. Previously only products that had their own custom config and managed their own hikari pool could update the password at runtime. No behavior is changed when the new dbkvs runtime config is absent.
-
-    **Implementation Description (bullets)**:
-    * adds a new dbkvs runtime config
-    * when the dbkvs runtime config is absent, behavior is the same as before
-    * subscribes to the runtime config so that the hikari pool is updated any time the config changes
-
-    **Testing (What was existing testing like?  What have you done to improve it?)**:
-
-    **Concerns (what feedback would you like?)**:
-
-    **Where should we start reviewing?**:
-
-    **Priority (whenever / two weeks / yesterday)**: normal
+    Adds supports for live password changes for products that use the standard atlas install and runtime config. To take advantage of this products must add a runtime config for dbkvs (this appears in the same place as the cassandra runtime config would appear but has type "relational"). No behavior is changed when the new dbkvs runtime config is absent.
   links:
   - https://github.com/palantir/atlasdb/pull/5365


### PR DESCRIPTION
**Goals (and why)**: Supports live password changes for products that use the standard atlas install and runtime config. Previously only products that had their own custom config and managed their own hikari pool could update the password at runtime. No behavior is changed when the new dbkvs runtime config is absent.

**Implementation Description (bullets)**:
* adds a new dbkvs runtime config
* when the dbkvs runtime config is absent, behavior is the same as before
* subscribes to the runtime config so that the hikari pool is updated any time the config changes

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**: normal