### PR TITLE
[LW] Bug Hunter

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCache.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCache.java
@@ -46,7 +46,7 @@ public interface LockWatchValueScopingCache extends LockWatchValueCache {
     @Override
     void removeTransactionState(long startTimestamp);
 
-    TransactionScopedCache getOrCreateTransactionScopedCache(long startTs);
+    TransactionScopedCache getTransactionScopedCache(long startTs);
 
     /**
      * Returns a read-only view of the transaction cache at commit time (specifically, **after** getting the commit

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerInternal.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerInternal.java
@@ -24,7 +24,7 @@ public abstract class LockWatchManagerInternal extends LockWatchManager implemen
 
     public abstract void removeTransactionStateFromCache(long startTs);
 
-    public abstract TransactionScopedCache getOrCreateTransactionScopedCache(long startTs);
+    public abstract TransactionScopedCache getTransactionScopedCache(long startTs);
 
     public abstract TransactionScopedCache getReadOnlyTransactionScopedCache(long startTs);
 

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/NoOpLockWatchManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/NoOpLockWatchManager.java
@@ -70,7 +70,7 @@ public final class NoOpLockWatchManager extends LockWatchManagerInternal {
     }
 
     @Override
-    public TransactionScopedCache getOrCreateTransactionScopedCache(long startTs) {
+    public TransactionScopedCache getTransactionScopedCache(long startTs) {
         return NoOpTransactionScopedCache.create();
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/ResilientLockWatchProxy.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/ResilientLockWatchProxy.java
@@ -61,7 +61,6 @@ public final class ResilientLockWatchProxy<T> extends AbstractInvocationHandler 
 
     private final T fallbackCache;
     private final Runnable failureCallback;
-    private volatile boolean hasFallenBack;
     private volatile T delegate;
 
     private ResilientLockWatchProxy(T defaultCache, T fallbackCache, Runnable failureCallback) {
@@ -99,12 +98,12 @@ public final class ResilientLockWatchProxy<T> extends AbstractInvocationHandler 
     }
 
     public void fallback() {
-        hasFallenBack = true;
         delegate = fallbackCache;
         failureCallback.run();
     }
 
     public void setDelegate(T delegate) {
+        Preconditions.checkState(this.delegate == null, "delegate must be set exactly once, but it's already been set");
         this.delegate = delegate;
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/CacheStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/CacheStore.java
@@ -20,7 +20,7 @@ import com.palantir.atlasdb.keyvalue.api.watch.StartTimestamp;
 import com.palantir.lock.watch.CommitUpdate;
 
 interface CacheStore {
-    TransactionScopedCache getOrCreateCache(StartTimestamp timestamp);
+    void createCache(StartTimestamp timestamp);
 
     TransactionScopedCache getCache(StartTimestamp timestamp);
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/CacheStoreImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/CacheStoreImpl.java
@@ -20,6 +20,7 @@ import com.palantir.atlasdb.keyvalue.api.watch.StartTimestamp;
 import com.palantir.atlasdb.transaction.api.TransactionFailedRetriableException;
 import com.palantir.lock.watch.CommitUpdate;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -76,7 +77,13 @@ final class CacheStoreImpl implements CacheStore {
 
     @Override
     public void removeCache(StartTimestamp timestamp) {
-        cacheMap.remove(timestamp);
+        Optional<Caches> cache = Optional.ofNullable(cacheMap.remove(timestamp));
+
+        if (!cache.isPresent()) {
+            log.warn(
+                    "Attempted to remove cache state, but no cache was present for timestamp",
+                    SafeArg.of("timestamp", timestamp));
+        }
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/NoOpLockWatchValueScopingCache.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/NoOpLockWatchValueScopingCache.java
@@ -25,7 +25,7 @@ public final class NoOpLockWatchValueScopingCache extends NoOpLockWatchValueCach
     }
 
     @Override
-    public TransactionScopedCache getOrCreateTransactionScopedCache(long startTs) {
+    public TransactionScopedCache getTransactionScopedCache(long startTs) {
         return NoOpTransactionScopedCache.create();
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerImpl.java
@@ -133,8 +133,8 @@ public final class LockWatchManagerImpl extends LockWatchManagerInternal {
     }
 
     @Override
-    public TransactionScopedCache getOrCreateTransactionScopedCache(long startTs) {
-        return valueScopingCache.getOrCreateTransactionScopedCache(startTs);
+    public TransactionScopedCache getTransactionScopedCache(long startTs) {
+        return valueScopingCache.getTransactionScopedCache(startTs);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -319,7 +319,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     }
 
     protected TransactionScopedCache getCache() {
-        return lockWatchManager.getOrCreateTransactionScopedCache(getTimestamp());
+        return lockWatchManager.getTransactionScopedCache(getTimestamp());
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -30,6 +30,7 @@ import com.palantir.atlasdb.keyvalue.api.ClusterAvailabilityStatus;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.watch.LockWatchManager;
 import com.palantir.atlasdb.keyvalue.api.watch.LockWatchManagerInternal;
+import com.palantir.atlasdb.keyvalue.api.watch.NoOpLockWatchManager;
 import com.palantir.atlasdb.monitoring.TimestampTracker;
 import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
 import com.palantir.atlasdb.transaction.TransactionConfig;
@@ -317,7 +318,7 @@ import org.slf4j.LoggerFactory;
                 metricsManager,
                 keyValueService,
                 timelockService,
-                lockWatchManager,
+                NoOpLockWatchManager.create(),
                 transactionService,
                 NoOpCleaner.INSTANCE,
                 getStartTimestampSupplier(),

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImplTest.java
@@ -96,7 +96,7 @@ public final class LockWatchValueScopingCacheImplTest {
         eventCache.processStartTransactionsUpdate(ImmutableSet.of(TIMESTAMP_1, TIMESTAMP_2), LOCK_WATCH_SNAPSHOT);
         valueCache.processStartTransactions(ImmutableSet.of(TIMESTAMP_1, TIMESTAMP_2));
 
-        TransactionScopedCache scopedCache = valueCache.getOrCreateTransactionScopedCache(TIMESTAMP_1);
+        TransactionScopedCache scopedCache = valueCache.getTransactionScopedCache(TIMESTAMP_1);
         assertThat(getRemotelyReadCells(scopedCache, TABLE, CELL_1)).containsExactlyInAnyOrder(CELL_1);
         assertThat(getRemotelyReadCells(scopedCache, TABLE, CELL_1)).containsExactlyInAnyOrder(CELL_1);
         scopedCache.finalise();
@@ -111,7 +111,7 @@ public final class LockWatchValueScopingCacheImplTest {
         eventCache.processStartTransactionsUpdate(ImmutableSet.of(TIMESTAMP_1, TIMESTAMP_2), LOCK_WATCH_SNAPSHOT);
         valueCache.processStartTransactions(ImmutableSet.of(TIMESTAMP_1, TIMESTAMP_2));
 
-        TransactionScopedCache scopedCache = valueCache.getOrCreateTransactionScopedCache(TIMESTAMP_1);
+        TransactionScopedCache scopedCache = valueCache.getTransactionScopedCache(TIMESTAMP_1);
 
         // This confirms that we always read from remote when validation is set to 1.0.
         assertThat(getRemotelyReadCells(scopedCache, TABLE, CELL_1)).containsExactlyInAnyOrder(CELL_1);
@@ -128,7 +128,7 @@ public final class LockWatchValueScopingCacheImplTest {
         eventCache.processStartTransactionsUpdate(ImmutableSet.of(TIMESTAMP_1), LOCK_WATCH_SNAPSHOT);
         valueCache.processStartTransactions(ImmutableSet.of(TIMESTAMP_1));
 
-        TransactionScopedCache scopedCache1 = valueCache.getOrCreateTransactionScopedCache(TIMESTAMP_1);
+        TransactionScopedCache scopedCache1 = valueCache.getTransactionScopedCache(TIMESTAMP_1);
         assertThat(getRemotelyReadCells(scopedCache1, TABLE, CELL_1)).containsExactlyInAnyOrder(CELL_1);
         verify(metrics, times(1)).registerHits(0);
         verify(metrics, times(1)).registerMisses(1);
@@ -140,7 +140,7 @@ public final class LockWatchValueScopingCacheImplTest {
                 ImmutableSet.of(TIMESTAMP_2), LockWatchStateUpdate.success(LEADER, 0L, ImmutableList.of()));
         valueCache.processStartTransactions(ImmutableSet.of(TIMESTAMP_2));
 
-        TransactionScopedCache scopedCache2 = valueCache.getOrCreateTransactionScopedCache(TIMESTAMP_2);
+        TransactionScopedCache scopedCache2 = valueCache.getTransactionScopedCache(TIMESTAMP_2);
         assertThat(getRemotelyReadCells(scopedCache2, TABLE, CELL_1)).isEmpty();
         verify(metrics, times(1)).registerHits(1);
         verify(metrics, times(1)).registerMisses(0);
@@ -151,7 +151,7 @@ public final class LockWatchValueScopingCacheImplTest {
         eventCache.processStartTransactionsUpdate(ImmutableSet.of(TIMESTAMP_1), LOCK_WATCH_SNAPSHOT);
         valueCache.processStartTransactions(ImmutableSet.of(TIMESTAMP_1));
 
-        TransactionScopedCache scopedCache1 = valueCache.getOrCreateTransactionScopedCache(TIMESTAMP_1);
+        TransactionScopedCache scopedCache1 = valueCache.getTransactionScopedCache(TIMESTAMP_1);
         assertThat(getRemotelyReadCells(scopedCache1, TABLE, CELL_1)).containsExactlyInAnyOrder(CELL_1);
         processCommitTimestamp(TIMESTAMP_1, 0L);
 
@@ -171,7 +171,7 @@ public final class LockWatchValueScopingCacheImplTest {
         eventCache.processStartTransactionsUpdate(ImmutableSet.of(TIMESTAMP_1), LOCK_WATCH_SNAPSHOT);
         valueCache.processStartTransactions(ImmutableSet.of(TIMESTAMP_1));
 
-        TransactionScopedCache scopedCache1 = valueCache.getOrCreateTransactionScopedCache(TIMESTAMP_1);
+        TransactionScopedCache scopedCache1 = valueCache.getTransactionScopedCache(TIMESTAMP_1);
         scopedCache1.write(TABLE, ImmutableMap.of(CELL_2, VALUE_2.value().get()));
         assertThat(getRemotelyReadCells(scopedCache1, TABLE, CELL_1, CELL_2)).containsExactlyInAnyOrder(CELL_1);
         verify(metrics, times(1)).registerHits(1);
@@ -192,7 +192,7 @@ public final class LockWatchValueScopingCacheImplTest {
         verify(metrics, times(2)).registerHits(1);
         verify(metrics, times(2)).registerMisses(1);
 
-        TransactionScopedCache scopedCache2 = valueCache.getOrCreateTransactionScopedCache(TIMESTAMP_2);
+        TransactionScopedCache scopedCache2 = valueCache.getTransactionScopedCache(TIMESTAMP_2);
         assertThat(getRemotelyReadCells(scopedCache2, TABLE, CELL_1, CELL_2)).containsExactlyInAnyOrder(CELL_1, CELL_2);
         // noop cache
     }
@@ -202,7 +202,7 @@ public final class LockWatchValueScopingCacheImplTest {
         eventCache.processStartTransactionsUpdate(ImmutableSet.of(TIMESTAMP_1), LOCK_WATCH_SNAPSHOT);
         valueCache.processStartTransactions(ImmutableSet.of(TIMESTAMP_1));
 
-        TransactionScopedCache scopedCache1 = valueCache.getOrCreateTransactionScopedCache(TIMESTAMP_1);
+        TransactionScopedCache scopedCache1 = valueCache.getTransactionScopedCache(TIMESTAMP_1);
         assertThat(getRemotelyReadCells(scopedCache1, TABLE, CELL_1, CELL_3)).containsExactlyInAnyOrder(CELL_1, CELL_3);
         processCommitTimestamp(TIMESTAMP_1, 0L);
         valueCache.updateCacheOnCommit(ImmutableSet.of(TIMESTAMP_1));
@@ -213,7 +213,7 @@ public final class LockWatchValueScopingCacheImplTest {
         eventCache.processStartTransactionsUpdate(
                 ImmutableSet.of(TIMESTAMP_2), LockWatchStateUpdate.success(LEADER, 1L, ImmutableList.of(LOCK_EVENT)));
         valueCache.processStartTransactions(ImmutableSet.of(TIMESTAMP_2));
-        TransactionScopedCache scopedCache2 = valueCache.getOrCreateTransactionScopedCache(TIMESTAMP_2);
+        TransactionScopedCache scopedCache2 = valueCache.getTransactionScopedCache(TIMESTAMP_2);
 
         assertThat(getRemotelyReadCells(scopedCache2, TABLE, CELL_1, CELL_2, CELL_3))
                 .containsExactlyInAnyOrder(CELL_1, CELL_2);
@@ -233,7 +233,7 @@ public final class LockWatchValueScopingCacheImplTest {
                 ImmutableSet.of(TIMESTAMP_3), LockWatchStateUpdate.success(LEADER, 2L, ImmutableList.of(UNLOCK_EVENT)));
         valueCache.processStartTransactions(ImmutableSet.of(TIMESTAMP_3));
 
-        TransactionScopedCache scopedCache3 = valueCache.getOrCreateTransactionScopedCache(TIMESTAMP_3);
+        TransactionScopedCache scopedCache3 = valueCache.getTransactionScopedCache(TIMESTAMP_3);
         assertThat(getRemotelyReadCells(scopedCache3, TABLE, CELL_1, CELL_2, CELL_3))
                 .containsExactlyInAnyOrder(CELL_1);
         verify(metrics, times(2)).registerHits(2);
@@ -271,7 +271,7 @@ public final class LockWatchValueScopingCacheImplTest {
 
     @Test
     public void createTransactionScopedCacheWithMissingSnapshotReturnsNoOpCache() {
-        TransactionScopedCache scopedCache = valueCache.getOrCreateTransactionScopedCache(TIMESTAMP_1);
+        TransactionScopedCache scopedCache = valueCache.getTransactionScopedCache(TIMESTAMP_1);
         assertThat(getRemotelyReadCells(scopedCache, TABLE, CELL_1, CELL_2, CELL_3))
                 .containsExactlyInAnyOrder(CELL_1, CELL_2, CELL_3);
         assertThat(getRemotelyReadCells(scopedCache, TABLE, CELL_1, CELL_2, CELL_3))
@@ -287,7 +287,7 @@ public final class LockWatchValueScopingCacheImplTest {
         valueCache.processStartTransactions(ImmutableSet.of(TIMESTAMP_1));
 
         // Stores CELL_1 -> VALUE_1 in central cache
-        TransactionScopedCache scopedCache1 = valueCache.getOrCreateTransactionScopedCache(TIMESTAMP_1);
+        TransactionScopedCache scopedCache1 = valueCache.getTransactionScopedCache(TIMESTAMP_1);
         assertThat(getRemotelyReadCells(scopedCache1, TABLE, CELL_1)).containsExactlyInAnyOrder(CELL_1);
         processCommitTimestamp(TIMESTAMP_1, 0L);
         valueCache.updateCacheOnCommit(ImmutableSet.of(TIMESTAMP_1));
@@ -297,7 +297,7 @@ public final class LockWatchValueScopingCacheImplTest {
         valueCache.processStartTransactions(ImmutableSet.of(TIMESTAMP_2));
 
         // Confirms entry is present
-        TransactionScopedCache scopedCache2 = valueCache.getOrCreateTransactionScopedCache(TIMESTAMP_2);
+        TransactionScopedCache scopedCache2 = valueCache.getTransactionScopedCache(TIMESTAMP_2);
         assertThat(getRemotelyReadCells(scopedCache2, TABLE, CELL_1)).isEmpty();
         processCommitTimestamp(TIMESTAMP_2, 0L);
         valueCache.updateCacheOnCommit(ImmutableSet.of(TIMESTAMP_2));
@@ -309,7 +309,7 @@ public final class LockWatchValueScopingCacheImplTest {
         valueCache.processStartTransactions(ImmutableSet.of(TIMESTAMP_3));
 
         // Confirms entry is no longer present
-        TransactionScopedCache scopedCache3 = valueCache.getOrCreateTransactionScopedCache(TIMESTAMP_3);
+        TransactionScopedCache scopedCache3 = valueCache.getTransactionScopedCache(TIMESTAMP_3);
         assertThat(getRemotelyReadCells(scopedCache3, TABLE, CELL_1)).containsExactlyInAnyOrder(CELL_1);
         eventCache.processGetCommitTimestampsUpdate(
                 ImmutableList.of(TransactionUpdate.builder()
@@ -328,7 +328,7 @@ public final class LockWatchValueScopingCacheImplTest {
         eventCache.processStartTransactionsUpdate(ImmutableSet.of(TIMESTAMP_1, TIMESTAMP_2), LOCK_WATCH_SNAPSHOT);
         valueCache.processStartTransactions(ImmutableSet.of(TIMESTAMP_1));
 
-        TransactionScopedCache scopedCache1 = valueCache.getOrCreateTransactionScopedCache(TIMESTAMP_1);
+        TransactionScopedCache scopedCache1 = valueCache.getTransactionScopedCache(TIMESTAMP_1);
         assertThat(getRemotelyReadCells(scopedCache1, TABLE, CELL_1)).containsExactlyInAnyOrder(CELL_1);
         assertThatThrownBy(() -> scopedCache1.get(
                         TABLE, ImmutableSet.of(CELL_1), (_table, _cells) -> Futures.immediateFuture(ImmutableMap.of())))
@@ -337,7 +337,7 @@ public final class LockWatchValueScopingCacheImplTest {
 
         valueCache.processStartTransactions(ImmutableSet.of(TIMESTAMP_2));
 
-        TransactionScopedCache scopedCache2 = valueCache.getOrCreateTransactionScopedCache(TIMESTAMP_2);
+        TransactionScopedCache scopedCache2 = valueCache.getTransactionScopedCache(TIMESTAMP_2);
         assertThat(getRemotelyReadCells(scopedCache1, TABLE, CELL_1)).containsExactlyInAnyOrder(CELL_1);
         assertThat(getRemotelyReadCells(scopedCache1, TABLE, CELL_1)).containsExactlyInAnyOrder(CELL_1);
         assertThat(scopedCache2).isExactlyInstanceOf(NoOpTransactionScopedCache.class);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerImplTest.java
@@ -115,8 +115,8 @@ public final class LockWatchManagerImplTest {
 
     @Test
     public void createTransactionScopedCacheTest() {
-        manager.getOrCreateTransactionScopedCache(1L);
-        verify(valueScopingCache).getOrCreateTransactionScopedCache(1L);
+        manager.getTransactionScopedCache(1L);
+        verify(valueScopingCache).getTransactionScopedCache(1L);
         verifyNoMoreInteractions(lockWatchEventCache);
     }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/ResilientLockWatchProxyTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/ResilientLockWatchProxyTest.java
@@ -88,11 +88,11 @@ public final class ResilientLockWatchProxyTest {
         verify(fallbackCache, never()).updateCacheOnCommit(any());
 
         // Failure
-        when(defaultCache.getOrCreateTransactionScopedCache(timestamp))
+        when(defaultCache.getTransactionScopedCache(timestamp))
                 .thenThrow(new TransactionFailedNonRetriableException(""));
-        assertThatThrownBy(() -> proxyCache.getOrCreateTransactionScopedCache(timestamp))
+        assertThatThrownBy(() -> proxyCache.getTransactionScopedCache(timestamp))
                 .isExactlyInstanceOf(TransactionLockWatchFailedException.class);
-        verify(defaultCache).getOrCreateTransactionScopedCache(timestamp);
+        verify(defaultCache).getTransactionScopedCache(timestamp);
 
         // Fallback operation
         proxyCache.processStartTransactions(timestamps);

--- a/changelog/@unreleased/pr-5460.v2.yml
+++ b/changelog/@unreleased/pr-5460.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fixed a memory leak in read only transactions where no op caches were
+    being created but never cleaned up.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5460

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/LockWatchValueIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/LockWatchValueIntegrationTest.java
@@ -417,7 +417,7 @@ public final class LockWatchValueIntegrationTest {
     }
 
     private TransactionScopedCache extractTransactionCache(Transaction txn) {
-        return extractValueCache().getOrCreateTransactionScopedCache(txn.getTimestamp());
+        return extractValueCache().getTransactionScopedCache(txn.getTimestamp());
     }
 
     private void createTransactionManager(double validationProbability) {

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/LockWatchValueIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/LockWatchValueIntegrationTest.java
@@ -91,6 +91,20 @@ public final class LockWatchValueIntegrationTest {
     }
 
     @Test
+    public void readOnlyTransactionsDoNotUseCaching() {
+        putValue();
+        loadValue();
+
+        txnManager.runTaskReadOnly(txn -> {
+            Map<Cell, byte[]> cellMap = txn.get(TABLE_REF, ImmutableSet.of(CELL_1));
+            assertThat(cellMap).containsEntry(CELL_1, DATA_1);
+            assertHitValues(txn, ImmutableSet.of());
+            assertLoadedValues(txn, ImmutableMap.of());
+            return null;
+        });
+    }
+
+    @Test
     public void effectivelyReadOnlyTransactionsPublishValuesToCentralCache() {
         putValue();
 


### PR DESCRIPTION
**Goals (and why)**:
* We have a resource leak! Best fix it.

**Implementation Description (bullets)**:
* Transaction scoped caches are now only created at start transaction time, to bring them inline with all other state. This makes it easier for us to guarantee that it gets removed at the correct time.
* Read only transactions now actually only use the no-op cache.
* No op caches are not stored anywhere.

**Testing (What was existing testing like?  What have you done to improve it?)**:
* Added test for read only transactions
* Added relevant tests for changed behaviour.

**Concerns (what feedback would you like?)**:
* Did I miss anything? I think the defensiveness should fix all cases that we didn't consider (because now caches are only made _exactly_ on that start transactions call, and thus all go through the right place.

**Priority (whenever / two weeks / yesterday)**:
yesterday 🔥 