### PR TITLE
[Correctness Logger] Part 1b: Namespace Logs Correctly

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/TimestampCorroboratingTimelockService.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/TimestampCorroboratingTimelockService.java
@@ -17,7 +17,7 @@
 package com.palantir.atlasdb.factory.timelock;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.palantir.atlasdb.correctness.TimestampViolationsMetrics;
+import com.palantir.atlasdb.correctness.TimestampCorrectnessMetrics;
 import com.palantir.lock.v2.AutoDelegate_TimelockService;
 import com.palantir.lock.v2.StartIdentifiedAtlasDbTransactionResponse;
 import com.palantir.lock.v2.TimelockService;
@@ -57,7 +57,7 @@ public final class TimestampCorroboratingTimelockService implements AutoDelegate
     public static TimelockService create(
             Optional<String> userNamespace, TaggedMetricRegistry taggedMetricRegistry, TimelockService delegate) {
         return new TimestampCorroboratingTimelockService(
-                () -> TimestampViolationsMetrics.of(taggedMetricRegistry)
+                () -> TimestampCorrectnessMetrics.of(taggedMetricRegistry)
                         .timestampsGoingBackwards(userNamespace.orElse("[unknown or un-namespaced]"))
                         .inc(),
                 delegate);

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/timelock/TimestampCorroboratingTimelockServiceTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/timelock/TimestampCorroboratingTimelockServiceTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
-import com.palantir.atlasdb.correctness.TimestampViolationsMetrics;
+import com.palantir.atlasdb.correctness.TimestampCorrectnessMetrics;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
 import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.StartIdentifiedAtlasDbTransactionResponse;
@@ -161,11 +161,11 @@ public class TimestampCorroboratingTimelockServiceTest {
         assertThrowsClocksWentBackwardsException(timelockService::getFreshTimestamp);
         assertThrowsClocksWentBackwardsException(timelockService::getFreshTimestamp);
 
-        assertThat(TimestampViolationsMetrics.of(taggedMetricRegistry)
+        assertThat(TimestampCorrectnessMetrics.of(taggedMetricRegistry)
                         .timestampsGoingBackwards(NAMESPACE_1)
                         .getCount())
                 .isEqualTo(2);
-        assertThat(TimestampViolationsMetrics.of(taggedMetricRegistry)
+        assertThat(TimestampCorrectnessMetrics.of(taggedMetricRegistry)
                         .timestampsGoingBackwards(NAMESPACE_2)
                         .getCount())
                 .isEqualTo(0);

--- a/atlasdb-impl-shared/build.gradle
+++ b/atlasdb-impl-shared/build.gradle
@@ -6,7 +6,7 @@ libsDirName = file('build/artifacts')
 
 license {
   exclude '**/TargetedSweepProgressMetrics.java'
-  exclude '**/TimestampViolationsMetrics.java'
+  exclude '**/TimestampCorrectnessMetrics.java'
 }
 
 dependencies {

--- a/atlasdb-impl-shared/src/main/metrics/correctness-violations.yml
+++ b/atlasdb-impl-shared/src/main/metrics/correctness-violations.yml
@@ -2,8 +2,9 @@ options:
   javaPackage: 'com.palantir.atlasdb.correctness'
 
 namespaces:
-  com.palantir.atlasdb.correctness:
-    docs: Correctness violations pertaining to irregularities with timestamps.
+  com.palantir.atlasdb.correctness.timestamp:
+    shortName: TimestampCorrectness
+    docs: Metrics pertaining to irregularities with timestamps.
     metrics:
       timestampsGoingBackwards:
         type: counter

--- a/atlasdb-impl-shared/src/main/metrics/correctness-violations.yml
+++ b/atlasdb-impl-shared/src/main/metrics/correctness-violations.yml
@@ -2,7 +2,7 @@ options:
   javaPackage: 'com.palantir.atlasdb.correctness'
 
 namespaces:
-  timestampViolations:
+  com.palantir.atlasdb.correctness:
     docs: Correctness violations pertaining to irregularities with timestamps.
     metrics:
       timestampsGoingBackwards:

--- a/changelog/@unreleased/pr-5604.v2.yml
+++ b/changelog/@unreleased/pr-5604.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Correctness metrics are now generated under the `com.palantir.atlasdb.correctness`
+    namespace. Previously, they were generated under a generic `timestampViolations`
+    top-level namespace.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5604


### PR DESCRIPTION
**Goals (and why)**:
- Don't pollute the global namespace of 'timestampViolations'

**Implementation Description (bullets)**:
- Change generated metric to use the 'com.palantir.atlasdb.correctness' namespace

**Testing (What was existing testing like?  What have you done to improve it?)**:
none

**Concerns (what feedback would you like?)**:
not much

**Where should we start reviewing?**:
+1-1

**Priority (whenever / two weeks / yesterday)**: ASAP please 🔥 
