### PR TITLE
Make TransactionConflictExceptions actually useful

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionConflictException.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionConflictException.java
@@ -80,6 +80,7 @@ public final class TransactionConflictException extends TransactionFailedRetriab
 
     private final ImmutableList<CellConflict> spanningWrites;
     private final ImmutableList<CellConflict> dominatingWrites;
+    private final TableReference conflictingTable;
 
     /**
      * These conflicts had a start timestamp before our start and a commit timestamp after our start.
@@ -94,6 +95,10 @@ public final class TransactionConflictException extends TransactionFailedRetriab
      */
     public Collection<CellConflict> getDominatingWrites() {
         return dominatingWrites;
+    }
+
+    public TableReference getConflictingTable() {
+        return conflictingTable;
     }
 
     public static TransactionConflictException create(
@@ -122,7 +127,7 @@ public final class TransactionConflictException extends TransactionFailedRetriab
             formatConflicts(dominatingWrites, sb);
             sb.append('\n');
         }
-        return new TransactionConflictException(sb.toString(), spanningWrites, dominatingWrites);
+        return new TransactionConflictException(sb.toString(), spanningWrites, dominatingWrites, tableRef);
     }
 
     private static void formatConflicts(Collection<CellConflict> conflicts, StringBuilder sb) {
@@ -136,9 +141,13 @@ public final class TransactionConflictException extends TransactionFailedRetriab
     }
 
     private TransactionConflictException(
-            String message, Collection<CellConflict> spanningWrites, Collection<CellConflict> dominatingWrites) {
+            String message,
+            Collection<CellConflict> spanningWrites,
+            Collection<CellConflict> dominatingWrites,
+            TableReference conflictingTable) {
         super(message);
         this.spanningWrites = ImmutableList.copyOf(spanningWrites);
         this.dominatingWrites = ImmutableList.copyOf(dominatingWrites);
+        this.conflictingTable = conflictingTable;
     }
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionSerializableConflictException.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionSerializableConflictException.java
@@ -20,8 +20,11 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 public class TransactionSerializableConflictException extends TransactionFailedRetriableException {
     private static final long serialVersionUID = 1L;
 
-    public TransactionSerializableConflictException(String message) {
+    private final TableReference conflictingTable;
+
+    public TransactionSerializableConflictException(String message, TableReference conflictingTable) {
         super(message);
+        this.conflictingTable = conflictingTable;
     }
 
     public static TransactionSerializableConflictException create(
@@ -31,6 +34,10 @@ public class TransactionSerializableConflictException extends TransactionFailedR
                         + " and another transaction wrote a different value than this transaction read.  startTs: %d "
                         + " elapsedMillis: %d",
                 tableRef.getQualifiedName(), timestamp, elapsedMillis);
-        return new TransactionSerializableConflictException(msg);
+        return new TransactionSerializableConflictException(msg, tableRef);
+    }
+
+    public TableReference getConflictingTable() {
+        return conflictingTable;
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -924,11 +924,13 @@ public class SerializableTransaction extends SnapshotTransaction {
                             // should just fail out early.  It may be the case that abort more transactions
                             // than needed to break the deadlock cycle, but this should be pretty rare.
                             transactionOutcomeMetrics.markReadWriteConflict(tableRef);
-                            throw new TransactionSerializableConflictException("An uncommitted conflicting read was "
-                                    + "written after our start timestamp for table "
-                                    + tableRef + ".  "
-                                    + "This case can cause deadlock and is very likely to be a "
-                                    + "read write conflict.");
+                            throw new TransactionSerializableConflictException(
+                                    "An uncommitted conflicting read was "
+                                            + "written after our start timestamp for table "
+                                            + tableRef + ".  "
+                                            + "This case can cause deadlock and is very likely to be a "
+                                            + "read write conflict.",
+                                    tableRef);
                         },
                         MoreExecutors.directExecutor());
             }

--- a/changelog/@unreleased/pr-5497.v2.yml
+++ b/changelog/@unreleased/pr-5497.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: '`TransactionConflictException` and `TransactionSerializableConflictException`
+    now track the conflicting table, which can be retrieved via a getter.'
+  links:
+  - https://github.com/palantir/atlasdb/pull/5497


### PR DESCRIPTION
**Goals (and why)**:
Conflict exceptions have a load of info that is not really useful to us as-is. Aim is to change that by recording the table - it's not logged anywhere, just accessible so that internally we can use it.

**Implementation Description (bullets)**:
Make TCE and TSCE track the conflicting table.

**Testing (What was existing testing like?  What have you done to improve it?)**:
N/A.

**Concerns (what feedback would you like?)**:
Should be safe.

**Where should we start reviewing?**:
diff

**Priority (whenever / two weeks / yesterday)**:
ASAP.
