### PR TITLE
[PDS-180370] Targeted Sweep Migration Docs Should Comment On When To Change Transaction Types

### DIFF
--- a/docs/source/cluster_management/sweep/targeted-sweep.rst
+++ b/docs/source/cluster_management/sweep/targeted-sweep.rst
@@ -67,6 +67,12 @@ Changing Sweep Strategy for a Table
    Consult with the AtlasDB team before changing the sweep strategy of a table. Doing this incorrectly can invalidate
    AtlasDB's correctness guarantees.
 
+.. danger::
+
+   Throughout this section, when distinct sequential steps are indicated to roll the cluster from one version to
+   another, it is imperative that each roll is complete before the next roll begins, and also that rolls that skip any
+   version in the sequence are not allowed.
+
 Whenever targeted sweep enqueues a write into the sweep queue, it does so using the latest known sweep strategy for the
 table. If the sweep strategy for that table later changes, **targeted sweep does not recheck the strategy**, and will
 therefore sweep those entries using the old strategy.

--- a/docs/source/cluster_management/sweep/targeted-sweep.rst
+++ b/docs/source/cluster_management/sweep/targeted-sweep.rst
@@ -71,7 +71,7 @@ Changing Sweep Strategy for a Table
 
    Throughout this section, when distinct sequential steps are indicated to roll the cluster from one version to
    another, it is imperative that each roll is complete before the next roll begins, and also that rolls that skip any
-   version in the sequence are not allowed.
+   version in the sequence are not allowed. Failure to follow this may result in **SEVERE DATA CORRUPTION**(TM).
 
 Whenever targeted sweep enqueues a write into the sweep queue, it does so using the latest known sweep strategy for the
 table. If the sweep strategy for that table later changes, **targeted sweep does not recheck the strategy**, and will

--- a/docs/source/cluster_management/sweep/targeted-sweep.rst
+++ b/docs/source/cluster_management/sweep/targeted-sweep.rst
@@ -71,7 +71,7 @@ Changing Sweep Strategy for a Table
 
    Throughout this section, when distinct sequential steps are indicated to roll the cluster from one version to
    another, it is imperative that each roll is complete before the next roll begins, and also that rolls that skip any
-   version in the sequence are not allowed. Failure to follow this may result in **SEVERE DATA CORRUPTION**(TM).
+   version in the sequence are not allowed. Failure to follow this may result in **SEVERE DATA CORRUPTION**\ (TM).
 
 Whenever targeted sweep enqueues a write into the sweep queue, it does so using the latest known sweep strategy for the
 table. If the sweep strategy for that table later changes, **targeted sweep does not recheck the strategy**, and will


### PR DESCRIPTION
**Goals (and why)**:
- Avoid liveness issues seen in e.g. PDS-180730
- It is non-intuitive that switching to read-only transactions MUST currently happen in a distinct upgrade from the upgrade to THOROUGH_MIGRATION.

**Implementation Description (bullets)**:
- Outline this

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Docs

**Concerns (what feedback would you like?)**:
- Is the reverse process correct?

**Where should we start reviewing?**: small

**Priority (whenever / two weeks / yesterday)**: this week please