### PR TITLE
Improve utility of SQLException logging

### DIFF
--- a/changelog/@unreleased/pr-5489.v2.yml
+++ b/changelog/@unreleased/pr-5489.v2.yml
@@ -1,0 +1,22 @@
+type: improvement
+improvement:
+  description: |-
+    Improve utility of SQLException logging
+
+    **Goals:**
+
+    SQLExceptions currently provide details of all bind variables, however for binary arrays which are used for all columns except timestamps, we just print the array object number. This isn't actually useful.
+
+    **Implementation Description:**
+
+    - We'll now print first 64 bytes in hex notation (with ... indicating truncation)
+    - Oracle's HEXTORAW can use this representation (quoted)
+    - Postgres' notation '\x'
+
+    ** Testing (What was existing testing like? What have you done to improve it?): **
+    N/A, N/A
+
+    Priority (whenever / two weeks / yesterday):
+    Low
+  links:
+  - https://github.com/palantir/atlasdb/pull/5489

--- a/changelog/@unreleased/pr-5489.v2.yml
+++ b/changelog/@unreleased/pr-5489.v2.yml
@@ -1,22 +1,5 @@
 type: improvement
 improvement:
-  description: |-
-    Improve utility of SQLException logging
-
-    **Goals:**
-
-    SQLExceptions currently provide details of all bind variables, however for binary arrays which are used for all columns except timestamps, we just print the array object number. This isn't actually useful.
-
-    **Implementation Description:**
-
-    - We'll now print first 64 bytes in hex notation (with ... indicating truncation)
-    - Oracle's HEXTORAW can use this representation (quoted)
-    - Postgres' notation '\x'
-
-    ** Testing (What was existing testing like? What have you done to improve it?): **
-    N/A, N/A
-
-    Priority (whenever / two weeks / yesterday):
-    Low
+  description: Print byte[]/ByteArrayInputStream SQL bind arg contents in SQLExceptions
   links:
   - https://github.com/palantir/atlasdb/pull/5489

--- a/commons-db/src/main/java/com/palantir/nexus/db/sql/BasicSQLUtils.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/sql/BasicSQLUtils.java
@@ -336,7 +336,7 @@ public class BasicSQLUtils {
                     }
                     sb.append("'"); // $NON-NLS-1$
                 }
-                if (i != 0 && i != args.length - 1) {
+                if (i != args.length - 1) {
                     sb.append(", ");
                 }
             }
@@ -348,12 +348,12 @@ public class BasicSQLUtils {
 
     // Oracle use HEXTORAW('0f1f') to create a 2 byte RAW literal
     // Postgres use '\\x0f1f' to create a 2 byte bytea literal
-    private static void prettyPrintByteArray(final StringBuilder sb, byte[] args) {
-        int printLength = Math.min(args.length, MAX_ARRAY_PRINT_BYTES);
+    private static void prettyPrintByteArray(final StringBuilder sb, byte[] arg) {
+        int printLength = Math.min(arg.length, MAX_ARRAY_PRINT_BYTES);
         for (int i = 0; i < printLength; i++) {
-            sb.append(String.format("%02x", args[i] & 0xff));
+            sb.append(String.format("%02x", arg[i] & 0xff));
         }
-        if (args.length > MAX_ARRAY_PRINT_BYTES) {
+        if (arg.length > MAX_ARRAY_PRINT_BYTES) {
             sb.append("...");
         }
     }

--- a/commons-db/src/main/java/com/palantir/nexus/db/sql/BasicSQLUtils.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/sql/BasicSQLUtils.java
@@ -25,7 +25,6 @@ import java.io.ByteArrayInputStream;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -329,17 +328,33 @@ public class BasicSQLUtils {
                         ByteArrayInputStream bais = (ByteArrayInputStream) arg;
                         byte[] bytes = new byte[bais.available()];
                         bais.read(bytes, 0, bais.available());
-                        sb.append(Arrays.toString(bytes));
+                        prettyPrintByteArray(sb, bytes);
+                    } else if (arg instanceof byte[]) {
+                        prettyPrintByteArray(sb, (byte[]) arg);
                     } else {
-                        sb.append(arg.toString());
+                        sb.append(arg);
                     }
                     sb.append("'"); // $NON-NLS-1$
                 }
-                if (i != args.length - 1) {
+                if (i != 0 && i != args.length - 1) {
                     sb.append(", ");
                 }
             }
             sb.append(")\n"); // $NON-NLS-1$
+        }
+    }
+
+    private static final int MAX_ARRAY_PRINT_BYTES = 64;
+
+    // Oracle use HEXTORAW('0f1f') to create a 2 byte RAW literal
+    // Postgres use '\\x0f1f' to create a 2 byte bytea literal
+    private static void prettyPrintByteArray(final StringBuilder sb, byte[] args) {
+        int printLength = Math.min(args.length, MAX_ARRAY_PRINT_BYTES);
+        for (int i = 0; i < printLength; i++) {
+            sb.append(String.format("%02x", args[i] & 0xff));
+        }
+        if (args.length > MAX_ARRAY_PRINT_BYTES) {
+            sb.append("...");
         }
     }
 

--- a/commons-db/src/test/java/com/palantir/nexus/db/sql/BasicSQLTest.java
+++ b/commons-db/src/test/java/com/palantir/nexus/db/sql/BasicSQLTest.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.nexus.db.sql;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -23,6 +24,7 @@ import static org.mockito.Mockito.when;
 
 import com.palantir.nexus.db.monitoring.timer.DurationSqlTimer;
 import com.palantir.nexus.db.monitoring.timer.SqlTimer;
+import java.io.ByteArrayInputStream;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -61,6 +63,17 @@ public class BasicSQLTest {
 
         verify(executeExecutorOne, times(1)).submit(any(Callable.class));
         verify(executeExecutorTwo, times(2)).submit(any(Callable.class));
+    }
+
+    @Test
+    public void testSQLException() {
+        StringBuilder sb = new StringBuilder();
+        byte[] bytes = new byte[] {0, 1, (byte) 0xff};
+        ByteArrayInputStream bis = new ByteArrayInputStream(bytes);
+        // A typical atlas key is identified by row_name, column_name, ts
+        BasicSQLUtils.toStringSqlArgs(sb, new Object[] {bytes, bis, 123L});
+        assertThat(sb.toString())
+                .isEqualTo("([B: '0001ff', java.io.ByteArrayInputStream: '0001ff', java.lang.Long: '123')\n");
     }
 
     private void executeSqlQuery(BasicSQL basicSql) throws SQLException {


### PR DESCRIPTION
**Goals:**

SQLExceptions currently provide details of all bind variables, however for binary arrays which are used for all columns except timestamps, we just print the array object number. This isn't actually useful.

**Implementation Description:**

- We'll now print first 64 bytes in hex notation (with ... indicating truncation)
- Oracle's HEXTORAW can use this representation (quoted)
- Postgres' notation '\x'

** Testing (What was existing testing like? What have you done to improve it?): **
N/A, N/A

Priority (whenever / two weeks / yesterday):
Low