### PR TITLE
[LW] Fix getRows Caching

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ValidatingTransactionScopedCache.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ValidatingTransactionScopedCache.java
@@ -181,7 +181,10 @@ final class ValidatingTransactionScopedCache implements TransactionScopedCache {
             NavigableMap<byte[], RowResult<byte[]>> remoteReads,
             NavigableMap<byte[], RowResult<byte[]>> cacheReads) {
         if (!ByteArrayUtilities.areRowResultsEqual(remoteReads, cacheReads)) {
-            failAndLog(UnsafeArg.of("table", tableReference));
+            failAndLog(
+                    UnsafeArg.of("table", tableReference),
+                    UnsafeArg.of("remoteReads", remoteReads),
+                    UnsafeArg.of("cacheReads", cacheReads));
         }
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/util/ByteArrayUtilities.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/util/ByteArrayUtilities.java
@@ -23,6 +23,7 @@ import com.palantir.atlasdb.keyvalue.api.RowResult;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Optional;
+import java.util.SortedMap;
 
 public final class ByteArrayUtilities {
 
@@ -45,7 +46,7 @@ public final class ByteArrayUtilities {
         return true;
     }
 
-    private static boolean areByteMapsEqual(Map<byte[], byte[]> map1, Map<byte[], byte[]> map2) {
+    private static boolean areByteMapsEqual(SortedMap<byte[], byte[]> map1, SortedMap<byte[], byte[]> map2) {
         if (map1.size() != map2.size()) {
             return false;
         }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/util/ByteArrayUtilities.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/util/ByteArrayUtilities.java
@@ -71,8 +71,8 @@ public final class ByteArrayUtilities {
             if (!second.containsKey(e.getKey())) {
                 return false;
             }
-            Map<byte[], byte[]> firstColumns = e.getValue().getColumns();
-            Map<byte[], byte[]> secondColumns = Optional.ofNullable(second.get(e.getKey()))
+            SortedMap<byte[], byte[]> firstColumns = e.getValue().getColumns();
+            SortedMap<byte[], byte[]> secondColumns = Optional.ofNullable(second.get(e.getKey()))
                     .map(RowResult::getColumns)
                     .orElseGet(ImmutableSortedMap::of);
 

--- a/changelog/@unreleased/pr-5475.v2.yml
+++ b/changelog/@unreleased/pr-5475.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Fix a bug where lock watch caching would fail validation for `getRows`
+    even when the results are the same.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5475

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/LockWatchValueIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/LockWatchValueIntegrationTest.java
@@ -79,7 +79,7 @@ public final class LockWatchValueIntegrationTest {
     private static final TestableTimelockCluster CLUSTER = new TestableTimelockCluster(
             "non-batched timestamp paxos single leader",
             "paxosMultiServer.ftl",
-            generateThreeNodeTimelockCluster(9090, builder -> builder.clientPaxosBuilder(
+            generateThreeNodeTimelockCluster(9080, builder -> builder.clientPaxosBuilder(
                             builder.clientPaxosBuilder().isUseBatchPaxosTimestamp(false))
                     .leaderMode(PaxosLeaderMode.SINGLE_LEADER)));
 

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/LockWatchValueIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/LockWatchValueIntegrationTest.java
@@ -79,7 +79,7 @@ public final class LockWatchValueIntegrationTest {
     private static final TestableTimelockCluster CLUSTER = new TestableTimelockCluster(
             "non-batched timestamp paxos single leader",
             "paxosMultiServer.ftl",
-            generateThreeNodeTimelockCluster(9080, builder -> builder.clientPaxosBuilder(
+            generateThreeNodeTimelockCluster(9090, builder -> builder.clientPaxosBuilder(
                             builder.clientPaxosBuilder().isUseBatchPaxosTimestamp(false))
                     .leaderMode(PaxosLeaderMode.SINGLE_LEADER)));
 
@@ -311,8 +311,12 @@ public final class LockWatchValueIntegrationTest {
             return read;
         });
 
+        // New set of rows and columns to force new references (to test every part of the equality checking)
+        Set<byte[]> rows2 = ImmutableSet.of("bar".getBytes(), "eggs".getBytes());
+        ColumnSelection columns2 = ColumnSelection.create(ImmutableSet.of("baz".getBytes(), "spam".getBytes()));
+
         NavigableMap<byte[], RowResult<byte[]>> cacheRead = txnManager.runTaskThrowOnConflict(txn -> {
-            NavigableMap<byte[], RowResult<byte[]>> read = txn.getRows(TABLE_REF, rows, columns);
+            NavigableMap<byte[], RowResult<byte[]>> read = txn.getRows(TABLE_REF, rows2, columns2);
             assertHitValues(txn, ImmutableSet.of(TABLE_CELL_1, TABLE_CELL_2, TABLE_CELL_3, TABLE_CELL_4));
             assertLoadedValues(txn, ImmutableMap.of());
             return read;

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/LockWatchValueIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/LockWatchValueIntegrationTest.java
@@ -45,6 +45,7 @@ import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionLockWatchFailedException;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.atlasdb.transaction.api.TransactionSerializableConflictException;
+import com.palantir.atlasdb.util.ByteArrayUtilities;
 import com.palantir.lock.watch.LockWatchVersion;
 import com.palantir.timelock.config.PaxosInstallConfiguration.PaxosLeaderMode;
 import java.time.Duration;
@@ -64,6 +65,7 @@ public final class LockWatchValueIntegrationTest {
     private static final byte[] DATA_1 = "foo".getBytes();
     private static final byte[] DATA_2 = "Caecilius est in horto".getBytes();
     private static final byte[] DATA_3 = "canis est in via".getBytes();
+    private static final byte[] DATA_4 = "Quintus Caecilius Iucundus".getBytes();
     private static final Cell CELL_1 = Cell.create("bar".getBytes(), "baz".getBytes());
     private static final Cell CELL_2 = Cell.create("bar".getBytes(), "spam".getBytes());
     private static final Cell CELL_3 = Cell.create("eggs".getBytes(), "baz".getBytes());
@@ -75,7 +77,7 @@ public final class LockWatchValueIntegrationTest {
     private static final TestableTimelockCluster CLUSTER = new TestableTimelockCluster(
             "non-batched timestamp paxos single leader",
             "paxosMultiServer.ftl",
-            generateThreeNodeTimelockCluster(9080, builder -> builder.clientPaxosBuilder(
+            generateThreeNodeTimelockCluster(9090, builder -> builder.clientPaxosBuilder(
                             builder.clientPaxosBuilder().isUseBatchPaxosTimestamp(false))
                     .leaderMode(PaxosLeaderMode.SINGLE_LEADER)));
 
@@ -273,6 +275,52 @@ public final class LockWatchValueIntegrationTest {
             assertLoadedValues(txn, ImmutableMap.of());
             return null;
         });
+    }
+
+    @Test
+    public void allRowsCached() {
+        createTransactionManager(1.0);
+
+        txnManager.runTaskThrowOnConflict(txn -> {
+            txn.put(TABLE_REF, ImmutableMap.of(CELL_1, DATA_1, CELL_2, DATA_2, CELL_3, DATA_3, CELL_4, DATA_4));
+            return null;
+        });
+
+        awaitUnlock();
+
+        Set<byte[]> rows = ImmutableSet.of(CELL_1.getRowName(), CELL_3.getRowName());
+        ColumnSelection columns =
+                ColumnSelection.create(ImmutableSet.of(CELL_1.getColumnName(), CELL_2.getColumnName()));
+
+        CellReference tc1 = CellReference.of(TABLE_REF, CELL_1);
+        CellReference tc2 = CellReference.of(TABLE_REF, CELL_2);
+        CellReference tc3 = CellReference.of(TABLE_REF, CELL_3);
+        CellReference tc4 = CellReference.of(TABLE_REF, CELL_4);
+        NavigableMap<byte[], RowResult<byte[]>> remoteRead = txnManager.runTaskThrowOnConflict(txn -> {
+            NavigableMap<byte[], RowResult<byte[]>> read = txn.getRows(TABLE_REF, rows, columns);
+            assertHitValues(txn, ImmutableSet.of());
+            assertLoadedValues(
+                    txn,
+                    ImmutableMap.of(
+                            tc1,
+                            CacheValue.of(DATA_1),
+                            tc2,
+                            CacheValue.of(DATA_2),
+                            tc3,
+                            CacheValue.of(DATA_3),
+                            tc4,
+                            CacheValue.of(DATA_4)));
+            return read;
+        });
+
+        NavigableMap<byte[], RowResult<byte[]>> cacheRead = txnManager.runTaskThrowOnConflict(txn -> {
+            NavigableMap<byte[], RowResult<byte[]>> read = txn.getRows(TABLE_REF, rows, columns);
+            assertHitValues(txn, ImmutableSet.of(tc1, tc2, tc3, tc4));
+            assertLoadedValues(txn, ImmutableMap.of());
+            return read;
+        });
+
+        assertThat(ByteArrayUtilities.areRowResultsEqual(remoteRead, cacheRead)).isTrue();
     }
 
     @Test


### PR DESCRIPTION
**Goals (and why)**:
`RowResult<byte[]>` doesn't do equality properly.

**Implementation Description (bullets)**:
Fix `RowResult` comparison as done in the validation.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added a test for `getRows` validation.

**Concerns (what feedback would you like?)**:
Is this just stupid copy-paste? Can we make it better without compromising current code?

**Where should we start reviewing?**:
Diff

**Priority (whenever / two weeks / yesterday)**:
yesterday 🔥 
