### PR TITLE
fix operation name

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TracingCassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TracingCassandraClient.java
@@ -84,7 +84,7 @@ public class TracingCassandraClient implements AutoDelegate_CassandraClient {
             throws InvalidRequestException, UnavailableException, TimedOutException, TException {
         int numberOfKeyPredicates = keyPredicates.size();
 
-        try (CloseableTracer trace = startLocalTrace("cassandra-thrift-client.client.multiget_slice", sink -> {
+        try (CloseableTracer trace = startLocalTrace("cassandra-thrift-client.client.multiget_multislice", sink -> {
             sink.tableRef(tableRef);
             sink.size("key_predicates", keyPredicates);
             sink.accept("consistency", consistency_level.name());

--- a/changelog/@unreleased/pr-5483.v2.yml
+++ b/changelog/@unreleased/pr-5483.v2.yml
@@ -1,5 +1,0 @@
-type: improvement
-fix:
-  description: Add operation names to traced calls to Cassandra.
-  links:
-  - https://github.com/palantir/atlasdb/pull/5483

--- a/changelog/@unreleased/pr-5484.v2.yml
+++ b/changelog/@unreleased/pr-5484.v2.yml
@@ -1,24 +1,6 @@
 type: improvement
 improvement:
   description: |-
-    fix operation name
-
-    **Goals (and why)**:
-    We use the same operation name for multiget_slice and multiget_multislice
-    **Implementation Description (bullets)**:
-    Fix operation name for multiget_multislice.
-    **Testing (What was existing testing like?  What have you done to improve it?)**:
-
-    **Concerns (what feedback would you like?)**:
-
-    **Where should we start reviewing?**:
-
-    **Priority (whenever / two weeks / yesterday)**:
-
-    <!---
-    Please remember to:
-    - Add any necessary release notes (including breaking changes)
-    - Make sure the documentation is up to date for your change
-    --->
+    Fix operation name in TracingCassandraClient.
   links:
   - https://github.com/palantir/atlasdb/pull/5484

--- a/changelog/@unreleased/pr-5484.v2.yml
+++ b/changelog/@unreleased/pr-5484.v2.yml
@@ -1,0 +1,24 @@
+type: improvement
+improvement:
+  description: |-
+    fix operation name
+
+    **Goals (and why)**:
+    We use the same operation name for multiget_slice and multiget_multislice
+    **Implementation Description (bullets)**:
+    Fix operation name for multiget_multislice.
+    **Testing (What was existing testing like?  What have you done to improve it?)**:
+
+    **Concerns (what feedback would you like?)**:
+
+    **Where should we start reviewing?**:
+
+    **Priority (whenever / two weeks / yesterday)**:
+
+    <!---
+    Please remember to:
+    - Add any necessary release notes (including breaking changes)
+    - Make sure the documentation is up to date for your change
+    --->
+  links:
+  - https://github.com/palantir/atlasdb/pull/5484


### PR DESCRIPTION
**Goals (and why)**:
We use the same operation name for multiget_slice and multiget_multislice
**Implementation Description (bullets)**:
Fix operation name for multiget_multislice.
**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
