### PR TITLE
Fix wrong write lock status reported by the getLockState

### DIFF
--- a/changelog/@unreleased/pr-5618.v2.yml
+++ b/changelog/@unreleased/pr-5618.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix wrong write lock status reported by the getLockState
+  links:
+  - https://github.com/palantir/atlasdb/pull/5618

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockServerSync.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockServerSync.java
@@ -21,6 +21,7 @@ import com.palantir.logsafe.Preconditions;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.locks.AbstractQueuedSynchronizer;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
@@ -266,5 +267,13 @@ class LockServerSync extends AbstractQueuedSynchronizer {
         }
         return Collections.unmodifiableList(
                 readLockHolders.keysView().collect(clients::fromIndex, new ArrayList<>(readLockHolders.size())));
+    }
+
+    synchronized Optional<LockClient> getWriteClient() {
+        if (getState() > 0) {
+            return Optional.of(clients.fromIndex(writeLockHolder));
+        } else {
+            return Optional.empty();
+        }
     }
 }

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockServerSync.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockServerSync.java
@@ -270,10 +270,9 @@ class LockServerSync extends AbstractQueuedSynchronizer {
     }
 
     synchronized Optional<LockClient> getWriteClient() {
-        if (getState() > 0) {
-            return Optional.of(clients.fromIndex(writeLockHolder));
-        } else {
+        if (getState() <= 0) {
             return Optional.empty();
         }
+        return Optional.of(clients.fromIndex(writeLockHolder));
     }
 }

--- a/lock-impl/src/test/java/com/palantir/lock/LockServiceTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/LockServiceTest.java
@@ -579,6 +579,22 @@ public abstract class LockServiceTest {
         assertThat(Iterables.getOnlyElement(state2.requesters()).versionId()).hasValue(100L);
     }
 
+    @Test
+    public void testGetLockStateOfReadWriteReentrancy() throws Exception {
+        LockResponse response1 = server.lockWithFullLockResponse(
+                client,
+                LockRequest.builder(ImmutableSortedMap.of(lock1, LockMode.WRITE))
+                        .build());
+        assertThat(response1.success()).isTrue();
+        assertThat(server.getLockState(lock1).isWriteLocked()).isTrue();
+
+        LockResponse response2 = server.lockWithFullLockResponse(
+                client,
+                LockRequest.builder(ImmutableSortedMap.of(lock1, LockMode.READ)).build());
+        assertThat(response2.success()).isTrue();
+        assertThat(server.getLockState(lock1).isWriteLocked()).isTrue();
+    }
+
     /**
      * Tests lock responses
      */

--- a/lock-impl/src/test/java/com/palantir/lock/LockServiceTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/LockServiceTest.java
@@ -595,6 +595,18 @@ public abstract class LockServiceTest {
         assertThat(server.getLockState(lock1).isWriteLocked()).isTrue();
     }
 
+    @Test
+    public void testGetLockStateQuicklyAfterReadRelease() throws Exception {
+        LockResponse response1 = server.lockWithFullLockResponse(
+                client,
+                LockRequest.builder(ImmutableSortedMap.of(lock1, LockMode.READ)).build());
+        assertThat(response1.success()).isTrue();
+        assertThat(server.getLockState(lock1).isWriteLocked()).isFalse();
+
+        assertThat(server.unlock(response1.getLockRefreshToken())).isTrue();
+        assertThat(server.getLockState(lock1).isWriteLocked()).isFalse();
+    }
+
     /**
      * Tests lock responses
      */


### PR DESCRIPTION
**Goals (and why)**: Fix wrong write lock status reported by the getLockState debugging endpoint.

**Implementation Description (bullets)**:

- The old implementation assumed a lock is write-locked when it exists in cache, but has no read holders.
- This can be incorrect when a lock is both read-locked and write-locked due to reentrancy, which [can happen](https://github.com/palantir/atlasdb/blob/4ec93785191c82dbc3aca27f0145e137cf485a51/lock-impl/src/test/java/com/palantir/lock/LockServiceTest.java#L1250-L1253).
- This can also be incorrect when a lock was recently unlocked, but wasn't evicted from [a weakValues cache](https://github.com/palantir/atlasdb/blob/4ec93785191c82dbc3aca27f0145e137cf485a51/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java#L198-L205) yet.
- New implementation get the owner of the write lock directly from the underlying lock implementation.

**Testing (What was existing testing like?  What have you done to improve it?)**: This endpoint is not tested very thoroughly, as it is a debugging endpoint. I added two tests for the specific issues (they fail without the first commit), but I haven't improved the testing situation more than that.

**Concerns (what feedback would you like?)**: Tests could be made more thorough.

**Where should we start reviewing?**: Wherever.

**Priority (whenever / two weeks / yesterday)**: Whenever.
