### PR TITLE
fix oracle ete tests

### DIFF
--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/DbKvsOracleTestSuite.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/DbKvsOracleTestSuite.java
@@ -38,6 +38,7 @@ import com.palantir.nexus.db.sql.SQL;
 import com.palantir.nexus.db.sql.SqlConnection;
 import com.palantir.nexus.db.sql.SqlConnectionHelper;
 import java.net.InetSocketAddress;
+import java.sql.Connection;
 import java.time.Duration;
 import java.util.concurrent.Callable;
 import org.awaitility.Awaitility;
@@ -162,16 +163,11 @@ public final class DbKvsOracleTestSuite {
 
     private static Callable<Boolean> canCreateKeyValueService() {
         return () -> {
-            ConnectionManagerAwareDbKvs kvs = null;
-            try {
-                kvs = ConnectionManagerAwareDbKvs.create(getKvsConfig());
-                return kvs.getConnectionManager().getConnection().isValid(5);
+            try (ConnectionManagerAwareDbKvs kvs = ConnectionManagerAwareDbKvs.create(getKvsConfig());
+                    Connection conn = kvs.getConnectionManager().getConnection()) {
+                return conn.isValid(5);
             } catch (Exception e) {
                 return false;
-            } finally {
-                if (kvs != null) {
-                    kvs.close();
-                }
             }
         };
     }

--- a/atlasdb-dbkvs-tests/src/test/resources/docker-compose.oracle.yml
+++ b/atlasdb-dbkvs-tests/src/test/resources/docker-compose.oracle.yml
@@ -2,18 +2,6 @@ version: '2'
 
 services:
   oracle:
-    image: palantirtechnologies/oracle-atlasdb:19.9.0.0-se
-    environment:
-      SQLPLUS_INIT_00: startup nomount
-      SQLPLUS_INIT_01: alter system set processes=1000 scope=spfile
-      SQLPLUS_INIT_02: alter system set open_cursors=1000 scope=spfile
-      SQLPLUS_INIT_03: alter system set sessions=1000 scope=spfile
-      SQLPLUS_INIT_04: alter system set max_shared_servers=4000 scope=spfile
-      SQLPLUS_INIT_05: alter system set sga_max_size=1000M scope=spfile
-      SQLPLUS_INIT_06: alter system set sga_target=1000M scope=spfile
-      SQLPLUS_INIT_07: alter system set pga_aggregate_target=160M scope=spfile
-      SQLPLUS_INIT_08: shutdown immediate
-      SQLPLUS_INIT_09: startup
+    image: palantirtechnologies/oracle-atlasdb:19.11.0.0-se
     ports:
-      - "2080"
       - "1521"

--- a/atlasdb-ete-tests/docker-compose.oracle.yml
+++ b/atlasdb-ete-tests/docker-compose.oracle.yml
@@ -2,20 +2,8 @@ version: '2'
 
 services:
   oracle:
-    image: palantirtechnologies/oracle-atlasdb:19.9.0.0-se
-    environment:
-      SQLPLUS_INIT_00: startup nomount
-      SQLPLUS_INIT_01: alter system set processes=1000 scope=spfile
-      SQLPLUS_INIT_02: alter system set open_cursors=1000 scope=spfile
-      SQLPLUS_INIT_03: alter system set sessions=1000 scope=spfile
-      SQLPLUS_INIT_04: alter system set max_shared_servers=4000 scope=spfile
-      SQLPLUS_INIT_05: alter system set sga_max_size=1000M scope=spfile
-      SQLPLUS_INIT_06: alter system set sga_target=1000M scope=spfile
-      SQLPLUS_INIT_07: alter system set pga_aggregate_target=160M scope=spfile
-      SQLPLUS_INIT_08: shutdown immediate
-      SQLPLUS_INIT_09: startup
+    image: palantirtechnologies/oracle-atlasdb:19.11.0.0-se
     ports:
-      - "2080"
       - "1521"
 
   ete1:

--- a/changelog/@unreleased/pr-5496.v2.yml
+++ b/changelog/@unreleased/pr-5496.v2.yml
@@ -1,0 +1,10 @@
+type: fix
+fix:
+  description: |-
+    Removes unused docker environment variables and an unused port from the
+    oracle docker config. Also fixes a connection leak in the test setup
+    code (connections must be closed).
+
+    Also update to the latest patch version of oracle.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5496

--- a/scripts/circle-ci/run-circle-tests.sh
+++ b/scripts/circle-ci/run-circle-tests.sh
@@ -54,6 +54,9 @@ fi
 
 if [ $CIRCLE_NODE_INDEX -eq 9 ] || [ $CIRCLE_NODE_INDEX -eq 10 ]; then
     printenv DOCKERHUB_PASSWORD | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
+    # The oracle container is very large and takes a long time to pull.
+    # If this image is not pulled here, the circle build usually times out.
+    docker-compose -f atlasdb-dbkvs-tests/src/test/resources/docker-compose.oracle.yml pull oracle
 fi
 
 JAVA_GC_LOGGING_OPTIONS="${JAVA_GC_LOGGING_OPTIONS} -XX:+HeapDumpOnOutOfMemoryError"


### PR DESCRIPTION
Removes unused docker environment variables and an unused port from the
oracle docker config. Also fixes a connection leak in the test setup
code (connections must be closed).

Also update to the latest patch version of oracle.

Note that the old container version somehow barely managed to work under
the circle 10 minute no-output timeout. This newer patched version of oracle
is a slightly larger image and would consistently fail due to a circle timeout.
Adding a workaround to pull the image ahead of time instead of pulling during
testing.