### PR TITLE
[LW] Resilient Proxy for the value cache

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/ResilientLockWatchProxy.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/ResilientLockWatchProxy.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package com.palantir.atlasdb.keyvalue.api.watch;
+package com.palantir.atlasdb.keyvalue.api;
 
 import com.codahale.metrics.Counter;
 import com.google.common.reflect.AbstractInvocationHandler;
-import com.google.errorprone.annotations.concurrent.GuardedBy;
+import com.palantir.atlasdb.keyvalue.api.cache.LockWatchValueScopingCache;
 import com.palantir.atlasdb.transaction.api.TransactionLockWatchFailedException;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.lock.watch.LockWatchEventCache;
@@ -26,38 +26,46 @@ import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import javax.annotation.concurrent.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-final class ResilientLockWatchEventCache extends AbstractInvocationHandler {
+@ThreadSafe
+public final class ResilientLockWatchProxy<T> extends AbstractInvocationHandler {
+    private static final Logger log = LoggerFactory.getLogger(ResilientLockWatchProxy.class);
 
-    private static final Logger log = LoggerFactory.getLogger(ResilientLockWatchEventCache.class);
-
-    static LockWatchEventCache newProxyInstance(
+    public static LockWatchEventCache newEventCacheProxy(
             LockWatchEventCache defaultCache, LockWatchEventCache fallbackCache, MetricsManager metricsManager) {
         return (LockWatchEventCache) Proxy.newProxyInstance(
                 LockWatchEventCache.class.getClassLoader(),
                 new Class<?>[] {LockWatchEventCache.class},
-                new ResilientLockWatchEventCache(defaultCache, fallbackCache, metricsManager));
+                new ResilientLockWatchProxy<>(defaultCache, fallbackCache, metricsManager));
     }
 
-    private final LockWatchEventCache fallbackCache;
+    public static LockWatchValueScopingCache newValueCacheProxy(
+            LockWatchValueScopingCache defaultCache,
+            LockWatchValueScopingCache fallbackCache,
+            MetricsManager metricsManager) {
+        return (LockWatchValueScopingCache) Proxy.newProxyInstance(
+                LockWatchValueScopingCache.class.getClassLoader(),
+                new Class<?>[] {LockWatchValueScopingCache.class},
+                new ResilientLockWatchProxy<>(defaultCache, fallbackCache, metricsManager));
+    }
+
+    private final T fallbackCache;
     private final Counter fallbackCacheSelectedCounter;
 
-    @GuardedBy("this")
-    private LockWatchEventCache delegate;
+    private volatile T delegate;
 
-    private ResilientLockWatchEventCache(
-            LockWatchEventCache defaultCache, LockWatchEventCache fallbackCache, MetricsManager metricsManager) {
+    private ResilientLockWatchProxy(T defaultCache, T fallbackCache, MetricsManager metricsManager) {
         this.delegate = defaultCache;
         this.fallbackCache = fallbackCache;
         this.fallbackCacheSelectedCounter =
-                metricsManager.registerOrGetCounter(ResilientLockWatchEventCache.class, "fallbackCacheSelectedCounter");
+                metricsManager.registerOrGetCounter(ResilientLockWatchProxy.class, "fallbackCacheSelectedCounter");
     }
 
     @Override
-    protected synchronized Object handleInvocation(Object proxy, Method method, Object[] args)
-            throws IllegalAccessException {
+    protected Object handleInvocation(Object proxy, Method method, Object[] args) throws IllegalAccessException {
         try {
             return method.invoke(delegate, args);
         } catch (InvocationTargetException e) {
@@ -65,7 +73,7 @@ final class ResilientLockWatchEventCache extends AbstractInvocationHandler {
         }
     }
 
-    synchronized RuntimeException handleException(InvocationTargetException rethrow) {
+    private synchronized RuntimeException handleException(InvocationTargetException rethrow) {
         try {
             throw rethrow.getCause();
         } catch (TransactionLockWatchFailedException e) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/ResilientLockWatchProxy.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/ResilientLockWatchProxy.java
@@ -39,7 +39,7 @@ public final class ResilientLockWatchProxy<T> extends AbstractInvocationHandler 
         return (LockWatchEventCache) Proxy.newProxyInstance(
                 LockWatchEventCache.class.getClassLoader(),
                 new Class<?>[] {LockWatchEventCache.class},
-                new ResilientLockWatchProxy<>(defaultCache, fallbackCache, metricsManager));
+                new ResilientLockWatchProxy<>(defaultCache, fallbackCache, metricsManager, "eventCacheFallbackCount"));
     }
 
     public static LockWatchValueScopingCache newValueCacheProxy(
@@ -49,7 +49,7 @@ public final class ResilientLockWatchProxy<T> extends AbstractInvocationHandler 
         return (LockWatchValueScopingCache) Proxy.newProxyInstance(
                 LockWatchValueScopingCache.class.getClassLoader(),
                 new Class<?>[] {LockWatchValueScopingCache.class},
-                new ResilientLockWatchProxy<>(defaultCache, fallbackCache, metricsManager));
+                new ResilientLockWatchProxy<>(defaultCache, fallbackCache, metricsManager, "valueCacheFallbackCount"));
     }
 
     private final T fallbackCache;
@@ -57,11 +57,11 @@ public final class ResilientLockWatchProxy<T> extends AbstractInvocationHandler 
 
     private volatile T delegate;
 
-    private ResilientLockWatchProxy(T defaultCache, T fallbackCache, MetricsManager metricsManager) {
+    private ResilientLockWatchProxy(T defaultCache, T fallbackCache, MetricsManager metricsManager, String metricName) {
         this.delegate = defaultCache;
         this.fallbackCache = fallbackCache;
         this.fallbackCacheSelectedCounter =
-                metricsManager.registerOrGetCounter(ResilientLockWatchProxy.class, "fallbackCacheSelectedCounter");
+                metricsManager.registerOrGetCounter(ResilientLockWatchProxy.class, metricName);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
@@ -16,14 +16,17 @@
 
 package com.palantir.atlasdb.keyvalue.api.cache;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.palantir.atlasdb.keyvalue.api.AtlasLockDescriptorUtils;
 import com.palantir.atlasdb.keyvalue.api.CellReference;
+import com.palantir.atlasdb.keyvalue.api.ResilientLockWatchProxy;
 import com.palantir.atlasdb.keyvalue.api.watch.Sequence;
 import com.palantir.atlasdb.keyvalue.api.watch.StartTimestamp;
 import com.palantir.atlasdb.transaction.api.TransactionLockWatchFailedException;
+import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.common.streams.KeyedStream;
 import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.watch.CommitUpdate;
@@ -33,29 +36,46 @@ import com.palantir.lock.watch.LockWatchEventCache;
 import com.palantir.lock.watch.LockWatchVersion;
 import com.palantir.lock.watch.TransactionsLockWatchUpdate;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
 @ThreadSafe
 public final class LockWatchValueScopingCacheImpl implements LockWatchValueScopingCache {
     private final LockWatchEventCache eventCache;
-    private final ValueStore valueStore;
-    private final SnapshotStore snapshotStore;
-    private final CacheStore cacheStore;
     private final double validationProbability;
+    private final CacheStore cacheStore;
 
+    @GuardedBy("this")
+    private final ValueStore valueStore;
+
+    @GuardedBy("this")
+    private final SnapshotStore snapshotStore;
+
+    @GuardedBy("this")
     private volatile Optional<LockWatchVersion> currentVersion = Optional.empty();
 
-    public LockWatchValueScopingCacheImpl(
-            LockWatchEventCache eventCache, long maxCacheSize, double validationProbability) {
+    @VisibleForTesting
+    LockWatchValueScopingCacheImpl(LockWatchEventCache eventCache, long maxCacheSize, double validationProbability) {
         this.eventCache = eventCache;
         this.valueStore = new ValueStoreImpl(maxCacheSize);
         this.validationProbability = validationProbability;
         this.snapshotStore = new SnapshotStoreImpl();
         this.cacheStore = new CacheStoreImpl(snapshotStore);
+    }
+
+    public static LockWatchValueScopingCache create(
+            LockWatchEventCache eventCache,
+            MetricsManager metricsManager,
+            long maxCacheSize,
+            double validationProbability) {
+        return ResilientLockWatchProxy.newValueCacheProxy(
+                new LockWatchValueScopingCacheImpl(eventCache, maxCacheSize, validationProbability),
+                NoOpLockWatchValueScopingCache.create(),
+                metricsManager);
     }
 
     @Override
@@ -114,7 +134,8 @@ public final class LockWatchValueScopingCacheImpl implements LockWatchValueScopi
             @Override
             public Void invalidateSome(Set<LockDescriptor> invalidatedLocks) {
                 Set<CellReference> invalidatedCells = invalidatedLocks.stream()
-                        .flatMap(LockWatchValueScopingCacheImpl::extractTableAndCell)
+                        .map(AtlasLockDescriptorUtils::candidateCells)
+                        .flatMap(List::stream)
                         .collect(Collectors.toSet());
                 KeyedStream.stream(cacheStore
                                 .getCache(StartTimestamp.of(startTimestamp))
@@ -218,9 +239,5 @@ public final class LockWatchValueScopingCacheImpl implements LockWatchValueScopi
                 .map(Sequence::of)
                 .mapEntries((timestamp, sequence) -> Maps.immutableEntry(sequence, timestamp))
                 .collectToSetMultimap();
-    }
-
-    private static Stream<CellReference> extractTableAndCell(LockDescriptor descriptor) {
-        return AtlasLockDescriptorUtils.candidateCells(descriptor).stream();
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
@@ -40,7 +40,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
 @ThreadSafe
@@ -48,14 +47,9 @@ public final class LockWatchValueScopingCacheImpl implements LockWatchValueScopi
     private final LockWatchEventCache eventCache;
     private final double validationProbability;
     private final CacheStore cacheStore;
-
-    @GuardedBy("this")
     private final ValueStore valueStore;
-
-    @GuardedBy("this")
     private final SnapshotStore snapshotStore;
 
-    @GuardedBy("this")
     private volatile Optional<LockWatchVersion> currentVersion = Optional.empty();
 
     @VisibleForTesting

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheImpl.java
@@ -31,7 +31,6 @@ import com.palantir.lock.watch.TransactionsLockWatchUpdate;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
-import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
 @ThreadSafe
@@ -40,10 +39,7 @@ public final class LockWatchEventCacheImpl implements LockWatchEventCache {
     private static final int MIN_EVENTS = 1000;
     private static final int MAX_EVENTS = 10_000;
 
-    @GuardedBy("this")
     private final LockWatchEventLog eventLog;
-
-    @GuardedBy("this")
     private final TimestampStateStore timestampStateStore;
 
     public static LockWatchEventCache create(MetricsManager metricsManager) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLog.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLog.java
@@ -26,7 +26,9 @@ import com.palantir.lock.watch.LockWatchVersion;
 import com.palantir.logsafe.Preconditions;
 import java.util.Collection;
 import java.util.Optional;
+import javax.annotation.concurrent.NotThreadSafe;
 
+@NotThreadSafe
 final class LockWatchEventLog {
     private final ClientLockWatchSnapshot snapshot;
     private final VersionedEventStore eventStore;
@@ -55,7 +57,7 @@ final class LockWatchEventLog {
      *         this may begin with a snapshot if the latest version is too far behind, and this snapshot may be
      *         condensed.
      */
-    public ClientLogEvents getEventsBetweenVersions(VersionBounds versionBounds) {
+    ClientLogEvents getEventsBetweenVersions(VersionBounds versionBounds) {
         Optional<LockWatchVersion> startVersion = versionBounds.startVersion().map(this::createStartVersion);
         LockWatchVersion currentVersion = getLatestVersionAndVerify(versionBounds.endVersion());
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStore.java
@@ -31,8 +31,10 @@ import java.util.Collection;
 import java.util.NavigableMap;
 import java.util.Optional;
 import java.util.TreeMap;
+import javax.annotation.concurrent.NotThreadSafe;
 import org.immutables.value.Value;
 
+@NotThreadSafe
 final class TimestampStateStore {
     private final NavigableMap<StartTimestamp, MapEntry> timestampMap = new TreeMap<>();
     private final SortedSetMultimap<Sequence, StartTimestamp> livingVersions = TreeMultimap.create();

--- a/changelog/@unreleased/pr-5418.v2.yml
+++ b/changelog/@unreleased/pr-5418.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Refactor the resilient lock watch event proxy to be more generic and use it for the lock watch value cache.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5418


### PR DESCRIPTION
**Goals (and why)**:
* We want to be able to fall back to a no-op cache for the value cache too.

**Implementation Description (bullets)**:
* Modify the `ResilientLockWatchEventCache` to be a more generic proxy appropriate for both event and value cache.
* Since not all methods are synchronised on the value cache, remove the synchronised aspect of the proxy, and make LWEC thread safe.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Fix up the proxy tests. Note that there are _no_ concurrency tests for LWEC.

**Concerns (what feedback would you like?)**:
Have I missed a synchronised method? Are we exposing ourselves to race conditions here on the volatile read of the delegate?

**Where should we start reviewing?**:
`ResilientLockWatchProxy`

**Priority (whenever / two weeks / yesterday)**:
This week or early next week.
