### PR TITLE
[LW] Validating Transaction Cache causes global cache to fall back

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ValidatingTransactionScopedCache.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ValidatingTransactionScopedCache.java
@@ -136,7 +136,7 @@ final class ValidatingTransactionScopedCache implements TransactionScopedCache {
                     UnsafeArg.of("cacheReads", cacheReads));
             failureCallback.run();
             throw new TransactionLockWatchFailedException(
-                    "Failed lock watch cache validation - will retry with a no-op cache");
+                    "Failed lock watch cache validation - will retry without caching");
         }
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/CacheStoreImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/CacheStoreImplTest.java
@@ -33,7 +33,7 @@ public final class CacheStoreImplTest {
     @Test
     public void updatesToSnapshotStoreReflectedInCacheStore() {
         SnapshotStoreImpl snapshotStore = new SnapshotStoreImpl();
-        CacheStore cacheStore = new CacheStoreImpl(snapshotStore, VALIDATION_PROBABILITY);
+        CacheStore cacheStore = new CacheStoreImpl(snapshotStore, VALIDATION_PROBABILITY, () -> {});
 
         assertThat(cacheStore.getOrCreateCache(TIMESTAMP_1)).isExactlyInstanceOf(NoOpTransactionScopedCache.class);
 
@@ -48,7 +48,7 @@ public final class CacheStoreImplTest {
     @Test
     public void multipleCallsToGetOrCreateReturnsTheSameCache() {
         SnapshotStoreImpl snapshotStore = new SnapshotStoreImpl();
-        CacheStore cacheStore = new CacheStoreImpl(snapshotStore, VALIDATION_PROBABILITY);
+        CacheStore cacheStore = new CacheStoreImpl(snapshotStore, VALIDATION_PROBABILITY, () -> {});
         snapshotStore.storeSnapshot(
                 Sequence.of(5L),
                 ImmutableSet.of(TIMESTAMP_1, TIMESTAMP_2),

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImplTest.java
@@ -83,12 +83,12 @@ public final class LockWatchValueScopingCacheImplTest {
     @Before
     public void before() {
         eventCache = LockWatchEventCacheImpl.create(MetricsManagers.createForTests());
-        valueCache = new LockWatchValueScopingCacheImpl(eventCache, 20_000, 0.0, ImmutableSet.of(TABLE));
+        valueCache = new LockWatchValueScopingCacheImpl(eventCache, 20_000, 0.0, ImmutableSet.of(TABLE), () -> {});
     }
 
     @Test
     public void tableNotWatchedInSchemaDoesNotCache() {
-        valueCache = new LockWatchValueScopingCacheImpl(eventCache, 20_000, 0.0, ImmutableSet.of());
+        valueCache = new LockWatchValueScopingCacheImpl(eventCache, 20_000, 0.0, ImmutableSet.of(), () -> {});
         eventCache.processStartTransactionsUpdate(ImmutableSet.of(TIMESTAMP_1, TIMESTAMP_2), LOCK_WATCH_SNAPSHOT);
         valueCache.processStartTransactions(ImmutableSet.of(TIMESTAMP_1, TIMESTAMP_2));
 
@@ -102,7 +102,7 @@ public final class LockWatchValueScopingCacheImplTest {
 
     @Test
     public void valueCacheCreatesValidatingTransactionCaches() {
-        valueCache = new LockWatchValueScopingCacheImpl(eventCache, 20_000, 1.0, ImmutableSet.of(TABLE));
+        valueCache = new LockWatchValueScopingCacheImpl(eventCache, 20_000, 1.0, ImmutableSet.of(TABLE), () -> {});
         eventCache.processStartTransactionsUpdate(ImmutableSet.of(TIMESTAMP_1, TIMESTAMP_2), LOCK_WATCH_SNAPSHOT);
         valueCache.processStartTransactions(ImmutableSet.of(TIMESTAMP_1, TIMESTAMP_2));
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImplTest.java
@@ -294,7 +294,7 @@ public final class LockWatchValueScopingCacheImplTest {
                 eventCache, MetricsManagers.createForTests(), 20_000, 1.0, ImmutableSet.of(TABLE));
 
         eventCache.processStartTransactionsUpdate(ImmutableSet.of(TIMESTAMP_1, TIMESTAMP_2), LOCK_WATCH_SNAPSHOT);
-        valueCache.processStartTransactions(ImmutableSet.of(TIMESTAMP_1, TIMESTAMP_2));
+        valueCache.processStartTransactions(ImmutableSet.of(TIMESTAMP_1));
 
         TransactionScopedCache scopedCache1 = valueCache.getOrCreateTransactionScopedCache(TIMESTAMP_1);
         assertThat(getRemotelyReadCells(scopedCache1, TABLE, CELL_1)).containsExactlyInAnyOrder(CELL_1);
@@ -302,6 +302,8 @@ public final class LockWatchValueScopingCacheImplTest {
                         TABLE, ImmutableSet.of(CELL_1), (_table, _cells) -> Futures.immediateFuture(ImmutableMap.of())))
                 .isExactlyInstanceOf(TransactionLockWatchFailedException.class)
                 .hasMessage("Failed lock watch cache validation - will retry without caching");
+
+        valueCache.processStartTransactions(ImmutableSet.of(TIMESTAMP_2));
 
         TransactionScopedCache scopedCache2 = valueCache.getOrCreateTransactionScopedCache(TIMESTAMP_2);
         assertThat(getRemotelyReadCells(scopedCache1, TABLE, CELL_1)).containsExactlyInAnyOrder(CELL_1);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/ValidatingTransactionScopedCacheTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/ValidatingTransactionScopedCacheTest.java
@@ -94,7 +94,7 @@ public final class ValidatingTransactionScopedCacheTest {
         when(delegate.getAsync(eq(TABLE), eq(CELLS), any())).thenReturn(Futures.immediateFuture(ImmutableMap.of()));
         assertThatThrownBy(() -> validatingCache.get(TABLE, CELLS, valueLoader))
                 .isExactlyInstanceOf(TransactionLockWatchFailedException.class)
-                .hasMessage("Failed lock watch cache validation - will retry with a no-op cache");
+                .hasMessage("Failed lock watch cache validation - will retry without caching");
         verify(failureCallback).run();
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/ResilientLockWatchProxyTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/ResilientLockWatchProxyTest.java
@@ -63,8 +63,10 @@ public final class ResilientLockWatchProxyTest {
     public void valueCacheProxyAlsoFallsBackOnException() {
         LockWatchValueScopingCache defaultCache = mock(LockWatchValueScopingCache.class);
         LockWatchValueScopingCache fallbackCache = mock(LockWatchValueScopingCache.class);
-        LockWatchValueScopingCache proxyCache =
-                ResilientLockWatchProxy.newValueCacheProxy(defaultCache, fallbackCache, metricsManager);
+        ResilientLockWatchProxy<LockWatchValueScopingCache> proxyFactory =
+                ResilientLockWatchProxy.newValueCacheProxyFactory(fallbackCache, metricsManager);
+        proxyFactory.setDelegate(defaultCache);
+        LockWatchValueScopingCache proxyCache = proxyFactory.newValueCacheProxy();
 
         // Normal operation
         long timestamp = 1L;


### PR DESCRIPTION
**Goals (and why)**:
The individual transaction caches were not causing the central cache to fall back. Now they do!

**Implementation Description (bullets)**:
* Rejig the proxy to act as a factory for the value cache, giving it a handle on the proxy itself.
* Give this handle to the validation transaction caches, and call it when validation fails

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added unit and integration tests.

**Concerns (what feedback would you like?)**:
Usual

**Where should we start reviewing?**:
`ResilientLockWatchProxy` is probably a good place

**Priority (whenever / two weeks / yesterday)**:
Today