### PR TITLE
Transaction onSuccess(Runnable) / Callback Registration

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
@@ -343,11 +343,10 @@ public interface Transaction {
     void useTable(TableReference tableRef, ConstraintCheckable table);
 
     /**
-     * Registers a callback that will be called after a successful commit of a transaction.
+     * Registers a callback that will be called after the AtlasDB client perceives a successful commit of a transaction.
      *
      * We guarantee that if the provided callback runs, the transaction has definitely committed successfully.
-     * The converse is NOT true: it is possible that the callback is NOT called even though the transaction was
-     * successful.
+     * The converse is NOT true: it is possible that the callback is NOT called even if the transaction was successful.
      *
      * The semantics of callbacks are as follows:
      * <ul>

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
@@ -343,6 +343,25 @@ public interface Transaction {
     void useTable(TableReference tableRef, ConstraintCheckable table);
 
     /**
+     * Registers a callback that will be called after a successful commit of a transaction.
+     *
+     * We guarantee that if the provided callback runs, the transaction has definitely committed successfully.
+     * The converse is NOT true: it is possible that the callback is NOT called even though the transaction was
+     * successful.
+     *
+     * The semantics of callbacks are as follows:
+     * <ul>
+     *     <li>Callbacks must be registered before a transaction commits or aborts; registration of a callback once
+     *     either of the above is true will throw an exception.</li>
+     *     <li>Callbacks will run serially in the order they were registered.</li>
+     *     <li>Exceptions thrown from any callback will be propagated immediately, and cause callbacks registered
+     *     later to not run.</li>
+     *     <li>Exceptions thrown from any callback will not change the result of the transaction.</li>
+     * </ul>
+     */
+    void onSuccess(Runnable callback);
+
+    /**
      * Disables read-write conflict checking for this table for the duration of this transaction only.
      *
      * This method should be called before any reads are done on this table.

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransaction.java
@@ -188,6 +188,11 @@ public abstract class ForwardingTransaction extends ForwardingObject implements 
     }
 
     @Override
+    public void onSuccess(Runnable callback) {
+        delegate().onSuccess(callback);
+    }
+
+    @Override
     public ListenableFuture<Map<Cell, byte[]>> getAsync(TableReference tableRef, Set<Cell> cells) {
         return delegate().getAsync(tableRef, cells);
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -2494,7 +2494,6 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
 
     @Override
     public void onSuccess(Runnable callback) {
-        ensureUncommitted();
         Preconditions.checkNotNull(callback, "Callback cannot be null");
         successCallbackManager.registerCallback(callback);
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -2591,7 +2591,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         INDETERMINATE;
     }
 
-    private class SuccessCallbackManager {
+    private final class SuccessCallbackManager {
         private final List<Runnable> callbacks = new CopyOnWriteArrayList<>();
 
         public void registerCallback(Runnable runnable) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -2601,7 +2601,8 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         }
 
         public void runCallbacks() {
-            Preconditions.checkState(isDefinitivelyCommitted(),
+            Preconditions.checkState(
+                    isDefinitivelyCommitted(),
                     "Callbacks must not be run if it is not known that the transaction has definitively committed! "
                             + "This is likely a bug in AtlasDB transaction code.");
             callbacks.forEach(Runnable::run);

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -1938,6 +1938,17 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
     }
 
     @Test
+    public void callbacksOnlyRunOnceEvenOnMultipleCommits() {
+        Transaction transaction = txManager.createNewTransaction();
+        Runnable callback = mock(Runnable.class);
+        transaction.onSuccess(callback);
+        transaction.commit();
+        transaction.commit();
+
+        verify(callback, times(1)).run();
+    }
+
+    @Test
     public void transactionStillCommittedEvenIfCallbackThrows() {
         assertThatThrownBy(() -> txManager.runTaskThrowOnConflict(txn -> {
                     txn.put(TABLE, ImmutableMap.of(TEST_CELL, PtBytes.toBytes("tom")));

--- a/changelog/@unreleased/pr-5421.v2.yml
+++ b/changelog/@unreleased/pr-5421.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Transaction now supports an `onSuccess(Runnable)` method, that can invoke a callback when a transaction is successful. Please read the javadocs of this method very carefully for more details of the semantics if you wish to use this method.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5421


### PR DESCRIPTION
**Goals (and why)**:
- Support `onSuccess(...)` which is needed for an internal workflow

**Implementation Description (bullets)**:
- Store a list of registered callbacks that is thread safe
- Run these callbacks when the transaction successfully commits.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Tests that cover most cases in `SnapshotTransactionTest`

**Concerns (what feedback would you like?)**:
- Does this accidentally break anything?
- Is my choice of list bad? It needs to be threadsafe.

**Where should we start reviewing?**: Transaction.java

**Priority (whenever / two weeks / yesterday)**: this week; on critical path