### PR TITLE
LW Caching II: Refactor current internal stores to use not raw longs

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLog.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLog.java
@@ -95,7 +95,7 @@ final class LockWatchEventLog {
         }
     }
 
-    void retentionEvents(Optional<Long> earliestSequence) {
+    void retentionEvents(Optional<Sequence> earliestSequence) {
         getLatestKnownVersion().ifPresent(version -> {
             LockWatchEvents eventsToBeRemoved = eventStore.retentionEvents(earliestSequence);
             snapshot.processEvents(eventsToBeRemoved, version.id());

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/Sequence.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/Sequence.java
@@ -16,6 +16,10 @@
 
 package com.palantir.atlasdb.keyvalue.api.watch;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.Comparator;
 import org.immutables.value.Value;
 
 /**
@@ -23,10 +27,18 @@ import org.immutables.value.Value;
  * intended to be used internally.
  */
 @Value.Immutable
-public interface Sequence {
+@JsonSerialize(as = ImmutableSequence.class)
+@JsonDeserialize(as = ImmutableSequence.class)
+public interface Sequence extends Comparable<Sequence> {
+    @JsonProperty("sequence")
     long value();
 
     static Sequence of(long value) {
         return ImmutableSequence.builder().value(value).build();
+    }
+
+    @Override
+    default int compareTo(Sequence other) {
+        return Comparator.comparingLong(Sequence::value).compare(this, other);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/Sequence.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/Sequence.java
@@ -1,0 +1,32 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.api.watch;
+
+import org.immutables.value.Value;
+
+/**
+ * Encapsulates the sequence or version number from {@link com.palantir.lock.watch.LockWatchVersion}. This is only
+ * intended to be used internally.
+ */
+@Value.Immutable
+public interface Sequence {
+    long value();
+
+    static Sequence of(long value) {
+        return ImmutableSequence.builder().value(value).build();
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/StartTimestamp.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/StartTimestamp.java
@@ -16,6 +16,10 @@
 
 package com.palantir.atlasdb.keyvalue.api.watch;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.Comparator;
 import org.immutables.value.Value;
 
 /**
@@ -23,10 +27,18 @@ import org.immutables.value.Value;
  * intended to be used internally.
  */
 @Value.Immutable
-public interface StartTimestamp {
+@JsonSerialize(as = ImmutableStartTimestamp.class)
+@JsonDeserialize(as = ImmutableStartTimestamp.class)
+public interface StartTimestamp extends Comparable<StartTimestamp> {
+    @JsonProperty("start-ts")
     long value();
 
     static StartTimestamp of(long value) {
         return ImmutableStartTimestamp.builder().value(value).build();
+    }
+
+    @Override
+    default int compareTo(StartTimestamp other) {
+        return Comparator.comparingLong(StartTimestamp::value).compare(this, other);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/StartTimestamp.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/StartTimestamp.java
@@ -1,0 +1,32 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.api.watch;
+
+import org.immutables.value.Value;
+
+/**
+ * Encapsulates a start timestamp to avoid the need to use excessive numbers of longs everywhere. This is only
+ * intended to be used internally.
+ */
+@Value.Immutable
+public interface StartTimestamp {
+    long value();
+
+    static StartTimestamp of(long value) {
+        return ImmutableStartTimestamp.builder().value(value).build();
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStore.java
@@ -28,17 +28,14 @@ import com.palantir.lock.watch.LockWatchVersion;
 import com.palantir.lock.watch.TransactionUpdate;
 import com.palantir.logsafe.Preconditions;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.NavigableMap;
 import java.util.Optional;
 import java.util.TreeMap;
 import org.immutables.value.Value;
 
 final class TimestampStateStore {
-    private final NavigableMap<StartTimestamp, MapEntry> timestampMap =
-            new TreeMap<>(Comparator.comparingLong(StartTimestamp::value));
-    private final SortedSetMultimap<Sequence, StartTimestamp> livingVersions = TreeMultimap.create(
-            Comparator.comparingLong(Sequence::value), Comparator.comparingLong(StartTimestamp::value));
+    private final NavigableMap<StartTimestamp, MapEntry> timestampMap = new TreeMap<>();
+    private final SortedSetMultimap<Sequence, StartTimestamp> livingVersions = TreeMultimap.create();
 
     void putStartTimestamps(Collection<Long> startTimestamps, LockWatchVersion version) {
         startTimestamps.stream().map(StartTimestamp::of).forEach(startTimestamp -> {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStore.java
@@ -28,26 +28,30 @@ import com.palantir.lock.watch.LockWatchVersion;
 import com.palantir.lock.watch.TransactionUpdate;
 import com.palantir.logsafe.Preconditions;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.NavigableMap;
 import java.util.Optional;
 import java.util.TreeMap;
 import org.immutables.value.Value;
 
 final class TimestampStateStore {
-    private final NavigableMap<Long, MapEntry> timestampMap = new TreeMap<>();
-    private final SortedSetMultimap<Long, Long> livingVersions = TreeMultimap.create();
+    private final NavigableMap<StartTimestamp, MapEntry> timestampMap =
+            new TreeMap<>(Comparator.comparingLong(StartTimestamp::value));
+    private final SortedSetMultimap<Sequence, StartTimestamp> livingVersions = TreeMultimap.create(
+            Comparator.comparingLong(Sequence::value), Comparator.comparingLong(StartTimestamp::value));
 
     void putStartTimestamps(Collection<Long> startTimestamps, LockWatchVersion version) {
-        startTimestamps.forEach(startTimestamp -> {
+        startTimestamps.stream().map(StartTimestamp::of).forEach(startTimestamp -> {
             MapEntry previous = timestampMap.putIfAbsent(startTimestamp, MapEntry.of(version));
             Preconditions.checkArgument(previous == null, "Start timestamp already present in map");
-            livingVersions.put(version.version(), startTimestamp);
+            livingVersions.put(Sequence.of(version.version()), startTimestamp);
         });
     }
 
     void putCommitUpdates(Collection<TransactionUpdate> transactionUpdates, LockWatchVersion newVersion) {
         transactionUpdates.forEach(transactionUpdate -> {
-            MapEntry previousEntry = timestampMap.get(transactionUpdate.startTs());
+            StartTimestamp startTimestamp = StartTimestamp.of(transactionUpdate.startTs());
+            MapEntry previousEntry = timestampMap.get(startTimestamp);
             if (previousEntry == null) {
                 throw new TransactionLockWatchFailedException("start timestamp missing from map");
             }
@@ -56,14 +60,15 @@ final class TimestampStateStore {
                     !previousEntry.commitInfo().isPresent(), "Commit info already present for given timestamp");
 
             timestampMap.replace(
-                    transactionUpdate.startTs(),
+                    startTimestamp,
                     previousEntry.withCommitInfo(CommitInfo.of(transactionUpdate.writesToken(), newVersion)));
         });
     }
 
     void remove(long startTimestamp) {
-        Optional.ofNullable(timestampMap.remove(startTimestamp))
-                .ifPresent(entry -> livingVersions.remove(entry.version().version(), startTimestamp));
+        Optional.ofNullable(timestampMap.remove(StartTimestamp.of(startTimestamp)))
+                .ifPresent(entry -> livingVersions.remove(
+                        Sequence.of(entry.version().version()), StartTimestamp.of(startTimestamp)));
     }
 
     void clear() {
@@ -72,11 +77,13 @@ final class TimestampStateStore {
     }
 
     Optional<LockWatchVersion> getStartVersion(long startTimestamp) {
-        return Optional.ofNullable(timestampMap.get(startTimestamp)).map(MapEntry::version);
+        return Optional.ofNullable(timestampMap.get(StartTimestamp.of(startTimestamp)))
+                .map(MapEntry::version);
     }
 
     Optional<CommitInfo> getCommitInfo(long startTimestamp) {
-        return Optional.ofNullable(timestampMap.get(startTimestamp)).flatMap(MapEntry::commitInfo);
+        return Optional.ofNullable(timestampMap.get(StartTimestamp.of(startTimestamp)))
+                .flatMap(MapEntry::commitInfo);
     }
 
     @VisibleForTesting
@@ -87,7 +94,7 @@ final class TimestampStateStore {
                 .build();
     }
 
-    public Optional<Long> getEarliestLiveSequence() {
+    public Optional<Sequence> getEarliestLiveSequence() {
         return Optional.ofNullable(Iterables.getFirst(livingVersions.keySet(), null));
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStoreState.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStoreState.java
@@ -26,7 +26,7 @@ import org.immutables.value.Value;
 @JsonSerialize(as = ImmutableTimestampStateStoreState.class)
 @JsonDeserialize(as = ImmutableTimestampStateStoreState.class)
 interface TimestampStateStoreState {
-    Map<Long, TimestampStateStore.MapEntry> timestampMap();
+    Map<StartTimestamp, TimestampStateStore.MapEntry> timestampMap();
 
-    SortedSetMultimap<Long, Long> livingVersions();
+    SortedSetMultimap<Sequence, StartTimestamp> livingVersions();
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStore.java
@@ -23,6 +23,7 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -32,10 +33,12 @@ import java.util.stream.Collectors;
 
 final class VersionedEventStore {
     private static final boolean INCLUSIVE = true;
+    private static final Sequence MAX_VERSION = Sequence.of(Long.MAX_VALUE);
 
     private final int minEvents;
     private final int maxEvents;
-    private final NavigableMap<Long, LockWatchEvent> eventMap = new TreeMap<>();
+    private final NavigableMap<Sequence, LockWatchEvent> eventMap =
+            new TreeMap<>(Comparator.comparingLong(Sequence::value));
 
     VersionedEventStore(int minEvents, int maxEvents) {
         Preconditions.checkArgument(minEvents > 0, "minEvents must be positive", SafeArg.of("minEvents", minEvents));
@@ -59,7 +62,7 @@ final class VersionedEventStore {
                 .orElseGet(ImmutableList::of);
     }
 
-    LockWatchEvents retentionEvents(Optional<Long> earliestSequenceToKeep) {
+    LockWatchEvents retentionEvents(Optional<Sequence> earliestSequenceToKeep) {
         if (eventMap.size() < minEvents) {
             return LockWatchEvents.builder().build();
         }
@@ -67,10 +70,9 @@ final class VersionedEventStore {
         // Guarantees that we remove some events while still also potentially performing further retention - note
         // that each call to retentionEventsInternal modifies eventMap.
         if (eventMap.size() > maxEvents) {
-            List<LockWatchEvent> overMaxSizeEvents =
-                    retentionEventsInternal(eventMap.size() - maxEvents, Long.MAX_VALUE);
+            List<LockWatchEvent> overMaxSizeEvents = retentionEventsInternal(eventMap.size() - maxEvents, MAX_VERSION);
             List<LockWatchEvent> restOfEvents =
-                    retentionEventsInternal(eventMap.size() - minEvents, earliestSequenceToKeep.orElse(Long.MAX_VALUE));
+                    retentionEventsInternal(eventMap.size() - minEvents, earliestSequenceToKeep.orElse(MAX_VERSION));
             return ImmutableLockWatchEvents.builder()
                     .addAllEvents(overMaxSizeEvents)
                     .addAllEvents(restOfEvents)
@@ -78,18 +80,18 @@ final class VersionedEventStore {
         } else {
             return ImmutableLockWatchEvents.builder()
                     .addAllEvents(retentionEventsInternal(
-                            eventMap.size() - minEvents, earliestSequenceToKeep.orElse(Long.MAX_VALUE)))
+                            eventMap.size() - minEvents, earliestSequenceToKeep.orElse(MAX_VERSION)))
                     .build();
         }
     }
 
-    private List<LockWatchEvent> retentionEventsInternal(int numToRetention, long maxVersion) {
+    private List<LockWatchEvent> retentionEventsInternal(int numToRetention, Sequence maxVersion) {
         List<LockWatchEvent> events = new ArrayList<>(numToRetention);
 
         // The correctness of this depends upon eventMap's entrySet returning entries in ascending sorted order.
-        List<Map.Entry<Long, LockWatchEvent>> eventsToClear = eventMap.entrySet().stream()
+        List<Map.Entry<Sequence, LockWatchEvent>> eventsToClear = eventMap.entrySet().stream()
                 .limit(numToRetention)
-                .filter(entry -> entry.getKey() < maxVersion)
+                .filter(entry -> entry.getKey().value() < maxVersion.value())
                 .collect(Collectors.toList());
 
         eventsToClear.forEach(entry -> {
@@ -100,12 +102,12 @@ final class VersionedEventStore {
         return events;
     }
 
-    boolean containsEntryLessThanOrEqualTo(long key) {
-        return eventMap.floorKey(key) != null;
+    boolean containsEntryLessThanOrEqualTo(long version) {
+        return eventMap.floorKey(Sequence.of(version)) != null;
     }
 
     long putAll(LockWatchEvents events) {
-        events.events().forEach(event -> eventMap.put(event.sequence(), event));
+        events.events().forEach(event -> eventMap.put(Sequence.of(event.sequence()), event));
         return getLastKey();
     }
 
@@ -119,19 +121,20 @@ final class VersionedEventStore {
     }
 
     private Collection<LockWatchEvent> getValuesBetweenInclusive(long endVersion, long startVersion) {
-        return eventMap.subMap(startVersion, INCLUSIVE, endVersion, INCLUSIVE).values();
+        return eventMap.subMap(Sequence.of(startVersion), INCLUSIVE, Sequence.of(endVersion), INCLUSIVE)
+                .values();
     }
 
     private Optional<Long> getFirstKey() {
         if (eventMap.isEmpty()) {
             return Optional.empty();
         } else {
-            return Optional.of(eventMap.firstKey());
+            return Optional.of(eventMap.firstKey()).map(Sequence::value);
         }
     }
 
     private long getLastKey() {
         Preconditions.checkState(!eventMap.isEmpty(), "Cannot get last key from empty map");
-        return eventMap.lastKey();
+        return eventMap.lastKey().value();
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStore.java
@@ -23,7 +23,6 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -37,8 +36,7 @@ final class VersionedEventStore {
 
     private final int minEvents;
     private final int maxEvents;
-    private final NavigableMap<Sequence, LockWatchEvent> eventMap =
-            new TreeMap<>(Comparator.comparingLong(Sequence::value));
+    private final NavigableMap<Sequence, LockWatchEvent> eventMap = new TreeMap<>();
 
     VersionedEventStore(int minEvents, int maxEvents) {
         Preconditions.checkArgument(minEvents > 0, "minEvents must be positive", SafeArg.of("minEvents", minEvents));

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStoreState.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStoreState.java
@@ -26,5 +26,5 @@ import org.immutables.value.Value;
 @JsonSerialize(as = ImmutableVersionedEventStoreState.class)
 @JsonDeserialize(as = ImmutableVersionedEventStoreState.class)
 interface VersionedEventStoreState {
-    NavigableMap<Long, LockWatchEvent> eventMap();
+    NavigableMap<Sequence, LockWatchEvent> eventMap();
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStoreTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStoreTest.java
@@ -47,7 +47,7 @@ public final class TimestampStateStoreTest {
         timestampStateStore.putStartTimestamps(ImmutableSet.of(100L, 200L), VERSION_1);
         timestampStateStore.putStartTimestamps(ImmutableSet.of(400L, 800L), VERSION_2);
 
-        assertThat(timestampStateStore.getEarliestLiveSequence()).hasValue(1L);
+        assertThat(timestampStateStore.getEarliestLiveSequence()).hasValue(Sequence.of(1L));
 
         removeAndCheckEarliestVersion(100L, 1L);
         removeAndCheckEarliestVersion(800L, 1L);
@@ -87,6 +87,6 @@ public final class TimestampStateStoreTest {
 
     private void removeAndCheckEarliestVersion(long timestamp, long sequence) {
         timestampStateStore.remove(timestamp);
-        assertThat(timestampStateStore.getEarliestLiveSequence()).hasValue(sequence);
+        assertThat(timestampStateStore.getEarliestLiveSequence()).hasValue(Sequence.of(sequence));
     }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStoreTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStoreTest.java
@@ -36,6 +36,12 @@ public final class VersionedEventStoreTest {
     private static final LockWatchEvent EVENT_4 =
             UnlockEvent.builder(ImmutableSet.of()).build(4L);
 
+    private static final Sequence SEQ_MIN = Sequence.of(-1L);
+    private static final Sequence SEQ_1 = Sequence.of(1L);
+    private static final Sequence SEQ_2 = Sequence.of(2L);
+    private static final Sequence SEQ_3 = Sequence.of(3L);
+    private static final Sequence SEQ_4 = Sequence.of(4L);
+
     private VersionedEventStore eventStore;
 
     @Before
@@ -46,9 +52,10 @@ public final class VersionedEventStoreTest {
     @Test
     public void retentionEventsDoesNotRetentionAfterEarliestVersion() {
         eventStore.putAll(makeEvents(EVENT_1, EVENT_2, EVENT_3, EVENT_4));
-        LockWatchEvents emptyEvents = eventStore.retentionEvents(Optional.of(-1L));
+        LockWatchEvents emptyEvents = eventStore.retentionEvents(Optional.of(SEQ_MIN));
         assertThat(emptyEvents.events()).isEmpty();
-        assertThat(eventStore.getStateForTesting().eventMap().keySet()).containsExactlyInAnyOrder(1L, 2L, 3L, 4L);
+        assertThat(eventStore.getStateForTesting().eventMap().keySet())
+                .containsExactlyInAnyOrder(SEQ_1, SEQ_2, SEQ_3, SEQ_4);
 
         LockWatchEvents events = eventStore.retentionEvents(Optional.empty());
         assertThat(events.events().stream().map(LockWatchEvent::sequence)).containsExactly(1L, 2L);
@@ -80,7 +87,7 @@ public final class VersionedEventStoreTest {
     public void retentionEventsClearsEventsOverMaxBound() {
         eventStore = new VersionedEventStore(1, 3);
         eventStore.putAll(makeEvents(EVENT_1, EVENT_2, EVENT_3, EVENT_4));
-        assertThat(eventStore.retentionEvents(Optional.of(-1L)).events().stream()
+        assertThat(eventStore.retentionEvents(Optional.of(SEQ_MIN)).events().stream()
                         .map(LockWatchEvent::sequence))
                 .as("First event retentioned anyway as it exceeds maximum size")
                 .containsExactly(1L);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStoreTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStoreTest.java
@@ -59,7 +59,7 @@ public final class VersionedEventStoreTest {
 
         LockWatchEvents events = eventStore.retentionEvents(Optional.empty());
         assertThat(events.events().stream().map(LockWatchEvent::sequence)).containsExactly(1L, 2L);
-        assertThat(eventStore.getStateForTesting().eventMap().firstKey()).isEqualTo(3L);
+        assertThat(eventStore.getStateForTesting().eventMap().firstKey()).isEqualTo(SEQ_3);
     }
 
     @Test

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/cacheClearedOnSnapshotUpdate/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/cacheClearedOnSnapshotUpdate/event-cache-1.json
@@ -65,8 +65,12 @@
       }
     },
     "livingVersions" : {
-      "Sequence{value=3}" : [ { } ],
-      "Sequence{value=6}" : [ { } ]
+      "Sequence{value=3}" : [ {
+        "start-ts" : 1
+      } ],
+      "Sequence{value=6}" : [ {
+        "start-ts" : 16
+      } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/cacheClearedOnSnapshotUpdate/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/cacheClearedOnSnapshotUpdate/event-cache-1.json
@@ -12,7 +12,7 @@
     },
     "eventStoreState" : {
       "eventMap" : {
-        "4" : {
+        "Sequence{value=4}" : {
           "type" : "created",
           "sequence" : 4,
           "references" : [ {
@@ -23,14 +23,14 @@
             "bytes" : "dGFibGUAAQ=="
           } ]
         },
-        "5" : {
+        "Sequence{value=5}" : {
           "type" : "unlock",
           "sequence" : 5,
           "lockDescriptors" : [ {
             "bytes" : "dGFibGUAAg=="
           } ]
         },
-        "6" : {
+        "Sequence{value=6}" : {
           "type" : "lock",
           "sequence" : 6,
           "lockDescriptors" : [ {
@@ -49,14 +49,14 @@
   },
   "timestampStoreState" : {
     "timestampMap" : {
-      "1" : {
+      "StartTimestamp{value=1}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
         },
         "commitInfo" : null
       },
-      "16" : {
+      "StartTimestamp{value=16}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 6
@@ -65,8 +65,8 @@
       }
     },
     "livingVersions" : {
-      "3" : [ 1 ],
-      "6" : [ 16 ]
+      "Sequence{value=3}" : [ { } ],
+      "Sequence{value=6}" : [ { } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/cacheClearedOnSnapshotUpdate/event-cache-2.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/cacheClearedOnSnapshotUpdate/event-cache-2.json
@@ -20,14 +20,14 @@
   },
   "timestampStoreState" : {
     "timestampMap" : {
-      "123" : {
+      "StartTimestamp{value=123}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 7
         },
         "commitInfo" : null
       },
-      "1255" : {
+      "StartTimestamp{value=1255}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 7
@@ -36,7 +36,7 @@
       }
     },
     "livingVersions" : {
-      "7" : [ 123, 1255 ]
+      "Sequence{value=7}" : [ { }, { } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/cacheClearedOnSnapshotUpdate/event-cache-2.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/cacheClearedOnSnapshotUpdate/event-cache-2.json
@@ -36,7 +36,11 @@
       }
     },
     "livingVersions" : {
-      "Sequence{value=7}" : [ { }, { } ]
+      "Sequence{value=7}" : [ {
+        "start-ts" : 123
+      }, {
+        "start-ts" : 1255
+      } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-1.json
@@ -29,7 +29,9 @@
       }
     },
     "livingVersions" : {
-      "Sequence{value=3}" : [ { } ]
+      "Sequence{value=3}" : [ {
+        "start-ts" : 1
+      } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-1.json
@@ -20,7 +20,7 @@
   },
   "timestampStoreState" : {
     "timestampMap" : {
-      "1" : {
+      "StartTimestamp{value=1}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
@@ -29,7 +29,7 @@
       }
     },
     "livingVersions" : {
-      "3" : [ 1 ]
+      "Sequence{value=3}" : [ { } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-2.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-2.json
@@ -29,7 +29,9 @@
       }
     },
     "livingVersions" : {
-      "Sequence{value=3}" : [ { } ]
+      "Sequence{value=3}" : [ {
+        "start-ts" : 1
+      } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-2.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-2.json
@@ -20,7 +20,7 @@
   },
   "timestampStoreState" : {
     "timestampMap" : {
-      "1" : {
+      "StartTimestamp{value=1}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
@@ -29,7 +29,7 @@
       }
     },
     "livingVersions" : {
-      "3" : [ 1 ]
+      "Sequence{value=3}" : [ { } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-3.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-3.json
@@ -36,7 +36,11 @@
       }
     },
     "livingVersions" : {
-      "Sequence{value=3}" : [ { }, { } ]
+      "Sequence{value=3}" : [ {
+        "start-ts" : 1
+      }, {
+        "start-ts" : 2
+      } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-3.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-3.json
@@ -20,14 +20,14 @@
   },
   "timestampStoreState" : {
     "timestampMap" : {
-      "1" : {
+      "StartTimestamp{value=1}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
         },
         "commitInfo" : null
       },
-      "2" : {
+      "StartTimestamp{value=2}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
@@ -36,7 +36,7 @@
       }
     },
     "livingVersions" : {
-      "3" : [ 1, 2 ]
+      "Sequence{value=3}" : [ { }, { } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-4.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-4.json
@@ -20,21 +20,21 @@
   },
   "timestampStoreState" : {
     "timestampMap" : {
-      "1" : {
+      "StartTimestamp{value=1}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
         },
         "commitInfo" : null
       },
-      "2" : {
+      "StartTimestamp{value=2}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
         },
         "commitInfo" : null
       },
-      "3" : {
+      "StartTimestamp{value=3}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
@@ -43,7 +43,7 @@
       }
     },
     "livingVersions" : {
-      "3" : [ 1, 2, 3 ]
+      "Sequence{value=3}" : [ { }, { }, { } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-4.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-4.json
@@ -43,7 +43,13 @@
       }
     },
     "livingVersions" : {
-      "Sequence{value=3}" : [ { }, { }, { } ]
+      "Sequence{value=3}" : [ {
+        "start-ts" : 1
+      }, {
+        "start-ts" : 2
+      }, {
+        "start-ts" : 3
+      } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-5.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-5.json
@@ -61,8 +61,16 @@
       }
     },
     "livingVersions" : {
-      "Sequence{value=3}" : [ { }, { }, { } ],
-      "Sequence{value=4}" : [ { } ]
+      "Sequence{value=3}" : [ {
+        "start-ts" : 1
+      }, {
+        "start-ts" : 2
+      }, {
+        "start-ts" : 3
+      } ],
+      "Sequence{value=4}" : [ {
+        "start-ts" : 99
+      } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-5.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance/event-cache-5.json
@@ -12,7 +12,7 @@
     },
     "eventStoreState" : {
       "eventMap" : {
-        "4" : {
+        "Sequence{value=4}" : {
           "type" : "lock",
           "sequence" : 4,
           "lockDescriptors" : [ {
@@ -31,28 +31,28 @@
   },
   "timestampStoreState" : {
     "timestampMap" : {
-      "1" : {
+      "StartTimestamp{value=1}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
         },
         "commitInfo" : null
       },
-      "2" : {
+      "StartTimestamp{value=2}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
         },
         "commitInfo" : null
       },
-      "3" : {
+      "StartTimestamp{value=3}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
         },
         "commitInfo" : null
       },
-      "99" : {
+      "StartTimestamp{value=99}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 4
@@ -61,8 +61,8 @@
       }
     },
     "livingVersions" : {
-      "3" : [ 1, 2, 3 ],
-      "4" : [ 99 ]
+      "Sequence{value=3}" : [ { }, { }, { } ],
+      "Sequence{value=4}" : [ { } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getCommitUpdateIsInvalidateSomeAsEventsAreRetained/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getCommitUpdateIsInvalidateSomeAsEventsAreRetained/event-cache-1.json
@@ -12,7 +12,7 @@
     },
     "eventStoreState" : {
       "eventMap" : {
-        "4" : {
+        "Sequence{value=4}" : {
           "type" : "created",
           "sequence" : 4,
           "references" : [ {
@@ -23,14 +23,14 @@
             "bytes" : "dGFibGUAAQ=="
           } ]
         },
-        "5" : {
+        "Sequence{value=5}" : {
           "type" : "unlock",
           "sequence" : 5,
           "lockDescriptors" : [ {
             "bytes" : "dGFibGUAAg=="
           } ]
         },
-        "6" : {
+        "Sequence{value=6}" : {
           "type" : "lock",
           "sequence" : 6,
           "lockDescriptors" : [ {
@@ -40,7 +40,7 @@
             "requestId" : "203fcd7a-b3d7-4c2a-9d2c-3d61cde1ba59"
           }
         },
-        "7" : {
+        "Sequence{value=7}" : {
           "type" : "lock",
           "sequence" : 7,
           "lockDescriptors" : [ {
@@ -59,7 +59,7 @@
   },
   "timestampStoreState" : {
     "timestampMap" : {
-      "1" : {
+      "StartTimestamp{value=1}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
@@ -76,7 +76,7 @@
       }
     },
     "livingVersions" : {
-      "3" : [ 1 ]
+      "Sequence{value=3}" : [ { } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getCommitUpdateIsInvalidateSomeAsEventsAreRetained/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getCommitUpdateIsInvalidateSomeAsEventsAreRetained/event-cache-1.json
@@ -76,7 +76,9 @@
       }
     },
     "livingVersions" : {
-      "Sequence{value=3}" : [ { } ]
+      "Sequence{value=3}" : [ {
+        "start-ts" : 1
+      } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getCommitUpdateIsInvalidateSomeAsEventsAreRetained/event-cache-2.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getCommitUpdateIsInvalidateSomeAsEventsAreRetained/event-cache-2.json
@@ -15,7 +15,7 @@
     },
     "eventStoreState" : {
       "eventMap" : {
-        "6" : {
+        "Sequence{value=6}" : {
           "type" : "lock",
           "sequence" : 6,
           "lockDescriptors" : [ {
@@ -25,7 +25,7 @@
             "requestId" : "203fcd7a-b3d7-4c2a-9d2c-3d61cde1ba59"
           }
         },
-        "7" : {
+        "Sequence{value=7}" : {
           "type" : "lock",
           "sequence" : 7,
           "lockDescriptors" : [ {

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getEventsForTransactionsMaxCondensing/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getEventsForTransactionsMaxCondensing/event-cache-1.json
@@ -12,7 +12,7 @@
     },
     "eventStoreState" : {
       "eventMap" : {
-        "4" : {
+        "Sequence{value=4}" : {
           "type" : "created",
           "sequence" : 4,
           "references" : [ {
@@ -23,14 +23,14 @@
             "bytes" : "dGFibGUAAQ=="
           } ]
         },
-        "5" : {
+        "Sequence{value=5}" : {
           "type" : "unlock",
           "sequence" : 5,
           "lockDescriptors" : [ {
             "bytes" : "dGFibGUAAg=="
           } ]
         },
-        "6" : {
+        "Sequence{value=6}" : {
           "type" : "lock",
           "sequence" : 6,
           "lockDescriptors" : [ {
@@ -40,7 +40,7 @@
             "requestId" : "203fcd7a-b3d7-4c2a-9d2c-3d61cde1ba59"
           }
         },
-        "7" : {
+        "Sequence{value=7}" : {
           "type" : "lock",
           "sequence" : 7,
           "lockDescriptors" : [ {
@@ -59,14 +59,14 @@
   },
   "timestampStoreState" : {
     "timestampMap" : {
-      "1" : {
+      "StartTimestamp{value=1}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
         },
         "commitInfo" : null
       },
-      "16" : {
+      "StartTimestamp{value=16}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 7
@@ -75,8 +75,8 @@
       }
     },
     "livingVersions" : {
-      "3" : [ 1 ],
-      "7" : [ 16 ]
+      "Sequence{value=3}" : [ { } ],
+      "Sequence{value=7}" : [ { } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getEventsForTransactionsMaxCondensing/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getEventsForTransactionsMaxCondensing/event-cache-1.json
@@ -75,8 +75,12 @@
       }
     },
     "livingVersions" : {
-      "Sequence{value=3}" : [ { } ],
-      "Sequence{value=7}" : [ { } ]
+      "Sequence{value=3}" : [ {
+        "start-ts" : 1
+      } ],
+      "Sequence{value=7}" : [ {
+        "start-ts" : 16
+      } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getEventsForTransactionsNoCondensing/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getEventsForTransactionsNoCondensing/event-cache-1.json
@@ -12,7 +12,7 @@
     },
     "eventStoreState" : {
       "eventMap" : {
-        "4" : {
+        "Sequence{value=4}" : {
           "type" : "created",
           "sequence" : 4,
           "references" : [ {
@@ -23,14 +23,14 @@
             "bytes" : "dGFibGUAAQ=="
           } ]
         },
-        "5" : {
+        "Sequence{value=5}" : {
           "type" : "unlock",
           "sequence" : 5,
           "lockDescriptors" : [ {
             "bytes" : "dGFibGUAAg=="
           } ]
         },
-        "6" : {
+        "Sequence{value=6}" : {
           "type" : "lock",
           "sequence" : 6,
           "lockDescriptors" : [ {
@@ -40,7 +40,7 @@
             "requestId" : "203fcd7a-b3d7-4c2a-9d2c-3d61cde1ba59"
           }
         },
-        "7" : {
+        "Sequence{value=7}" : {
           "type" : "lock",
           "sequence" : 7,
           "lockDescriptors" : [ {
@@ -59,14 +59,14 @@
   },
   "timestampStoreState" : {
     "timestampMap" : {
-      "1" : {
+      "StartTimestamp{value=1}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
         },
         "commitInfo" : null
       },
-      "16" : {
+      "StartTimestamp{value=16}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 7
@@ -75,8 +75,8 @@
       }
     },
     "livingVersions" : {
-      "3" : [ 1 ],
-      "7" : [ 16 ]
+      "Sequence{value=3}" : [ { } ],
+      "Sequence{value=7}" : [ { } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getEventsForTransactionsNoCondensing/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getEventsForTransactionsNoCondensing/event-cache-1.json
@@ -75,8 +75,12 @@
       }
     },
     "livingVersions" : {
-      "Sequence{value=3}" : [ { } ],
-      "Sequence{value=7}" : [ { } ]
+      "Sequence{value=3}" : [ {
+        "start-ts" : 1
+      } ],
+      "Sequence{value=7}" : [ {
+        "start-ts" : 16
+      } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getEventsForTransactionsSomeCondensing/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getEventsForTransactionsSomeCondensing/event-cache-1.json
@@ -65,8 +65,12 @@
       }
     },
     "livingVersions" : {
-      "Sequence{value=3}" : [ { } ],
-      "Sequence{value=6}" : [ { } ]
+      "Sequence{value=3}" : [ {
+        "start-ts" : 1
+      } ],
+      "Sequence{value=6}" : [ {
+        "start-ts" : 16
+      } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getEventsForTransactionsSomeCondensing/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getEventsForTransactionsSomeCondensing/event-cache-1.json
@@ -12,7 +12,7 @@
     },
     "eventStoreState" : {
       "eventMap" : {
-        "4" : {
+        "Sequence{value=4}" : {
           "type" : "created",
           "sequence" : 4,
           "references" : [ {
@@ -23,14 +23,14 @@
             "bytes" : "dGFibGUAAQ=="
           } ]
         },
-        "5" : {
+        "Sequence{value=5}" : {
           "type" : "unlock",
           "sequence" : 5,
           "lockDescriptors" : [ {
             "bytes" : "dGFibGUAAg=="
           } ]
         },
-        "6" : {
+        "Sequence{value=6}" : {
           "type" : "lock",
           "sequence" : 6,
           "lockDescriptors" : [ {
@@ -49,14 +49,14 @@
   },
   "timestampStoreState" : {
     "timestampMap" : {
-      "1" : {
+      "StartTimestamp{value=1}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
         },
         "commitInfo" : null
       },
-      "16" : {
+      "StartTimestamp{value=16}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 6
@@ -65,8 +65,8 @@
       }
     },
     "livingVersions" : {
-      "3" : [ 1 ],
-      "6" : [ 16 ]
+      "Sequence{value=3}" : [ { } ],
+      "Sequence{value=6}" : [ { } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getEventsForTransactionsSomeCondensing/event-cache-2.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getEventsForTransactionsSomeCondensing/event-cache-2.json
@@ -82,9 +82,15 @@
       }
     },
     "livingVersions" : {
-      "Sequence{value=3}" : [ { } ],
-      "Sequence{value=6}" : [ { } ],
-      "Sequence{value=7}" : [ { } ]
+      "Sequence{value=3}" : [ {
+        "start-ts" : 1
+      } ],
+      "Sequence{value=6}" : [ {
+        "start-ts" : 16
+      } ],
+      "Sequence{value=7}" : [ {
+        "start-ts" : 25
+      } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getEventsForTransactionsSomeCondensing/event-cache-2.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/getEventsForTransactionsSomeCondensing/event-cache-2.json
@@ -12,7 +12,7 @@
     },
     "eventStoreState" : {
       "eventMap" : {
-        "4" : {
+        "Sequence{value=4}" : {
           "type" : "created",
           "sequence" : 4,
           "references" : [ {
@@ -23,14 +23,14 @@
             "bytes" : "dGFibGUAAQ=="
           } ]
         },
-        "5" : {
+        "Sequence{value=5}" : {
           "type" : "unlock",
           "sequence" : 5,
           "lockDescriptors" : [ {
             "bytes" : "dGFibGUAAg=="
           } ]
         },
-        "6" : {
+        "Sequence{value=6}" : {
           "type" : "lock",
           "sequence" : 6,
           "lockDescriptors" : [ {
@@ -40,7 +40,7 @@
             "requestId" : "203fcd7a-b3d7-4c2a-9d2c-3d61cde1ba59"
           }
         },
-        "7" : {
+        "Sequence{value=7}" : {
           "type" : "lock",
           "sequence" : 7,
           "lockDescriptors" : [ {
@@ -59,21 +59,21 @@
   },
   "timestampStoreState" : {
     "timestampMap" : {
-      "1" : {
+      "StartTimestamp{value=1}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
         },
         "commitInfo" : null
       },
-      "16" : {
+      "StartTimestamp{value=16}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 6
         },
         "commitInfo" : null
       },
-      "25" : {
+      "StartTimestamp{value=25}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 7
@@ -82,9 +82,9 @@
       }
     },
     "livingVersions" : {
-      "3" : [ 1 ],
-      "6" : [ 16 ],
-      "7" : [ 25 ]
+      "Sequence{value=3}" : [ { } ],
+      "Sequence{value=6}" : [ { } ],
+      "Sequence{value=7}" : [ { } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/largerUpdateAfterSmallUpdateOnlyPicksUpNewEvents/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/largerUpdateAfterSmallUpdateOnlyPicksUpNewEvents/event-cache-1.json
@@ -62,8 +62,14 @@
       }
     },
     "livingVersions" : {
-      "Sequence{value=3}" : [ { } ],
-      "Sequence{value=5}" : [ { }, { } ]
+      "Sequence{value=3}" : [ {
+        "start-ts" : 1
+      } ],
+      "Sequence{value=5}" : [ {
+        "start-ts" : 11
+      }, {
+        "start-ts" : 12
+      } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/largerUpdateAfterSmallUpdateOnlyPicksUpNewEvents/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/largerUpdateAfterSmallUpdateOnlyPicksUpNewEvents/event-cache-1.json
@@ -12,7 +12,7 @@
     },
     "eventStoreState" : {
       "eventMap" : {
-        "4" : {
+        "Sequence{value=4}" : {
           "type" : "created",
           "sequence" : 4,
           "references" : [ {
@@ -23,7 +23,7 @@
             "bytes" : "dGFibGUAAQ=="
           } ]
         },
-        "5" : {
+        "Sequence{value=5}" : {
           "type" : "unlock",
           "sequence" : 5,
           "lockDescriptors" : [ {
@@ -39,21 +39,21 @@
   },
   "timestampStoreState" : {
     "timestampMap" : {
-      "1" : {
+      "StartTimestamp{value=1}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
         },
         "commitInfo" : null
       },
-      "11" : {
+      "StartTimestamp{value=11}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 5
         },
         "commitInfo" : null
       },
-      "12" : {
+      "StartTimestamp{value=12}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 5
@@ -62,8 +62,8 @@
       }
     },
     "livingVersions" : {
-      "3" : [ 1 ],
-      "5" : [ 11, 12 ]
+      "Sequence{value=3}" : [ { } ],
+      "Sequence{value=5}" : [ { }, { } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/largerUpdateAfterSmallUpdateOnlyPicksUpNewEvents/event-cache-2.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/largerUpdateAfterSmallUpdateOnlyPicksUpNewEvents/event-cache-2.json
@@ -12,7 +12,7 @@
     },
     "eventStoreState" : {
       "eventMap" : {
-        "4" : {
+        "Sequence{value=4}" : {
           "type" : "created",
           "sequence" : 4,
           "references" : [ {
@@ -23,14 +23,14 @@
             "bytes" : "dGFibGUAAQ=="
           } ]
         },
-        "5" : {
+        "Sequence{value=5}" : {
           "type" : "unlock",
           "sequence" : 5,
           "lockDescriptors" : [ {
             "bytes" : "dGFibGUAAg=="
           } ]
         },
-        "6" : {
+        "Sequence{value=6}" : {
           "type" : "lock",
           "sequence" : 6,
           "lockDescriptors" : [ {
@@ -40,7 +40,7 @@
             "requestId" : "203fcd7a-b3d7-4c2a-9d2c-3d61cde1ba59"
           }
         },
-        "7" : {
+        "Sequence{value=7}" : {
           "type" : "lock",
           "sequence" : 7,
           "lockDescriptors" : [ {
@@ -59,42 +59,42 @@
   },
   "timestampStoreState" : {
     "timestampMap" : {
-      "1" : {
+      "StartTimestamp{value=1}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
         },
         "commitInfo" : null
       },
-      "11" : {
+      "StartTimestamp{value=11}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 5
         },
         "commitInfo" : null
       },
-      "12" : {
+      "StartTimestamp{value=12}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 5
         },
         "commitInfo" : null
       },
-      "91" : {
+      "StartTimestamp{value=91}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 7
         },
         "commitInfo" : null
       },
-      "92" : {
+      "StartTimestamp{value=92}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 7
         },
         "commitInfo" : null
       },
-      "93" : {
+      "StartTimestamp{value=93}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 7
@@ -103,9 +103,9 @@
       }
     },
     "livingVersions" : {
-      "3" : [ 1 ],
-      "5" : [ 11, 12 ],
-      "7" : [ 91, 92, 93 ]
+      "Sequence{value=3}" : [ { } ],
+      "Sequence{value=5}" : [ { }, { } ],
+      "Sequence{value=7}" : [ { }, { }, { } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/largerUpdateAfterSmallUpdateOnlyPicksUpNewEvents/event-cache-2.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/largerUpdateAfterSmallUpdateOnlyPicksUpNewEvents/event-cache-2.json
@@ -103,9 +103,21 @@
       }
     },
     "livingVersions" : {
-      "Sequence{value=3}" : [ { } ],
-      "Sequence{value=5}" : [ { }, { } ],
-      "Sequence{value=7}" : [ { }, { }, { } ]
+      "Sequence{value=3}" : [ {
+        "start-ts" : 1
+      } ],
+      "Sequence{value=5}" : [ {
+        "start-ts" : 11
+      }, {
+        "start-ts" : 12
+      } ],
+      "Sequence{value=7}" : [ {
+        "start-ts" : 91
+      }, {
+        "start-ts" : 92
+      }, {
+        "start-ts" : 93
+      } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/newEventsCauseOldEventsToBeDeletedOnceTransactionsRemoved/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/newEventsCauseOldEventsToBeDeletedOnceTransactionsRemoved/event-cache-1.json
@@ -12,7 +12,7 @@
     },
     "eventStoreState" : {
       "eventMap" : {
-        "4" : {
+        "Sequence{value=4}" : {
           "type" : "created",
           "sequence" : 4,
           "references" : [ {
@@ -23,14 +23,14 @@
             "bytes" : "dGFibGUAAQ=="
           } ]
         },
-        "5" : {
+        "Sequence{value=5}" : {
           "type" : "unlock",
           "sequence" : 5,
           "lockDescriptors" : [ {
             "bytes" : "dGFibGUAAg=="
           } ]
         },
-        "6" : {
+        "Sequence{value=6}" : {
           "type" : "lock",
           "sequence" : 6,
           "lockDescriptors" : [ {
@@ -49,7 +49,7 @@
   },
   "timestampStoreState" : {
     "timestampMap" : {
-      "1" : {
+      "StartTimestamp{value=1}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
@@ -58,7 +58,7 @@
       }
     },
     "livingVersions" : {
-      "3" : [ 1 ]
+      "Sequence{value=3}" : [ { } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/newEventsCauseOldEventsToBeDeletedOnceTransactionsRemoved/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/newEventsCauseOldEventsToBeDeletedOnceTransactionsRemoved/event-cache-1.json
@@ -58,7 +58,9 @@
       }
     },
     "livingVersions" : {
-      "Sequence{value=3}" : [ { } ]
+      "Sequence{value=3}" : [ {
+        "start-ts" : 1
+      } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/newEventsCauseOldEventsToBeDeletedOnceTransactionsRemoved/event-cache-2.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/newEventsCauseOldEventsToBeDeletedOnceTransactionsRemoved/event-cache-2.json
@@ -12,7 +12,7 @@
     },
     "eventStoreState" : {
       "eventMap" : {
-        "4" : {
+        "Sequence{value=4}" : {
           "type" : "created",
           "sequence" : 4,
           "references" : [ {
@@ -23,14 +23,14 @@
             "bytes" : "dGFibGUAAQ=="
           } ]
         },
-        "5" : {
+        "Sequence{value=5}" : {
           "type" : "unlock",
           "sequence" : 5,
           "lockDescriptors" : [ {
             "bytes" : "dGFibGUAAg=="
           } ]
         },
-        "6" : {
+        "Sequence{value=6}" : {
           "type" : "lock",
           "sequence" : 6,
           "lockDescriptors" : [ {
@@ -40,7 +40,7 @@
             "requestId" : "203fcd7a-b3d7-4c2a-9d2c-3d61cde1ba59"
           }
         },
-        "7" : {
+        "Sequence{value=7}" : {
           "type" : "lock",
           "sequence" : 7,
           "lockDescriptors" : [ {
@@ -59,14 +59,14 @@
   },
   "timestampStoreState" : {
     "timestampMap" : {
-      "1" : {
+      "StartTimestamp{value=1}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
         },
         "commitInfo" : null
       },
-      "16" : {
+      "StartTimestamp{value=16}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 7
@@ -75,8 +75,8 @@
       }
     },
     "livingVersions" : {
-      "3" : [ 1 ],
-      "7" : [ 16 ]
+      "Sequence{value=3}" : [ { } ],
+      "Sequence{value=7}" : [ { } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/newEventsCauseOldEventsToBeDeletedOnceTransactionsRemoved/event-cache-2.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/newEventsCauseOldEventsToBeDeletedOnceTransactionsRemoved/event-cache-2.json
@@ -75,8 +75,12 @@
       }
     },
     "livingVersions" : {
-      "Sequence{value=3}" : [ { } ],
-      "Sequence{value=7}" : [ { } ]
+      "Sequence{value=3}" : [ {
+        "start-ts" : 1
+      } ],
+      "Sequence{value=7}" : [ {
+        "start-ts" : 16
+      } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/newEventsCauseOldEventsToBeDeletedOnceTransactionsRemoved/event-cache-3.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/newEventsCauseOldEventsToBeDeletedOnceTransactionsRemoved/event-cache-3.json
@@ -17,14 +17,14 @@
     },
     "eventStoreState" : {
       "eventMap" : {
-        "5" : {
+        "Sequence{value=5}" : {
           "type" : "unlock",
           "sequence" : 5,
           "lockDescriptors" : [ {
             "bytes" : "dGFibGUAAg=="
           } ]
         },
-        "6" : {
+        "Sequence{value=6}" : {
           "type" : "lock",
           "sequence" : 6,
           "lockDescriptors" : [ {
@@ -34,7 +34,7 @@
             "requestId" : "203fcd7a-b3d7-4c2a-9d2c-3d61cde1ba59"
           }
         },
-        "7" : {
+        "Sequence{value=7}" : {
           "type" : "lock",
           "sequence" : 7,
           "lockDescriptors" : [ {

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/processStartTimestampUpdateOnMultipleBatches/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/processStartTimestampUpdateOnMultipleBatches/event-cache-1.json
@@ -29,7 +29,9 @@
       }
     },
     "livingVersions" : {
-      "Sequence{value=3}" : [ { } ]
+      "Sequence{value=3}" : [ {
+        "start-ts" : 1
+      } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/processStartTimestampUpdateOnMultipleBatches/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/processStartTimestampUpdateOnMultipleBatches/event-cache-1.json
@@ -20,7 +20,7 @@
   },
   "timestampStoreState" : {
     "timestampMap" : {
-      "1" : {
+      "StartTimestamp{value=1}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
@@ -29,7 +29,7 @@
       }
     },
     "livingVersions" : {
-      "3" : [ 1 ]
+      "Sequence{value=3}" : [ { } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/processStartTimestampUpdateOnMultipleBatches/event-cache-2.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/processStartTimestampUpdateOnMultipleBatches/event-cache-2.json
@@ -72,8 +72,14 @@
       }
     },
     "livingVersions" : {
-      "Sequence{value=3}" : [ { } ],
-      "Sequence{value=6}" : [ { }, { } ]
+      "Sequence{value=3}" : [ {
+        "start-ts" : 1
+      } ],
+      "Sequence{value=6}" : [ {
+        "start-ts" : 5
+      }, {
+        "start-ts" : 123
+      } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/processStartTimestampUpdateOnMultipleBatches/event-cache-2.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/processStartTimestampUpdateOnMultipleBatches/event-cache-2.json
@@ -12,7 +12,7 @@
     },
     "eventStoreState" : {
       "eventMap" : {
-        "4" : {
+        "Sequence{value=4}" : {
           "type" : "created",
           "sequence" : 4,
           "references" : [ {
@@ -23,14 +23,14 @@
             "bytes" : "dGFibGUAAQ=="
           } ]
         },
-        "5" : {
+        "Sequence{value=5}" : {
           "type" : "unlock",
           "sequence" : 5,
           "lockDescriptors" : [ {
             "bytes" : "dGFibGUAAg=="
           } ]
         },
-        "6" : {
+        "Sequence{value=6}" : {
           "type" : "lock",
           "sequence" : 6,
           "lockDescriptors" : [ {
@@ -49,21 +49,21 @@
   },
   "timestampStoreState" : {
     "timestampMap" : {
-      "1" : {
+      "StartTimestamp{value=1}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
         },
         "commitInfo" : null
       },
-      "5" : {
+      "StartTimestamp{value=5}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 6
         },
         "commitInfo" : null
       },
-      "123" : {
+      "StartTimestamp{value=123}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 6
@@ -72,8 +72,8 @@
       }
     },
     "livingVersions" : {
-      "3" : [ 1 ],
-      "6" : [ 5, 123 ]
+      "Sequence{value=3}" : [ { } ],
+      "Sequence{value=6}" : [ { }, { } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/processStartTimestampUpdateOnMultipleBatches/event-cache-3.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/processStartTimestampUpdateOnMultipleBatches/event-cache-3.json
@@ -12,7 +12,7 @@
     },
     "eventStoreState" : {
       "eventMap" : {
-        "4" : {
+        "Sequence{value=4}" : {
           "type" : "created",
           "sequence" : 4,
           "references" : [ {
@@ -23,14 +23,14 @@
             "bytes" : "dGFibGUAAQ=="
           } ]
         },
-        "5" : {
+        "Sequence{value=5}" : {
           "type" : "unlock",
           "sequence" : 5,
           "lockDescriptors" : [ {
             "bytes" : "dGFibGUAAg=="
           } ]
         },
-        "6" : {
+        "Sequence{value=6}" : {
           "type" : "lock",
           "sequence" : 6,
           "lockDescriptors" : [ {
@@ -40,7 +40,7 @@
             "requestId" : "203fcd7a-b3d7-4c2a-9d2c-3d61cde1ba59"
           }
         },
-        "7" : {
+        "Sequence{value=7}" : {
           "type" : "lock",
           "sequence" : 7,
           "lockDescriptors" : [ {
@@ -59,35 +59,35 @@
   },
   "timestampStoreState" : {
     "timestampMap" : {
-      "1" : {
+      "StartTimestamp{value=1}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
         },
         "commitInfo" : null
       },
-      "5" : {
+      "StartTimestamp{value=5}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 6
         },
         "commitInfo" : null
       },
-      "123" : {
+      "StartTimestamp{value=123}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 6
         },
         "commitInfo" : null
       },
-      "6677" : {
+      "StartTimestamp{value=6677}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 7
         },
         "commitInfo" : null
       },
-      "8888" : {
+      "StartTimestamp{value=8888}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 7
@@ -96,9 +96,9 @@
       }
     },
     "livingVersions" : {
-      "3" : [ 1 ],
-      "6" : [ 5, 123 ],
-      "7" : [ 6677, 8888 ]
+      "Sequence{value=3}" : [ { } ],
+      "Sequence{value=6}" : [ { }, { } ],
+      "Sequence{value=7}" : [ { }, { } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/processStartTimestampUpdateOnMultipleBatches/event-cache-3.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/processStartTimestampUpdateOnMultipleBatches/event-cache-3.json
@@ -96,9 +96,19 @@
       }
     },
     "livingVersions" : {
-      "Sequence{value=3}" : [ { } ],
-      "Sequence{value=6}" : [ { }, { } ],
-      "Sequence{value=7}" : [ { }, { } ]
+      "Sequence{value=3}" : [ {
+        "start-ts" : 1
+      } ],
+      "Sequence{value=6}" : [ {
+        "start-ts" : 5
+      }, {
+        "start-ts" : 123
+      } ],
+      "Sequence{value=7}" : [ {
+        "start-ts" : 6677
+      }, {
+        "start-ts" : 8888
+      } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/removingEntriesDoesNotRetentionVersions/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/removingEntriesDoesNotRetentionVersions/event-cache-1.json
@@ -65,8 +65,12 @@
       }
     },
     "livingVersions" : {
-      "Sequence{value=3}" : [ { } ],
-      "Sequence{value=6}" : [ { } ]
+      "Sequence{value=3}" : [ {
+        "start-ts" : 1
+      } ],
+      "Sequence{value=6}" : [ {
+        "start-ts" : 16
+      } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/removingEntriesDoesNotRetentionVersions/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/removingEntriesDoesNotRetentionVersions/event-cache-1.json
@@ -12,7 +12,7 @@
     },
     "eventStoreState" : {
       "eventMap" : {
-        "4" : {
+        "Sequence{value=4}" : {
           "type" : "created",
           "sequence" : 4,
           "references" : [ {
@@ -23,14 +23,14 @@
             "bytes" : "dGFibGUAAQ=="
           } ]
         },
-        "5" : {
+        "Sequence{value=5}" : {
           "type" : "unlock",
           "sequence" : 5,
           "lockDescriptors" : [ {
             "bytes" : "dGFibGUAAg=="
           } ]
         },
-        "6" : {
+        "Sequence{value=6}" : {
           "type" : "lock",
           "sequence" : 6,
           "lockDescriptors" : [ {
@@ -49,14 +49,14 @@
   },
   "timestampStoreState" : {
     "timestampMap" : {
-      "1" : {
+      "StartTimestamp{value=1}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
         },
         "commitInfo" : null
       },
-      "16" : {
+      "StartTimestamp{value=16}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 6
@@ -65,8 +65,8 @@
       }
     },
     "livingVersions" : {
-      "3" : [ 1 ],
-      "6" : [ 16 ]
+      "Sequence{value=3}" : [ { } ],
+      "Sequence{value=6}" : [ { } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/removingEntriesDoesNotRetentionVersions/event-cache-2.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/removingEntriesDoesNotRetentionVersions/event-cache-2.json
@@ -58,7 +58,9 @@
       }
     },
     "livingVersions" : {
-      "Sequence{value=6}" : [ { } ]
+      "Sequence{value=6}" : [ {
+        "start-ts" : 16
+      } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/removingEntriesDoesNotRetentionVersions/event-cache-2.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/removingEntriesDoesNotRetentionVersions/event-cache-2.json
@@ -12,7 +12,7 @@
     },
     "eventStoreState" : {
       "eventMap" : {
-        "4" : {
+        "Sequence{value=4}" : {
           "type" : "created",
           "sequence" : 4,
           "references" : [ {
@@ -23,14 +23,14 @@
             "bytes" : "dGFibGUAAQ=="
           } ]
         },
-        "5" : {
+        "Sequence{value=5}" : {
           "type" : "unlock",
           "sequence" : 5,
           "lockDescriptors" : [ {
             "bytes" : "dGFibGUAAg=="
           } ]
         },
-        "6" : {
+        "Sequence{value=6}" : {
           "type" : "lock",
           "sequence" : 6,
           "lockDescriptors" : [ {
@@ -49,7 +49,7 @@
   },
   "timestampStoreState" : {
     "timestampMap" : {
-      "16" : {
+      "StartTimestamp{value=16}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 6
@@ -58,7 +58,7 @@
       }
     },
     "livingVersions" : {
-      "6" : [ 16 ]
+      "Sequence{value=6}" : [ { } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/sameUpdateTwiceButDifferentTimestamps/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/sameUpdateTwiceButDifferentTimestamps/event-cache-1.json
@@ -72,8 +72,14 @@
       }
     },
     "livingVersions" : {
-      "Sequence{value=3}" : [ { } ],
-      "Sequence{value=6}" : [ { }, { } ]
+      "Sequence{value=3}" : [ {
+        "start-ts" : 1
+      } ],
+      "Sequence{value=6}" : [ {
+        "start-ts" : 11
+      }, {
+        "start-ts" : 12
+      } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/sameUpdateTwiceButDifferentTimestamps/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/sameUpdateTwiceButDifferentTimestamps/event-cache-1.json
@@ -12,7 +12,7 @@
     },
     "eventStoreState" : {
       "eventMap" : {
-        "4" : {
+        "Sequence{value=4}" : {
           "type" : "created",
           "sequence" : 4,
           "references" : [ {
@@ -23,14 +23,14 @@
             "bytes" : "dGFibGUAAQ=="
           } ]
         },
-        "5" : {
+        "Sequence{value=5}" : {
           "type" : "unlock",
           "sequence" : 5,
           "lockDescriptors" : [ {
             "bytes" : "dGFibGUAAg=="
           } ]
         },
-        "6" : {
+        "Sequence{value=6}" : {
           "type" : "lock",
           "sequence" : 6,
           "lockDescriptors" : [ {
@@ -49,21 +49,21 @@
   },
   "timestampStoreState" : {
     "timestampMap" : {
-      "1" : {
+      "StartTimestamp{value=1}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
         },
         "commitInfo" : null
       },
-      "11" : {
+      "StartTimestamp{value=11}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 6
         },
         "commitInfo" : null
       },
-      "12" : {
+      "StartTimestamp{value=12}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 6
@@ -72,8 +72,8 @@
       }
     },
     "livingVersions" : {
-      "3" : [ 1 ],
-      "6" : [ 11, 12 ]
+      "Sequence{value=3}" : [ { } ],
+      "Sequence{value=6}" : [ { }, { } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/sameUpdateTwiceButDifferentTimestamps/event-cache-2.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/sameUpdateTwiceButDifferentTimestamps/event-cache-2.json
@@ -12,7 +12,7 @@
     },
     "eventStoreState" : {
       "eventMap" : {
-        "4" : {
+        "Sequence{value=4}" : {
           "type" : "created",
           "sequence" : 4,
           "references" : [ {
@@ -23,14 +23,14 @@
             "bytes" : "dGFibGUAAQ=="
           } ]
         },
-        "5" : {
+        "Sequence{value=5}" : {
           "type" : "unlock",
           "sequence" : 5,
           "lockDescriptors" : [ {
             "bytes" : "dGFibGUAAg=="
           } ]
         },
-        "6" : {
+        "Sequence{value=6}" : {
           "type" : "lock",
           "sequence" : 6,
           "lockDescriptors" : [ {
@@ -49,42 +49,42 @@
   },
   "timestampStoreState" : {
     "timestampMap" : {
-      "1" : {
+      "StartTimestamp{value=1}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
         },
         "commitInfo" : null
       },
-      "11" : {
+      "StartTimestamp{value=11}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 6
         },
         "commitInfo" : null
       },
-      "12" : {
+      "StartTimestamp{value=12}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 6
         },
         "commitInfo" : null
       },
-      "91" : {
+      "StartTimestamp{value=91}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 6
         },
         "commitInfo" : null
       },
-      "92" : {
+      "StartTimestamp{value=92}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 6
         },
         "commitInfo" : null
       },
-      "93" : {
+      "StartTimestamp{value=93}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 6
@@ -93,8 +93,8 @@
       }
     },
     "livingVersions" : {
-      "3" : [ 1 ],
-      "6" : [ 11, 12, 91, 92, 93 ]
+      "Sequence{value=3}" : [ { } ],
+      "Sequence{value=6}" : [ { }, { }, { }, { }, { } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/sameUpdateTwiceButDifferentTimestamps/event-cache-2.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/sameUpdateTwiceButDifferentTimestamps/event-cache-2.json
@@ -93,8 +93,20 @@
       }
     },
     "livingVersions" : {
-      "Sequence{value=3}" : [ { } ],
-      "Sequence{value=6}" : [ { }, { }, { }, { }, { } ]
+      "Sequence{value=3}" : [ {
+        "start-ts" : 1
+      } ],
+      "Sequence{value=6}" : [ {
+        "start-ts" : 11
+      }, {
+        "start-ts" : 12
+      }, {
+        "start-ts" : 91
+      }, {
+        "start-ts" : 92
+      }, {
+        "start-ts" : 93
+      } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/smallerUpdateAfterLargeUpdateDoesNotAffectCache/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/smallerUpdateAfterLargeUpdateDoesNotAffectCache/event-cache-1.json
@@ -82,8 +82,14 @@
       }
     },
     "livingVersions" : {
-      "Sequence{value=3}" : [ { } ],
-      "Sequence{value=7}" : [ { }, { } ]
+      "Sequence{value=3}" : [ {
+        "start-ts" : 1
+      } ],
+      "Sequence{value=7}" : [ {
+        "start-ts" : 11
+      }, {
+        "start-ts" : 12
+      } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/smallerUpdateAfterLargeUpdateDoesNotAffectCache/event-cache-1.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/smallerUpdateAfterLargeUpdateDoesNotAffectCache/event-cache-1.json
@@ -12,7 +12,7 @@
     },
     "eventStoreState" : {
       "eventMap" : {
-        "4" : {
+        "Sequence{value=4}" : {
           "type" : "created",
           "sequence" : 4,
           "references" : [ {
@@ -23,14 +23,14 @@
             "bytes" : "dGFibGUAAQ=="
           } ]
         },
-        "5" : {
+        "Sequence{value=5}" : {
           "type" : "unlock",
           "sequence" : 5,
           "lockDescriptors" : [ {
             "bytes" : "dGFibGUAAg=="
           } ]
         },
-        "6" : {
+        "Sequence{value=6}" : {
           "type" : "lock",
           "sequence" : 6,
           "lockDescriptors" : [ {
@@ -40,7 +40,7 @@
             "requestId" : "203fcd7a-b3d7-4c2a-9d2c-3d61cde1ba59"
           }
         },
-        "7" : {
+        "Sequence{value=7}" : {
           "type" : "lock",
           "sequence" : 7,
           "lockDescriptors" : [ {
@@ -59,21 +59,21 @@
   },
   "timestampStoreState" : {
     "timestampMap" : {
-      "1" : {
+      "StartTimestamp{value=1}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
         },
         "commitInfo" : null
       },
-      "11" : {
+      "StartTimestamp{value=11}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 7
         },
         "commitInfo" : null
       },
-      "12" : {
+      "StartTimestamp{value=12}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 7
@@ -82,8 +82,8 @@
       }
     },
     "livingVersions" : {
-      "3" : [ 1 ],
-      "7" : [ 11, 12 ]
+      "Sequence{value=3}" : [ { } ],
+      "Sequence{value=7}" : [ { }, { } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/smallerUpdateAfterLargeUpdateDoesNotAffectCache/event-cache-2.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/smallerUpdateAfterLargeUpdateDoesNotAffectCache/event-cache-2.json
@@ -103,9 +103,21 @@
       }
     },
     "livingVersions" : {
-      "Sequence{value=3}" : [ { } ],
-      "Sequence{value=5}" : [ { }, { }, { } ],
-      "Sequence{value=7}" : [ { }, { } ]
+      "Sequence{value=3}" : [ {
+        "start-ts" : 1
+      } ],
+      "Sequence{value=5}" : [ {
+        "start-ts" : 91
+      }, {
+        "start-ts" : 92
+      }, {
+        "start-ts" : 93
+      } ],
+      "Sequence{value=7}" : [ {
+        "start-ts" : 11
+      }, {
+        "start-ts" : 12
+      } ]
     }
   }
 }

--- a/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/smallerUpdateAfterLargeUpdateDoesNotAffectCache/event-cache-2.json
+++ b/atlasdb-impl-shared/src/test/resources/lockwatch-event-cache-output/smallerUpdateAfterLargeUpdateDoesNotAffectCache/event-cache-2.json
@@ -12,7 +12,7 @@
     },
     "eventStoreState" : {
       "eventMap" : {
-        "4" : {
+        "Sequence{value=4}" : {
           "type" : "created",
           "sequence" : 4,
           "references" : [ {
@@ -23,14 +23,14 @@
             "bytes" : "dGFibGUAAQ=="
           } ]
         },
-        "5" : {
+        "Sequence{value=5}" : {
           "type" : "unlock",
           "sequence" : 5,
           "lockDescriptors" : [ {
             "bytes" : "dGFibGUAAg=="
           } ]
         },
-        "6" : {
+        "Sequence{value=6}" : {
           "type" : "lock",
           "sequence" : 6,
           "lockDescriptors" : [ {
@@ -40,7 +40,7 @@
             "requestId" : "203fcd7a-b3d7-4c2a-9d2c-3d61cde1ba59"
           }
         },
-        "7" : {
+        "Sequence{value=7}" : {
           "type" : "lock",
           "sequence" : 7,
           "lockDescriptors" : [ {
@@ -59,42 +59,42 @@
   },
   "timestampStoreState" : {
     "timestampMap" : {
-      "1" : {
+      "StartTimestamp{value=1}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 3
         },
         "commitInfo" : null
       },
-      "11" : {
+      "StartTimestamp{value=11}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 7
         },
         "commitInfo" : null
       },
-      "12" : {
+      "StartTimestamp{value=12}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 7
         },
         "commitInfo" : null
       },
-      "91" : {
+      "StartTimestamp{value=91}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 5
         },
         "commitInfo" : null
       },
-      "92" : {
+      "StartTimestamp{value=92}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 5
         },
         "commitInfo" : null
       },
-      "93" : {
+      "StartTimestamp{value=93}" : {
         "version" : {
           "id" : "470c855e-f77b-44df-b56a-14d3df085dbc",
           "version" : 5
@@ -103,9 +103,9 @@
       }
     },
     "livingVersions" : {
-      "3" : [ 1 ],
-      "5" : [ 91, 92, 93 ],
-      "7" : [ 11, 12 ]
+      "Sequence{value=3}" : [ { } ],
+      "Sequence{value=5}" : [ { }, { }, { } ],
+      "Sequence{value=7}" : [ { }, { } ]
     }
   }
 }


### PR DESCRIPTION
**Goals (and why)**:
Too many longs in these datastructures makes it hard to reason about what is going on.

**Implementation Description (bullets)**:
Replaced `<Long>` things with either `Sequence` or `StartTimestamp` to make it much clearer what the hell is going. Note that I didn't do this for API things - the scope is mostly where we could very easily confuse which was which.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Just fixed tests. Warning, a lot of json changes (but this is good because it'll become much much clearer what these longs are).

**Concerns (what feedback would you like?)**:
Hopefully this isn't uglier.

**Where should we start reviewing?**:
diff

**Priority (whenever / two weeks / yesterday)**:
Today to unblock things.

