### PR TITLE
[PDS-198280] Banishing Corrupted Banishment: Prevent TimeLock Self-Confusion

### DIFF
--- a/changelog/@unreleased/pr-5539.v2.yml
+++ b/changelog/@unreleased/pr-5539.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: '[PDS-198280] A race condition that could cause TimeLock to give out
+    the same timestamps twice and/or give out non-sequential timestamps in rare circumstances
+    is fixed; please consult the PR for more details.'
+  links:
+  - https://github.com/palantir/atlasdb/pull/5539

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResourcesFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResourcesFactory.java
@@ -18,7 +18,6 @@ package com.palantir.atlasdb.timelock.paxos;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
-import com.palantir.atlasdb.timelock.paxos.NetworkClientFactories.Factory;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.common.proxy.PredicateSwitchedProxy;
 import com.palantir.conjure.java.api.config.service.UserAgent;
@@ -241,7 +240,7 @@ public final class PaxosResourcesFactory {
     }
 
     @VisibleForTesting
-    static Factory<PaxosProposer> getPaxosProposerFactory(
+    static NetworkClientFactories.Factory<PaxosProposer> getPaxosProposerFactory(
             TimelockPaxosMetrics timelockMetrics, NetworkClientFactories combinedNetworkClientFactories) {
         return client -> {
             PaxosAcceptorNetworkClient acceptorNetworkClient =

--- a/timelock-agent/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosResourcesFactoryTest.java
+++ b/timelock-agent/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosResourcesFactoryTest.java
@@ -1,0 +1,39 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.palantir.atlasdb.util.MetricsManagers;
+import com.palantir.paxos.Client;
+import com.palantir.paxos.PaxosProposer;
+import org.junit.Test;
+import org.mockito.Answers;
+
+public class PaxosResourcesFactoryTest {
+    @Test
+    public void individualTimestampServicesHaveDifferingProposers() {
+        NetworkClientFactories.Factory<PaxosProposer> proposerFactory = PaxosResourcesFactory.getPaxosProposerFactory(
+                TimelockPaxosMetrics.of(PaxosUseCase.TIMESTAMP, MetricsManagers.createForTests()),
+                mock(NetworkClientFactories.class, Answers.RETURNS_DEEP_STUBS));
+        Client client = Client.of("client");
+        PaxosProposer proposer1 = proposerFactory.create(client);
+        PaxosProposer proposer2 = proposerFactory.create(client);
+        assertThat(proposer1.getUuid()).isNotEqualTo(proposer2.getUuid());
+    }
+}

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/transaction/timestamp/LeadershipGuardedClientAwareManagedTimestampService.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/transaction/timestamp/LeadershipGuardedClientAwareManagedTimestampService.java
@@ -1,0 +1,98 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.transaction.timestamp;
+
+import com.palantir.leader.NotCurrentLeaderException;
+import com.palantir.lock.v2.PartitionedTimestamps;
+import com.palantir.timestamp.TimestampRange;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A {@link ClientAwareManagedTimestampService} that also verifies that it is not known to not be the leader before
+ * returning results to the user.
+ */
+public class LeadershipGuardedClientAwareManagedTimestampService
+        implements ClientAwareManagedTimestampService, AutoCloseable {
+    private static final Logger log =
+            LoggerFactory.getLogger(LeadershipGuardedClientAwareManagedTimestampService.class);
+
+    private final ClientAwareManagedTimestampService delegate;
+    private final AtomicBoolean isClosed = new AtomicBoolean(false);
+
+    public LeadershipGuardedClientAwareManagedTimestampService(ClientAwareManagedTimestampService delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public PartitionedTimestamps getFreshTimestampsForClient(UUID clientIdentifier, int numTimestampsRequested) {
+        return ensureStillOpen(() -> delegate.getFreshTimestampsForClient(clientIdentifier, numTimestampsRequested));
+    }
+
+    @Override
+    public void fastForwardTimestamp(long currentTimestamp) {
+        ensureStillOpen(() -> {
+            delegate.fastForwardTimestamp(currentTimestamp);
+            return null;
+        });
+    }
+
+    @Override
+    public String ping() {
+        return ensureStillOpen(delegate::ping);
+    }
+
+    @Override
+    public boolean isInitialized() {
+        return ensureStillOpen(delegate::isInitialized);
+    }
+
+    @Override
+    public long getFreshTimestamp() {
+        return ensureStillOpen(delegate::getFreshTimestamp);
+    }
+
+    @Override
+    public TimestampRange getFreshTimestamps(int numTimestampsRequested) {
+        return ensureStillOpen(() -> delegate.getFreshTimestamps(numTimestampsRequested));
+    }
+
+    @Override
+    public void close() {
+        if (!isClosed.compareAndSet(false, true)) {
+            log.info("Could not close the client-aware managed timestamp service, because it was already closed."
+                    + " Possibly indicative of weirdness in Atlas code, but should be benign as far as the user is"
+                    + " concerned.");
+        }
+    }
+
+    private <T> T ensureStillOpen(Supplier<T> operation) {
+        T value = operation.get();
+        // Ensure that no one else may have made a new timestamp service and invalidated us
+        throwIfClosed();
+        return value;
+    }
+
+    private void throwIfClosed() {
+        if (isClosed.get()) {
+            throw new NotCurrentLeaderException("Lost leadership elsewhere");
+        }
+    }
+}

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/transaction/timestamp/LeadershipGuardedClientAwareManagedTimestampServiceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/transaction/timestamp/LeadershipGuardedClientAwareManagedTimestampServiceTest.java
@@ -1,0 +1,51 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.transaction.timestamp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.palantir.leader.NotCurrentLeaderException;
+import org.junit.Test;
+
+public class LeadershipGuardedClientAwareManagedTimestampServiceTest {
+    private final ClientAwareManagedTimestampService delegate = mock(ClientAwareManagedTimestampService.class);
+    private final LeadershipGuardedClientAwareManagedTimestampService delegatingService =
+            new LeadershipGuardedClientAwareManagedTimestampService(delegate);
+
+    @Test
+    public void passThroughCalls() {
+        when(delegate.getFreshTimestamp()).thenReturn(88L);
+        assertThat(delegatingService.getFreshTimestamp()).isEqualTo(88L);
+        verify(delegate).getFreshTimestamp();
+    }
+
+    @Test
+    public void doesNotReturnResultsAfterClosing() {
+        when(delegate.getFreshTimestamp()).thenReturn(88L);
+        delegatingService.close();
+        assertThatThrownBy(delegatingService::getFreshTimestamp)
+                .isInstanceOf(NotCurrentLeaderException.class)
+                .hasMessage("Lost leadership elsewhere");
+
+        // Maybe excessive, but I think reasonable
+        verify(delegate).getFreshTimestamp();
+    }
+}

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/transaction/timestamp/LeadershipGuardedClientAwareManagedTimestampServiceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/transaction/timestamp/LeadershipGuardedClientAwareManagedTimestampServiceTest.java
@@ -48,4 +48,15 @@ public class LeadershipGuardedClientAwareManagedTimestampServiceTest {
         // Maybe excessive, but I think reasonable
         verify(delegate).getFreshTimestamp();
     }
+
+    @Test
+    public void doNotReturnIfClosedAfterDelegateInvocationBegins() {
+        when(delegate.getFreshTimestamp()).thenAnswer(invocation -> {
+            delegatingService.close();
+            return 42L;
+        });
+        assertThatThrownBy(delegatingService::getFreshTimestamp)
+                .isInstanceOf(NotCurrentLeaderException.class)
+                .hasMessage("Lost leadership elsewhere");
+    }
 }


### PR DESCRIPTION
**Goals (and why)**:
- See PDS-198280 - the timestamp corroboration check was failing on occasion at a number of installations. It was noted that this correlates with (1) leader elections, AND (2) very high timestamp load (in the region of 100K QPS).
- Not having corruption is, well, important.

**Implementation Description (bullets)**:
- TimeLock previously had an edge case where it was possible for it to break its standard guarantees of giving out numbers that are monotonically increasing. Specifically, this occurs as a race condition when a timestamp service from a previous term may still be live if request threads have acquired a reference to it and then slept, and needs to refresh its bound (the fact that it should be invalidated by the leadership proxy is irrelevant, because timestamp services generally aren't meaningfully closed). This and a newly created timestamp service can race to propose a new value, and if they happen to propose the *same* value, both instances of the service will think their Paxos succeeded, meaning that the timestamps used to service the request prompting a refresh of the old bound could potentially be the same as timestamps later handed out by the newly created service.
- See following diagram for thought process and pathing.
![ALP-path](https://user-images.githubusercontent.com/5955510/124598212-491e1d80-de5c-11eb-81ef-5ea1428811f8.jpg)

- This change prevents this case, because a closing of the old delegate when gaining leadership happens before the new delegate is created, and also a read to confirm the old delegate has not been closed happens before a response is returned to the user. Thus, in the previous case, even if the old delegate falls into the same race condition, any timestamps it tries to return will not actually be returned to the user, because it will be caught in the `LeadershipGuardedClientAwareManagedTimestampService`.
 
**Testing (What was existing testing like?  What have you done to improve it?)**:
- Added a simple test. I tried to write a stress test but wasn't able to reproduce the original issue.

**Concerns (what feedback would you like?)**:
- I believe this is the minimal fix. There will still be a bit of noise when we run into this race condition, and it may be possible to mitigate some of that by judiciously adding closes and or close-checks at the correct places in the timestamp service code, but I think this addresses the core issue.

**Where should we start reviewing?**: PaxosResourcesFactory.java

**Priority (whenever / two weeks / yesterday)**: yesterday 🔥  or since 2016, perhaps?
