### PR TITLE
Leaky sweep

### DIFF
--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/SweepCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/SweepCommand.java
@@ -181,7 +181,8 @@ public class SweepCommand extends SingleBackendCommand {
                         : sweepRunner.run(
                                 tableToSweep,
                                 batchConfig,
-                                accumulatedResults.getNextStartRow().get());
+                                accumulatedResults.getNextStartRow().get(),
+                                SweepTaskRunner.RunType.FULL);
 
                 accumulatedResults = accumulatedResults.accumulateWith(newResults);
                 printer.info(

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -201,6 +201,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -861,7 +862,8 @@ public abstract class TransactionManagers {
                 transactionService,
                 sweepStrategyManager,
                 cellsSweeper,
-                sweepMetrics);
+                sweepMetrics,
+                () -> ThreadLocalRandom.current().nextInt(100) == 0);
         BackgroundSweeperPerformanceLogger sweepPerfLogger = new NoOpBackgroundSweeperPerformanceLogger();
         AdjustableSweepBatchConfigSource sweepBatchConfigSource = AdjustableSweepBatchConfigSource.create(
                 metricsManager,

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/todo/TodoClient.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/todo/TodoClient.java
@@ -202,7 +202,7 @@ public class TodoClient {
                 .deleteBatchSize(AtlasDbConstants.DEFAULT_SWEEP_DELETE_BATCH_HINT)
                 .maxCellTsPairsToExamine(AtlasDbConstants.DEFAULT_SWEEP_READ_LIMIT)
                 .build();
-        return sweepTaskRunner.get().run(table, sweepConfig, PtBytes.EMPTY_BYTE_ARRAY);
+        return sweepTaskRunner.get().run(table, sweepConfig, PtBytes.EMPTY_BYTE_ARRAY, SweepTaskRunner.RunType.FULL);
     }
 
     public long numAtlasDeletes(TableReference tableRef) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SpecificTableSweeper.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SpecificTableSweeper.java
@@ -120,13 +120,14 @@ public class SpecificTableSweeper {
         TableReference tableRef = tableToSweep.getTableRef();
         byte[] startRow = tableToSweep.getStartRow();
 
-        SweepResults results = runOneIteration(tableRef, startRow, batchConfig);
+        SweepResults results = runOneIteration(tableRef, startRow, batchConfig, SweepTaskRunner.RunType.FULL);
         processSweepResults(tableToSweep, results);
     }
 
-    SweepResults runOneIteration(TableReference tableRef, byte[] startRow, SweepBatchConfig batchConfig) {
+    SweepResults runOneIteration(
+            TableReference tableRef, byte[] startRow, SweepBatchConfig batchConfig, SweepTaskRunner.RunType runType) {
         try {
-            SweepResults results = sweepRunner.run(tableRef, batchConfig, startRow);
+            SweepResults results = sweepRunner.run(tableRef, batchConfig, startRow, runType);
             logSweepPerformance(tableRef, startRow, results);
 
             return results;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTaskRunner.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTaskRunner.java
@@ -305,7 +305,8 @@ public class SweepTaskRunner {
                             currentCellTimestamps.subList(numberOfTimestampsForThisBatch, currentCellTimestamps.size());
                 }
                 if (!currentCellTimestamps.isEmpty()) {
-                    addCurrentCellTimestamps(currentBatch, cell.cell(), currentCellTimestamps, runType);
+                    safeToDeleteLast = safeToDeleteLast
+                            && addCurrentCellTimestamps(currentBatch, cell.cell(), currentCellTimestamps, runType);
                     if (!safeToDeleteLast) {
                         currentBatch.remove(cell.cell(), currentCellTimestamps.get(currentCellTimestamps.size() - 1));
                     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweeperService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweeperService.java
@@ -72,7 +72,7 @@ public interface SweeperService {
      * might arise from having too many consecutive deletes in the underlying KVS. This is expected to be safe to
      * invoke at least twice without cleanup at the KVS level, but generally the expected usage is to run once, and
      * then invoke {@link #sweepTable(String, Optional, Optional, Optional, Optional, Optional)} to clean any
-     * skipped values once KVS cleanup is done.
+     * skipped values once KVS cleanup, such as compactions, is done.
      *
      * @param tableName the table to sweep, in the format namespace.table_name (e.g. myapp.users)
      * @param startRow (Optional) the row to start from, encoded as a hex string (e.g. 12345abcde)

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweeperService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweeperService.java
@@ -66,4 +66,25 @@ public interface SweeperService {
             @Safe @QueryParam("maxCellTsPairsToExamine") Optional<Integer> maxCellTsPairsToExamine,
             @Safe @QueryParam("candidateBatchSize") Optional<Integer> candidateBatchSize,
             @Safe @QueryParam("deleteBatchSize") Optional<Integer> deleteBatchSize);
+
+    /**
+     * Sweeps a table, but intentionally probabilistically skips a fraction of eligible entries to prevent issues that
+     * might arise from having too many consecutive deletes in the underlying KVS.
+     *
+     * @param tableName the table to sweep, in the format namespace.table_name (e.g. myapp.users)
+     * @param startRow (Optional) the row to start from, encoded as a hex string (e.g. 12345abcde)
+     * @param fullSweep (Optional; default true) whether to sweep the full table; if false just runs one batch
+     * @param maxCellTsPairsToExamine (Optional) see {@link SweepBatchConfig#maxCellTsPairsToExamine()}
+     * @param candidateBatchSize (Optional) see {@link SweepBatchConfig#candidateBatchSize()}
+     * @param deleteBatchSize (Optional) see {@link SweepBatchConfig#deleteBatchSize()}
+     */
+    @POST
+    @Path("sweep-previously-conservative-now-thorough-table")
+    SweepTableResponse sweepPreviouslyConservativeNowThoroughTable(
+            @QueryParam("tablename") String tableName,
+            @QueryParam("startRow") Optional<String> startRow,
+            @Safe @QueryParam("fullSweep") Optional<Boolean> fullSweep,
+            @Safe @QueryParam("maxCellTsPairsToExamine") Optional<Integer> maxCellTsPairsToExamine,
+            @Safe @QueryParam("candidateBatchSize") Optional<Integer> candidateBatchSize,
+            @Safe @QueryParam("deleteBatchSize") Optional<Integer> deleteBatchSize);
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweeperService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweeperService.java
@@ -69,7 +69,10 @@ public interface SweeperService {
 
     /**
      * Sweeps a table, but intentionally probabilistically skips a fraction of eligible entries to prevent issues that
-     * might arise from having too many consecutive deletes in the underlying KVS.
+     * might arise from having too many consecutive deletes in the underlying KVS. This is expected to be safe to
+     * invoke at least twice without cleanup at the KVS level, but generally the expected usage is to run once, and
+     * then invoke {@link #sweepTable(String, Optional, Optional, Optional, Optional, Optional)} to clean any
+     * skipped values once KVS cleanup is done.
      *
      * @param tableName the table to sweep, in the format namespace.table_name (e.g. myapp.users)
      * @param startRow (Optional) the row to start from, encoded as a hex string (e.g. 12345abcde)

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweeperService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweeperService.java
@@ -74,6 +74,11 @@ public interface SweeperService {
      * then invoke {@link #sweepTable(String, Optional, Optional, Optional, Optional, Optional)} to clean any
      * skipped values once KVS cleanup, such as compactions, is done.
      *
+     * Implementation must respect the usual sweep guarantee: no (possibly in-flight) transaction may as a result of
+     * this operation read a version (or lack of one) of a cell different than it would have read if this operation had
+     * not run, and still succeed. In particular, this means that if any version of a cell is retained, then also the
+     * latest version prior to the sweep timestamp of the same cell must not be removed (even if it is a delete).
+     *
      * @param tableName the table to sweep, in the format namespace.table_name (e.g. myapp.users)
      * @param startRow (Optional) the row to start from, encoded as a hex string (e.g. 12345abcde)
      * @param fullSweep (Optional; default true) whether to sweep the full table; if false just runs one batch

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweeperServiceImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweeperServiceImplTest.java
@@ -163,12 +163,12 @@ public class SweeperServiceImplTest extends SweeperTestSetup {
                     (i + 1) == startRows.size() ? Optional.empty() : Optional.of(startRows.get(i + 1));
 
             SweepResults results = SweepResults.createEmptySweepResult(nextRow);
-            when(sweepTaskRunner.run(any(), any(), eq(currentRow))).thenReturn(results);
+            when(sweepTaskRunner.run(any(), any(), eq(currentRow), any())).thenReturn(results);
         }
 
         sweeperService.sweepTableFully(TABLE_REF.getQualifiedName());
 
-        startRows.forEach(row -> verify(sweepTaskRunner).run(any(), any(), eq(row)));
+        startRows.forEach(row -> verify(sweepTaskRunner).run(any(), any(), eq(row), any()));
         verifyNoMoreInteractions(sweepTaskRunner);
     }
 
@@ -184,7 +184,7 @@ public class SweeperServiceImplTest extends SweeperTestSetup {
                 Optional.empty(),
                 Optional.empty());
 
-        verify(sweepTaskRunner, times(1)).run(any(), any(), any());
+        verify(sweepTaskRunner, times(1)).run(any(), any(), any(), any());
         verifyNoMoreInteractions(sweepTaskRunner);
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweeperTestSetup.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweeperTestSetup.java
@@ -153,6 +153,6 @@ public class SweeperTestSetup {
     }
 
     protected void setupTaskRunner(TableReference tableRef, SweepResults results) {
-        doReturn(results).when(sweepTaskRunner).run(eq(tableRef), any(), any());
+        doReturn(results).when(sweepTaskRunner).run(eq(tableRef), any(), any(), any());
     }
 }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/SweepBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/SweepBenchmarks.java
@@ -44,7 +44,8 @@ public class SweepBenchmarks {
                 .candidateBatchSize(RegeneratingTable.SWEEP_DUPLICATES * uniqueCellsToSweep + 1)
                 .maxCellTsPairsToExamine(RegeneratingTable.SWEEP_DUPLICATES * uniqueCellsToSweep)
                 .build();
-        SweepResults sweepResults = sweepTaskRunner.run(table.getTableRef(), batchConfig, PtBytes.EMPTY_BYTE_ARRAY);
+        SweepResults sweepResults = sweepTaskRunner.run(
+                table.getTableRef(), batchConfig, PtBytes.EMPTY_BYTE_ARRAY, SweepTaskRunner.RunType.FULL);
         assertThat(sweepResults.getStaleValuesDeleted()).isEqualTo((long) DELETED_COUNT * uniqueCellsToSweep);
         return sweepResults;
     }
@@ -59,7 +60,8 @@ public class SweepBenchmarks {
                     .candidateBatchSize(1)
                     .maxCellTsPairsToExamine(RegeneratingTable.SWEEP_DUPLICATES)
                     .build();
-            sweepResults = sweepTaskRunner.run(table.getTableRef(), batchConfig, nextStartRow);
+            sweepResults =
+                    sweepTaskRunner.run(table.getTableRef(), batchConfig, nextStartRow, SweepTaskRunner.RunType.FULL);
             nextStartRow = sweepResults.getNextStartRow().get();
             assertThat(sweepResults.getStaleValuesDeleted()).isEqualTo((long) DELETED_COUNT);
         }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractBackgroundSweeperIntegrationTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractBackgroundSweeperIntegrationTest.java
@@ -289,7 +289,7 @@ public abstract class AbstractBackgroundSweeperIntegrationTest {
                 Optional.empty());
 
         // deletes all but a ninth of the entries at the lower timestamp
-        assertThat(kvs.get(TABLE_1, readMap)).hasSize(110);
+        assertThat(kvs.get(TABLE_1, readMap)).hasSize(111);
         Map<Cell, Long> readsAtMaxTs =
                 KeyedStream.stream(readMap).map(_ignore -> Long.MAX_VALUE).collectToMap();
         // none of the cells at lower timestamp became visible
@@ -299,8 +299,7 @@ public abstract class AbstractBackgroundSweeperIntegrationTest {
                         .collect(Collectors.toList()))
                 .hasSize(0);
         // 500 cannot be completely removed because they are not deletes, 111 of the remaining 500 have either of the
-        // two versions skipped from sweep, which results in a version here (also allow off-by-one discrepancy as
-        // mentioned in the test above)
+        // two versions skipped from sweep, which results in a version here
         assertThat(kvs.get(TABLE_1, readsAtMaxTs)).hasSize(500 + 111);
     }
 

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractSweepTaskRunnerTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractSweepTaskRunnerTest.java
@@ -84,7 +84,8 @@ public abstract class AbstractSweepTaskRunnerTest extends AbstractSweepTest {
                         .candidateBatchSize(DEFAULT_BATCH_SIZE)
                         .maxCellTsPairsToExamine(DEFAULT_BATCH_SIZE)
                         .build(),
-                PtBytes.EMPTY_BYTE_ARRAY);
+                PtBytes.EMPTY_BYTE_ARRAY,
+                SweepTaskRunner.RunType.FULL);
         assertThat(results).isEqualTo(SweepResults.createEmptySweepResult(Optional.empty()));
         assertThat(getAllTsFromDefaultColumn("foo")).isEqualTo(ImmutableSet.of(50L, 75L, 100L, 125L, 150L));
     }
@@ -249,7 +250,8 @@ public abstract class AbstractSweepTaskRunnerTest extends AbstractSweepTest {
                         .candidateBatchSize(DEFAULT_BATCH_SIZE)
                         .maxCellTsPairsToExamine(DEFAULT_BATCH_SIZE)
                         .build(),
-                nextStartRow);
+                nextStartRow,
+                SweepTaskRunner.RunType.FULL);
         assertThat(results).isEqualTo(SweepResults.createEmptySweepResult(Optional.empty()));
     }
 
@@ -350,7 +352,8 @@ public abstract class AbstractSweepTaskRunnerTest extends AbstractSweepTest {
                         .candidateBatchSize(candidateBatchSize)
                         .deleteBatchSize(deleteBatchSize)
                         .build(),
-                PtBytes.EMPTY_BYTE_ARRAY);
+                PtBytes.EMPTY_BYTE_ARRAY,
+                SweepTaskRunner.RunType.FULL);
 
         return new Pair(sweptCells, sweepResults);
     }
@@ -378,7 +381,8 @@ public abstract class AbstractSweepTaskRunnerTest extends AbstractSweepTest {
                             .candidateBatchSize(batchSize)
                             .maxCellTsPairsToExamine(batchSize)
                             .build(),
-                    startRow);
+                    startRow,
+                    SweepTaskRunner.RunType.FULL);
             assertThat(results.getMinSweptTimestamp()).isEqualTo(ts);
             assertThat(results.getPreviousStartRow().orElse(null)).isEqualTo(startRow);
             totalStaleValuesDeleted += results.getStaleValuesDeleted();
@@ -408,7 +412,8 @@ public abstract class AbstractSweepTaskRunnerTest extends AbstractSweepTest {
                         .candidateBatchSize(1)
                         .maxCellTsPairsToExamine(1)
                         .build(),
-                PtBytes.EMPTY_BYTE_ARRAY);
+                PtBytes.EMPTY_BYTE_ARRAY,
+                SweepTaskRunner.RunType.FULL);
         assertThat(results.getNextStartRow()).isPresent();
         return results;
     }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/SweeperServiceImplIntegrationTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/SweeperServiceImplIntegrationTest.java
@@ -61,7 +61,6 @@ public class SweeperServiceImplIntegrationTest extends AbstractBackgroundSweeper
         putManyCells(TABLE_1, 103, 104);
         putManyCells(TABLE_1, 107, 109);
 
-        SweeperService sweeperService = new SweeperServiceImpl(specificTableSweeper, sweepBatchConfigSource);
         sweeperService.sweepPreviouslyConservativeNowThoroughTable(
                 TABLE_1.getQualifiedName(),
                 Optional.empty(),
@@ -88,7 +87,6 @@ public class SweeperServiceImplIntegrationTest extends AbstractBackgroundSweeper
                 .collectToMap();
         assertThat(kvs.get(TABLE_1, readMap)).hasSize(100);
 
-        SweeperService sweeperService = new SweeperServiceImpl(specificTableSweeper, sweepBatchConfigSource);
         sweeperService.sweepPreviouslyConservativeNowThoroughTable(
                 TABLE_1.getQualifiedName(),
                 Optional.empty(),
@@ -104,7 +102,6 @@ public class SweeperServiceImplIntegrationTest extends AbstractBackgroundSweeper
     public void previouslyConservativeThrowsIfTableIsStillConservativelySwept() {
         createTable(TABLE_1, SweepStrategy.CONSERVATIVE);
 
-        SweeperService sweeperService = new SweeperServiceImpl(specificTableSweeper, sweepBatchConfigSource);
         assertThatThrownBy(() -> sweeperService.sweepPreviouslyConservativeNowThoroughTable(
                         TABLE_1.getQualifiedName(),
                         Optional.empty(),
@@ -131,7 +128,6 @@ public class SweeperServiceImplIntegrationTest extends AbstractBackgroundSweeper
                 .collectToMap();
         assertThat(kvs.get(TABLE_1, readMap)).hasSize(100);
 
-        SweeperService sweeperService = new SweeperServiceImpl(specificTableSweeper, sweepBatchConfigSource);
         sweeperService.sweepPreviouslyConservativeNowThoroughTable(
                 TABLE_1.getQualifiedName(),
                 Optional.empty(),
@@ -164,7 +160,6 @@ public class SweeperServiceImplIntegrationTest extends AbstractBackgroundSweeper
                 KeyedStream.stream(writes).map(_ignore -> 102L).collectToMap();
         assertThat(kvs.get(TABLE_1, readMap)).hasSize(1000);
 
-        SweeperService sweeperService = new SweeperServiceImpl(specificTableSweeper, sweepBatchConfigSource);
         sweeperService.sweepPreviouslyConservativeNowThoroughTable(
                 TABLE_1.getQualifiedName(),
                 Optional.empty(),

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/SweeperServiceImplIntegrationTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/SweeperServiceImplIntegrationTest.java
@@ -15,9 +15,20 @@
  */
 package com.palantir.atlasdb.sweep;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence.SweepStrategy;
+import com.palantir.common.streams.KeyedStream;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -40,6 +51,141 @@ public class SweeperServiceImplIntegrationTest extends AbstractBackgroundSweeper
         putManyCells(TABLE_1, 105, 115);
         sweeperService.sweepTableFully(TABLE_1.getQualifiedName());
         verifyTableSwept(TABLE_1, 75, true);
+    }
+
+    @Test
+    public void previouslyConservativeSweepsEverythingWhenNothingIsSkipped() {
+        skipCellVersion.setPeriod(Integer.MAX_VALUE);
+        createTable(TABLE_1, SweepStrategy.THOROUGH);
+        putManyCells(TABLE_1, 100, 101);
+        putManyCells(TABLE_1, 103, 104);
+        putManyCells(TABLE_1, 107, 109);
+
+        SweeperService sweeperService = new SweeperServiceImpl(specificTableSweeper, sweepBatchConfigSource);
+        sweeperService.sweepPreviouslyConservativeNowThoroughTable(
+                TABLE_1.getQualifiedName(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
+
+        verifyTableSwept(TABLE_1, 58, false);
+    }
+
+    @Test
+    public void previouslyConservativeErasesExistingSentinelsInThoroughTable() {
+        skipCellVersion.setPeriod(Integer.MAX_VALUE);
+        createTable(TABLE_1, SweepStrategy.THOROUGH);
+
+        Map<Cell, byte[]> sentinelWrites = IntStream.range(0, 100)
+                .mapToObj(PtBytes::toBytes)
+                .map(bytes -> Cell.create(bytes, bytes))
+                .collect(Collectors.toMap(cell -> cell, _ignore -> PtBytes.EMPTY_BYTE_ARRAY));
+        kvs.put(TABLE_1, sentinelWrites, Value.INVALID_VALUE_TIMESTAMP);
+        Map<Cell, Long> readMap = KeyedStream.stream(sentinelWrites)
+                .map(_ignore -> Long.MAX_VALUE)
+                .collectToMap();
+        assertThat(kvs.get(TABLE_1, readMap)).hasSize(100);
+
+        SweeperService sweeperService = new SweeperServiceImpl(specificTableSweeper, sweepBatchConfigSource);
+        sweeperService.sweepPreviouslyConservativeNowThoroughTable(
+                TABLE_1.getQualifiedName(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
+
+        assertThat(kvs.get(TABLE_1, readMap)).isEmpty();
+    }
+
+    @Test
+    public void previouslyConservativeThrowsIfTableIsStillConservativelySwept() {
+        createTable(TABLE_1, SweepStrategy.CONSERVATIVE);
+
+        SweeperService sweeperService = new SweeperServiceImpl(specificTableSweeper, sweepBatchConfigSource);
+        assertThatThrownBy(() -> sweeperService.sweepPreviouslyConservativeNowThoroughTable(
+                        TABLE_1.getQualifiedName(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("it is not safe to run this type of sweep on conservatively swept tables");
+    }
+
+    @Test
+    public void previouslyConservativeRespectsSkipPeriodWhenErasingSentinels() {
+        skipCellVersion.setPeriod(4);
+        createTable(TABLE_1, SweepStrategy.THOROUGH);
+
+        Map<Cell, byte[]> sentinelWrites = IntStream.range(0, 100)
+                .mapToObj(PtBytes::toBytes)
+                .map(bytes -> Cell.create(bytes, bytes))
+                .collect(Collectors.toMap(cell -> cell, _ignore -> PtBytes.EMPTY_BYTE_ARRAY));
+        kvs.put(TABLE_1, sentinelWrites, Value.INVALID_VALUE_TIMESTAMP);
+        Map<Cell, Long> readMap = KeyedStream.stream(sentinelWrites)
+                .map(_ignore -> Long.MAX_VALUE)
+                .collectToMap();
+        assertThat(kvs.get(TABLE_1, readMap)).hasSize(100);
+
+        SweeperService sweeperService = new SweeperServiceImpl(specificTableSweeper, sweepBatchConfigSource);
+        sweeperService.sweepPreviouslyConservativeNowThoroughTable(
+                TABLE_1.getQualifiedName(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
+
+        // Impl specific, documenting here -- exact last row will be swept twice, so the sentinel will be erased on
+        // second pass-through; this is fine, not worth the risk of modifying behaviour
+        assertThat(kvs.get(TABLE_1, readMap)).hasSize(24);
+    }
+
+    @Test
+    public void previouslyConservativeRespectsSkipPeriodWhenSweepingNormally() {
+        skipCellVersion.setPeriod(9);
+        createTable(TABLE_1, SweepStrategy.THOROUGH);
+
+        Map<Cell, byte[]> writes = KeyedStream.of(IntStream.range(0, 1000).boxed())
+                .mapKeys(PtBytes::toBytes)
+                .mapKeys(bytes -> Cell.create(bytes, bytes))
+                .map(count -> count < 500 ? PtBytes.toBytes(count) : PtBytes.EMPTY_BYTE_ARRAY)
+                .collectToMap();
+        kvs.put(TABLE_1, writes, 100L);
+        txService.putUnlessExists(100L, 101L);
+        kvs.put(TABLE_1, writes, 103L);
+        txService.putUnlessExists(103L, 104L);
+
+        Map<Cell, Long> readMap =
+                KeyedStream.stream(writes).map(_ignore -> 102L).collectToMap();
+        assertThat(kvs.get(TABLE_1, readMap)).hasSize(1000);
+
+        SweeperService sweeperService = new SweeperServiceImpl(specificTableSweeper, sweepBatchConfigSource);
+        sweeperService.sweepPreviouslyConservativeNowThoroughTable(
+                TABLE_1.getQualifiedName(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
+
+        // deletes all but a ninth of the entries at the lower timestamp
+        assertThat(kvs.get(TABLE_1, readMap)).hasSize(111);
+        Map<Cell, Long> readsAtMaxTs =
+                KeyedStream.stream(readMap).map(_ignore -> Long.MAX_VALUE).collectToMap();
+        // none of the cells at lower timestamp became visible
+        assertThat(kvs.get(TABLE_1, readsAtMaxTs).values().stream()
+                        .map(Value::getTimestamp)
+                        .filter(timestamp -> timestamp == 100L)
+                        .collect(Collectors.toList()))
+                .hasSize(0);
+        // 500 cannot be completely removed because they are not deletes, 111 of the remaining 500 have either of the
+        // two versions skipped from sweep, which results in a version here
+        assertThat(kvs.get(TABLE_1, readsAtMaxTs)).hasSize(500 + 111);
     }
 
     @Override

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/SweeperServiceImplIntegrationTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/SweeperServiceImplIntegrationTest.java
@@ -33,7 +33,7 @@ public class SweeperServiceImplIntegrationTest extends AbstractBackgroundSweeper
 
     @Override
     @Test
-    public void smokeTest() throws Exception {
+    public void smokeTest() {
         createTable(TABLE_1, SweepStrategy.CONSERVATIVE);
         putManyCells(TABLE_1, 100, 110);
         putManyCells(TABLE_1, 103, 113);

--- a/changelog/@unreleased/pr-5628.v2.yml
+++ b/changelog/@unreleased/pr-5628.v2.yml
@@ -1,0 +1,11 @@
+type: feature
+feature:
+  description: AtlasDB sweeper service (``/sweep``) now exposes a new endpoint (``sweep-previously-conservative-now-thorough-table``)
+    that can be used to safely sweep tables that were previously used with conservative
+    sweep and now use thorough sweep, by intentionally leaving a small fraction of
+    the data. This was previously not safe, as sweeping away too many consecutive
+    legacy sentinels can cause range scan failures in Cassandra. Once compactions
+    have been completed, it should be safe to run an iteration of full sweep to remove
+    all the left over sweepable values.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5628


### PR DESCRIPTION
**Goals (and why)**:
Be able to sweep away sentinels from tables that were conservatively swept and are now thoroughly swept without destroying Cassandra.

**Implementation Description (bullets)**:
The issue that we want to avoid is having 100k+ consecutive tombstones, this adds a new endpoint to the sweep endpoint which adds a 1% chance of skipping sweeping any one entry. This is correct because:

1) it is only allowed on thoroughly swept tables (hence no read only transactions would see an old version)
2) if any version is skipped, we keep the freshest version so that old writes do not come back to life

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added a bunch of tests

**Concerns (what feedback would you like?)**:
Thought carefully about this, but at first missed point 2) above -- have I missed anything else?

**Where should we start reviewing?**:
Tests?

**Priority (whenever / two weeks / yesterday)**:
This week?
