### PR TITLE
[LW] Additional filtering for values flushed to central cache

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
@@ -28,11 +28,11 @@ import com.palantir.atlasdb.keyvalue.api.watch.StartTimestamp;
 import com.palantir.atlasdb.transaction.api.TransactionLockWatchFailedException;
 import com.palantir.common.streams.KeyedStream;
 import com.palantir.lock.LockDescriptor;
-import com.palantir.lock.watch.CommitUpdate;
 import com.palantir.lock.watch.CommitUpdate.Visitor;
 import com.palantir.lock.watch.LockWatchEvent;
 import com.palantir.lock.watch.LockWatchEventCache;
 import com.palantir.lock.watch.LockWatchVersion;
+import com.palantir.lock.watch.SpanningCommitUpdate;
 import com.palantir.lock.watch.TransactionsLockWatchUpdate;
 import java.util.Comparator;
 import java.util.List;
@@ -131,10 +131,10 @@ public final class LockWatchValueScopingCacheImpl implements LockWatchValueScopi
             return;
         }
 
-        CommitUpdate commitUpdate = eventCache.getCommitUpdate(startTimestamp);
-        cacheStore.createReadOnlyCache(startTs, commitUpdate);
+        SpanningCommitUpdate spanningCommitUpdate = eventCache.getSpanningCommitUpdate(startTimestamp);
+        cacheStore.createReadOnlyCache(startTs, spanningCommitUpdate.transactionCommitUpdate());
 
-        commitUpdate.accept(new Visitor<Void>() {
+        spanningCommitUpdate.spanningCommitUpdate().accept(new Visitor<Void>() {
             @Override
             public Void invalidateAll() {
                 // This might happen due to an election or if we exceeded the maximum number of events held in

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/ClientLogEvents.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/ClientLogEvents.java
@@ -81,22 +81,6 @@ interface ClientLogEvents {
                 .build();
     }
 
-    default CommitUpdate toCommitUpdate(LockWatchVersion startVersion, CommitInfo commitInfo) {
-        if (clearCache()) {
-            return CommitUpdate.invalidateAll();
-        }
-
-        // We want to ensure that we do not miss any versions, but we do not care about the event with the same version
-        // as the start version.
-        verifyReturnedEventsEnclosesTransactionVersions(
-                startVersion.version() + 1, commitInfo.commitVersion().version());
-
-        LockEventVisitor eventVisitor = new LockEventVisitor(commitInfo.commitLockToken());
-        Set<LockDescriptor> locksTakenOut = new HashSet<>();
-        events().events().forEach(event -> locksTakenOut.addAll(event.accept(eventVisitor)));
-        return CommitUpdate.invalidateSome(locksTakenOut);
-    }
-
     default SpanningCommitUpdate toSpanningCommitUpdate(
             LockWatchVersion startVersion, CommitInfo commitInfo, LockWatchVersion endVersion) {
         if (clearCache()) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/ClientLogEvents.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/ClientLogEvents.java
@@ -29,6 +29,7 @@ import com.palantir.lock.watch.LockEvent;
 import com.palantir.lock.watch.LockWatchCreatedEvent;
 import com.palantir.lock.watch.LockWatchEvent;
 import com.palantir.lock.watch.LockWatchVersion;
+import com.palantir.lock.watch.SpanningCommitUpdate;
 import com.palantir.lock.watch.TransactionsLockWatchUpdate;
 import com.palantir.lock.watch.UnlockEvent;
 import com.palantir.logsafe.SafeArg;
@@ -94,6 +95,33 @@ interface ClientLogEvents {
         Set<LockDescriptor> locksTakenOut = new HashSet<>();
         events().events().forEach(event -> locksTakenOut.addAll(event.accept(eventVisitor)));
         return CommitUpdate.invalidateSome(locksTakenOut);
+    }
+
+    default SpanningCommitUpdate toSpanningCommitUpdate(
+            LockWatchVersion startVersion, CommitInfo commitInfo, LockWatchVersion endVersion) {
+        if (clearCache()) {
+            return SpanningCommitUpdate.invalidateAll();
+        }
+
+        // We want to ensure that we do not miss any versions, but we do not care about the event with the same version
+        // as the start version.
+        verifyReturnedEventsEnclosesTransactionVersions(startVersion.version() + 1, endVersion.version());
+
+        LockEventVisitor eventVisitor = new LockEventVisitor(commitInfo.commitLockToken());
+        Set<LockDescriptor> transactionLocks = new HashSet<>();
+        Set<LockDescriptor> spanningLocks = new HashSet<>();
+        events().events().forEach(event -> {
+            Set<LockDescriptor> descriptors = event.accept(eventVisitor);
+            spanningLocks.addAll(descriptors);
+
+            if (event.sequence() <= commitInfo.commitVersion().version()) {
+                transactionLocks.addAll(descriptors);
+            }
+        });
+        return SpanningCommitUpdate.builder()
+                .transactionCommitUpdate(CommitUpdate.invalidateSome(transactionLocks))
+                .spanningCommitUpdate(CommitUpdate.invalidateSome(spanningLocks))
+                .build();
     }
 
     default void verifyReturnedEventsEnclosesTransactionVersions(long lowerBound, long upperBound) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheImpl.java
@@ -81,21 +81,7 @@ public final class LockWatchEventCacheImpl implements LockWatchEventCache {
 
     @Override
     public synchronized CommitUpdate getCommitUpdate(long startTs) {
-        Optional<LockWatchVersion> startVersion = timestampStateStore.getStartVersion(startTs);
-        Optional<CommitInfo> maybeCommitInfo = timestampStateStore.getCommitInfo(startTs);
-
-        assertTrue(
-                maybeCommitInfo.isPresent() && startVersion.isPresent(),
-                "start or commit info not processed for start timestamp");
-
-        CommitInfo commitInfo = maybeCommitInfo.get();
-
-        VersionBounds versionBounds = VersionBounds.builder()
-                .startVersion(startVersion)
-                .endVersion(commitInfo.commitVersion())
-                .build();
-
-        return eventLog.getEventsBetweenVersions(versionBounds).toCommitUpdate(startVersion.get(), commitInfo);
+        return getSpanningCommitUpdate(startTs).transactionCommitUpdate();
     }
 
     @Override
@@ -107,7 +93,7 @@ public final class LockWatchEventCacheImpl implements LockWatchEventCache {
                 maybeCommitInfo.isPresent()
                         && startVersion.isPresent()
                         && eventLog.getLatestKnownVersion().isPresent(),
-                "start or commit info not processed for start timestamp");
+                "start or commit info not processed for start timestamp, or current version missing");
 
         LockWatchVersion currentVersion = eventLog.getLatestKnownVersion().get();
         CommitInfo commitInfo = maybeCommitInfo.get();

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheImpl.java
@@ -116,15 +116,8 @@ public final class LockWatchEventCacheImpl implements LockWatchEventCache {
                 .endVersion(currentVersion)
                 .build();
 
-        ClientLogEvents events = eventLog.getEventsBetweenVersions(versionBounds);
-        CommitUpdate transactionCommitUpdate = events.toCommitUpdate(startVersion.get(), commitInfo);
-        CommitUpdate spanningCommitUpdate =
-                events.toCommitUpdate(startVersion.get(), CommitInfo.of(commitInfo.commitLockToken(), currentVersion));
-
-        return SpanningCommitUpdate.builder()
-                .transactionCommitUpdate(transactionCommitUpdate)
-                .spanningCommitUpdate(spanningCommitUpdate)
-                .build();
+        return eventLog.getEventsBetweenVersions(versionBounds)
+                .toSpanningCommitUpdate(startVersion.get(), commitInfo, currentVersion);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImplTest.java
@@ -163,7 +163,7 @@ public final class LockWatchValueScopingCacheImplTest {
         // there was an election)
         assertThatThrownBy(() -> valueCache.updateCacheOnCommit(ImmutableSet.of(TIMESTAMP_1)))
                 .isExactlyInstanceOf(TransactionLockWatchFailedException.class)
-                .hasMessage("start or commit info not processed for start timestamp");
+                .hasMessage("start or commit info not processed for start timestamp, or current version missing");
     }
 
     @Test

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImplTest.java
@@ -354,7 +354,8 @@ public final class LockWatchValueScopingCacheImplTest {
         verify(metrics, times(1)).registerHits(0);
         verify(metrics, times(1)).registerMisses(2);
 
-        // Simulate the case where the transaction gets a commit timestamp but has not yet committed
+        // Simulate the case where the transaction gets a commit timestamp but has not yet committed. This start
+        // transactions update introduces the lock taken out on CELL_1
         eventCache.processStartTransactionsUpdate(
                 ImmutableSet.of(TIMESTAMP_2), LockWatchStateUpdate.success(LEADER, 1L, ImmutableList.of(LOCK_EVENT)));
         valueCache.processStartTransactions(ImmutableSet.of(TIMESTAMP_2));

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/DuplicatingLockWatchEventCache.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/DuplicatingLockWatchEventCache.java
@@ -22,13 +22,14 @@ import com.palantir.lock.watch.CommitUpdate;
 import com.palantir.lock.watch.LockWatchEventCache;
 import com.palantir.lock.watch.LockWatchStateUpdate;
 import com.palantir.lock.watch.LockWatchVersion;
+import com.palantir.lock.watch.SpanningCommitUpdate;
 import com.palantir.lock.watch.TransactionUpdate;
 import com.palantir.lock.watch.TransactionsLockWatchUpdate;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
 
-class DuplicatingLockWatchEventCache implements LockWatchEventCache {
+final class DuplicatingLockWatchEventCache implements LockWatchEventCache {
     private final LockWatchEventCache mainCache;
     private final LockWatchEventCache secondaryCache;
 
@@ -65,6 +66,11 @@ class DuplicatingLockWatchEventCache implements LockWatchEventCache {
     @Override
     public CommitUpdate getCommitUpdate(long startTs) {
         return mainCache.getCommitUpdate(startTs);
+    }
+
+    @Override
+    public SpanningCommitUpdate getSpanningCommitUpdate(long startTs) {
+        return mainCache.getSpanningCommitUpdate(startTs);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheIntegrationTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheIntegrationTest.java
@@ -528,7 +528,7 @@ public class LockWatchEventCacheIntegrationTest {
 
         assertThatThrownBy(() -> eventCache.getCommitUpdate(START_TS_1))
                 .isExactlyInstanceOf(TransactionLockWatchFailedException.class)
-                .hasMessage("start or commit info not processed for start timestamp");
+                .hasMessage("start or commit info not processed for start timestamp, or current version missing");
     }
 
     @Test

--- a/changelog/@unreleased/pr-5635.v2.yml
+++ b/changelog/@unreleased/pr-5635.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Resolved an edge case in the lock watch value cache whereby loaded
+    values where not invalidated if the write happened after the commit timestamp
+    but before the commit was completed.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5635

--- a/lock-api-objects/src/main/java/com/palantir/lock/watch/SpanningCommitUpdate.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/watch/SpanningCommitUpdate.java
@@ -30,4 +30,11 @@ public interface SpanningCommitUpdate {
     static TransactionCommitUpdateBuildStage builder() {
         return ImmutableSpanningCommitUpdate.builder();
     }
+
+    static SpanningCommitUpdate invalidateAll() {
+        return SpanningCommitUpdate.builder()
+                .transactionCommitUpdate(CommitUpdate.invalidateAll())
+                .spanningCommitUpdate(CommitUpdate.invalidateAll())
+                .build();
+    }
 }

--- a/lock-api-objects/src/main/java/com/palantir/lock/watch/SpanningCommitUpdate.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/watch/SpanningCommitUpdate.java
@@ -1,0 +1,33 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.watch;
+
+import com.palantir.common.annotations.ImmutablesStyles.StagedBuilderStyle;
+import com.palantir.lock.watch.ImmutableSpanningCommitUpdate.TransactionCommitUpdateBuildStage;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@StagedBuilderStyle
+public interface SpanningCommitUpdate {
+    CommitUpdate transactionCommitUpdate();
+
+    CommitUpdate spanningCommitUpdate();
+
+    static TransactionCommitUpdateBuildStage builder() {
+        return ImmutableSpanningCommitUpdate.builder();
+    }
+}

--- a/lock-api/src/main/java/com/palantir/lock/watch/LockWatchEventCache.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/LockWatchEventCache.java
@@ -42,13 +42,25 @@ public interface LockWatchEventCache {
             Collection<TransactionUpdate> transactionUpdates, LockWatchStateUpdate update);
 
     /**
-     * Updates the cache with the update, and calculates the {@link CommitUpdate} taking into account all changes to
-     * lock watch state since the start of the transaction, excluding the transaction's own commit locks.
+     * Calculates the {@link CommitUpdate} taking into account all changes to lock watch state since the start of the
+     * transaction, excluding the transaction's own commit locks.
      *
      * @param startTs start timestamp of the transaction
      * @return the commit update for this transaction's precommit condition
      */
     CommitUpdate getCommitUpdate(long startTs);
+
+    /**
+     * Computes a {@link SpanningCommitUpdate}, which is essentially two regular commit updates. The former is the
+     * same as the result from {@link LockWatchEventCache#getCommitUpdate(long)}, but the latter also includes locks
+     * taken out between commit time and the present. This is critical for flushing values to the central cache, as
+     * the central cache may be on a later version than the commit time of the transaction.
+     *
+     * @param startTs start timestamp of the transaction
+     * @return a spanning commit update, which contains the commit update for this transaction, as well as a commit
+     * update which contains all lock descriptors from the start of the transaction until **now**.
+     */
+    SpanningCommitUpdate getSpanningCommitUpdate(long startTs);
 
     /**
      * Given a set of start timestamps, and a lock watch state version, returns a list of all events that occurred since

--- a/lock-api/src/main/java/com/palantir/lock/watch/NoOpLockWatchEventCache.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/NoOpLockWatchEventCache.java
@@ -60,6 +60,14 @@ public class NoOpLockWatchEventCache implements LockWatchEventCache {
     }
 
     @Override
+    public SpanningCommitUpdate getSpanningCommitUpdate(long startTs) {
+        return SpanningCommitUpdate.builder()
+                .transactionCommitUpdate(CommitUpdate.invalidateAll())
+                .spanningCommitUpdate(CommitUpdate.invalidateAll())
+                .build();
+    }
+
+    @Override
     public TransactionsLockWatchUpdate getUpdateForTransactions(
             Set<Long> startTimestamps, Optional<LockWatchVersion> version) {
         return ImmutableTransactionsLockWatchUpdate.builder()

--- a/lock-api/src/main/java/com/palantir/lock/watch/NoOpLockWatchEventCache.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/NoOpLockWatchEventCache.java
@@ -61,10 +61,7 @@ public class NoOpLockWatchEventCache implements LockWatchEventCache {
 
     @Override
     public SpanningCommitUpdate getSpanningCommitUpdate(long startTs) {
-        return SpanningCommitUpdate.builder()
-                .transactionCommitUpdate(CommitUpdate.invalidateAll())
-                .spanningCommitUpdate(CommitUpdate.invalidateAll())
-                .build();
+        return SpanningCommitUpdate.invalidateAll();
     }
 
     @Override


### PR DESCRIPTION
**Goals (and why)**:
When a transaction is committed, it will get a commit timestamp, along with lock watch information at that point. These are stored in the event cache. Then, when the values are to be flushed to the central cache, the events between start and commit timestamp are retrieved, unlock events are filtered out, and the resultant set of lock descriptors represents the set of locks taken out from start to end of that transaction.

These are used to filter the values loaded within the transaction, and the remaining values are flushed to the central cache. However, the time at which values are flushed to the central cache is later than the commit timestamp: the transaction needs to actually be committed (and thus conflict checking etc. needs to happen) before we can use those values. Thus, the central cache will likely have progressed its own version by then, including having new lock descriptors taken out. The result is that we might attempt to write values to the central cache that are out of date or no longer valid.

Atlasdb-proxy doesn't have this issue as it did the correct thing simply because it couldn't do the incorrect thing: it retrieved events from the start of the transaction up until _the present_ (at value flushing time) - this is guaranteed to only ever be more conservative (as well as being correct, of course). AtlasDB just needs to do the same thing here.

**Implementation Description (bullets)**:
Added a `SpanningCommitUpdate` that contains two commit updates: one which includes start timestamp to commit timestamp events, and one that contains events from start to latest. The reason for two is that serializiable conflict checking _should_ only be using the former, since it is only evaluating against writes that could have happened within the scope of the transaction, and using the latter one would result in more cache misses than is strictly necessary.

**Testing (What was existing testing like?  What have you done to improve it?)**:
WIP

**Concerns (what feedback would you like?)**:
* Is it worth splitting the commit update like this? Should we just be more conservative and invalidate more when it comes to conflict checking?

**Where should we start reviewing?**:
`LockWatchValueScopingCacheImpl`

**Priority (whenever / two weeks / yesterday)**:
This week
