### PR TITLE
Add explicit dependency on okio

### DIFF
--- a/atlasdb-api/build.gradle
+++ b/atlasdb-api/build.gradle
@@ -8,6 +8,7 @@ dependencies {
   compile group: 'org.apache.commons', name: 'commons-lang3'
   compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations'
   compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
+  compile group: 'com.squareup.okio', name: 'okio'
   compile group: 'jakarta.annotation', name: 'jakarta.annotation-api'
   compile group: 'jakarta.validation', name: 'jakarta.validation-api'
 

--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -43,6 +43,8 @@ dependencies {
   explicitShadow group: 'com.palantir.conjure.java.runtime', name: 'keystores'
   explicitShadow group: 'com.palantir.tracing', name: 'tracing'
 
+  explicitShadow group: 'com.squareup.okio', name: 'okio'
+
   // does shadowing statically analysed annotations really buy us anything?
   explicitShadow group: 'com.google.code.findbugs', name: 'findbugs-annotations'
   explicitShadow group: 'com.google.code.findbugs', name: 'jsr305'

--- a/atlasdb-client/build.gradle
+++ b/atlasdb-client/build.gradle
@@ -67,6 +67,7 @@ dependencies {
     exclude (group: 'org.hdrhistogram', module: 'HdrHistogram')
   }
   compile group: 'com.squareup', name:'javapoet'
+  compile group: 'com.squareup.okio', name: 'okio'
   compile group: 'org.hdrhistogram', name: 'HdrHistogram'
   compile group: 'com.palantir.common', name: 'streams'
   compile group: 'com.github.rholder', name: 'guava-retrying'


### PR DESCRIPTION
Add explicit dependency on `com.squareup.okio:okio`.

Currently this is an implicit dependency coming from https://github.com/palantir/conjure-java-runtime. But this dependency was removed in https://github.com/palantir/conjure-java-runtime/pull/1971, which results in `NoClassDefFoundError` in consumers using newer versions of conjure-java-runtime.

```
Caused by: java.lang.NoClassDefFoundError: okio/ByteString
	at com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServiceImpl.partitionPerRow(CassandraKeyValueServiceImpl.java:1849)
	at com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServiceImpl.lambda$putUnlessExists$28(CassandraKeyValueServiceImpl.java:1821)
	at com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer.lambda$runWithGoodResource$0(CassandraClientPoolingContainer.java:156)
	at com.palantir.util.TimedRunner.lambda$run$0(TimedRunner.java:47)
	at com.palantir.tritium.metrics.TaggedMetricsExecutorService$TaggedMetricsCallable.call(TaggedMetricsExecutorService.java:196)
	at java.util.concurrent.FutureTask.run(FutureTask.java:264)
```