### PR TITLE
Use SafeLoggable.getLogMessage() when available during rewrap

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/common/base/Throwables.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/base/Throwables.java
@@ -19,6 +19,7 @@ import com.palantir.common.exception.AtlasDbDependencyException;
 import com.palantir.common.exception.PalantirRuntimeException;
 import com.palantir.exception.PalantirInterruptedException;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeLoggable;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.io.InterruptedIOException;
 import java.io.PrintWriter;
@@ -69,12 +70,19 @@ public final class Throwables {
         throwable.initCause(cause);
         return throwable;
     }
+    
+    private static String extractMessageSafely(Throwable ex) {
+        if (ex instanceof SafeLoggable) {
+            return ((SafeLoggable) ex).getLogMessage();
+        }
+        return ex.getMessage();
+    }
 
     /**
      * If Throwable is a RuntimeException or Error, rewrap and throw it. If not, throw a PalantirRuntimeException.
      */
     public static RuntimeException rewrapAndThrowUncheckedException(Throwable ex) {
-        throw rewrapAndThrowUncheckedException(ex.getMessage(), ex);
+        throw rewrapAndThrowUncheckedException(extractMessageSafely(ex), ex);
     }
 
     /**
@@ -97,8 +105,9 @@ public final class Throwables {
     public static Throwable unwrapIfPossible(Throwable ex) {
         if (ex instanceof ExecutionException || ex instanceof InvocationTargetException) {
             return ex.getCause();
+        } else {
+            return ex;
         }
-        return ex;
     }
 
     private static RuntimeException createAtlasDbDependencyException(Throwable ex) {
@@ -145,7 +154,7 @@ public final class Throwables {
      * clazz is a supertype of t.
      */
     public static <K extends Throwable> void rewrapAndThrowIfInstance(Throwable t, Class<K> clazz) throws K {
-        rewrapAndThrowIfInstance(t == null ? "null" : t.getMessage(), t, clazz);
+        rewrapAndThrowIfInstance(t == null ? "null" : extractMessageSafely(t), t, clazz);
     }
 
     /**
@@ -189,7 +198,7 @@ public final class Throwables {
      */
     public static <T extends Throwable> T rewrap(T throwable) {
         Preconditions.checkNotNull(throwable);
-        return rewrap(throwable.getMessage(), throwable);
+        return rewrap(extractMessageSafely(throwable), throwable);
     }
 
     /**

--- a/atlasdb-commons/src/main/java/com/palantir/common/base/Throwables.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/base/Throwables.java
@@ -166,7 +166,7 @@ public final class Throwables {
     @SuppressWarnings("unchecked")
     public static <K extends Throwable> void rewrapAndThrowIfInstance(String newMessage, Throwable t, Class<K> clazz)
             throws K {
-        if ((t != null) && clazz.isAssignableFrom(t.getClass())) {
+        if (clazz.isInstance(t)) {
             K kt = (K) t;
             K wrapped = Throwables.rewrap(newMessage, kt);
             throw wrapped;
@@ -181,14 +181,10 @@ public final class Throwables {
      */
     @SuppressWarnings("unchecked")
     public static <K extends Throwable> void throwIfInstance(Throwable t, Class<K> clazz) throws K {
-        if (isInstance(t, clazz)) {
+        if (clazz.isInstance(t)) {
             K kt = (K) t;
             throw kt;
         }
-    }
-
-    private static <K extends Throwable> boolean isInstance(Throwable t, Class<K> clazz) {
-        return (t != null) && clazz.isAssignableFrom(t.getClass());
     }
 
     /**

--- a/atlasdb-commons/src/main/java/com/palantir/common/base/Throwables.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/base/Throwables.java
@@ -70,7 +70,7 @@ public final class Throwables {
         throwable.initCause(cause);
         return throwable;
     }
-    
+
     private static String extractMessageSafely(Throwable ex) {
         if (ex instanceof SafeLoggable) {
             return ((SafeLoggable) ex).getLogMessage();

--- a/atlasdb-commons/src/test/java/com/palantir/common/base/ThrowablesTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/common/base/ThrowablesTest.java
@@ -19,9 +19,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
+import com.google.errorprone.annotations.CompileTimeConstant;
+import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.SafeLoggable;
+import com.palantir.logsafe.UnsafeArg;
+import com.palantir.logsafe.exceptions.SafeExceptions;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -90,6 +98,25 @@ public class ThrowablesTest {
                 .isEqualTo(uncheckedException);
     }
 
+    @Test
+    public void testDoesNotLeakUnsafeMessage() {
+        SafeRewrappableException original =
+                new SafeRewrappableException("alpha", null, UnsafeArg.of("property", "secret"));
+        assertThat(original.getMessage()).contains("secret");
+
+        SafeRewrappableException rewrapped1 = Throwables.rewrap(original);
+        assertThat(rewrapped1.getLogMessage()).doesNotContain("secret");
+
+        SafeRewrappableException rewrapped2 = null;
+        try {
+            Throwables.rewrapAndThrowIfInstance(rewrapped1, SafeRewrappableException.class);
+        } catch (SafeRewrappableException ex) {
+            rewrapped2 = ex;
+        }
+        assertThat(rewrapped2).isNotNull();
+        assertThat(rewrapped2.getLogMessage()).doesNotContain("secret");
+    }
+
     // only has a (string, throwable) constructor
     public void throwTwoArgConstructorException() throws TwoArgConstructorException {
         throw new TwoArgConstructorException("Told you so", new IOException("Contained"));
@@ -123,6 +150,33 @@ public class ThrowablesTest {
             } else {
                 noUsefulConstructorCalled = true;
             }
+        }
+    }
+
+    static class SafeRewrappableException extends RuntimeException implements SafeLoggable {
+        private final String logMessage;
+        private final List<Arg<?>> arguments;
+
+        public SafeRewrappableException(@CompileTimeConstant String message, Throwable cause) {
+            super(SafeExceptions.renderMessage(message), cause);
+            this.logMessage = message;
+            this.arguments = Collections.emptyList();
+        }
+
+        public SafeRewrappableException(@CompileTimeConstant String message, Throwable cause, Arg<?>... arguments) {
+            super(SafeExceptions.renderMessage(message, arguments), cause);
+            this.logMessage = message;
+            this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));
+        }
+
+        @Override
+        public String getLogMessage() {
+            return logMessage;
+        }
+
+        @Override
+        public List<Arg<?>> getArgs() {
+            return arguments;
         }
     }
 }

--- a/atlasdb-commons/src/test/java/com/palantir/common/base/ThrowablesTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/common/base/ThrowablesTest.java
@@ -107,14 +107,10 @@ public class ThrowablesTest {
         SafeRewrappableException rewrapped1 = Throwables.rewrap(original);
         assertThat(rewrapped1.getLogMessage()).doesNotContain("secret");
 
-        SafeRewrappableException rewrapped2 = null;
-        try {
-            Throwables.rewrapAndThrowIfInstance(rewrapped1, SafeRewrappableException.class);
-        } catch (SafeRewrappableException ex) {
-            rewrapped2 = ex;
-        }
-        assertThat(rewrapped2).isNotNull();
-        assertThat(rewrapped2.getLogMessage()).doesNotContain("secret");
+        assertThatThrownBy(() -> Throwables.rewrapAndThrowIfInstance(original, SafeRewrappableException.class))
+                .isExactlyInstanceOf(SafeRewrappableException.class)
+                .extracting(ex -> ((SafeRewrappableException) ex).getLogMessage())
+                .isEqualTo("alpha");
     }
 
     // only has a (string, throwable) constructor

--- a/changelog/@unreleased/pr-5585.v2.yml
+++ b/changelog/@unreleased/pr-5585.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: |-
+    `Throwables.rewrap()` and variants use the `SafeLoggable` message if available
+    to avoid leaking unsafe data.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5585


### PR DESCRIPTION
Don't risk leaking unsafe information from getMessage() into a
SafeLoggable constructor (which is likely declared @CompileTimeConstant).