### PR TITLE
Increase default max fetch size for AgnosticLightResultSetImpl

### DIFF
--- a/changelog/@unreleased/agnostic-light-result-set-fetch-size.v2.yml
+++ b/changelog/@unreleased/agnostic-light-result-set-fetch-size.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Increase default max fetch size for AgnosticLightResultSetImpl
+  links:
+    - https://github.com/palantir/atlasdb/pull/5625

--- a/commons-db/src/main/java/com/palantir/nexus/db/sql/AgnosticLightResultSetImpl.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/sql/AgnosticLightResultSetImpl.java
@@ -122,11 +122,7 @@ class AgnosticLightResultSetImpl implements AgnosticLightResultSet {
 
     protected static final int INITIAL_FETCH_SIZE = 10;
 
-    // NOTE: the following was decreased from its original setting of 1000,
-    // which seemed to cause the server to churn through huge amounts of memory
-    // quickly on certain workloads. Documentation suggests that values over 50
-    // are not useful.
-    protected static final int DEFAULT_MAX_FETCH_SIZE = 50;
+    protected static final int DEFAULT_MAX_FETCH_SIZE = 1000;
 
     /**
      * Geometrically increases the fetch size, so that we don't have to GC a lot

--- a/commons-db/src/main/java/com/palantir/nexus/db/sql/BasicSQL.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/sql/BasicSQL.java
@@ -737,7 +737,7 @@ public abstract class BasicSQL {
         PreparedStatementVisitor<AgnosticLightResultSet> preparedStatementVisitor = ps -> {
             final ResultSetVisitor<AgnosticLightResultSet> resultSetVisitor = rs -> {
                 try {
-                    return new AgnosticLightResultSetImpl(
+                    AgnosticLightResultSet resultSet = new AgnosticLightResultSetImpl(
                             rs,
                             dbType,
                             rs.getMetaData(),
@@ -745,6 +745,10 @@ public abstract class BasicSQL {
                             "selectList", //$NON-NLS-1$
                             sql,
                             getSqlTimer());
+                    if (fetchSize != null) {
+                        resultSet.setFetchSize(fetchSize);
+                    }
+                    return resultSet;
                 } catch (Exception e) {
                     closeSilently(rs);
                     BasicSQLUtils.throwUncheckedIfSQLException(e);


### PR DESCRIPTION
**Goals (and why)**:

The default was lowered back in 2009 and hadn't been revisited since. PG-139709 increased the default fetch size for other connections but AgnosticLightResultSetImpl overrides that on the result set. On PDS-210269 we observed a drop from 5 minutes to 13 seconds of fetching overhead when iterating over a result set with millions of rows.

**Implementation Description (bullets)**:

* Increased the default max fetch size back to 1000.
* Drive-by fix for `selectLightResultSetSpecifyingDBType` which applied the provided fetch size to the prepared statement but not the result set.

**Testing (What was existing testing like?  What have you done to improve it?)**:

Tested with high scale ACL loading on an internal test stack.

**Concerns (what feedback would you like?)**:

Copying @CVdV-au's comment from https://github.com/palantir/atlasdb/pull/5625: The original change @afchang made was in pgdev 496cad6707dab2ed5d452321ff79e9247f075904 in 2009.
In Oracle 12, JDBC memory handling was significantly improved https://www.oracle.com/technetwork/database/application-development/jdbc-memory-management-12c-1964666.pdf, and less and less non-Atlas code actually uses these classes as JOOQ permeates the PG code base. Atlas code already overrides the default in most pathways, so overall this is a low risk change IMHO.

**Where should we start reviewing?**:

N/A

**Priority (whenever / two weeks / yesterday):**

Two weeks.