### PR TITLE
[LW] Serializable Transactions Part II: updateCacheOnCommit

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCache.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCache.java
@@ -36,13 +36,13 @@ public interface LockWatchValueScopingCache extends LockWatchValueCache {
     @Override
     void processStartTransactions(Set<Long> startTimestamps);
 
-    @Override
-    void updateCacheAndRemoveTransactionState(Set<Long> startTimestamps);
-
     /**
-     * This method should only be used when the transaction has failed and the state needs to be removed from the
-     * cache without updating the central value store.
+     * This does *not* remove state from the cache - {@link #removeTransactionState(long)} must be called at the end
+     * of the transaction to do so, or else there will be a memory leak.
      */
+    @Override
+    void updateCacheOnCommit(Set<Long> startTimestamps);
+
     @Override
     void removeTransactionState(long startTimestamp);
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
@@ -93,13 +93,7 @@ public final class LockWatchValueScopingCacheImpl implements LockWatchValueScopi
     @Override
     public synchronized void removeTransactionState(long startTimestamp) {
         StartTimestamp startTs = StartTimestamp.of(startTimestamp);
-        // Remove the timestamps, and if the sequence has not updated, update the snapshot with the reads from
-        // these transactions (there is no guarantee that all the start timestamps have the same sequence).
-        snapshotStore
-                .removeTimestamp(startTs)
-                .filter(sequence -> currentVersion.isPresent()
-                        && sequence.value() == currentVersion.get().version())
-                .ifPresent(sequence -> snapshotStore.updateSnapshot(sequence, valueStore.getSnapshot()));
+        snapshotStore.removeTimestamp(startTs);
         cacheStore.removeCache(startTs);
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
@@ -86,27 +86,20 @@ public final class LockWatchValueScopingCacheImpl implements LockWatchValueScopi
     }
 
     @Override
-    public synchronized void updateCacheAndRemoveTransactionState(Set<Long> startTimestamps) {
-        try {
-            startTimestamps.forEach(this::processCommitUpdate);
-        } finally {
-            // Remove the timestamps, and if the sequence has not updated, update the snapshot with the reads from
-            // these transactions (there is no guarantee that all the start timestamps have the same sequence).
-            startTimestamps.stream().map(StartTimestamp::of).forEach(startTs -> {
-                snapshotStore
-                        .removeTimestamp(startTs)
-                        .filter(sequence -> currentVersion.isPresent()
-                                && sequence.value() == currentVersion.get().version())
-                        .ifPresent(sequence -> snapshotStore.updateSnapshot(sequence, valueStore.getSnapshot()));
-                cacheStore.removeCache(startTs);
-            });
-        }
+    public synchronized void updateCacheOnCommit(Set<Long> startTimestamps) {
+        startTimestamps.forEach(this::processCommitUpdate);
     }
 
     @Override
     public synchronized void removeTransactionState(long startTimestamp) {
         StartTimestamp startTs = StartTimestamp.of(startTimestamp);
-        snapshotStore.removeTimestamp(startTs);
+        // Remove the timestamps, and if the sequence has not updated, update the snapshot with the reads from
+        // these transactions (there is no guarantee that all the start timestamps have the same sequence).
+        snapshotStore
+                .removeTimestamp(startTs)
+                .filter(sequence -> currentVersion.isPresent()
+                        && sequence.value() == currentVersion.get().version())
+                .ifPresent(sequence -> snapshotStore.updateSnapshot(sequence, valueStore.getSnapshot()));
         cacheStore.removeCache(startTs);
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/SnapshotStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/SnapshotStore.java
@@ -30,8 +30,8 @@ public interface SnapshotStore {
     /**
      * Stores a snapshot for a given sequence and set of timestamps. Calls with the same sequence but a different
      * snapshot will overwrite the snapshot - this means that multiple calls to {@link #getSnapshot(StartTimestamp)}
-     * may return different snapshots over time for the same start timestamp. However, these newer snapshots should
-     * just be more complete versions of past snapshots, and thus maintains correctness (the timestamp could
+     * may return different snapshots over time for the same start timestamp. However, these newer snapshots *should*
+     * just be more complete versions of past snapshots, and thus maintain correctness (the timestamp could
      * correctly receive any one of the snapshots, and the only factor that changes is how much is cached, not the
      * values themselves).
      */

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/SnapshotStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/SnapshotStore.java
@@ -27,6 +27,14 @@ import java.util.Optional;
  * and and removes snapshots when they are no longer referenced by any live start timestamps.
  */
 public interface SnapshotStore {
+    /**
+     * Stores a snapshot for a given sequence and set of timestamps. Calls with the same sequence but a different
+     * snapshot will overwrite the snapshot - this means that multiple calls to {@link #getSnapshot(StartTimestamp)}
+     * may return different snapshots over time for the same start timestamp. However, these newer snapshots should
+     * just be more complete versions of past snapshots, and thus maintains correctness (the timestamp could
+     * correctly receive any one of the snapshots, and the only factor that changes is how much is cached, not the
+     * values themselves).
+     */
     void storeSnapshot(Sequence sequence, Collection<StartTimestamp> timestamps, ValueCacheSnapshot snapshot);
 
     Optional<ValueCacheSnapshot> getSnapshot(StartTimestamp timestamp);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/SnapshotStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/SnapshotStore.java
@@ -29,13 +29,11 @@ import java.util.Optional;
 public interface SnapshotStore {
     void storeSnapshot(Sequence sequence, Collection<StartTimestamp> timestamps, ValueCacheSnapshot snapshot);
 
-    void updateSnapshot(Sequence sequence, ValueCacheSnapshot snapshot);
-
     Optional<ValueCacheSnapshot> getSnapshot(StartTimestamp timestamp);
 
     Optional<ValueCacheSnapshot> getSnapshotForSequence(Sequence sequence);
 
-    Optional<Sequence> removeTimestamp(StartTimestamp timestamp);
+    void removeTimestamp(StartTimestamp timestamp);
 
     void reset();
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/SnapshotStoreImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/SnapshotStoreImpl.java
@@ -20,7 +20,6 @@ import com.google.common.collect.MultimapBuilder;
 import com.google.common.collect.SetMultimap;
 import com.palantir.atlasdb.keyvalue.api.watch.Sequence;
 import com.palantir.atlasdb.keyvalue.api.watch.StartTimestamp;
-import com.palantir.logsafe.Preconditions;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -42,28 +41,12 @@ final class SnapshotStoreImpl implements SnapshotStore {
     @Override
     public void storeSnapshot(Sequence sequence, Collection<StartTimestamp> timestamps, ValueCacheSnapshot snapshot) {
         if (!timestamps.isEmpty()) {
-            snapshotMap.compute(sequence, (_seq, currentSnapshot) -> {
-                Preconditions.checkState(
-                        currentSnapshot == null || snapshot.equals(currentSnapshot),
-                        "Attempted to store a snapshot where one already exists, and does not match");
-                return snapshot;
-            });
+            snapshotMap.put(sequence, snapshot);
             timestamps.forEach(timestamp -> {
                 liveSequences.put(sequence, timestamp);
                 timestampMap.put(timestamp, sequence);
             });
         }
-    }
-
-    /**
-     * If there are *very* infrequent updates, the cache may not progress the sequence at all. In this case, we want
-     * to update the latest snapshot so that subsequent transactions may benefit from the reads. However, if the
-     * transaction was the last for that sequence, the snapshot may have been removed, in which case we do not need
-     * to re-write the snapshot, as that will happen when the next transaction is started.
-     */
-    @Override
-    public void updateSnapshot(Sequence sequence, ValueCacheSnapshot snapshot) {
-        snapshotMap.computeIfPresent(sequence, (_sequence, _snapshot) -> snapshot);
     }
 
     @Override
@@ -72,17 +55,13 @@ final class SnapshotStoreImpl implements SnapshotStore {
     }
 
     @Override
-    public Optional<Sequence> removeTimestamp(StartTimestamp timestamp) {
-        Optional<Sequence> removedSequence = Optional.ofNullable(timestampMap.remove(timestamp));
-
-        removedSequence.ifPresent(sequence -> {
+    public void removeTimestamp(StartTimestamp timestamp) {
+        Optional.ofNullable(timestampMap.remove(timestamp)).ifPresent(sequence -> {
             liveSequences.remove(sequence, timestamp);
             if (!liveSequences.containsKey(sequence)) {
                 snapshotMap.remove(sequence);
             }
         });
-
-        return removedSequence;
     }
 
     @Override

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImplTest.java
@@ -107,7 +107,7 @@ public final class LockWatchValueScopingCacheImplTest {
         TransactionScopedCache scopedCache1 = valueCache.createTransactionScopedCache(TIMESTAMP_1);
         assertThat(getRemotelyReadCells(scopedCache1, TABLE, CELL_1)).containsExactlyInAnyOrder(CELL_1);
         processCommitTimestamp(TIMESTAMP_1, 0L);
-        valueCache.updateCacheAndRemoveTransactionState(ImmutableSet.of(TIMESTAMP_1));
+        valueCache.updateCacheOnCommit(ImmutableSet.of(TIMESTAMP_1));
 
         TransactionScopedCache scopedCache2 = valueCache.createTransactionScopedCache(TIMESTAMP_2);
         assertThat(getRemotelyReadCells(scopedCache2, TABLE, CELL_1)).isEmpty();
@@ -121,7 +121,7 @@ public final class LockWatchValueScopingCacheImplTest {
         TransactionScopedCache scopedCache1 = valueCache.createTransactionScopedCache(TIMESTAMP_1);
         assertThat(getRemotelyReadCells(scopedCache1, TABLE, CELL_1)).containsExactlyInAnyOrder(CELL_1);
         processCommitTimestamp(TIMESTAMP_1, 0L);
-        valueCache.updateCacheAndRemoveTransactionState(ImmutableSet.of(TIMESTAMP_1));
+        valueCache.updateCacheOnCommit(ImmutableSet.of(TIMESTAMP_1));
 
         eventCache.processStartTransactionsUpdate(
                 ImmutableSet.of(TIMESTAMP_2), LockWatchStateUpdate.success(LEADER, 0L, ImmutableList.of()));
@@ -146,7 +146,7 @@ public final class LockWatchValueScopingCacheImplTest {
 
         // Throws this message because the leader election cleared the info entirely (as opposed to us knowing that
         // there was an election)
-        assertThatThrownBy(() -> valueCache.updateCacheAndRemoveTransactionState(ImmutableSet.of(TIMESTAMP_1)))
+        assertThatThrownBy(() -> valueCache.updateCacheOnCommit(ImmutableSet.of(TIMESTAMP_1)))
                 .isExactlyInstanceOf(TransactionLockWatchFailedException.class)
                 .hasMessage("start or commit info not processed for start timestamp");
     }
@@ -159,7 +159,7 @@ public final class LockWatchValueScopingCacheImplTest {
         TransactionScopedCache scopedCache1 = valueCache.createTransactionScopedCache(TIMESTAMP_1);
         assertThat(getRemotelyReadCells(scopedCache1, TABLE, CELL_1, CELL_3)).containsExactlyInAnyOrder(CELL_1, CELL_3);
         processCommitTimestamp(TIMESTAMP_1, 0L);
-        valueCache.updateCacheAndRemoveTransactionState(ImmutableSet.of(TIMESTAMP_1));
+        valueCache.updateCacheOnCommit(ImmutableSet.of(TIMESTAMP_1));
         assertThat(scopedCache1.getHitDigest().hitCells()).isEmpty();
 
         eventCache.processStartTransactionsUpdate(
@@ -172,7 +172,7 @@ public final class LockWatchValueScopingCacheImplTest {
         assertThat(getRemotelyReadCells(scopedCache2, TABLE, CELL_1, CELL_2, CELL_3))
                 .containsExactlyInAnyOrder(CELL_1);
         processCommitTimestamp(TIMESTAMP_2, 1L);
-        valueCache.updateCacheAndRemoveTransactionState(ImmutableSet.of(TIMESTAMP_2));
+        valueCache.updateCacheOnCommit(ImmutableSet.of(TIMESTAMP_2));
         assertThat(scopedCache2.getHitDigest().hitCells()).containsExactly(CellReference.of(TABLE, CELL_3));
 
         eventCache.processStartTransactionsUpdate(
@@ -231,7 +231,7 @@ public final class LockWatchValueScopingCacheImplTest {
         TransactionScopedCache scopedCache1 = valueCache.createTransactionScopedCache(TIMESTAMP_1);
         assertThat(getRemotelyReadCells(scopedCache1, TABLE, CELL_1)).containsExactlyInAnyOrder(CELL_1);
         processCommitTimestamp(TIMESTAMP_1, 0L);
-        valueCache.updateCacheAndRemoveTransactionState(ImmutableSet.of(TIMESTAMP_1));
+        valueCache.updateCacheOnCommit(ImmutableSet.of(TIMESTAMP_1));
 
         eventCache.processStartTransactionsUpdate(
                 ImmutableSet.of(TIMESTAMP_2), LockWatchStateUpdate.success(LEADER, 0L, ImmutableList.of()));
@@ -241,7 +241,7 @@ public final class LockWatchValueScopingCacheImplTest {
         TransactionScopedCache scopedCache2 = valueCache.createTransactionScopedCache(TIMESTAMP_2);
         assertThat(getRemotelyReadCells(scopedCache2, TABLE, CELL_1)).isEmpty();
         processCommitTimestamp(TIMESTAMP_2, 0L);
-        valueCache.updateCacheAndRemoveTransactionState(ImmutableSet.of(TIMESTAMP_2));
+        valueCache.updateCacheOnCommit(ImmutableSet.of(TIMESTAMP_2));
 
         UUID newLeader = UUID.randomUUID();
         eventCache.processStartTransactionsUpdate(
@@ -259,7 +259,7 @@ public final class LockWatchValueScopingCacheImplTest {
                         .writesToken(LockToken.of(UUID.randomUUID()))
                         .build()),
                 LockWatchStateUpdate.success(newLeader, -1L, ImmutableList.of()));
-        valueCache.updateCacheAndRemoveTransactionState(ImmutableSet.of(TIMESTAMP_3));
+        valueCache.updateCacheOnCommit(ImmutableSet.of(TIMESTAMP_3));
     }
 
     private void processCommitTimestamp(long startTimestamp, long sequence) {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImplTest.java
@@ -100,20 +100,6 @@ public final class LockWatchValueScopingCacheImplTest {
     }
 
     @Test
-    public void updateCacheOnCommitFlushesValuesToLatestSequenceCache() {
-        eventCache.processStartTransactionsUpdate(ImmutableSet.of(TIMESTAMP_1, TIMESTAMP_2), LOCK_WATCH_SNAPSHOT);
-        valueCache.processStartTransactions(ImmutableSet.of(TIMESTAMP_1, TIMESTAMP_2));
-
-        TransactionScopedCache scopedCache1 = valueCache.createTransactionScopedCache(TIMESTAMP_1);
-        assertThat(getRemotelyReadCells(scopedCache1, TABLE, CELL_1)).containsExactlyInAnyOrder(CELL_1);
-        processCommitTimestamp(TIMESTAMP_1, 0L);
-        valueCache.updateCacheOnCommit(ImmutableSet.of(TIMESTAMP_1));
-
-        TransactionScopedCache scopedCache2 = valueCache.createTransactionScopedCache(TIMESTAMP_2);
-        assertThat(getRemotelyReadCells(scopedCache2, TABLE, CELL_1)).isEmpty();
-    }
-
-    @Test
     public void updateCacheOnCommitFlushesValuesToCentralCache() {
         eventCache.processStartTransactionsUpdate(ImmutableSet.of(TIMESTAMP_1), LOCK_WATCH_SNAPSHOT);
         valueCache.processStartTransactions(ImmutableSet.of(TIMESTAMP_1));

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/SnapshotStoreImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/SnapshotStoreImplTest.java
@@ -17,7 +17,6 @@
 package com.palantir.atlasdb.keyvalue.api.cache;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.keyvalue.api.Cell;
@@ -25,7 +24,6 @@ import com.palantir.atlasdb.keyvalue.api.CellReference;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.watch.Sequence;
 import com.palantir.atlasdb.keyvalue.api.watch.StartTimestamp;
-import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import io.vavr.collection.HashMap;
 import io.vavr.collection.HashSet;
 import java.util.stream.Stream;
@@ -65,12 +63,14 @@ public final class SnapshotStoreImplTest {
     }
 
     @Test
-    public void snapshotsNotOverwrittenForSameSequence() {
+    public void snapshotsOverwriteForSameSequence() {
         snapshotStore.storeSnapshot(SEQUENCE_1, ImmutableSet.of(TIMESTAMP_1), SNAPSHOT_1);
+        snapshotStore.storeSnapshot(SEQUENCE_1, ImmutableSet.of(TIMESTAMP_2), SNAPSHOT_2);
 
-        assertThatThrownBy(() -> snapshotStore.storeSnapshot(SEQUENCE_1, ImmutableSet.of(TIMESTAMP_2), SNAPSHOT_2))
-                .isExactlyInstanceOf(SafeIllegalStateException.class)
-                .hasMessage("Attempted to store a snapshot where one already exists, and does not match");
+        assertThat(snapshotStore.getSnapshot(TIMESTAMP_1).get())
+                .isEqualTo(SNAPSHOT_2)
+                .isNotEqualTo(SNAPSHOT_1);
+        assertSnapshotsEqualForTimestamp(SNAPSHOT_2, TIMESTAMP_1, TIMESTAMP_2);
     }
 
     @Test
@@ -89,21 +89,10 @@ public final class SnapshotStoreImplTest {
         assertThat(snapshotStore.getSnapshot(TIMESTAMP_1)).isEmpty();
 
         snapshotStore.removeTimestamp(TIMESTAMP_3);
+        assertSnapshotsEqualForTimestamp(SNAPSHOT_2, TIMESTAMP_4);
         assertThat(snapshotStore.getSnapshot(TIMESTAMP_1)).isEmpty();
 
-        assertSnapshotsEqualForTimestamp(SNAPSHOT_2, TIMESTAMP_4);
         assertThat(snapshotStore.getSnapshotForSequence(SEQUENCE_1)).isEmpty();
-    }
-
-    @Test
-    public void updateSnapshotOnlyUpdatesIfPresent() {
-        snapshotStore.storeSnapshot(SEQUENCE_1, ImmutableSet.of(TIMESTAMP_1), SNAPSHOT_1);
-
-        snapshotStore.updateSnapshot(SEQUENCE_1, SNAPSHOT_2);
-        assertThat(snapshotStore.getSnapshot(TIMESTAMP_1)).hasValue(SNAPSHOT_2);
-
-        snapshotStore.updateSnapshot(SEQUENCE_2, SNAPSHOT_1);
-        assertThat(snapshotStore.getSnapshotForSequence(SEQUENCE_2)).isEmpty();
     }
 
     private void assertSnapshotsEqualForTimestamp(ValueCacheSnapshot expectedValue, StartTimestamp... timestamps) {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/ResilientLockWatchProxyTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/ResilientLockWatchProxyTest.java
@@ -69,9 +69,9 @@ public final class ResilientLockWatchProxyTest {
         // Normal operation
         long timestamp = 1L;
         Set<Long> timestamps = ImmutableSet.of(timestamp);
-        proxyCache.updateCacheAndRemoveTransactionState(timestamps);
-        verify(defaultCache).updateCacheAndRemoveTransactionState(timestamps);
-        verify(fallbackCache, never()).updateCacheAndRemoveTransactionState(any());
+        proxyCache.updateCacheOnCommit(timestamps);
+        verify(defaultCache).updateCacheOnCommit(timestamps);
+        verify(fallbackCache, never()).updateCacheOnCommit(any());
 
         // Failure
         when(defaultCache.createTransactionScopedCache(timestamp))

--- a/changelog/@unreleased/pr-5433.v2.yml
+++ b/changelog/@unreleased/pr-5433.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Modified the lock watch value cache to update snapshots for a fixed sequence at start transaction time instead of commit transaction time.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5433

--- a/lock-api/src/main/java/com/palantir/lock/watch/LockWatchCacheImpl.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/LockWatchCacheImpl.java
@@ -43,7 +43,7 @@ public final class LockWatchCacheImpl implements LockWatchCache {
     public void processCommitTimestampsUpdate(
             Collection<TransactionUpdate> transactionUpdates, LockWatchStateUpdate update) {
         eventCache.processGetCommitTimestampsUpdate(transactionUpdates, update);
-        valueCache.updateCacheAndRemoveTransactionState(
+        valueCache.updateCacheOnCommit(
                 transactionUpdates.stream().map(TransactionUpdate::startTs).collect(Collectors.toSet()));
     }
 

--- a/lock-api/src/main/java/com/palantir/lock/watch/LockWatchValueCache.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/LockWatchValueCache.java
@@ -21,7 +21,7 @@ import java.util.Set;
 public interface LockWatchValueCache {
     void processStartTransactions(Set<Long> startTimestamps);
 
-    void updateCacheAndRemoveTransactionState(Set<Long> startTimestamps);
+    void updateCacheOnCommit(Set<Long> startTimestamps);
 
     void removeTransactionState(long startTimestamp);
 }

--- a/lock-api/src/main/java/com/palantir/lock/watch/NoOpLockWatchValueCache.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/NoOpLockWatchValueCache.java
@@ -27,7 +27,7 @@ public class NoOpLockWatchValueCache implements LockWatchValueCache {
     public void processStartTransactions(Set<Long> startTimestamps) {}
 
     @Override
-    public void updateCacheAndRemoveTransactionState(Set<Long> startTimestamps) {}
+    public void updateCacheOnCommit(Set<Long> startTimestamps) {}
 
     @Override
     public void removeTransactionState(long startTimestamp) {}

--- a/lock-api/src/test/java/com/palantir/lock/watch/LockWatchCacheImplTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/watch/LockWatchCacheImplTest.java
@@ -56,7 +56,7 @@ public class LockWatchCacheImplTest {
     public void commitTest() {
         cache.processCommitTimestampsUpdate(UPDATES, SUCCESS);
         verify(eventCache).processGetCommitTimestampsUpdate(UPDATES, SUCCESS);
-        verify(valueCache).updateCacheAndRemoveTransactionState(TIMESTAMPS);
+        verify(valueCache).updateCacheOnCommit(TIMESTAMPS);
     }
 
     @Test


### PR DESCRIPTION
**Goals (and why)**:
It is important that we do _not_ remove the state from the cache at commit time, as we'll need to retrieve information just after the commit timestamp update, but before we enter the `finally` block.

**Implementation Description (bullets)**:
* Removed the state removal at commit timestamp time.
* Renamed usages to reflect

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added tests to confirm that the state still exists after calling update cache on commit.

**Concerns (what feedback would you like?)**:
We didn't solely rely on this for cleanup, so this should be fine - we still call `removeTimestampState` in the `finally` block.

**Where should we start reviewing?**:
LWVSCI.

**Priority (whenever / two weeks / yesterday)**:
Again, sooner rather than later to unblock subsequent work.
