### PR TITLE
[WIP][LW] Resilient Cache for values

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheImpl.java
@@ -17,6 +17,7 @@
 package com.palantir.atlasdb.keyvalue.api.watch;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.palantir.atlasdb.keyvalue.api.ResilientLockWatchProxy;
 import com.palantir.atlasdb.keyvalue.api.watch.TimestampStateStore.CommitInfo;
 import com.palantir.atlasdb.transaction.api.TransactionLockWatchFailedException;
 import com.palantir.atlasdb.util.MetricsManager;
@@ -32,7 +33,7 @@ import java.util.Optional;
 import java.util.Set;
 
 /**
- * This class should only be used through {@link ResilientLockWatchEventCache} as a proxy; failure to do so will result
+ * This class should only be used through {@link ResilientLockWatchProxy} as a proxy; failure to do so will result
  * in concurrency issues and inconsistency in the cache state.
  */
 public final class LockWatchEventCacheImpl implements LockWatchEventCache {
@@ -44,7 +45,7 @@ public final class LockWatchEventCacheImpl implements LockWatchEventCache {
     private final TimestampStateStore timestampStateStore;
 
     public static LockWatchEventCache create(MetricsManager metricsManager) {
-        return ResilientLockWatchEventCache.newProxyInstance(
+        return ResilientLockWatchProxy.newEventCacheProxy(
                 new LockWatchEventCacheImpl(LockWatchEventLog.create(MIN_EVENTS, MAX_EVENTS)),
                 NoOpLockWatchEventCache.create(),
                 metricsManager);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/ResilientLockWatchProxyTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/ResilientLockWatchProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.atlasdb.keyvalue.api.watch;
+package com.palantir.atlasdb.keyvalue.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -37,7 +37,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public final class ResilientLockWatchEventCacheTest {
+public final class ResilientLockWatchProxyTest {
 
     private final MetricsManager metricsManager =
             new MetricsManager(new MetricRegistry(), new DefaultTaggedMetricRegistry(), unused -> false);
@@ -52,7 +52,7 @@ public final class ResilientLockWatchEventCacheTest {
 
     @Before
     public void before() {
-        proxyCache = ResilientLockWatchEventCache.newProxyInstance(defaultCache, fallbackCache, metricsManager);
+        proxyCache = ResilientLockWatchProxy.newEventCacheProxy(defaultCache, fallbackCache, metricsManager);
     }
 
     @Test

--- a/changelog/@unreleased/pr-5416.v2.yml
+++ b/changelog/@unreleased/pr-5416.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Refactor the resilient cache proxy to support the value cache as well as the event cache.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5416


### PR DESCRIPTION
**Goals (and why)**:
* We want to be able to fall back to a no-op cache for the value cache too.

**Implementation Description (bullets)**:
* Modify the `ResilientLockWatchEventCache` to be a more generic proxy appropriate for both event and value cache.
* Since not all methods are synchronised on the value cache, do some magic to not always run the methods as synchronised.

**Testing (What was existing testing like?  What have you done to improve it?)**:
WIP

**Concerns (what feedback would you like?)**:
Is this just worse than having two very similar proxies? Maybe a common proxy and two variants?

**Where should we start reviewing?**:
`ResilientLockWatchProxy`

**Priority (whenever / two weeks / yesterday)**:
This week or early next week.
