### PR TITLE
Upgrade GBJ

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         classpath 'com.netflix.nebula:gradle-info-plugin:9.3.0'
         classpath 'com.netflix.nebula:nebula-publishing-plugin:17.3.2'
         classpath 'com.palantir.gradle.externalpublish:gradle-external-publish-plugin:1.2.1'
-        classpath 'com.palantir.baseline:gradle-baseline-java:3.75.0'
+        classpath 'com.palantir.baseline:gradle-baseline-java:3.81.1'
         classpath 'com.palantir.gradle.conjure:gradle-conjure:5.3.0'
         classpath 'com.palantir.javaformat:gradle-palantir-java-format:1.0.1'
         classpath 'com.palantir.metricschema:gradle-metric-schema:0.5.22'

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         classpath 'com.netflix.nebula:gradle-info-plugin:9.3.0'
         classpath 'com.netflix.nebula:nebula-publishing-plugin:17.3.2'
         classpath 'com.palantir.gradle.externalpublish:gradle-external-publish-plugin:1.2.1'
-        classpath 'com.palantir.baseline:gradle-baseline-java:3.74.0'
+        classpath 'com.palantir.baseline:gradle-baseline-java:3.75.0'
         classpath 'com.palantir.gradle.conjure:gradle-conjure:5.3.0'
         classpath 'com.palantir.javaformat:gradle-palantir-java-format:1.0.1'
         classpath 'com.palantir.metricschema:gradle-metric-schema:0.5.22'

--- a/build.gradle
+++ b/build.gradle
@@ -102,6 +102,9 @@ allprojects {
     }
 
     tasks.withType(JavaCompile) {
+        options.compilerArgs.removeAll {
+            it == '-parameter'
+        }
         options.compilerArgs += ['-Werror']
         // temporarily relax constraints until we can fix all violations
         options.errorprone.disable 'ArrayAsKeyOfSetOrMap',

--- a/build.gradle
+++ b/build.gradle
@@ -103,7 +103,7 @@ allprojects {
 
     tasks.withType(JavaCompile) {
         options.compilerArgs.removeAll {
-            it == '-parameter'
+            it == '-parameters'
         }
         options.compilerArgs += ['-Werror']
         // temporarily relax constraints until we can fix all violations

--- a/build.gradle
+++ b/build.gradle
@@ -98,13 +98,9 @@ allprojects {
             it.substitute it.module('jakarta.el:jakarta.el-api') with it.module('org.glassfish:jakarta.el:3.0.3')
             it.substitute it.module('org.glassfish:javax.el') with it.module('org.glassfish:jakarta.el:3.0.3')
             it.substitute it.module('org.glassfish.web:javax.el') with it.module('org.glassfish:jakarta.el:3.0.3')
-        }
     }
 
     tasks.withType(JavaCompile) {
-        options.compilerArgs.removeAll {
-            it == '-parameters'
-        }
         options.compilerArgs += ['-Werror']
         // temporarily relax constraints until we can fix all violations
         options.errorprone.disable 'ArrayAsKeyOfSetOrMap',

--- a/build.gradle
+++ b/build.gradle
@@ -98,6 +98,7 @@ allprojects {
             it.substitute it.module('jakarta.el:jakarta.el-api') with it.module('org.glassfish:jakarta.el:3.0.3')
             it.substitute it.module('org.glassfish:javax.el') with it.module('org.glassfish:jakarta.el:3.0.3')
             it.substitute it.module('org.glassfish.web:javax.el') with it.module('org.glassfish:jakarta.el:3.0.3')
+        }
     }
 
     tasks.withType(JavaCompile) {

--- a/lock-impl/src/test/java/com/palantir/lock/LockServiceTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/LockServiceTest.java
@@ -558,7 +558,7 @@ public abstract class LockServiceTest {
         barrier.await();
         Thread.sleep(500);
         LockState state2 = server.getLockState(lock1);
-        Assert.assertEquals(state2.requesters().size(), 1);
+        Assert.assertEquals(1, state2.requesters().size());
         Assert.assertEquals(Iterables.getOnlyElement(state2.requesters()).versionId(), Optional.of(100L));
     }
 

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
@@ -27,6 +27,7 @@ import com.palantir.atlasdb.timelock.logging.NonBlockingFileAppenderFactory;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.conjure.java.api.config.service.UserAgent;
+import com.palantir.conjure.java.serialization.ObjectMappers;
 import com.palantir.conjure.java.server.jersey.ConjureJerseyFeature;
 import com.palantir.sls.versions.OrderableSlsVersion;
 import com.palantir.timelock.paxos.TimeLockAgent;
@@ -68,6 +69,7 @@ public class TimeLockServerLauncher extends Application<CombinedTimeLockServerCo
         MetricRegistry metricRegistry = SharedMetricRegistries.getOrCreate(
                 "AtlasDbTest" + UUID.randomUUID().toString());
         bootstrap.setMetricRegistry(metricRegistry);
+        bootstrap.setObjectMapper(ObjectMappers.newServerObjectMapper());
         bootstrap.getObjectMapper().registerSubtypes(NonBlockingFileAppenderFactory.class);
         bootstrap.getObjectMapper().registerModule(new Jdk8Module());
         super.initialize(bootstrap);

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
@@ -30,10 +30,13 @@ import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.serialization.ObjectMappers;
 import com.palantir.conjure.java.server.jersey.ConjureJerseyFeature;
 import com.palantir.sls.versions.OrderableSlsVersion;
+import com.palantir.timelock.config.DatabaseTsBoundPersisterConfiguration;
 import com.palantir.timelock.paxos.TimeLockAgent;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import io.dropwizard.Application;
+import io.dropwizard.http2.Http2ConnectorFactory;
+import io.dropwizard.jackson.DiscoverableSubtypeResolver;
 import io.dropwizard.jersey.optional.EmptyOptionalException;
 import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.logging.ConsoleAppenderFactory;
@@ -71,8 +74,13 @@ public class TimeLockServerLauncher extends Application<CombinedTimeLockServerCo
                 "AtlasDbTest" + UUID.randomUUID().toString());
         bootstrap.setMetricRegistry(metricRegistry);
         bootstrap.setObjectMapper(ObjectMappers.newServerObjectMapper());
+
+        // Add base Dropwizard Subtypes required for Multipass to start.
+        bootstrap.getObjectMapper().registerSubtypes(Http2ConnectorFactory.class);
         bootstrap.getObjectMapper().registerSubtypes(NonBlockingFileAppenderFactory.class);
         bootstrap.getObjectMapper().registerSubtypes(ConsoleAppenderFactory.class);
+        bootstrap.getObjectMapper().registerSubtypes(DatabaseTsBoundPersisterConfiguration.class);
+        bootstrap.getObjectMapper().setSubtypeResolver(new DiscoverableSubtypeResolver());
         bootstrap.getObjectMapper().registerModule(new Jdk8Module());
         super.initialize(bootstrap);
     }

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
@@ -36,6 +36,7 @@ import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import io.dropwizard.Application;
 import io.dropwizard.jersey.optional.EmptyOptionalException;
 import io.dropwizard.lifecycle.Managed;
+import io.dropwizard.logging.ConsoleAppenderFactory;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import java.util.Optional;
@@ -71,6 +72,7 @@ public class TimeLockServerLauncher extends Application<CombinedTimeLockServerCo
         bootstrap.setMetricRegistry(metricRegistry);
         bootstrap.setObjectMapper(ObjectMappers.newServerObjectMapper());
         bootstrap.getObjectMapper().registerSubtypes(NonBlockingFileAppenderFactory.class);
+        bootstrap.getObjectMapper().registerSubtypes(ConsoleAppenderFactory.class);
         bootstrap.getObjectMapper().registerModule(new Jdk8Module());
         super.initialize(bootstrap);
     }

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
@@ -30,16 +30,13 @@ import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.serialization.ObjectMappers;
 import com.palantir.conjure.java.server.jersey.ConjureJerseyFeature;
 import com.palantir.sls.versions.OrderableSlsVersion;
-import com.palantir.timelock.config.DatabaseTsBoundPersisterConfiguration;
 import com.palantir.timelock.paxos.TimeLockAgent;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import io.dropwizard.Application;
-import io.dropwizard.http2.Http2ConnectorFactory;
 import io.dropwizard.jackson.DiscoverableSubtypeResolver;
 import io.dropwizard.jersey.optional.EmptyOptionalException;
 import io.dropwizard.lifecycle.Managed;
-import io.dropwizard.logging.ConsoleAppenderFactory;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import java.util.Optional;
@@ -75,11 +72,7 @@ public class TimeLockServerLauncher extends Application<CombinedTimeLockServerCo
         bootstrap.setMetricRegistry(metricRegistry);
         bootstrap.setObjectMapper(ObjectMappers.newServerObjectMapper());
 
-        // Add base Dropwizard Subtypes required for Multipass to start.
-        bootstrap.getObjectMapper().registerSubtypes(Http2ConnectorFactory.class);
         bootstrap.getObjectMapper().registerSubtypes(NonBlockingFileAppenderFactory.class);
-        bootstrap.getObjectMapper().registerSubtypes(ConsoleAppenderFactory.class);
-        bootstrap.getObjectMapper().registerSubtypes(DatabaseTsBoundPersisterConfiguration.class);
         bootstrap.getObjectMapper().setSubtypeResolver(new DiscoverableSubtypeResolver());
         bootstrap.getObjectMapper().registerModule(new Jdk8Module());
         super.initialize(bootstrap);


### PR DESCRIPTION
**Goals (and why)**:
- upgrade gradle baseline java

**Implementation Description (bullets)**:
- bump the version...
- and register an ObjectMapper on the server side that is consistent with internal framework.

- ~BUT disable the `-parameters` compile flag. After this bump it seems that there are consistently Jackson failures of the form~

```
com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Invalid definition for property 'jsonValue' (of type `com.palantir.paxos.ImmutableClient`): Could not find creator property with name 'jsonValue' (known Creator properties: [original, value])
```

Most likely this is some strange interaction between Immutables, the @JsonValue  flag and this argument…

**Testing (What was existing testing like?  What have you done to improve it?)**:
existing stuff will do

**Concerns (what feedback would you like?)**:
It's kind of terrifying that our Jackson config is dependent on compiler flags. But at least it fails and we can't compile as opposed to silent breaks

**Where should we start reviewing?**: build.gradle

**Priority (whenever / two weeks / yesterday)**: soon please
