### PR TITLE
[PDS-146088/174322] Actually take details of stacktraces

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
@@ -237,7 +237,7 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
 
     private static void expensivelyLogAllThreadState() {
         ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
-        ThreadInfo[] threadInfos = threadBean.getThreadInfo(threadBean.getAllThreadIds());
+        ThreadInfo[] threadInfos = threadBean.getThreadInfo(threadBean.getAllThreadIds(), Integer.MAX_VALUE);
         for (int index = 0; index < threadInfos.length; index++) {
             // This is superior to using standard jstacks because it is based on what we believe to be the unique
             // trigger of PDS-146088.

--- a/changelog/@unreleased/pr-5367.v2.yml
+++ b/changelog/@unreleased/pr-5367.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Cassandra client pool diagnostic thread dumps now include stack traces.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5367


### PR DESCRIPTION
**Goals (and why)**:
We want the debugging information when the cassandra client pool is in a weird state.

**Implementation Description (bullets)**:
Set up the programmatic thread dump to take the full stacktrace. From Javadoc the 0 arg constructor passes 0 for the stack depth.

**Testing (What was existing testing like?  What have you done to improve it?)**:
None

**Concerns (what feedback would you like?)**:
Nothing in particular. I think max value is safe as the thread stacks should be bounded by -Xss anyway.

**Where should we start reviewing?**: +1-1

**Priority (whenever / two weeks / yesterday)**: this week
