### PR TITLE
Expose SafeLogger to consumers

### DIFF
--- a/atlasdb-commons/build.gradle
+++ b/atlasdb-commons/build.gradle
@@ -11,6 +11,8 @@ dependencies {
     compile group: 'com.palantir.common', name: 'streams'
     compile group: 'com.palantir.safe-logging', name: 'preconditions'
 
+    api 'com.palantir.safe-logging:logger'
+
     implementation 'com.fasterxml.jackson.core:jackson-annotations'
     implementation 'com.google.errorprone:error_prone_annotations'
     implementation 'com.google.guava:guava'


### PR DESCRIPTION
Getting compilation failures in generated code after https://github.com/palantir/atlasdb/pull/5583 because `atlasdb-client` does not expose `SafeLogger` to the compile classpath of consumers and it is used in method signatures of `AssertUtils`, which is used in generated code.
```
MyStreamStore.java:123: cannot access SafeLogger
ERROR: cannot access SafeLogger
                    AssertUtils.assertAndLog(log, hashForStreams.get(streamId).equals(hash), "(BUG) Stream ID has 2 different hashes: " + streamId);
                               ^
  class file for com.palantir.logsafe.logger.SafeLogger not found
```