### PR TITLE
Fix build; revert implicit dependency check

### DIFF
--- a/atlasdb-api/build.gradle
+++ b/atlasdb-api/build.gradle
@@ -21,7 +21,6 @@ dependencies {
     exclude (group: 'org.hdrhistogram', module: 'HdrHistogram')
   }
 
-  implementation 'com.boundary:high-scale-lib'
   implementation 'com.google.errorprone:error_prone_annotations'
   implementation 'com.google.guava:guava'
   implementation 'com.palantir.common:streams'

--- a/atlasdb-autobatch/build.gradle
+++ b/atlasdb-autobatch/build.gradle
@@ -8,7 +8,6 @@ dependencies {
     compile group: 'com.palantir.safe-logging', name: 'safe-logging'
     compile group: 'com.palantir.tritium', name: 'tritium-registry'
 
-    implementation 'com.boundary:high-scale-lib'
     implementation 'com.google.errorprone:error_prone_annotations'
     implementation 'com.google.guava:guava'
     implementation 'com.palantir.safe-logging:preconditions'

--- a/atlasdb-cassandra-integration-tests/build.gradle
+++ b/atlasdb-cassandra-integration-tests/build.gradle
@@ -3,7 +3,6 @@ apply from: "../gradle/shared.gradle"
 apply from: "../gradle/tests.gradle"
 
 dependencies {
-    testImplementation 'com.boundary:high-scale-lib'
     testImplementation 'com.google.guava:guava'
     testImplementation 'com.palantir.common:streams'
     testImplementation 'com.palantir.safe-logging:safe-logging'

--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -52,7 +52,6 @@ dependencies {
       exclude group: 'org.hamcrest'
   }
 
-  implementation 'com.boundary:high-scale-lib'
   implementation 'com.fasterxml.jackson.core:jackson-annotations'
   implementation 'com.fasterxml.jackson.core:jackson-databind'
   implementation 'com.github.ben-manes.caffeine:caffeine'

--- a/atlasdb-client/build.gradle
+++ b/atlasdb-client/build.gradle
@@ -89,7 +89,6 @@ dependencies {
 
   integrationInputCompile project(":atlasdb-client")
 
-  implementation 'com.boundary:high-scale-lib'
   implementation 'com.fasterxml.jackson.core:jackson-annotations'
   implementation 'com.google.errorprone:error_prone_annotations'
   implementation 'com.google.guava:guava'

--- a/atlasdb-commons/build.gradle
+++ b/atlasdb-commons/build.gradle
@@ -11,7 +11,6 @@ dependencies {
     compile group: 'com.palantir.common', name: 'streams'
     compile group: 'com.palantir.safe-logging', name: 'preconditions'
 
-    implementation 'com.boundary:high-scale-lib'
     implementation 'com.fasterxml.jackson.core:jackson-annotations'
     implementation 'com.google.errorprone:error_prone_annotations'
     implementation 'com.google.guava:guava'

--- a/atlasdb-ete-tests/build.gradle
+++ b/atlasdb-ete-tests/build.gradle
@@ -18,7 +18,6 @@ dependencies {
     compile group: 'com.palantir.tritium', name: 'tritium-lib'
     compile group: 'io.dropwizard', name: 'dropwizard-core'
 
-    implementation 'com.boundary:high-scale-lib'
     implementation 'com.fasterxml.jackson.core:jackson-annotations'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8'

--- a/atlasdb-impl-shared/build.gradle
+++ b/atlasdb-impl-shared/build.gradle
@@ -24,7 +24,6 @@ dependencies {
   compile group: 'com.palantir.safe-logging', name: 'safe-logging'
   compile group: 'com.palantir.safe-logging', name: 'preconditions'
 
-  implementation 'com.boundary:high-scale-lib'
   implementation 'com.fasterxml.jackson.core:jackson-annotations'
   implementation 'com.fasterxml.jackson.core:jackson-core'
   implementation 'com.fasterxml.jackson.core:jackson-databind'
@@ -54,7 +53,6 @@ dependencies {
   implementation project(':timelock-api:timelock-api-jersey')
   implementation project(':timelock-api:timelock-api-objects')
 
-  testImplementation 'com.boundary:high-scale-lib'
   testImplementation 'com.fasterxml.jackson.core:jackson-core'
   testImplementation 'com.fasterxml.jackson.core:jackson-databind'
   testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-guava'

--- a/atlasdb-tests-shared/build.gradle
+++ b/atlasdb-tests-shared/build.gradle
@@ -20,7 +20,6 @@ dependencies {
   compile group: 'org.mockito', name: 'mockito-core'
   compile group: "org.awaitility", name: "awaitility"
 
-  implementation 'com.boundary:high-scale-lib'
   implementation 'com.fasterxml.jackson.core:jackson-core'
   implementation 'com.google.guava:guava'
   implementation 'com.palantir.common:streams'

--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,6 @@ allprojects {
             it.substitute it.module('org.glassfish.web:javax.el') with it.module('org.glassfish:jakarta.el:3.0.3')
         }
     }
-    check.dependsOn checkImplicitDependencies
 
     tasks.withType(JavaCompile) {
         options.compilerArgs += ['-Werror']

--- a/changelog/@unreleased/pr-5534.v2.yml
+++ b/changelog/@unreleased/pr-5534.v2.yml
@@ -1,0 +1,9 @@
+type: fix
+fix:
+  description: Publishing of AtlasDB dependent services should work again; this was
+    broken because of what the maintainers believe to be a bad interaction between
+    dependency-control and check implicit dependencies. This reverts the offending
+    dependency and disables the check which is believed to be erroneously firing.
+    We seek to re-enable the implicit dependency check soon.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5534

--- a/commons-db/build.gradle
+++ b/commons-db/build.gradle
@@ -23,7 +23,6 @@ dependencies {
   compile group: 'com.zaxxer', name: 'HikariCP', version: libVersions.hikariCP
   compile group: 'joda-time', name: 'joda-time'
 
-  implementation 'com.boundary:high-scale-lib'
   implementation 'com.h2database:h2'
   implementation 'com.google.guava:guava'
   implementation 'com.palantir.safe-logging:preconditions'

--- a/commons-executors-api/build.gradle
+++ b/commons-executors-api/build.gradle
@@ -6,5 +6,4 @@ libsDirName = file('build/artifacts')
 // api projects outside of atlasdb that try very hard to minimize
 // their dependency footprint.
 dependencies {
-    implementation 'com.boundary:high-scale-lib'
 }

--- a/leader-election-impl/build.gradle
+++ b/leader-election-impl/build.gradle
@@ -20,7 +20,6 @@ dependencies {
   compile group: "org.jdbi", name: 'jdbi3-sqlobject'
   compile group: 'org.xerial', name: 'sqlite-jdbc'
 
-  implementation 'com.boundary:high-scale-lib'
   implementation group: 'com.palantir.common', name: 'streams'
   implementation 'com.fasterxml.jackson.core:jackson-annotations'
   implementation 'com.fasterxml.jackson.core:jackson-databind'

--- a/lock-api/build.gradle
+++ b/lock-api/build.gradle
@@ -22,7 +22,6 @@ dependencies {
     compile group: 'com.palantir.refreshable', name: 'refreshable'
     compile group: 'one.util', name: 'streamex'
 
-    implementation 'com.boundary:high-scale-lib'
     implementation 'com.google.guava:guava'
     implementation 'com.palantir.common:streams'
     implementation 'com.palantir.conjure.java:conjure-lib'

--- a/lock-impl/build.gradle
+++ b/lock-impl/build.gradle
@@ -10,7 +10,6 @@ dependencies {
   compile group: 'joda-time', name: 'joda-time'
   compile group: 'org.yaml', name: 'snakeyaml'
 
-  implementation 'com.boundary:high-scale-lib'
   implementation 'com.fasterxml.jackson.core:jackson-annotations'
   implementation 'com.fasterxml.jackson.core:jackson-databind'
   implementation 'com.google.errorprone:error_prone_annotations'

--- a/timelock-agent/build.gradle
+++ b/timelock-agent/build.gradle
@@ -10,7 +10,6 @@ dependencies {
     compile group: 'com.google.guava', name: 'guava'
     compile group: 'com.palantir.conjure.java.api', name: 'service-config'
 
-    implementation 'com.boundary:high-scale-lib'
     implementation 'com.fasterxml.jackson.core:jackson-annotations'
     implementation 'com.fasterxml.jackson.core:jackson-core'
     implementation 'com.fasterxml.jackson.core:jackson-databind'

--- a/timelock-corruption-detection/build.gradle
+++ b/timelock-corruption-detection/build.gradle
@@ -19,7 +19,6 @@ dependencies {
     compile group: 'com.palantir.conjure.java.api', name: 'service-config'
     compile group: 'one.util', name: 'streamex'
 
-    implementation 'com.boundary:high-scale-lib'
     implementation 'com.fasterxml.jackson.core:jackson-annotations'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.google.errorprone:error_prone_annotations'

--- a/timelock-impl/build.gradle
+++ b/timelock-impl/build.gradle
@@ -18,7 +18,6 @@ dependencies {
     compile group: 'com.palantir.safe-logging', name: 'safe-logging'
     compile group: 'org.mindrot', name: 'jbcrypt'
 
-    implementation 'com.boundary:high-scale-lib'
     implementation 'com.fasterxml.jackson.core:jackson-annotations'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.github.ben-manes.caffeine:caffeine'

--- a/timelock-server/build.gradle
+++ b/timelock-server/build.gradle
@@ -127,7 +127,6 @@ dependencies {
     testCommonImplementation group: 'com.github.peterwippermann.junit4', name: 'parameterized-suite'
     testCommonImplementation group: 'com.ea.agentloader', name: 'ea-agent-loader'
     testCommonImplementation group: 'io.dropwizard', name: 'dropwizard-testing'
-    testCommonImplementation 'com.boundary:high-scale-lib'
     testCommonImplementation 'com.fasterxml.jackson.core:jackson-core'
     testCommonImplementation 'com.fasterxml.jackson.core:jackson-databind'
     testCommonImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'


### PR DESCRIPTION
**Goals (and why)**:
Fix the build

**Implementation Description (bullets)**:
Publishing of Atlas dependent services is broken because of what I believe to be a bad interaction between dependency-control and check implicit dependencies. This reverts the offending dependency and disables the check which I believe is erroneously firing.

**Testing (What was existing testing like?  What have you done to improve it?)**:
CI works.

**Concerns (what feedback would you like?)**:
Would the build actually be fixed?

**Where should we start reviewing?**: small

**Priority (whenever / two weeks / yesterday)**: yesterday 🔥 