### PR TITLE
Reduce flakes in the SingleLeaderPaxosSuite

### DIFF
--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
@@ -202,7 +202,7 @@ public class TestableTimelockCluster implements TestRule {
     }
 
     void failoverToNewLeader(String namespace) {
-        int maxTries = 5;
+        int maxTries = 8;
         for (int i = 0; i < maxTries; i++) {
             if (tryFailoverToNewLeader(namespace)) {
                 return;
@@ -213,12 +213,16 @@ public class TestableTimelockCluster implements TestRule {
     }
 
     private boolean tryFailoverToNewLeader(String namespace) {
-        TestableTimelockServer leader = currentLeaderFor(namespace);
-        leader.killSync();
-        waitUntilLeaderIsElected(ImmutableList.of(namespace));
-        leader.start();
+        try {
+            TestableTimelockServer leader = currentLeaderFor(namespace);
+            leader.killSync();
+            waitUntilLeaderIsElected(ImmutableList.of(namespace));
+            leader.start();
 
-        return !currentLeaderFor(namespace).equals(leader);
+            return !currentLeaderFor(namespace).equals(leader);
+        } catch (Throwable t) {
+            return false;
+        }
     }
 
     Set<TestableTimelockServer> servers() {

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
@@ -38,6 +38,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
@@ -220,7 +221,7 @@ public class TestableTimelockCluster implements TestRule {
             leader.start();
 
             return !currentLeaderFor(namespace).equals(leader);
-        } catch (Throwable t) {
+        } catch (NoSuchElementException e) {
             return false;
         }
     }


### PR DESCRIPTION
**Goals (and why)**:
Reduce flakes as part of our termly goals.

**Implementation Description (bullets)**:
* `currentLeaderFor` can throw `NoSuchElementException` if no leader was successfully elected yet. I'm not 100% certain as to how this can be the case (given that we wait until a leader is elected first), but I feel that we may as well defend against the case, since we clearly tried but failed.

**Testing (What was existing testing like?  What have you done to improve it?)**:
I'll run it a few times and see if it flakes.

**Concerns (what feedback would you like?)**:
Should or can we fix `waitUntilLeaderIsElected` instead?

**Where should we start reviewing?**:
Diff

**Priority (whenever / two weeks / yesterday)**:
Whenever, but this should make builds less painful.
