### PR TITLE
Introduce Immutables Meta-Annotations

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/persistent/api/PersistentStore.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/persistent/api/PersistentStore.java
@@ -16,6 +16,7 @@
 
 package com.palantir.atlasdb.persistent.api;
 
+import com.palantir.common.annotations.ImmutablesStyles.PackageVisibleImmutablesStyle;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.List;
 import java.util.Map;
@@ -31,7 +32,7 @@ public interface PersistentStore extends AutoCloseable {
      * PostgreSQL table or RocksdDb column family. Handle is linked with one underlying store space.
      */
     @Value.Immutable
-    @Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+    @PackageVisibleImmutablesStyle
     interface Handle {
         UUID id();
 

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/GuardedValue.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/GuardedValue.java
@@ -16,10 +16,11 @@
 
 package com.palantir.atlasdb.transaction.api;
 
+import com.palantir.common.annotations.ImmutablesStyles.PackageVisibleImmutablesStyle;
 import org.immutables.value.Value;
 
 @Value.Immutable
-@Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+@PackageVisibleImmutablesStyle
 /**
  * A GuardedValue represents a value with a limited validity window.
  *

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/RowLockDescriptorMapping.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/RowLockDescriptorMapping.java
@@ -16,13 +16,14 @@
 
 package com.palantir.atlasdb.transaction.api;
 
+import com.palantir.common.annotations.ImmutablesStyles.PackageVisibleImmutablesStyle;
 import com.palantir.lock.LockDescriptor;
 import java.util.Map;
 import java.util.Optional;
 import org.immutables.value.Value;
 
 @Value.Immutable
-@Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+@PackageVisibleImmutablesStyle
 public abstract class RowLockDescriptorMapping {
     abstract Map<LockDescriptor, RowReference> mapping();
 

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/RowReference.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/RowReference.java
@@ -17,10 +17,11 @@
 package com.palantir.atlasdb.transaction.api;
 
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.common.annotations.ImmutablesStyles.PackageVisibleImmutablesStyle;
 import org.immutables.value.Value;
 
 @Value.Immutable
-@Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+@PackageVisibleImmutablesStyle
 public interface RowReference {
     TableReference tableRef();
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/cache/DefaultOffHeapCache.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/cache/DefaultOffHeapCache.java
@@ -28,6 +28,7 @@ import com.palantir.atlasdb.autobatch.Autobatchers;
 import com.palantir.atlasdb.autobatch.CoalescingRequestFunction;
 import com.palantir.atlasdb.autobatch.DisruptorAutobatcher;
 import com.palantir.atlasdb.persistent.api.PersistentStore;
+import com.palantir.common.annotations.ImmutablesStyles.PackageVisibleImmutablesStyle;
 import com.palantir.common.streams.KeyedStream;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.tritium.metrics.registry.MetricName;
@@ -190,7 +191,7 @@ public final class DefaultOffHeapCache<K, V> implements OffHeapCache<K, V> {
     }
 
     @Value.Immutable
-    @Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+    @PackageVisibleImmutablesStyle
     interface CacheDescriptor {
         AtomicInteger currentSize();
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/TableMetadata.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/TableMetadata.java
@@ -28,7 +28,7 @@ import java.util.List;
 import org.immutables.value.Value;
 
 @Value.Immutable
-@Value.Style(get = {"get*", "is*", "has*"})
+@TableMetadataStyle
 public abstract class TableMetadata implements Persistable {
 
     @Value.Default

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/TableMetadataStyle.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/TableMetadataStyle.java
@@ -1,0 +1,28 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.table.description;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.immutables.value.Value;
+
+@Target({ElementType.PACKAGE, ElementType.TYPE})
+@Retention(RetentionPolicy.SOURCE)
+@Value.Style(get = {"get*", "is*", "has*"})
+public @interface TableMetadataStyle {}

--- a/atlasdb-commons/build.gradle
+++ b/atlasdb-commons/build.gradle
@@ -15,7 +15,6 @@ dependencies {
     compileOnly 'org.immutables:value::annotations'
 
     testAnnotationProcessor group: 'org.immutables', name: 'value'
-    testCompileOnly 'org.immutables:value::annotations'
 
     testCompile group: 'junit', name: 'junit'
     testCompile group: 'org.assertj', name: 'assertj-core'

--- a/atlasdb-commons/build.gradle
+++ b/atlasdb-commons/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     compileOnly 'org.immutables:value::annotations'
 
     testAnnotationProcessor group: 'org.immutables', name: 'value'
+    testCompileOnly 'org.immutables:value::annotations'
 
     testCompile group: 'junit', name: 'junit'
     testCompile group: 'org.assertj', name: 'assertj-core'

--- a/atlasdb-commons/src/main/java/com/palantir/common/annotations/ImmutablesStyles.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/annotations/ImmutablesStyles.java
@@ -35,6 +35,11 @@ public interface ImmutablesStyles {
 
     @Target({ElementType.PACKAGE, ElementType.TYPE})
     @Retention(RetentionPolicy.SOURCE)
+    @Value.Style(stagedBuilder = false) // Intentional: used for e.g. inner classes of staged builder public classes.
+    @interface NoStagedBuilderStyle {}
+
+    @Target({ElementType.PACKAGE, ElementType.TYPE})
+    @Retention(RetentionPolicy.SOURCE)
     @Value.Style(allParameters = true)
     @interface AllParametersStyle {}
 

--- a/atlasdb-commons/src/main/java/com/palantir/common/annotations/ImmutablesStyles.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/annotations/ImmutablesStyles.java
@@ -1,0 +1,45 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.common.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.immutables.value.Value;
+
+public interface ImmutablesStyles {
+    @Target({ElementType.PACKAGE, ElementType.TYPE})
+    @Retention(RetentionPolicy.SOURCE)
+    @Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+    @interface PackageVisibleImmutablesStyle {}
+
+    @Target({ElementType.PACKAGE, ElementType.TYPE})
+    @Retention(RetentionPolicy.SOURCE)
+    @Value.Style(stagedBuilder = true)
+    @interface StagedBuilderStyle {}
+
+    @Target({ElementType.PACKAGE, ElementType.TYPE})
+    @Retention(RetentionPolicy.SOURCE)
+    @Value.Style(allParameters = true)
+    @interface AllParametersStyle {}
+
+    @Target({ElementType.PACKAGE, ElementType.TYPE})
+    @Retention(RetentionPolicy.SOURCE)
+    @Value.Style(attributeBuilderDetection = true)
+    @interface AttributeBuilderDetectionStyle {}
+}

--- a/atlasdb-commons/src/main/java/com/palantir/common/annotations/ImmutablesStyles.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/annotations/ImmutablesStyles.java
@@ -36,7 +36,7 @@ public interface ImmutablesStyles {
     @Target({ElementType.PACKAGE, ElementType.TYPE})
     @Retention(RetentionPolicy.SOURCE)
     @Value.Style(stagedBuilder = false) // Intentional: used for e.g. inner classes of staged builder public classes.
-    @SuppressWarnings("RedundantModifier") // 
+    @SuppressWarnings("RedundantModifier") // Unexpected bug in baseline check?
     @interface NoStagedBuilderStyle {}
 
     @Target({ElementType.PACKAGE, ElementType.TYPE})

--- a/atlasdb-commons/src/main/java/com/palantir/common/annotations/ImmutablesStyles.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/annotations/ImmutablesStyles.java
@@ -36,6 +36,7 @@ public interface ImmutablesStyles {
     @Target({ElementType.PACKAGE, ElementType.TYPE})
     @Retention(RetentionPolicy.SOURCE)
     @Value.Style(stagedBuilder = false) // Intentional: used for e.g. inner classes of staged builder public classes.
+    @SuppressWarnings("RedundantModifier") // 
     @interface NoStagedBuilderStyle {}
 
     @Target({ElementType.PACKAGE, ElementType.TYPE})

--- a/atlasdb-commons/src/main/java/com/palantir/common/time/NanoTime.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/time/NanoTime.java
@@ -18,12 +18,13 @@ package com.palantir.common.time;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.common.annotations.ImmutablesStyles.PackageVisibleImmutablesStyle;
 import java.time.Duration;
 import java.util.concurrent.locks.LockSupport;
 import org.immutables.value.Value;
 
 @Value.Immutable
-@Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+@PackageVisibleImmutablesStyle
 public abstract class NanoTime implements Comparable<NanoTime> {
     @JsonValue
     abstract long time();

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -134,6 +134,7 @@ import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.atlasdb.versions.AtlasDbVersion;
 import com.palantir.common.annotation.Output;
+import com.palantir.common.annotations.ImmutablesStyles.NoStagedBuilderStyle;
 import com.palantir.common.annotations.ImmutablesStyles.StagedBuilderStyle;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.common.time.Clock;
@@ -1501,6 +1502,7 @@ public abstract class TransactionManagers {
     }
 
     @Value.Immutable
+    @NoStagedBuilderStyle
     public interface LockAndTimestampServices {
         LockService lock();
 

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -134,6 +134,7 @@ import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.atlasdb.versions.AtlasDbVersion;
 import com.palantir.common.annotation.Output;
+import com.palantir.common.annotations.ImmutablesStyles.StagedBuilderStyle;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.common.time.Clock;
 import com.palantir.conjure.java.api.config.service.ServicesConfigBlock;
@@ -210,7 +211,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Value.Immutable
-@Value.Style(stagedBuilder = true)
+@StagedBuilderStyle
 public abstract class TransactionManagers {
     private static final int LOGGING_INTERVAL = 60;
     private static final Logger log = LoggerFactory.getLogger(TransactionManagers.class);
@@ -1500,7 +1501,6 @@ public abstract class TransactionManagers {
     }
 
     @Value.Immutable
-    @Value.Style(stagedBuilder = false)
     public interface LockAndTimestampServices {
         LockService lock();
 

--- a/leader-election-impl/src/main/java/com/palantir/paxos/LeaderPingerContext.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/LeaderPingerContext.java
@@ -17,10 +17,11 @@
 package com.palantir.paxos;
 
 import com.google.common.net.HostAndPort;
+import com.palantir.common.annotations.ImmutablesStyles.AllParametersStyle;
 import org.immutables.value.Value;
 
 @Value.Immutable
-@Value.Style(allParameters = true)
+@AllParametersStyle
 public interface LeaderPingerContext<T> {
     T pinger();
 

--- a/lock-api-objects/src/main/java/com/palantir/lock/v2/LeadershipId.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/v2/LeadershipId.java
@@ -18,11 +18,12 @@ package com.palantir.lock.v2;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.common.annotations.ImmutablesStyles.PackageVisibleImmutablesStyle;
 import java.util.UUID;
 import org.immutables.value.Value;
 
 @Value.Immutable
-@Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+@PackageVisibleImmutablesStyle
 public abstract class LeadershipId {
     @JsonValue
     @Value.Parameter

--- a/lock-api-objects/src/main/java/com/palantir/lock/v2/StartTransactionWithWatchesResponse.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/v2/StartTransactionWithWatchesResponse.java
@@ -18,11 +18,12 @@ package com.palantir.lock.v2;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.palantir.common.annotations.ImmutablesStyles.PackageVisibleImmutablesStyle;
 import com.palantir.lock.watch.LockWatchStateUpdate;
 import org.immutables.value.Value;
 
 @Value.Immutable
-@Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+@PackageVisibleImmutablesStyle
 @JsonSerialize(as = ImmutableStartTransactionWithWatchesResponse.class)
 @JsonDeserialize(as = ImmutableStartTransactionWithWatchesResponse.class)
 public interface StartTransactionWithWatchesResponse {

--- a/lock-api-objects/src/main/java/com/palantir/lock/watch/LockWatchReferences.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/watch/LockWatchReferences.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.Range;
+import com.palantir.common.annotations.ImmutablesStyles.PackageVisibleImmutablesStyle;
 import com.palantir.lock.AtlasLockDescriptorRanges;
 import com.palantir.lock.LockDescriptor;
 import org.immutables.value.Value;
@@ -78,7 +79,7 @@ public final class LockWatchReferences {
     }
 
     @Value.Immutable
-    @Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+    @PackageVisibleImmutablesStyle
     @JsonDeserialize(as = ImmutableEntireTable.class)
     @JsonSerialize(as = ImmutableEntireTable.class)
     @JsonTypeName(EntireTable.TYPE)
@@ -95,7 +96,7 @@ public final class LockWatchReferences {
     }
 
     @Value.Immutable
-    @Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+    @PackageVisibleImmutablesStyle
     @JsonDeserialize(as = ImmutableRowPrefix.class)
     @JsonSerialize(as = ImmutableRowPrefix.class)
     @JsonTypeName(RowPrefix.TYPE)
@@ -115,7 +116,7 @@ public final class LockWatchReferences {
     }
 
     @Value.Immutable
-    @Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+    @PackageVisibleImmutablesStyle
     @JsonDeserialize(as = ImmutableRowRange.class)
     @JsonSerialize(as = ImmutableRowRange.class)
     @JsonTypeName(RowRange.TYPE)
@@ -138,7 +139,7 @@ public final class LockWatchReferences {
     }
 
     @Value.Immutable
-    @Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+    @PackageVisibleImmutablesStyle
     @JsonDeserialize(as = ImmutableExactRow.class)
     @JsonSerialize(as = ImmutableExactRow.class)
     @JsonTypeName(ExactRow.TYPE)
@@ -158,7 +159,7 @@ public final class LockWatchReferences {
     }
 
     @Value.Immutable
-    @Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+    @PackageVisibleImmutablesStyle
     @JsonDeserialize(as = ImmutableExactCell.class)
     @JsonSerialize(as = ImmutableExactCell.class)
     @JsonTypeName(ExactCell.TYPE)

--- a/lock-api-objects/src/main/java/com/palantir/lock/watch/LockWatchStateUpdate.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/watch/LockWatchStateUpdate.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.errorprone.annotations.DoNotMock;
+import com.palantir.common.annotations.ImmutablesStyles.PackageVisibleImmutablesStyle;
 import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.watch.LockWatchReferences.LockWatchReference;
 import java.util.List;
@@ -63,7 +64,7 @@ public interface LockWatchStateUpdate {
      * last known version.
      */
     @Value.Immutable
-    @Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+    @PackageVisibleImmutablesStyle
     @JsonSerialize(as = ImmutableSuccess.class)
     @JsonDeserialize(as = ImmutableSuccess.class)
     @JsonTypeName(Success.TYPE)
@@ -87,7 +88,7 @@ public interface LockWatchStateUpdate {
      * missed, but contains all of the current lock watch information as the state of the world moving forward.
      */
     @Value.Immutable
-    @Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+    @PackageVisibleImmutablesStyle
     @JsonSerialize(as = ImmutableSnapshot.class)
     @JsonDeserialize(as = ImmutableSnapshot.class)
     @JsonTypeName(Snapshot.TYPE)

--- a/lock-api-objects/src/main/java/com/palantir/lock/watch/TimestampedLockResponse.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/watch/TimestampedLockResponse.java
@@ -18,12 +18,13 @@ package com.palantir.lock.watch;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.palantir.common.annotations.ImmutablesStyles.PackageVisibleImmutablesStyle;
 import com.palantir.lock.v2.LockResponse;
 import java.util.Optional;
 import org.immutables.value.Value;
 
 @Value.Immutable
-@Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+@PackageVisibleImmutablesStyle
 @JsonSerialize(as = ImmutableTimestampedLockResponse.class)
 @JsonDeserialize(as = ImmutableTimestampedLockResponse.class)
 public interface TimestampedLockResponse {

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/DoNotMatchInnerBuilderStyle.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/DoNotMatchInnerBuilderStyle.java
@@ -1,0 +1,28 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.immutables.value.Value;
+
+@Target({ElementType.PACKAGE, ElementType.TYPE})
+@Retention(RetentionPolicy.SOURCE)
+@Value.Style(typeInnerBuilder = "DoNotMatch")
+public @interface DoNotMatchInnerBuilderStyle {}

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/NetworkClientFactories.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/NetworkClientFactories.java
@@ -24,7 +24,7 @@ import java.util.List;
 import org.immutables.value.Value;
 
 @Value.Immutable
-@Value.Style(typeInnerBuilder = "DoNotMatch")
+@DoNotMatchInnerBuilderStyle
 public interface NetworkClientFactories {
     Factory<PaxosAcceptorNetworkClient> acceptor();
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/ValueAndLockWatchStateUpdate.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/ValueAndLockWatchStateUpdate.java
@@ -16,11 +16,12 @@
 
 package com.palantir.atlasdb.timelock.lock.watch;
 
+import com.palantir.common.annotations.ImmutablesStyles.PackageVisibleImmutablesStyle;
 import com.palantir.lock.watch.LockWatchStateUpdate;
 import org.immutables.value.Value;
 
 @Value.Immutable
-@Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+@PackageVisibleImmutablesStyle
 public interface ValueAndLockWatchStateUpdate<T> {
     @Value.Parameter
     LockWatchStateUpdate lockWatchStateUpdate();

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AutobatchingPingableLeaderFactory.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/AutobatchingPingableLeaderFactory.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.timelock.paxos;
 
 import com.palantir.atlasdb.autobatch.Autobatchers;
 import com.palantir.atlasdb.autobatch.DisruptorAutobatcher;
+import com.palantir.common.annotations.ImmutablesStyles.AllParametersStyle;
 import com.palantir.common.concurrent.CheckedRejectionExecutorService;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.paxos.Client;
@@ -138,7 +139,7 @@ public final class AutobatchingPingableLeaderFactory implements Closeable {
     }
 
     @Value.Immutable
-    @Value.Style(allParameters = true)
+    @AllParametersStyle
     interface PingRequest {
         Client client();
 

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TemplateVariables.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TemplateVariables.java
@@ -16,6 +16,7 @@
 
 package com.palantir.atlasdb.timelock;
 
+import com.palantir.common.annotations.ImmutablesStyles.AttributeBuilderDetectionStyle;
 import com.palantir.timelock.config.PaxosInstallConfiguration.PaxosLeaderMode;
 import java.util.List;
 import java.util.function.UnaryOperator;
@@ -26,7 +27,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @Value.Enclosing
-@Value.Style(attributeBuilderDetection = true)
+@AttributeBuilderDetectionStyle
 public interface TemplateVariables {
     int PROXY_OFFSET = 100;
 


### PR DESCRIPTION
**Goals (and why)**:
- Upgrade gradle-baseline.
- Introduce source retention for immutables style annotations: this should help to eliminate compilation warnings for consumers that do not directly depend on immutables.

**Implementation Description (bullets)**:
- Switch to using meta-annotations that can be configured to be only retained in source jars.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Does it build? I think other than that the existing tests passing should be good enough evidence.

**Concerns (what feedback would you like?)**:
- I've had to introduce one suppression to deal with https://app.circleci.com/pipelines/github/palantir/atlasdb/4136/workflows/4e239c84-9eac-4cba-b6c1-b0ebcc310f0f/jobs/23071.
- I think this is probably less readable than the original, though given the benefits (unblocking upgrades, prerequisite for more sensible annotation behaviour) it's worthwhile.

**Where should we start reviewing?**: ImmutablesStyles.java

**Priority (whenever / two weeks / yesterday)**: this week please: not good to get behind on dependencies.
