### PR TITLE
Fix internal errors

### DIFF
--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/ConjureResourceExceptionHandler.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/ConjureResourceExceptionHandler.java
@@ -61,6 +61,13 @@ public class ConjureResourceExceptionHandler {
                         tooManyRequests -> {
                             throw QosException.throttle();
                         },
+                        MoreExecutors.directExecutor())
+                .catching(
+                        InterruptedException.class,
+                        interrupted -> {
+                            Thread.currentThread().interrupt();
+                            throw QosException.unavailable(interrupted);
+                        },
                         MoreExecutors.directExecutor());
     }
 }


### PR DESCRIPTION
**Goals (and why)**:
`BlockingTimeLimitedLockService.callWithTimeLimit()` leaks InterruptedExceptions that manifest as internal errors from timelock server. This should map them to the closest approximation of not current leader

**Concerns (what feedback would you like?)**:
Does this actually do what we want? Does resetting the interrupted flag make sense in this context?

**Where should we start reviewing?**:
small

**Priority (whenever / two weeks / yesterday)**:
nowish