### PR TITLE
fix dbkvs runtime config

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/DbKeyValueServiceRuntimeConfig.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/DbKeyValueServiceRuntimeConfig.java
@@ -16,6 +16,7 @@
 
 package com.palantir.atlasdb.keyvalue.dbkvs;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.auto.service.AutoService;
@@ -26,6 +27,7 @@ import org.immutables.value.Value;
 @AutoService(KeyValueServiceRuntimeConfig.class)
 @JsonSerialize(as = ImmutableDbKeyValueServiceRuntimeConfig.class)
 @JsonDeserialize(as = ImmutableDbKeyValueServiceRuntimeConfig.class)
+@JsonTypeName(DbAtlasDbFactory.TYPE)
 @Value.Immutable
 public abstract class DbKeyValueServiceRuntimeConfig implements KeyValueServiceRuntimeConfig {
 

--- a/changelog/@unreleased/pr-5374.v2.yml
+++ b/changelog/@unreleased/pr-5374.v2.yml
@@ -1,24 +1,7 @@
 type: fix
 fix:
   description: |-
-    fix dbkvs runtime config
-
-    **Goals (and why)**: Accidentally did not set a jackson type name for the new dbkvs runtime config, which means that it relied on using the class name instead of the logical name ("relational").
-
-    **Implementation Description (bullets)**: Add missing jackson annotation.
-
-    **Testing (What was existing testing like?  What have you done to improve it?)**:
-
-    **Concerns (what feedback would you like?)**:
-
-    **Where should we start reviewing?**:
-
-    **Priority (whenever / two weeks / yesterday)**: normal
-
-    <!---
-    Please remember to:
-    - Add any necessary release notes (including breaking changes)
-    - Make sure the documentation is up to date for your change
-    --->
+    Add missing jackson type name annotation to DbKeyValueServiceRuntimeConfig.
+    This makes the intended logical type name work when jackson is parsing config.
   links:
   - https://github.com/palantir/atlasdb/pull/5374

--- a/changelog/@unreleased/pr-5374.v2.yml
+++ b/changelog/@unreleased/pr-5374.v2.yml
@@ -1,0 +1,24 @@
+type: fix
+fix:
+  description: |-
+    fix dbkvs runtime config
+
+    **Goals (and why)**: Accidentally did not set a jackson type name for the new dbkvs runtime config, which means that it relied on using the class name instead of the logical name ("relational").
+
+    **Implementation Description (bullets)**: Add missing jackson annotation.
+
+    **Testing (What was existing testing like?  What have you done to improve it?)**:
+
+    **Concerns (what feedback would you like?)**:
+
+    **Where should we start reviewing?**:
+
+    **Priority (whenever / two weeks / yesterday)**: normal
+
+    <!---
+    Please remember to:
+    - Add any necessary release notes (including breaking changes)
+    - Make sure the documentation is up to date for your change
+    --->
+  links:
+  - https://github.com/palantir/atlasdb/pull/5374


### PR DESCRIPTION
**Goals (and why)**: Accidentally did not set a jackson type name for the new dbkvs runtime config, which means that it relied on using the class name instead of the logical name ("relational").

**Implementation Description (bullets)**: Add missing jackson annotation.

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**: normal

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
