### PR TITLE
Make maxConnectionAge default 888 seconds (a little less than 15min)

### DIFF
--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
@@ -79,7 +79,7 @@ public abstract class ConnectionConfig {
 
     @Value.Default
     public Integer getMaxConnectionAge() {
-        return 1800;
+        return 888;
     }
 
     @Value.Default

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
@@ -77,6 +77,12 @@ public abstract class ConnectionConfig {
         return 256;
     }
 
+    /**
+     * STIG O121-C2-016500 and Fedramp requires idle connections are closed within 15 mins.
+     * Because typically minimum pool sizes are > 0, we frequently create connections that are
+     * never used. Hence, this setting needs to be < 15 min - "a few seconds" (recommended in
+     * Hikari docs to allow for client side latency). 900 - a dozen = 888.
+     */
     @Value.Default
     public Integer getMaxConnectionAge() {
         return 888;

--- a/changelog/@unreleased/pr-5492.v2.yml
+++ b/changelog/@unreleased/pr-5492.v2.yml
@@ -1,0 +1,15 @@
+type: improvement
+improvement:
+  description: |-
+    Make maxConnectionAge default 888 seconds (a little less than 15min)
+
+    **Goals (and why)**:
+    This is required so products don't need to override this value to achieve compliance with STIG/Fedramp O121-C2-016500
+    which requires idle timeout at 15 min. Hikari cautions that this value should be set "a few seconds less
+    than any server side enforcement" hence 888.
+
+
+    **Concerns (what feedback would you like?)**:
+    None - the drop of this value should have no real consequence at either client or DB server, as it only applies to connections that are fulfilling the minConnections constraint (which we set to 8). The vast majority of our connections are actually closed as a results of the maxIdleTime configuration (600).
+  links:
+  - https://github.com/palantir/atlasdb/pull/5492

--- a/changelog/@unreleased/pr-5492.v2.yml
+++ b/changelog/@unreleased/pr-5492.v2.yml
@@ -1,15 +1,6 @@
 type: improvement
 improvement:
-  description: |-
-    Make maxConnectionAge default 888 seconds (a little less than 15min)
-
-    **Goals (and why)**:
-    This is required so products don't need to override this value to achieve compliance with STIG/Fedramp O121-C2-016500
-    which requires idle timeout at 15 min. Hikari cautions that this value should be set "a few seconds less
-    than any server side enforcement" hence 888.
-
-
-    **Concerns (what feedback would you like?)**:
-    None - the drop of this value should have no real consequence at either client or DB server, as it only applies to connections that are fulfilling the minConnections constraint (which we set to 8). The vast majority of our connections are actually closed as a results of the maxIdleTime configuration (600).
+  description: Make default `maxConnectionAge` 888 seconds (a little less than 15min)
+    for Hikari connection pool.
   links:
   - https://github.com/palantir/atlasdb/pull/5492

--- a/changelog/@unreleased/pr-5492.v2.yml
+++ b/changelog/@unreleased/pr-5492.v2.yml
@@ -1,6 +1,7 @@
 type: improvement
 improvement:
-  description: Make default `maxConnectionAge` 888 seconds (a little less than 15min)
-    for Hikari connection pool.
+  description: "Make default `maxConnectionAge` 888 seconds (a little less than 15min)
+    for Hikari connection pool. This default value is now  \ncompliant with STIG/Fedramp
+    O121-C2-016500 which requires idle timeout at 15 min."
   links:
   - https://github.com/palantir/atlasdb/pull/5492

--- a/changelog/@unreleased/pr-5492.v2.yml
+++ b/changelog/@unreleased/pr-5492.v2.yml
@@ -1,7 +1,7 @@
 type: improvement
 improvement:
-  description: "Make default `maxConnectionAge` 888 seconds (a little less than 15min)
-    for Hikari connection pool. This default value is now  \ncompliant with STIG/Fedramp
-    O121-C2-016500 which requires idle timeout at 15 min."
+  description: Make default `maxConnectionAge` 888 seconds (a little less than 15min)
+    for Hikari connection pool. This default value is now compliant with STIG/Fedramp
+    O121-C2-016500 which requires idle timeout at 15 min.
   links:
   - https://github.com/palantir/atlasdb/pull/5492

--- a/docs/source/configuration/key_value_service_configs/postgres_key_value_service_config.rst
+++ b/docs/source/configuration/key_value_service_configs/postgres_key_value_service_config.rst
@@ -87,7 +87,7 @@ We also provide the following options, which are mapped to `Hikari connection op
     *    - ``maxConnectionAge``
          - 888
          - ``maxLifetime``
-         - The maximum lifetime, in seconds, of a connection in the pool. ``maxLifetime`` is in ``ms``, so we multiply the provided value by 1000.
+         - The maximum lifetime, in seconds, of a connection in the pool. ``maxLifetime`` is in ``ms``, so we multiply the provided value by 1000.  STIG O121-C2-016500 and Fedramp requires idle connections are closed within 15 mins. Because typically minimum pool sizes are > 0, we may create connections that are never used. Hence, this setting needs to be < 15 min - "a few seconds" (recommended in Hikari docs to allow for client side latency): 900 - a dozen = 888.
 
     *    - ``maxIdleTime``
          - 600

--- a/docs/source/configuration/key_value_service_configs/postgres_key_value_service_config.rst
+++ b/docs/source/configuration/key_value_service_configs/postgres_key_value_service_config.rst
@@ -85,7 +85,7 @@ We also provide the following options, which are mapped to `Hikari connection op
          - The maximum size the pool is allowed to reach.
 
     *    - ``maxConnectionAge``
-         - 1800
+         - 888
          - ``maxLifetime``
          - The maximum lifetime, in seconds, of a connection in the pool. ``maxLifetime`` is in ``ms``, so we multiply the provided value by 1000.
 


### PR DESCRIPTION
**Goals (and why)**:
This is required so products don't need to override this value to achieve compliance with STIG/Fedramp O121-C2-016500
which requires idle timeout at 15 min. Hikari cautions that this value should be set "a few seconds less
than any server side enforcement" hence 888.


**Concerns (what feedback would you like?)**:
None - the drop of this value should have no real consequence at either client or DB server, as it only applies to connections that are fulfilling the minConnections constraint (which we set to 8). The vast majority of our connections are actually closed as a results of the maxIdleTime configuration (600).