### PR TITLE
[Exclusions] NonAtomicVolatileUpdate

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/util/AggregatingVersionedSupplier.java
+++ b/atlasdb-commons/src/main/java/com/palantir/util/AggregatingVersionedSupplier.java
@@ -29,6 +29,8 @@ public class AggregatingVersionedSupplier<T> implements Supplier<VersionedType<T
 
     private final Function<Collection<T>, T> aggregator;
     private final Supplier<VersionedType<T>> memoizedValue;
+
+    // Only accessed in the context of the memoized supplier
     private volatile long version = UNINITIALIZED_VERSION;
 
     private final ConcurrentMap<Integer, T> latestValues = new ConcurrentHashMap<>();
@@ -63,6 +65,7 @@ public class AggregatingVersionedSupplier<T> implements Supplier<VersionedType<T
         latestValues.put(key, value);
     }
 
+    @SuppressWarnings("NonAtomicVolatileUpdate") // Accessed by 1 thread at a time, but needed for visibility.
     private VersionedType<T> recalculate() {
         version++;
         return VersionedType.of(aggregator.apply(latestValues.values()), version);

--- a/build.gradle
+++ b/build.gradle
@@ -138,7 +138,6 @@ allprojects {
                 'MockitoInternalUsage',
                 'ModifyCollectionInEnhancedForLoop',
                 'NarrowingCompoundAssignment',
-                'NonAtomicVolatileUpdate',
                 'NullOptional',
                 'OperatorPrecedence',
                 'OverrideThrowableToString',

--- a/timestamp-impl/src/test/java/com/palantir/timestamp/InMemoryTimestampBoundStore.java
+++ b/timestamp-impl/src/test/java/com/palantir/timestamp/InMemoryTimestampBoundStore.java
@@ -30,7 +30,6 @@ public class InMemoryTimestampBoundStore implements TimestampBoundStore {
         return upperLimit;
     }
 
-    @SuppressWarnings("NonAtomicVolatileUpdate")
     @Override
     public void storeUpperLimit(long newLimit) throws MultipleRunningTimestampServiceError {
         if (shouldThrowErrorMultipleServerError) {


### PR DESCRIPTION
**Goals (and why)**:
- Not have errorprone exclusions

**Implementation Description (bullets)**:
- Justify the one instance of this thing

**Testing (What was existing testing like?  What have you done to improve it?)**:
- No actual code change

**Concerns (what feedback would you like?)**:
- Is there something trickier I'm missing here?
- Strictly speaking one can rely on an implementation detail of `ExpiringMemoizingSupplier`, that the run on one thread in JMM terms _happens-before_ the run on another (because of the volatile read/write of the time) to have the version be a non-volatile variable, but since I didn't see an explicit guarantee of this in the API I'd prefer not to do that.

**Where should we start reviewing?**: +3-1

**Priority (whenever / two weeks / yesterday)**: whenever
