### PR TITLE
[LW] Throw when exceeding maximum cache store size

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
@@ -44,6 +44,7 @@ import javax.annotation.concurrent.ThreadSafe;
 
 @ThreadSafe
 public final class LockWatchValueScopingCacheImpl implements LockWatchValueScopingCache {
+    private static final int MAX_CACHE_COUNT = 100_000;
     private final LockWatchEventCache eventCache;
     private final CacheStore cacheStore;
     private final ValueStore valueStore;
@@ -62,7 +63,8 @@ public final class LockWatchValueScopingCacheImpl implements LockWatchValueScopi
         this.eventCache = eventCache;
         this.valueStore = new ValueStoreImpl(watchedTablesFromSchema, maxCacheSize, metrics);
         this.snapshotStore = new SnapshotStoreImpl();
-        this.cacheStore = new CacheStoreImpl(snapshotStore, validationProbability, failureCallback, metrics);
+        this.cacheStore =
+                new CacheStoreImpl(snapshotStore, validationProbability, failureCallback, metrics, MAX_CACHE_COUNT);
     }
 
     public static LockWatchValueScopingCache create(

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/CacheStoreImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/CacheStoreImplTest.java
@@ -70,12 +70,14 @@ public final class CacheStoreImplTest {
         SnapshotStore snapshotStore = new SnapshotStoreImpl();
         CacheStore cacheStore = new CacheStoreImpl(snapshotStore, VALIDATION_PROBABILITY, () -> {}, metrics, 1);
 
+        StartTimestamp timestamp = StartTimestamp.of(22222L);
         snapshotStore.storeSnapshot(
                 Sequence.of(5L),
-                ImmutableSet.of(TIMESTAMP_1, TIMESTAMP_2),
+                ImmutableSet.of(TIMESTAMP_1, TIMESTAMP_2, timestamp),
                 ValueCacheSnapshotImpl.of(HashMap.empty(), HashSet.empty(), ImmutableSet.of()));
 
         cacheStore.getOrCreateCache(TIMESTAMP_1);
+        cacheStore.getOrCreateCache(timestamp);
         assertThatThrownBy(() -> cacheStore.getOrCreateCache(TIMESTAMP_2))
                 .isExactlyInstanceOf(TransactionFailedRetriableException.class)
                 .hasMessage("Exceeded maximum concurrent caches; transaction can be retried, but with caching "

--- a/changelog/@unreleased/pr-5454.v2.yml
+++ b/changelog/@unreleased/pr-5454.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Throw if the internal cache store exceeds 100k caches stored.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5454


### PR DESCRIPTION
**Goals (and why)**:
We're seeing a memory leak.

**Implementation Description (bullets)**:
Throw if we exceed 100_000 cache objects stored at any one time

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added a test for this

**Concerns (what feedback would you like?)**:
Too heavy handed? Limit too high / low?

**Where should we start reviewing?**:
Diff

**Priority (whenever / two weeks / yesterday)**:
Yesterday 🔥 

