### PR TITLE
AtlasDb "dynamic snitch" -- do not route to very slow hosts 

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -381,4 +381,9 @@ public interface CassandraKeyValueServiceConfig extends KeyValueServiceConfig {
                 localHostWeighting() >= 0.0 && localHostWeighting() <= 1.0,
                 "'localHostWeighting' must be between 0 and 1 inclusive");
     }
+
+    @Value.Default
+    default double slowHostThreshold() {
+        return Double.MAX_VALUE;
+    }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TracingCassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TracingCassandraClient.java
@@ -44,7 +44,7 @@ import org.apache.thrift.TException;
 public class TracingCassandraClient implements AutoDelegate_CassandraClient {
     private final CassandraClient client;
 
-    public TracingCassandraClient(CassandraClient client) {
+    public  TracingCassandraClient(CassandraClient client) {
         this.client = client;
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TracingCassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TracingCassandraClient.java
@@ -44,7 +44,7 @@ import org.apache.thrift.TException;
 public class TracingCassandraClient implements AutoDelegate_CassandraClient {
     private final CassandraClient client;
 
-    public  TracingCassandraClient(CassandraClient client) {
+    public TracingCassandraClient(CassandraClient client) {
         this.client = client;
     }
 

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
@@ -85,6 +85,7 @@ public class CassandraClientPoolTest {
     @Before
     public void setup() {
         config = mock(CassandraKeyValueServiceConfig.class);
+        when(config.slowHostThreshold()).thenReturn(Double.MAX_VALUE);
         when(config.poolRefreshIntervalSeconds()).thenReturn(POOL_REFRESH_INTERVAL_SECONDS);
         when(config.timeBetweenConnectionEvictionRunsSeconds()).thenReturn(TIME_BETWEEN_EVICTION_RUNS_SECONDS);
         when(config.unresponsiveHostBackoffTimeSeconds()).thenReturn(UNRESPONSIVE_HOST_BACKOFF_SECONDS);

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
@@ -74,6 +74,14 @@ public class CassandraServiceTest {
     }
 
     @Test
+    public void shouldKeepSlowHostIfOnlyHost() {
+        ImmutableSet<InetSocketAddress> hosts = ImmutableSet.of(HOST_1);
+        CassandraService cassandra = clientPoolWithServersAndParams(hosts, 1.0);
+        cassandra.getPools().get(HOST_1).getLatency().update(10000);
+        assertThat(cassandra.maybeFilterSlowHosts(hosts)).containsExactly(HOST_1);
+    }
+
+    @Test
     public void shouldOnlyReturnLocalHosts() {
         ImmutableSet<InetSocketAddress> hosts = ImmutableSet.of(HOST_1, HOST_2);
         ImmutableSet<InetSocketAddress> localHosts = ImmutableSet.of(HOST_1);

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
@@ -62,7 +62,7 @@ public class CassandraServiceTest {
         cassandra.getPools().get(HOST_1).getLatency().update(10);
         cassandra.getPools().get(HOST_2).getLatency().update(10);
         cassandra.getPools().get(HOST_3).getLatency().update(99);
-        assertThat(cassandra.maybeFilterSlowHosts(hosts)).containsExactly(HOST_1, HOST_2);
+        assertThat(cassandra.maybeFilterSlowHosts(hosts)).containsExactly(HOST_1, HOST_2, HOST_3);
     }
 
     @Test


### PR DESCRIPTION
**Goals (and why)**:
Remove hosts from host list if they're 10x slower than every other node. This is useful for SND/AZ outages, as the client will purposefully not route to a slow coordinator node. 

**Implementation Description (bullets)**:
- Track all (successful) requests in an **ExponentiallyDecayingReservoir**, which is associated with a single host 
  - Entries have a maximum life of 5 minutes
- When fetching hosts, determine the average p99 latency for all hosts, and compare it against each of our hosts
- If any p99 latency is N times greater (recommendation: 10) than the _average excluding itself_ , then we remove the host from the host list 
- All hosts that have not been queried (value = 0) have been assigned a default value of 1; this is done in-order to ensure we query all hosts at least once every 5 minutes
- In the case of coordinator SND in a large cluster (9 nodes, 3 nodes in AZs A/B/C), we still prefer to route to AZ local hosts instead, unless they are as well N times slower.  

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Unit tests
- Will try on IL? Maybe Oregano. 

**Concerns (what feedback would you like?)**:
- Overhead per call is now higher; probably worth memoizing this
- Code change could have refactored and done a more proper "generic" pattern for creating weighting patterns
- This will increase costs ($$$) for cross-AZ traffic, even if there is no degradation. We've to query all hosts in order to determine our latencies. However, this cost _should_ be small, as it should be a small number of requests every 5 minutes (default window for ExponentiallyDecayingReservoir). 

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
