### PR TITLE
[PDS-183571] Maximum Lock Tenuring, Part 1: Forced Release

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/TransactionConfig.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/TransactionConfig.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.transaction.impl.TransactionRetryStrategy;
+import com.palantir.conjure.java.api.config.service.HumanReadableDuration;
 import org.immutables.value.Value;
 
 @JsonDeserialize(as = ImmutableTransactionConfig.class)
@@ -49,6 +50,15 @@ public abstract class TransactionConfig {
     @Value.Default
     public boolean lockImmutableTsOnReadOnlyTransactions() {
         return false;
+    }
+
+    /**
+     * Indicates how long user transactions are allowed to take to commit, in terms of how long we'll refresh the
+     * commit locks for.
+     */
+    @Value.Default
+    public HumanReadableDuration commitLockTenure() {
+        return HumanReadableDuration.minutes(5);
     }
 
     /**

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/TransactionConfig.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/TransactionConfig.java
@@ -54,7 +54,8 @@ public abstract class TransactionConfig {
 
     /**
      * Indicates how long user transactions are allowed to take to commit, in terms of how long we'll refresh the
-     * commit locks for.
+     * commit locks for. Note that locks may still require more time before TimeLock realises that they are no longer
+     * actively held and releases them.
      */
     @Value.Default
     public HumanReadableDuration commitLockTenure() {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/TransactionConfig.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/TransactionConfig.java
@@ -59,7 +59,7 @@ public abstract class TransactionConfig {
      */
     @Value.Default
     public HumanReadableDuration commitLockTenure() {
-        return HumanReadableDuration.minutes(5);
+        return HumanReadableDuration.minutes(15);
     }
 
     /**

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/InstrumentedTimelockService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/InstrumentedTimelockService.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.transaction.impl;
 import com.codahale.metrics.Meter;
 import com.palantir.atlasdb.AtlasDbMetricNames;
 import com.palantir.atlasdb.util.MetricsManager;
+import com.palantir.lock.v2.ClientLockingOptions;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
 import com.palantir.lock.v2.LockRequest;
 import com.palantir.lock.v2.LockResponse;
@@ -95,6 +96,11 @@ public final class InstrumentedTimelockService implements TimelockService {
     @Override
     public LockResponse lock(LockRequest request) {
         return executeWithRecord(() -> timelockService.lock(request));
+    }
+
+    @Override
+    public LockResponse lock(LockRequest lockRequest, ClientLockingOptions options) {
+        return executeWithRecord(() -> timelockService.lock(lockRequest, options));
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -2215,6 +2215,8 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                 lockDescriptors,
                 lockAcquireTimeoutMillis,
                 Optional.ofNullable(getStartTimestampAsClientDescription(currentTransactionConfig)));
+
+        RuntimeException stackTraceSnapshot = new RuntimeException("I exist to show you the stack trace");
         LockResponse lockResponse = timelockService.lock(
                 request,
                 ClientLockingOptions.builder()
@@ -2226,7 +2228,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                                         + " other transactions to proceed.",
                                 SafeArg.of("commitLockTenure", currentTransactionConfig.commitLockTenure()),
                                 UnsafeArg.of("firstTenLockDescriptors", Iterables.limit(lockDescriptors, 10)),
-                                new RuntimeException("I exist to show you the stack trace")))
+                                stackTraceSnapshot))
                         .build());
         if (!lockResponse.wasSuccessful()) {
             log.error(

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -2220,6 +2220,12 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                 request,
                 ClientLockingOptions.builder()
                         .maximumLockTenure(Duration.ofMinutes(5))
+                        .tenureExpirationCallback(() -> log.warn(
+                                "This transaction held on to its commit locks for five minutes, which is"
+                                        + " suspicious. In the interest of liveness we will unlock this lock and allow"
+                                        + " other transactions to proceed.",
+                                UnsafeArg.of("firstTenLockDescriptors", Iterables.limit(lockDescriptors, 10)),
+                                new RuntimeException("I exist to show you the stack trace")))
                         .build());
         if (!lockResponse.wasSuccessful()) {
             log.error(

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -119,6 +119,7 @@ import com.palantir.common.streams.MoreStreams;
 import com.palantir.lock.AtlasCellLockDescriptor;
 import com.palantir.lock.AtlasRowLockDescriptor;
 import com.palantir.lock.LockDescriptor;
+import com.palantir.lock.v2.ClientLockingOptions;
 import com.palantir.lock.v2.ImmutableLockRequest;
 import com.palantir.lock.v2.LockRequest;
 import com.palantir.lock.v2.LockResponse;
@@ -136,6 +137,7 @@ import com.palantir.tracing.CloseableTracer;
 import com.palantir.util.AssertUtils;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
 import java.nio.ByteBuffer;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -2214,7 +2216,11 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                 lockDescriptors,
                 lockAcquireTimeoutMillis,
                 Optional.ofNullable(getStartTimestampAsClientDescription(currentTransactionConfig)));
-        LockResponse lockResponse = timelockService.lock(request);
+        LockResponse lockResponse = timelockService.lock(
+                request,
+                ClientLockingOptions.builder()
+                        .maximumLockTenure(Duration.ofMinutes(5))
+                        .build());
         if (!lockResponse.wasSuccessful()) {
             log.error(
                     "Timed out waiting while acquiring commit locks. Timeout was {} ms. "

--- a/changelog/@unreleased/pr-5438.v2.yml
+++ b/changelog/@unreleased/pr-5438.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: 'AtlasDB now by default releases the locks of transactions that are spending more than 5 minutes committing (note: this does not mean that an AtlasDB _transaction_ is bounded by 5 minutes, only the parts of the protocol during which the transaction locks need to be held) to allow forward progress. If this is a problem, consider configuring `transaction.commitLockTenure` in runtime config.'
+  links:
+  - https://github.com/palantir/atlasdb/pull/5438

--- a/changelog/@unreleased/pr-5438.v2.yml
+++ b/changelog/@unreleased/pr-5438.v2.yml
@@ -1,5 +1,8 @@
 type: improvement
 improvement:
-  description: 'AtlasDB now by default releases the locks of transactions that are spending more than 5 minutes committing (note: this does not mean that an AtlasDB _transaction_ is bounded by 5 minutes, only the parts of the protocol during which the transaction locks need to be held) to allow forward progress. If this is a problem, consider configuring `transaction.commitLockTenure` in runtime config.'
+  description: |-
+    AtlasDB now by default releases the locks of transactions that are spending more than 5 minutes committing (note: this does not mean that an AtlasDB _transaction_ is bounded by 5 minutes, only the parts of the protocol during which the transaction locks need to be held) to allow forward progress. Transactions that have had their locks expired in this way may be aborted (note that atomicity is preserved: the commit either happens or not).
+
+    If this is a problem, consider configuring `transaction.commitLockTenure` in runtime config.
   links:
   - https://github.com/palantir/atlasdb/pull/5438

--- a/lock-api-objects/src/main/java/com/palantir/lock/v2/ClientLockingOptions.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/v2/ClientLockingOptions.java
@@ -35,7 +35,9 @@ public interface ClientLockingOptions {
     Optional<Duration> maximumLockTenure();
 
     /**
-     * Invoked if the lock tenure expired on the client. Must be cheap to execute.
+     * Invoked if the lock tenure expired on the client. Must be cheap to execute: in particular, explicitly unlocking
+     * the lock or making any other RPCs is not allowed. These callbacks may be executed serially for each lock that
+     * has expired, and may block general operation of the lock server, if they are too expensive.
      */
     @Value.Default
     default Runnable tenureExpirationCallback() {

--- a/lock-api-objects/src/main/java/com/palantir/lock/v2/ClientLockingOptions.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/v2/ClientLockingOptions.java
@@ -26,11 +26,21 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 public interface ClientLockingOptions {
+    Runnable NO_OP_CALLBACK = () -> {};
+
     /**
      * After {@link ClientLockingOptions#maximumLockTenure()} has passed since the client acquired the lock, we will
      * not try to refresh the lock any longer. This is infinite by default.
      */
     Optional<Duration> maximumLockTenure();
+
+    /**
+     * Invoked if the lock tenure expired on the client. Must be cheap
+     */
+    @Value.Default
+    default Runnable tenureExpirationCallback() {
+        return NO_OP_CALLBACK;
+    }
 
     static ClientLockingOptions getDefault() {
         return builder().build();

--- a/lock-api-objects/src/main/java/com/palantir/lock/v2/ClientLockingOptions.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/v2/ClientLockingOptions.java
@@ -35,7 +35,7 @@ public interface ClientLockingOptions {
     Optional<Duration> maximumLockTenure();
 
     /**
-     * Invoked if the lock tenure expired on the client. Must be cheap
+     * Invoked if the lock tenure expired on the client. Must be cheap to execute.
      */
     @Value.Default
     default Runnable tenureExpirationCallback() {

--- a/lock-api-objects/src/main/java/com/palantir/lock/v2/ClientLockingOptions.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/v2/ClientLockingOptions.java
@@ -33,6 +33,10 @@ public interface ClientLockingOptions {
     Optional<Duration> maximumLockTenure();
 
     static ClientLockingOptions getDefault() {
-        return ImmutableClientLockingOptions.builder().build();
+        return builder().build();
+    }
+
+    static ImmutableClientLockingOptions.Builder builder() {
+        return ImmutableClientLockingOptions.builder();
     }
 }

--- a/lock-api-objects/src/main/java/com/palantir/lock/v2/ClientLockingOptions.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/v2/ClientLockingOptions.java
@@ -1,0 +1,38 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.v2;
+
+import java.time.Duration;
+import java.util.Optional;
+import org.immutables.value.Value;
+
+/**
+ * Options for, on the client-side, how AtlasDB lock requests should be processed. This class should not be visible
+ * to TimeLock servers, and must not be leaked to other services.
+ */
+@Value.Immutable
+public interface ClientLockingOptions {
+    /**
+     * After {@link ClientLockingOptions#maximumLockTenure()} has passed since the client acquired the lock, we will
+     * not try to refresh the lock any longer. This is infinite by default.
+     */
+    Optional<Duration> maximumLockTenure();
+
+    static ClientLockingOptions getDefault() {
+        return ImmutableClientLockingOptions.builder().build();
+    }
+}

--- a/lock-api-objects/src/main/java/com/palantir/lock/v2/TimelockService.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/v2/TimelockService.java
@@ -52,6 +52,12 @@ public interface TimelockService {
 
     LockResponse lock(LockRequest request);
 
+    /**
+     * Similar to {@link this#lock(LockRequest)}, but will attempt to respect the provided
+     * {@link ClientLockingOptions}. Support for these options is not guaranteed in legacy lock configurations.
+     */
+    LockResponse lock(LockRequest lockRequest, ClientLockingOptions options);
+
     WaitForLocksResponse waitForLocks(WaitForLocksRequest request);
 
     Set<LockToken> refreshLockLeases(Set<LockToken> tokens);

--- a/lock-api/src/main/java/com/palantir/lock/client/LockRefresher.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockRefresher.java
@@ -93,7 +93,9 @@ public class LockRefresher implements AutoCloseable {
             Instant deadline = candidate.getValue();
             if (now.isAfter(deadline)) {
                 log.info(
-                        "A lock token has expired, because it has exceeded its tenure.",
+                        "A lock token has expired on the client, because it has exceeded its tenure: we will stop"
+                                + " refreshing it automatically. Some time may still be required (20 seconds by"
+                                + " default) before the server releases an unrefreshed token.",
                         SafeArg.of("lockToken", candidate.getKey()),
                         SafeArg.of("expiryDeadline", deadline),
                         SafeArg.of("now", now));

--- a/lock-api/src/main/java/com/palantir/lock/client/LockRefresher.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockRefresher.java
@@ -18,6 +18,7 @@ package com.palantir.lock.client;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
+import com.palantir.lock.v2.ClientLockingOptions;
 import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.TimelockService;
 import com.palantir.logsafe.SafeArg;
@@ -80,6 +81,10 @@ public class LockRefresher implements AutoCloseable {
     }
 
     public void registerLocks(Collection<LockToken> tokens) {
+        registerLocks(tokens, ClientLockingOptions.getDefault());
+    }
+
+    public void registerLocks(Collection<LockToken> tokens, ClientLockingOptions lockingOptions) {
         tokensToRefresh.addAll(tokens);
     }
 

--- a/lock-api/src/main/java/com/palantir/lock/client/LockRefresher.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockRefresher.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.lock.client;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.palantir.lock.v2.ClientLockingOptions;
@@ -51,6 +52,7 @@ public class LockRefresher implements AutoCloseable {
         this(executor, timelockService, refreshIntervalMillis, Clock.systemUTC());
     }
 
+    @VisibleForTesting
     public LockRefresher(
             ScheduledExecutorService executor,
             TimelockService timelockService,
@@ -116,6 +118,8 @@ public class LockRefresher implements AutoCloseable {
                 tokensToRefresh.add(candidate.getKey());
             }
         }
+
+        Sets.difference(tokensToClientContext.keySet(), tokensToRefresh).forEach(tokensToClientContext::remove);
         return tokensToRefresh;
     }
 

--- a/lock-api/src/main/java/com/palantir/lock/client/ProfilingTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/ProfilingTimelockService.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
 import com.google.common.util.concurrent.RateLimiter;
 import com.palantir.common.base.Throwables;
+import com.palantir.lock.v2.ClientLockingOptions;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
 import com.palantir.lock.v2.LockRequest;
 import com.palantir.lock.v2.LockResponse;
@@ -131,6 +132,13 @@ public class ProfilingTimelockService implements AutoCloseable, TimelockService 
         // Don't profile this, as it may be skewed by user contention on locks.
         tryFlushLogs();
         return delegate.lock(request);
+    }
+
+    @Override
+    public LockResponse lock(LockRequest lockRequest, ClientLockingOptions options) {
+        // Don't profile this, as it may be skewed by user contention on locks.
+        tryFlushLogs();
+        return delegate.lock(lockRequest, options);
     }
 
     @Override

--- a/lock-api/src/main/java/com/palantir/lock/client/RemoteTimelockServiceAdapter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/RemoteTimelockServiceAdapter.java
@@ -19,6 +19,7 @@ package com.palantir.lock.client;
 import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsRequest;
 import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponse;
 import com.palantir.atlasdb.timelock.api.Namespace;
+import com.palantir.lock.v2.ClientLockingOptions;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
 import com.palantir.lock.v2.LockRequest;
 import com.palantir.lock.v2.LockResponse;
@@ -33,8 +34,12 @@ import com.palantir.timestamp.TimestampRange;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class RemoteTimelockServiceAdapter implements TimelockService, AutoCloseable {
+    private static final Logger log = LoggerFactory.getLogger(RemoteTimelockServiceAdapter.class);
+
     private final NamespacedTimelockRpcClient rpcClient;
     private final NamespacedConjureTimelockService conjureTimelockService;
     private final LockLeaseService lockLeaseService;
@@ -108,6 +113,15 @@ public final class RemoteTimelockServiceAdapter implements TimelockService, Auto
     @Override
     public LockResponse lock(LockRequest request) {
         return lockLeaseService.lock(request);
+    }
+
+    @Override
+    public LockResponse lock(LockRequest lockRequest, ClientLockingOptions options) {
+        log.warn(
+                "Locking with client options should not happen at the level of the remote adapter. We will perform a"
+                        + " normal lock, disregarding these options here.",
+                new RuntimeException("I exist to show you the stack trace"));
+        return lockLeaseService.lock(lockRequest);
     }
 
     @Override

--- a/lock-api/src/main/java/com/palantir/lock/client/TimeLockClient.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/TimeLockClient.java
@@ -41,8 +41,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 
-// TODO (jkong): This class almost shouldn't be a plain TimelockService, but the amount of effort that would be
-//  required to break the interface into two distinct components is large.
+// Ideally, this class shouldn't be a plain TimelockService, but the amount of effort that would be required to break
+// the interface into two distinct components is large.
 public class TimeLockClient implements AutoCloseable, TimelockService {
     private static final ScheduledExecutorService refreshExecutor = createSingleThreadScheduledExecutor("refresh");
 
@@ -129,11 +129,7 @@ public class TimeLockClient implements AutoCloseable, TimelockService {
 
     @Override
     public LockResponse lock(LockRequest request) {
-        LockResponse response = executeOnTimeLock(() -> delegate.lock(request));
-        if (response.wasSuccessful()) {
-            lockRefresher.registerLocks(ImmutableSet.of(response.getToken()));
-        }
-        return response;
+        return lock(request, ClientLockingOptions.getDefault());
     }
 
     @Override

--- a/lock-api/src/main/java/com/palantir/lock/client/TimeLockClient.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/TimeLockClient.java
@@ -142,7 +142,7 @@ public class TimeLockClient implements AutoCloseable, TimelockService {
         if (response.wasSuccessful()) {
             lockRefresher.registerLocks(ImmutableSet.of(response.getToken()), options);
         }
-        return null;
+        return response;
     }
 
     @Override

--- a/lock-api/src/main/java/com/palantir/lock/client/TimeLockClient.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/TimeLockClient.java
@@ -21,6 +21,7 @@ import com.palantir.common.base.Throwables;
 import com.palantir.common.concurrent.NamedThreadFactory;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.leader.NotCurrentLeaderException;
+import com.palantir.lock.v2.ClientLockingOptions;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
 import com.palantir.lock.v2.LockRequest;
 import com.palantir.lock.v2.LockResponse;
@@ -40,6 +41,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 
+// TODO (jkong): This class almost shouldn't be a plain TimelockService, but the amount of effort that would be
+//  required to break the interface into two distinct components is large.
 public class TimeLockClient implements AutoCloseable, TimelockService {
     private static final ScheduledExecutorService refreshExecutor = createSingleThreadScheduledExecutor("refresh");
 
@@ -131,6 +134,15 @@ public class TimeLockClient implements AutoCloseable, TimelockService {
             lockRefresher.registerLocks(ImmutableSet.of(response.getToken()));
         }
         return response;
+    }
+
+    @Override
+    public LockResponse lock(LockRequest lockRequest, ClientLockingOptions options) {
+        LockResponse response = executeOnTimeLock(() -> delegate.lock(lockRequest));
+        if (response.wasSuccessful()) {
+            lockRefresher.registerLocks(ImmutableSet.of(response.getToken()), options);
+        }
+        return null;
     }
 
     @Override

--- a/lock-api/src/test/java/com/palantir/lock/client/LockRefresherTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/LockRefresherTest.java
@@ -17,14 +17,19 @@ package com.palantir.lock.client;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableSet;
+import com.palantir.lock.v2.ClientLockingOptions;
 import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.TimelockService;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.jmock.lib.concurrent.DeterministicScheduler;
@@ -40,7 +45,8 @@ public class LockRefresherTest {
 
     private final DeterministicScheduler executor = new DeterministicScheduler();
     private final TimelockService timelock = mock(TimelockService.class);
-    private final LockRefresher refresher = new LockRefresher(executor, timelock, REFRESH_INTERVAL_MILLIS);
+    private final Clock clock = mock(Clock.class);
+    private final LockRefresher refresher = new LockRefresher(executor, timelock, REFRESH_INTERVAL_MILLIS, clock);
 
     @Test
     public void continuesRefreshingLocksThatAreReturned() {
@@ -93,6 +99,50 @@ public class LockRefresherTest {
         tick();
         tick();
         verify(timelock, times(2)).refreshLockLeases(lockTokensToRefresh);
+    }
+
+    @Test
+    public void locksWithoutSpecifiedOptionsHaveLongTenure() {
+        when(timelock.refreshLockLeases(TOKENS)).thenReturn(TOKENS);
+        when(clock.instant()).thenReturn(Instant.EPOCH);
+        refresher.registerLocks(TOKENS);
+
+        tick();
+        verify(timelock).refreshLockLeases(TOKENS);
+
+        when(clock.instant()).thenReturn(Instant.MAX); // O(1 billion years). AtlasDB probably won't exist then...?
+        tick();
+        verify(timelock, times(2)).refreshLockLeases(TOKENS);
+        tick();
+        verify(timelock, times(3)).refreshLockLeases(TOKENS);
+    }
+
+    @Test
+    public void lockNoLongerRefreshedAfterTenureElapses() {
+        Runnable callback = mock(Runnable.class);
+
+        when(timelock.refreshLockLeases(TOKENS)).thenReturn(TOKENS);
+        when(clock.instant()).thenReturn(Instant.EPOCH);
+        refresher.registerLocks(
+                TOKENS,
+                ClientLockingOptions.builder()
+                        .maximumLockTenure(Duration.ofMinutes(5))
+                        .tenureExpirationCallback(callback)
+                        .build());
+
+        tick();
+        verify(timelock).refreshLockLeases(TOKENS);
+        verify(callback, never()).run();
+
+        when(clock.instant()).thenReturn(Instant.EPOCH.plus(Duration.ofMinutes(3)));
+        tick();
+        verify(timelock, times(2)).refreshLockLeases(TOKENS);
+        verify(callback, never()).run();
+
+        when(clock.instant()).thenReturn(Instant.EPOCH.plus(Duration.ofMinutes(7)));
+        tick();
+        verify(timelock, times(2)).refreshLockLeases(TOKENS);
+        verify(callback).run();
     }
 
     private void registerLocks() {

--- a/lock-api/src/test/java/com/palantir/lock/client/LockRefresherTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/LockRefresherTest.java
@@ -33,6 +33,7 @@ import java.time.Instant;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.jmock.lib.concurrent.DeterministicScheduler;
+import org.junit.Before;
 import org.junit.Test;
 
 public class LockRefresherTest {
@@ -47,6 +48,11 @@ public class LockRefresherTest {
     private final TimelockService timelock = mock(TimelockService.class);
     private final Clock clock = mock(Clock.class);
     private final LockRefresher refresher = new LockRefresher(executor, timelock, REFRESH_INTERVAL_MILLIS, clock);
+
+    @Before
+    public void setUp() {
+        when(clock.instant()).thenReturn(Instant.EPOCH);
+    }
 
     @Test
     public void continuesRefreshingLocksThatAreReturned() {
@@ -142,7 +148,8 @@ public class LockRefresherTest {
         when(clock.instant()).thenReturn(Instant.EPOCH.plus(Duration.ofMinutes(7)));
         tick();
         verify(timelock, times(2)).refreshLockLeases(TOKENS);
-        verify(callback).run();
+        // Callback ran once per expired token
+        verify(callback, times(TOKENS.size())).run();
     }
 
     private void registerLocks() {

--- a/lock-api/src/test/java/com/palantir/lock/client/LockRefresherTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/LockRefresherTest.java
@@ -150,6 +150,10 @@ public class LockRefresherTest {
         verify(timelock, times(2)).refreshLockLeases(TOKENS);
         // Callback ran once per expired token
         verify(callback, times(TOKENS.size())).run();
+
+        tick();
+        // No more
+        verify(callback, times(TOKENS.size())).run();
     }
 
     private void registerLocks() {

--- a/lock-api/src/test/java/com/palantir/lock/client/TimeLockClientTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/TimeLockClientTest.java
@@ -17,6 +17,8 @@ package com.palantir.lock.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -31,6 +33,7 @@ import com.palantir.common.exception.AtlasDbDependencyException;
 import com.palantir.leader.NotCurrentLeaderException;
 import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.StringLockDescriptor;
+import com.palantir.lock.v2.ClientLockingOptions;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
 import com.palantir.lock.v2.LockRequest;
 import com.palantir.lock.v2.LockResponse;
@@ -92,7 +95,7 @@ public class TimeLockClientTest {
 
         timelock.lock(request);
 
-        verify(refresher).registerLocks(ImmutableSet.of(TOKEN_1));
+        verify(refresher).registerLocks(eq(ImmutableSet.of(TOKEN_1)), any(ClientLockingOptions.class));
     }
 
     @Test

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LegacyTimelockService.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LegacyTimelockService.java
@@ -24,6 +24,7 @@ import com.palantir.lock.LockMode;
 import com.palantir.lock.LockRefreshToken;
 import com.palantir.lock.LockService;
 import com.palantir.lock.SimpleTimeDuration;
+import com.palantir.lock.v2.ClientLockingOptions;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
 import com.palantir.lock.v2.LockRequest;
 import com.palantir.lock.v2.LockResponse;
@@ -151,6 +152,11 @@ public class LegacyTimelockService implements TimelockService {
         } else {
             return LockResponse.successful(LockTokenConverter.toTokenV2(legacyToken));
         }
+    }
+
+    @Override
+    public LockResponse lock(LockRequest lockRequest, ClientLockingOptions options) {
+        return lock(lockRequest);
     }
 
     @Override


### PR DESCRIPTION
**Goals (and why)**:
- See PDS-183571.
- In general, if a user holds a commit lock for a long period of time (for whatever reason: intractable serializable check, badly written pre-commit condition, etc) other transactions that read the row or cell (depending on lock level) that that user wrote to will all fail.

**Implementation Description (bullets)**:
- Introduce a maximum tenure for a lock on the client side, after which we will cease refreshing it.
- Allow a callback to be provided.
- Configure transactions to hold their locks for 5 minutes, and thereafter log and release them.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Added unit tests for the new bits.
- SnapshotTransaction integration tests run with the expiry mechanism as well.

**Concerns (what feedback would you like?)**:
- Should expiration actively unlock the lock as opposed to merely stopping it from being refreshed?
- Are there any *correctness* properties this might accidentally break?
- Is there too much perf overhead?

**Where should we start reviewing?**: ClientLockingOptions maybe

**Priority (whenever / two weeks / yesterday)**: next week
