### PR TITLE
Fix the Leaky Roof: Fail Fast on Post-Transaction Iterator Usage

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
@@ -78,6 +78,8 @@ public interface Transaction {
      * It is guaranteed that the {@link Map#keySet()} of the returned map has a corresponding element for each of the
      * input {@code rows}, even if there are rows where no columns match the predicate.
      *
+     * Batching visitables must be used strictly within the scope of the transaction.
+     *
      * @param tableRef table to load values from
      * @param rows unique rows to apply the column range selection to
      * @param columnRangeSelection range of columns and batch size to load for each of the rows provided
@@ -97,6 +99,8 @@ public interface Transaction {
      * If the {@link Iterable} does not have a stable ordering (i.e. iteration order can change across iterators
      * returned) then the returned iterator is sorted lexicographically with columns sorted on byte ordering, but
      * the ordering of rows is undefined.
+     *
+     * Iterators must be used strictly within the scope of the transaction.
      *
      * @param tableRef table to load values from
      * @param rows unique rows to apply the column range selection to
@@ -120,6 +124,8 @@ public interface Transaction {
      * It is guaranteed that the {@link Map#keySet()} of the returned map has a corresponding element for each of the
      * input {@code rows}, even if there are rows where no columns match the predicate.
      *
+     * Iterators must be used strictly within the scope of the transaction.
+     *
      * @param tableRef table to load values from
      * @param rows unique rows to apply the column range selection to
      * @param columnRangeSelection range of columns and batch size to load for each of the rows provided
@@ -142,6 +148,8 @@ public interface Transaction {
      * returned) then the returned iterator is sorted lexicographically with columns sorted on byte ordering, but the
      * ordering of rows is undefined. In case of duplicate rows, the ordering is based on the first occurrence of
      * the row.
+     *
+     * Iterators must be used strictly within the scope of the transaction.
      *
      * @param tableRef table to load values from
      * @param rows unique rows to apply column range selection to
@@ -175,6 +183,8 @@ public interface Transaction {
     /**
      * Creates a visitable that scans the provided range.
      *
+     * Batching visitables must be used strictly within the scope of the transaction.
+     *
      * @param tableRef the table to scan
      * @param rangeRequest the range of rows and columns to scan
      * @return an array of <code>RowResult</code> objects representing the range
@@ -189,6 +199,8 @@ public interface Transaction {
      * the batch hint in each RangeRequest. If this isn't done then this method may do more work
      * than you need and will be slower than it needs to be.  If the batchHint isn't specified it
      * will default to 1 for the first page in each range.
+     *
+     * Batching visitables must be used strictly within the scope of the transaction.
      *
      * @deprecated Should use either {@link #getRanges(TableReference, Iterable, int, BiFunction)} or
      * {@link #getRangesLazy(TableReference, Iterable)} to ensure you are using an appropriate level
@@ -205,6 +217,8 @@ public interface Transaction {
      *
      * It is guaranteed that the range requests seen by the provided visitable processor are equal to the provided
      * iterable of range requests, though no guarantees are made on the order they are encountered in.
+     *
+     * Streams must be read within the scope of the transaction.
      */
     @Idempotent
     <T> Stream<T> getRanges(
@@ -233,6 +247,8 @@ public interface Transaction {
     /**
      * Returns visitibles that scan the provided ranges. This does no pre-fetching so visiting the resulting
      * visitibles will incur database reads on first access.
+     *
+     * Streams and visitables must be read within the scope of this transaction.
      */
     @Idempotent
     Stream<BatchingVisitable<RowResult<byte[]>>> getRangesLazy(

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -2630,30 +2630,29 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         }
     }
 
-    private BatchingVisitable<Entry<Cell, byte[]>> scopeToTransaction(
-            BatchingVisitable<Entry<Cell, byte[]>> delegateVisitable) {
-        return new BatchingVisitable<Entry<Cell, byte[]>>() {
+    private <T> BatchingVisitable<T> scopeToTransaction(BatchingVisitable<T> delegateVisitable) {
+        return new BatchingVisitable<T>() {
             @Override
             public <K extends Exception> boolean batchAccept(
-                    int batchSize, AbortingVisitor<? super List<Entry<Cell, byte[]>>, K> visitor) throws K {
+                    int batchSize, AbortingVisitor<? super List<T>, K> visitor) throws K {
                 ensureStillRunning();
                 return delegateVisitable.batchAccept(batchSize, visitor);
             }
         };
     }
 
-    private Iterator<Entry<Cell, byte[]>> scopeToTransaction(Iterator<Entry<Cell, byte[]>> postFilteredIterator) {
-        return new Iterator<Entry<Cell, byte[]>>() {
+    private <T> Iterator<T> scopeToTransaction(Iterator<T> delegateIterator) {
+        return new Iterator<T>() {
             @Override
             public boolean hasNext() {
                 ensureStillRunning();
-                return postFilteredIterator.hasNext();
+                return delegateIterator.hasNext();
             }
 
             @Override
-            public Entry<Cell, byte[]> next() {
+            public T next() {
                 ensureStillRunning();
-                return postFilteredIterator.next();
+                return delegateIterator.next();
             }
         };
     }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -49,6 +49,7 @@ import com.google.common.collect.Streams;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.SettableFuture;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.AtlasDbTestCase;
 import com.palantir.atlasdb.cache.DefaultTimestampCache;
@@ -77,6 +78,7 @@ import com.palantir.atlasdb.transaction.ImmutableTransactionConfig;
 import com.palantir.atlasdb.transaction.TransactionConfig;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
+import com.palantir.atlasdb.transaction.api.ImmutableGetRangesQuery;
 import com.palantir.atlasdb.transaction.api.LockAwareTransactionTask;
 import com.palantir.atlasdb.transaction.api.PreCommitCondition;
 import com.palantir.atlasdb.transaction.api.Transaction;
@@ -96,6 +98,7 @@ import com.palantir.common.base.AbortingVisitor;
 import com.palantir.common.base.AbortingVisitors;
 import com.palantir.common.base.BatchingVisitable;
 import com.palantir.common.base.BatchingVisitableView;
+import com.palantir.common.base.BatchingVisitables;
 import com.palantir.common.base.Throwables;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.common.proxy.MultiDelegateProxy;
@@ -124,6 +127,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Random;
 import java.util.SortedMap;
@@ -136,10 +140,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.commons.lang3.mutable.MutableLong;
@@ -1889,6 +1895,81 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                     .containsExactly(Maps.immutableEntry(TEST_CELL, PtBytes.toBytes("tom")));
             return null;
         });
+    }
+
+    @Test
+    public void cannotCompleteFutureAfterTransactionCommit() {
+        SettableFuture<Object> blocker = SettableFuture.create();
+        ListenableFuture<Map<Cell, byte[]>> getFuture = txManager.runTaskThrowOnConflict(txn -> {
+            txn.put(TABLE, ImmutableMap.of(TEST_CELL, PtBytes.toBytes("jeremy")));
+            return Futures.transformAsync(
+                    blocker,
+                    _unused -> txn.getAsync(TABLE, ImmutableSet.of(TEST_CELL)),
+                    MoreExecutors.directExecutor());
+        });
+        blocker.set(new Object());
+        assertThatThrownBy(getFuture::get)
+                .isInstanceOf(ExecutionException.class)
+                .satisfies(exception ->
+                        assertThat(exception.getCause()).isInstanceOf(CommittedTransactionException.class));
+    }
+
+    @Test
+    public void cannotReadStreamAfterTransactionCommit() {
+        Stream<byte[]> values = txManager.runTaskThrowOnConflict(txn -> {
+            txn.put(TABLE, ImmutableMap.of(TEST_CELL, PtBytes.toBytes("tom")));
+
+            BiFunction<RangeRequest, BatchingVisitable<RowResult<byte[]>>, byte[]> singleValueExtractor =
+                    ($, visitable) -> Iterables.getOnlyElement(BatchingVisitables.copyToList(visitable))
+                            .getOnlyColumnValue();
+            return txn.getRanges(ImmutableGetRangesQuery.<byte[]>builder()
+                    .tableRef(TABLE)
+                    .rangeRequests(ImmutableList.of(RangeRequest.all()))
+                    .visitableProcessor(singleValueExtractor)
+                    .build());
+        });
+        assertThatThrownBy(() -> values.collect(Collectors.toList())).isInstanceOf(CommittedTransactionException.class);
+    }
+
+    @Test
+    public void cannotPerformUnmergedGetRowsColumnRangeAfterTransactionCommit() {
+        Map<byte[], BatchingVisitable<Entry<Cell, byte[]>>> visitables = txManager.runTaskThrowOnConflict(txn -> {
+            txn.put(TABLE, ImmutableMap.of(TEST_CELL, PtBytes.toBytes("alice")));
+            return txn.getRowsColumnRange(
+                    TABLE,
+                    ImmutableList.of(TEST_CELL.getRowName()),
+                    BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 100));
+        });
+
+        assertThatThrownBy(() -> BatchingVisitables.copyToList(visitables.get(TEST_CELL.getRowName())))
+                .isInstanceOf(CommittedTransactionException.class);
+    }
+
+    @Test
+    public void cannotPerformMergedGetRowsColumnRangeAfterTransactionCommit() {
+        Iterator<Entry<Cell, byte[]>> entryIterator = txManager.runTaskThrowOnConflict(txn -> {
+            txn.put(TABLE, ImmutableMap.of(TEST_CELL, PtBytes.toBytes("bob")));
+            return txn.getRowsColumnRange(
+                    TABLE,
+                    ImmutableList.of(TEST_CELL.getRowName()),
+                    new ColumnRangeSelection(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY),
+                    100);
+        });
+
+        assertThatThrownBy(entryIterator::next).isInstanceOf(CommittedTransactionException.class);
+    }
+
+    @Test
+    public void cannotReadSortedColumnsAfterTransactionCommit() {
+        Iterator<Entry<Cell, byte[]>> cellIterator = txManager.runTaskThrowOnConflict(txn -> {
+            txn.put(TABLE, ImmutableMap.of(TEST_CELL, PtBytes.toBytes("will")));
+
+            return txn.getSortedColumns(
+                    TABLE,
+                    ImmutableList.of(TEST_CELL.getRowName()),
+                    BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 100));
+        });
+        assertThatThrownBy(cellIterator::next).isInstanceOf(CommittedTransactionException.class);
     }
 
     private void verifyPrefetchValidations(


### PR DESCRIPTION
**Goals (and why)**:
- Prevent users from using Iterators, Streams, Visitables and Async operations after a transaction has ended.
- Ensure that AtlasDB devs do not accidentally allow users to do this in the future

**Implementation Description (bullets)**:
- Add tests.
- In the cases we have not handled correctly, fix the transaction code.
- Add information to the javadoc indicating our decision.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Tests added that exceptions are thrown if one tries to use the forbidden incantations.

**Concerns (what feedback would you like?)**:
- Did I miss any key tests?

**Where should we start reviewing?**: SnapshotTransactionTest

**Priority (whenever / two weeks / yesterday)**: 1 week
