### PR TITLE
[k8s TL] | Runtime clusterConfig

### DIFF
--- a/atlasdb-jepsen-tests/resources/atlasdb/timelock.yml
+++ b/atlasdb-jepsen-tests/resources/atlasdb/timelock.yml
@@ -3,7 +3,7 @@ install:
     is-new-service: true
 
 runtime:
-  cluster:
+  cluster-config-not-live-reloaded:
     local-server: <HOSTNAME>:8080
     cluster:
       security:

--- a/atlasdb-jepsen-tests/resources/atlasdb/timelock.yml
+++ b/atlasdb-jepsen-tests/resources/atlasdb/timelock.yml
@@ -1,4 +1,8 @@
 install:
+  paxos:
+    is-new-service: true
+
+runtime:
   cluster:
     local-server: <HOSTNAME>:8080
     cluster:
@@ -12,10 +16,6 @@ install:
         - n3:8080
         - n4:8080
         - n5:8080
-  paxos:
-    is-new-service: true
-
-runtime: {}
 
 server:
   applicationConnectors:

--- a/changelog/@unreleased/pr-5624.v2.yml
+++ b/changelog/@unreleased/pr-5624.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: ClusterConfiguration moved from TimeLockInstallConfig to TimeLockRuntimeConfig.
+    Note that the ClusterConfiguration will still not be live re-loaded.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5624

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResourcesFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResourcesFactory.java
@@ -32,6 +32,7 @@ import com.palantir.paxos.PaxosProposer;
 import com.palantir.paxos.PaxosProposerImpl;
 import com.palantir.paxos.SqliteConnections;
 import com.palantir.sls.versions.OrderableSlsVersion;
+import com.palantir.timelock.config.ClusterConfiguration;
 import com.palantir.timelock.config.PaxosInstallConfiguration.PaxosLeaderMode;
 import com.palantir.timelock.config.PaxosRuntimeConfiguration;
 import com.palantir.timelock.config.TimeLockInstallConfiguration;
@@ -287,6 +288,9 @@ public final class PaxosResourcesFactory {
         TimeLockInstallConfiguration install();
 
         @Value.Parameter
+        ClusterConfiguration cluster();
+
+        @Value.Parameter
         UserAgent userAgent();
 
         @Value.Parameter
@@ -307,12 +311,12 @@ public final class PaxosResourcesFactory {
 
         @Value.Derived
         default List<String> clusterAddresses() {
-            return PaxosRemotingUtils.getClusterAddresses(install());
+            return PaxosRemotingUtils.getClusterAddresses(cluster());
         }
 
         @Value.Derived
         default List<String> remoteUris() {
-            return PaxosRemotingUtils.getRemoteServerPaths(install());
+            return PaxosRemotingUtils.getRemoteServerPaths(cluster());
         }
 
         @Value.Derived
@@ -329,7 +333,7 @@ public final class PaxosResourcesFactory {
 
         @Value.Derived
         default Optional<TrustContext> trustContext() {
-            return PaxosRemotingUtils.getSslConfigurationOptional(install())
+            return PaxosRemotingUtils.getSslConfigurationOptional(cluster())
                     .map(SslSocketFactories::createTrustContext);
         }
 

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/ClusterConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/ClusterConfiguration.java
@@ -65,25 +65,4 @@ public interface ClusterConfiguration {
                 SafeArg.of("localServer", localServer()),
                 SafeArg.of("clusterMembers", clusterMembers()));
     }
-
-    @Value.Check
-    default void checkTopologyOffersHighAvailability() {
-        if (enableNonstandardAndPossiblyDangerousTopology()) {
-            return;
-        }
-
-        Preconditions.checkArgument(
-                clusterMembers().size() >= 3,
-                "This TimeLock cluster is set up to use an insufficient (< 3) number of servers, which is not a"
-                        + " standard configuration! With fewer than three servers, your service will not have high"
-                        + " availability. In the event a node goes down, timelock will become unresponsive, meaning"
-                        + " that ALL your AtlasDB clients will become unable to perform transactions. Furthermore, if"
-                        + " 1-node, your TimeLock  cluster has NO resilience to failures of the underlying storage"
-                        + " layer; if your disks fail, the timestamp information may be IRRECOVERABLY COMPROMISED,"
-                        + " meaning that your AtlasDB deployments may become completely unusable."
-                        + " If you know what you are doing and you want to run in this configuration, you must set"
-                        + " 'enableNonstandardAndPossiblyDangerousTopology' to true.",
-                SafeArg.of("clusterSize", clusterMembers().size()),
-                SafeArg.of("minimumClusterSize", 3));
-    }
 }

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/ClusterConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/ClusterConfiguration.java
@@ -52,6 +52,11 @@ public interface ClusterConfiguration {
         return false;
     }
 
+    @Value.Derived
+    default boolean isNewServiceNode() {
+        return knownNewServers().contains(localServer());
+    }
+
     @Value.Check
     default void checkClusterMembersIncludesLocalServer() {
         Preconditions.checkArgument(

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/ClusterInstallConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/ClusterInstallConfiguration.java
@@ -16,9 +16,13 @@
 
 package com.palantir.timelock.config;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 
 @Value.Immutable
+@JsonDeserialize(as = ImmutableClusterInstallConfiguration.class)
+@JsonSerialize(as = ImmutableClusterInstallConfiguration.class)
 public interface ClusterInstallConfiguration {
     @Value.Default
     default boolean enableNonstandardAndPossiblyDangerousTopology() {

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/ClusterInstallConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/ClusterInstallConfiguration.java
@@ -1,0 +1,27 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.timelock.config;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface ClusterInstallConfiguration {
+    @Value.Default
+    default boolean enableNonstandardAndPossiblyDangerousTopology() {
+        return false;
+    }
+}

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/RestrictedTimeLockRuntimeConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/RestrictedTimeLockRuntimeConfiguration.java
@@ -1,0 +1,63 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.timelock.config;
+
+import com.palantir.atlasdb.timelock.lock.watch.LockWatchTestRuntimeConfig;
+import java.util.Optional;
+
+public class RestrictedTimeLockRuntimeConfiguration extends TimeLockRuntimeConfiguration {
+    private final TimeLockRuntimeConfiguration runtime;
+
+    public RestrictedTimeLockRuntimeConfiguration(TimeLockRuntimeConfiguration runtime) {
+        this.runtime = runtime;
+    }
+
+    @Override
+    public PaxosRuntimeConfiguration paxos() {
+        return runtime.paxos();
+    }
+
+    @Override
+    public ClusterConfiguration clusterSnapshot() {
+        throw new UnsupportedOperationException("Cannot access live-reloaded cluster configuration!");
+    }
+
+    @Override
+    public Integer maxNumberOfClients() {
+        return runtime.maxNumberOfClients();
+    }
+
+    @Override
+    public long slowLockLogTriggerMillis() {
+        return runtime.slowLockLogTriggerMillis();
+    }
+
+    @Override
+    public LockWatchTestRuntimeConfig lockWatchTestConfig() {
+        return runtime.lockWatchTestConfig();
+    }
+
+    @Override
+    public TimeLockAdjudicationConfiguration adjudication() {
+        return runtime.adjudication();
+    }
+
+    @Override
+    public Optional<TsBoundPersisterRuntimeConfiguration> timestampBoundPersistence() {
+        return runtime.timestampBoundPersistence();
+    }
+}

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockInstallConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockInstallConfiguration.java
@@ -32,10 +32,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonIgnoreProperties(value = "asyncLock")
 public interface TimeLockInstallConfiguration {
-
     PaxosInstallConfiguration paxos();
-
-    ClusterConfiguration cluster();
 
     @Value.Default
     default boolean iAmOnThePersistenceTeamAndKnowWhatImDoingSkipSqliteConsistencyCheckAndTruncateFileBasedLog() {
@@ -61,9 +58,8 @@ public interface TimeLockInstallConfiguration {
     }
 
     @Value.Derived
-    default boolean isNewServiceNode() {
-        return paxos().isNewService()
-                || cluster().knownNewServers().contains(cluster().localServer());
+    default boolean isNewService() {
+        return paxos().isNewService();
     }
 
     static Builder builder() {

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockInstallConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockInstallConfiguration.java
@@ -36,7 +36,11 @@ public interface TimeLockInstallConfiguration {
     PaxosInstallConfiguration paxos();
 
     @Deprecated
-    ClusterInstallConfiguration cluster();
+    @Value.Default
+    default ClusterInstallConfiguration cluster() {
+        return ImmutableClusterInstallConfiguration.builder().build();
+    }
+    ;
 
     @Value.Default
     default boolean iAmOnThePersistenceTeamAndKnowWhatImDoingSkipSqliteConsistencyCheckAndTruncateFileBasedLog() {

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockInstallConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockInstallConfiguration.java
@@ -32,7 +32,11 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonIgnoreProperties(value = "asyncLock")
 public interface TimeLockInstallConfiguration {
+
     PaxosInstallConfiguration paxos();
+
+    @Deprecated
+    ClusterInstallConfiguration cluster();
 
     @Value.Default
     default boolean iAmOnThePersistenceTeamAndKnowWhatImDoingSkipSqliteConsistencyCheckAndTruncateFileBasedLog() {

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockInstallConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockInstallConfiguration.java
@@ -36,7 +36,8 @@ public interface TimeLockInstallConfiguration {
     PaxosInstallConfiguration paxos();
 
     /**
-     * The ClusterInstallConfiguration has been moved to {@link TimeLockRuntimeConfiguration#clusterSnapshot()}.
+     * @deprecated The ClusterInstallConfiguration has been moved to
+     * {@link TimeLockRuntimeConfiguration#clusterSnapshot()}.
      */
     @Deprecated
     @Value.Default

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockInstallConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockInstallConfiguration.java
@@ -40,7 +40,6 @@ public interface TimeLockInstallConfiguration {
     default ClusterInstallConfiguration cluster() {
         return ImmutableClusterInstallConfiguration.builder().build();
     }
-    ;
 
     @Value.Default
     default boolean iAmOnThePersistenceTeamAndKnowWhatImDoingSkipSqliteConsistencyCheckAndTruncateFileBasedLog() {

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockInstallConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockInstallConfiguration.java
@@ -35,6 +35,9 @@ public interface TimeLockInstallConfiguration {
 
     PaxosInstallConfiguration paxos();
 
+    /**
+     * The ClusterInstallConfiguration has been moved to {@link TimeLockRuntimeConfiguration#clusterSnapshot()}.
+     */
     @Deprecated
     @Value.Default
     default ClusterInstallConfiguration cluster() {

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockRuntimeConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockRuntimeConfiguration.java
@@ -26,6 +26,8 @@ import org.immutables.value.Value;
 
 /**
  * Dynamic (live-reloaded) portions of TimeLock's configuration.
+ *
+ * Note that the {@link ClusterConfiguration} is an exception to above rule.
  */
 @JsonDeserialize(as = ImmutableTimeLockRuntimeConfiguration.class)
 @JsonSerialize(as = ImmutableTimeLockRuntimeConfiguration.class)
@@ -38,6 +40,11 @@ public abstract class TimeLockRuntimeConfiguration {
         return ImmutablePaxosRuntimeConfiguration.builder().build();
     }
 
+    /**
+     * As of now, TimeLock is not equipped to handle live-changes in the cluster configuration. For this reason,
+     * TimeLock must be initialized with a snapshot of the clusterConfiguration which is not live-reloaded instead of
+     * accessing ClusterConfiguration via {@code TimeLockRuntimeConfiguration.cluster()}.
+     * */
     @JsonProperty("cluster-config-not-live-reloaded")
     public abstract ClusterConfiguration cluster();
 

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockRuntimeConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockRuntimeConfiguration.java
@@ -38,6 +38,7 @@ public abstract class TimeLockRuntimeConfiguration {
         return ImmutablePaxosRuntimeConfiguration.builder().build();
     }
 
+    @JsonProperty("cluster-config-not-live-reloaded")
     public abstract ClusterConfiguration cluster();
 
     /**

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockRuntimeConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockRuntimeConfiguration.java
@@ -38,6 +38,8 @@ public abstract class TimeLockRuntimeConfiguration {
         return ImmutablePaxosRuntimeConfiguration.builder().build();
     }
 
+    public abstract ClusterConfiguration cluster();
+
     /**
      * The maximum number of client namespaces to allow. Each distinct client consumes some amount of memory and disk
      * space.

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockRuntimeConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockRuntimeConfiguration.java
@@ -46,7 +46,7 @@ public abstract class TimeLockRuntimeConfiguration {
      * accessing ClusterConfiguration via {@code TimeLockRuntimeConfiguration.cluster()}.
      * */
     @JsonProperty("cluster-config-not-live-reloaded")
-    public abstract ClusterConfiguration cluster();
+    public abstract ClusterConfiguration clusterSnapshot();
 
     /**
      * The maximum number of client namespaces to allow. Each distinct client consumes some amount of memory and disk

--- a/timelock-agent/src/main/java/com/palantir/timelock/invariants/TimeLockActivityCheckerFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/invariants/TimeLockActivityCheckerFactory.java
@@ -23,25 +23,25 @@ import com.palantir.atlasdb.factory.ServiceCreator;
 import com.palantir.atlasdb.timelock.api.ConjureTimelockService;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.conjure.java.api.config.service.UserAgent;
-import com.palantir.timelock.config.TimeLockInstallConfiguration;
+import com.palantir.timelock.config.ClusterConfiguration;
 import com.palantir.timelock.paxos.PaxosRemotingUtils;
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class TimeLockActivityCheckerFactory {
-    private final TimeLockInstallConfiguration installConfiguration;
+    private final ClusterConfiguration cluster;
     private final MetricsManager metricsManager;
     private final UserAgent userAgent;
 
     public TimeLockActivityCheckerFactory(
-            TimeLockInstallConfiguration installConfiguration, MetricsManager metricsManager, UserAgent userAgent) {
-        this.installConfiguration = installConfiguration;
+            ClusterConfiguration cluster, MetricsManager metricsManager, UserAgent userAgent) {
+        this.cluster = cluster;
         this.metricsManager = metricsManager;
         this.userAgent = userAgent;
     }
 
     public List<TimeLockActivityChecker> getTimeLockActivityCheckers() {
-        return installConfiguration.cluster().clusterMembers().stream()
+        return cluster.clusterMembers().stream()
                 .map(this::createServiceCreatorForRemote)
                 .map(creator -> creator.createService(ConjureTimelockService.class))
                 .map(TimeLockActivityChecker::new)
@@ -55,9 +55,9 @@ public class TimeLockActivityCheckerFactory {
 
     private ServerListConfig getServerListConfig(String remoteUrl) {
         return ImmutableServerListConfig.builder()
-                .addServers(PaxosRemotingUtils.addProtocol(installConfiguration, remoteUrl))
-                .sslConfiguration(installConfiguration.cluster().cluster().security())
-                .proxyConfiguration(installConfiguration.cluster().cluster().proxyConfiguration())
+                .addServers(PaxosRemotingUtils.addProtocol(cluster, remoteUrl))
+                .sslConfiguration(cluster.cluster().security())
+                .proxyConfiguration(cluster.cluster().proxyConfiguration())
                 .build();
     }
 }

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/PaxosRemotingUtils.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/PaxosRemotingUtils.java
@@ -63,19 +63,17 @@ public final class PaxosRemotingUtils {
         return addresses.stream().map(address -> addProtocol(cluster, address)).collect(Collectors.toList());
     }
 
-    public static URL convertAddressToUrl(ClusterConfiguration cluster) {
+    public static URL convertAddressToUrl(ClusterConfiguration cluster, String address) {
         try {
-            return UriBuilder.fromPath(addProtocol(cluster, cluster.localServer()))
-                    .build()
-                    .toURL();
+            return UriBuilder.fromPath(addProtocol(cluster, address)).build().toURL();
         } catch (MalformedURLException e) {
             throw new RuntimeException(e);
         }
     }
 
-    public static List<URL> convertAddressesToUrls(ClusterConfiguration cluster) {
-        return cluster.clusterMembers().stream()
-                .map(address -> convertAddressToUrl(cluster))
+    public static List<URL> convertAddressesToUrls(ClusterConfiguration cluster, List<String> addresses) {
+        return addresses.stream()
+                .map(address -> convertAddressToUrl(cluster, address))
                 .collect(Collectors.toList());
     }
 }

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/PaxosRemotingUtils.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/PaxosRemotingUtils.java
@@ -18,7 +18,6 @@ package com.palantir.timelock.paxos;
 import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
 import com.palantir.timelock.config.ClusterConfiguration;
-import com.palantir.timelock.config.TimeLockInstallConfiguration;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -37,48 +36,46 @@ public final class PaxosRemotingUtils {
         return elements.size() / 2 + 1;
     }
 
-    public static List<String> getRemoteServerPaths(TimeLockInstallConfiguration install) {
-        return addProtocols(install, getRemoteServerAddresses(install));
+    public static List<String> getRemoteServerPaths(ClusterConfiguration cluster) {
+        return addProtocols(cluster, getRemoteServerAddresses(cluster));
     }
 
-    public static ImmutableList<String> getClusterAddresses(TimeLockInstallConfiguration install) {
-        return ImmutableList.copyOf(getClusterConfiguration(install).clusterMembers());
+    public static ImmutableList<String> getClusterAddresses(ClusterConfiguration cluster) {
+        return ImmutableList.copyOf(cluster.clusterMembers());
     }
 
-    public static List<String> getRemoteServerAddresses(TimeLockInstallConfiguration install) {
-        List<String> result = new ArrayList<>(getClusterAddresses(install));
-        result.remove(install.cluster().localServer());
+    public static List<String> getRemoteServerAddresses(ClusterConfiguration cluster) {
+        List<String> result = new ArrayList<>(getClusterAddresses(cluster));
+        result.remove(cluster.localServer());
         return ImmutableList.copyOf(result);
     }
 
-    public static ClusterConfiguration getClusterConfiguration(TimeLockInstallConfiguration install) {
-        return install.cluster();
+    public static Optional<SslConfiguration> getSslConfigurationOptional(ClusterConfiguration cluster) {
+        return cluster.cluster().security();
     }
 
-    public static Optional<SslConfiguration> getSslConfigurationOptional(TimeLockInstallConfiguration install) {
-        return getClusterConfiguration(install).cluster().security();
-    }
-
-    public static String addProtocol(TimeLockInstallConfiguration install, String address) {
-        String protocolPrefix = getSslConfigurationOptional(install).isPresent() ? "https://" : "http://";
+    public static String addProtocol(ClusterConfiguration cluster, String address) {
+        String protocolPrefix = getSslConfigurationOptional(cluster).isPresent() ? "https://" : "http://";
         return protocolPrefix + address;
     }
 
-    public static List<String> addProtocols(TimeLockInstallConfiguration install, List<String> addresses) {
-        return addresses.stream().map(address -> addProtocol(install, address)).collect(Collectors.toList());
+    public static List<String> addProtocols(ClusterConfiguration cluster, List<String> addresses) {
+        return addresses.stream().map(address -> addProtocol(cluster, address)).collect(Collectors.toList());
     }
 
-    public static URL convertAddressToUrl(TimeLockInstallConfiguration install, String address) {
+    public static URL convertAddressToUrl(ClusterConfiguration cluster) {
         try {
-            return UriBuilder.fromPath(addProtocol(install, address)).build().toURL();
+            return UriBuilder.fromPath(addProtocol(cluster, cluster.localServer()))
+                    .build()
+                    .toURL();
         } catch (MalformedURLException e) {
             throw new RuntimeException(e);
         }
     }
 
-    public static List<URL> convertAddressesToUrls(TimeLockInstallConfiguration install, List<String> addresses) {
-        return addresses.stream()
-                .map(address -> convertAddressToUrl(install, address))
+    public static List<URL> convertAddressesToUrls(ClusterConfiguration cluster) {
+        return cluster.clusterMembers().stream()
+                .map(address -> convertAddressToUrl(cluster))
                 .collect(Collectors.toList());
     }
 }

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -503,8 +503,8 @@ public class TimeLockAgent {
     }
 
     private RedirectRetryTargeter redirectRetryTargeter() {
-        URL localServer = PaxosRemotingUtils.convertAddressToUrl(cluster);
-        List<URL> clusterUrls = PaxosRemotingUtils.convertAddressesToUrls(cluster);
+        URL localServer = PaxosRemotingUtils.convertAddressToUrl(cluster, cluster.localServer());
+        List<URL> clusterUrls = PaxosRemotingUtils.convertAddressesToUrls(cluster, cluster.clusterMembers());
         return RedirectRetryTargeter.create(localServer, clusterUrls);
     }
 

--- a/timelock-agent/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClientsTest.java
+++ b/timelock-agent/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClientsTest.java
@@ -60,11 +60,6 @@ public class PaxosRemoteClientsTest {
                 .leaderMode(PaxosInstallConfiguration.PaxosLeaderMode.SINGLE_LEADER)
                 .build();
         installConfiguration = TimeLockInstallConfiguration.builder()
-                .cluster(ImmutableDefaultClusterConfiguration.builder()
-                        .localServer("a:1")
-                        .cluster(
-                                PartialServiceConfiguration.of(ImmutableList.of("a:1", "b:2", "c:3"), Optional.empty()))
-                        .build())
                 .paxos(paxosInstallConfiguration) // Normally awful, but too onerous to set up
                 .timestampBoundPersistence(
                         ImmutablePaxosTsBoundPersisterConfiguration.builder().build())
@@ -74,6 +69,11 @@ public class PaxosRemoteClientsTest {
                 .thenAnswer(invocation -> mock(invocation.getArgument(1)));
         context = ImmutableTimelockPaxosInstallationContext.builder()
                 .install(installConfiguration)
+                .cluster(ImmutableDefaultClusterConfiguration.builder()
+                        .localServer("a:1")
+                        .cluster(
+                                PartialServiceConfiguration.of(ImmutableList.of("a:1", "b:2", "c:3"), Optional.empty()))
+                        .build())
                 .dialogueServiceProvider(dialogueServiceProvider)
                 .userAgent(UserAgent.of(UserAgent.Agent.of("aaa", "1.2.3")))
                 .timeLockVersion(OrderableSlsVersion.valueOf("0.0.0"))

--- a/timelock-agent/src/test/java/com/palantir/timelock/config/ClusterConfigurationTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/config/ClusterConfigurationTest.java
@@ -43,7 +43,9 @@ public class ClusterConfigurationTest {
         assertThatIllegalArgumentException().isThrownBy(builder::build);
     }
 
-    // Todo(snanda): Remove ignore when ClusterInstallConfig is killed
+    // TODO(snanda): These tests are ignored for now as the config check has been moved to
+    //  TimeLockAgent#verifyTopologyOffersHighAvailability. The tests will be valid when ClusterInstallConfiguration
+    //  is killed.
     @Ignore
     @Test
     public void shouldThrowIfConfigurationContainsOneServerAndDisclaimerNotEnabled() {

--- a/timelock-agent/src/test/java/com/palantir/timelock/config/ClusterConfigurationTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/config/ClusterConfigurationTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class ClusterConfigurationTest {
@@ -42,11 +43,14 @@ public class ClusterConfigurationTest {
         assertThatIllegalArgumentException().isThrownBy(builder::build);
     }
 
+    // Todo(snanda): Remove ignore when ClusterInstallConfig is killed
+    @Ignore
     @Test
     public void shouldThrowIfConfigurationContainsOneServerAndDisclaimerNotEnabled() {
         assertConfigurationWithFixedNumberOfServersIsInvalidWithoutDisclaimer(1);
     }
 
+    @Ignore
     @Test
     public void shouldThrowIfConfigurationContainsTwoServersAndDisclaimerNotEnabled() {
         assertConfigurationWithFixedNumberOfServersIsInvalidWithoutDisclaimer(2);

--- a/timelock-agent/src/test/java/com/palantir/timelock/config/TimeLockInstallConfigurationTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/config/TimeLockInstallConfigurationTest.java
@@ -18,13 +18,10 @@ package com.palantir.timelock.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.collect.ImmutableList;
-import com.palantir.conjure.java.api.config.service.PartialServiceConfiguration;
 import com.palantir.timelock.config.PaxosInstallConfiguration.PaxosLeaderMode;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
-import java.util.Optional;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,15 +30,6 @@ import org.junit.rules.TemporaryFolder;
 public class TimeLockInstallConfigurationTest {
     @Rule
     public final TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-    private static final String SERVER_A = "horses-for-courses:1234";
-    public static final String SERVER_B = "paddock-and-chips:2345";
-    private static final ClusterConfiguration CLUSTER_CONFIG = ImmutableDefaultClusterConfiguration.builder()
-            .localServer(SERVER_A)
-            .cluster(PartialServiceConfiguration.of(
-                    ImmutableList.of(SERVER_A, SERVER_B, "the-mane-event:3456"), Optional.empty()))
-            .addKnownNewServers(SERVER_B)
-            .build();
 
     private File newPaxosLogDirectory;
     private File newSqliteLogDirectory;
@@ -62,37 +50,19 @@ public class TimeLockInstallConfigurationTest {
     @Test
     public void newServiceIfNewServiceFlagSetToTrue() {
         assertThat(TimeLockInstallConfiguration.builder()
-                        .cluster(CLUSTER_CONFIG)
                         .paxos(createPaxosInstall(true, false))
                         .build()
-                        .isNewServiceNode())
+                        .isNewService())
                 .isTrue();
     }
 
     @Test
     public void existingServiceIfNewServiceFlagSetToFalse() {
         assertThat(TimeLockInstallConfiguration.builder()
-                        .cluster(CLUSTER_CONFIG)
                         .paxos(createPaxosInstall(false, true))
                         .build()
-                        .isNewServiceNode())
+                        .isNewService())
                 .isFalse();
-    }
-
-    @Test
-    public void newNodeInExistingServiceRecognisedAsNew() {
-        assertThat(TimeLockInstallConfiguration.builder()
-                        .cluster(ImmutableDefaultClusterConfiguration.builder()
-                                .localServer(SERVER_A)
-                                .cluster(PartialServiceConfiguration.of(
-                                        ImmutableList.of(SERVER_A, SERVER_B, "hoof-moved-my-cheese:4567"),
-                                        Optional.empty()))
-                                .addKnownNewServers(SERVER_A)
-                                .build())
-                        .paxos(createPaxosInstall(false, false))
-                        .build()
-                        .isNewServiceNode())
-                .isTrue();
     }
 
     private PaxosInstallConfiguration createPaxosInstall(boolean isNewService, boolean shouldDirectoriesExist) {

--- a/timelock-agent/src/test/java/com/palantir/timelock/config/TimeLockPersistenceInvariantsTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/config/TimeLockPersistenceInvariantsTest.java
@@ -21,21 +21,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.common.collect.ImmutableList;
-import com.palantir.conjure.java.api.config.service.PartialServiceConfiguration;
 import java.io.File;
 import java.io.IOException;
-import java.util.Optional;
 import org.junit.Test;
 
 public class TimeLockPersistenceInvariantsTest {
-
-    private static final String SERVER_A = "a";
-    private static final ClusterConfiguration CLUSTER_CONFIG = ImmutableDefaultClusterConfiguration.builder()
-            .localServer(SERVER_A)
-            .cluster(PartialServiceConfiguration.of(ImmutableList.of(SERVER_A, "b", "c"), Optional.empty()))
-            .build();
-
     @Test
     public void doesNotCreateDirectoryForPaxosDirectoryIfNewService() throws IOException {
         File mockFile = getMockFileWith(false, true);
@@ -68,9 +58,6 @@ public class TimeLockPersistenceInvariantsTest {
     @SuppressWarnings("CheckReturnValue")
     private void assertCanBuildConfiguration(ImmutablePaxosInstallConfiguration.Builder configBuilder) {
         PaxosInstallConfiguration installConfiguration = configBuilder.build();
-        TimeLockInstallConfiguration.builder()
-                .cluster(CLUSTER_CONFIG)
-                .paxos(installConfiguration)
-                .build();
+        TimeLockInstallConfiguration.builder().paxos(installConfiguration).build();
     }
 }

--- a/timelock-agent/src/test/java/com/palantir/timelock/config/TimeLockRuntimeConfigurationTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/config/TimeLockRuntimeConfigurationTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 @SuppressWarnings("CheckReturnValue")
 public class TimeLockRuntimeConfigurationTest {
     private static final String SERVER_A = "horses-for-courses:1234";
-    public static final String SERVER_B = "paddock-and-chips:2345";
+    private static final String SERVER_B = "paddock-and-chips:2345";
     private static final ClusterConfiguration CLUSTER_CONFIG = ImmutableDefaultClusterConfiguration.builder()
             .localServer(SERVER_A)
             .cluster(PartialServiceConfiguration.of(
@@ -36,13 +36,15 @@ public class TimeLockRuntimeConfigurationTest {
 
     @Test
     public void canCreateWithZeroClients() {
-        ImmutableTimeLockRuntimeConfiguration.builder().cluster(CLUSTER_CONFIG).build();
+        ImmutableTimeLockRuntimeConfiguration.builder()
+                .clusterSnapshot(CLUSTER_CONFIG)
+                .build();
     }
 
     @Test
     public void canSpecifyPositiveLockLoggerTimeout() {
         ImmutableTimeLockRuntimeConfiguration.builder()
-                .cluster(CLUSTER_CONFIG)
+                .clusterSnapshot(CLUSTER_CONFIG)
                 .slowLockLogTriggerMillis(1L)
                 .build();
     }
@@ -50,7 +52,7 @@ public class TimeLockRuntimeConfigurationTest {
     @Test
     public void throwOnNegativeLeaderPingResponseWait() {
         assertThatThrownBy(() -> ImmutableTimeLockRuntimeConfiguration.builder()
-                        .cluster(CLUSTER_CONFIG)
+                        .clusterSnapshot(CLUSTER_CONFIG)
                         .slowLockLogTriggerMillis(-1L)
                         .build())
                 .isInstanceOf(IllegalStateException.class);
@@ -59,7 +61,7 @@ public class TimeLockRuntimeConfigurationTest {
     @Test
     public void newNodeInExistingServiceRecognisedAsNew() {
         assertThat(ImmutableTimeLockRuntimeConfiguration.builder()
-                        .cluster(ImmutableDefaultClusterConfiguration.builder()
+                        .clusterSnapshot(ImmutableDefaultClusterConfiguration.builder()
                                 .localServer(SERVER_A)
                                 .cluster(PartialServiceConfiguration.of(
                                         ImmutableList.of(SERVER_A, SERVER_B, "hoof-moved-my-cheese:4567"),
@@ -67,7 +69,7 @@ public class TimeLockRuntimeConfigurationTest {
                                 .addKnownNewServers(SERVER_A)
                                 .build())
                         .build()
-                        .cluster()
+                        .clusterSnapshot()
                         .isNewServiceNode())
                 .isTrue();
     }

--- a/timelock-agent/src/test/java/com/palantir/timelock/config/TimeLockRuntimeConfigurationTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/config/TimeLockRuntimeConfigurationTest.java
@@ -27,15 +27,22 @@ import org.junit.Test;
 public class TimeLockRuntimeConfigurationTest {
     private static final String SERVER_A = "horses-for-courses:1234";
     public static final String SERVER_B = "paddock-and-chips:2345";
+    private static final ClusterConfiguration CLUSTER_CONFIG = ImmutableDefaultClusterConfiguration.builder()
+            .localServer(SERVER_A)
+            .cluster(PartialServiceConfiguration.of(
+                    ImmutableList.of(SERVER_A, SERVER_B, "the-mane-event:3456"), Optional.empty()))
+            .addKnownNewServers(SERVER_B)
+            .build();
 
     @Test
     public void canCreateWithZeroClients() {
-        ImmutableTimeLockRuntimeConfiguration.builder().build();
+        ImmutableTimeLockRuntimeConfiguration.builder().cluster(CLUSTER_CONFIG).build();
     }
 
     @Test
     public void canSpecifyPositiveLockLoggerTimeout() {
         ImmutableTimeLockRuntimeConfiguration.builder()
+                .cluster(CLUSTER_CONFIG)
                 .slowLockLogTriggerMillis(1L)
                 .build();
     }
@@ -43,6 +50,7 @@ public class TimeLockRuntimeConfigurationTest {
     @Test
     public void throwOnNegativeLeaderPingResponseWait() {
         assertThatThrownBy(() -> ImmutableTimeLockRuntimeConfiguration.builder()
+                        .cluster(CLUSTER_CONFIG)
                         .slowLockLogTriggerMillis(-1L)
                         .build())
                 .isInstanceOf(IllegalStateException.class);

--- a/timelock-agent/src/test/java/com/palantir/timelock/paxos/PaxosRemotingUtilsTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/paxos/PaxosRemotingUtilsTest.java
@@ -26,7 +26,6 @@ import com.palantir.paxos.PaxosAcceptor;
 import com.palantir.timelock.config.ClusterConfiguration;
 import com.palantir.timelock.config.ImmutableDefaultClusterConfiguration;
 import com.palantir.timelock.config.PaxosInstallConfiguration;
-import com.palantir.timelock.config.TimeLockInstallConfiguration;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Paths;
@@ -44,12 +43,6 @@ public class PaxosRemotingUtilsTest {
                     .addAllUris(CLUSTER_URIS)
                     .build())
             .build();
-    private static final PaxosInstallConfiguration PAXOS_CONFIGURATION = createPaxosConfiguration();
-    private static final TimeLockInstallConfiguration NO_SSL_TIMELOCK = TimeLockInstallConfiguration.builder()
-            .paxos(PAXOS_CONFIGURATION)
-            .cluster(NO_SSL_CLUSTER)
-            .build();
-
     private static final SslConfiguration SSL_CONFIGURATION = SslConfiguration.of(Paths.get("dev", "null"));
     private static final ClusterConfiguration SSL_CLUSTER = ImmutableDefaultClusterConfiguration.builder()
             .localServer("foo:1")
@@ -57,10 +50,6 @@ public class PaxosRemotingUtilsTest {
                     .addAllUris(CLUSTER_URIS)
                     .security(SSL_CONFIGURATION)
                     .build())
-            .build();
-    private static final TimeLockInstallConfiguration SSL_TIMELOCK = TimeLockInstallConfiguration.builder()
-            .paxos(PAXOS_CONFIGURATION)
-            .cluster(SSL_CLUSTER)
             .build();
 
     @Test
@@ -95,68 +84,62 @@ public class PaxosRemotingUtilsTest {
     @Test
     public void canGetRemoteServerPaths() {
         // foo should not be present, because it is the local server
-        assertThat(PaxosRemotingUtils.getRemoteServerPaths(SSL_TIMELOCK))
+        assertThat(PaxosRemotingUtils.getRemoteServerPaths(SSL_CLUSTER))
                 .isEqualTo(ImmutableList.of("https://bar:2", "https://baz:3"));
     }
 
     @Test
     public void canGetClusterAddresses() {
-        assertThat(PaxosRemotingUtils.getClusterAddresses(SSL_TIMELOCK))
+        assertThat(PaxosRemotingUtils.getClusterAddresses(SSL_CLUSTER))
                 .isEqualTo(ImmutableList.of("foo:1", "bar:2", "baz:3"));
     }
 
     @Test
     public void canGetRemoteServerAddresses() {
-        assertThat(PaxosRemotingUtils.getRemoteServerAddresses(SSL_TIMELOCK))
+        assertThat(PaxosRemotingUtils.getRemoteServerAddresses(SSL_CLUSTER))
                 .isEqualTo(ImmutableList.of("bar:2", "baz:3"));
     }
 
     @Test
-    public void canGetClusterConfiguration() {
-        assertThat(PaxosRemotingUtils.getClusterConfiguration(SSL_TIMELOCK)).isEqualTo(SSL_CLUSTER);
-        assertThat(PaxosRemotingUtils.getClusterConfiguration(NO_SSL_TIMELOCK)).isEqualTo(NO_SSL_CLUSTER);
-    }
-
-    @Test
     public void canGetSslConfiguration() {
-        assertThat(PaxosRemotingUtils.getSslConfigurationOptional(SSL_TIMELOCK))
+        assertThat(PaxosRemotingUtils.getSslConfigurationOptional(SSL_CLUSTER))
                 .isEqualTo(Optional.of(SSL_CONFIGURATION));
-        assertThat(PaxosRemotingUtils.getSslConfigurationOptional(NO_SSL_TIMELOCK))
+        assertThat(PaxosRemotingUtils.getSslConfigurationOptional(NO_SSL_CLUSTER))
                 .isNotPresent();
     }
 
     @Test
     public void addProtocolAddsHttpIfSslNotPresent() {
-        assertThat(PaxosRemotingUtils.addProtocol(NO_SSL_TIMELOCK, "atlasdb:1234"))
+        assertThat(PaxosRemotingUtils.addProtocol(NO_SSL_CLUSTER, "atlasdb:1234"))
                 .isEqualTo("http://atlasdb:1234");
     }
 
     @Test
     public void addProtocolAddsHttpsIfSslPresent() {
-        assertThat(PaxosRemotingUtils.addProtocol(SSL_TIMELOCK, "atlasdb:1234")).isEqualTo("https://atlasdb:1234");
+        assertThat(PaxosRemotingUtils.addProtocol(SSL_CLUSTER, "atlasdb:1234")).isEqualTo("https://atlasdb:1234");
     }
 
     @Test
     public void addProtocolsAddsHttpIfSslNotPresent() {
-        assertThat(PaxosRemotingUtils.addProtocols(NO_SSL_TIMELOCK, ImmutableList.of("foo:1", "bar:2")))
+        assertThat(PaxosRemotingUtils.addProtocols(NO_SSL_CLUSTER, ImmutableList.of("foo:1", "bar:2")))
                 .isEqualTo(ImmutableList.of("http://foo:1", "http://bar:2"));
     }
 
     @Test
     public void addProtocolsAddsHttpsIfSslPresent() {
-        assertThat(PaxosRemotingUtils.addProtocols(SSL_TIMELOCK, ImmutableList.of("foo:1", "bar:2")))
+        assertThat(PaxosRemotingUtils.addProtocols(SSL_CLUSTER, ImmutableList.of("foo:1", "bar:2")))
                 .isEqualTo(ImmutableList.of("https://foo:1", "https://bar:2"));
     }
 
     @Test
     public void convertAddressToUrlCreatesComponentsCorrectly_NoSsl() throws MalformedURLException {
-        assertThat(PaxosRemotingUtils.convertAddressToUrl(NO_SSL_TIMELOCK, "foo:42/timelock/api/timelock"))
+        assertThat(PaxosRemotingUtils.convertAddressToUrl(NO_SSL_CLUSTER, "foo:42/timelock/api/timelock"))
                 .isEqualTo(new URL("http", "foo", 42, "/timelock/api/timelock"));
     }
 
     @Test
     public void convertAddressToUrlCreatesComponentsCorrectly_Ssl() throws MalformedURLException {
-        assertThat(PaxosRemotingUtils.convertAddressToUrl(SSL_TIMELOCK, "foo:42/api/bar/baz/bzzt"))
+        assertThat(PaxosRemotingUtils.convertAddressToUrl(SSL_CLUSTER, "foo:42/api/bar/baz/bzzt"))
                 .isEqualTo(new URL("https", "foo", 42, "/api/bar/baz/bzzt"));
     }
 

--- a/timelock-agent/src/test/java/com/palantir/timelock/paxos/PaxosRemotingUtilsTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/paxos/PaxosRemotingUtilsTest.java
@@ -16,8 +16,6 @@
 package com.palantir.timelock.paxos;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.java.api.config.service.PartialServiceConfiguration;
@@ -25,7 +23,6 @@ import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
 import com.palantir.paxos.PaxosAcceptor;
 import com.palantir.timelock.config.ClusterConfiguration;
 import com.palantir.timelock.config.ImmutableDefaultClusterConfiguration;
-import com.palantir.timelock.config.PaxosInstallConfiguration;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Paths;
@@ -141,11 +138,5 @@ public class PaxosRemotingUtilsTest {
     public void convertAddressToUrlCreatesComponentsCorrectly_Ssl() throws MalformedURLException {
         assertThat(PaxosRemotingUtils.convertAddressToUrl(SSL_CLUSTER, "foo:42/api/bar/baz/bzzt"))
                 .isEqualTo(new URL("https", "foo", 42, "/api/bar/baz/bzzt"));
-    }
-
-    private static PaxosInstallConfiguration createPaxosConfiguration() {
-        PaxosInstallConfiguration installConfiguration = mock(PaxosInstallConfiguration.class);
-        when(installConfiguration.isNewService()).thenReturn(true);
-        return installConfiguration;
     }
 }

--- a/timelock-agent/src/test/java/com/palantir/timelock/paxos/TimeLockAgentTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/paxos/TimeLockAgentTest.java
@@ -175,7 +175,7 @@ public class TimeLockAgentTest {
     }
 
     @Test
-    public void throwIfStartedWithLessThanThreeServers_DangerousTopologyNotEnabled() {
+    public void throwsIfStartedWithLessThanThreeServers_dangerousTopologyNotEnabled() {
         DefaultClusterConfiguration dangerousTopologyConfig = ImmutableDefaultClusterConfiguration.builder()
                 .localServer(SERVER_A)
                 .cluster(PartialServiceConfiguration.of(ImmutableList.of(SERVER_A, SERVER_B), Optional.empty()))
@@ -189,7 +189,7 @@ public class TimeLockAgentTest {
     }
 
     @Test
-    public void doNotIfStartedWithLessThanThreeServers_DangerousTopologyEnabledInInstallConfig() {
+    public void doesNotThrowIfStartedWithLessThanThreeServers_dangerousTopologyEnabledInInstallConfig() {
         DefaultClusterConfiguration dangerousTopologyConfig = ImmutableDefaultClusterConfiguration.builder()
                 .localServer(SERVER_A)
                 .cluster(PartialServiceConfiguration.of(ImmutableList.of(SERVER_A, SERVER_B), Optional.empty()))
@@ -206,7 +206,7 @@ public class TimeLockAgentTest {
     }
 
     @Test
-    public void doNotIfStartedWithLessThanThreeServers_DangerousTopologyEnabledInRuntimeConfig() {
+    public void doesNotThrowIfStartedWithLessThanThreeServers_dangerousTopologyEnabledInRuntimeConfig() {
         DefaultClusterConfiguration dangerousTopologyConfig = ImmutableDefaultClusterConfiguration.builder()
                 .localServer(SERVER_A)
                 .cluster(PartialServiceConfiguration.of(ImmutableList.of(SERVER_A, SERVER_B), Optional.empty()))

--- a/timelock-agent/src/test/java/com/palantir/timelock/paxos/TimeLockAgentTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/paxos/TimeLockAgentTest.java
@@ -133,10 +133,9 @@ public class TimeLockAgentTest {
     public void newServiceNotSetNoDataDirectoryThrows() {
         assertThatThrownBy(() -> TimeLockAgent.verifyIsNewServiceInvariant(
                         TimeLockInstallConfiguration.builder()
-                                .cluster(CLUSTER_CONFIG)
                                 .paxos(createPaxosInstall(false, false))
                                 .build(),
-                        runtime.get()))
+                        CLUSTER_CONFIG))
                 .isInstanceOf(SafeIllegalArgumentException.class);
     }
 
@@ -144,10 +143,9 @@ public class TimeLockAgentTest {
     public void newServiceSetNoDataDirectoryExistsThrows() {
         assertThatThrownBy(() -> TimeLockAgent.verifyIsNewServiceInvariant(
                         TimeLockInstallConfiguration.builder()
-                                .cluster(CLUSTER_CONFIG)
                                 .paxos(createPaxosInstall(true, true))
                                 .build(),
-                        runtime.get()))
+                        CLUSTER_CONFIG))
                 .isInstanceOf(SafeIllegalArgumentException.class);
     }
 
@@ -155,10 +153,9 @@ public class TimeLockAgentTest {
     public void newServiceNotSetNoDataDirectoryDoesNotThrowWhenIgnoreFlagSet() {
         assertThatCode(() -> TimeLockAgent.verifyIsNewServiceInvariant(
                         TimeLockInstallConfiguration.builder()
-                                .cluster(CLUSTER_CONFIG)
                                 .paxos(createPaxosInstall(false, false, true))
                                 .build(),
-                        runtime.get()))
+                        CLUSTER_CONFIG))
                 .doesNotThrowAnyException();
     }
 
@@ -166,10 +163,9 @@ public class TimeLockAgentTest {
     public void newServiceSetNoDataDirectoryExistsDoesNotThrowWhenIgnoreFlagSet() {
         assertThatCode(() -> TimeLockAgent.verifyIsNewServiceInvariant(
                         TimeLockInstallConfiguration.builder()
-                                .cluster(CLUSTER_CONFIG)
                                 .paxos(createPaxosInstall(true, true, true))
                                 .build(),
-                        runtime.get()))
+                        CLUSTER_CONFIG))
                 .doesNotThrowAnyException();
     }
 
@@ -201,13 +197,12 @@ public class TimeLockAgentTest {
 
         assertThatThrownBy(() -> TimeLockAgent.verifyIsNewServiceInvariant(
                         TimeLockInstallConfiguration.builder()
-                                .cluster(differentClusterConfig)
                                 .paxos(PaxosInstallConfiguration.builder()
                                         .dataDirectory(mockFile)
                                         .isNewService(false)
                                         .build())
                                 .build(),
-                        runtime.get()))
+                        CLUSTER_CONFIG))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -241,10 +236,9 @@ public class TimeLockAgentTest {
         PaxosInstallConfiguration installConfiguration = configBuilder.build();
         assertThatThrownBy(() -> TimeLockAgent.verifyIsNewServiceInvariant(
                         TimeLockInstallConfiguration.builder()
-                                .cluster(CLUSTER_CONFIG)
                                 .paxos(installConfiguration)
                                 .build(),
-                        runtime.get()))
+                        CLUSTER_CONFIG))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/timelock-agent/src/test/java/com/palantir/timelock/paxos/TimeLockAgentTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/paxos/TimeLockAgentTest.java
@@ -103,6 +103,7 @@ public class TimeLockAgentTest {
         assertThatThrownBy(() ->
                         TimeLockAgent.getKeyValueServiceRuntimeConfig(ImmutableTimeLockRuntimeConfiguration.builder()
                                 .timestampBoundPersistence(mock(TsBoundPersisterRuntimeConfiguration.class))
+                                .cluster(CLUSTER_CONFIG)
                                 .build()))
                 .isInstanceOf(SafeIllegalStateException.class)
                 .hasMessageContaining("Should not initialise DB Timelock with non-database runtime configuration");
@@ -110,8 +111,9 @@ public class TimeLockAgentTest {
 
     @Test
     public void getKeyValueServiceRuntimeConfigReturnsEmptyIfNotProvided() {
-        assertThat(TimeLockAgent.getKeyValueServiceRuntimeConfig(
-                        ImmutableTimeLockRuntimeConfiguration.builder().build()))
+        assertThat(TimeLockAgent.getKeyValueServiceRuntimeConfig(ImmutableTimeLockRuntimeConfiguration.builder()
+                        .cluster(CLUSTER_CONFIG)
+                        .build()))
                 .isEmpty();
     }
 
@@ -125,6 +127,7 @@ public class TimeLockAgentTest {
                         .timestampBoundPersistence(ImmutableDatabaseTsBoundPersisterRuntimeConfiguration.builder()
                                 .keyValueServiceRuntimeConfig(runtimeConfig)
                                 .build())
+                        .cluster(CLUSTER_CONFIG)
                         .build()))
                 .contains(runtimeConfig);
     }
@@ -202,7 +205,7 @@ public class TimeLockAgentTest {
                                         .isNewService(false)
                                         .build())
                                 .build(),
-                        CLUSTER_CONFIG))
+                        differentClusterConfig))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 

--- a/timelock-agent/src/test/java/com/palantir/timelock/paxos/TimeLockAgentTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/paxos/TimeLockAgentTest.java
@@ -131,37 +131,45 @@ public class TimeLockAgentTest {
 
     @Test
     public void newServiceNotSetNoDataDirectoryThrows() {
-        assertThatThrownBy(() -> TimeLockAgent.verifyIsNewServiceInvariant(TimeLockInstallConfiguration.builder()
-                        .cluster(CLUSTER_CONFIG)
-                        .paxos(createPaxosInstall(false, false))
-                        .build()))
+        assertThatThrownBy(() -> TimeLockAgent.verifyIsNewServiceInvariant(
+                        TimeLockInstallConfiguration.builder()
+                                .cluster(CLUSTER_CONFIG)
+                                .paxos(createPaxosInstall(false, false))
+                                .build(),
+                        runtime.get()))
                 .isInstanceOf(SafeIllegalArgumentException.class);
     }
 
     @Test
     public void newServiceSetNoDataDirectoryExistsThrows() {
-        assertThatThrownBy(() -> TimeLockAgent.verifyIsNewServiceInvariant(TimeLockInstallConfiguration.builder()
-                        .cluster(CLUSTER_CONFIG)
-                        .paxos(createPaxosInstall(true, true))
-                        .build()))
+        assertThatThrownBy(() -> TimeLockAgent.verifyIsNewServiceInvariant(
+                        TimeLockInstallConfiguration.builder()
+                                .cluster(CLUSTER_CONFIG)
+                                .paxos(createPaxosInstall(true, true))
+                                .build(),
+                        runtime.get()))
                 .isInstanceOf(SafeIllegalArgumentException.class);
     }
 
     @Test
     public void newServiceNotSetNoDataDirectoryDoesNotThrowWhenIgnoreFlagSet() {
-        assertThatCode(() -> TimeLockAgent.verifyIsNewServiceInvariant(TimeLockInstallConfiguration.builder()
-                        .cluster(CLUSTER_CONFIG)
-                        .paxos(createPaxosInstall(false, false, true))
-                        .build()))
+        assertThatCode(() -> TimeLockAgent.verifyIsNewServiceInvariant(
+                        TimeLockInstallConfiguration.builder()
+                                .cluster(CLUSTER_CONFIG)
+                                .paxos(createPaxosInstall(false, false, true))
+                                .build(),
+                        runtime.get()))
                 .doesNotThrowAnyException();
     }
 
     @Test
     public void newServiceSetNoDataDirectoryExistsDoesNotThrowWhenIgnoreFlagSet() {
-        assertThatCode(() -> TimeLockAgent.verifyIsNewServiceInvariant(TimeLockInstallConfiguration.builder()
-                        .cluster(CLUSTER_CONFIG)
-                        .paxos(createPaxosInstall(true, true, true))
-                        .build()))
+        assertThatCode(() -> TimeLockAgent.verifyIsNewServiceInvariant(
+                        TimeLockInstallConfiguration.builder()
+                                .cluster(CLUSTER_CONFIG)
+                                .paxos(createPaxosInstall(true, true, true))
+                                .build(),
+                        runtime.get()))
                 .doesNotThrowAnyException();
     }
 
@@ -191,13 +199,15 @@ public class TimeLockAgentTest {
                 .cluster(PartialServiceConfiguration.of(ImmutableList.of(SERVER_A, "b", "c"), Optional.empty()))
                 .build();
 
-        assertThatThrownBy(() -> TimeLockAgent.verifyIsNewServiceInvariant(TimeLockInstallConfiguration.builder()
-                        .cluster(differentClusterConfig)
-                        .paxos(PaxosInstallConfiguration.builder()
-                                .dataDirectory(mockFile)
-                                .isNewService(false)
-                                .build())
-                        .build()))
+        assertThatThrownBy(() -> TimeLockAgent.verifyIsNewServiceInvariant(
+                        TimeLockInstallConfiguration.builder()
+                                .cluster(differentClusterConfig)
+                                .paxos(PaxosInstallConfiguration.builder()
+                                        .dataDirectory(mockFile)
+                                        .isNewService(false)
+                                        .build())
+                                .build(),
+                        runtime.get()))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -229,10 +239,12 @@ public class TimeLockAgentTest {
 
     private void assertFailsToVerifyConfiguration(ImmutablePaxosInstallConfiguration.Builder configBuilder) {
         PaxosInstallConfiguration installConfiguration = configBuilder.build();
-        assertThatThrownBy(() -> TimeLockAgent.verifyIsNewServiceInvariant(TimeLockInstallConfiguration.builder()
-                        .cluster(CLUSTER_CONFIG)
-                        .paxos(installConfiguration)
-                        .build()))
+        assertThatThrownBy(() -> TimeLockAgent.verifyIsNewServiceInvariant(
+                        TimeLockInstallConfiguration.builder()
+                                .cluster(CLUSTER_CONFIG)
+                                .paxos(installConfiguration)
+                                .build(),
+                        runtime.get()))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/timelock-server-benchmark-cluster/src/main/java/com/palantir/atlasdb/timelock/benchmarks/server/TimelockBenchmarkServerLauncher.java
+++ b/timelock-server-benchmark-cluster/src/main/java/com/palantir/atlasdb/timelock/benchmarks/server/TimelockBenchmarkServerLauncher.java
@@ -54,7 +54,7 @@ public class TimelockBenchmarkServerLauncher extends Application<CombinedTimeLoc
                 MetricsManagers.of(environment.metrics(), SharedTaggedMetricRegistries.getSingleton()),
                 configuration.install(),
                 Refreshable.only(runtime), // This won't actually live reload.
-                runtime.cluster(),
+                runtime.clusterSnapshot(),
                 USER_AGENT,
                 CombinedTimeLockServerConfiguration.threadPoolSize(),
                 CombinedTimeLockServerConfiguration.blockingTimeoutMs(),

--- a/timelock-server-benchmark-cluster/src/main/java/com/palantir/atlasdb/timelock/benchmarks/server/TimelockBenchmarkServerLauncher.java
+++ b/timelock-server-benchmark-cluster/src/main/java/com/palantir/atlasdb/timelock/benchmarks/server/TimelockBenchmarkServerLauncher.java
@@ -23,6 +23,7 @@ import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.serialization.ObjectMappers;
 import com.palantir.refreshable.Refreshable;
 import com.palantir.sls.versions.OrderableSlsVersion;
+import com.palantir.timelock.config.TimeLockRuntimeConfiguration;
 import com.palantir.timelock.paxos.TimeLockAgent;
 import com.palantir.tritium.metrics.registry.SharedTaggedMetricRegistries;
 import io.dropwizard.Application;
@@ -48,10 +49,12 @@ public class TimelockBenchmarkServerLauncher extends Application<CombinedTimeLoc
 
     @Override
     public void run(CombinedTimeLockServerConfiguration configuration, Environment environment) throws Exception {
+        TimeLockRuntimeConfiguration runtime = configuration.runtime();
         TimeLockAgent.create(
                 MetricsManagers.of(environment.metrics(), SharedTaggedMetricRegistries.getSingleton()),
                 configuration.install(),
-                Refreshable.only(configuration.runtime()), // This won't actually live reload.
+                Refreshable.only(runtime), // This won't actually live reload.
+                runtime.cluster(),
                 USER_AGENT,
                 CombinedTimeLockServerConfiguration.threadPoolSize(),
                 CombinedTimeLockServerConfiguration.blockingTimeoutMs(),

--- a/timelock-server-benchmark-cluster/var/conf/template/timelock-remote0.yml
+++ b/timelock-server-benchmark-cluster/var/conf/template/timelock-remote0.yml
@@ -3,7 +3,7 @@ install:
     is-new-service: true
 
 runtime:
-  cluster:
+  cluster-config-not-live-reloaded:
     local-server: SERVER1:9421
     cluster:
       security:

--- a/timelock-server-benchmark-cluster/var/conf/template/timelock-remote0.yml
+++ b/timelock-server-benchmark-cluster/var/conf/template/timelock-remote0.yml
@@ -1,6 +1,8 @@
 install:
   paxos:
     is-new-service: true
+
+runtime:
   cluster:
     local-server: SERVER1:9421
     cluster:
@@ -9,10 +11,9 @@ install:
         keyStorePath: ./var/security/keystore.jks
         trustStorePath: ./var/security/truststore.jks
       uris:
-      - SERVER1:9421
-      - SERVER2:9421
-      - SERVER3:9421
-runtime: {}
+        - SERVER1:9421
+        - SERVER2:9421
+        - SERVER3:9421
 
 server:
   idleThreadTimeout: 60s

--- a/timelock-server-benchmark-cluster/var/conf/template/timelock-remote1.yml
+++ b/timelock-server-benchmark-cluster/var/conf/template/timelock-remote1.yml
@@ -3,7 +3,7 @@ install:
     is-new-service: true
 
 runtime:
-  cluster:
+  cluster-config-not-live-reloaded:
     local-server: SERVER2:9421
     cluster:
       security:

--- a/timelock-server-benchmark-cluster/var/conf/template/timelock-remote1.yml
+++ b/timelock-server-benchmark-cluster/var/conf/template/timelock-remote1.yml
@@ -1,6 +1,8 @@
 install:
   paxos:
     is-new-service: true
+
+runtime:
   cluster:
     local-server: SERVER2:9421
     cluster:
@@ -9,10 +11,9 @@ install:
         keyStorePath: ./var/security/keystore.jks
         trustStorePath: ./var/security/truststore.jks
       uris:
-      - SERVER1:9421
-      - SERVER2:9421
-      - SERVER3:9421
-runtime: {}
+        - SERVER1:9421
+        - SERVER2:9421
+        - SERVER3:9421
 
 server:
   idleThreadTimeout: 60s

--- a/timelock-server-benchmark-cluster/var/conf/template/timelock-remote2.yml
+++ b/timelock-server-benchmark-cluster/var/conf/template/timelock-remote2.yml
@@ -1,6 +1,8 @@
 install:
   paxos:
     is-new-service: true
+
+runtime:
   cluster:
     local-server: SERVER3:9421
     cluster:
@@ -9,10 +11,9 @@ install:
         keyStorePath: ./var/security/keystore.jks
         trustStorePath: ./var/security/truststore.jks
       uris:
-      - SERVER1:9421
-      - SERVER2:9421
-      - SERVER3:9421
-runtime: {}
+        - SERVER1:9421
+        - SERVER2:9421
+        - SERVER3:9421
 
 server:
   idleThreadTimeout: 60s

--- a/timelock-server-benchmark-cluster/var/conf/template/timelock-remote2.yml
+++ b/timelock-server-benchmark-cluster/var/conf/template/timelock-remote2.yml
@@ -3,7 +3,7 @@ install:
     is-new-service: true
 
 runtime:
-  cluster:
+  cluster-config-not-live-reloaded:
     local-server: SERVER3:9421
     cluster:
       security:

--- a/timelock-server-distribution/var/conf/timelock-db.yml
+++ b/timelock-server-distribution/var/conf/timelock-db.yml
@@ -8,7 +8,7 @@ install:
       type: "memory"
 
 runtime:
-  cluster:
+  cluster-config-not-live-reloaded:
     cluster:
       uris:
         - "localhost:8421"

--- a/timelock-server-distribution/var/conf/timelock-db.yml
+++ b/timelock-server-distribution/var/conf/timelock-db.yml
@@ -2,18 +2,18 @@ install:
   paxos:
     data-directory: "var/data/paxos"
     is-new-service: false
-  cluster:
-    cluster:
-      uris:
-      - "localhost:8421"
-    local-server: "localhost:8421"
-    enableNonstandardAndPossiblyDangerousTopology: true
   timestampBoundPersistence:
     type: database
     key-value-service:
       type: "memory"
 
 runtime:
+  cluster:
+    cluster:
+      uris:
+        - "localhost:8421"
+    local-server: "localhost:8421"
+    enableNonstandardAndPossiblyDangerousTopology: true
   paxos:
 
 server:

--- a/timelock-server-distribution/var/conf/timelock-http2.yml
+++ b/timelock-server-distribution/var/conf/timelock-http2.yml
@@ -2,15 +2,15 @@ install:
   paxos:
     data-directory: "var/data/paxos"
     is-new-service: false
-  cluster:
-    cluster:
-      uris:
-      - "localhost:8421"
-    local-server: "localhost:8421"
-    enableNonstandardAndPossiblyDangerousTopology: true
   timestampBoundPersistence:
 
 runtime:
+  cluster:
+    cluster:
+      uris:
+        - "localhost:8421"
+    local-server: "localhost:8421"
+    enableNonstandardAndPossiblyDangerousTopology: true
   paxos:
 
 server:

--- a/timelock-server-distribution/var/conf/timelock-http2.yml
+++ b/timelock-server-distribution/var/conf/timelock-http2.yml
@@ -5,7 +5,7 @@ install:
   timestampBoundPersistence:
 
 runtime:
-  cluster:
+  cluster-config-not-live-reloaded:
     cluster:
       uris:
         - "localhost:8421"

--- a/timelock-server-distribution/var/conf/timelock-oracle.yml
+++ b/timelock-server-distribution/var/conf/timelock-oracle.yml
@@ -2,12 +2,6 @@ install:
   paxos:
     data-directory: "var/data/paxos"
     is-new-service: false
-  cluster:
-    cluster:
-      uris:
-      - "localhost:8421"
-    local-server: "localhost:8421"
-    enableNonstandardAndPossiblyDangerousTopology: true
   timestampBoundPersistence:
     type: database
     key-value-service:
@@ -26,6 +20,12 @@ install:
         dbPassword: palpal
 
 runtime:
+  cluster:
+    cluster:
+      uris:
+        - "localhost:8421"
+    local-server: "localhost:8421"
+    enableNonstandardAndPossiblyDangerousTopology: true
   paxos:
 
 server:

--- a/timelock-server-distribution/var/conf/timelock-oracle.yml
+++ b/timelock-server-distribution/var/conf/timelock-oracle.yml
@@ -20,7 +20,7 @@ install:
         dbPassword: palpal
 
 runtime:
-  cluster:
+  cluster-config-not-live-reloaded:
     cluster:
       uris:
         - "localhost:8421"

--- a/timelock-server-distribution/var/conf/timelock-postgres.yml
+++ b/timelock-server-distribution/var/conf/timelock-postgres.yml
@@ -17,7 +17,7 @@ install:
         dbPassword: "palantir"
 
 runtime:
-  cluster:
+  cluster-config-not-live-reloaded:
     cluster:
       uris:
         - "localhost:8421"

--- a/timelock-server-distribution/var/conf/timelock-postgres.yml
+++ b/timelock-server-distribution/var/conf/timelock-postgres.yml
@@ -2,12 +2,6 @@ install:
   paxos:
     data-directory: "var/data/paxos"
     is-new-service: false
-  cluster:
-    cluster:
-      uris:
-      - "localhost:8421"
-    enableNonstandardAndPossiblyDangerousTopology: true
-    local-server: "localhost:8421"
   timestampBoundPersistence:
     type: database
     key-value-service:
@@ -23,6 +17,12 @@ install:
         dbPassword: "palantir"
 
 runtime:
+  cluster:
+    cluster:
+      uris:
+        - "localhost:8421"
+    enableNonstandardAndPossiblyDangerousTopology: true
+    local-server: "localhost:8421"
   paxos:
 
 server:

--- a/timelock-server-distribution/var/conf/timelock.yml
+++ b/timelock-server-distribution/var/conf/timelock.yml
@@ -2,15 +2,15 @@ install:
   paxos:
     data-directory: "var/data/paxos"
     is-new-service: false
-  cluster:
-    cluster:
-      uris:
-      - "localhost:8421"
-    local-server: "localhost:8421"
-    enableNonstandardAndPossiblyDangerousTopology: true
   timestampBoundPersistence:
 
 runtime:
+  cluster:
+    cluster:
+      uris:
+        - "localhost:8421"
+    local-server: "localhost:8421"
+    enableNonstandardAndPossiblyDangerousTopology: true
   paxos:
 
 server:

--- a/timelock-server-distribution/var/conf/timelock.yml
+++ b/timelock-server-distribution/var/conf/timelock.yml
@@ -5,7 +5,7 @@ install:
   timestampBoundPersistence:
 
 runtime:
-  cluster:
+  cluster-config-not-live-reloaded:
     cluster:
       uris:
         - "localhost:8421"

--- a/timelock-server/src/integTest/resources/paxosSingleServer.ftl
+++ b/timelock-server/src/integTest/resources/paxosSingleServer.ftl
@@ -10,7 +10,7 @@ install:
   timestampBoundPersistence:
 
 runtime:
-  cluster:
+  cluster-config-not-live-reloaded:
     cluster:
       security:
         trustStorePath: "var/security/trustStore.jks"

--- a/timelock-server/src/integTest/resources/paxosSingleServer.ftl
+++ b/timelock-server/src/integTest/resources/paxosSingleServer.ftl
@@ -7,6 +7,9 @@ install:
   paxos:
     data-directory: "${dataDirectory}"
     is-new-service: false
+  timestampBoundPersistence:
+
+runtime:
   cluster:
     cluster:
       security:
@@ -19,9 +22,6 @@ install:
       - "localhost:${localServerPort?c}"
     local-server: "localhost:${localServerPort?c}"
     enableNonstandardAndPossiblyDangerousTopology: true
-  timestampBoundPersistence:
-
-runtime:
   paxos:
     timestamp-paxos:
       use-batch-paxos: ${clientPaxos.useBatchPaxosTimestamp?c}

--- a/timelock-server/src/integTest/resources/paxosStaticThreeServers.ftl
+++ b/timelock-server/src/integTest/resources/paxosStaticThreeServers.ftl
@@ -2,6 +2,9 @@ install:
   paxos:
     data-directory: "${dataDirectory}"
     is-new-service: false
+  timestampBoundPersistence:
+
+runtime:
   cluster:
     cluster:
       security:
@@ -15,9 +18,6 @@ install:
       - "localhost:9061"
       - "localhost:9062"
     local-server: "localhost:${localServerPort?c}"
-  timestampBoundPersistence:
-
-runtime:
   paxos:
 
 server:

--- a/timelock-server/src/integTest/resources/paxosStaticThreeServers.ftl
+++ b/timelock-server/src/integTest/resources/paxosStaticThreeServers.ftl
@@ -5,7 +5,7 @@ install:
   timestampBoundPersistence:
 
 runtime:
-  cluster:
+  cluster-config-not-live-reloaded:
     cluster:
       security:
         trustStorePath: "var/security/trustStore.jks"

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
@@ -31,6 +31,7 @@ import com.palantir.conjure.java.serialization.ObjectMappers;
 import com.palantir.conjure.java.server.jersey.ConjureJerseyFeature;
 import com.palantir.refreshable.Refreshable;
 import com.palantir.sls.versions.OrderableSlsVersion;
+import com.palantir.timelock.config.TimeLockRuntimeConfiguration;
 import com.palantir.timelock.paxos.TimeLockAgent;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
@@ -95,10 +96,12 @@ public class TimeLockServerLauncher extends Application<CombinedTimeLockServerCo
                         .getObjectMapper()
                         .writerWithDefaultPrettyPrinter()
                         .writeValueAsString(configuration.install().paxos()));
+        TimeLockRuntimeConfiguration runtime = configuration.runtime();
         TimeLockAgent timeLockAgent = TimeLockAgent.create(
                 metricsManager,
                 configuration.install(),
-                Refreshable.only(configuration.runtime()), // this won't actually live reload
+                Refreshable.only(runtime), // this won't actually live reload
+                runtime.cluster(),
                 USER_AGENT,
                 CombinedTimeLockServerConfiguration.threadPoolSize(),
                 CombinedTimeLockServerConfiguration.blockingTimeoutMs(),

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
@@ -101,7 +101,7 @@ public class TimeLockServerLauncher extends Application<CombinedTimeLockServerCo
                 metricsManager,
                 configuration.install(),
                 Refreshable.only(runtime), // this won't actually live reload
-                runtime.cluster(),
+                runtime.clusterSnapshot(),
                 USER_AGENT,
                 CombinedTimeLockServerConfiguration.threadPoolSize(),
                 CombinedTimeLockServerConfiguration.blockingTimeoutMs(),

--- a/timelock-server/src/testCommon/resources/dbTimeLockPaxosMultiServer.ftl
+++ b/timelock-server/src/testCommon/resources/dbTimeLockPaxosMultiServer.ftl
@@ -5,19 +5,6 @@ install:
       data-directory: "${sqliteDataDirectory}"
     is-new-service: false
     leader-mode: ${leaderMode}
-  cluster:
-    cluster:
-      security:
-        trustStorePath: "var/security/trustStore.jks"
-        trustStoreType: "JKS"
-        keyStorePath: "var/security/keyStore.jks"
-        keyStorePassword: "keystore"
-        keyStoreType: "JKS"
-      uris:
-<#list serverProxyPorts as serverProxyPort>
-      - "localhost:${serverProxyPort?c}"
-</#list>
-    local-server: "localhost:${localProxyPort?c}"
   timestampBoundPersistence:
     type: database
     key-value-service:
@@ -38,6 +25,19 @@ runtime:
     timestamp-paxos:
       use-batch-paxos: ${clientPaxos.useBatchPaxosTimestamp?c}
     enable-batching-for-single-leader: ${clientPaxos.batchSingleLeader?c}
+  cluster:
+    cluster:
+      security:
+        trustStorePath: "var/security/trustStore.jks"
+        trustStoreType: "JKS"
+        keyStorePath: "var/security/keyStore.jks"
+        keyStorePassword: "keystore"
+        keyStoreType: "JKS"
+      uris:
+<#list serverProxyPorts as serverProxyPort>
+      - "localhost:${serverProxyPort?c}"
+</#list>
+    local-server: "localhost:${localProxyPort?c}"
 
 logging:
   appenders:

--- a/timelock-server/src/testCommon/resources/dbTimeLockPaxosMultiServer.ftl
+++ b/timelock-server/src/testCommon/resources/dbTimeLockPaxosMultiServer.ftl
@@ -37,7 +37,7 @@ runtime:
 <#list serverProxyPorts as serverProxyPort>
       - "localhost:${serverProxyPort?c}"
 </#list>
-    Flocal-server: "localhost:${localProxyPort?c}"
+    local-server: "localhost:${localProxyPort?c}"
 
 logging:
   appenders:

--- a/timelock-server/src/testCommon/resources/dbTimeLockPaxosMultiServer.ftl
+++ b/timelock-server/src/testCommon/resources/dbTimeLockPaxosMultiServer.ftl
@@ -25,7 +25,7 @@ runtime:
     timestamp-paxos:
       use-batch-paxos: ${clientPaxos.useBatchPaxosTimestamp?c}
     enable-batching-for-single-leader: ${clientPaxos.batchSingleLeader?c}
-  cluster:
+  cluster-config-not-live-reloaded:
     cluster:
       security:
         trustStorePath: "var/security/trustStore.jks"
@@ -37,7 +37,7 @@ runtime:
 <#list serverProxyPorts as serverProxyPort>
       - "localhost:${serverProxyPort?c}"
 </#list>
-    local-server: "localhost:${localProxyPort?c}"
+    Flocal-server: "localhost:${localProxyPort?c}"
 
 logging:
   appenders:

--- a/timelock-server/src/testCommon/resources/paxosMultiServer.ftl
+++ b/timelock-server/src/testCommon/resources/paxosMultiServer.ftl
@@ -13,7 +13,7 @@ runtime:
     timestamp-paxos:
       use-batch-paxos: ${clientPaxos.useBatchPaxosTimestamp?c}
     enable-batching-for-single-leader: ${clientPaxos.batchSingleLeader?c}
-  cluster:
+  cluster-config-not-live-reloaded:
     cluster:
       security:
         trustStorePath: "var/security/trustStore.jks"

--- a/timelock-server/src/testCommon/resources/paxosMultiServer.ftl
+++ b/timelock-server/src/testCommon/resources/paxosMultiServer.ftl
@@ -5,6 +5,14 @@ install:
       data-directory: "${sqliteDataDirectory}"
     is-new-service: false
     leader-mode: ${leaderMode}
+  timestampBoundPersistence:
+
+runtime:
+  paxos:
+    leader-ping-response-wait-in-ms: 1000
+    timestamp-paxos:
+      use-batch-paxos: ${clientPaxos.useBatchPaxosTimestamp?c}
+    enable-batching-for-single-leader: ${clientPaxos.batchSingleLeader?c}
   cluster:
     cluster:
       security:
@@ -18,14 +26,6 @@ install:
       - "localhost:${serverProxyPort?c}"
 </#list>
     local-server: "localhost:${localProxyPort?c}"
-  timestampBoundPersistence:
-
-runtime:
-  paxos:
-    leader-ping-response-wait-in-ms: 1000
-    timestamp-paxos:
-      use-batch-paxos: ${clientPaxos.useBatchPaxosTimestamp?c}
-    enable-batching-for-single-leader: ${clientPaxos.batchSingleLeader?c}
 
 logging:
   appenders:


### PR DESCRIPTION
**Goals (and why)**:
Move ClusterConfiguration from install to runtime. This is required for setting TimeLock service in the Rubix world. Note that the config will still not be live re-loaded.

**Implementation Description (bullets)**:
Move ClusterConfiguration from TimeLockInstallConfig to TimeLockRuntimeConfig. 

The clusterConfig with `enableNonstandardAndPossiblyDangerousTopology` is still part of install config as this config has been overridden in several places.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Modified existing tests.

**Concerns (what feedback would you like?)**:

1. Initializing TimeLockAgent with a snapshot of clusterConfiguration right now. Is this reasonable? If not, at what point can we reliably take this snapshot?
2. Did I break something accidentally?

**Where should we start reviewing?**:
TimeLockInstallConfiguration/ TimeLockAgent

**Priority (whenever / two weeks / yesterday)**:
Before EOD 7 September 

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
