### PR TITLE
[LW] Fix rare edge case

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLog.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLog.java
@@ -163,7 +163,13 @@ final class LockWatchEventLog {
 
         if (success.lastKnownVersion() > latestVersion.get().version()) {
             LockWatchEvents events =
-                    LockWatchEvents.builder().addAllEvents(success.events()).build();
+                    LockWatchEvents.builder().events(success.events()).build();
+            if (events.events().isEmpty()) {
+                throw new TransactionLockWatchFailedException("Success event has a later version than the current "
+                        + "version, but has no events to bridge the gap. The transaction should be tried, but this "
+                        + "should only happen rarely.");
+            }
+
             events.assertNoEventsAreMissingAfterLatestVersion(latestVersion);
             latestVersion = Optional.of(LockWatchVersion.of(success.logId(), eventStore.putAll(events)));
         }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheIntegrationTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheIntegrationTest.java
@@ -156,6 +156,17 @@ public class LockWatchEventCacheIntegrationTest {
     }
 
     @Test
+    public void successUpdateWithNoEventsButLaterVersionThrowsRetryableException() {
+        LockWatchStateUpdate emptySuccess = LockWatchStateUpdate.success(LEADER, 4L, ImmutableList.of());
+        setupInitialState();
+        assertThatThrownBy(() -> eventCache.processStartTransactionsUpdate(TIMESTAMPS_2, emptySuccess))
+                .isExactlyInstanceOf(TransactionLockWatchFailedException.class)
+                .hasMessage(
+                        "Success event has a later version than the current version, but has no events to bridge the "
+                                + "gap. The transaction should be tried, but this should only happen rarely.");
+    }
+
+    @Test
     public void emptySuccessesFollowingSnapshotsDoNotCauseAdditionalCacheClearance() {
         LockWatchStateUpdate snapshot =
                 LockWatchStateUpdate.snapshot(LEADER, 3L, ImmutableSet.of(DESCRIPTOR_2), ImmutableSet.of());

--- a/changelog/@unreleased/pr-5417.v2.yml
+++ b/changelog/@unreleased/pr-5417.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Handle a rare edge case where an empty success update causes the lock watch event cache to throw a non-retryable exception.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5417


### PR DESCRIPTION
**Goals (and why)**:
In the last month, we've had a single instance where a success event has been received with no events but a later version than the one known in LWEC. I don't know how, and my read of the code didn't yield how, but I think we should just retry in this case.

**Implementation Description (bullets)**:
* Retry on success event edge case.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added test to LWECIT.

**Concerns (what feedback would you like?)**:
I still don't know how we hit this, and I am a little concerned, but at least we throw instead of silently accepting it. Understanding how we hit this / reproing would be great, but the fact that it is so rare makes this probably quite hard.

**Where should we start reviewing?**:
diff

**Priority (whenever / two weeks / yesterday)**:
Sooner rather than later!
