### PR TITLE
AutoDelegateProcessor supports gradle incremental builds

### DIFF
--- a/atlasdb-processors/src/main/java/com/palantir/processors/AutoDelegateProcessor.java
+++ b/atlasdb-processors/src/main/java/com/palantir/processors/AutoDelegateProcessor.java
@@ -197,10 +197,11 @@ public final class AutoDelegateProcessor extends AbstractProcessor {
 
     private void generateCode(TypeToExtend typeToExtend) throws IOException {
         String newTypeName = PREFIX + typeToExtend.getSimpleName();
-        TypeSpec.Builder typeBuilder = TypeSpec.interfaceBuilder(newTypeName);
-        typeBuilder.addTypeVariables(typeToExtend.getTypeParameterElements().stream()
-                .map(TypeVariableName::get)
-                .collect(Collectors.toList()));
+        TypeSpec.Builder typeBuilder = TypeSpec.interfaceBuilder(newTypeName)
+                .addOriginatingElement(typeToExtend.getTypeElement())
+                .addTypeVariables(typeToExtend.getTypeParameterElements().stream()
+                        .map(TypeVariableName::get)
+                        .collect(Collectors.toList()));
 
         // Add modifiers
         TypeMirror typeMirror = typeToExtend.getType();

--- a/atlasdb-processors/src/main/java/com/palantir/processors/TypeToExtend.java
+++ b/atlasdb-processors/src/main/java/com/palantir/processors/TypeToExtend.java
@@ -90,6 +90,10 @@ final class TypeToExtend {
         return typeToExtend.asType();
     }
 
+    TypeElement getTypeElement() {
+        return typeToExtend;
+    }
+
     Set<ExecutableElement> getMethods() {
         return methods;
     }

--- a/atlasdb-processors/src/main/resources/META-INF/gradle/incremental.annotation.processors
+++ b/atlasdb-processors/src/main/resources/META-INF/gradle/incremental.annotation.processors
@@ -1,2 +1,1 @@
 com.palantir.processors.AutoDelegateProcessor,ISOLATING
-

--- a/atlasdb-processors/src/main/resources/META-INF/gradle/incremental.annotation.processors
+++ b/atlasdb-processors/src/main/resources/META-INF/gradle/incremental.annotation.processors
@@ -1,0 +1,2 @@
+com.palantir.processors.AutoDelegateProcessor,ISOLATING
+

--- a/changelog/@unreleased/pr-5558.v2.yml
+++ b/changelog/@unreleased/pr-5558.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: AutoDelegateProcessor supports gradle incremental builds
+  links:
+  - https://github.com/palantir/atlasdb/pull/5558


### PR DESCRIPTION
Documentation: https://docs.gradle.org/6.9/userguide/java_plugin.html#sec:incremental_annotation_processing

This allows us to avoid full recompilation when sources change
in modules using the annotation processor. Faster builds.
