### PR TITLE
[LW] Serializable Transactions IV: Wiring

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -51,6 +51,7 @@ import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.RangeRequests;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.api.cache.TransactionScopedCache;
 import com.palantir.atlasdb.keyvalue.api.watch.LockWatchManagerInternal;
 import com.palantir.atlasdb.keyvalue.impl.Cells;
 import com.palantir.atlasdb.logging.LoggingArgs;
@@ -880,6 +881,11 @@ public class SerializableTransaction extends SnapshotTransaction {
                 transactionConfig,
                 conflictTracer,
                 tableLevelMetricsController) {
+            @Override
+            protected TransactionScopedCache getCache() {
+                return lockWatchManager.getReadOnlyTransactionScopedCache(SerializableTransaction.this.getTimestamp());
+            }
+
             @Override
             protected ListenableFuture<Map<Long, Long>> getCommitTimestamps(
                     TableReference tableRef,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -26,7 +26,6 @@ import com.google.common.base.Functions;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
-import com.google.common.base.Suppliers;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.FluentIterable;
@@ -209,7 +208,6 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
 
     protected final TimelockService timelockService;
     protected final LockWatchManagerInternal lockWatchManager;
-    protected final Supplier<TransactionScopedCache> cache;
     final KeyValueService keyValueService;
     final AsyncKeyValueService immediateKeyValueService;
     final TransactionService defaultTransactionService;
@@ -289,7 +287,6 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             TableLevelMetricsController tableLevelMetricsController) {
         this.metricsManager = metricsManager;
         this.lockWatchManager = lockWatchManager;
-        this.cache = Suppliers.memoize(() -> lockWatchManager.getOrCreateTransactionScopedCache(startTimeStamp.get()));
         this.conflictTracer = conflictTracer;
         this.transactionTimerContext = getTimer("transactionMillis").time();
         this.keyValueService = keyValueService;
@@ -318,6 +315,10 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         this.validateLocksOnReads = validateLocksOnReads;
         this.transactionConfig = transactionConfig;
         this.tableLevelMetricsController = tableLevelMetricsController;
+    }
+
+    protected TransactionScopedCache getCache() {
+        return lockWatchManager.getOrCreateTransactionScopedCache(getTimestamp());
     }
 
     @Override
@@ -777,7 +778,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     @Override
     @Idempotent
     public Map<Cell, byte[]> get(TableReference tableRef, Set<Cell> cells) {
-        return cache.get()
+        return getCache()
                 .get(
                         tableRef,
                         cells,
@@ -788,7 +789,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     @Override
     @Idempotent
     public ListenableFuture<Map<Cell, byte[]>> getAsync(TableReference tableRef, Set<Cell> cells) {
-        return cache.get()
+        return getCache()
                 .getAsync(
                         tableRef,
                         cells,
@@ -1584,14 +1585,14 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     @Override
     public final void delete(TableReference tableRef, Set<Cell> cells) {
         putInternal(tableRef, Cells.constantValueMap(cells, PtBytes.EMPTY_BYTE_ARRAY));
-        cache.get().delete(tableRef, cells);
+        getCache().delete(tableRef, cells);
     }
 
     @Override
     public void put(TableReference tableRef, Map<Cell, byte[]> values) {
         ensureNoEmptyValues(values);
         putInternal(tableRef, values);
-        cache.get().write(tableRef, values);
+        getCache().write(tableRef, values);
     }
 
     public void putInternal(TableReference tableRef, Map<Cell, byte[]> values) {


### PR DESCRIPTION
**Goals (and why)**:
We have this fancy read-only cache, but we still aren't using it in the one-off snapshot transaction created by a serializable transaction.

**Implementation Description (bullets)**:
* Change the way in which snapshot transactions get the cache (use an overridable method instead of a memoized supplier)
* Override this method in SerializableTransaction's one-off snapshot transaction
* Note that the cache _is_ effectively memoized because of the implementation - it is persisted inside LWM, so each call should just be a map lookup.

**Testing (What was existing testing like?  What have you done to improve it?)**:
**None** - I think this is hard to test at the unit level. Will test at the integration level - I don't mind leaving this until we have integration tests before merging.

**Concerns (what feedback would you like?)**:
The usual AtlasDB things - correctness, performance.

**Where should we start reviewing?**:
`SerializableTransaction`

**Priority (whenever / two weeks / yesterday)**:
This week!
