### PR TITLE
Fix Runaway Retries When HikariConnectionPool is Closed

### DIFF
--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/HikariCPConnectionManager.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/HikariCPConnectionManager.java
@@ -256,6 +256,11 @@ public class HikariCPConnectionManager extends BaseConnectionManager {
         }
     }
 
+    @Override
+    public boolean isClosed() {
+        return state.type == StateType.CLOSED;
+    }
+
     /**
      * Initializes a connection to the provided database.
      */

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/nexus/db/pool/HikariCpConnectionManagerTest.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/nexus/db/pool/HikariCpConnectionManagerTest.java
@@ -69,6 +69,13 @@ public class HikariCpConnectionManagerTest {
     }
 
     @Test
+    public void testIsClosedWhenManagerClosed() throws SQLException {
+        assertThat(manager.isClosed()).isFalse();
+        manager.close();
+        assertThat(manager.isClosed()).isTrue();
+    }
+
+    @Test
     public void testCantGetConnectionIfPoolExhausted() throws SQLException {
         //noinspection unused - try-with-resources gets & closes connections
         try (Connection conn1 = manager.getConnection();

--- a/changelog/@unreleased/pr-5587.v2.yml
+++ b/changelog/@unreleased/pr-5587.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+improvement:
+  description: |-
+    Fixed an issue where closing an underlying Hikari ConnectionManager may cause a RetriableTransaction to spin rapidly producing a large volume of log spam.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5587

--- a/commons-db/src/main/java/com/palantir/nexus/db/pool/ConnectionManager.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/pool/ConnectionManager.java
@@ -41,6 +41,8 @@ public interface ConnectionManager {
 
     void closeUnchecked();
 
+    boolean isClosed();
+
     /**
      * Initializes the connection pool if necessary, and verifies that it does indeed work. Since
      * initialization is implicit in getConnection(), this is mostly useful to force an exception in

--- a/commons-db/src/main/java/com/palantir/nexus/db/pool/ResourceTypes.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/pool/ResourceTypes.java
@@ -51,6 +51,11 @@ public final class ResourceTypes {
                         }
 
                         @Override
+                        public boolean isClosed() {
+                            return delegate.isClosed();
+                        }
+
+                        @Override
                         public void init() throws SQLException {
                             delegate.init();
                         }

--- a/commons-db/src/main/java/com/palantir/nexus/db/pool/RetriableTransactions.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/pool/RetriableTransactions.java
@@ -172,7 +172,7 @@ public final class RetriableTransactions {
                                     e);
                         }
                         if (cm.isClosed()) {
-                            log.warn("Aborting tx retry, underlying connection is closed", e);
+                            log.error("Aborting transaction retry, underlying connection manager is closed", e);
                             return TransactionResult.failure(e);
                         }
                         if (shouldStillRetry(startTimeMs, attemptTimeMs)) {

--- a/commons-db/src/main/java/com/palantir/nexus/db/pool/RetriableTransactions.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/pool/RetriableTransactions.java
@@ -171,6 +171,10 @@ public final class RetriableTransactions {
                                     now,
                                     e);
                         }
+                        if (cm.isClosed()) {
+                            log.warn("Aborting tx retry, underlying connection is closed", e);
+                            return TransactionResult.failure(e);
+                        }
                         if (shouldStillRetry(startTimeMs, attemptTimeMs)) {
                             long attemptLengthMs = now - attemptTimeMs;
                             long totalLengthMs = now - startTimeMs;

--- a/commons-db/src/main/java/com/palantir/nexus/db/pool/RetriableTransactions.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/pool/RetriableTransactions.java
@@ -172,7 +172,7 @@ public final class RetriableTransactions {
                                     e);
                         }
                         if (cm.isClosed()) {
-                            log.error("Aborting transaction retry, underlying connection manager is closed", e);
+                            log.warn("Aborting transaction retry, underlying connection manager is closed", e);
                             return TransactionResult.failure(e);
                         }
                         if (shouldStillRetry(startTimeMs, attemptTimeMs)) {


### PR DESCRIPTION
**Goals (and why)**:
Some of our testing infrastructure for an internal project was experiencing a considerable amount of INFO logs due to `RetriableTransactions` quickly spinning when the underlying connection was closed. We are working to track down why the connection pool was closed, but the `AsyncPuncher` was not closed. However, since a closed connection pool throws a SQLException the `RetriableTransactions` believes that it needs to retry despite this scenario never recovering. This produced logs in excess of 5GB for a single test run.

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
