### PR TITLE
Add metrics for cache instance count

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbMetricNames.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbMetricNames.java
@@ -106,5 +106,5 @@ public final class AtlasDbMetricNames {
     public static final String LW_CACHE_RATIO_USED = "lockWatchCacheRatioUsed";
     public static final String LW_EVENT_CACHE_FALLBACK_COUNT = "lockWatchEventCacheFallbackCount";
     public static final String LW_VALUE_CACHE_FALLBACK_COUNT = "lockWatchValueCacheFallbackCount";
-    public static final String LW_CACHE_INSTANCE_COUNT = "lockWatchCacheInstanceCount";
+    public static final String LW_TRANSACTION_CACHE_INSTANCE_COUNT = "lockWatchTransactionCacheInstanceCount";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbMetricNames.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbMetricNames.java
@@ -106,4 +106,5 @@ public final class AtlasDbMetricNames {
     public static final String LW_CACHE_RATIO_USED = "lockWatchCacheRatioUsed";
     public static final String LW_EVENT_CACHE_FALLBACK_COUNT = "lockWatchEventCacheFallbackCount";
     public static final String LW_VALUE_CACHE_FALLBACK_COUNT = "lockWatchValueCacheFallbackCount";
+    public static final String LW_CACHE_INSTANCE_COUNT = "lockWatchCacheInstanceCount";
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/CacheMetrics.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/CacheMetrics.java
@@ -17,6 +17,7 @@
 package com.palantir.atlasdb.keyvalue.api.cache;
 
 import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
 import com.palantir.atlasdb.AtlasDbMetricNames;
 import com.palantir.atlasdb.util.CurrentValueMetric;
 import com.palantir.atlasdb.util.MetricsManager;
@@ -111,5 +112,10 @@ public final class CacheMetrics {
                 CacheMetrics.class,
                 AtlasDbMetricNames.LW_CACHE_RATIO_USED,
                 () -> () -> cacheSize.getCount() / (double) maximumCacheSize);
+    }
+
+    public void setCacheInstanceCountGauge(Gauge<Integer> getCacheMapCount) {
+        metricsManager.registerOrGetGauge(
+                CacheMetrics.class, AtlasDbMetricNames.LW_CACHE_INSTANCE_COUNT, () -> getCacheMapCount);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/CacheMetrics.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/CacheMetrics.java
@@ -114,8 +114,8 @@ public final class CacheMetrics {
                 () -> () -> cacheSize.getCount() / (double) maximumCacheSize);
     }
 
-    public void setCacheInstanceCountGauge(Gauge<Integer> getCacheMapCount) {
+    public void setTransactionCacheInstanceCountGauge(Gauge<Integer> getCacheMapCount) {
         metricsManager.registerOrGetGauge(
-                CacheMetrics.class, AtlasDbMetricNames.LW_CACHE_INSTANCE_COUNT, () -> getCacheMapCount);
+                CacheMetrics.class, AtlasDbMetricNames.LW_TRANSACTION_CACHE_INSTANCE_COUNT, () -> getCacheMapCount);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/CacheStoreImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/CacheStoreImpl.java
@@ -51,7 +51,7 @@ final class CacheStoreImpl implements CacheStore {
         this.maxCacheCount = maxCacheCount;
         this.cacheMap = new ConcurrentHashMap<>();
         this.validationProbability = validationProbability;
-        metrics.setCacheInstanceCountGauge(cacheMap::size);
+        metrics.setTransactionCacheInstanceCountGauge(cacheMap::size);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/CacheStoreImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/CacheStoreImpl.java
@@ -51,6 +51,7 @@ final class CacheStoreImpl implements CacheStore {
         this.maxCacheCount = maxCacheCount;
         this.cacheMap = new ConcurrentHashMap<>();
         this.validationProbability = validationProbability;
+        metrics.setCacheInstanceCountGauge(cacheMap::size);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/CacheStoreImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/CacheStoreImplTest.java
@@ -123,7 +123,7 @@ public final class CacheStoreImplTest {
     @SuppressWarnings("unchecked")
     private int getTransactionCacheInstanceCount() {
         ArgumentCaptor<Gauge<Integer>> cacheInstanceCount = ArgumentCaptor.forClass(Gauge.class);
-        verify(metrics).setCacheInstanceCountGauge(cacheInstanceCount.capture());
+        verify(metrics).setTransactionCacheInstanceCountGauge(cacheInstanceCount.capture());
         return cacheInstanceCount.getValue().getValue();
     }
 }

--- a/changelog/@unreleased/pr-5631.v2.yml
+++ b/changelog/@unreleased/pr-5631.v2.yml
@@ -1,5 +1,5 @@
 type: improvement
 improvement:
-  description: Add metrics for cache instance count
+  description: Add metric for tracking the count of transaction caches stored in the transaction map, connected to memory leaks such as PDS-185998 and PDS-209612
   links:
   - https://github.com/palantir/atlasdb/pull/5631

--- a/changelog/@unreleased/pr-5631.v2.yml
+++ b/changelog/@unreleased/pr-5631.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add metrics for cache instance count
+  links:
+  - https://github.com/palantir/atlasdb/pull/5631


### PR DESCRIPTION
**Goals (and why)**: Start tracking the count of existing caches in metrics, to help diagnosing memory leaks such as PDS-185998 and (currently) PDS-209612.

**Implementation Description (bullets)**:
- Simple gauge which tracks the map size.

**Testing (What was existing testing like?  What have you done to improve it?)**: Metrics are contained in a CacheMetrics class, which is usually mocked and receives some simple testing. I added a minimal assertion to one of the existing tests.

**Concerns (what feedback would you like?)**: A single CacheMetrics instance seems to be exclusive to a single CacheStoreImpl instance, but metric names are strings registered in MetricsManager - is it certain individual gauges will be tagged appropriately?

**Where should we start reviewing?**: Wherever.

**Priority (whenever / two weeks / yesterday)**: Two weeks.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
