### PR TITLE
Change semantics of priority tables to be exclusive

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/priority/NextTableToSweepProvider.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/priority/NextTableToSweepProvider.java
@@ -67,10 +67,7 @@ public class NextTableToSweepProvider {
     public Optional<TableToSweep> getNextTableToSweep(
             Transaction tx, long conservativeSweepTimestamp, SweepPriorityOverrideConfig overrideConfig) {
         if (!overrideConfig.priorityTables().isEmpty()) {
-            Optional<TableToSweep> maybeChosenTable = attemptToChooseTable(overrideConfig);
-            if (maybeChosenTable.isPresent()) {
-                return maybeChosenTable;
-            }
+            return attemptToChooseTable(overrideConfig);
         }
 
         Map<TableReference, Double> scores = calculator.calculateSweepPriorityScores(tx, conservativeSweepTimestamp);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/priority/NextTableToSweepProviderTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/priority/NextTableToSweepProviderTest.java
@@ -174,7 +174,7 @@ public class NextTableToSweepProviderTest {
 
         whenGettingNextTableToSweep();
 
-        thenTableChosenIs(table("table2"));
+        thenProviderReturnsEmpty();
     }
 
     @Test

--- a/changelog/@unreleased/pr-5506.v2.yml
+++ b/changelog/@unreleased/pr-5506.v2.yml
@@ -1,0 +1,11 @@
+type: improvement
+improvement:
+  description: When priority tables are specified for background sweep, it will now
+    sweep *only* these tables. Previously, it begins one iteration of sweep for another
+    table, realises it shouldn't continue, and then begins one iteration for another
+    table and so on, ad infinitum.  This behaviour does not make sense, and furthermore
+    could mean that we can't "make background sweep run ONLY on table xyz", because
+    it might select other tables that are eligible in a larger deployment or if there
+    are more threads.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5506

--- a/docs/source/cluster_management/sweep/standard-sweep.rst
+++ b/docs/source/cluster_management/sweep/standard-sweep.rst
@@ -78,7 +78,7 @@ Priority Overrides
 
 .. warning::
    Specifying ``priorityTables`` can be useful for influencing sweep's behaviour in the short run.
-   However, if any tables are specified as ``priorityTables``, and the number of priority tables is at least ``sweepThreads``, then no other tables will ever be swept, meaning that old versions of cells for those tables will accumulate.
+   However, if any tables are specified as ``priorityTables`` then no other tables will ever be swept, meaning that old versions of cells for those tables will accumulate.
    It is not intended for priority tables to be specified in a steady state, generally speaking.
 
 There may be situations in which the background sweeper's heuristics for selecting tables to sweep may not satisfy one's requirements.


### PR DESCRIPTION
**Goals (and why)**:
- When priority tables are specified, background sweep will previously begin one iteration of sweep for another table, realise it shouldn't do that, and then begin one iteration for another table and so on. This behaviour does not make sense, and furthermore could mean that we can't "make background sweep run ONLY on table xyz", because it might select other tables that are eligible in a larger deployment or if there are more threads.

**Implementation Description (bullets)**:
- Only select tables to be considered for sweeping when priority tables are non-empty IF there is a priority table.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Updated the one test that matters.

**Concerns (what feedback would you like?)**:
- This is a semantic change, would it cause problems for anyone?

**Where should we start reviewing?**: small

**Priority (whenever / two weeks / yesterday)**: Tuesday would be good
