### PR TITLE
[PDS-210062] Fix SnapshotTransaction/Delete Executor Resource Leak

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -167,6 +167,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -1462,12 +1463,23 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                         .map(_ignore -> Value.INVALID_VALUE_TIMESTAMP)
                         .collectToSetMultimap();
                 try {
-                    deleteExecutor.execute(() -> keyValueService.delete(table, sentinels));
+                    runTaskOnDeleteExecutor(kvs -> kvs.delete(table, sentinels));
                 } catch (Throwable th) {
                     // best effort
                 }
             }
         });
+    }
+
+    /**
+     * This method exists to ensure that tasks run on the delete executor do not have references to the
+     * SnapshotTransaction that spawned the task (so that it can be garbage collected, which may be significant as
+     * large write or serializable read transactions may have allocated a lot of memory).
+     */
+    private void runTaskOnDeleteExecutor(Consumer<KeyValueService> task) {
+        // Do not inline this without thinking carefully about exactly what this means
+        KeyValueService theKeyValueService = keyValueService;
+        deleteExecutor.submit(() -> task.accept(theKeyValueService));
     }
 
     private static boolean isSweepSentinel(Value value) {
@@ -2170,7 +2182,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         }
 
         try {
-            deleteExecutor.execute(() -> deleteCells(keyValueService, tableRef, keysToDelete));
+            runTaskOnDeleteExecutor(kvs -> deleteCells(kvs, tableRef, keysToDelete));
         } catch (RejectedExecutionException rejected) {
             log.info(
                     "Could not delete keys {} for table {}, because the delete executor's queue was full."
@@ -2182,10 +2194,6 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         return true;
     }
 
-    /**
-     * This method is made static so it loses reference to the SnapshotTransaction reference when passed to
-     * deleteExecutor::execute in a lambda reducing its retained memory size.
-     */
     private static void deleteCells(
             KeyValueService keyValueService, TableReference tableRef, Map<Cell, Long> keysToDelete) {
         try {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -1479,7 +1479,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     private void runTaskOnDeleteExecutor(Consumer<KeyValueService> task) {
         // Do not inline this without thinking carefully about exactly what this means
         KeyValueService theKeyValueService = keyValueService;
-        deleteExecutor.submit(() -> task.accept(theKeyValueService));
+        deleteExecutor.execute(() -> task.accept(theKeyValueService));
     }
 
     private static boolean isSweepSentinel(Value value) {

--- a/changelog/@unreleased/pr-5632.v2.yml
+++ b/changelog/@unreleased/pr-5632.v2.yml
@@ -1,0 +1,9 @@
+type: fix
+fix:
+  description: Fixed a memory leak that occurred where cleanup tasks from failed transactions
+    maintained a reference to the transaction (as opposed to just the information
+    needed for the cleanup task), preventing them from being garbage collected. This
+    is significant as writes and, in the case of serializable transactions, reads,
+    are retained in the transaction objects.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5632


### PR DESCRIPTION
**Goals (and why)**:
- See PDS-210062
- Resource leaks are bad, we don't want them.

**Implementation Description (bullets)**:
- #4656 was an attempt at reducing the memory in the delete executor's work queue. It wasn't a complete fix: 

```
deleteExecutor.execute(() -> deleteCells(keyValueService, tableRef, keysToDelete));
```

still reads the value of `keyValueService` _at the time the lambda is called_, and so that must maintain a reference to `this`. It would suffice to read it first

```
KeyValueService theKvs = keyValueService;
deleteExecutor.execute(() -> deleteCells(theKvs, tableRef, keysToDelete));
```

- But this PR adds a bit more abstraction so it's harder to misuse the delete executor.
- Possibly worthwhile reading for a broader coverage of the subject: https://cr.openjdk.java.net/~briangoetz/lambda/lambda-state-final.html

**Testing (What was existing testing like?  What have you done to improve it?)**:
Manual testing with a debugger to verify whether or not references to `this` were present in the lambda. 

**Concerns (what feedback would you like?)**:
- Is the additional layer of abstraction worthwhile?
- Did I mess anything up when fixing?

**Where should we start reviewing?**: SnapshotTransaction

**Priority (whenever / two weeks / yesterday)**: this week please

---

@Chrisbattarbee for SA (and also h/t for excellent internal sleuthing, without which this would have been _really_ hard to find).
