### PR TITLE
[PDS-202945] Only load 1 column from the stream store when checking index validity

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/CompactMetadataTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/CompactMetadataTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class CompactMetadataTable implements
         AtlasDbMutablePersistentTable<CompactMetadataTable.CompactMetadataRow,
                                          CompactMetadataTable.CompactMetadataNamedColumnValue<?>,
@@ -681,5 +681,5 @@ public final class CompactMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "MrDfIwfaNhuV8d5jErTNLg==";
+    static String __CLASS_HASH = "2gGbOYcqE0bNlw1kWmNLIQ==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/CompactTableFactory.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/CompactTableFactory.java
@@ -18,20 +18,18 @@ public final class CompactTableFactory {
 
     private final Namespace namespace;
 
-    private CompactTableFactory(List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
-            Namespace namespace) {
+    private CompactTableFactory(
+            List<Function<? super Transaction, SharedTriggers>> sharedTriggers, Namespace namespace) {
         this.sharedTriggers = sharedTriggers;
         this.namespace = namespace;
     }
 
     public static CompactTableFactory of(
-            List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
-            Namespace namespace) {
+            List<Function<? super Transaction, SharedTriggers>> sharedTriggers, Namespace namespace) {
         return new CompactTableFactory(sharedTriggers, namespace);
     }
 
-    public static CompactTableFactory of(
-            List<Function<? super Transaction, SharedTriggers>> sharedTriggers) {
+    public static CompactTableFactory of(List<Function<? super Transaction, SharedTriggers>> sharedTriggers) {
         return new CompactTableFactory(sharedTriggers, defaultNamespace);
     }
 
@@ -43,18 +41,20 @@ public final class CompactTableFactory {
         return of(ImmutableList.<Function<? super Transaction, SharedTriggers>>of(), defaultNamespace);
     }
 
-    public CompactMetadataTable getCompactMetadataTable(Transaction t,
-            CompactMetadataTable.CompactMetadataTrigger... triggers) {
+    public CompactMetadataTable getCompactMetadataTable(
+            Transaction t, CompactMetadataTable.CompactMetadataTrigger... triggers) {
         return CompactMetadataTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public interface SharedTriggers extends CompactMetadataTable.CompactMetadataTrigger {
-    }
+    public interface SharedTriggers extends CompactMetadataTable.CompactMetadataTrigger {}
 
     public abstract static class NullSharedTriggers implements SharedTriggers {
         @Override
         public void putCompactMetadata(
-                Multimap<CompactMetadataTable.CompactMetadataRow, ? extends CompactMetadataTable.CompactMetadataNamedColumnValue<?>> newRows) {
+                Multimap<
+                                CompactMetadataTable.CompactMetadataRow,
+                                ? extends CompactMetadataTable.CompactMetadataNamedColumnValue<?>>
+                        newRows) {
             // do nothing
         }
     }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepIdToNameTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepIdToNameTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class SweepIdToNameTable implements
         AtlasDbDynamicMutablePersistentTable<SweepIdToNameTable.SweepIdToNameRow,
                                                 SweepIdToNameTable.SweepIdToNameColumn,
@@ -754,5 +754,5 @@ public final class SweepIdToNameTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "MTwT+c4XR7VTGs8Dm4MVIQ==";
+    static String __CLASS_HASH = "EOZ88gJXh1tXBjNBFJIO0g==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepNameToIdTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepNameToIdTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class SweepNameToIdTable implements
         AtlasDbMutablePersistentTable<SweepNameToIdTable.SweepNameToIdRow,
                                          SweepNameToIdTable.SweepNameToIdNamedColumnValue<?>,
@@ -695,5 +695,5 @@ public final class SweepNameToIdTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "UC+q/bbGbkBcB7dFYP+hTA==";
+    static String __CLASS_HASH = "26eSHzi0SrHfYPlHdTiJHQ==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepPriorityTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepPriorityTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class SweepPriorityTable implements
         AtlasDbMutablePersistentTable<SweepPriorityTable.SweepPriorityRow,
                                          SweepPriorityTable.SweepPriorityNamedColumnValue<?>,
@@ -1251,5 +1251,5 @@ public final class SweepPriorityTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "f+xi0T0RVYABX3sUEu/eEw==";
+    static String __CLASS_HASH = "x4e//sU8HojuLoJg24wmLA==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepShardProgressTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepShardProgressTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class SweepShardProgressTable implements
         AtlasDbMutablePersistentTable<SweepShardProgressTable.SweepShardProgressRow,
                                          SweepShardProgressTable.SweepShardProgressNamedColumnValue<?>,
@@ -707,5 +707,5 @@ public final class SweepShardProgressTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "9fIU3tQN60+8LXqLrgYyJg==";
+    static String __CLASS_HASH = "MwcLMbM2Az+ejzNl7pcfKg==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepTableFactory.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepTableFactory.java
@@ -18,20 +18,17 @@ public final class SweepTableFactory {
 
     private final Namespace namespace;
 
-    private SweepTableFactory(List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
-            Namespace namespace) {
+    private SweepTableFactory(List<Function<? super Transaction, SharedTriggers>> sharedTriggers, Namespace namespace) {
         this.sharedTriggers = sharedTriggers;
         this.namespace = namespace;
     }
 
     public static SweepTableFactory of(
-            List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
-            Namespace namespace) {
+            List<Function<? super Transaction, SharedTriggers>> sharedTriggers, Namespace namespace) {
         return new SweepTableFactory(sharedTriggers, namespace);
     }
 
-    public static SweepTableFactory of(
-            List<Function<? super Transaction, SharedTriggers>> sharedTriggers) {
+    public static SweepTableFactory of(List<Function<? super Transaction, SharedTriggers>> sharedTriggers) {
         return new SweepTableFactory(sharedTriggers, defaultNamespace);
     }
 
@@ -43,18 +40,20 @@ public final class SweepTableFactory {
         return of(ImmutableList.<Function<? super Transaction, SharedTriggers>>of(), defaultNamespace);
     }
 
-    public SweepPriorityTable getSweepPriorityTable(Transaction t,
-            SweepPriorityTable.SweepPriorityTrigger... triggers) {
+    public SweepPriorityTable getSweepPriorityTable(
+            Transaction t, SweepPriorityTable.SweepPriorityTrigger... triggers) {
         return SweepPriorityTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public interface SharedTriggers extends SweepPriorityTable.SweepPriorityTrigger {
-    }
+    public interface SharedTriggers extends SweepPriorityTable.SweepPriorityTrigger {}
 
     public abstract static class NullSharedTriggers implements SharedTriggers {
         @Override
         public void putSweepPriority(
-                Multimap<SweepPriorityTable.SweepPriorityRow, ? extends SweepPriorityTable.SweepPriorityNamedColumnValue<?>> newRows) {
+                Multimap<
+                                SweepPriorityTable.SweepPriorityRow,
+                                ? extends SweepPriorityTable.SweepPriorityNamedColumnValue<?>>
+                        newRows) {
             // do nothing
         }
     }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepableCellsTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepableCellsTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class SweepableCellsTable implements
         AtlasDbDynamicMutablePersistentTable<SweepableCellsTable.SweepableCellsRow,
                                                 SweepableCellsTable.SweepableCellsColumn,
@@ -789,5 +789,5 @@ public final class SweepableCellsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "+1gMAUSA+NS4EWXpS65rng==";
+    static String __CLASS_HASH = "Txtgb8DFuOwj83JGx3rzXQ==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepableTimestampsTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepableTimestampsTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class SweepableTimestampsTable implements
         AtlasDbDynamicMutablePersistentTable<SweepableTimestampsTable.SweepableTimestampsRow,
                                                 SweepableTimestampsTable.SweepableTimestampsColumn,
@@ -786,5 +786,5 @@ public final class SweepableTimestampsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "n5Zd+38q1vmJksKkpM+Vrw==";
+    static String __CLASS_HASH = "ZldNHckg6Jn99/m/D/IS/w==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/TableClearsTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/TableClearsTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class TableClearsTable implements
         AtlasDbMutablePersistentTable<TableClearsTable.TableClearsRow,
                                          TableClearsTable.TableClearsNamedColumnValue<?>,
@@ -681,5 +681,5 @@ public final class TableClearsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "lAs81CkqCmiiCpWFVIgJNg==";
+    static String __CLASS_HASH = "ZTQrUhB7dvmc+eZsO+E7CA==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/TargetedSweepTableFactory.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/TargetedSweepTableFactory.java
@@ -19,20 +19,17 @@ public final class TargetedSweepTableFactory {
     private final Namespace namespace;
 
     private TargetedSweepTableFactory(
-            List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
-            Namespace namespace) {
+            List<Function<? super Transaction, SharedTriggers>> sharedTriggers, Namespace namespace) {
         this.sharedTriggers = sharedTriggers;
         this.namespace = namespace;
     }
 
     public static TargetedSweepTableFactory of(
-            List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
-            Namespace namespace) {
+            List<Function<? super Transaction, SharedTriggers>> sharedTriggers, Namespace namespace) {
         return new TargetedSweepTableFactory(sharedTriggers, namespace);
     }
 
-    public static TargetedSweepTableFactory of(
-            List<Function<? super Transaction, SharedTriggers>> sharedTriggers) {
+    public static TargetedSweepTableFactory of(List<Function<? super Transaction, SharedTriggers>> sharedTriggers) {
         return new TargetedSweepTableFactory(sharedTriggers, defaultNamespace);
     }
 
@@ -44,73 +41,89 @@ public final class TargetedSweepTableFactory {
         return of(ImmutableList.<Function<? super Transaction, SharedTriggers>>of(), defaultNamespace);
     }
 
-    public SweepIdToNameTable getSweepIdToNameTable(Transaction t,
-            SweepIdToNameTable.SweepIdToNameTrigger... triggers) {
+    public SweepIdToNameTable getSweepIdToNameTable(
+            Transaction t, SweepIdToNameTable.SweepIdToNameTrigger... triggers) {
         return SweepIdToNameTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public SweepNameToIdTable getSweepNameToIdTable(Transaction t,
-            SweepNameToIdTable.SweepNameToIdTrigger... triggers) {
+    public SweepNameToIdTable getSweepNameToIdTable(
+            Transaction t, SweepNameToIdTable.SweepNameToIdTrigger... triggers) {
         return SweepNameToIdTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public SweepShardProgressTable getSweepShardProgressTable(Transaction t,
-            SweepShardProgressTable.SweepShardProgressTrigger... triggers) {
+    public SweepShardProgressTable getSweepShardProgressTable(
+            Transaction t, SweepShardProgressTable.SweepShardProgressTrigger... triggers) {
         return SweepShardProgressTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public SweepableCellsTable getSweepableCellsTable(Transaction t,
-            SweepableCellsTable.SweepableCellsTrigger... triggers) {
+    public SweepableCellsTable getSweepableCellsTable(
+            Transaction t, SweepableCellsTable.SweepableCellsTrigger... triggers) {
         return SweepableCellsTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public SweepableTimestampsTable getSweepableTimestampsTable(Transaction t,
-            SweepableTimestampsTable.SweepableTimestampsTrigger... triggers) {
+    public SweepableTimestampsTable getSweepableTimestampsTable(
+            Transaction t, SweepableTimestampsTable.SweepableTimestampsTrigger... triggers) {
         return SweepableTimestampsTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public TableClearsTable getTableClearsTable(Transaction t,
-            TableClearsTable.TableClearsTrigger... triggers) {
+    public TableClearsTable getTableClearsTable(Transaction t, TableClearsTable.TableClearsTrigger... triggers) {
         return TableClearsTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public interface SharedTriggers extends SweepIdToNameTable.SweepIdToNameTrigger, SweepNameToIdTable.SweepNameToIdTrigger, SweepShardProgressTable.SweepShardProgressTrigger, SweepableCellsTable.SweepableCellsTrigger, SweepableTimestampsTable.SweepableTimestampsTrigger, TableClearsTable.TableClearsTrigger {
-    }
+    public interface SharedTriggers
+            extends SweepIdToNameTable.SweepIdToNameTrigger,
+                    SweepNameToIdTable.SweepNameToIdTrigger,
+                    SweepShardProgressTable.SweepShardProgressTrigger,
+                    SweepableCellsTable.SweepableCellsTrigger,
+                    SweepableTimestampsTable.SweepableTimestampsTrigger,
+                    TableClearsTable.TableClearsTrigger {}
 
     public abstract static class NullSharedTriggers implements SharedTriggers {
         @Override
         public void putSweepIdToName(
-                Multimap<SweepIdToNameTable.SweepIdToNameRow, ? extends SweepIdToNameTable.SweepIdToNameColumnValue> newRows) {
+                Multimap<SweepIdToNameTable.SweepIdToNameRow, ? extends SweepIdToNameTable.SweepIdToNameColumnValue>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putSweepNameToId(
-                Multimap<SweepNameToIdTable.SweepNameToIdRow, ? extends SweepNameToIdTable.SweepNameToIdNamedColumnValue<?>> newRows) {
+                Multimap<
+                                SweepNameToIdTable.SweepNameToIdRow,
+                                ? extends SweepNameToIdTable.SweepNameToIdNamedColumnValue<?>>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putSweepShardProgress(
-                Multimap<SweepShardProgressTable.SweepShardProgressRow, ? extends SweepShardProgressTable.SweepShardProgressNamedColumnValue<?>> newRows) {
+                Multimap<
+                                SweepShardProgressTable.SweepShardProgressRow,
+                                ? extends SweepShardProgressTable.SweepShardProgressNamedColumnValue<?>>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putSweepableCells(
-                Multimap<SweepableCellsTable.SweepableCellsRow, ? extends SweepableCellsTable.SweepableCellsColumnValue> newRows) {
+                Multimap<SweepableCellsTable.SweepableCellsRow, ? extends SweepableCellsTable.SweepableCellsColumnValue>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putSweepableTimestamps(
-                Multimap<SweepableTimestampsTable.SweepableTimestampsRow, ? extends SweepableTimestampsTable.SweepableTimestampsColumnValue> newRows) {
+                Multimap<
+                                SweepableTimestampsTable.SweepableTimestampsRow,
+                                ? extends SweepableTimestampsTable.SweepableTimestampsColumnValue>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putTableClears(
-                Multimap<TableClearsTable.TableClearsRow, ? extends TableClearsTable.TableClearsNamedColumnValue<?>> newRows) {
+                Multimap<TableClearsTable.TableClearsRow, ? extends TableClearsTable.TableClearsNamedColumnValue<?>>
+                        newRows) {
             // do nothing
         }
     }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/GenericRangeScanTestTable.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/GenericRangeScanTestTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class GenericRangeScanTestTable implements
         AtlasDbDynamicMutablePersistentTable<GenericRangeScanTestTable.GenericRangeScanTestRow,
                                                 GenericRangeScanTestTable.GenericRangeScanTestColumn,
@@ -805,5 +805,5 @@ public final class GenericRangeScanTestTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "TfefBeyZ4FkbPXKBGS9baA==";
+    static String __CLASS_HASH = "MUMDhUC8qX2VcMbAP/ldog==";
 }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/GenericTestSchemaTableFactory.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/GenericTestSchemaTableFactory.java
@@ -19,20 +19,17 @@ public final class GenericTestSchemaTableFactory {
     private final Namespace namespace;
 
     private GenericTestSchemaTableFactory(
-            List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
-            Namespace namespace) {
+            List<Function<? super Transaction, SharedTriggers>> sharedTriggers, Namespace namespace) {
         this.sharedTriggers = sharedTriggers;
         this.namespace = namespace;
     }
 
     public static GenericTestSchemaTableFactory of(
-            List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
-            Namespace namespace) {
+            List<Function<? super Transaction, SharedTriggers>> sharedTriggers, Namespace namespace) {
         return new GenericTestSchemaTableFactory(sharedTriggers, namespace);
     }
 
-    public static GenericTestSchemaTableFactory of(
-            List<Function<? super Transaction, SharedTriggers>> sharedTriggers) {
+    public static GenericTestSchemaTableFactory of(List<Function<? super Transaction, SharedTriggers>> sharedTriggers) {
         return new GenericTestSchemaTableFactory(sharedTriggers, defaultNamespace);
     }
 
@@ -44,29 +41,35 @@ public final class GenericTestSchemaTableFactory {
         return of(ImmutableList.<Function<? super Transaction, SharedTriggers>>of(), defaultNamespace);
     }
 
-    public GenericRangeScanTestTable getGenericRangeScanTestTable(Transaction t,
-            GenericRangeScanTestTable.GenericRangeScanTestTrigger... triggers) {
+    public GenericRangeScanTestTable getGenericRangeScanTestTable(
+            Transaction t, GenericRangeScanTestTable.GenericRangeScanTestTrigger... triggers) {
         return GenericRangeScanTestTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public RangeScanTestTable getRangeScanTestTable(Transaction t,
-            RangeScanTestTable.RangeScanTestTrigger... triggers) {
+    public RangeScanTestTable getRangeScanTestTable(
+            Transaction t, RangeScanTestTable.RangeScanTestTrigger... triggers) {
         return RangeScanTestTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public interface SharedTriggers extends GenericRangeScanTestTable.GenericRangeScanTestTrigger, RangeScanTestTable.RangeScanTestTrigger {
-    }
+    public interface SharedTriggers
+            extends GenericRangeScanTestTable.GenericRangeScanTestTrigger, RangeScanTestTable.RangeScanTestTrigger {}
 
     public abstract static class NullSharedTriggers implements SharedTriggers {
         @Override
         public void putGenericRangeScanTest(
-                Multimap<GenericRangeScanTestTable.GenericRangeScanTestRow, ? extends GenericRangeScanTestTable.GenericRangeScanTestColumnValue> newRows) {
+                Multimap<
+                                GenericRangeScanTestTable.GenericRangeScanTestRow,
+                                ? extends GenericRangeScanTestTable.GenericRangeScanTestColumnValue>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putRangeScanTest(
-                Multimap<RangeScanTestTable.RangeScanTestRow, ? extends RangeScanTestTable.RangeScanTestNamedColumnValue<?>> newRows) {
+                Multimap<
+                                RangeScanTestTable.RangeScanTestRow,
+                                ? extends RangeScanTestTable.RangeScanTestNamedColumnValue<?>>
+                        newRows) {
             // do nothing
         }
     }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/RangeScanTestTable.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/RangeScanTestTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class RangeScanTestTable implements
         AtlasDbMutablePersistentTable<RangeScanTestTable.RangeScanTestRow,
                                          RangeScanTestTable.RangeScanTestNamedColumnValue<?>,
@@ -743,5 +743,5 @@ public final class RangeScanTestTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "Ex6PJ6X8PBlxh+yYFmpG6w==";
+    static String __CLASS_HASH = "Kk820OBu61QOpf2Klq3yTQ==";
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/LatestSnapshotTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/LatestSnapshotTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class LatestSnapshotTable implements
         AtlasDbMutablePersistentTable<LatestSnapshotTable.LatestSnapshotRow,
                                          LatestSnapshotTable.LatestSnapshotNamedColumnValue<?>,
@@ -681,5 +681,5 @@ public final class LatestSnapshotTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "IRj0RA+8Q0W/0gWZp8Mr+w==";
+    static String __CLASS_HASH = "uDjDzxHTwUPFE6axOmFPNw==";
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/NamespacedTodoTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/NamespacedTodoTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class NamespacedTodoTable implements
         AtlasDbDynamicMutablePersistentTable<NamespacedTodoTable.NamespacedTodoRow,
                                                 NamespacedTodoTable.NamespacedTodoColumn,
@@ -739,5 +739,5 @@ public final class NamespacedTodoTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "bcvziYgz3RaL6vF0kT9vhQ==";
+    static String __CLASS_HASH = "3DJdGHmS1KFWFWaP05WZiQ==";
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsMetadataCleanupTask.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsMetadataCleanupTask.java
@@ -1,5 +1,14 @@
 package com.palantir.atlasdb.todo.generated;
 
+import java.util.Iterator;
+import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
@@ -13,19 +22,10 @@ import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.common.streams.KeyedStream;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.logger.SafeLogger;
-import com.palantir.logsafe.logger.SafeLoggerFactory;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class SnapshotsMetadataCleanupTask implements OnCleanupTask {
 
-    private static final SafeLogger log = SafeLoggerFactory.get(SnapshotsMetadataCleanupTask.class);
+    private static final Logger log = LoggerFactory.getLogger(SnapshotsMetadataCleanupTask.class);
 
     private final TodoSchemaTableFactory tables;
 
@@ -42,7 +42,7 @@ public class SnapshotsMetadataCleanupTask implements OnCleanupTask {
         }
         SnapshotsStreamIdxTable indexTable = tables.getSnapshotsStreamIdxTable(t);
         Set<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> rowsWithNoIndexEntries =
-                        executeUnreferencedStreamDiagnostics(indexTable, rows);
+                        getUnreferencedStreamsByIterator(indexTable, rows);
         Set<Long> toDelete = new HashSet<>();
         Map<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow, StreamMetadata> currentMetadata =
                 metaTable.getMetadatas(rows);
@@ -55,58 +55,19 @@ public class SnapshotsMetadataCleanupTask implements OnCleanupTask {
         return false;
     }
 
-    private static SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow convertFromIndexRow(SnapshotsStreamIdxTable.SnapshotsStreamIdxRow idxRow) {
-        return SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow.of(idxRow.getId());
-    }
-    private static Set<Long> convertToIdsForLogging(Set<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> iteratorExcess) {
-        return iteratorExcess.stream()
+    private static Set<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> getUnreferencedStreamsByIterator(SnapshotsStreamIdxTable indexTable, Set<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> metadataRows) {
+        Set<SnapshotsStreamIdxTable.SnapshotsStreamIdxRow> indexRows = metadataRows.stream()
                 .map(SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow::getId)
+                .map(SnapshotsStreamIdxTable.SnapshotsStreamIdxRow::of)
                 .collect(Collectors.toSet());
-    }
-
-    private static Set<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> getUnreferencedStreamsByMultimap(SnapshotsStreamIdxTable indexTable, Set<SnapshotsStreamIdxTable.SnapshotsStreamIdxRow> indexRows) {
-        Multimap<SnapshotsStreamIdxTable.SnapshotsStreamIdxRow, SnapshotsStreamIdxTable.SnapshotsStreamIdxColumnValue> indexValues = indexTable.getRowsMultimap(indexRows);
-        Set<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> presentMetadataRows
-                = indexValues.keySet().stream()
-                .map(SnapshotsMetadataCleanupTask::convertFromIndexRow)
-                .collect(Collectors.toSet());
-        Set<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> queriedMetadataRows
-                = indexRows.stream()
-                .map(SnapshotsMetadataCleanupTask::convertFromIndexRow)
-                .collect(Collectors.toSet());
-        return Sets.difference(queriedMetadataRows, presentMetadataRows);
-    }
-
-    private static Set<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> getUnreferencedStreamsByIterator(SnapshotsStreamIdxTable indexTable, Set<SnapshotsStreamIdxTable.SnapshotsStreamIdxRow> indexRows) {
         Map<SnapshotsStreamIdxTable.SnapshotsStreamIdxRow, Iterator<SnapshotsStreamIdxTable.SnapshotsStreamIdxColumnValue>> referenceIteratorByStream
                 = indexTable.getRowsColumnRangeIterator(indexRows,
                         BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 1));
-        Set<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> unreferencedStreamMetadata
-                = KeyedStream.stream(referenceIteratorByStream)
+        return KeyedStream.stream(referenceIteratorByStream)
                 .filter(valueIterator -> !valueIterator.hasNext())
                 .keys() // (authorized)
                 .map(SnapshotsStreamIdxTable.SnapshotsStreamIdxRow::getId)
                 .map(SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow::of)
                 .collect(Collectors.toSet());
-        return unreferencedStreamMetadata;
-    }
-
-    private static Set<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> executeUnreferencedStreamDiagnostics(SnapshotsStreamIdxTable indexTable, Set<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> metadataRows) {
-        Set<SnapshotsStreamIdxTable.SnapshotsStreamIdxRow> indexRows = metadataRows.stream()
-                .map(SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow::getId)
-                .map(SnapshotsStreamIdxTable.SnapshotsStreamIdxRow::of)
-                .collect(Collectors.toSet());
-        Set<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> unreferencedStreamsByIterator = getUnreferencedStreamsByIterator(indexTable, indexRows);
-        Set<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> unreferencedStreamsByMultimap = getUnreferencedStreamsByMultimap(indexTable, indexRows);
-        if (!unreferencedStreamsByIterator.equals(unreferencedStreamsByMultimap)) {
-            log.info("We searched for unreferenced streams with methodological inconsistency: iterators claimed we could delete {}, but multimaps {}.",
-                    SafeArg.of("unreferencedByIterator", convertToIdsForLogging(unreferencedStreamsByIterator)),
-                    SafeArg.of("unreferencedByMultimap", convertToIdsForLogging(unreferencedStreamsByMultimap)));
-            return new HashSet<>();
-        } else {
-            log.info("We searched for unreferenced streams and consistently found {}.",
-                    SafeArg.of("unreferencedStreamIds", convertToIdsForLogging(unreferencedStreamsByIterator)));
-            return unreferencedStreamsByIterator;
-        }
     }
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamHashAidxTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamHashAidxTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class SnapshotsStreamHashAidxTable implements
         AtlasDbDynamicMutablePersistentTable<SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxRow,
                                                 SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxColumn,
@@ -739,5 +739,5 @@ public final class SnapshotsStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "kQk49iNV9kqn1ipdE8ve2g==";
+    static String __CLASS_HASH = "rdNWsjVEIQHBTTSMqCSU9Q==";
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamIdxTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamIdxTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class SnapshotsStreamIdxTable implements
         AtlasDbDynamicMutablePersistentTable<SnapshotsStreamIdxTable.SnapshotsStreamIdxRow,
                                                 SnapshotsStreamIdxTable.SnapshotsStreamIdxColumn,
@@ -739,5 +739,5 @@ public final class SnapshotsStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "KssGXQgCx3ZyEycfz10fYQ==";
+    static String __CLASS_HASH = "NnVQADBOCWqv0ES1aEyg7Q==";
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamMetadataTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamMetadataTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class SnapshotsStreamMetadataTable implements
         AtlasDbMutablePersistentTable<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow,
                                          SnapshotsStreamMetadataTable.SnapshotsStreamMetadataNamedColumnValue<?>,
@@ -705,5 +705,5 @@ public final class SnapshotsStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "WvvhzZ+89VnQJNKMOe7mWA==";
+    static String __CLASS_HASH = "vXdAdtvwyfLfrzs7QCMkdQ==";
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamStore.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamStore.java
@@ -1,6 +1,5 @@
 package com.palantir.atlasdb.todo.generated;
 
-import com.palantir.atlasdb.stream.StreamStorePersistenceConfigurations;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -73,7 +72,7 @@ import com.palantir.util.file.DeleteOnCloseFileInputStream;
 import com.palantir.util.file.TempFileUtils;
 
 @Generated("com.palantir.atlasdb.table.description.render.StreamStoreRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class SnapshotsStreamStore extends AbstractPersistentStreamStore {
     public static final int BLOCK_SIZE_IN_BYTES = 1000000; // 1MB. DO NOT CHANGE THIS WITHOUT AN UPGRADE TASK
     public static final int IN_MEMORY_THRESHOLD = 4194304; // streams under this size are kept in memory when loaded
@@ -85,7 +84,7 @@ public final class SnapshotsStreamStore extends AbstractPersistentStreamStore {
     private final TodoSchemaTableFactory tables;
 
     private SnapshotsStreamStore(TransactionManager txManager, TodoSchemaTableFactory tables) {
-        this(txManager, tables, () -> StreamStorePersistenceConfigurations.DEFAULT_CONFIG);
+        this(txManager, tables, () -> StreamStorePersistenceConfiguration.DEFAULT_CONFIG);
     }
 
     private SnapshotsStreamStore(TransactionManager txManager, TodoSchemaTableFactory tables, Supplier<StreamStorePersistenceConfiguration> persistenceConfiguration) {

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamValueTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamValueTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class SnapshotsStreamValueTable implements
         AtlasDbMutablePersistentTable<SnapshotsStreamValueTable.SnapshotsStreamValueRow,
                                          SnapshotsStreamValueTable.SnapshotsStreamValueNamedColumnValue<?>,
@@ -693,5 +693,5 @@ public final class SnapshotsStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "UE+znj3LPapEGBsg8ViX+w==";
+    static String __CLASS_HASH = "c24vecz4NreILMqw0GBZcg==";
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/TodoSchemaTableFactory.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/TodoSchemaTableFactory.java
@@ -19,20 +19,17 @@ public final class TodoSchemaTableFactory {
     private final Namespace namespace;
 
     private TodoSchemaTableFactory(
-            List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
-            Namespace namespace) {
+            List<Function<? super Transaction, SharedTriggers>> sharedTriggers, Namespace namespace) {
         this.sharedTriggers = sharedTriggers;
         this.namespace = namespace;
     }
 
     public static TodoSchemaTableFactory of(
-            List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
-            Namespace namespace) {
+            List<Function<? super Transaction, SharedTriggers>> sharedTriggers, Namespace namespace) {
         return new TodoSchemaTableFactory(sharedTriggers, namespace);
     }
 
-    public static TodoSchemaTableFactory of(
-            List<Function<? super Transaction, SharedTriggers>> sharedTriggers) {
+    public static TodoSchemaTableFactory of(List<Function<? super Transaction, SharedTriggers>> sharedTriggers) {
         return new TodoSchemaTableFactory(sharedTriggers, defaultNamespace);
     }
 
@@ -44,33 +41,33 @@ public final class TodoSchemaTableFactory {
         return of(ImmutableList.<Function<? super Transaction, SharedTriggers>>of(), defaultNamespace);
     }
 
-    public LatestSnapshotTable getLatestSnapshotTable(Transaction t,
-            LatestSnapshotTable.LatestSnapshotTrigger... triggers) {
+    public LatestSnapshotTable getLatestSnapshotTable(
+            Transaction t, LatestSnapshotTable.LatestSnapshotTrigger... triggers) {
         return LatestSnapshotTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public NamespacedTodoTable getNamespacedTodoTable(Transaction t,
-            NamespacedTodoTable.NamespacedTodoTrigger... triggers) {
+    public NamespacedTodoTable getNamespacedTodoTable(
+            Transaction t, NamespacedTodoTable.NamespacedTodoTrigger... triggers) {
         return NamespacedTodoTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public SnapshotsStreamHashAidxTable getSnapshotsStreamHashAidxTable(Transaction t,
-            SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxTrigger... triggers) {
+    public SnapshotsStreamHashAidxTable getSnapshotsStreamHashAidxTable(
+            Transaction t, SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxTrigger... triggers) {
         return SnapshotsStreamHashAidxTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public SnapshotsStreamIdxTable getSnapshotsStreamIdxTable(Transaction t,
-            SnapshotsStreamIdxTable.SnapshotsStreamIdxTrigger... triggers) {
+    public SnapshotsStreamIdxTable getSnapshotsStreamIdxTable(
+            Transaction t, SnapshotsStreamIdxTable.SnapshotsStreamIdxTrigger... triggers) {
         return SnapshotsStreamIdxTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public SnapshotsStreamMetadataTable getSnapshotsStreamMetadataTable(Transaction t,
-            SnapshotsStreamMetadataTable.SnapshotsStreamMetadataTrigger... triggers) {
+    public SnapshotsStreamMetadataTable getSnapshotsStreamMetadataTable(
+            Transaction t, SnapshotsStreamMetadataTable.SnapshotsStreamMetadataTrigger... triggers) {
         return SnapshotsStreamMetadataTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public SnapshotsStreamValueTable getSnapshotsStreamValueTable(Transaction t,
-            SnapshotsStreamValueTable.SnapshotsStreamValueTrigger... triggers) {
+    public SnapshotsStreamValueTable getSnapshotsStreamValueTable(
+            Transaction t, SnapshotsStreamValueTable.SnapshotsStreamValueTrigger... triggers) {
         return SnapshotsStreamValueTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
@@ -78,49 +75,70 @@ public final class TodoSchemaTableFactory {
         return TodoTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public interface SharedTriggers extends LatestSnapshotTable.LatestSnapshotTrigger, NamespacedTodoTable.NamespacedTodoTrigger, SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxTrigger, SnapshotsStreamIdxTable.SnapshotsStreamIdxTrigger, SnapshotsStreamMetadataTable.SnapshotsStreamMetadataTrigger, SnapshotsStreamValueTable.SnapshotsStreamValueTrigger, TodoTable.TodoTrigger {
-    }
+    public interface SharedTriggers
+            extends LatestSnapshotTable.LatestSnapshotTrigger,
+                    NamespacedTodoTable.NamespacedTodoTrigger,
+                    SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxTrigger,
+                    SnapshotsStreamIdxTable.SnapshotsStreamIdxTrigger,
+                    SnapshotsStreamMetadataTable.SnapshotsStreamMetadataTrigger,
+                    SnapshotsStreamValueTable.SnapshotsStreamValueTrigger,
+                    TodoTable.TodoTrigger {}
 
     public abstract static class NullSharedTriggers implements SharedTriggers {
         @Override
         public void putLatestSnapshot(
-                Multimap<LatestSnapshotTable.LatestSnapshotRow, ? extends LatestSnapshotTable.LatestSnapshotNamedColumnValue<?>> newRows) {
+                Multimap<
+                                LatestSnapshotTable.LatestSnapshotRow,
+                                ? extends LatestSnapshotTable.LatestSnapshotNamedColumnValue<?>>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putNamespacedTodo(
-                Multimap<NamespacedTodoTable.NamespacedTodoRow, ? extends NamespacedTodoTable.NamespacedTodoColumnValue> newRows) {
+                Multimap<NamespacedTodoTable.NamespacedTodoRow, ? extends NamespacedTodoTable.NamespacedTodoColumnValue>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putSnapshotsStreamHashAidx(
-                Multimap<SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxRow, ? extends SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxColumnValue> newRows) {
+                Multimap<
+                                SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxRow,
+                                ? extends SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxColumnValue>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putSnapshotsStreamIdx(
-                Multimap<SnapshotsStreamIdxTable.SnapshotsStreamIdxRow, ? extends SnapshotsStreamIdxTable.SnapshotsStreamIdxColumnValue> newRows) {
+                Multimap<
+                                SnapshotsStreamIdxTable.SnapshotsStreamIdxRow,
+                                ? extends SnapshotsStreamIdxTable.SnapshotsStreamIdxColumnValue>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putSnapshotsStreamMetadata(
-                Multimap<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow, ? extends SnapshotsStreamMetadataTable.SnapshotsStreamMetadataNamedColumnValue<?>> newRows) {
+                Multimap<
+                                SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow,
+                                ? extends SnapshotsStreamMetadataTable.SnapshotsStreamMetadataNamedColumnValue<?>>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putSnapshotsStreamValue(
-                Multimap<SnapshotsStreamValueTable.SnapshotsStreamValueRow, ? extends SnapshotsStreamValueTable.SnapshotsStreamValueNamedColumnValue<?>> newRows) {
+                Multimap<
+                                SnapshotsStreamValueTable.SnapshotsStreamValueRow,
+                                ? extends SnapshotsStreamValueTable.SnapshotsStreamValueNamedColumnValue<?>>
+                        newRows) {
             // do nothing
         }
 
         @Override
-        public void putTodo(
-                Multimap<TodoTable.TodoRow, ? extends TodoTable.TodoNamedColumnValue<?>> newRows) {
+        public void putTodo(Multimap<TodoTable.TodoRow, ? extends TodoTable.TodoNamedColumnValue<?>> newRows) {
             // do nothing
         }
     }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/TodoTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/TodoTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class TodoTable implements
         AtlasDbMutablePersistentTable<TodoTable.TodoRow,
                                          TodoTable.TodoNamedColumnValue<?>,
@@ -681,5 +681,5 @@ public final class TodoTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "qAwD1itxr+YLnCFccrqyYQ==";
+    static String __CLASS_HASH = "2TUlQO74MDuPAp1x+H3UCw==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/AuditedDataTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/AuditedDataTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class AuditedDataTable implements
         AtlasDbMutablePersistentTable<AuditedDataTable.AuditedDataRow,
                                          AuditedDataTable.AuditedDataNamedColumnValue<?>,
@@ -681,5 +681,5 @@ public final class AuditedDataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "tsp9JwSFs0a0IXVAyipFyw==";
+    static String __CLASS_HASH = "3dnqqHdi4s83XI/7WEOh5g==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/BlobSchemaTableFactory.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/BlobSchemaTableFactory.java
@@ -19,20 +19,17 @@ public final class BlobSchemaTableFactory {
     private final Namespace namespace;
 
     private BlobSchemaTableFactory(
-            List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
-            Namespace namespace) {
+            List<Function<? super Transaction, SharedTriggers>> sharedTriggers, Namespace namespace) {
         this.sharedTriggers = sharedTriggers;
         this.namespace = namespace;
     }
 
     public static BlobSchemaTableFactory of(
-            List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
-            Namespace namespace) {
+            List<Function<? super Transaction, SharedTriggers>> sharedTriggers, Namespace namespace) {
         return new BlobSchemaTableFactory(sharedTriggers, namespace);
     }
 
-    public static BlobSchemaTableFactory of(
-            List<Function<? super Transaction, SharedTriggers>> sharedTriggers) {
+    public static BlobSchemaTableFactory of(List<Function<? super Transaction, SharedTriggers>> sharedTriggers) {
         return new BlobSchemaTableFactory(sharedTriggers, defaultNamespace);
     }
 
@@ -44,106 +41,137 @@ public final class BlobSchemaTableFactory {
         return of(ImmutableList.<Function<? super Transaction, SharedTriggers>>of(), defaultNamespace);
     }
 
-    public AuditedDataTable getAuditedDataTable(Transaction t,
-            AuditedDataTable.AuditedDataTrigger... triggers) {
+    public AuditedDataTable getAuditedDataTable(Transaction t, AuditedDataTable.AuditedDataTrigger... triggers) {
         return AuditedDataTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public DataStreamHashAidxTable getDataStreamHashAidxTable(Transaction t,
-            DataStreamHashAidxTable.DataStreamHashAidxTrigger... triggers) {
+    public DataStreamHashAidxTable getDataStreamHashAidxTable(
+            Transaction t, DataStreamHashAidxTable.DataStreamHashAidxTrigger... triggers) {
         return DataStreamHashAidxTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public DataStreamIdxTable getDataStreamIdxTable(Transaction t,
-            DataStreamIdxTable.DataStreamIdxTrigger... triggers) {
+    public DataStreamIdxTable getDataStreamIdxTable(
+            Transaction t, DataStreamIdxTable.DataStreamIdxTrigger... triggers) {
         return DataStreamIdxTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public DataStreamMetadataTable getDataStreamMetadataTable(Transaction t,
-            DataStreamMetadataTable.DataStreamMetadataTrigger... triggers) {
+    public DataStreamMetadataTable getDataStreamMetadataTable(
+            Transaction t, DataStreamMetadataTable.DataStreamMetadataTrigger... triggers) {
         return DataStreamMetadataTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public DataStreamValueTable getDataStreamValueTable(Transaction t,
-            DataStreamValueTable.DataStreamValueTrigger... triggers) {
+    public DataStreamValueTable getDataStreamValueTable(
+            Transaction t, DataStreamValueTable.DataStreamValueTrigger... triggers) {
         return DataStreamValueTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public HotspottyDataStreamHashAidxTable getHotspottyDataStreamHashAidxTable(Transaction t,
-            HotspottyDataStreamHashAidxTable.HotspottyDataStreamHashAidxTrigger... triggers) {
+    public HotspottyDataStreamHashAidxTable getHotspottyDataStreamHashAidxTable(
+            Transaction t, HotspottyDataStreamHashAidxTable.HotspottyDataStreamHashAidxTrigger... triggers) {
         return HotspottyDataStreamHashAidxTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public HotspottyDataStreamIdxTable getHotspottyDataStreamIdxTable(Transaction t,
-            HotspottyDataStreamIdxTable.HotspottyDataStreamIdxTrigger... triggers) {
+    public HotspottyDataStreamIdxTable getHotspottyDataStreamIdxTable(
+            Transaction t, HotspottyDataStreamIdxTable.HotspottyDataStreamIdxTrigger... triggers) {
         return HotspottyDataStreamIdxTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public HotspottyDataStreamMetadataTable getHotspottyDataStreamMetadataTable(Transaction t,
-            HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataTrigger... triggers) {
+    public HotspottyDataStreamMetadataTable getHotspottyDataStreamMetadataTable(
+            Transaction t, HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataTrigger... triggers) {
         return HotspottyDataStreamMetadataTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public HotspottyDataStreamValueTable getHotspottyDataStreamValueTable(Transaction t,
-            HotspottyDataStreamValueTable.HotspottyDataStreamValueTrigger... triggers) {
+    public HotspottyDataStreamValueTable getHotspottyDataStreamValueTable(
+            Transaction t, HotspottyDataStreamValueTable.HotspottyDataStreamValueTrigger... triggers) {
         return HotspottyDataStreamValueTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public interface SharedTriggers extends AuditedDataTable.AuditedDataTrigger, DataStreamHashAidxTable.DataStreamHashAidxTrigger, DataStreamIdxTable.DataStreamIdxTrigger, DataStreamMetadataTable.DataStreamMetadataTrigger, DataStreamValueTable.DataStreamValueTrigger, HotspottyDataStreamHashAidxTable.HotspottyDataStreamHashAidxTrigger, HotspottyDataStreamIdxTable.HotspottyDataStreamIdxTrigger, HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataTrigger, HotspottyDataStreamValueTable.HotspottyDataStreamValueTrigger {
-    }
+    public interface SharedTriggers
+            extends AuditedDataTable.AuditedDataTrigger,
+                    DataStreamHashAidxTable.DataStreamHashAidxTrigger,
+                    DataStreamIdxTable.DataStreamIdxTrigger,
+                    DataStreamMetadataTable.DataStreamMetadataTrigger,
+                    DataStreamValueTable.DataStreamValueTrigger,
+                    HotspottyDataStreamHashAidxTable.HotspottyDataStreamHashAidxTrigger,
+                    HotspottyDataStreamIdxTable.HotspottyDataStreamIdxTrigger,
+                    HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataTrigger,
+                    HotspottyDataStreamValueTable.HotspottyDataStreamValueTrigger {}
 
     public abstract static class NullSharedTriggers implements SharedTriggers {
         @Override
         public void putAuditedData(
-                Multimap<AuditedDataTable.AuditedDataRow, ? extends AuditedDataTable.AuditedDataNamedColumnValue<?>> newRows) {
+                Multimap<AuditedDataTable.AuditedDataRow, ? extends AuditedDataTable.AuditedDataNamedColumnValue<?>>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putDataStreamHashAidx(
-                Multimap<DataStreamHashAidxTable.DataStreamHashAidxRow, ? extends DataStreamHashAidxTable.DataStreamHashAidxColumnValue> newRows) {
+                Multimap<
+                                DataStreamHashAidxTable.DataStreamHashAidxRow,
+                                ? extends DataStreamHashAidxTable.DataStreamHashAidxColumnValue>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putDataStreamIdx(
-                Multimap<DataStreamIdxTable.DataStreamIdxRow, ? extends DataStreamIdxTable.DataStreamIdxColumnValue> newRows) {
+                Multimap<DataStreamIdxTable.DataStreamIdxRow, ? extends DataStreamIdxTable.DataStreamIdxColumnValue>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putDataStreamMetadata(
-                Multimap<DataStreamMetadataTable.DataStreamMetadataRow, ? extends DataStreamMetadataTable.DataStreamMetadataNamedColumnValue<?>> newRows) {
+                Multimap<
+                                DataStreamMetadataTable.DataStreamMetadataRow,
+                                ? extends DataStreamMetadataTable.DataStreamMetadataNamedColumnValue<?>>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putDataStreamValue(
-                Multimap<DataStreamValueTable.DataStreamValueRow, ? extends DataStreamValueTable.DataStreamValueNamedColumnValue<?>> newRows) {
+                Multimap<
+                                DataStreamValueTable.DataStreamValueRow,
+                                ? extends DataStreamValueTable.DataStreamValueNamedColumnValue<?>>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putHotspottyDataStreamHashAidx(
-                Multimap<HotspottyDataStreamHashAidxTable.HotspottyDataStreamHashAidxRow, ? extends HotspottyDataStreamHashAidxTable.HotspottyDataStreamHashAidxColumnValue> newRows) {
+                Multimap<
+                                HotspottyDataStreamHashAidxTable.HotspottyDataStreamHashAidxRow,
+                                ? extends HotspottyDataStreamHashAidxTable.HotspottyDataStreamHashAidxColumnValue>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putHotspottyDataStreamIdx(
-                Multimap<HotspottyDataStreamIdxTable.HotspottyDataStreamIdxRow, ? extends HotspottyDataStreamIdxTable.HotspottyDataStreamIdxColumnValue> newRows) {
+                Multimap<
+                                HotspottyDataStreamIdxTable.HotspottyDataStreamIdxRow,
+                                ? extends HotspottyDataStreamIdxTable.HotspottyDataStreamIdxColumnValue>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putHotspottyDataStreamMetadata(
-                Multimap<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow, ? extends HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataNamedColumnValue<?>> newRows) {
+                Multimap<
+                                HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow,
+                                ? extends
+                                        HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataNamedColumnValue<?>>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putHotspottyDataStreamValue(
-                Multimap<HotspottyDataStreamValueTable.HotspottyDataStreamValueRow, ? extends HotspottyDataStreamValueTable.HotspottyDataStreamValueNamedColumnValue<?>> newRows) {
+                Multimap<
+                                HotspottyDataStreamValueTable.HotspottyDataStreamValueRow,
+                                ? extends HotspottyDataStreamValueTable.HotspottyDataStreamValueNamedColumnValue<?>>
+                        newRows) {
             // do nothing
         }
     }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataMetadataCleanupTask.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataMetadataCleanupTask.java
@@ -1,6 +1,5 @@
 package com.palantir.atlasdb.blob.generated;
 
-import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
 import com.palantir.atlasdb.encoding.PtBytes;
@@ -9,10 +8,8 @@ import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.protos.generated.StreamPersistence.Status;
 import com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata;
-import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.common.streams.KeyedStream;
-import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.util.HashSet;
@@ -20,8 +17,6 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DataMetadataCleanupTask implements OnCleanupTask {
 
@@ -42,7 +37,7 @@ public class DataMetadataCleanupTask implements OnCleanupTask {
         }
         DataStreamIdxTable indexTable = tables.getDataStreamIdxTable(t);
         Set<DataStreamMetadataTable.DataStreamMetadataRow> rowsWithNoIndexEntries =
-                        executeUnreferencedStreamDiagnostics(indexTable, rows);
+                        getUnreferencedStreamsByIterator(indexTable, rows);
         Set<Long> toDelete = new HashSet<>();
         Map<DataStreamMetadataTable.DataStreamMetadataRow, StreamMetadata> currentMetadata =
                 metaTable.getMetadatas(rows);
@@ -55,29 +50,11 @@ public class DataMetadataCleanupTask implements OnCleanupTask {
         return false;
     }
 
-    private static DataStreamMetadataTable.DataStreamMetadataRow convertFromIndexRow(DataStreamIdxTable.DataStreamIdxRow idxRow) {
-        return DataStreamMetadataTable.DataStreamMetadataRow.of(idxRow.getId());
-    }
-    private static Set<Long> convertToIdsForLogging(Set<DataStreamMetadataTable.DataStreamMetadataRow> iteratorExcess) {
-        return iteratorExcess.stream()
+    private static Set<DataStreamMetadataTable.DataStreamMetadataRow> getUnreferencedStreamsByIterator(DataStreamIdxTable indexTable, Set<DataStreamMetadataTable.DataStreamMetadataRow> metadataRows) {
+        Set<DataStreamIdxTable.DataStreamIdxRow> indexRows = metadataRows.stream()
                 .map(DataStreamMetadataTable.DataStreamMetadataRow::getId)
+                .map(DataStreamIdxTable.DataStreamIdxRow::of)
                 .collect(Collectors.toSet());
-    }
-
-    private static Set<DataStreamMetadataTable.DataStreamMetadataRow> getUnreferencedStreamsByMultimap(DataStreamIdxTable indexTable, Set<DataStreamIdxTable.DataStreamIdxRow> indexRows) {
-        Multimap<DataStreamIdxTable.DataStreamIdxRow, DataStreamIdxTable.DataStreamIdxColumnValue> indexValues = indexTable.getRowsMultimap(indexRows);
-        Set<DataStreamMetadataTable.DataStreamMetadataRow> presentMetadataRows
-                = indexValues.keySet().stream()
-                .map(DataMetadataCleanupTask::convertFromIndexRow)
-                .collect(Collectors.toSet());
-        Set<DataStreamMetadataTable.DataStreamMetadataRow> queriedMetadataRows
-                = indexRows.stream()
-                .map(DataMetadataCleanupTask::convertFromIndexRow)
-                .collect(Collectors.toSet());
-        return Sets.difference(queriedMetadataRows, presentMetadataRows);
-    }
-
-    private static Set<DataStreamMetadataTable.DataStreamMetadataRow> getUnreferencedStreamsByIterator(DataStreamIdxTable indexTable, Set<DataStreamIdxTable.DataStreamIdxRow> indexRows) {
         Map<DataStreamIdxTable.DataStreamIdxRow, Iterator<DataStreamIdxTable.DataStreamIdxColumnValue>> referenceIteratorByStream
                 = indexTable.getRowsColumnRangeIterator(indexRows,
                         BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 1));
@@ -89,24 +66,5 @@ public class DataMetadataCleanupTask implements OnCleanupTask {
                 .map(DataStreamMetadataTable.DataStreamMetadataRow::of)
                 .collect(Collectors.toSet());
         return unreferencedStreamMetadata;
-    }
-
-    private static Set<DataStreamMetadataTable.DataStreamMetadataRow> executeUnreferencedStreamDiagnostics(DataStreamIdxTable indexTable, Set<DataStreamMetadataTable.DataStreamMetadataRow> metadataRows) {
-        Set<DataStreamIdxTable.DataStreamIdxRow> indexRows = metadataRows.stream()
-                .map(DataStreamMetadataTable.DataStreamMetadataRow::getId)
-                .map(DataStreamIdxTable.DataStreamIdxRow::of)
-                .collect(Collectors.toSet());
-        Set<DataStreamMetadataTable.DataStreamMetadataRow> unreferencedStreamsByIterator = getUnreferencedStreamsByIterator(indexTable, indexRows);
-        Set<DataStreamMetadataTable.DataStreamMetadataRow> unreferencedStreamsByMultimap = getUnreferencedStreamsByMultimap(indexTable, indexRows);
-        if (!unreferencedStreamsByIterator.equals(unreferencedStreamsByMultimap)) {
-            log.info("We searched for unreferenced streams with methodological inconsistency: iterators claimed we could delete {}, but multimaps {}.",
-                    SafeArg.of("unreferencedByIterator", convertToIdsForLogging(unreferencedStreamsByIterator)),
-                    SafeArg.of("unreferencedByMultimap", convertToIdsForLogging(unreferencedStreamsByMultimap)));
-            return new HashSet<>();
-        } else {
-            log.info("We searched for unreferenced streams and consistently found {}.",
-                    SafeArg.of("unreferencedStreamIds", convertToIdsForLogging(unreferencedStreamsByIterator)));
-            return unreferencedStreamsByIterator;
-        }
     }
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamHashAidxTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamHashAidxTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class DataStreamHashAidxTable implements
         AtlasDbDynamicMutablePersistentTable<DataStreamHashAidxTable.DataStreamHashAidxRow,
                                                 DataStreamHashAidxTable.DataStreamHashAidxColumn,
@@ -739,5 +739,5 @@ public final class DataStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "YtrgaXdMg8OsSx3myGzQfA==";
+    static String __CLASS_HASH = "qaZcABmiU5N5B5TcPoLl7A==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamIdxTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamIdxTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class DataStreamIdxTable implements
         AtlasDbDynamicMutablePersistentTable<DataStreamIdxTable.DataStreamIdxRow,
                                                 DataStreamIdxTable.DataStreamIdxColumn,
@@ -753,5 +753,5 @@ public final class DataStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "ati1gIFTu2YisJnkFnewZQ==";
+    static String __CLASS_HASH = "JelgYU1LGPHdRT6dwB6nNA==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamMetadataTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamMetadataTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class DataStreamMetadataTable implements
         AtlasDbMutablePersistentTable<DataStreamMetadataTable.DataStreamMetadataRow,
                                          DataStreamMetadataTable.DataStreamMetadataNamedColumnValue<?>,
@@ -719,5 +719,5 @@ public final class DataStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "hRQ1Ky5c7Gvd5q12PGn/Jg==";
+    static String __CLASS_HASH = "uvHlKu+TF/ycbN12aiFuxA==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamStore.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamStore.java
@@ -1,6 +1,5 @@
 package com.palantir.atlasdb.blob.generated;
 
-import com.palantir.atlasdb.stream.StreamStorePersistenceConfigurations;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -73,7 +72,7 @@ import com.palantir.util.file.DeleteOnCloseFileInputStream;
 import com.palantir.util.file.TempFileUtils;
 
 @Generated("com.palantir.atlasdb.table.description.render.StreamStoreRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class DataStreamStore extends AbstractPersistentStreamStore {
     public static final int BLOCK_SIZE_IN_BYTES = 1000000; // 1MB. DO NOT CHANGE THIS WITHOUT AN UPGRADE TASK
     public static final int IN_MEMORY_THRESHOLD = 4194304; // streams under this size are kept in memory when loaded
@@ -85,7 +84,7 @@ public final class DataStreamStore extends AbstractPersistentStreamStore {
     private final BlobSchemaTableFactory tables;
 
     private DataStreamStore(TransactionManager txManager, BlobSchemaTableFactory tables) {
-        this(txManager, tables, () -> StreamStorePersistenceConfigurations.DEFAULT_CONFIG);
+        this(txManager, tables, () -> StreamStorePersistenceConfiguration.DEFAULT_CONFIG);
     }
 
     private DataStreamStore(TransactionManager txManager, BlobSchemaTableFactory tables, Supplier<StreamStorePersistenceConfiguration> persistenceConfiguration) {

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamValueTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamValueTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class DataStreamValueTable implements
         AtlasDbMutablePersistentTable<DataStreamValueTable.DataStreamValueRow,
                                          DataStreamValueTable.DataStreamValueNamedColumnValue<?>,
@@ -708,5 +708,5 @@ public final class DataStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "C+FXo6VndtXVI/bzWA7rGg==";
+    static String __CLASS_HASH = "s1XA0zoRtLSu1Ujl28XAeA==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamHashAidxTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamHashAidxTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class HotspottyDataStreamHashAidxTable implements
         AtlasDbDynamicMutablePersistentTable<HotspottyDataStreamHashAidxTable.HotspottyDataStreamHashAidxRow,
                                                 HotspottyDataStreamHashAidxTable.HotspottyDataStreamHashAidxColumn,
@@ -739,5 +739,5 @@ public final class HotspottyDataStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "7PjvLQTVZkN4Nm/Yxy+Dzw==";
+    static String __CLASS_HASH = "PZMhFByWrjoFmggQWBef1g==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamIdxTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamIdxTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class HotspottyDataStreamIdxTable implements
         AtlasDbDynamicMutablePersistentTable<HotspottyDataStreamIdxTable.HotspottyDataStreamIdxRow,
                                                 HotspottyDataStreamIdxTable.HotspottyDataStreamIdxColumn,
@@ -739,5 +739,5 @@ public final class HotspottyDataStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "Q7AA2hgYuQxHBO04yox+Fg==";
+    static String __CLASS_HASH = "XxXRl4oFJrmzG8PwnSuwzg==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamMetadataTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamMetadataTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class HotspottyDataStreamMetadataTable implements
         AtlasDbMutablePersistentTable<HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataRow,
                                          HotspottyDataStreamMetadataTable.HotspottyDataStreamMetadataNamedColumnValue<?>,
@@ -705,5 +705,5 @@ public final class HotspottyDataStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "0Rfr2rl4N9kxZp4CP3IwLA==";
+    static String __CLASS_HASH = "ZAmuaTg7KVhrSM8jgiLdFA==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamStore.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamStore.java
@@ -1,6 +1,5 @@
 package com.palantir.atlasdb.blob.generated;
 
-import com.palantir.atlasdb.stream.StreamStorePersistenceConfigurations;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -73,7 +72,7 @@ import com.palantir.util.file.DeleteOnCloseFileInputStream;
 import com.palantir.util.file.TempFileUtils;
 
 @Generated("com.palantir.atlasdb.table.description.render.StreamStoreRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class HotspottyDataStreamStore extends AbstractPersistentStreamStore {
     public static final int BLOCK_SIZE_IN_BYTES = 1000000; // 1MB. DO NOT CHANGE THIS WITHOUT AN UPGRADE TASK
     public static final int IN_MEMORY_THRESHOLD = 4194304; // streams under this size are kept in memory when loaded
@@ -85,7 +84,7 @@ public final class HotspottyDataStreamStore extends AbstractPersistentStreamStor
     private final BlobSchemaTableFactory tables;
 
     private HotspottyDataStreamStore(TransactionManager txManager, BlobSchemaTableFactory tables) {
-        this(txManager, tables, () -> StreamStorePersistenceConfigurations.DEFAULT_CONFIG);
+        this(txManager, tables, () -> StreamStorePersistenceConfiguration.DEFAULT_CONFIG);
     }
 
     private HotspottyDataStreamStore(TransactionManager txManager, BlobSchemaTableFactory tables, Supplier<StreamStorePersistenceConfiguration> persistenceConfiguration) {

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamValueTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamValueTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class HotspottyDataStreamValueTable implements
         AtlasDbMutablePersistentTable<HotspottyDataStreamValueTable.HotspottyDataStreamValueRow,
                                          HotspottyDataStreamValueTable.HotspottyDataStreamValueNamedColumnValue<?>,
@@ -693,5 +693,5 @@ public final class HotspottyDataStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "JBZ1BxSIpq8q7u8QtmGskQ==";
+    static String __CLASS_HASH = "WgGV3tTBVKug1Y6FQllJmw==";
 }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/KeyValueTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/KeyValueTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class KeyValueTable implements
         AtlasDbMutablePersistentTable<KeyValueTable.KeyValueRow,
                                          KeyValueTable.KeyValueNamedColumnValue<?>,
@@ -743,5 +743,5 @@ public final class KeyValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "m5yA1RA7LO64BThk0w8/Ig==";
+    static String __CLASS_HASH = "Zj0rVKfCofCDDchhuD5R2w==";
 }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/StreamTestTableFactory.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/StreamTestTableFactory.java
@@ -19,20 +19,17 @@ public final class StreamTestTableFactory {
     private final Namespace namespace;
 
     private StreamTestTableFactory(
-            List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
-            Namespace namespace) {
+            List<Function<? super Transaction, SharedTriggers>> sharedTriggers, Namespace namespace) {
         this.sharedTriggers = sharedTriggers;
         this.namespace = namespace;
     }
 
     public static StreamTestTableFactory of(
-            List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
-            Namespace namespace) {
+            List<Function<? super Transaction, SharedTriggers>> sharedTriggers, Namespace namespace) {
         return new StreamTestTableFactory(sharedTriggers, namespace);
     }
 
-    public static StreamTestTableFactory of(
-            List<Function<? super Transaction, SharedTriggers>> sharedTriggers) {
+    public static StreamTestTableFactory of(List<Function<? super Transaction, SharedTriggers>> sharedTriggers) {
         return new StreamTestTableFactory(sharedTriggers, defaultNamespace);
     }
 
@@ -44,33 +41,36 @@ public final class StreamTestTableFactory {
         return of(ImmutableList.<Function<? super Transaction, SharedTriggers>>of(), defaultNamespace);
     }
 
-    public KeyValueTable getKeyValueTable(Transaction t,
-            KeyValueTable.KeyValueTrigger... triggers) {
+    public KeyValueTable getKeyValueTable(Transaction t, KeyValueTable.KeyValueTrigger... triggers) {
         return KeyValueTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public ValueStreamHashAidxTable getValueStreamHashAidxTable(Transaction t,
-            ValueStreamHashAidxTable.ValueStreamHashAidxTrigger... triggers) {
+    public ValueStreamHashAidxTable getValueStreamHashAidxTable(
+            Transaction t, ValueStreamHashAidxTable.ValueStreamHashAidxTrigger... triggers) {
         return ValueStreamHashAidxTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public ValueStreamIdxTable getValueStreamIdxTable(Transaction t,
-            ValueStreamIdxTable.ValueStreamIdxTrigger... triggers) {
+    public ValueStreamIdxTable getValueStreamIdxTable(
+            Transaction t, ValueStreamIdxTable.ValueStreamIdxTrigger... triggers) {
         return ValueStreamIdxTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public ValueStreamMetadataTable getValueStreamMetadataTable(Transaction t,
-            ValueStreamMetadataTable.ValueStreamMetadataTrigger... triggers) {
+    public ValueStreamMetadataTable getValueStreamMetadataTable(
+            Transaction t, ValueStreamMetadataTable.ValueStreamMetadataTrigger... triggers) {
         return ValueStreamMetadataTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public ValueStreamValueTable getValueStreamValueTable(Transaction t,
-            ValueStreamValueTable.ValueStreamValueTrigger... triggers) {
+    public ValueStreamValueTable getValueStreamValueTable(
+            Transaction t, ValueStreamValueTable.ValueStreamValueTrigger... triggers) {
         return ValueStreamValueTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public interface SharedTriggers extends KeyValueTable.KeyValueTrigger, ValueStreamHashAidxTable.ValueStreamHashAidxTrigger, ValueStreamIdxTable.ValueStreamIdxTrigger, ValueStreamMetadataTable.ValueStreamMetadataTrigger, ValueStreamValueTable.ValueStreamValueTrigger {
-    }
+    public interface SharedTriggers
+            extends KeyValueTable.KeyValueTrigger,
+                    ValueStreamHashAidxTable.ValueStreamHashAidxTrigger,
+                    ValueStreamIdxTable.ValueStreamIdxTrigger,
+                    ValueStreamMetadataTable.ValueStreamMetadataTrigger,
+                    ValueStreamValueTable.ValueStreamValueTrigger {}
 
     public abstract static class NullSharedTriggers implements SharedTriggers {
         @Override
@@ -81,25 +81,35 @@ public final class StreamTestTableFactory {
 
         @Override
         public void putValueStreamHashAidx(
-                Multimap<ValueStreamHashAidxTable.ValueStreamHashAidxRow, ? extends ValueStreamHashAidxTable.ValueStreamHashAidxColumnValue> newRows) {
+                Multimap<
+                                ValueStreamHashAidxTable.ValueStreamHashAidxRow,
+                                ? extends ValueStreamHashAidxTable.ValueStreamHashAidxColumnValue>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putValueStreamIdx(
-                Multimap<ValueStreamIdxTable.ValueStreamIdxRow, ? extends ValueStreamIdxTable.ValueStreamIdxColumnValue> newRows) {
+                Multimap<ValueStreamIdxTable.ValueStreamIdxRow, ? extends ValueStreamIdxTable.ValueStreamIdxColumnValue>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putValueStreamMetadata(
-                Multimap<ValueStreamMetadataTable.ValueStreamMetadataRow, ? extends ValueStreamMetadataTable.ValueStreamMetadataNamedColumnValue<?>> newRows) {
+                Multimap<
+                                ValueStreamMetadataTable.ValueStreamMetadataRow,
+                                ? extends ValueStreamMetadataTable.ValueStreamMetadataNamedColumnValue<?>>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putValueStreamValue(
-                Multimap<ValueStreamValueTable.ValueStreamValueRow, ? extends ValueStreamValueTable.ValueStreamValueNamedColumnValue<?>> newRows) {
+                Multimap<
+                                ValueStreamValueTable.ValueStreamValueRow,
+                                ? extends ValueStreamValueTable.ValueStreamValueNamedColumnValue<?>>
+                        newRows) {
             // do nothing
         }
     }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueMetadataCleanupTask.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueMetadataCleanupTask.java
@@ -1,5 +1,14 @@
 package com.palantir.atlasdb.performance.schema.generated;
 
+import java.util.Iterator;
+import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
@@ -13,19 +22,10 @@ import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.common.streams.KeyedStream;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.logger.SafeLogger;
-import com.palantir.logsafe.logger.SafeLoggerFactory;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ValueMetadataCleanupTask implements OnCleanupTask {
 
-    private static final SafeLogger log = SafeLoggerFactory.get(ValueMetadataCleanupTask.class);
+    private static final Logger log = LoggerFactory.getLogger(ValueMetadataCleanupTask.class);
 
     private final StreamTestTableFactory tables;
 
@@ -42,7 +42,7 @@ public class ValueMetadataCleanupTask implements OnCleanupTask {
         }
         ValueStreamIdxTable indexTable = tables.getValueStreamIdxTable(t);
         Set<ValueStreamMetadataTable.ValueStreamMetadataRow> rowsWithNoIndexEntries =
-                        executeUnreferencedStreamDiagnostics(indexTable, rows);
+                        getUnreferencedStreamsByIterator(indexTable, rows);
         Set<Long> toDelete = new HashSet<>();
         Map<ValueStreamMetadataTable.ValueStreamMetadataRow, StreamMetadata> currentMetadata =
                 metaTable.getMetadatas(rows);
@@ -55,58 +55,19 @@ public class ValueMetadataCleanupTask implements OnCleanupTask {
         return false;
     }
 
-    private static ValueStreamMetadataTable.ValueStreamMetadataRow convertFromIndexRow(ValueStreamIdxTable.ValueStreamIdxRow idxRow) {
-        return ValueStreamMetadataTable.ValueStreamMetadataRow.of(idxRow.getId());
-    }
-    private static Set<Long> convertToIdsForLogging(Set<ValueStreamMetadataTable.ValueStreamMetadataRow> iteratorExcess) {
-        return iteratorExcess.stream()
+    private static Set<ValueStreamMetadataTable.ValueStreamMetadataRow> getUnreferencedStreamsByIterator(ValueStreamIdxTable indexTable, Set<ValueStreamMetadataTable.ValueStreamMetadataRow> metadataRows) {
+        Set<ValueStreamIdxTable.ValueStreamIdxRow> indexRows = metadataRows.stream()
                 .map(ValueStreamMetadataTable.ValueStreamMetadataRow::getId)
+                .map(ValueStreamIdxTable.ValueStreamIdxRow::of)
                 .collect(Collectors.toSet());
-    }
-
-    private static Set<ValueStreamMetadataTable.ValueStreamMetadataRow> getUnreferencedStreamsByMultimap(ValueStreamIdxTable indexTable, Set<ValueStreamIdxTable.ValueStreamIdxRow> indexRows) {
-        Multimap<ValueStreamIdxTable.ValueStreamIdxRow, ValueStreamIdxTable.ValueStreamIdxColumnValue> indexValues = indexTable.getRowsMultimap(indexRows);
-        Set<ValueStreamMetadataTable.ValueStreamMetadataRow> presentMetadataRows
-                = indexValues.keySet().stream()
-                .map(ValueMetadataCleanupTask::convertFromIndexRow)
-                .collect(Collectors.toSet());
-        Set<ValueStreamMetadataTable.ValueStreamMetadataRow> queriedMetadataRows
-                = indexRows.stream()
-                .map(ValueMetadataCleanupTask::convertFromIndexRow)
-                .collect(Collectors.toSet());
-        return Sets.difference(queriedMetadataRows, presentMetadataRows);
-    }
-
-    private static Set<ValueStreamMetadataTable.ValueStreamMetadataRow> getUnreferencedStreamsByIterator(ValueStreamIdxTable indexTable, Set<ValueStreamIdxTable.ValueStreamIdxRow> indexRows) {
         Map<ValueStreamIdxTable.ValueStreamIdxRow, Iterator<ValueStreamIdxTable.ValueStreamIdxColumnValue>> referenceIteratorByStream
                 = indexTable.getRowsColumnRangeIterator(indexRows,
                         BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 1));
-        Set<ValueStreamMetadataTable.ValueStreamMetadataRow> unreferencedStreamMetadata
-                = KeyedStream.stream(referenceIteratorByStream)
+        return KeyedStream.stream(referenceIteratorByStream)
                 .filter(valueIterator -> !valueIterator.hasNext())
                 .keys() // (authorized)
                 .map(ValueStreamIdxTable.ValueStreamIdxRow::getId)
                 .map(ValueStreamMetadataTable.ValueStreamMetadataRow::of)
                 .collect(Collectors.toSet());
-        return unreferencedStreamMetadata;
-    }
-
-    private static Set<ValueStreamMetadataTable.ValueStreamMetadataRow> executeUnreferencedStreamDiagnostics(ValueStreamIdxTable indexTable, Set<ValueStreamMetadataTable.ValueStreamMetadataRow> metadataRows) {
-        Set<ValueStreamIdxTable.ValueStreamIdxRow> indexRows = metadataRows.stream()
-                .map(ValueStreamMetadataTable.ValueStreamMetadataRow::getId)
-                .map(ValueStreamIdxTable.ValueStreamIdxRow::of)
-                .collect(Collectors.toSet());
-        Set<ValueStreamMetadataTable.ValueStreamMetadataRow> unreferencedStreamsByIterator = getUnreferencedStreamsByIterator(indexTable, indexRows);
-        Set<ValueStreamMetadataTable.ValueStreamMetadataRow> unreferencedStreamsByMultimap = getUnreferencedStreamsByMultimap(indexTable, indexRows);
-        if (!unreferencedStreamsByIterator.equals(unreferencedStreamsByMultimap)) {
-            log.info("We searched for unreferenced streams with methodological inconsistency: iterators claimed we could delete {}, but multimaps {}.",
-                    SafeArg.of("unreferencedByIterator", convertToIdsForLogging(unreferencedStreamsByIterator)),
-                    SafeArg.of("unreferencedByMultimap", convertToIdsForLogging(unreferencedStreamsByMultimap)));
-            return new HashSet<>();
-        } else {
-            log.info("We searched for unreferenced streams and consistently found {}.",
-                    SafeArg.of("unreferencedStreamIds", convertToIdsForLogging(unreferencedStreamsByIterator)));
-            return unreferencedStreamsByIterator;
-        }
     }
 }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamHashAidxTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamHashAidxTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class ValueStreamHashAidxTable implements
         AtlasDbDynamicMutablePersistentTable<ValueStreamHashAidxTable.ValueStreamHashAidxRow,
                                                 ValueStreamHashAidxTable.ValueStreamHashAidxColumn,
@@ -739,5 +739,5 @@ public final class ValueStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "JWcNmVHfIDvVMXLuVr3J9w==";
+    static String __CLASS_HASH = "GbQwTJueswaPb8BY2Zb+cw==";
 }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamIdxTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamIdxTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class ValueStreamIdxTable implements
         AtlasDbDynamicMutablePersistentTable<ValueStreamIdxTable.ValueStreamIdxRow,
                                                 ValueStreamIdxTable.ValueStreamIdxColumn,
@@ -739,5 +739,5 @@ public final class ValueStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "k443j7b83kpeasfvaZjY9Q==";
+    static String __CLASS_HASH = "AaO2qXe3eP1wnoPhGy6XdQ==";
 }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamMetadataTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamMetadataTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class ValueStreamMetadataTable implements
         AtlasDbMutablePersistentTable<ValueStreamMetadataTable.ValueStreamMetadataRow,
                                          ValueStreamMetadataTable.ValueStreamMetadataNamedColumnValue<?>,
@@ -705,5 +705,5 @@ public final class ValueStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "MtcTdiHmULkLLn/pLY5Mjg==";
+    static String __CLASS_HASH = "GTHsibXmo9ZZoXc8cmKpCQ==";
 }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamStore.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamStore.java
@@ -1,6 +1,5 @@
 package com.palantir.atlasdb.performance.schema.generated;
 
-import com.palantir.atlasdb.stream.StreamStorePersistenceConfigurations;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -73,7 +72,7 @@ import com.palantir.util.file.DeleteOnCloseFileInputStream;
 import com.palantir.util.file.TempFileUtils;
 
 @Generated("com.palantir.atlasdb.table.description.render.StreamStoreRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class ValueStreamStore extends AbstractPersistentStreamStore {
     public static final int BLOCK_SIZE_IN_BYTES = 1000000; // 1MB. DO NOT CHANGE THIS WITHOUT AN UPGRADE TASK
     public static final int IN_MEMORY_THRESHOLD = 1048576; // streams under this size are kept in memory when loaded
@@ -85,7 +84,7 @@ public final class ValueStreamStore extends AbstractPersistentStreamStore {
     private final StreamTestTableFactory tables;
 
     private ValueStreamStore(TransactionManager txManager, StreamTestTableFactory tables) {
-        this(txManager, tables, () -> StreamStorePersistenceConfigurations.DEFAULT_CONFIG);
+        this(txManager, tables, () -> StreamStorePersistenceConfiguration.DEFAULT_CONFIG);
     }
 
     private ValueStreamStore(TransactionManager txManager, StreamTestTableFactory tables, Supplier<StreamStorePersistenceConfiguration> persistenceConfiguration) {

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamValueTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamValueTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class ValueStreamValueTable implements
         AtlasDbMutablePersistentTable<ValueStreamValueTable.ValueStreamValueRow,
                                          ValueStreamValueTable.ValueStreamValueNamedColumnValue<?>,
@@ -693,5 +693,5 @@ public final class ValueStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "yN7lWhbGAlI/oud8Nu+oeA==";
+    static String __CLASS_HASH = "m9iOXlG+xicfTAeiMtfcOA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/DataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/DataTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class DataTable implements
         AtlasDbMutablePersistentTable<DataTable.DataRow,
                                          DataTable.DataNamedColumnValue<?>,
@@ -826,7 +826,7 @@ public final class DataTable implements
     }
 
     @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-    @SuppressWarnings("all")
+    @SuppressWarnings({"all", "deprecation"})
     public static final class Index1IdxTable implements
             AtlasDbDynamicMutablePersistentTable<Index1IdxTable.Index1IdxRow,
                                                     Index1IdxTable.Index1IdxColumn,
@@ -1520,7 +1520,7 @@ public final class DataTable implements
 
 
     @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-    @SuppressWarnings("all")
+    @SuppressWarnings({"all", "deprecation"})
     public static final class Index2IdxTable implements
             AtlasDbDynamicMutablePersistentTable<Index2IdxTable.Index2IdxRow,
                                                     Index2IdxTable.Index2IdxColumn,
@@ -2202,7 +2202,7 @@ public final class DataTable implements
 
 
     @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-    @SuppressWarnings("all")
+    @SuppressWarnings({"all", "deprecation"})
     public static final class Index3IdxTable implements
             AtlasDbDynamicMutablePersistentTable<Index3IdxTable.Index3IdxRow,
                                                     Index3IdxTable.Index3IdxColumn,
@@ -2862,7 +2862,7 @@ public final class DataTable implements
 
 
     @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-    @SuppressWarnings("all")
+    @SuppressWarnings({"all", "deprecation"})
     public static final class Index4IdxTable implements
             AtlasDbDynamicMutablePersistentTable<Index4IdxTable.Index4IdxRow,
                                                     Index4IdxTable.Index4IdxColumn,
@@ -3628,5 +3628,5 @@ public final class DataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "jOkK5nxjeQ7PgeGPcQ2Jlw==";
+    static String __CLASS_HASH = "5smQlgPEeoFu1azUh8FBpg==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/IndexTestTableFactory.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/IndexTestTableFactory.java
@@ -19,20 +19,17 @@ public final class IndexTestTableFactory {
     private final Namespace namespace;
 
     private IndexTestTableFactory(
-            List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
-            Namespace namespace) {
+            List<Function<? super Transaction, SharedTriggers>> sharedTriggers, Namespace namespace) {
         this.sharedTriggers = sharedTriggers;
         this.namespace = namespace;
     }
 
     public static IndexTestTableFactory of(
-            List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
-            Namespace namespace) {
+            List<Function<? super Transaction, SharedTriggers>> sharedTriggers, Namespace namespace) {
         return new IndexTestTableFactory(sharedTriggers, namespace);
     }
 
-    public static IndexTestTableFactory of(
-            List<Function<? super Transaction, SharedTriggers>> sharedTriggers) {
+    public static IndexTestTableFactory of(List<Function<? super Transaction, SharedTriggers>> sharedTriggers) {
         return new IndexTestTableFactory(sharedTriggers, defaultNamespace);
     }
 
@@ -48,24 +45,22 @@ public final class IndexTestTableFactory {
         return DataTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public TwoColumnsTable getTwoColumnsTable(Transaction t,
-            TwoColumnsTable.TwoColumnsTrigger... triggers) {
+    public TwoColumnsTable getTwoColumnsTable(Transaction t, TwoColumnsTable.TwoColumnsTrigger... triggers) {
         return TwoColumnsTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public interface SharedTriggers extends DataTable.DataTrigger, TwoColumnsTable.TwoColumnsTrigger {
-    }
+    public interface SharedTriggers extends DataTable.DataTrigger, TwoColumnsTable.TwoColumnsTrigger {}
 
     public abstract static class NullSharedTriggers implements SharedTriggers {
         @Override
-        public void putData(
-                Multimap<DataTable.DataRow, ? extends DataTable.DataNamedColumnValue<?>> newRows) {
+        public void putData(Multimap<DataTable.DataRow, ? extends DataTable.DataNamedColumnValue<?>> newRows) {
             // do nothing
         }
 
         @Override
         public void putTwoColumns(
-                Multimap<TwoColumnsTable.TwoColumnsRow, ? extends TwoColumnsTable.TwoColumnsNamedColumnValue<?>> newRows) {
+                Multimap<TwoColumnsTable.TwoColumnsRow, ? extends TwoColumnsTable.TwoColumnsNamedColumnValue<?>>
+                        newRows) {
             // do nothing
         }
     }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/TwoColumnsTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/TwoColumnsTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class TwoColumnsTable implements
         AtlasDbMutablePersistentTable<TwoColumnsTable.TwoColumnsRow,
                                          TwoColumnsTable.TwoColumnsNamedColumnValue<?>,
@@ -844,7 +844,7 @@ public final class TwoColumnsTable implements
     }
 
     @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-    @SuppressWarnings("all")
+    @SuppressWarnings({"all", "deprecation"})
     public static final class FooToIdCondIdxTable implements
             AtlasDbDynamicMutablePersistentTable<FooToIdCondIdxTable.FooToIdCondIdxRow,
                                                     FooToIdCondIdxTable.FooToIdCondIdxColumn,
@@ -1472,7 +1472,7 @@ public final class TwoColumnsTable implements
 
 
     @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-    @SuppressWarnings("all")
+    @SuppressWarnings({"all", "deprecation"})
     public static final class FooToIdIdxTable implements
             AtlasDbDynamicMutablePersistentTable<FooToIdIdxTable.FooToIdIdxRow,
                                                     FooToIdIdxTable.FooToIdIdxColumn,
@@ -2198,5 +2198,5 @@ public final class TwoColumnsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "B/Wf6J4AcMoVfbiflIQwKQ==";
+    static String __CLASS_HASH = "WaJpH1EGwXSVcsjD1Ik0iQ==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/KeyValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/KeyValueTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class KeyValueTable implements
         AtlasDbMutablePersistentTable<KeyValueTable.KeyValueRow,
                                          KeyValueTable.KeyValueNamedColumnValue<?>,
@@ -681,5 +681,5 @@ public final class KeyValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "JmQnXfDdpE/MCp1o+UDh6A==";
+    static String __CLASS_HASH = "9QB2ElKcwMxo2fUh0a0hww==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemMetadataCleanupTask.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemMetadataCleanupTask.java
@@ -1,5 +1,14 @@
 package com.palantir.atlasdb.schema.stream.generated;
 
+import java.util.Iterator;
+import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
@@ -13,19 +22,10 @@ import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.common.streams.KeyedStream;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.logger.SafeLogger;
-import com.palantir.logsafe.logger.SafeLoggerFactory;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class StreamTestMaxMemMetadataCleanupTask implements OnCleanupTask {
 
-    private static final SafeLogger log = SafeLoggerFactory.get(StreamTestMaxMemMetadataCleanupTask.class);
+    private static final Logger log = LoggerFactory.getLogger(StreamTestMaxMemMetadataCleanupTask.class);
 
     private final StreamTestTableFactory tables;
 
@@ -42,7 +42,7 @@ public class StreamTestMaxMemMetadataCleanupTask implements OnCleanupTask {
         }
         StreamTestMaxMemStreamIdxTable indexTable = tables.getStreamTestMaxMemStreamIdxTable(t);
         Set<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow> rowsWithNoIndexEntries =
-                        executeUnreferencedStreamDiagnostics(indexTable, rows);
+                        getUnreferencedStreamsByIterator(indexTable, rows);
         Set<Long> toDelete = new HashSet<>();
         Map<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow, StreamMetadata> currentMetadata =
                 metaTable.getMetadatas(rows);
@@ -55,58 +55,19 @@ public class StreamTestMaxMemMetadataCleanupTask implements OnCleanupTask {
         return false;
     }
 
-    private static StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow convertFromIndexRow(StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow idxRow) {
-        return StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow.of(idxRow.getId());
-    }
-    private static Set<Long> convertToIdsForLogging(Set<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow> iteratorExcess) {
-        return iteratorExcess.stream()
+    private static Set<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow> getUnreferencedStreamsByIterator(StreamTestMaxMemStreamIdxTable indexTable, Set<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow> metadataRows) {
+        Set<StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow> indexRows = metadataRows.stream()
                 .map(StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow::getId)
+                .map(StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow::of)
                 .collect(Collectors.toSet());
-    }
-
-    private static Set<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow> getUnreferencedStreamsByMultimap(StreamTestMaxMemStreamIdxTable indexTable, Set<StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow> indexRows) {
-        Multimap<StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxColumnValue> indexValues = indexTable.getRowsMultimap(indexRows);
-        Set<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow> presentMetadataRows
-                = indexValues.keySet().stream()
-                .map(StreamTestMaxMemMetadataCleanupTask::convertFromIndexRow)
-                .collect(Collectors.toSet());
-        Set<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow> queriedMetadataRows
-                = indexRows.stream()
-                .map(StreamTestMaxMemMetadataCleanupTask::convertFromIndexRow)
-                .collect(Collectors.toSet());
-        return Sets.difference(queriedMetadataRows, presentMetadataRows);
-    }
-
-    private static Set<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow> getUnreferencedStreamsByIterator(StreamTestMaxMemStreamIdxTable indexTable, Set<StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow> indexRows) {
         Map<StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow, Iterator<StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxColumnValue>> referenceIteratorByStream
                 = indexTable.getRowsColumnRangeIterator(indexRows,
                         BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 1));
-        Set<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow> unreferencedStreamMetadata
-                = KeyedStream.stream(referenceIteratorByStream)
+        return KeyedStream.stream(referenceIteratorByStream)
                 .filter(valueIterator -> !valueIterator.hasNext())
                 .keys() // (authorized)
                 .map(StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow::getId)
                 .map(StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow::of)
                 .collect(Collectors.toSet());
-        return unreferencedStreamMetadata;
-    }
-
-    private static Set<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow> executeUnreferencedStreamDiagnostics(StreamTestMaxMemStreamIdxTable indexTable, Set<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow> metadataRows) {
-        Set<StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow> indexRows = metadataRows.stream()
-                .map(StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow::getId)
-                .map(StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow::of)
-                .collect(Collectors.toSet());
-        Set<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow> unreferencedStreamsByIterator = getUnreferencedStreamsByIterator(indexTable, indexRows);
-        Set<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow> unreferencedStreamsByMultimap = getUnreferencedStreamsByMultimap(indexTable, indexRows);
-        if (!unreferencedStreamsByIterator.equals(unreferencedStreamsByMultimap)) {
-            log.info("We searched for unreferenced streams with methodological inconsistency: iterators claimed we could delete {}, but multimaps {}.",
-                    SafeArg.of("unreferencedByIterator", convertToIdsForLogging(unreferencedStreamsByIterator)),
-                    SafeArg.of("unreferencedByMultimap", convertToIdsForLogging(unreferencedStreamsByMultimap)));
-            return new HashSet<>();
-        } else {
-            log.info("We searched for unreferenced streams and consistently found {}.",
-                    SafeArg.of("unreferencedStreamIds", convertToIdsForLogging(unreferencedStreamsByIterator)));
-            return unreferencedStreamsByIterator;
-        }
     }
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamHashAidxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamHashAidxTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class StreamTestMaxMemStreamHashAidxTable implements
         AtlasDbDynamicMutablePersistentTable<StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxRow,
                                                 StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxColumn,
@@ -739,5 +739,5 @@ public final class StreamTestMaxMemStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "RcfPRo0cb7q0gtdAjxxLYQ==";
+    static String __CLASS_HASH = "VPEUYmpTACD8vVyg7DMWWw==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamIdxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamIdxTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class StreamTestMaxMemStreamIdxTable implements
         AtlasDbDynamicMutablePersistentTable<StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow,
                                                 StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxColumn,
@@ -739,5 +739,5 @@ public final class StreamTestMaxMemStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "JtgHIKW0RWq0UXfHcITrlA==";
+    static String __CLASS_HASH = "mdc3ZXDaRdTDV/QU6SnHmw==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamMetadataTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class StreamTestMaxMemStreamMetadataTable implements
         AtlasDbMutablePersistentTable<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow,
                                          StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataNamedColumnValue<?>,
@@ -705,5 +705,5 @@ public final class StreamTestMaxMemStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "BfUKfzbpVr8YLt8eRFxumw==";
+    static String __CLASS_HASH = "bg6frU5mIdbVIiQWToWm1g==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamStore.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamStore.java
@@ -1,6 +1,5 @@
 package com.palantir.atlasdb.schema.stream.generated;
 
-import com.palantir.atlasdb.stream.StreamStorePersistenceConfigurations;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -73,7 +72,7 @@ import com.palantir.util.file.DeleteOnCloseFileInputStream;
 import com.palantir.util.file.TempFileUtils;
 
 @Generated("com.palantir.atlasdb.table.description.render.StreamStoreRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class StreamTestMaxMemStreamStore extends AbstractPersistentStreamStore {
     public static final int BLOCK_SIZE_IN_BYTES = 1000000; // 1MB. DO NOT CHANGE THIS WITHOUT AN UPGRADE TASK
     public static final int IN_MEMORY_THRESHOLD = 2147483639; // streams under this size are kept in memory when loaded
@@ -85,7 +84,7 @@ public final class StreamTestMaxMemStreamStore extends AbstractPersistentStreamS
     private final StreamTestTableFactory tables;
 
     private StreamTestMaxMemStreamStore(TransactionManager txManager, StreamTestTableFactory tables) {
-        this(txManager, tables, () -> StreamStorePersistenceConfigurations.DEFAULT_CONFIG);
+        this(txManager, tables, () -> StreamStorePersistenceConfiguration.DEFAULT_CONFIG);
     }
 
     private StreamTestMaxMemStreamStore(TransactionManager txManager, StreamTestTableFactory tables, Supplier<StreamStorePersistenceConfiguration> persistenceConfiguration) {

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamValueTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class StreamTestMaxMemStreamValueTable implements
         AtlasDbMutablePersistentTable<StreamTestMaxMemStreamValueTable.StreamTestMaxMemStreamValueRow,
                                          StreamTestMaxMemStreamValueTable.StreamTestMaxMemStreamValueNamedColumnValue<?>,
@@ -693,5 +693,5 @@ public final class StreamTestMaxMemStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "uw1pyYid5J45mCs3dCCsyA==";
+    static String __CLASS_HASH = "OF33YFqOoa6rErfIE6Reew==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamHashAidxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamHashAidxTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class StreamTestStreamHashAidxTable implements
         AtlasDbDynamicMutablePersistentTable<StreamTestStreamHashAidxTable.StreamTestStreamHashAidxRow,
                                                 StreamTestStreamHashAidxTable.StreamTestStreamHashAidxColumn,
@@ -739,5 +739,5 @@ public final class StreamTestStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "n1Ji+IXKejaNz+wUbmp0+g==";
+    static String __CLASS_HASH = "udUmVCU5CjaqCML8TN5H0g==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamIdxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamIdxTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class StreamTestStreamIdxTable implements
         AtlasDbDynamicMutablePersistentTable<StreamTestStreamIdxTable.StreamTestStreamIdxRow,
                                                 StreamTestStreamIdxTable.StreamTestStreamIdxColumn,
@@ -739,5 +739,5 @@ public final class StreamTestStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "Dw5FfwjmOJjg8RAvTNx/Sg==";
+    static String __CLASS_HASH = "UpLQoZwCK/Ov1pclyB+iSA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamMetadataTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class StreamTestStreamMetadataTable implements
         AtlasDbMutablePersistentTable<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow,
                                          StreamTestStreamMetadataTable.StreamTestStreamMetadataNamedColumnValue<?>,
@@ -705,5 +705,5 @@ public final class StreamTestStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "VkColcnVQYAb3oqZf2xyUg==";
+    static String __CLASS_HASH = "6kCzpnN3cc1+KDY/g4bhlA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamStore.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamStore.java
@@ -1,6 +1,5 @@
 package com.palantir.atlasdb.schema.stream.generated;
 
-import com.palantir.atlasdb.stream.StreamStorePersistenceConfigurations;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -73,7 +72,7 @@ import com.palantir.util.file.DeleteOnCloseFileInputStream;
 import com.palantir.util.file.TempFileUtils;
 
 @Generated("com.palantir.atlasdb.table.description.render.StreamStoreRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class StreamTestStreamStore extends AbstractPersistentStreamStore {
     public static final int BLOCK_SIZE_IN_BYTES = 1000000; // 1MB. DO NOT CHANGE THIS WITHOUT AN UPGRADE TASK
     public static final int IN_MEMORY_THRESHOLD = 4194304; // streams under this size are kept in memory when loaded
@@ -85,7 +84,7 @@ public final class StreamTestStreamStore extends AbstractPersistentStreamStore {
     private final StreamTestTableFactory tables;
 
     private StreamTestStreamStore(TransactionManager txManager, StreamTestTableFactory tables) {
-        this(txManager, tables, () -> StreamStorePersistenceConfigurations.DEFAULT_CONFIG);
+        this(txManager, tables, () -> StreamStorePersistenceConfiguration.DEFAULT_CONFIG);
     }
 
     private StreamTestStreamStore(TransactionManager txManager, StreamTestTableFactory tables, Supplier<StreamStorePersistenceConfiguration> persistenceConfiguration) {

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamValueTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class StreamTestStreamValueTable implements
         AtlasDbMutablePersistentTable<StreamTestStreamValueTable.StreamTestStreamValueRow,
                                          StreamTestStreamValueTable.StreamTestStreamValueNamedColumnValue<?>,
@@ -693,5 +693,5 @@ public final class StreamTestStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "3aS3c6DpzBvSYExGZxJ5Qg==";
+    static String __CLASS_HASH = "sVBYOdKwksOUAfQ9jcStlA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestTableFactory.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestTableFactory.java
@@ -19,20 +19,17 @@ public final class StreamTestTableFactory {
     private final Namespace namespace;
 
     private StreamTestTableFactory(
-            List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
-            Namespace namespace) {
+            List<Function<? super Transaction, SharedTriggers>> sharedTriggers, Namespace namespace) {
         this.sharedTriggers = sharedTriggers;
         this.namespace = namespace;
     }
 
     public static StreamTestTableFactory of(
-            List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
-            Namespace namespace) {
+            List<Function<? super Transaction, SharedTriggers>> sharedTriggers, Namespace namespace) {
         return new StreamTestTableFactory(sharedTriggers, namespace);
     }
 
-    public static StreamTestTableFactory of(
-            List<Function<? super Transaction, SharedTriggers>> sharedTriggers) {
+    public static StreamTestTableFactory of(List<Function<? super Transaction, SharedTriggers>> sharedTriggers) {
         return new StreamTestTableFactory(sharedTriggers, defaultNamespace);
     }
 
@@ -44,97 +41,116 @@ public final class StreamTestTableFactory {
         return of(ImmutableList.<Function<? super Transaction, SharedTriggers>>of(), defaultNamespace);
     }
 
-    public KeyValueTable getKeyValueTable(Transaction t,
-            KeyValueTable.KeyValueTrigger... triggers) {
+    public KeyValueTable getKeyValueTable(Transaction t, KeyValueTable.KeyValueTrigger... triggers) {
         return KeyValueTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public StreamTestMaxMemStreamHashAidxTable getStreamTestMaxMemStreamHashAidxTable(Transaction t,
-            StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxTrigger... triggers) {
-        return StreamTestMaxMemStreamHashAidxTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
+    public StreamTestMaxMemStreamHashAidxTable getStreamTestMaxMemStreamHashAidxTable(
+            Transaction t, StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxTrigger... triggers) {
+        return StreamTestMaxMemStreamHashAidxTable.of(
+                t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public StreamTestMaxMemStreamIdxTable getStreamTestMaxMemStreamIdxTable(Transaction t,
-            StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxTrigger... triggers) {
+    public StreamTestMaxMemStreamIdxTable getStreamTestMaxMemStreamIdxTable(
+            Transaction t, StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxTrigger... triggers) {
         return StreamTestMaxMemStreamIdxTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public StreamTestMaxMemStreamMetadataTable getStreamTestMaxMemStreamMetadataTable(Transaction t,
-            StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataTrigger... triggers) {
-        return StreamTestMaxMemStreamMetadataTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
+    public StreamTestMaxMemStreamMetadataTable getStreamTestMaxMemStreamMetadataTable(
+            Transaction t, StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataTrigger... triggers) {
+        return StreamTestMaxMemStreamMetadataTable.of(
+                t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public StreamTestMaxMemStreamValueTable getStreamTestMaxMemStreamValueTable(Transaction t,
-            StreamTestMaxMemStreamValueTable.StreamTestMaxMemStreamValueTrigger... triggers) {
+    public StreamTestMaxMemStreamValueTable getStreamTestMaxMemStreamValueTable(
+            Transaction t, StreamTestMaxMemStreamValueTable.StreamTestMaxMemStreamValueTrigger... triggers) {
         return StreamTestMaxMemStreamValueTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public StreamTestStreamHashAidxTable getStreamTestStreamHashAidxTable(Transaction t,
-            StreamTestStreamHashAidxTable.StreamTestStreamHashAidxTrigger... triggers) {
+    public StreamTestStreamHashAidxTable getStreamTestStreamHashAidxTable(
+            Transaction t, StreamTestStreamHashAidxTable.StreamTestStreamHashAidxTrigger... triggers) {
         return StreamTestStreamHashAidxTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public StreamTestStreamIdxTable getStreamTestStreamIdxTable(Transaction t,
-            StreamTestStreamIdxTable.StreamTestStreamIdxTrigger... triggers) {
+    public StreamTestStreamIdxTable getStreamTestStreamIdxTable(
+            Transaction t, StreamTestStreamIdxTable.StreamTestStreamIdxTrigger... triggers) {
         return StreamTestStreamIdxTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public StreamTestStreamMetadataTable getStreamTestStreamMetadataTable(Transaction t,
-            StreamTestStreamMetadataTable.StreamTestStreamMetadataTrigger... triggers) {
+    public StreamTestStreamMetadataTable getStreamTestStreamMetadataTable(
+            Transaction t, StreamTestStreamMetadataTable.StreamTestStreamMetadataTrigger... triggers) {
         return StreamTestStreamMetadataTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public StreamTestStreamValueTable getStreamTestStreamValueTable(Transaction t,
-            StreamTestStreamValueTable.StreamTestStreamValueTrigger... triggers) {
+    public StreamTestStreamValueTable getStreamTestStreamValueTable(
+            Transaction t, StreamTestStreamValueTable.StreamTestStreamValueTrigger... triggers) {
         return StreamTestStreamValueTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
     public StreamTestWithHashStreamHashAidxTable getStreamTestWithHashStreamHashAidxTable(
-            Transaction t,
-            StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxTrigger... triggers) {
-        return StreamTestWithHashStreamHashAidxTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
+            Transaction t, StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxTrigger... triggers) {
+        return StreamTestWithHashStreamHashAidxTable.of(
+                t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public StreamTestWithHashStreamIdxTable getStreamTestWithHashStreamIdxTable(Transaction t,
-            StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxTrigger... triggers) {
+    public StreamTestWithHashStreamIdxTable getStreamTestWithHashStreamIdxTable(
+            Transaction t, StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxTrigger... triggers) {
         return StreamTestWithHashStreamIdxTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
     public StreamTestWithHashStreamMetadataTable getStreamTestWithHashStreamMetadataTable(
-            Transaction t,
-            StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataTrigger... triggers) {
-        return StreamTestWithHashStreamMetadataTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
+            Transaction t, StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataTrigger... triggers) {
+        return StreamTestWithHashStreamMetadataTable.of(
+                t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public StreamTestWithHashStreamValueTable getStreamTestWithHashStreamValueTable(Transaction t,
-            StreamTestWithHashStreamValueTable.StreamTestWithHashStreamValueTrigger... triggers) {
-        return StreamTestWithHashStreamValueTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
+    public StreamTestWithHashStreamValueTable getStreamTestWithHashStreamValueTable(
+            Transaction t, StreamTestWithHashStreamValueTable.StreamTestWithHashStreamValueTrigger... triggers) {
+        return StreamTestWithHashStreamValueTable.of(
+                t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
     public TestHashComponentsStreamHashAidxTable getTestHashComponentsStreamHashAidxTable(
-            Transaction t,
-            TestHashComponentsStreamHashAidxTable.TestHashComponentsStreamHashAidxTrigger... triggers) {
-        return TestHashComponentsStreamHashAidxTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
+            Transaction t, TestHashComponentsStreamHashAidxTable.TestHashComponentsStreamHashAidxTrigger... triggers) {
+        return TestHashComponentsStreamHashAidxTable.of(
+                t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public TestHashComponentsStreamIdxTable getTestHashComponentsStreamIdxTable(Transaction t,
-            TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxTrigger... triggers) {
+    public TestHashComponentsStreamIdxTable getTestHashComponentsStreamIdxTable(
+            Transaction t, TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxTrigger... triggers) {
         return TestHashComponentsStreamIdxTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
     public TestHashComponentsStreamMetadataTable getTestHashComponentsStreamMetadataTable(
-            Transaction t,
-            TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataTrigger... triggers) {
-        return TestHashComponentsStreamMetadataTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
+            Transaction t, TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataTrigger... triggers) {
+        return TestHashComponentsStreamMetadataTable.of(
+                t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public TestHashComponentsStreamValueTable getTestHashComponentsStreamValueTable(Transaction t,
-            TestHashComponentsStreamValueTable.TestHashComponentsStreamValueTrigger... triggers) {
-        return TestHashComponentsStreamValueTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
+    public TestHashComponentsStreamValueTable getTestHashComponentsStreamValueTable(
+            Transaction t, TestHashComponentsStreamValueTable.TestHashComponentsStreamValueTrigger... triggers) {
+        return TestHashComponentsStreamValueTable.of(
+                t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public interface SharedTriggers extends KeyValueTable.KeyValueTrigger, StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxTrigger, StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxTrigger, StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataTrigger, StreamTestMaxMemStreamValueTable.StreamTestMaxMemStreamValueTrigger, StreamTestStreamHashAidxTable.StreamTestStreamHashAidxTrigger, StreamTestStreamIdxTable.StreamTestStreamIdxTrigger, StreamTestStreamMetadataTable.StreamTestStreamMetadataTrigger, StreamTestStreamValueTable.StreamTestStreamValueTrigger, StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxTrigger, StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxTrigger, StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataTrigger, StreamTestWithHashStreamValueTable.StreamTestWithHashStreamValueTrigger, TestHashComponentsStreamHashAidxTable.TestHashComponentsStreamHashAidxTrigger, TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxTrigger, TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataTrigger, TestHashComponentsStreamValueTable.TestHashComponentsStreamValueTrigger {
-    }
+    public interface SharedTriggers
+            extends KeyValueTable.KeyValueTrigger,
+                    StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxTrigger,
+                    StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxTrigger,
+                    StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataTrigger,
+                    StreamTestMaxMemStreamValueTable.StreamTestMaxMemStreamValueTrigger,
+                    StreamTestStreamHashAidxTable.StreamTestStreamHashAidxTrigger,
+                    StreamTestStreamIdxTable.StreamTestStreamIdxTrigger,
+                    StreamTestStreamMetadataTable.StreamTestStreamMetadataTrigger,
+                    StreamTestStreamValueTable.StreamTestStreamValueTrigger,
+                    StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxTrigger,
+                    StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxTrigger,
+                    StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataTrigger,
+                    StreamTestWithHashStreamValueTable.StreamTestWithHashStreamValueTrigger,
+                    TestHashComponentsStreamHashAidxTable.TestHashComponentsStreamHashAidxTrigger,
+                    TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxTrigger,
+                    TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataTrigger,
+                    TestHashComponentsStreamValueTable.TestHashComponentsStreamValueTrigger {}
 
     public abstract static class NullSharedTriggers implements SharedTriggers {
         @Override
@@ -145,97 +161,165 @@ public final class StreamTestTableFactory {
 
         @Override
         public void putStreamTestMaxMemStreamHashAidx(
-                Multimap<StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxRow, ? extends StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxColumnValue> newRows) {
+                Multimap<
+                                StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxRow,
+                                ? extends StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxColumnValue>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putStreamTestMaxMemStreamIdx(
-                Multimap<StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow, ? extends StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxColumnValue> newRows) {
+                Multimap<
+                                StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow,
+                                ? extends StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxColumnValue>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putStreamTestMaxMemStreamMetadata(
-                Multimap<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow, ? extends StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataNamedColumnValue<?>> newRows) {
+                Multimap<
+                                StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow,
+                                ? extends
+                                        StreamTestMaxMemStreamMetadataTable
+                                                        .StreamTestMaxMemStreamMetadataNamedColumnValue<
+                                                ?>>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putStreamTestMaxMemStreamValue(
-                Multimap<StreamTestMaxMemStreamValueTable.StreamTestMaxMemStreamValueRow, ? extends StreamTestMaxMemStreamValueTable.StreamTestMaxMemStreamValueNamedColumnValue<?>> newRows) {
+                Multimap<
+                                StreamTestMaxMemStreamValueTable.StreamTestMaxMemStreamValueRow,
+                                ? extends
+                                        StreamTestMaxMemStreamValueTable.StreamTestMaxMemStreamValueNamedColumnValue<?>>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putStreamTestStreamHashAidx(
-                Multimap<StreamTestStreamHashAidxTable.StreamTestStreamHashAidxRow, ? extends StreamTestStreamHashAidxTable.StreamTestStreamHashAidxColumnValue> newRows) {
+                Multimap<
+                                StreamTestStreamHashAidxTable.StreamTestStreamHashAidxRow,
+                                ? extends StreamTestStreamHashAidxTable.StreamTestStreamHashAidxColumnValue>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putStreamTestStreamIdx(
-                Multimap<StreamTestStreamIdxTable.StreamTestStreamIdxRow, ? extends StreamTestStreamIdxTable.StreamTestStreamIdxColumnValue> newRows) {
+                Multimap<
+                                StreamTestStreamIdxTable.StreamTestStreamIdxRow,
+                                ? extends StreamTestStreamIdxTable.StreamTestStreamIdxColumnValue>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putStreamTestStreamMetadata(
-                Multimap<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow, ? extends StreamTestStreamMetadataTable.StreamTestStreamMetadataNamedColumnValue<?>> newRows) {
+                Multimap<
+                                StreamTestStreamMetadataTable.StreamTestStreamMetadataRow,
+                                ? extends StreamTestStreamMetadataTable.StreamTestStreamMetadataNamedColumnValue<?>>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putStreamTestStreamValue(
-                Multimap<StreamTestStreamValueTable.StreamTestStreamValueRow, ? extends StreamTestStreamValueTable.StreamTestStreamValueNamedColumnValue<?>> newRows) {
+                Multimap<
+                                StreamTestStreamValueTable.StreamTestStreamValueRow,
+                                ? extends StreamTestStreamValueTable.StreamTestStreamValueNamedColumnValue<?>>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putStreamTestWithHashStreamHashAidx(
-                Multimap<StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxRow, ? extends StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxColumnValue> newRows) {
+                Multimap<
+                                StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxRow,
+                                ? extends
+                                        StreamTestWithHashStreamHashAidxTable
+                                                .StreamTestWithHashStreamHashAidxColumnValue>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putStreamTestWithHashStreamIdx(
-                Multimap<StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxRow, ? extends StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxColumnValue> newRows) {
+                Multimap<
+                                StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxRow,
+                                ? extends StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxColumnValue>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putStreamTestWithHashStreamMetadata(
-                Multimap<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow, ? extends StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataNamedColumnValue<?>> newRows) {
+                Multimap<
+                                StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow,
+                                ? extends
+                                        StreamTestWithHashStreamMetadataTable
+                                                        .StreamTestWithHashStreamMetadataNamedColumnValue<
+                                                ?>>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putStreamTestWithHashStreamValue(
-                Multimap<StreamTestWithHashStreamValueTable.StreamTestWithHashStreamValueRow, ? extends StreamTestWithHashStreamValueTable.StreamTestWithHashStreamValueNamedColumnValue<?>> newRows) {
+                Multimap<
+                                StreamTestWithHashStreamValueTable.StreamTestWithHashStreamValueRow,
+                                ? extends
+                                        StreamTestWithHashStreamValueTable
+                                                        .StreamTestWithHashStreamValueNamedColumnValue<
+                                                ?>>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putTestHashComponentsStreamHashAidx(
-                Multimap<TestHashComponentsStreamHashAidxTable.TestHashComponentsStreamHashAidxRow, ? extends TestHashComponentsStreamHashAidxTable.TestHashComponentsStreamHashAidxColumnValue> newRows) {
+                Multimap<
+                                TestHashComponentsStreamHashAidxTable.TestHashComponentsStreamHashAidxRow,
+                                ? extends
+                                        TestHashComponentsStreamHashAidxTable
+                                                .TestHashComponentsStreamHashAidxColumnValue>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putTestHashComponentsStreamIdx(
-                Multimap<TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxRow, ? extends TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxColumnValue> newRows) {
+                Multimap<
+                                TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxRow,
+                                ? extends TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxColumnValue>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putTestHashComponentsStreamMetadata(
-                Multimap<TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow, ? extends TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataNamedColumnValue<?>> newRows) {
+                Multimap<
+                                TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow,
+                                ? extends
+                                        TestHashComponentsStreamMetadataTable
+                                                        .TestHashComponentsStreamMetadataNamedColumnValue<
+                                                ?>>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putTestHashComponentsStreamValue(
-                Multimap<TestHashComponentsStreamValueTable.TestHashComponentsStreamValueRow, ? extends TestHashComponentsStreamValueTable.TestHashComponentsStreamValueNamedColumnValue<?>> newRows) {
+                Multimap<
+                                TestHashComponentsStreamValueTable.TestHashComponentsStreamValueRow,
+                                ? extends
+                                        TestHashComponentsStreamValueTable
+                                                        .TestHashComponentsStreamValueNamedColumnValue<
+                                                ?>>
+                        newRows) {
             // do nothing
         }
     }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamHashAidxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamHashAidxTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class StreamTestWithHashStreamHashAidxTable implements
         AtlasDbDynamicMutablePersistentTable<StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxRow,
                                                 StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxColumn,
@@ -739,5 +739,5 @@ public final class StreamTestWithHashStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "/xwAyQ7vszm+kUGGwDnxvg==";
+    static String __CLASS_HASH = "N1ZVUKBp5e4EiyZN3lOukQ==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamIdxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamIdxTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class StreamTestWithHashStreamIdxTable implements
         AtlasDbDynamicMutablePersistentTable<StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxRow,
                                                 StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxColumn,
@@ -753,5 +753,5 @@ public final class StreamTestWithHashStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "SSmMmZnAKwY6Q5IbZRJZyQ==";
+    static String __CLASS_HASH = "Fw7uBkNZB8+Uz59gyPTkgw==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamMetadataTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class StreamTestWithHashStreamMetadataTable implements
         AtlasDbMutablePersistentTable<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow,
                                          StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataNamedColumnValue<?>,
@@ -719,5 +719,5 @@ public final class StreamTestWithHashStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "mu1Qm2dusVXLNQdP6zmYGg==";
+    static String __CLASS_HASH = "1VSlI4x38qhyOljyKBZ1xA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamStore.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamStore.java
@@ -1,6 +1,5 @@
 package com.palantir.atlasdb.schema.stream.generated;
 
-import com.palantir.atlasdb.stream.StreamStorePersistenceConfigurations;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -73,7 +72,7 @@ import com.palantir.util.file.DeleteOnCloseFileInputStream;
 import com.palantir.util.file.TempFileUtils;
 
 @Generated("com.palantir.atlasdb.table.description.render.StreamStoreRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class StreamTestWithHashStreamStore extends AbstractPersistentStreamStore {
     public static final int BLOCK_SIZE_IN_BYTES = 1000000; // 1MB. DO NOT CHANGE THIS WITHOUT AN UPGRADE TASK
     public static final int IN_MEMORY_THRESHOLD = 4000; // streams under this size are kept in memory when loaded
@@ -85,7 +84,7 @@ public final class StreamTestWithHashStreamStore extends AbstractPersistentStrea
     private final StreamTestTableFactory tables;
 
     private StreamTestWithHashStreamStore(TransactionManager txManager, StreamTestTableFactory tables) {
-        this(txManager, tables, () -> StreamStorePersistenceConfigurations.DEFAULT_CONFIG);
+        this(txManager, tables, () -> StreamStorePersistenceConfiguration.DEFAULT_CONFIG);
     }
 
     private StreamTestWithHashStreamStore(TransactionManager txManager, StreamTestTableFactory tables, Supplier<StreamStorePersistenceConfiguration> persistenceConfiguration) {

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamValueTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class StreamTestWithHashStreamValueTable implements
         AtlasDbMutablePersistentTable<StreamTestWithHashStreamValueTable.StreamTestWithHashStreamValueRow,
                                          StreamTestWithHashStreamValueTable.StreamTestWithHashStreamValueNamedColumnValue<?>,
@@ -707,5 +707,5 @@ public final class StreamTestWithHashStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "SRbDp9dcq1ldohHl5WmIcg==";
+    static String __CLASS_HASH = "LKSE7chgsUlcY/sLWwjgMQ==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsMetadataCleanupTask.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsMetadataCleanupTask.java
@@ -1,5 +1,14 @@
 package com.palantir.atlasdb.schema.stream.generated;
 
+import java.util.Iterator;
+import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
@@ -13,19 +22,10 @@ import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.common.streams.KeyedStream;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.logger.SafeLogger;
-import com.palantir.logsafe.logger.SafeLoggerFactory;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class TestHashComponentsMetadataCleanupTask implements OnCleanupTask {
 
-    private static final SafeLogger log = SafeLoggerFactory.get(TestHashComponentsMetadataCleanupTask.class);
+    private static final Logger log = LoggerFactory.getLogger(TestHashComponentsMetadataCleanupTask.class);
 
     private final StreamTestTableFactory tables;
 
@@ -42,7 +42,7 @@ public class TestHashComponentsMetadataCleanupTask implements OnCleanupTask {
         }
         TestHashComponentsStreamIdxTable indexTable = tables.getTestHashComponentsStreamIdxTable(t);
         Set<TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow> rowsWithNoIndexEntries =
-                        executeUnreferencedStreamDiagnostics(indexTable, rows);
+                        getUnreferencedStreamsByIterator(indexTable, rows);
         Set<Long> toDelete = new HashSet<>();
         Map<TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow, StreamMetadata> currentMetadata =
                 metaTable.getMetadatas(rows);
@@ -55,58 +55,19 @@ public class TestHashComponentsMetadataCleanupTask implements OnCleanupTask {
         return false;
     }
 
-    private static TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow convertFromIndexRow(TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxRow idxRow) {
-        return TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow.of(idxRow.getId());
-    }
-    private static Set<Long> convertToIdsForLogging(Set<TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow> iteratorExcess) {
-        return iteratorExcess.stream()
+    private static Set<TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow> getUnreferencedStreamsByIterator(TestHashComponentsStreamIdxTable indexTable, Set<TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow> metadataRows) {
+        Set<TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxRow> indexRows = metadataRows.stream()
                 .map(TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow::getId)
+                .map(TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxRow::of)
                 .collect(Collectors.toSet());
-    }
-
-    private static Set<TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow> getUnreferencedStreamsByMultimap(TestHashComponentsStreamIdxTable indexTable, Set<TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxRow> indexRows) {
-        Multimap<TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxRow, TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxColumnValue> indexValues = indexTable.getRowsMultimap(indexRows);
-        Set<TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow> presentMetadataRows
-                = indexValues.keySet().stream()
-                .map(TestHashComponentsMetadataCleanupTask::convertFromIndexRow)
-                .collect(Collectors.toSet());
-        Set<TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow> queriedMetadataRows
-                = indexRows.stream()
-                .map(TestHashComponentsMetadataCleanupTask::convertFromIndexRow)
-                .collect(Collectors.toSet());
-        return Sets.difference(queriedMetadataRows, presentMetadataRows);
-    }
-
-    private static Set<TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow> getUnreferencedStreamsByIterator(TestHashComponentsStreamIdxTable indexTable, Set<TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxRow> indexRows) {
         Map<TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxRow, Iterator<TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxColumnValue>> referenceIteratorByStream
                 = indexTable.getRowsColumnRangeIterator(indexRows,
                         BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 1));
-        Set<TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow> unreferencedStreamMetadata
-                = KeyedStream.stream(referenceIteratorByStream)
+        return KeyedStream.stream(referenceIteratorByStream)
                 .filter(valueIterator -> !valueIterator.hasNext())
                 .keys() // (authorized)
                 .map(TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxRow::getId)
                 .map(TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow::of)
                 .collect(Collectors.toSet());
-        return unreferencedStreamMetadata;
-    }
-
-    private static Set<TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow> executeUnreferencedStreamDiagnostics(TestHashComponentsStreamIdxTable indexTable, Set<TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow> metadataRows) {
-        Set<TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxRow> indexRows = metadataRows.stream()
-                .map(TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow::getId)
-                .map(TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxRow::of)
-                .collect(Collectors.toSet());
-        Set<TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow> unreferencedStreamsByIterator = getUnreferencedStreamsByIterator(indexTable, indexRows);
-        Set<TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow> unreferencedStreamsByMultimap = getUnreferencedStreamsByMultimap(indexTable, indexRows);
-        if (!unreferencedStreamsByIterator.equals(unreferencedStreamsByMultimap)) {
-            log.info("We searched for unreferenced streams with methodological inconsistency: iterators claimed we could delete {}, but multimaps {}.",
-                    SafeArg.of("unreferencedByIterator", convertToIdsForLogging(unreferencedStreamsByIterator)),
-                    SafeArg.of("unreferencedByMultimap", convertToIdsForLogging(unreferencedStreamsByMultimap)));
-            return new HashSet<>();
-        } else {
-            log.info("We searched for unreferenced streams and consistently found {}.",
-                    SafeArg.of("unreferencedStreamIds", convertToIdsForLogging(unreferencedStreamsByIterator)));
-            return unreferencedStreamsByIterator;
-        }
     }
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamHashAidxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamHashAidxTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class TestHashComponentsStreamHashAidxTable implements
         AtlasDbDynamicMutablePersistentTable<TestHashComponentsStreamHashAidxTable.TestHashComponentsStreamHashAidxRow,
                                                 TestHashComponentsStreamHashAidxTable.TestHashComponentsStreamHashAidxColumn,
@@ -739,5 +739,5 @@ public final class TestHashComponentsStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "f5p/s1LGJltwsVX2sNjpIw==";
+    static String __CLASS_HASH = "2Qzy1IodgvsDDYRguLne/Q==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamIdxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamIdxTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class TestHashComponentsStreamIdxTable implements
         AtlasDbDynamicMutablePersistentTable<TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxRow,
                                                 TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxColumn,
@@ -753,5 +753,5 @@ public final class TestHashComponentsStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "uZ4FMeLEKAfYagc9+Waxww==";
+    static String __CLASS_HASH = "Qn6mO587PWFhTpgT4rdwPw==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamMetadataTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class TestHashComponentsStreamMetadataTable implements
         AtlasDbMutablePersistentTable<TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow,
                                          TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataNamedColumnValue<?>,
@@ -719,5 +719,5 @@ public final class TestHashComponentsStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "Wue1+pd/iIiaZ6wKAyKxKQ==";
+    static String __CLASS_HASH = "UicfW27TGG9bWrV+QAqsfg==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamStore.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamStore.java
@@ -1,6 +1,5 @@
 package com.palantir.atlasdb.schema.stream.generated;
 
-import com.palantir.atlasdb.stream.StreamStorePersistenceConfigurations;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -73,7 +72,7 @@ import com.palantir.util.file.DeleteOnCloseFileInputStream;
 import com.palantir.util.file.TempFileUtils;
 
 @Generated("com.palantir.atlasdb.table.description.render.StreamStoreRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class TestHashComponentsStreamStore extends AbstractPersistentStreamStore {
     public static final int BLOCK_SIZE_IN_BYTES = 1000000; // 1MB. DO NOT CHANGE THIS WITHOUT AN UPGRADE TASK
     public static final int IN_MEMORY_THRESHOLD = 4194304; // streams under this size are kept in memory when loaded
@@ -85,7 +84,7 @@ public final class TestHashComponentsStreamStore extends AbstractPersistentStrea
     private final StreamTestTableFactory tables;
 
     private TestHashComponentsStreamStore(TransactionManager txManager, StreamTestTableFactory tables) {
-        this(txManager, tables, () -> StreamStorePersistenceConfigurations.DEFAULT_CONFIG);
+        this(txManager, tables, () -> StreamStorePersistenceConfiguration.DEFAULT_CONFIG);
     }
 
     private TestHashComponentsStreamStore(TransactionManager txManager, StreamTestTableFactory tables, Supplier<StreamStorePersistenceConfiguration> persistenceConfiguration) {

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamValueTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class TestHashComponentsStreamValueTable implements
         AtlasDbMutablePersistentTable<TestHashComponentsStreamValueTable.TestHashComponentsStreamValueRow,
                                          TestHashComponentsStreamValueTable.TestHashComponentsStreamValueNamedColumnValue<?>,
@@ -708,5 +708,5 @@ public final class TestHashComponentsStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "mlpqC/MJIRxqQz9mO295/g==";
+    static String __CLASS_HASH = "RGE142O7UD2OKjOspNm8Hw==";
 }

--- a/changelog/@unreleased/pr-5620.v2.yml
+++ b/changelog/@unreleased/pr-5620.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: '[PDS-202945] Key value service load should be reduced when sweeping
+    tables that have highly referenced streams; the check for whether a stream was
+    referenced now only loads one cell into memory, while it would previously load
+    the entire row of references.'
+  links:
+  - https://github.com/palantir/atlasdb/pull/5620

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/ProfileTableFactory.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/ProfileTableFactory.java
@@ -18,20 +18,18 @@ public final class ProfileTableFactory {
 
     private final Namespace namespace;
 
-    private ProfileTableFactory(List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
-            Namespace namespace) {
+    private ProfileTableFactory(
+            List<Function<? super Transaction, SharedTriggers>> sharedTriggers, Namespace namespace) {
         this.sharedTriggers = sharedTriggers;
         this.namespace = namespace;
     }
 
     public static ProfileTableFactory of(
-            List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
-            Namespace namespace) {
+            List<Function<? super Transaction, SharedTriggers>> sharedTriggers, Namespace namespace) {
         return new ProfileTableFactory(sharedTriggers, namespace);
     }
 
-    public static ProfileTableFactory of(
-            List<Function<? super Transaction, SharedTriggers>> sharedTriggers) {
+    public static ProfileTableFactory of(List<Function<? super Transaction, SharedTriggers>> sharedTriggers) {
         return new ProfileTableFactory(sharedTriggers, defaultNamespace);
     }
 
@@ -43,62 +41,78 @@ public final class ProfileTableFactory {
         return of(ImmutableList.<Function<? super Transaction, SharedTriggers>>of(), defaultNamespace);
     }
 
-    public UserPhotosStreamHashAidxTable getUserPhotosStreamHashAidxTable(Transaction t,
-            UserPhotosStreamHashAidxTable.UserPhotosStreamHashAidxTrigger... triggers) {
+    public UserPhotosStreamHashAidxTable getUserPhotosStreamHashAidxTable(
+            Transaction t, UserPhotosStreamHashAidxTable.UserPhotosStreamHashAidxTrigger... triggers) {
         return UserPhotosStreamHashAidxTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public UserPhotosStreamIdxTable getUserPhotosStreamIdxTable(Transaction t,
-            UserPhotosStreamIdxTable.UserPhotosStreamIdxTrigger... triggers) {
+    public UserPhotosStreamIdxTable getUserPhotosStreamIdxTable(
+            Transaction t, UserPhotosStreamIdxTable.UserPhotosStreamIdxTrigger... triggers) {
         return UserPhotosStreamIdxTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public UserPhotosStreamMetadataTable getUserPhotosStreamMetadataTable(Transaction t,
-            UserPhotosStreamMetadataTable.UserPhotosStreamMetadataTrigger... triggers) {
+    public UserPhotosStreamMetadataTable getUserPhotosStreamMetadataTable(
+            Transaction t, UserPhotosStreamMetadataTable.UserPhotosStreamMetadataTrigger... triggers) {
         return UserPhotosStreamMetadataTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public UserPhotosStreamValueTable getUserPhotosStreamValueTable(Transaction t,
-            UserPhotosStreamValueTable.UserPhotosStreamValueTrigger... triggers) {
+    public UserPhotosStreamValueTable getUserPhotosStreamValueTable(
+            Transaction t, UserPhotosStreamValueTable.UserPhotosStreamValueTrigger... triggers) {
         return UserPhotosStreamValueTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public UserProfileTable getUserProfileTable(Transaction t,
-            UserProfileTable.UserProfileTrigger... triggers) {
+    public UserProfileTable getUserProfileTable(Transaction t, UserProfileTable.UserProfileTrigger... triggers) {
         return UserProfileTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public interface SharedTriggers extends UserPhotosStreamHashAidxTable.UserPhotosStreamHashAidxTrigger, UserPhotosStreamIdxTable.UserPhotosStreamIdxTrigger, UserPhotosStreamMetadataTable.UserPhotosStreamMetadataTrigger, UserPhotosStreamValueTable.UserPhotosStreamValueTrigger, UserProfileTable.UserProfileTrigger {
-    }
+    public interface SharedTriggers
+            extends UserPhotosStreamHashAidxTable.UserPhotosStreamHashAidxTrigger,
+                    UserPhotosStreamIdxTable.UserPhotosStreamIdxTrigger,
+                    UserPhotosStreamMetadataTable.UserPhotosStreamMetadataTrigger,
+                    UserPhotosStreamValueTable.UserPhotosStreamValueTrigger,
+                    UserProfileTable.UserProfileTrigger {}
 
     public abstract static class NullSharedTriggers implements SharedTriggers {
         @Override
         public void putUserPhotosStreamHashAidx(
-                Multimap<UserPhotosStreamHashAidxTable.UserPhotosStreamHashAidxRow, ? extends UserPhotosStreamHashAidxTable.UserPhotosStreamHashAidxColumnValue> newRows) {
+                Multimap<
+                                UserPhotosStreamHashAidxTable.UserPhotosStreamHashAidxRow,
+                                ? extends UserPhotosStreamHashAidxTable.UserPhotosStreamHashAidxColumnValue>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putUserPhotosStreamIdx(
-                Multimap<UserPhotosStreamIdxTable.UserPhotosStreamIdxRow, ? extends UserPhotosStreamIdxTable.UserPhotosStreamIdxColumnValue> newRows) {
+                Multimap<
+                                UserPhotosStreamIdxTable.UserPhotosStreamIdxRow,
+                                ? extends UserPhotosStreamIdxTable.UserPhotosStreamIdxColumnValue>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putUserPhotosStreamMetadata(
-                Multimap<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow, ? extends UserPhotosStreamMetadataTable.UserPhotosStreamMetadataNamedColumnValue<?>> newRows) {
+                Multimap<
+                                UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow,
+                                ? extends UserPhotosStreamMetadataTable.UserPhotosStreamMetadataNamedColumnValue<?>>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putUserPhotosStreamValue(
-                Multimap<UserPhotosStreamValueTable.UserPhotosStreamValueRow, ? extends UserPhotosStreamValueTable.UserPhotosStreamValueNamedColumnValue<?>> newRows) {
+                Multimap<
+                                UserPhotosStreamValueTable.UserPhotosStreamValueRow,
+                                ? extends UserPhotosStreamValueTable.UserPhotosStreamValueNamedColumnValue<?>>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putUserProfile(
-                Multimap<UserProfileTable.UserProfileRow, ? extends UserProfileTable.UserProfileNamedColumnValue<?>> newRows) {
+                Multimap<UserProfileTable.UserProfileRow, ? extends UserProfileTable.UserProfileNamedColumnValue<?>>
+                        newRows) {
             // do nothing
         }
     }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosIndexCleanupTask.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosIndexCleanupTask.java
@@ -1,6 +1,7 @@
 package com.palantir.example.profile.schema.generated;
 
 import java.util.Map;
+import java.util.HashSet;
 import java.util.Set;
 
 import com.google.common.collect.Sets;

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosMetadataCleanupTask.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosMetadataCleanupTask.java
@@ -1,5 +1,14 @@
 package com.palantir.example.profile.schema.generated;
 
+import java.util.Iterator;
+import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
@@ -13,19 +22,10 @@ import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.common.streams.KeyedStream;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.logger.SafeLogger;
-import com.palantir.logsafe.logger.SafeLoggerFactory;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class UserPhotosMetadataCleanupTask implements OnCleanupTask {
 
-    private static final SafeLogger log = SafeLoggerFactory.get(UserPhotosMetadataCleanupTask.class);
+    private static final Logger log = LoggerFactory.getLogger(UserPhotosMetadataCleanupTask.class);
 
     private final ProfileTableFactory tables;
 
@@ -42,7 +42,7 @@ public class UserPhotosMetadataCleanupTask implements OnCleanupTask {
         }
         UserPhotosStreamIdxTable indexTable = tables.getUserPhotosStreamIdxTable(t);
         Set<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow> rowsWithNoIndexEntries =
-                        executeUnreferencedStreamDiagnostics(indexTable, rows);
+                        getUnreferencedStreamsByIterator(indexTable, rows);
         Set<Long> toDelete = new HashSet<>();
         Map<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow, StreamMetadata> currentMetadata =
                 metaTable.getMetadatas(rows);
@@ -55,58 +55,19 @@ public class UserPhotosMetadataCleanupTask implements OnCleanupTask {
         return false;
     }
 
-    private static UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow convertFromIndexRow(UserPhotosStreamIdxTable.UserPhotosStreamIdxRow idxRow) {
-        return UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow.of(idxRow.getId());
-    }
-    private static Set<Long> convertToIdsForLogging(Set<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow> iteratorExcess) {
-        return iteratorExcess.stream()
+    private static Set<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow> getUnreferencedStreamsByIterator(UserPhotosStreamIdxTable indexTable, Set<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow> metadataRows) {
+        Set<UserPhotosStreamIdxTable.UserPhotosStreamIdxRow> indexRows = metadataRows.stream()
                 .map(UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow::getId)
+                .map(UserPhotosStreamIdxTable.UserPhotosStreamIdxRow::of)
                 .collect(Collectors.toSet());
-    }
-
-    private static Set<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow> getUnreferencedStreamsByMultimap(UserPhotosStreamIdxTable indexTable, Set<UserPhotosStreamIdxTable.UserPhotosStreamIdxRow> indexRows) {
-        Multimap<UserPhotosStreamIdxTable.UserPhotosStreamIdxRow, UserPhotosStreamIdxTable.UserPhotosStreamIdxColumnValue> indexValues = indexTable.getRowsMultimap(indexRows);
-        Set<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow> presentMetadataRows
-                = indexValues.keySet().stream()
-                .map(UserPhotosMetadataCleanupTask::convertFromIndexRow)
-                .collect(Collectors.toSet());
-        Set<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow> queriedMetadataRows
-                = indexRows.stream()
-                .map(UserPhotosMetadataCleanupTask::convertFromIndexRow)
-                .collect(Collectors.toSet());
-        return Sets.difference(queriedMetadataRows, presentMetadataRows);
-    }
-
-    private static Set<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow> getUnreferencedStreamsByIterator(UserPhotosStreamIdxTable indexTable, Set<UserPhotosStreamIdxTable.UserPhotosStreamIdxRow> indexRows) {
         Map<UserPhotosStreamIdxTable.UserPhotosStreamIdxRow, Iterator<UserPhotosStreamIdxTable.UserPhotosStreamIdxColumnValue>> referenceIteratorByStream
                 = indexTable.getRowsColumnRangeIterator(indexRows,
                         BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 1));
-        Set<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow> unreferencedStreamMetadata
-                = KeyedStream.stream(referenceIteratorByStream)
+        return KeyedStream.stream(referenceIteratorByStream)
                 .filter(valueIterator -> !valueIterator.hasNext())
                 .keys() // (authorized)
                 .map(UserPhotosStreamIdxTable.UserPhotosStreamIdxRow::getId)
                 .map(UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow::of)
                 .collect(Collectors.toSet());
-        return unreferencedStreamMetadata;
-    }
-
-    private static Set<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow> executeUnreferencedStreamDiagnostics(UserPhotosStreamIdxTable indexTable, Set<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow> metadataRows) {
-        Set<UserPhotosStreamIdxTable.UserPhotosStreamIdxRow> indexRows = metadataRows.stream()
-                .map(UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow::getId)
-                .map(UserPhotosStreamIdxTable.UserPhotosStreamIdxRow::of)
-                .collect(Collectors.toSet());
-        Set<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow> unreferencedStreamsByIterator = getUnreferencedStreamsByIterator(indexTable, indexRows);
-        Set<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow> unreferencedStreamsByMultimap = getUnreferencedStreamsByMultimap(indexTable, indexRows);
-        if (!unreferencedStreamsByIterator.equals(unreferencedStreamsByMultimap)) {
-            log.info("We searched for unreferenced streams with methodological inconsistency: iterators claimed we could delete {}, but multimaps {}.",
-                    SafeArg.of("unreferencedByIterator", convertToIdsForLogging(unreferencedStreamsByIterator)),
-                    SafeArg.of("unreferencedByMultimap", convertToIdsForLogging(unreferencedStreamsByMultimap)));
-            return new HashSet<>();
-        } else {
-            log.info("We searched for unreferenced streams and consistently found {}.",
-                    SafeArg.of("unreferencedStreamIds", convertToIdsForLogging(unreferencedStreamsByIterator)));
-            return unreferencedStreamsByIterator;
-        }
     }
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamHashAidxTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamHashAidxTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class UserPhotosStreamHashAidxTable implements
         AtlasDbDynamicMutablePersistentTable<UserPhotosStreamHashAidxTable.UserPhotosStreamHashAidxRow,
                                                 UserPhotosStreamHashAidxTable.UserPhotosStreamHashAidxColumn,
@@ -739,5 +739,5 @@ public final class UserPhotosStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "+iAvW6ConEtWCjph8BSHHw==";
+    static String __CLASS_HASH = "dZYcT9+ev8B7R2CRl5PtOg==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamIdxTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamIdxTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class UserPhotosStreamIdxTable implements
         AtlasDbDynamicMutablePersistentTable<UserPhotosStreamIdxTable.UserPhotosStreamIdxRow,
                                                 UserPhotosStreamIdxTable.UserPhotosStreamIdxColumn,
@@ -739,5 +739,5 @@ public final class UserPhotosStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "yFnrREfZ2xEdWJY2+X/KOA==";
+    static String __CLASS_HASH = "xkzH3ePg9bEd2qkecxe+6Q==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamMetadataTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamMetadataTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class UserPhotosStreamMetadataTable implements
         AtlasDbMutablePersistentTable<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow,
                                          UserPhotosStreamMetadataTable.UserPhotosStreamMetadataNamedColumnValue<?>,
@@ -705,5 +705,5 @@ public final class UserPhotosStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "jqJ9MbJSHQtHT3oo1Qu+qg==";
+    static String __CLASS_HASH = "g8PU4gm3yjGhq+p+rYxvuQ==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamValueTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamValueTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class UserPhotosStreamValueTable implements
         AtlasDbMutablePersistentTable<UserPhotosStreamValueTable.UserPhotosStreamValueRow,
                                          UserPhotosStreamValueTable.UserPhotosStreamValueNamedColumnValue<?>,
@@ -693,5 +693,5 @@ public final class UserPhotosStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "uglJj9/u94Hifz8OyoJDdg==";
+    static String __CLASS_HASH = "R2gHn2m91TdDJPY63NhUhQ==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserProfileTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserProfileTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class UserProfileTable implements
         AtlasDbMutablePersistentTable<UserProfileTable.UserProfileRow,
                                          UserProfileTable.UserProfileNamedColumnValue<?>,
@@ -1170,7 +1170,7 @@ public final class UserProfileTable implements
     }
 
     @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-    @SuppressWarnings("all")
+    @SuppressWarnings({"all", "deprecation"})
     public static final class CookiesIdxTable implements
             AtlasDbDynamicMutablePersistentTable<CookiesIdxTable.CookiesIdxRow,
                                                     CookiesIdxTable.CookiesIdxColumn,
@@ -1864,7 +1864,7 @@ public final class UserProfileTable implements
 
 
     @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-    @SuppressWarnings("all")
+    @SuppressWarnings({"all", "deprecation"})
     public static final class CreatedIdxTable implements
             AtlasDbDynamicMutablePersistentTable<CreatedIdxTable.CreatedIdxRow,
                                                     CreatedIdxTable.CreatedIdxColumn,
@@ -2558,7 +2558,7 @@ public final class UserProfileTable implements
 
 
     @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-    @SuppressWarnings("all")
+    @SuppressWarnings({"all", "deprecation"})
     public static final class UserBirthdaysIdxTable implements
             AtlasDbDynamicMutablePersistentTable<UserBirthdaysIdxTable.UserBirthdaysIdxRow,
                                                     UserBirthdaysIdxTable.UserBirthdaysIdxColumn,
@@ -3336,5 +3336,5 @@ public final class UserProfileTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "BgObqeWg1QTD69+0+yj1GA==";
+    static String __CLASS_HASH = "ElEfEgDtzUQU+6sxJk99mQ==";
 }

--- a/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/BenchmarksTableFactory.java
+++ b/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/BenchmarksTableFactory.java
@@ -19,20 +19,17 @@ public final class BenchmarksTableFactory {
     private final Namespace namespace;
 
     private BenchmarksTableFactory(
-            List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
-            Namespace namespace) {
+            List<Function<? super Transaction, SharedTriggers>> sharedTriggers, Namespace namespace) {
         this.sharedTriggers = sharedTriggers;
         this.namespace = namespace;
     }
 
     public static BenchmarksTableFactory of(
-            List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
-            Namespace namespace) {
+            List<Function<? super Transaction, SharedTriggers>> sharedTriggers, Namespace namespace) {
         return new BenchmarksTableFactory(sharedTriggers, namespace);
     }
 
-    public static BenchmarksTableFactory of(
-            List<Function<? super Transaction, SharedTriggers>> sharedTriggers) {
+    public static BenchmarksTableFactory of(List<Function<? super Transaction, SharedTriggers>> sharedTriggers) {
         return new BenchmarksTableFactory(sharedTriggers, defaultNamespace);
     }
 
@@ -48,13 +45,13 @@ public final class BenchmarksTableFactory {
         return BlobsTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public BlobsSerializableTable getBlobsSerializableTable(Transaction t,
-            BlobsSerializableTable.BlobsSerializableTrigger... triggers) {
+    public BlobsSerializableTable getBlobsSerializableTable(
+            Transaction t, BlobsSerializableTable.BlobsSerializableTrigger... triggers) {
         return BlobsSerializableTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public KvDynamicColumnsTable getKvDynamicColumnsTable(Transaction t,
-            KvDynamicColumnsTable.KvDynamicColumnsTrigger... triggers) {
+    public KvDynamicColumnsTable getKvDynamicColumnsTable(
+            Transaction t, KvDynamicColumnsTable.KvDynamicColumnsTrigger... triggers) {
         return KvDynamicColumnsTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
@@ -62,30 +59,38 @@ public final class BenchmarksTableFactory {
         return KvRowsTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public MetadataTable getMetadataTable(Transaction t,
-            MetadataTable.MetadataTrigger... triggers) {
+    public MetadataTable getMetadataTable(Transaction t, MetadataTable.MetadataTrigger... triggers) {
         return MetadataTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public interface SharedTriggers extends BlobsTable.BlobsTrigger, BlobsSerializableTable.BlobsSerializableTrigger, KvDynamicColumnsTable.KvDynamicColumnsTrigger, KvRowsTable.KvRowsTrigger, MetadataTable.MetadataTrigger {
-    }
+    public interface SharedTriggers
+            extends BlobsTable.BlobsTrigger,
+                    BlobsSerializableTable.BlobsSerializableTrigger,
+                    KvDynamicColumnsTable.KvDynamicColumnsTrigger,
+                    KvRowsTable.KvRowsTrigger,
+                    MetadataTable.MetadataTrigger {}
 
     public abstract static class NullSharedTriggers implements SharedTriggers {
         @Override
-        public void putBlobs(
-                Multimap<BlobsTable.BlobsRow, ? extends BlobsTable.BlobsNamedColumnValue<?>> newRows) {
+        public void putBlobs(Multimap<BlobsTable.BlobsRow, ? extends BlobsTable.BlobsNamedColumnValue<?>> newRows) {
             // do nothing
         }
 
         @Override
         public void putBlobsSerializable(
-                Multimap<BlobsSerializableTable.BlobsSerializableRow, ? extends BlobsSerializableTable.BlobsSerializableNamedColumnValue<?>> newRows) {
+                Multimap<
+                                BlobsSerializableTable.BlobsSerializableRow,
+                                ? extends BlobsSerializableTable.BlobsSerializableNamedColumnValue<?>>
+                        newRows) {
             // do nothing
         }
 
         @Override
         public void putKvDynamicColumns(
-                Multimap<KvDynamicColumnsTable.KvDynamicColumnsRow, ? extends KvDynamicColumnsTable.KvDynamicColumnsColumnValue> newRows) {
+                Multimap<
+                                KvDynamicColumnsTable.KvDynamicColumnsRow,
+                                ? extends KvDynamicColumnsTable.KvDynamicColumnsColumnValue>
+                        newRows) {
             // do nothing
         }
 

--- a/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/BlobsSerializableTable.java
+++ b/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/BlobsSerializableTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class BlobsSerializableTable implements
         AtlasDbMutablePersistentTable<BlobsSerializableTable.BlobsSerializableRow,
                                          BlobsSerializableTable.BlobsSerializableNamedColumnValue<?>,
@@ -681,5 +681,5 @@ public final class BlobsSerializableTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "Ksn226nEGvq0mFO4uqxptw==";
+    static String __CLASS_HASH = "kEu4r6ZeyQGSln9x7e/bKg==";
 }

--- a/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/BlobsTable.java
+++ b/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/BlobsTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class BlobsTable implements
         AtlasDbMutablePersistentTable<BlobsTable.BlobsRow,
                                          BlobsTable.BlobsNamedColumnValue<?>,
@@ -681,5 +681,5 @@ public final class BlobsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "AmE2T3C2AbQbceIL0/mKfQ==";
+    static String __CLASS_HASH = "jj/KO9DsTJuZeuYVV0T+HQ==";
 }

--- a/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/KvDynamicColumnsTable.java
+++ b/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/KvDynamicColumnsTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class KvDynamicColumnsTable implements
         AtlasDbDynamicMutablePersistentTable<KvDynamicColumnsTable.KvDynamicColumnsRow,
                                                 KvDynamicColumnsTable.KvDynamicColumnsColumn,
@@ -833,5 +833,5 @@ public final class KvDynamicColumnsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "AUHX2d91IINW6dxAajKwcA==";
+    static String __CLASS_HASH = "afiyTnltfesp99pfyrOGSg==";
 }

--- a/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/KvRowsTable.java
+++ b/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/KvRowsTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class KvRowsTable implements
         AtlasDbMutablePersistentTable<KvRowsTable.KvRowsRow,
                                          KvRowsTable.KvRowsNamedColumnValue<?>,
@@ -799,5 +799,5 @@ public final class KvRowsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "Dp0AEqmMCvHJ8i3O4PdV1g==";
+    static String __CLASS_HASH = "qQ8yVU6mlFnS76qaOYTVtg==";
 }

--- a/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/MetadataTable.java
+++ b/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/MetadataTable.java
@@ -86,7 +86,7 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-@SuppressWarnings("all")
+@SuppressWarnings({"all", "deprecation"})
 public final class MetadataTable implements
         AtlasDbMutablePersistentTable<MetadataTable.MetadataRow,
                                          MetadataTable.MetadataNamedColumnValue<?>,
@@ -771,5 +771,5 @@ public final class MetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "dkVfxVk7XZMFHy54L2X7ZQ==";
+    static String __CLASS_HASH = "dODm8JfCNENQMGubJd/7+g==";
 }


### PR DESCRIPTION
**Goals (and why)**:
- Reduce load on Cassandra when sweeping tables that have highly referenced streams.

**Implementation Description (bullets)**:
- Use a getRowsColumnRange to retrieve at most one cell per row to check whether a stream is referenced.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Externally validated across the fleet
- There are some existing tests (e.g. TargetedSweepEteTest).

**Concerns (what feedback would you like?)**:
Did I accidentally break something? I verified that the erroneous log message was _never_ printed across the fleet for the past 10 days.

**Where should we start reviewing?**: `StreamTableRenderer`. The rest is generated code.

**Priority (whenever / two weeks / yesterday)**: this week
