### PR TITLE
Move isNewService check to TimelockAgent

### DIFF
--- a/changelog/@unreleased/pr-5555.v2.yml
+++ b/changelog/@unreleased/pr-5555.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Move isNewService check to TimelockAgent
+  links:
+  - https://github.com/palantir/atlasdb/pull/5555

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosInstallConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosInstallConfiguration.java
@@ -114,4 +114,10 @@ public interface PaxosInstallConfiguration {
     default boolean doDataDirectoriesExist() {
         return dataDirectory().isDirectory();
     }
+
+    static Builder builder() {
+        return new Builder();
+    }
+
+    class Builder extends ImmutablePaxosInstallConfiguration.Builder {}
 }

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockInstallConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockInstallConfiguration.java
@@ -21,9 +21,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.palantir.atlasdb.debug.LockDiagnosticConfig;
 import com.palantir.paxos.Client;
-import org.immutables.value.Value;
-
 import java.util.Map;
+import org.immutables.value.Value;
 
 /**
  * Static (not live-reloaded) portions of TimeLock's configuration.
@@ -66,4 +65,10 @@ public interface TimeLockInstallConfiguration {
         return paxos().isNewService()
                 || cluster().knownNewServers().contains(cluster().localServer());
     }
+
+    static Builder builder() {
+        return new Builder();
+    }
+
+    class Builder extends ImmutableTimeLockInstallConfiguration.Builder {}
 }

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockInstallConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockInstallConfiguration.java
@@ -21,8 +21,9 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.palantir.atlasdb.debug.LockDiagnosticConfig;
 import com.palantir.paxos.Client;
-import java.util.Map;
 import org.immutables.value.Value;
+
+import java.util.Map;
 
 /**
  * Static (not live-reloaded) portions of TimeLock's configuration.
@@ -64,13 +65,5 @@ public interface TimeLockInstallConfiguration {
     default boolean isNewServiceNode() {
         return paxos().isNewService()
                 || cluster().knownNewServers().contains(cluster().localServer());
-    }
-
-    @Value.Check
-    default void check() {
-        if (!paxos().ignoreNewServiceCheck()) {
-            TimeLockPersistenceInvariants.checkPersistenceConsistentWithState(
-                    isNewServiceNode(), paxos().doDataDirectoriesExist());
-        }
     }
 }

--- a/timelock-agent/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClientsTest.java
+++ b/timelock-agent/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClientsTest.java
@@ -30,9 +30,7 @@ import com.palantir.conjure.java.api.config.service.PartialServiceConfiguration;
 import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.sls.versions.OrderableSlsVersion;
 import com.palantir.timelock.config.ImmutableDefaultClusterConfiguration;
-import com.palantir.timelock.config.ImmutablePaxosInstallConfiguration;
 import com.palantir.timelock.config.ImmutablePaxosTsBoundPersisterConfiguration;
-import com.palantir.timelock.config.ImmutableTimeLockInstallConfiguration;
 import com.palantir.timelock.config.PaxosInstallConfiguration;
 import com.palantir.timelock.config.SqlitePaxosPersistenceConfigurations;
 import com.palantir.timelock.config.TimeLockInstallConfiguration;
@@ -55,13 +53,13 @@ public class PaxosRemoteClientsTest {
 
     @Before
     public void setUp() {
-        paxosInstallConfiguration = ImmutablePaxosInstallConfiguration.builder()
+        paxosInstallConfiguration = PaxosInstallConfiguration.builder()
                 .isNewService(false)
                 .dataDirectory(temporaryFolder.getRoot())
                 .sqlitePersistence(SqlitePaxosPersistenceConfigurations.DEFAULT)
                 .leaderMode(PaxosInstallConfiguration.PaxosLeaderMode.SINGLE_LEADER)
                 .build();
-        installConfiguration = ImmutableTimeLockInstallConfiguration.builder()
+        installConfiguration = TimeLockInstallConfiguration.builder()
                 .cluster(ImmutableDefaultClusterConfiguration.builder()
                         .localServer("a:1")
                         .cluster(

--- a/timelock-agent/src/test/java/com/palantir/timelock/config/PaxosInstallConfigurationIntegrationTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/config/PaxosInstallConfigurationIntegrationTest.java
@@ -130,7 +130,7 @@ public class PaxosInstallConfigurationIntegrationTest {
 
     private static ImmutablePaxosInstallConfiguration.Builder createPartialConfiguration(
             File dataDirectory, File sqliteDataDirectory) {
-        return ImmutablePaxosInstallConfiguration.builder()
+        return PaxosInstallConfiguration.builder()
                 .dataDirectory(dataDirectory)
                 .sqlitePersistence(ImmutableSqlitePaxosPersistenceConfiguration.builder()
                         .dataDirectory(sqliteDataDirectory)
@@ -168,7 +168,7 @@ public class PaxosInstallConfigurationIntegrationTest {
     @SuppressWarnings("CheckReturnValue")
     private static void attemptConstructTopLevelConfigWithoutOverrides(
             PaxosInstallConfiguration paxosInstallConfiguration) {
-        ImmutableTimeLockInstallConfiguration.builder()
+        TimeLockInstallConfiguration.builder()
                 .paxos(paxosInstallConfiguration)
                 .cluster(CLUSTER_CONFIG)
                 .build();

--- a/timelock-agent/src/test/java/com/palantir/timelock/config/TimeLockInstallConfigurationTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/config/TimeLockInstallConfigurationTest.java
@@ -17,12 +17,9 @@
 package com.palantir.timelock.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.java.api.config.service.PartialServiceConfiguration;
-import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.timelock.config.PaxosInstallConfiguration.PaxosLeaderMode;
 import java.io.File;
 import java.io.IOException;
@@ -51,9 +48,6 @@ public class TimeLockInstallConfigurationTest {
     private File extantPaxosLogDirectory;
     private File extantSqliteLogDirectory;
 
-    private PaxosInstallConfiguration newService;
-    private PaxosInstallConfiguration extantService;
-
     @Before
     public void setUp() throws IOException {
         newPaxosLogDirectory = Paths.get(temporaryFolder.getRoot().toString(), "part-time-parliament")
@@ -67,7 +61,7 @@ public class TimeLockInstallConfigurationTest {
 
     @Test
     public void newServiceIfNewServiceFlagSetToTrue() {
-        assertThat(ImmutableTimeLockInstallConfiguration.builder()
+        assertThat(TimeLockInstallConfiguration.builder()
                         .cluster(CLUSTER_CONFIG)
                         .paxos(createPaxosInstall(true, false))
                         .build()
@@ -77,7 +71,7 @@ public class TimeLockInstallConfigurationTest {
 
     @Test
     public void existingServiceIfNewServiceFlagSetToFalse() {
-        assertThat(ImmutableTimeLockInstallConfiguration.builder()
+        assertThat(TimeLockInstallConfiguration.builder()
                         .cluster(CLUSTER_CONFIG)
                         .paxos(createPaxosInstall(false, true))
                         .build()
@@ -87,7 +81,7 @@ public class TimeLockInstallConfigurationTest {
 
     @Test
     public void newNodeInExistingServiceRecognisedAsNew() {
-        assertThat(ImmutableTimeLockInstallConfiguration.builder()
+        assertThat(TimeLockInstallConfiguration.builder()
                         .cluster(ImmutableDefaultClusterConfiguration.builder()
                                 .localServer(SERVER_A)
                                 .cluster(PartialServiceConfiguration.of(
@@ -101,49 +95,13 @@ public class TimeLockInstallConfigurationTest {
                 .isTrue();
     }
 
-    @Test
-    public void newServiceNotSetNoDataDirectoryThrows() {
-        assertThatThrownBy(() -> ImmutableTimeLockInstallConfiguration.builder()
-                        .cluster(CLUSTER_CONFIG)
-                        .paxos(createPaxosInstall(false, false))
-                        .build())
-                .isInstanceOf(SafeIllegalArgumentException.class);
-    }
-
-    @Test
-    public void newServiceSetNoDataDirectoryExistsThrows() {
-        assertThatThrownBy(() -> ImmutableTimeLockInstallConfiguration.builder()
-                        .cluster(CLUSTER_CONFIG)
-                        .paxos(createPaxosInstall(true, true))
-                        .build())
-                .isInstanceOf(SafeIllegalArgumentException.class);
-    }
-
-    @Test
-    public void newServiceNotSetNoDataDirectoryDoesNotThrowWhenIgnoreFlagSet() {
-        assertThatCode(() -> ImmutableTimeLockInstallConfiguration.builder()
-                        .cluster(CLUSTER_CONFIG)
-                        .paxos(createPaxosInstall(false, false, true))
-                        .build())
-                .doesNotThrowAnyException();
-    }
-
-    @Test
-    public void newServiceSetNoDataDirectoryExistsDoesNotThrowWhenIgnoreFlagSet() {
-        assertThatCode(() -> ImmutableTimeLockInstallConfiguration.builder()
-                        .cluster(CLUSTER_CONFIG)
-                        .paxos(createPaxosInstall(true, true, true))
-                        .build())
-                .doesNotThrowAnyException();
-    }
-
     private PaxosInstallConfiguration createPaxosInstall(boolean isNewService, boolean shouldDirectoriesExist) {
         return createPaxosInstall(isNewService, shouldDirectoriesExist, false);
     }
 
     private PaxosInstallConfiguration createPaxosInstall(
             boolean isNewService, boolean shouldDirectoriesExist, boolean ignoreCheck) {
-        return ImmutablePaxosInstallConfiguration.builder()
+        return PaxosInstallConfiguration.builder()
                 .dataDirectory(shouldDirectoriesExist ? extantPaxosLogDirectory : newPaxosLogDirectory)
                 .sqlitePersistence(ImmutableSqlitePaxosPersistenceConfiguration.builder()
                         .dataDirectory(shouldDirectoriesExist ? extantSqliteLogDirectory : extantPaxosLogDirectory)

--- a/timelock-agent/src/test/java/com/palantir/timelock/config/TimeLockPersistenceInvariantsTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/config/TimeLockPersistenceInvariantsTest.java
@@ -42,9 +42,8 @@ public class TimeLockPersistenceInvariantsTest {
     public void doesNotCreateDirectoryForPaxosDirectoryIfNewService() throws IOException {
         File mockFile = getMockFileWith(false, true);
 
-        assertCanBuildConfiguration(ImmutablePaxosInstallConfiguration.builder()
-                .dataDirectory(mockFile)
-                .isNewService(true));
+        assertCanBuildConfiguration(
+                PaxosInstallConfiguration.builder().dataDirectory(mockFile).isNewService(true));
 
         verify(mockFile, times(0)).mkdirs();
     }
@@ -53,9 +52,8 @@ public class TimeLockPersistenceInvariantsTest {
     public void canUseExistingDirectoryAsPaxosDirectory() throws IOException {
         File mockFile = getMockFileWith(true, false);
 
-        assertCanBuildConfiguration(ImmutablePaxosInstallConfiguration.builder()
-                .dataDirectory(mockFile)
-                .isNewService(false));
+        assertCanBuildConfiguration(
+                PaxosInstallConfiguration.builder().dataDirectory(mockFile).isNewService(false));
 
         verify(mockFile, atLeastOnce()).isDirectory();
     }
@@ -64,18 +62,16 @@ public class TimeLockPersistenceInvariantsTest {
     public void throwsIfConfiguredToBeNewServiceWithExistingDirectory() throws IOException {
         File mockFile = getMockFileWith(true, true);
 
-        assertFailsToBuildConfiguration(ImmutablePaxosInstallConfiguration.builder()
-                .dataDirectory(mockFile)
-                .isNewService(true));
+        assertFailsToBuildConfiguration(
+                PaxosInstallConfiguration.builder().dataDirectory(mockFile).isNewService(true));
     }
 
     @Test
     public void throwsIfConfiguredToBeExistingServiceWithoutDirectory() throws IOException {
         File mockFile = getMockFileWith(false, true);
 
-        assertFailsToBuildConfiguration(ImmutablePaxosInstallConfiguration.builder()
-                .dataDirectory(mockFile)
-                .isNewService(false));
+        assertFailsToBuildConfiguration(
+                PaxosInstallConfiguration.builder().dataDirectory(mockFile).isNewService(false));
     }
 
     @Test
@@ -88,9 +84,9 @@ public class TimeLockPersistenceInvariantsTest {
                 .cluster(PartialServiceConfiguration.of(ImmutableList.of(SERVER_A, "b", "c"), Optional.empty()))
                 .build();
 
-        assertThatThrownBy(ImmutableTimeLockInstallConfiguration.builder()
+        assertThatThrownBy(TimeLockInstallConfiguration.builder()
                         .cluster(differentClusterConfig)
-                        .paxos(ImmutablePaxosInstallConfiguration.builder()
+                        .paxos(PaxosInstallConfiguration.builder()
                                 .dataDirectory(mockFile)
                                 .isNewService(false)
                                 .build())::build)
@@ -107,9 +103,9 @@ public class TimeLockPersistenceInvariantsTest {
                 .cluster(PartialServiceConfiguration.of(ImmutableList.of(SERVER_A, "b", "c"), Optional.empty()))
                 .build();
 
-        assertThatCode(ImmutableTimeLockInstallConfiguration.builder()
+        assertThatCode(TimeLockInstallConfiguration.builder()
                         .cluster(differentClusterConfig)
-                        .paxos(ImmutablePaxosInstallConfiguration.builder()
+                        .paxos(PaxosInstallConfiguration.builder()
                                 .dataDirectory(mockFile)
                                 .isNewService(false)
                                 .build())::build)
@@ -128,7 +124,7 @@ public class TimeLockPersistenceInvariantsTest {
     @SuppressWarnings("CheckReturnValue")
     private void assertCanBuildConfiguration(ImmutablePaxosInstallConfiguration.Builder configBuilder) {
         PaxosInstallConfiguration installConfiguration = configBuilder.build();
-        ImmutableTimeLockInstallConfiguration.builder()
+        TimeLockInstallConfiguration.builder()
                 .cluster(CLUSTER_CONFIG)
                 .paxos(installConfiguration)
                 .build();
@@ -136,7 +132,7 @@ public class TimeLockPersistenceInvariantsTest {
 
     private void assertFailsToBuildConfiguration(ImmutablePaxosInstallConfiguration.Builder configBuilder) {
         PaxosInstallConfiguration installConfiguration = configBuilder.build();
-        assertThatThrownBy(ImmutableTimeLockInstallConfiguration.builder()
+        assertThatThrownBy(TimeLockInstallConfiguration.builder()
                         .cluster(CLUSTER_CONFIG)
                         .paxos(installConfiguration)::build)
                 .isInstanceOf(IllegalArgumentException.class);

--- a/timelock-agent/src/test/java/com/palantir/timelock/paxos/PaxosRemotingUtilsTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/paxos/PaxosRemotingUtilsTest.java
@@ -25,7 +25,6 @@ import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
 import com.palantir.paxos.PaxosAcceptor;
 import com.palantir.timelock.config.ClusterConfiguration;
 import com.palantir.timelock.config.ImmutableDefaultClusterConfiguration;
-import com.palantir.timelock.config.ImmutableTimeLockInstallConfiguration;
 import com.palantir.timelock.config.PaxosInstallConfiguration;
 import com.palantir.timelock.config.TimeLockInstallConfiguration;
 import java.net.MalformedURLException;
@@ -46,7 +45,7 @@ public class PaxosRemotingUtilsTest {
                     .build())
             .build();
     private static final PaxosInstallConfiguration PAXOS_CONFIGURATION = createPaxosConfiguration();
-    private static final TimeLockInstallConfiguration NO_SSL_TIMELOCK = ImmutableTimeLockInstallConfiguration.builder()
+    private static final TimeLockInstallConfiguration NO_SSL_TIMELOCK = TimeLockInstallConfiguration.builder()
             .paxos(PAXOS_CONFIGURATION)
             .cluster(NO_SSL_CLUSTER)
             .build();
@@ -59,7 +58,7 @@ public class PaxosRemotingUtilsTest {
                     .security(SSL_CONFIGURATION)
                     .build())
             .build();
-    private static final TimeLockInstallConfiguration SSL_TIMELOCK = ImmutableTimeLockInstallConfiguration.builder()
+    private static final TimeLockInstallConfiguration SSL_TIMELOCK = TimeLockInstallConfiguration.builder()
             .paxos(PAXOS_CONFIGURATION)
             .cluster(SSL_CLUSTER)
             .build();

--- a/timelock-agent/src/test/java/com/palantir/timelock/paxos/TimeLockAgentTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/paxos/TimeLockAgentTest.java
@@ -16,27 +16,33 @@
 
 package com.palantir.timelock.paxos;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.spi.KeyValueServiceRuntimeConfig;
 import com.palantir.conjure.java.api.config.service.PartialServiceConfiguration;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.timelock.config.ClusterConfiguration;
+import com.palantir.timelock.config.ImmutableDatabaseTsBoundPersisterRuntimeConfiguration;
+import com.palantir.timelock.config.ImmutableDefaultClusterConfiguration;
+import com.palantir.timelock.config.ImmutableSqlitePaxosPersistenceConfiguration;
+import com.palantir.timelock.config.ImmutableTimeLockRuntimeConfiguration;
 import com.palantir.timelock.config.PaxosInstallConfiguration;
+import com.palantir.timelock.config.TimeLockInstallConfiguration;
 import com.palantir.timelock.config.TsBoundPersisterRuntimeConfiguration;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class TimeLockAgentTest {
 
@@ -124,27 +130,25 @@ public class TimeLockAgentTest {
 
     @Test
     public void newServiceNotSetNoDataDirectoryThrows() {
-        assertThatThrownBy(
-                        () -> TimeLockAgent.verifyIsNewServiceInvariant(ImmutableTimeLockInstallConfiguration.builder()
-                                .cluster(CLUSTER_CONFIG)
-                                .paxos(createPaxosInstall(false, false))
-                                .build()))
+        assertThatThrownBy(() -> TimeLockAgent.verifyIsNewServiceInvariant(TimeLockInstallConfiguration.builder()
+                        .cluster(CLUSTER_CONFIG)
+                        .paxos(createPaxosInstall(false, false))
+                        .build()))
                 .isInstanceOf(SafeIllegalArgumentException.class);
     }
 
     @Test
     public void newServiceSetNoDataDirectoryExistsThrows() {
-        assertThatThrownBy(
-                        () -> TimeLockAgent.verifyIsNewServiceInvariant(ImmutableTimeLockInstallConfiguration.builder()
-                                .cluster(CLUSTER_CONFIG)
-                                .paxos(createPaxosInstall(true, true))
-                                .build()))
+        assertThatThrownBy(() -> TimeLockAgent.verifyIsNewServiceInvariant(TimeLockInstallConfiguration.builder()
+                        .cluster(CLUSTER_CONFIG)
+                        .paxos(createPaxosInstall(true, true))
+                        .build()))
                 .isInstanceOf(SafeIllegalArgumentException.class);
     }
 
     @Test
     public void newServiceNotSetNoDataDirectoryDoesNotThrowWhenIgnoreFlagSet() {
-        assertThatCode(() -> TimeLockAgent.verifyIsNewServiceInvariant(ImmutableTimeLockInstallConfiguration.builder()
+        assertThatCode(() -> TimeLockAgent.verifyIsNewServiceInvariant(TimeLockInstallConfiguration.builder()
                         .cluster(CLUSTER_CONFIG)
                         .paxos(createPaxosInstall(false, false, true))
                         .build()))
@@ -153,7 +157,7 @@ public class TimeLockAgentTest {
 
     @Test
     public void newServiceSetNoDataDirectoryExistsDoesNotThrowWhenIgnoreFlagSet() {
-        assertThatCode(() -> TimeLockAgent.verifyIsNewServiceInvariant(ImmutableTimeLockInstallConfiguration.builder()
+        assertThatCode(() -> TimeLockAgent.verifyIsNewServiceInvariant(TimeLockInstallConfiguration.builder()
                         .cluster(CLUSTER_CONFIG)
                         .paxos(createPaxosInstall(true, true, true))
                         .build()))
@@ -166,7 +170,7 @@ public class TimeLockAgentTest {
 
     private PaxosInstallConfiguration createPaxosInstall(
             boolean isNewService, boolean shouldDirectoriesExist, boolean ignoreCheck) {
-        return ImmutablePaxosInstallConfiguration.builder()
+        return PaxosInstallConfiguration.builder()
                 .dataDirectory(shouldDirectoriesExist ? extantPaxosLogDirectory : newPaxosLogDirectory)
                 .sqlitePersistence(ImmutableSqlitePaxosPersistenceConfiguration.builder()
                         .dataDirectory(shouldDirectoriesExist ? extantSqliteLogDirectory : extantPaxosLogDirectory)


### PR DESCRIPTION
**Goals (and why)**:
We are looking to introduce a dynamic check for `is-new-service` which is not based on the static configuration supplied to Timelock.  To do this, we intend to override the value supplied by configuration.

So, we need to disable the invariant check that happens on immutable creation since this may not yet be the "final" state.

**Implementation Description (bullets)**:
- Move the invariant check to the TimelockAgent create function.  I believe this is still the critical path.
- Expose the PaxosInstallConfiguration and TimelockInstallConfiguration builders so that these objects can be re-created externally.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Existing unit testing should be sufficient.  Unfortunately any of the testing that checks for failure needs to be moved into TimelockAgentTest.

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:
ASAP