### PR TITLE
[do not merge] [PDS-198544] Allow configuration mode with slow async lock reaping

### DIFF
--- a/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockInstallConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockInstallConfiguration.java
@@ -38,6 +38,11 @@ public interface TimeLockInstallConfiguration {
     ClusterConfiguration cluster();
 
     @Value.Default
+    default boolean iAmOnThePersistenceTeamAndKnowWhatIAmDoingTemporarilyDisableExpiredLockReaperOnV2Locks() {
+        return false;
+    }
+
+    @Value.Default
     default boolean iAmOnThePersistenceTeamAndKnowWhatImDoingSkipSqliteConsistencyCheckAndTruncateFileBasedLog() {
         return false;
     }

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockInstallConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockInstallConfiguration.java
@@ -38,7 +38,7 @@ public interface TimeLockInstallConfiguration {
     ClusterConfiguration cluster();
 
     @Value.Default
-    default boolean iAmOnThePersistenceTeamAndKnowWhatIAmDoingTemporarilyDisableExpiredLockReaperOnV2Locks() {
+    default boolean iAmOnThePersistenceTeamAndKnowWhatIAmDoingUseVerySlowAsyncLockReaperOnV2Locks() {
         return false;
     }
 

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/AsyncTimeLockServicesCreator.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/AsyncTimeLockServicesCreator.java
@@ -62,7 +62,7 @@ public class AsyncTimeLockServicesCreator implements TimeLockServicesCreator {
 
     @Override
     public TimeLockServices createTimeLockServices(
-            boolean disableAsyncLockReaper,
+            boolean slowAsyncLockReaper,
             Client client,
             Supplier<ManagedTimestampService> rawTimestampServiceSupplier,
             Supplier<LockService> rawLockServiceSupplier) {
@@ -73,7 +73,7 @@ public class AsyncTimeLockServicesCreator implements TimeLockServicesCreator {
                 client,
                 AsyncTimelockService.class,
                 () -> createRawAsyncTimelockService(
-                        disableAsyncLockReaper, client, rawTimestampServiceSupplier, maybeEnhancedLockLog));
+                        slowAsyncLockReaper, client, rawTimestampServiceSupplier, maybeEnhancedLockLog));
 
         AsyncTimelockResource asyncTimelockResource =
                 new AsyncTimelockResource(maybeEnhancedLockLog, asyncTimelockService);
@@ -90,7 +90,7 @@ public class AsyncTimeLockServicesCreator implements TimeLockServicesCreator {
     }
 
     private AsyncTimelockService createRawAsyncTimelockService(
-            boolean disableAsyncLockReaper,
+            boolean slowAsyncLockReaper,
             Client client,
             Supplier<ManagedTimestampService> timestampServiceSupplier,
             LockLog maybeEnhancedLockLog) {
@@ -106,7 +106,7 @@ public class AsyncTimeLockServicesCreator implements TimeLockServicesCreator {
                 "async-lock-timeouts");
         return new AsyncTimelockServiceImpl(
                 AsyncLockService.createDefault(
-                        disableAsyncLockReaper, maybeEnhancedLockLog, reaperExecutor, timeoutExecutor),
+                        slowAsyncLockReaper, maybeEnhancedLockLog, reaperExecutor, timeoutExecutor),
                 timestampServiceSupplier.get(),
                 maybeEnhancedLockLog);
     }

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -506,7 +506,11 @@ public class TimeLockAgent {
         Supplier<ManagedTimestampService> rawTimestampServiceSupplier =
                 timestampStorage.timestampCreator().createTimestampService(typedClient, leaderConfig);
         Supplier<LockService> rawLockServiceSupplier = lockCreator::createThreadPoolingLockService;
-        return timelockCreator.createTimeLockServices(typedClient, rawTimestampServiceSupplier, rawLockServiceSupplier);
+        return timelockCreator.createTimeLockServices(
+                install.iAmOnThePersistenceTeamAndKnowWhatIAmDoingTemporarilyDisableExpiredLockReaperOnV2Locks(),
+                typedClient,
+                rawTimestampServiceSupplier,
+                rawLockServiceSupplier);
     }
 
     private LeaderConfig createLeaderConfig() {

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -507,7 +507,7 @@ public class TimeLockAgent {
                 timestampStorage.timestampCreator().createTimestampService(typedClient, leaderConfig);
         Supplier<LockService> rawLockServiceSupplier = lockCreator::createThreadPoolingLockService;
         return timelockCreator.createTimeLockServices(
-                install.iAmOnThePersistenceTeamAndKnowWhatIAmDoingTemporarilyDisableExpiredLockReaperOnV2Locks(),
+                install.iAmOnThePersistenceTeamAndKnowWhatIAmDoingUseVerySlowAsyncLockReaperOnV2Locks(),
                 typedClient,
                 rawTimestampServiceSupplier,
                 rawLockServiceSupplier);

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockServicesCreator.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockServicesCreator.java
@@ -27,7 +27,7 @@ public interface TimeLockServicesCreator {
      * and lock service supplier.
      */
     TimeLockServices createTimeLockServices(
-            boolean disableAsyncLockReaper,
+            boolean slowAsyncLockReaper,
             Client client,
             Supplier<ManagedTimestampService> rawTimestampServiceSupplier,
             Supplier<LockService> rawLockServiceSupplier);

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockServicesCreator.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockServicesCreator.java
@@ -27,6 +27,7 @@ public interface TimeLockServicesCreator {
      * and lock service supplier.
      */
     TimeLockServices createTimeLockServices(
+            boolean disableAsyncLockReaper,
             Client client,
             Supplier<ManagedTimestampService> rawTimestampServiceSupplier,
             Supplier<LockService> rawLockServiceSupplier);

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/AsyncLockService.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/AsyncLockService.java
@@ -119,8 +119,9 @@ public class AsyncLockService implements Closeable {
                     }
                 },
                 0,
-                slowAsyncLockReaper ? TimeUnit.MINUTES.toMillis(10) :
-                        LockLeaseContract.SERVER_LEASE_TIMEOUT.toMillis() / 2,
+                slowAsyncLockReaper
+                        ? TimeUnit.MINUTES.toMillis(10)
+                        : LockLeaseContract.SERVER_LEASE_TIMEOUT.toMillis() / 2,
                 TimeUnit.MILLISECONDS);
     }
 

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceTest.java
@@ -30,7 +30,7 @@ public class AsyncLockServiceTest {
         ScheduledExecutorService reaperExecutor = PTExecutors.newSingleThreadScheduledExecutor();
         ScheduledExecutorService timeoutExecutor = PTExecutors.newSingleThreadScheduledExecutor();
         AsyncLockService asyncLockService = AsyncLockService.createDefault(
-                disableAsyncLockReaper,
+                false,
                 new LockLog(MetricsManagers.createForTests().getRegistry(), () -> 1L),
                 reaperExecutor,
                 timeoutExecutor);

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceTest.java
@@ -30,7 +30,10 @@ public class AsyncLockServiceTest {
         ScheduledExecutorService reaperExecutor = PTExecutors.newSingleThreadScheduledExecutor();
         ScheduledExecutorService timeoutExecutor = PTExecutors.newSingleThreadScheduledExecutor();
         AsyncLockService asyncLockService = AsyncLockService.createDefault(
-                new LockLog(MetricsManagers.createForTests().getRegistry(), () -> 1L), reaperExecutor, timeoutExecutor);
+                disableAsyncLockReaper,
+                new LockLog(MetricsManagers.createForTests().getRegistry(), () -> 1L),
+                reaperExecutor,
+                timeoutExecutor);
 
         asyncLockService.close();
         assertThat(reaperExecutor.isShutdown()).isTrue();

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceEteTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceEteTest.java
@@ -65,6 +65,7 @@ public class AsyncLockServiceEteTest {
     private final HeldLocksCollection heldLocks = HeldLocksCollection.create(clock);
     private final LockWatchingService lockWatchingService = new LockWatchingServiceImpl(heldLocks, clock.id());
     private final AsyncLockService service = new AsyncLockService(
+            false,
             new LockCollection(),
             new ImmutableTimestampTracker(),
             new LockAcquirer(

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceTest.java
@@ -60,6 +60,7 @@ public class AsyncLockServiceTest {
     private final ImmutableTimestampTracker immutableTimestampTracker = mock(ImmutableTimestampTracker.class);
     private final DeterministicScheduler reaperExecutor = new DeterministicScheduler();
     private final AsyncLockService lockService = new AsyncLockService(
+            false,
             locks,
             immutableTimestampTracker,
             acquirer,


### PR DESCRIPTION
DNM in current form. But could be useful

**Goals (and why)**:
- allow users in more connection strained environments to still use atlasdb

**Implementation Description (bullets)**:
- reap overdue stuff every 10 mins as opposed to 10 seconds

**Testing (What was existing testing like?  What have you done to improve it?)**:
- not much :(

**Concerns (what feedback would you like?)**:
- this of course means that if a client dies it holds locks it had for 10 minutes.

**Where should we start reviewing?**: small

**Priority (whenever / two weeks / yesterday)**: it depends
