### PR TITLE
[DB TimeLock] 3A: AtlasDB Runtime Configuration for TimeLock

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/timestamp/DbTimeLockFactory.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/timestamp/DbTimeLockFactory.java
@@ -36,16 +36,6 @@ import java.util.Optional;
 public interface DbTimeLockFactory {
     String getType();
 
-    /**
-     * @deprecated Creating a DbKeyValueService with this method will not support live reloading the DB password. Use
-     * {@link #createRawKeyValueService(MetricsManager, KeyValueServiceConfig, Refreshable, LeaderConfig)} instead.
-     */
-    @Deprecated
-    default KeyValueService createRawKeyValueService(
-            MetricsManager metricsManager, KeyValueServiceConfig config, LeaderConfig leaderConfig) {
-        return createRawKeyValueService(metricsManager, config, Refreshable.only(Optional.empty()), leaderConfig);
-    }
-
     KeyValueService createRawKeyValueService(
             MetricsManager metricManager,
             KeyValueServiceConfig config,

--- a/changelog/@unreleased/pr-5519.v2.yml
+++ b/changelog/@unreleased/pr-5519.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Users may now specify runtime KVS configuration for DB-TimeLock.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5519

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/DatabaseTsBoundPersisterConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/DatabaseTsBoundPersisterConfiguration.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.google.common.base.Preconditions;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 import org.immutables.value.Value;
 
@@ -39,16 +38,9 @@ public abstract class DatabaseTsBoundPersisterConfiguration implements TsBoundPe
         return !(other instanceof DatabaseTsBoundPersisterConfiguration);
     }
 
-    /*
-     * "relational" is hard-coded from DbKeyValueServiceConfig
-     * to avoid taking a compile time dependency on atlasdb-dbkvs
-     */
     @Value.Check
     public void check() {
-        String kvsType = keyValueServiceConfig().type();
-        Preconditions.checkArgument(
-                kvsType.equals("relational") || kvsType.equals("memory"),
-                "Only InMemory/Dbkvs is a supported for TimeLock's database persister. Found %s.",
-                kvsType);
+        PermittedKeyValueServiceTypes.checkKeyValueServiceTypeIsPermitted(
+                keyValueServiceConfig().type());
     }
 }

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/DatabaseTsBoundPersisterRuntimeConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/DatabaseTsBoundPersisterRuntimeConfiguration.java
@@ -1,0 +1,35 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.timelock.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.palantir.atlasdb.spi.KeyValueServiceRuntimeConfig;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonDeserialize(as = DatabaseTsBoundPersisterRuntimeConfiguration.class)
+public interface DatabaseTsBoundPersisterRuntimeConfiguration {
+    @JsonProperty("key-value-service")
+    KeyValueServiceRuntimeConfig keyValueServiceRuntimeConfig();
+
+    @Value.Check
+    default void check() {
+        PermittedKeyValueServiceTypes.checkKeyValueServiceTypeIsPermitted(
+                keyValueServiceRuntimeConfig().type());
+    }
+}

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/DatabaseTsBoundPersisterRuntimeConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/DatabaseTsBoundPersisterRuntimeConfiguration.java
@@ -23,7 +23,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonDeserialize(as = DatabaseTsBoundPersisterRuntimeConfiguration.class)
-public interface DatabaseTsBoundPersisterRuntimeConfiguration {
+public interface DatabaseTsBoundPersisterRuntimeConfiguration extends TsBoundPersisterRuntimeConfiguration {
     @JsonProperty("key-value-service")
     KeyValueServiceRuntimeConfig keyValueServiceRuntimeConfig();
 

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/DatabaseTsBoundPersisterRuntimeConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/DatabaseTsBoundPersisterRuntimeConfiguration.java
@@ -22,7 +22,7 @@ import com.palantir.atlasdb.spi.KeyValueServiceRuntimeConfig;
 import org.immutables.value.Value;
 
 @Value.Immutable
-@JsonDeserialize(as = DatabaseTsBoundPersisterRuntimeConfiguration.class)
+@JsonDeserialize(as = ImmutableDatabaseTsBoundPersisterRuntimeConfiguration.class)
 public interface DatabaseTsBoundPersisterRuntimeConfiguration extends TsBoundPersisterRuntimeConfiguration {
     @JsonProperty("key-value-service")
     KeyValueServiceRuntimeConfig keyValueServiceRuntimeConfig();

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/PermittedKeyValueServiceTypes.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/PermittedKeyValueServiceTypes.java
@@ -1,0 +1,49 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.timelock.config;
+
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public enum PermittedKeyValueServiceTypes {
+    /*
+     * "relational" is hard-coded from DbKeyValueServiceConfig
+     * to avoid taking a compile time dependency on atlasdb-dbkvs
+     */
+    RELATIONAL("relational"),
+    MEMORY("memory");
+
+    private static final Set<String> PERMITTED_TYPES = Arrays.stream(PermittedKeyValueServiceTypes.values())
+            .map(specificType -> specificType.type)
+            .collect(Collectors.toSet());
+
+    private final String type;
+
+    PermittedKeyValueServiceTypes(String type) {
+        this.type = type;
+    }
+
+    static void checkKeyValueServiceTypeIsPermitted(String typeIdentifier) {
+        Preconditions.checkArgument(
+                PERMITTED_TYPES.contains(typeIdentifier),
+                "Only InMemory/Dbkvs is a supported for TimeLock's database persister. Found %s.",
+                SafeArg.of("userTypeIdentifier", typeIdentifier));
+    }
+}

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockRuntimeConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockRuntimeConfiguration.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Preconditions;
 import com.palantir.atlasdb.timelock.lock.watch.LockWatchTestRuntimeConfig;
+import java.util.Optional;
 import org.immutables.value.Value;
 
 /**
@@ -68,6 +69,10 @@ public abstract class TimeLockRuntimeConfiguration {
     public TimeLockAdjudicationConfiguration adjudication() {
         return ImmutableTimeLockAdjudicationConfiguration.builder().build();
     }
+
+    @JsonProperty
+    @Value.Default
+    public abstract Optional<TsBoundPersisterRuntimeConfiguration> timestampBoundPersistence();
 
     @Value.Check
     public void check() {

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockRuntimeConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockRuntimeConfiguration.java
@@ -71,7 +71,6 @@ public abstract class TimeLockRuntimeConfiguration {
     }
 
     @JsonProperty
-    @Value.Default
     public abstract Optional<TsBoundPersisterRuntimeConfiguration> timestampBoundPersistence();
 
     @Value.Check

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/TsBoundPersisterRuntimeConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/TsBoundPersisterRuntimeConfiguration.java
@@ -1,0 +1,24 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.timelock.config;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes(@JsonSubTypes.Type(value = DatabaseTsBoundPersisterRuntimeConfiguration.class, name = "database"))
+public interface TsBoundPersisterRuntimeConfiguration {}

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -33,6 +33,7 @@ import com.palantir.atlasdb.config.ServerListConfig;
 import com.palantir.atlasdb.http.BlockingTimeoutExceptionMapper;
 import com.palantir.atlasdb.http.NotCurrentLeaderExceptionMapper;
 import com.palantir.atlasdb.http.RedirectRetryTargeter;
+import com.palantir.atlasdb.spi.KeyValueServiceRuntimeConfig;
 import com.palantir.atlasdb.timelock.AsyncTimelockService;
 import com.palantir.atlasdb.timelock.ConjureLockWatchingResource;
 import com.palantir.atlasdb.timelock.ConjureTimelockResource;
@@ -69,6 +70,7 @@ import com.palantir.refreshable.Refreshable;
 import com.palantir.sls.versions.OrderableSlsVersion;
 import com.palantir.timelock.ServiceDiscoveringDatabaseTimeLockSupplier;
 import com.palantir.timelock.config.DatabaseTsBoundPersisterConfiguration;
+import com.palantir.timelock.config.DatabaseTsBoundPersisterRuntimeConfiguration;
 import com.palantir.timelock.config.PaxosTsBoundPersisterConfiguration;
 import com.palantir.timelock.config.TimeLockInstallConfiguration;
 import com.palantir.timelock.config.TimeLockRuntimeConfiguration;
@@ -105,7 +107,7 @@ public class TimeLockAgent {
 
     private final MetricsManager metricsManager;
     private final TimeLockInstallConfiguration install;
-    private final Supplier<TimeLockRuntimeConfiguration> runtime;
+    private final Refreshable<TimeLockRuntimeConfiguration> runtime;
     private final Consumer<Object> registrar;
     private final Optional<Consumer<UndertowService>> undertowRegistrar;
     private final PaxosResources paxosResources;
@@ -124,7 +126,7 @@ public class TimeLockAgent {
     public static TimeLockAgent create(
             MetricsManager metricsManager,
             TimeLockInstallConfiguration install,
-            Supplier<TimeLockRuntimeConfiguration> runtime,
+            Refreshable<TimeLockRuntimeConfiguration> runtime,
             UserAgent userAgent,
             int threadPoolSize,
             long blockingTimeoutMs,
@@ -197,7 +199,7 @@ public class TimeLockAgent {
     private TimeLockAgent(
             MetricsManager metricsManager,
             TimeLockInstallConfiguration install,
-            Supplier<TimeLockRuntimeConfiguration> runtime,
+            Refreshable<TimeLockRuntimeConfiguration> runtime,
             Optional<Consumer<UndertowService>> undertowRegistrar,
             int threadPoolSize,
             long blockingTimeoutMs,
@@ -256,12 +258,27 @@ public class TimeLockAgent {
     private TimestampStorage createDatabaseTimestampStorage(
             DatabaseTsBoundPersisterConfiguration timestampBoundPersistence) {
         ServiceDiscoveringDatabaseTimeLockSupplier dbTimeLockSupplier = new ServiceDiscoveringDatabaseTimeLockSupplier(
-                metricsManager, timestampBoundPersistence.keyValueServiceConfig(), createLeaderConfig());
+                metricsManager,
+                timestampBoundPersistence.keyValueServiceConfig(),
+                getKeyValueServiceRuntimeConfig(),
+                createLeaderConfig());
         return ImmutableTimestampStorage.builder()
                 .timestampCreator(new DbBoundTimestampCreator(dbTimeLockSupplier))
                 .persistentNamespaceContext(PersistentNamespaceContexts.dbBound(
                         dbTimeLockSupplier.getTimestampSeriesProvider(AtlasDbConstants.DB_TIMELOCK_TIMESTAMP_TABLE)))
                 .build();
+    }
+
+    private Refreshable<Optional<KeyValueServiceRuntimeConfig>> getKeyValueServiceRuntimeConfig() {
+        return runtime.map(TimeLockRuntimeConfiguration::timestampBoundPersistence)
+                .map(maybeConfig -> maybeConfig
+                        .map(config -> {
+                            Preconditions.checkState(
+                                    config instanceof DatabaseTsBoundPersisterRuntimeConfiguration,
+                                    "Should not initialise DB Timelock with non-database runtime configuration");
+                            return (DatabaseTsBoundPersisterRuntimeConfiguration) config;
+                        })
+                        .map(DatabaseTsBoundPersisterRuntimeConfiguration::keyValueServiceRuntimeConfig));
     }
 
     private void createAndRegisterResources() {

--- a/timelock-agent/src/test/java/com/palantir/timelock/ServiceDiscoveringDatabaseTimeLockSupplierTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/ServiceDiscoveringDatabaseTimeLockSupplierTest.java
@@ -32,7 +32,9 @@ import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import com.palantir.refreshable.Refreshable;
 import com.palantir.timestamp.ManagedTimestampService;
+import java.util.Optional;
 import java.util.function.Supplier;
 import org.junit.Test;
 
@@ -48,7 +50,8 @@ public class ServiceDiscoveringDatabaseTimeLockSupplierTest {
             .build();
 
     private final ServiceDiscoveringDatabaseTimeLockSupplier timeLockSupplier =
-            new ServiceDiscoveringDatabaseTimeLockSupplier(metricsManager, keyValueServiceConfig, leaderConfig);
+            new ServiceDiscoveringDatabaseTimeLockSupplier(
+                    metricsManager, keyValueServiceConfig, Refreshable.only(Optional.empty()), leaderConfig);
 
     @Test
     public void canGetTimestampServiceForDifferentSeries() {

--- a/timelock-agent/src/test/java/com/palantir/timelock/config/PermittedKeyValueServiceTypesTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/config/PermittedKeyValueServiceTypesTest.java
@@ -1,0 +1,50 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.timelock.config;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import org.junit.Test;
+
+public class PermittedKeyValueServiceTypesTest {
+    @Test
+    public void allExpectedTypesArePermitted() {
+        assertThatCode(() -> PermittedKeyValueServiceTypes.checkKeyValueServiceTypeIsPermitted("relational"))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> PermittedKeyValueServiceTypes.checkKeyValueServiceTypeIsPermitted("memory"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void cassandraIsNotPermitted() {
+        assertKeyValueServiceTypeNotPermitted("cassandra");
+    }
+
+    @Test
+    public void unknownTypesNotPermitted() {
+        assertKeyValueServiceTypeNotPermitted("");
+        assertKeyValueServiceTypeNotPermitted("s3");
+    }
+
+    public static void assertKeyValueServiceTypeNotPermitted(String typeIdentifier) {
+        assertThatThrownBy(() -> PermittedKeyValueServiceTypes.checkKeyValueServiceTypeIsPermitted(typeIdentifier))
+                .isInstanceOf(SafeIllegalArgumentException.class)
+                .hasMessageContaining("Only InMemory/Dbkvs is a supported for TimeLock's database persister.");
+    }
+}

--- a/timelock-server-benchmark-cluster/src/main/java/com/palantir/atlasdb/timelock/benchmarks/server/TimelockBenchmarkServerLauncher.java
+++ b/timelock-server-benchmark-cluster/src/main/java/com/palantir/atlasdb/timelock/benchmarks/server/TimelockBenchmarkServerLauncher.java
@@ -21,6 +21,7 @@ import com.palantir.atlasdb.timelock.logging.NonBlockingFileAppenderFactory;
 import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.serialization.ObjectMappers;
+import com.palantir.refreshable.Refreshable;
 import com.palantir.sls.versions.OrderableSlsVersion;
 import com.palantir.timelock.paxos.TimeLockAgent;
 import com.palantir.tritium.metrics.registry.SharedTaggedMetricRegistries;
@@ -47,10 +48,10 @@ public class TimelockBenchmarkServerLauncher extends Application<CombinedTimeLoc
 
     @Override
     public void run(CombinedTimeLockServerConfiguration configuration, Environment environment) throws Exception {
-        TimeLockAgent agent = TimeLockAgent.create(
+        TimeLockAgent.create(
                 MetricsManagers.of(environment.metrics(), SharedTaggedMetricRegistries.getSingleton()),
                 configuration.install(),
-                configuration::runtime, // this won't actually live reload
+                Refreshable.only(configuration.runtime()), // This won't actually live reload.
                 USER_AGENT,
                 CombinedTimeLockServerConfiguration.threadPoolSize(),
                 CombinedTimeLockServerConfiguration.blockingTimeoutMs(),

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
@@ -29,6 +29,7 @@ import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.serialization.ObjectMappers;
 import com.palantir.conjure.java.server.jersey.ConjureJerseyFeature;
+import com.palantir.refreshable.Refreshable;
 import com.palantir.sls.versions.OrderableSlsVersion;
 import com.palantir.timelock.paxos.TimeLockAgent;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
@@ -97,7 +98,7 @@ public class TimeLockServerLauncher extends Application<CombinedTimeLockServerCo
         TimeLockAgent timeLockAgent = TimeLockAgent.create(
                 metricsManager,
                 configuration.install(),
-                configuration::runtime, // this won't actually live reload
+                Refreshable.only(configuration.runtime()), // this won't actually live reload
                 USER_AGENT,
                 CombinedTimeLockServerConfiguration.threadPoolSize(),
                 CombinedTimeLockServerConfiguration.blockingTimeoutMs(),


### PR DESCRIPTION
**Goals (and why)**:
- Support live reloading of KVS configuration when one is using timelock. This is important at deployments using db-timelock, where the password might get rotated

**Implementation Description (bullets)**:
- Wiring, plus a bunch of tests

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Some unit tests were added.

**Concerns (what feedback would you like?)**:
- Is the design a bit too heavily engineered?

**Where should we start reviewing?**: eh

**Priority (whenever / two weeks / yesterday)**: this week would be nice