### PR TITLE
Config: Allow connecting to different timelock namespace than KVS

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
@@ -360,10 +360,12 @@ public abstract class AtlasDbConfig {
             String presentNamespace = namespace().get();
             Preconditions.checkState(!presentNamespace.contains("\""), "Namespace should not be quoted");
 
+            boolean allowDifferentKvsNamespace =
+                    enableNonstandardAndPossiblyErrorProneTopologyAllowDifferentKvsAndTimelockNamespaces();
             keyValueService()
                     .namespace()
                     .ifPresent(kvsNamespace -> Preconditions.checkState(
-                            kvsNamespace.equals(presentNamespace),
+                            kvsNamespace.equals(presentNamespace) || allowDifferentKvsNamespace,
                             "If present, keyspace/dbName/sid config should be the same as the"
                                     + " atlas root-level namespace config."));
 

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbConfigTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbConfigTest.java
@@ -17,6 +17,7 @@ package com.palantir.atlasdb.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -358,16 +359,13 @@ public class AtlasDbConfigTest {
     }
 
     @Test
-    public void globalNamespaceAlwaysReportsConflictsIfPresentForKvs() {
-        assertThatThrownBy(() -> ImmutableAtlasDbConfig.builder()
-                        .namespace(OTHER_CLIENT)
-                        .keyValueService(KVS_CONFIG_WITH_NAMESPACE)
-                        .timelock(TIMELOCK_CONFIG_WITH_OTHER_CLIENT)
-                        .enableNonstandardAndPossiblyErrorProneTopologyAllowDifferentKvsAndTimelockNamespaces(true)
-                        .build())
-                .isInstanceOf(IllegalStateException.class)
-                .satisfies(
-                        exception -> assertThat(exception.getMessage()).contains("atlas root-level namespace config"));
+    public void allowGlobalNamespaceAndKvsToDifferWhenFlagged() {
+        assertThatNoException().isThrownBy(() -> ImmutableAtlasDbConfig.builder()
+                .namespace(OTHER_CLIENT)
+                .keyValueService(KVS_CONFIG_WITH_NAMESPACE)
+                .timelock(TIMELOCK_CONFIG_WITH_OTHER_CLIENT)
+                .enableNonstandardAndPossiblyErrorProneTopologyAllowDifferentKvsAndTimelockNamespaces(true)
+                .build());
     }
 
     @Test

--- a/changelog/@unreleased/pr-5561.v2.yml
+++ b/changelog/@unreleased/pr-5561.v2.yml
@@ -1,0 +1,10 @@
+type: improvement
+improvement:
+  description: |-
+    Config: Allow connecting to different timelock namespace than KVS
+
+    There is currently no way to connect to a different timelock namespace than the configured KVS namespace. When using postgres/oracle as a DB-based KVS, the KVS namespace is set to their database name (such as 'db' or 'opgid' or something), which is undesirable as a timelock namespace.
+
+    This simply extends an existing config option to allow for the timelock namespace to differ.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5561


### PR DESCRIPTION
There is currently no way to connect to a different timelock namespace than the configured KVS namespace. When using postgres/oracle as a DB-based KVS, the KVS namespace is set to their database name (such as 'db' or 'opgid' or something), which is undesirable as a timelock namespace.

This simply extends an existing config option to allow for the timelock namespace to differ.