### PR TITLE
[Correctness Logging] Part 1: Explicit Timestamp Violation Metrics

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -1036,21 +1036,17 @@ public abstract class TransactionManagers {
                 timelockRequestBatcherProviders,
                 schemas);
         return withMetrics(
-                metricsManager, withCorroboratingTimestampService(
-                        config.namespace(),
-                        metricsManager,
-                        withRefreshingLockService(lockAndTimestampServices)));
+                metricsManager,
+                withCorroboratingTimestampService(
+                        config.namespace(), metricsManager, withRefreshingLockService(lockAndTimestampServices)));
     }
 
     private static LockAndTimestampServices withCorroboratingTimestampService(
             Optional<String> userNamespace,
             MetricsManager metricsManager,
             LockAndTimestampServices lockAndTimestampServices) {
-        TimelockService timelockService =
-                TimestampCorroboratingTimelockService.create(
-                        userNamespace,
-                        metricsManager.getTaggedRegistry(),
-                        lockAndTimestampServices.timelock());
+        TimelockService timelockService = TimestampCorroboratingTimelockService.create(
+                userNamespace, metricsManager.getTaggedRegistry(), lockAndTimestampServices.timelock());
         TimestampService corroboratingTimestampService = new TimelockTimestampServiceAdapter(timelockService);
 
         return ImmutableLockAndTimestampServices.builder()

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -1036,13 +1036,21 @@ public abstract class TransactionManagers {
                 timelockRequestBatcherProviders,
                 schemas);
         return withMetrics(
-                metricsManager, withCorroboratingTimestampService(withRefreshingLockService(lockAndTimestampServices)));
+                metricsManager, withCorroboratingTimestampService(
+                        config.namespace(),
+                        metricsManager,
+                        withRefreshingLockService(lockAndTimestampServices)));
     }
 
     private static LockAndTimestampServices withCorroboratingTimestampService(
+            Optional<String> userNamespace,
+            MetricsManager metricsManager,
             LockAndTimestampServices lockAndTimestampServices) {
         TimelockService timelockService =
-                TimestampCorroboratingTimelockService.create(lockAndTimestampServices.timelock());
+                TimestampCorroboratingTimelockService.create(
+                        userNamespace,
+                        metricsManager.getTaggedRegistry(),
+                        lockAndTimestampServices.timelock());
         TimestampService corroboratingTimestampService = new TimelockTimestampServiceAdapter(timelockService);
 
         return ImmutableLockAndTimestampServices.builder()

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/TimestampCorroboratingTimelockService.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/TimestampCorroboratingTimelockService.java
@@ -49,20 +49,17 @@ public final class TimestampCorroboratingTimelockService implements AutoDelegate
     private final AtomicLong lowerBoundFromTransactions = new AtomicLong(Long.MIN_VALUE);
 
     @VisibleForTesting
-    TimestampCorroboratingTimelockService(
-            Runnable timestampViolationCallback,
-            TimelockService delegate) {
+    TimestampCorroboratingTimelockService(Runnable timestampViolationCallback, TimelockService delegate) {
         this.timestampViolationCallback = timestampViolationCallback;
         this.delegate = delegate;
     }
 
     public static TimelockService create(
-            Optional<String> userNamespace,
-            TaggedMetricRegistry taggedMetricRegistry,
-            TimelockService delegate) {
+            Optional<String> userNamespace, TaggedMetricRegistry taggedMetricRegistry, TimelockService delegate) {
         return new TimestampCorroboratingTimelockService(
-                () -> TimestampViolationsMetrics.of(taggedMetricRegistry).timestampsGoingBackwards(
-                        userNamespace.orElse("[unknown or un-namespaced]")).inc(),
+                () -> TimestampViolationsMetrics.of(taggedMetricRegistry)
+                        .timestampsGoingBackwards(userNamespace.orElse("[unknown or un-namespaced]"))
+                        .inc(),
                 delegate);
     }
 

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/TimestampCorroboratingTimelockService.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/TimestampCorroboratingTimelockService.java
@@ -16,6 +16,8 @@
 
 package com.palantir.atlasdb.factory.timelock;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.palantir.atlasdb.correctness.TimestampViolationsMetrics;
 import com.palantir.lock.v2.AutoDelegate_TimelockService;
 import com.palantir.lock.v2.StartIdentifiedAtlasDbTransactionResponse;
 import com.palantir.lock.v2.TimelockService;
@@ -24,8 +26,10 @@ import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import com.palantir.timestamp.TimestampRange;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import java.util.function.ToLongFunction;
@@ -39,16 +43,27 @@ public final class TimestampCorroboratingTimelockService implements AutoDelegate
     private static final SafeLogger log = SafeLoggerFactory.get(TimestampCorroboratingTimelockService.class);
     private static final String CLOCKS_WENT_BACKWARDS_MESSAGE = "It appears that clocks went backwards!";
 
+    private final Runnable timestampViolationCallback;
     private final TimelockService delegate;
     private final AtomicLong lowerBoundFromTimestamps = new AtomicLong(Long.MIN_VALUE);
     private final AtomicLong lowerBoundFromTransactions = new AtomicLong(Long.MIN_VALUE);
 
-    private TimestampCorroboratingTimelockService(TimelockService delegate) {
+    @VisibleForTesting
+    TimestampCorroboratingTimelockService(
+            Runnable timestampViolationCallback,
+            TimelockService delegate) {
+        this.timestampViolationCallback = timestampViolationCallback;
         this.delegate = delegate;
     }
 
-    public static TimelockService create(TimelockService delegate) {
-        return new TimestampCorroboratingTimelockService(delegate);
+    public static TimelockService create(
+            Optional<String> userNamespace,
+            TaggedMetricRegistry taggedMetricRegistry,
+            TimelockService delegate) {
+        return new TimestampCorroboratingTimelockService(
+                () -> TimestampViolationsMetrics.of(taggedMetricRegistry).timestampsGoingBackwards(
+                        userNamespace.orElse("[unknown or un-namespaced]")).inc(),
+                delegate);
     }
 
     @Override
@@ -104,8 +119,9 @@ public final class TimestampCorroboratingTimelockService implements AutoDelegate
         return ImmutableTimestampBounds.of(threadLocalLowerBoundFromTimestamps, threadLocalLowerBoundFromTransactions);
     }
 
-    private static void checkTimestamp(TimestampBounds bounds, OperationType type, long freshTimestamp) {
+    private void checkTimestamp(TimestampBounds bounds, OperationType type, long freshTimestamp) {
         if (freshTimestamp <= Math.max(bounds.boundFromTimestamps(), bounds.boundFromTransactions())) {
+            timestampViolationCallback.run();
             throw clocksWentBackwards(bounds, type, freshTimestamp);
         }
     }

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/timelock/TimestampCorroboratingTimelockServiceTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/timelock/TimestampCorroboratingTimelockServiceTest.java
@@ -155,20 +155,20 @@ public class TimestampCorroboratingTimelockServiceTest {
         when(rawTimelockService.getFreshTimestamp()).thenReturn(1L);
         TaggedMetricRegistry taggedMetricRegistry = new DefaultTaggedMetricRegistry();
         timelockService = TimestampCorroboratingTimelockService.create(
-                Optional.of(NAMESPACE_1),
-                taggedMetricRegistry,
-                rawTimelockService);
+                Optional.of(NAMESPACE_1), taggedMetricRegistry, rawTimelockService);
 
         timelockService.getFreshTimestamp();
         assertThrowsClocksWentBackwardsException(timelockService::getFreshTimestamp);
         assertThrowsClocksWentBackwardsException(timelockService::getFreshTimestamp);
 
         assertThat(TimestampViolationsMetrics.of(taggedMetricRegistry)
-                .timestampsGoingBackwards(NAMESPACE_1)
-                .getCount()).isEqualTo(2);
+                        .timestampsGoingBackwards(NAMESPACE_1)
+                        .getCount())
+                .isEqualTo(2);
         assertThat(TimestampViolationsMetrics.of(taggedMetricRegistry)
-                .timestampsGoingBackwards(NAMESPACE_2)
-                .getCount()).isEqualTo(0);
+                        .timestampsGoingBackwards(NAMESPACE_2)
+                        .getCount())
+                .isEqualTo(0);
     }
 
     @Test
@@ -176,9 +176,7 @@ public class TimestampCorroboratingTimelockServiceTest {
         when(rawTimelockService.getFreshTimestamp()).thenReturn(1L);
         TaggedMetricRegistry taggedMetricRegistry = new DefaultTaggedMetricRegistry();
         timelockService = TimestampCorroboratingTimelockService.create(
-                Optional.of(NAMESPACE_1),
-                taggedMetricRegistry,
-                rawTimelockService);
+                Optional.of(NAMESPACE_1), taggedMetricRegistry, rawTimelockService);
 
         timelockService.getFreshTimestamp();
         assertThat(taggedMetricRegistry.getMetrics()).isEmpty();

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/timelock/TimestampCorroboratingTimelockServiceTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/timelock/TimestampCorroboratingTimelockServiceTest.java
@@ -21,9 +21,13 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
+import com.palantir.atlasdb.correctness.TimestampViolationsMetrics;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
 import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.StartIdentifiedAtlasDbTransactionResponse;
@@ -31,7 +35,10 @@ import com.palantir.lock.v2.TimelockService;
 import com.palantir.lock.v2.TimestampAndPartition;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.timestamp.TimestampRange;
+import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -45,13 +52,18 @@ public class TimestampCorroboratingTimelockServiceTest {
     private static final LockImmutableTimestampResponse LOCK_IMMUTABLE_TIMESTAMP_RESPONSE =
             LockImmutableTimestampResponse.of(1L, LockToken.of(UUID.randomUUID()));
 
+    private static final String NAMESPACE_1 = "tom";
+    private static final String NAMESPACE_2 = "nottom";
+
+    private Runnable callback;
     private TimelockService rawTimelockService;
     private TimelockService timelockService;
 
     @Before
     public void setUp() {
+        callback = mock(Runnable.class);
         rawTimelockService = mock(TimelockService.class);
-        timelockService = TimestampCorroboratingTimelockService.create(rawTimelockService);
+        timelockService = new TimestampCorroboratingTimelockService(callback, rawTimelockService);
     }
 
     @Test
@@ -59,6 +71,7 @@ public class TimestampCorroboratingTimelockServiceTest {
         when(rawTimelockService.getFreshTimestamp()).thenReturn(1L);
 
         assertThrowsOnSecondCall(timelockService::getFreshTimestamp);
+        verify(callback).run();
     }
 
     @Test
@@ -67,6 +80,7 @@ public class TimestampCorroboratingTimelockServiceTest {
         when(rawTimelockService.getFreshTimestamps(anyInt())).thenReturn(timestampRange);
 
         assertThrowsOnSecondCall(() -> timelockService.getFreshTimestamps(1));
+        verify(callback).run();
     }
 
     @Test
@@ -77,6 +91,7 @@ public class TimestampCorroboratingTimelockServiceTest {
                 .thenReturn(ImmutableList.of(startIdentifiedAtlasDbTransactionResponse));
 
         assertThrowsOnSecondCall(() -> timelockService.startIdentifiedAtlasDbTransactionBatch(1));
+        verify(callback).run();
     }
 
     @Test
@@ -90,6 +105,7 @@ public class TimestampCorroboratingTimelockServiceTest {
 
         timelockService.startIdentifiedAtlasDbTransactionBatch(1);
         assertThrowsClocksWentBackwardsException(() -> timelockService.getFreshTimestamps(2));
+        verify(callback).run();
     }
 
     @Test
@@ -100,6 +116,7 @@ public class TimestampCorroboratingTimelockServiceTest {
         when(rawTimelockService.startIdentifiedAtlasDbTransactionBatch(3)).thenReturn(responses);
 
         assertThrowsOnSecondCall(() -> timelockService.startIdentifiedAtlasDbTransactionBatch(3));
+        verify(callback).run();
     }
 
     @Test
@@ -120,6 +137,51 @@ public class TimestampCorroboratingTimelockServiceTest {
         // we want to now resume the blocked call, which will return timestamp of 1 and not throw
         blockingTimestampReturning1.countdown();
         assertThatCode(blockingGetFreshTimestampCall::get).doesNotThrowAnyException();
+        verify(callback, never()).run();
+    }
+
+    @Test
+    public void callbackInvokedMultipleTimesWithMultipleViolations() {
+        when(rawTimelockService.getFreshTimestamp()).thenReturn(1L);
+
+        timelockService.getFreshTimestamp();
+        assertThrowsClocksWentBackwardsException(timelockService::getFreshTimestamp);
+        assertThrowsClocksWentBackwardsException(timelockService::getFreshTimestamp);
+        verify(callback, times(2)).run();
+    }
+
+    @Test
+    public void metricsSuitablyIncremented() {
+        when(rawTimelockService.getFreshTimestamp()).thenReturn(1L);
+        TaggedMetricRegistry taggedMetricRegistry = new DefaultTaggedMetricRegistry();
+        timelockService = TimestampCorroboratingTimelockService.create(
+                Optional.of(NAMESPACE_1),
+                taggedMetricRegistry,
+                rawTimelockService);
+
+        timelockService.getFreshTimestamp();
+        assertThrowsClocksWentBackwardsException(timelockService::getFreshTimestamp);
+        assertThrowsClocksWentBackwardsException(timelockService::getFreshTimestamp);
+
+        assertThat(TimestampViolationsMetrics.of(taggedMetricRegistry)
+                .timestampsGoingBackwards(NAMESPACE_1)
+                .getCount()).isEqualTo(2);
+        assertThat(TimestampViolationsMetrics.of(taggedMetricRegistry)
+                .timestampsGoingBackwards(NAMESPACE_2)
+                .getCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void metricsNotRegisteredIfNoViolationsDetected() {
+        when(rawTimelockService.getFreshTimestamp()).thenReturn(1L);
+        TaggedMetricRegistry taggedMetricRegistry = new DefaultTaggedMetricRegistry();
+        timelockService = TimestampCorroboratingTimelockService.create(
+                Optional.of(NAMESPACE_1),
+                taggedMetricRegistry,
+                rawTimelockService);
+
+        timelockService.getFreshTimestamp();
+        assertThat(taggedMetricRegistry.getMetrics()).isEmpty();
     }
 
     private StartIdentifiedAtlasDbTransactionResponse makeResponse(long timestamp) {

--- a/atlasdb-impl-shared/build.gradle
+++ b/atlasdb-impl-shared/build.gradle
@@ -6,6 +6,7 @@ libsDirName = file('build/artifacts')
 
 license {
   exclude '**/TargetedSweepProgressMetrics.java'
+  exclude '**/TimestampViolationsMetrics.java'
 }
 
 dependencies {

--- a/atlasdb-impl-shared/src/main/metrics/correctness-violations.yml
+++ b/atlasdb-impl-shared/src/main/metrics/correctness-violations.yml
@@ -1,0 +1,14 @@
+options:
+  javaPackage: 'com.palantir.atlasdb.correctness'
+
+namespaces:
+  timestampViolations:
+    docs: Correctness violations pertaining to irregularities with timestamps.
+    metrics:
+      timestampsGoingBackwards:
+        type: counter
+        tags:
+          - namespace
+        docs: >-
+          Number of observations of timestamps going backwards (i.e. a request got a lower timestamp than another
+          request that finished before this request started).

--- a/changelog/@unreleased/pr-5599.v2.yml
+++ b/changelog/@unreleased/pr-5599.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: AtlasDB now exposes metrics when (but only when) it has determined
+    that clocks have gone backwards.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5599


### PR DESCRIPTION
**Goals (and why)**:
- Re-express timestamp violation metrics in a form where automation can pick up
- Ensure that this is cost-effective.

**Implementation Description (bullets)**:
- Add a callback when a timestamp violation is detected that increments a counter metric
- Invoke the callback when said violation is detected

**Testing (What was existing testing like?  What have you done to improve it?)**: 
- Added specific tests around callback behaviour

**Concerns (what feedback would you like?)**:
- If a violation is detected and we then quickly reset the AtlasDB-using service, we might not see it. I don't know if this is avoidable though.
- I don't really like the passing in of an Optional namespace, but this handles the general case with timelock or namespacing more easily. (This information will be very useful for services that use multiple transaction managers, such as AtlasDB Proxy.)

**Where should we start reviewing?**: TimestampCorroboratingTimelockService

**Priority (whenever / two weeks / yesterday)**: this week please
