### PR TITLE
Don't Overexpose Codegen Dependencies

### DIFF
--- a/atlasdb-client/build.gradle
+++ b/atlasdb-client/build.gradle
@@ -66,12 +66,14 @@ dependencies {
     exclude (group: 'io.dropwizard.metrics', module: 'metrics-core')
     exclude (group: 'org.hdrhistogram', module: 'HdrHistogram')
   }
-  compile group: 'com.squareup', name:'javapoet'
+  
   compile group: 'com.squareup.okio', name: 'okio'
   compile group: 'org.hdrhistogram', name: 'HdrHistogram'
   compile group: 'com.palantir.common', name: 'streams'
   compile group: 'com.github.rholder', name: 'guava-retrying'
   compile group: 'org.rocksdb', name: 'rocksdbjni'
+  
+  implementation group: 'com.squareup', name:'javapoet'
   implementation group: 'com.palantir.goethe', name: 'goethe'
 
   annotationProcessor group: 'org.immutables', name: 'value'

--- a/atlasdb-client/build.gradle
+++ b/atlasdb-client/build.gradle
@@ -72,7 +72,7 @@ dependencies {
   compile group: 'com.palantir.common', name: 'streams'
   compile group: 'com.github.rholder', name: 'guava-retrying'
   compile group: 'org.rocksdb', name: 'rocksdbjni'
-  compile group: 'com.palantir.goethe', name: 'goethe'
+  implementation group: 'com.palantir.goethe', name: 'goethe'
 
   annotationProcessor group: 'org.immutables', name: 'value'
   compileOnly 'org.immutables:value::annotations'

--- a/atlasdb-processors/build.gradle
+++ b/atlasdb-processors/build.gradle
@@ -6,8 +6,8 @@ dependencies {
     annotationProcessor group: 'com.google.auto.service', name: 'auto-service'
     compileOnly group: 'com.google.auto.service', name: 'auto-service'
 
-    compile group: 'com.squareup', name: 'javapoet'
     compile group: 'com.google.guava', name: 'guava'
+    implementation group: 'com.squareup', name: 'javapoet'
     implementation group: 'com.palantir.goethe', name: 'goethe'
 
     implementation 'com.google.auto.service:auto-service-annotations'

--- a/atlasdb-processors/build.gradle
+++ b/atlasdb-processors/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 
     compile group: 'com.squareup', name: 'javapoet'
     compile group: 'com.google.guava', name: 'guava'
-    compile group: 'com.palantir.goethe', name: 'goethe'
+    implementation group: 'com.palantir.goethe', name: 'goethe'
 
     implementation 'com.google.auto.service:auto-service-annotations'
     implementation 'com.google.errorprone:error_prone_annotations'


### PR DESCRIPTION
**Goals (and why)**:
This is causing pain in downstream consumers of the atlas-client and processors as shading Jackson transitively can lead to duplicate classes on the classpath.
