### PR TITLE
[PDS-198346] Internal Errors - Propagate Exception Types Correctly

### DIFF
--- a/changelog/@unreleased/pr-5545.v2.yml
+++ b/changelog/@unreleased/pr-5545.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: BlockingTimeLimitedLockService now propagates exceptions correctly;
+    users should see fewer 500s on failures to acquire locks (owing to timeout or
+    other runtime exceptions).
+  links:
+  - https://github.com/palantir/atlasdb/pull/5545

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/BlockingTimeLimitedLockService.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/BlockingTimeLimitedLockService.java
@@ -17,7 +17,6 @@ package com.palantir.atlasdb.timelock.lock;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
-import com.google.common.util.concurrent.ExecutionError;
 import com.google.common.util.concurrent.SimpleTimeLimiter;
 import com.google.common.util.concurrent.TimeLimiter;
 import com.google.common.util.concurrent.UncheckedExecutionException;
@@ -204,7 +203,7 @@ public class BlockingTimeLimitedLockService implements CloseableLockService {
         } catch (TimeoutException e) {
             // This is the legitimate timeout case we're trying to catch.
             throw logAndHandleTimeout(specification);
-        } catch (UncheckedExecutionException | ExecutionException | ExecutionError e) {
+        } catch (UncheckedExecutionException | ExecutionException e) {
             // We don't know, and would prefer not to throw checked exceptions apart from InterruptedException.
             Throwable cause = e.getCause();
             if (cause instanceof InterruptedException) {


### PR DESCRIPTION
**Goals (and why)**:
- Don't have internal errors.

**Implementation Description (bullets)**:
- The BlockingTimeLimitedLockService(BTLLS) was attempting to propagate an exception arising from a call to a SimpleTimeLimiter. But this is often going to be UncheckedExecutionException or ExecutionException (or in the rare case ExecutionError) and in these cases we want to propagate the _cause_. This is more significant when the cause has meaning e.g. is a NCLE or SNAE.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added test for the new case

**Concerns (what feedback would you like?)**:
not much

**Where should we start reviewing?**: small

**Priority (whenever / two weeks / yesterday)**: this week please