### PR TITLE
Reduce flakes on TargetedSweepEteTest

### DIFF
--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/StreamTestUtils.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/StreamTestUtils.java
@@ -25,9 +25,17 @@ public final class StreamTestUtils {
     }
 
     public static void storeFiveStreams(TodoResource todoClient, int streamSize) {
+        storeStreams(todoClient, streamSize, 5);
+    }
+
+    public static void storeThreeStreams(TodoResource todoClient, int streamSize) {
+        storeStreams(todoClient, streamSize, 3);
+    }
+
+    private static void storeStreams(TodoResource todoClient, int streamSize, int streamsCount) {
         Random random = new Random();
         byte[] bytes = new byte[streamSize];
-        for (int i = 0; i < 5; i++) {
+        for (int i = 0; i < streamsCount; i++) {
             random.nextBytes(bytes);
             todoClient.storeSnapshot(PtBytes.toString(bytes));
         }


### PR DESCRIPTION
**Goals (and why)**:
Flakes, flakes, flakes.

**Implementation Description (bullets)**:
* Reduce the number of stored streams
* Add flake retrying rule
* Reduce complexity of test

**Testing (What was existing testing like?  What have you done to improve it?)**:
This is a test PR.

**Concerns (what feedback would you like?)**:
Do we lose _useful_ signal here?

**Where should we start reviewing?**:
TWET.

**Priority (whenever / two weeks / yesterday)**:
ASAP to reduce flakes!
