### PR TITLE
Fix codegen of reusable persisters for dynamic column values

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/ColumnValueDescription.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/ColumnValueDescription.java
@@ -349,8 +349,9 @@ public final class ColumnValueDescription {
                 + ", com.palantir.atlasdb.table.description.ColumnValueDescription.Compression." + compression + ")";
     }
 
-    public String getInstantiateReusablePersisterCode() {
-        return "private final " + canonicalClassName + " REUSABLE_PERSISTER = " + "new " + canonicalClassName + "();";
+    public String getInstantiateReusablePersisterCode(boolean isStatic) {
+        return "private " + (isStatic ? "static " : "") + "final " + canonicalClassName + " REUSABLE_PERSISTER = new "
+                + canonicalClassName + "();";
     }
 
     @SuppressWarnings("unchecked")

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/DynamicColumnValueRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/DynamicColumnValueRenderer.java
@@ -204,7 +204,7 @@ public class DynamicColumnValueRenderer extends Renderer {
         line("}");
 
         if (val.isReusablePersister()) {
-            line(val.getInstantiateReusablePersisterCode());
+            line(val.getInstantiateReusablePersisterCode(true));
         }
     }
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/NamedColumnValueRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/NamedColumnValueRenderer.java
@@ -203,7 +203,7 @@ public class NamedColumnValueRenderer extends Renderer {
             line("}");
 
             if (col.getValue().isReusablePersister()) {
-                line(col.getValue().getInstantiateReusablePersisterCode());
+                line(col.getValue().getInstantiateReusablePersisterCode(false));
             }
         }
         line("};");

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/render/TableRendererTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/render/TableRendererTest.java
@@ -93,4 +93,26 @@ public class TableRendererTest {
             }
         };
     }
+
+    @Test
+    public void testReusablePersistersInDynamicColumns() {
+        TableRenderer renderer = new TableRenderer("package", Namespace.DEFAULT_NAMESPACE, OptionalType.JAVA8);
+        String renderedTableDefinition =
+                renderer.render("table", getTableWithUserSpecifiedPersisterInDynamicColumns(TABLE_REF), NO_INDICES);
+        assertThat(renderedTableDefinition)
+                .contains("private static final com.palantir.atlasdb.persister.JsonNodePersister REUSABLE_PERSISTER =");
+    }
+
+    private TableDefinition getTableWithUserSpecifiedPersisterInDynamicColumns(TableReference tableRef) {
+        return new TableDefinition() {
+            {
+                javaTableName(tableRef.getTablename());
+                rowName();
+                rowComponent("rowName", ValueType.STRING);
+                dynamicColumns();
+                columnComponent("colName", ValueType.STRING);
+                value(JsonNodePersister.class);
+            }
+        };
+    }
 }

--- a/changelog/@unreleased/pr-5605.v2.yml
+++ b/changelog/@unreleased/pr-5605.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix compilation errors in generated code of reusable persisters for
+    dynamic column values
+  links:
+  - https://github.com/palantir/atlasdb/pull/5605


### PR DESCRIPTION
**Goals (and why)**: Fix compilation errors in generated code related to a missing static identifier, when the user tries to create a schema with dynamic columns, and the value type is specified as a reusable persister.

**Implementation Description (bullets)**:

- There are two code generation context which need code generating a reusable persister, NamedColumnValueRenderer and DynamicColumnValueRenderer.
- Generating the declaration of the persister variable has been extracted into a getInstantiateReusablePersisterCode method in the ColumnValueDescription class.
- Unfortunately, this declaration goes either into a definition of an anonymous class implementing Hydrator (named columns case), or directly into a definition of the value class (dynamic columns case).
- The first case doesn't require static because the anonymous class definition is written into a static itself, but the second case requires static because the variable is used from a static method. Also, the first case doesn't allow static, because Java 11 does not allow statics in anonymous classes.

**Testing (What was existing testing like?  What have you done to improve it?)**: There exist both snapshot tests and tests which check whether the generated code contains certain substrings, but they do not cover the combination of dynamic columns (1 of 2) and reusable persisters (1 of 5). I added the second kind of test, to match an existing test for named columns with reusable persisters.

**Concerns (what feedback would you like?)**: It would be nice to share more code between the named and the dynamic case, as well as use snapshot tests more, though this would probably involve slightly bigger changes.

**Where should we start reviewing?**: Wherever.

**Priority (whenever / two weeks / yesterday)**: Whenever.