### PR TITLE
[WIP] [LW] getOrCreateCache

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCache.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCache.java
@@ -46,5 +46,5 @@ public interface LockWatchValueScopingCache extends LockWatchValueCache {
     @Override
     void removeTransactionState(long startTimestamp);
 
-    TransactionScopedCache createTransactionScopedCache(long startTs);
+    TransactionScopedCache getOrCreateTransactionScopedCache(long startTs);
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/CacheStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/CacheStore.java
@@ -17,12 +17,11 @@
 package com.palantir.atlasdb.keyvalue.api.cache;
 
 import com.palantir.atlasdb.keyvalue.api.watch.StartTimestamp;
-import java.util.Optional;
 
 interface CacheStore {
-    Optional<TransactionScopedCache> createCache(StartTimestamp timestamp);
+    TransactionScopedCache getOrCreateCache(StartTimestamp timestamp);
 
-    Optional<TransactionScopedCache> getCache(StartTimestamp timestamp);
+    TransactionScopedCache getCache(StartTimestamp timestamp);
 
     void removeCache(StartTimestamp timestamp);
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
@@ -17,7 +17,6 @@
 package com.palantir.atlasdb.keyvalue.api.cache;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.palantir.atlasdb.keyvalue.api.AtlasLockDescriptorUtils;
@@ -45,7 +44,6 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class LockWatchValueScopingCacheImpl implements LockWatchValueScopingCache {
     private final LockWatchEventCache eventCache;
-    private final double validationProbability;
     private final CacheStore cacheStore;
     private final ValueStore valueStore;
     private final SnapshotStore snapshotStore;
@@ -56,9 +54,8 @@ public final class LockWatchValueScopingCacheImpl implements LockWatchValueScopi
     LockWatchValueScopingCacheImpl(LockWatchEventCache eventCache, long maxCacheSize, double validationProbability) {
         this.eventCache = eventCache;
         this.valueStore = new ValueStoreImpl(maxCacheSize);
-        this.validationProbability = validationProbability;
         this.snapshotStore = new SnapshotStoreImpl();
-        this.cacheStore = new CacheStoreImpl(snapshotStore);
+        this.cacheStore = new CacheStoreImpl(snapshotStore, validationProbability);
     }
 
     public static LockWatchValueScopingCache create(
@@ -111,22 +108,15 @@ public final class LockWatchValueScopingCacheImpl implements LockWatchValueScopi
     }
 
     @Override
-    public TransactionScopedCache createTransactionScopedCache(long startTs) {
-        // Snapshots may be missing due to leader elections. In this case, the transaction will not read from the
-        // cache or publish anything to the cache at commit time.
-        return ValidatingTransactionScopedCache.create(
-                cacheStore.createCache(StartTimestamp.of(startTs)).orElseGet(NoOpTransactionScopedCache::create),
-                validationProbability);
+    public TransactionScopedCache getOrCreateTransactionScopedCache(long startTs) {
+        return cacheStore.getOrCreateCache(StartTimestamp.of(startTs));
     }
 
     private synchronized void processCommitUpdate(long startTimestamp) {
-        Optional<TransactionScopedCache> cache = cacheStore.getCache(StartTimestamp.of(startTimestamp));
-        cache.ifPresent(TransactionScopedCache::finalise);
+        TransactionScopedCache cache = cacheStore.getCache(StartTimestamp.of(startTimestamp));
+        cache.finalise();
 
-        Map<CellReference, CacheValue> cachedValues = cache.map(TransactionScopedCache::getValueDigest)
-                .map(ValueDigest::loadedValues)
-                .orElseGet(ImmutableMap::of);
-
+        Map<CellReference, CacheValue> cachedValues = cache.getValueDigest().loadedValues();
         if (cachedValues.isEmpty()) {
             return;
         }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/NoOpLockWatchValueScopingCache.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/NoOpLockWatchValueScopingCache.java
@@ -25,7 +25,7 @@ public final class NoOpLockWatchValueScopingCache extends NoOpLockWatchValueCach
     }
 
     @Override
-    public TransactionScopedCache createTransactionScopedCache(long startTs) {
+    public TransactionScopedCache getOrCreateTransactionScopedCache(long startTs) {
         return NoOpTransactionScopedCache.create();
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ValidatingTransactionScopedCache.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ValidatingTransactionScopedCache.java
@@ -48,7 +48,7 @@ final class ValidatingTransactionScopedCache implements TransactionScopedCache {
         this.random = new Random();
     }
 
-    static ValidatingTransactionScopedCache create(TransactionScopedCache delegate, double validationProbability) {
+    static TransactionScopedCache create(TransactionScopedCache delegate, double validationProbability) {
         return new ValidatingTransactionScopedCache(delegate, validationProbability);
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerImpl.java
@@ -125,7 +125,7 @@ public final class LockWatchManagerImpl extends LockWatchManagerInternal {
 
     @Override
     public TransactionScopedCache createTransactionScopedCache(long startTs) {
-        return valueScopingCache.createTransactionScopedCache(startTs);
+        return valueScopingCache.getOrCreateTransactionScopedCache(startTs);
     }
 
     private void registerWatchesWithTimelock() {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/CacheStoreImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/CacheStoreImplTest.java
@@ -32,14 +32,14 @@ public final class CacheStoreImplTest {
     @Test
     public void updatesToSnapshotStoreReflectedInCacheStore() {
         SnapshotStoreImpl snapshotStore = new SnapshotStoreImpl();
-        CacheStore cacheStore = new CacheStoreImpl(snapshotStore);
+        CacheStore cacheStore = new CacheStoreImpl(snapshotStore, validationProbability);
 
-        assertThat(cacheStore.createCache(TIMESTAMP_1)).isEmpty();
+        assertThat(cacheStore.getOrCreateCache(TIMESTAMP_1)).isEmpty();
 
         snapshotStore.storeSnapshot(
                 Sequence.of(5L),
                 ImmutableSet.of(TIMESTAMP_2),
                 ValueCacheSnapshotImpl.of(HashMap.empty(), HashSet.empty()));
-        assertThat(cacheStore.createCache(TIMESTAMP_2)).isPresent();
+        assertThat(cacheStore.getOrCreateCache(TIMESTAMP_2)).isPresent();
     }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImplTest.java
@@ -92,7 +92,7 @@ public final class LockWatchValueScopingCacheImplTest {
         eventCache.processStartTransactionsUpdate(ImmutableSet.of(TIMESTAMP_1, TIMESTAMP_2), LOCK_WATCH_SNAPSHOT);
         valueCache.processStartTransactions(ImmutableSet.of(TIMESTAMP_1, TIMESTAMP_2));
 
-        TransactionScopedCache scopedCache = valueCache.createTransactionScopedCache(TIMESTAMP_1);
+        TransactionScopedCache scopedCache = valueCache.getOrCreateTransactionScopedCache(TIMESTAMP_1);
 
         // This confirms that we always read from remote when validation is set to 1.0.
         assertThat(getRemotelyReadCells(scopedCache, TABLE, CELL_1)).containsExactlyInAnyOrder(CELL_1);
@@ -104,12 +104,12 @@ public final class LockWatchValueScopingCacheImplTest {
         eventCache.processStartTransactionsUpdate(ImmutableSet.of(TIMESTAMP_1, TIMESTAMP_2), LOCK_WATCH_SNAPSHOT);
         valueCache.processStartTransactions(ImmutableSet.of(TIMESTAMP_1, TIMESTAMP_2));
 
-        TransactionScopedCache scopedCache1 = valueCache.createTransactionScopedCache(TIMESTAMP_1);
+        TransactionScopedCache scopedCache1 = valueCache.getOrCreateTransactionScopedCache(TIMESTAMP_1);
         assertThat(getRemotelyReadCells(scopedCache1, TABLE, CELL_1)).containsExactlyInAnyOrder(CELL_1);
         processCommitTimestamp(TIMESTAMP_1, 0L);
         valueCache.updateCacheAndRemoveTransactionState(ImmutableSet.of(TIMESTAMP_1));
 
-        TransactionScopedCache scopedCache2 = valueCache.createTransactionScopedCache(TIMESTAMP_2);
+        TransactionScopedCache scopedCache2 = valueCache.getOrCreateTransactionScopedCache(TIMESTAMP_2);
         assertThat(getRemotelyReadCells(scopedCache2, TABLE, CELL_1)).isEmpty();
     }
 
@@ -118,7 +118,7 @@ public final class LockWatchValueScopingCacheImplTest {
         eventCache.processStartTransactionsUpdate(ImmutableSet.of(TIMESTAMP_1), LOCK_WATCH_SNAPSHOT);
         valueCache.processStartTransactions(ImmutableSet.of(TIMESTAMP_1));
 
-        TransactionScopedCache scopedCache1 = valueCache.createTransactionScopedCache(TIMESTAMP_1);
+        TransactionScopedCache scopedCache1 = valueCache.getOrCreateTransactionScopedCache(TIMESTAMP_1);
         assertThat(getRemotelyReadCells(scopedCache1, TABLE, CELL_1)).containsExactlyInAnyOrder(CELL_1);
         processCommitTimestamp(TIMESTAMP_1, 0L);
         valueCache.updateCacheAndRemoveTransactionState(ImmutableSet.of(TIMESTAMP_1));
@@ -127,7 +127,7 @@ public final class LockWatchValueScopingCacheImplTest {
                 ImmutableSet.of(TIMESTAMP_2), LockWatchStateUpdate.success(LEADER, 0L, ImmutableList.of()));
         valueCache.processStartTransactions(ImmutableSet.of(TIMESTAMP_2));
 
-        TransactionScopedCache scopedCache2 = valueCache.createTransactionScopedCache(TIMESTAMP_2);
+        TransactionScopedCache scopedCache2 = valueCache.getOrCreateTransactionScopedCache(TIMESTAMP_2);
         assertThat(getRemotelyReadCells(scopedCache2, TABLE, CELL_1)).isEmpty();
     }
 
@@ -136,7 +136,7 @@ public final class LockWatchValueScopingCacheImplTest {
         eventCache.processStartTransactionsUpdate(ImmutableSet.of(TIMESTAMP_1), LOCK_WATCH_SNAPSHOT);
         valueCache.processStartTransactions(ImmutableSet.of(TIMESTAMP_1));
 
-        TransactionScopedCache scopedCache1 = valueCache.createTransactionScopedCache(TIMESTAMP_1);
+        TransactionScopedCache scopedCache1 = valueCache.getOrCreateTransactionScopedCache(TIMESTAMP_1);
         assertThat(getRemotelyReadCells(scopedCache1, TABLE, CELL_1)).containsExactlyInAnyOrder(CELL_1);
         processCommitTimestamp(TIMESTAMP_1, 0L);
 
@@ -156,7 +156,7 @@ public final class LockWatchValueScopingCacheImplTest {
         eventCache.processStartTransactionsUpdate(ImmutableSet.of(TIMESTAMP_1), LOCK_WATCH_SNAPSHOT);
         valueCache.processStartTransactions(ImmutableSet.of(TIMESTAMP_1));
 
-        TransactionScopedCache scopedCache1 = valueCache.createTransactionScopedCache(TIMESTAMP_1);
+        TransactionScopedCache scopedCache1 = valueCache.getOrCreateTransactionScopedCache(TIMESTAMP_1);
         assertThat(getRemotelyReadCells(scopedCache1, TABLE, CELL_1, CELL_3)).containsExactlyInAnyOrder(CELL_1, CELL_3);
         processCommitTimestamp(TIMESTAMP_1, 0L);
         valueCache.updateCacheAndRemoveTransactionState(ImmutableSet.of(TIMESTAMP_1));
@@ -165,7 +165,7 @@ public final class LockWatchValueScopingCacheImplTest {
         eventCache.processStartTransactionsUpdate(
                 ImmutableSet.of(TIMESTAMP_2), LockWatchStateUpdate.success(LEADER, 1L, ImmutableList.of(LOCK_EVENT)));
         valueCache.processStartTransactions(ImmutableSet.of(TIMESTAMP_2));
-        TransactionScopedCache scopedCache2 = valueCache.createTransactionScopedCache(TIMESTAMP_2);
+        TransactionScopedCache scopedCache2 = valueCache.getOrCreateTransactionScopedCache(TIMESTAMP_2);
 
         assertThat(getRemotelyReadCells(scopedCache2, TABLE, CELL_1, CELL_2, CELL_3))
                 .containsExactlyInAnyOrder(CELL_1, CELL_2);
@@ -179,7 +179,7 @@ public final class LockWatchValueScopingCacheImplTest {
                 ImmutableSet.of(TIMESTAMP_3), LockWatchStateUpdate.success(LEADER, 2L, ImmutableList.of(UNLOCK_EVENT)));
         valueCache.processStartTransactions(ImmutableSet.of(TIMESTAMP_3));
 
-        TransactionScopedCache scopedCache3 = valueCache.createTransactionScopedCache(TIMESTAMP_3);
+        TransactionScopedCache scopedCache3 = valueCache.getOrCreateTransactionScopedCache(TIMESTAMP_3);
         assertThat(getRemotelyReadCells(scopedCache3, TABLE, CELL_1, CELL_2, CELL_3))
                 .containsExactlyInAnyOrder(CELL_1);
         assertThat(getRemotelyReadCells(scopedCache3, TABLE, CELL_1, CELL_2, CELL_3))
@@ -212,7 +212,7 @@ public final class LockWatchValueScopingCacheImplTest {
 
     @Test
     public void createTransactionScopedCacheWithMissingSnapshotReturnsNoOpCache() {
-        TransactionScopedCache scopedCache = valueCache.createTransactionScopedCache(TIMESTAMP_1);
+        TransactionScopedCache scopedCache = valueCache.getOrCreateTransactionScopedCache(TIMESTAMP_1);
         assertThat(getRemotelyReadCells(scopedCache, TABLE, CELL_1, CELL_2, CELL_3))
                 .containsExactlyInAnyOrder(CELL_1, CELL_2, CELL_3);
         assertThat(getRemotelyReadCells(scopedCache, TABLE, CELL_1, CELL_2, CELL_3))
@@ -228,7 +228,7 @@ public final class LockWatchValueScopingCacheImplTest {
         valueCache.processStartTransactions(ImmutableSet.of(TIMESTAMP_1));
 
         // Stores CELL_1 -> VALUE_1 in central cache
-        TransactionScopedCache scopedCache1 = valueCache.createTransactionScopedCache(TIMESTAMP_1);
+        TransactionScopedCache scopedCache1 = valueCache.getOrCreateTransactionScopedCache(TIMESTAMP_1);
         assertThat(getRemotelyReadCells(scopedCache1, TABLE, CELL_1)).containsExactlyInAnyOrder(CELL_1);
         processCommitTimestamp(TIMESTAMP_1, 0L);
         valueCache.updateCacheAndRemoveTransactionState(ImmutableSet.of(TIMESTAMP_1));
@@ -238,7 +238,7 @@ public final class LockWatchValueScopingCacheImplTest {
         valueCache.processStartTransactions(ImmutableSet.of(TIMESTAMP_2));
 
         // Confirms entry is present
-        TransactionScopedCache scopedCache2 = valueCache.createTransactionScopedCache(TIMESTAMP_2);
+        TransactionScopedCache scopedCache2 = valueCache.getOrCreateTransactionScopedCache(TIMESTAMP_2);
         assertThat(getRemotelyReadCells(scopedCache2, TABLE, CELL_1)).isEmpty();
         processCommitTimestamp(TIMESTAMP_2, 0L);
         valueCache.updateCacheAndRemoveTransactionState(ImmutableSet.of(TIMESTAMP_2));
@@ -250,7 +250,7 @@ public final class LockWatchValueScopingCacheImplTest {
         valueCache.processStartTransactions(ImmutableSet.of(TIMESTAMP_3));
 
         // Confirms entry is no longer present
-        TransactionScopedCache scopedCache3 = valueCache.createTransactionScopedCache(TIMESTAMP_3);
+        TransactionScopedCache scopedCache3 = valueCache.getOrCreateTransactionScopedCache(TIMESTAMP_3);
         assertThat(getRemotelyReadCells(scopedCache3, TABLE, CELL_1)).containsExactlyInAnyOrder(CELL_1);
         eventCache.processGetCommitTimestampsUpdate(
                 ImmutableList.of(TransactionUpdate.builder()

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerImplTest.java
@@ -103,7 +103,7 @@ public final class LockWatchManagerImplTest {
     @Test
     public void createTransactionScopedCacheTest() {
         manager.createTransactionScopedCache(1L);
-        verify(valueScopingCache).createTransactionScopedCache(1L);
+        verify(valueScopingCache).getOrCreateTransactionScopedCache(1L);
         verifyNoMoreInteractions(lockWatchEventCache);
     }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/ResilientLockWatchProxyTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/ResilientLockWatchProxyTest.java
@@ -74,11 +74,11 @@ public final class ResilientLockWatchProxyTest {
         verify(fallbackCache, never()).updateCacheAndRemoveTransactionState(any());
 
         // Failure
-        when(defaultCache.createTransactionScopedCache(timestamp))
+        when(defaultCache.getOrCreateTransactionScopedCache(timestamp))
                 .thenThrow(new TransactionFailedNonRetriableException(""));
-        assertThatThrownBy(() -> proxyCache.createTransactionScopedCache(timestamp))
+        assertThatThrownBy(() -> proxyCache.getOrCreateTransactionScopedCache(timestamp))
                 .isExactlyInstanceOf(TransactionLockWatchFailedException.class);
-        verify(defaultCache).createTransactionScopedCache(timestamp);
+        verify(defaultCache).getOrCreateTransactionScopedCache(timestamp);
 
         // Fallback operation
         proxyCache.processStartTransactions(timestamps);


### PR DESCRIPTION
**Goals (and why)**:
I need to modify the cache for the one-off snapshot transaction in `SerializableTransaction`. The first step will be to make the create cache method first check whether it exists or not, and get if it does, create if it does not.

**Implementation Description (bullets)**:
* Refactor the create cache method to first check if the cache is present
* Refactor the cache store to always provide a cache, instead of forcing the caller to handle optionals.


**Testing (What was existing testing like?  What have you done to improve it?)**:
Fixed old tests, added new.

**Concerns (what feedback would you like?)**:
Standard things - is this sensible, etc. etc.

**Where should we start reviewing?**:
LWVSCI.

**Priority (whenever / two weeks / yesterday)**:
Soon to unblock further work.
