### PR TITLE
[HD] Better(?) KVS calls for getSortedColumns when desired number of results is known

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
@@ -165,6 +165,18 @@ public interface Transaction {
     @Idempotent
     Iterator<Map.Entry<Cell, byte[]>> getSortedColumns(
             TableReference tableRef, Iterable<byte[]> rows, BatchColumnRangeSelection batchColumnRangeSelection);
+
+    /**
+     * Similar to {@link #getSortedColumns(TableReference, Iterable, BatchColumnRangeSelection)}, except that the
+     * returned iterator will be limited to {@code numResults} entries.
+     *
+     * The implementation of this method is expected to make fewer KVS calls than
+     * {@link #getSortedColumns(TableReference, Iterable, BatchColumnRangeSelection)}.
+     */
+    @Idempotent
+    Iterator<Map.Entry<Cell, byte[]>> getSortedColumns(
+            TableReference tableRef, Iterable<byte[]> rows, ColumnRangeSelection columnRangeSelection, int numResults);
+
     /**
      * Gets the values associated for each cell in {@code cells} from table specified by {@code tableRef}.
      *

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransaction.java
@@ -73,6 +73,12 @@ public abstract class ForwardingTransaction extends ForwardingObject implements 
     }
 
     @Override
+    public Iterator<Map.Entry<Cell, byte[]>> getSortedColumns(
+            TableReference tableRef, Iterable<byte[]> rows, ColumnRangeSelection columnRangeSelection, int numResults) {
+        return delegate().getSortedColumns(tableRef, rows, columnRangeSelection, numResults);
+    }
+
+    @Override
     public Iterator<Map.Entry<Cell, byte[]>> getRowsColumnRange(
             TableReference tableRef, Iterable<byte[]> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
         return delegate().getRowsColumnRange(tableRef, rows, columnRangeSelection, batchHint);

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ReadTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ReadTransaction.java
@@ -32,6 +32,7 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.NavigableMap;
 import java.util.Set;
 import java.util.function.BiFunction;
@@ -127,6 +128,12 @@ public class ReadTransaction extends ForwardingTransaction {
             TableReference tableRef, Iterable<byte[]> rows, BatchColumnRangeSelection batchColumnRangeSelection) {
         checkTableName(tableRef);
         return delegate().getSortedColumns(tableRef, rows, batchColumnRangeSelection);
+    }
+
+    @Override
+    public Iterator<Entry<Cell, byte[]>> getSortedColumns(
+            TableReference tableRef, Iterable<byte[]> rows, ColumnRangeSelection columnRangeSelection, int numResults) {
+        return delegate().getSortedColumns(tableRef, rows, columnRangeSelection, numResults);
     }
 
     @Override


### PR DESCRIPTION
**Goals (and why)**:
`getSortedColumns` returns an iterator that will lazily read more from the KVS as needed. If we know in advance how many results we need, the reads can be better optimised.

**Implementation Description (bullets)**:
The existing method's implementation reads `batchHint`/`numRows` entries from each row. The user would need to know (and rely on) this implementation detail to optimise their usage of `getSortedColumns`. The new method allows the user to specify the desired number of results, and the read batch size is calculated to not need additional lookups in 99.5% of cases.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Need to add tests.

**Concerns (what feedback would you like?)**:
Is this even useful? I was thinking we could in general have an A/B testing framework that we could use in cases like these where we could call either method with some probability and then compare metrics? Sounds like another hack(day/week) project, but it would probably be super useful as this is difficult to measure otherwise. Also note that we would probably want to measure the number of KVS calls since the lazy nature of the iterator makes time-based metrics useless.