### PR TITLE
Track open transactions

### DIFF
--- a/changelog/@unreleased/pr-5630.v2.yml
+++ b/changelog/@unreleased/pr-5630.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: The number of open transactions are now tracked in a metric, `openTransactionCounter`.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5630

--- a/changelog/@unreleased/pr-5630.v2.yml
+++ b/changelog/@unreleased/pr-5630.v2.yml
@@ -1,5 +1,5 @@
 type: improvement
 improvement:
-  description: The number of open transactions are now tracked in a metric, `openTransactionCounter`.
+  description: The number of open transactions are now tracked in a metric, `com.palantir.atlasdb.transaction.impl.SnapshotTransactionManager.openTransactionCounter`.
   links:
   - https://github.com/palantir/atlasdb/pull/5630


### PR DESCRIPTION
**Goals (and why)**:
We don't have a good way of knowing how many open transactions we have. This not only helps to solve some internal issues, but this may well tell us if we are leaking transaction state over time (if transaction count increases over time, this means we're missing a place to decrement, which in turn likely means we are missing some places to remove lock watch state, for instance).

**Implementation Description (bullets)**:
Add a counter to `SnapshotTransactionManager` that increments when transactions are started, and decrements when they finish. 

**Testing (What was existing testing like?  What have you done to improve it?)**:
None

**Concerns (what feedback would you like?)**:
Reasonable?

**Where should we start reviewing?**:
Diff

**Priority (whenever / two weeks / yesterday)**:
Today, for internal issues please.

