### PR TITLE
Switch Cluster client to use DCAwareRR

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/client/creation/DefaultCqlClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/client/creation/DefaultCqlClientFactory.java
@@ -138,11 +138,11 @@ public class DefaultCqlClientFactory implements CqlClientFactory {
         // Refuse to talk to nodes twice as (latency-wise) slow as the best one, over a timescale of 100ms,
         // and every 10s try to re-evaluate ignored nodes performance by giving them queries again.
         //
-        // We are using the DCAware RR policy specifically to support "datacenter switch"-style Cassandra,
-        // migrations (see https://thelastpickle.com/blog/2019/02/26/data-center-switch.html),
-        // and don't expect the policy to be helpful for latency improvements.
+        // The DCAware RR policy prevents auto-discovery of remote datacenter contact points in a multi-DC setup,
+        // which we are using to orchestrate migrations across datacenters.  We don't expect the policy to be helpful
+        // for latency improvements.
         //
-        // We don't specify the local DC, so it will get set based on the contact points we provide.
+        // Since the local DC isn't specified, it will get set based on the contact points we provide.
         LoadBalancingPolicy policy = LatencyAwarePolicy.builder(
                         DCAwareRoundRobinPolicy.builder().build())
                 .build();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/client/creation/DefaultCqlClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/client/creation/DefaultCqlClientFactory.java
@@ -25,10 +25,10 @@ import com.datastax.driver.core.QueryOptions;
 import com.datastax.driver.core.RemoteEndpointAwareJdkSSLOptions;
 import com.datastax.driver.core.SocketOptions;
 import com.datastax.driver.core.ThreadingOptions;
+import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
 import com.datastax.driver.core.policies.DefaultRetryPolicy;
 import com.datastax.driver.core.policies.LatencyAwarePolicy;
 import com.datastax.driver.core.policies.LoadBalancingPolicy;
-import com.datastax.driver.core.policies.RoundRobinPolicy;
 import com.datastax.driver.core.policies.TokenAwarePolicy;
 import com.datastax.driver.core.policies.WhiteListPolicy;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
@@ -137,12 +137,15 @@ public class DefaultCqlClientFactory implements CqlClientFactory {
             Cluster.Builder builder, CassandraKeyValueServiceConfig config, Set<InetSocketAddress> servers) {
         // Refuse to talk to nodes twice as (latency-wise) slow as the best one, over a timescale of 100ms,
         // and every 10s try to re-evaluate ignored nodes performance by giving them queries again.
-        // Note we are being purposely datacenter-irreverent here, instead relying on latency alone
-        // to approximate what DCAwareRR would do;
-        // this is because DCs for Atlas are always quite latency-close and should be used this way,
-        // not as if we have some cross-country backup DC.
-        LoadBalancingPolicy policy =
-                LatencyAwarePolicy.builder(new RoundRobinPolicy()).build();
+        //
+        // We are using the DCAware RR policy specifically to support "datacenter switch"-style Cassandra,
+        // migrations (see https://thelastpickle.com/blog/2019/02/26/data-center-switch.html),
+        // and don't expect the policy to be helpful for latency improvements.
+        //
+        // We don't specify the local DC, so it will get set based on the contact points we provide.
+        LoadBalancingPolicy policy = LatencyAwarePolicy.builder(
+                        DCAwareRoundRobinPolicy.builder().build())
+                .build();
 
         // If user wants, do not automatically add in new nodes to pool (useful during DC migrations / rebuilds)
         if (!config.autoRefreshNodes()) {

--- a/changelog/@unreleased/pr-5649.v2.yml
+++ b/changelog/@unreleased/pr-5649.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Switch Cluster client to use DCAwareRR
+  links:
+  - https://github.com/palantir/atlasdb/pull/5649


### PR DESCRIPTION
**Goals (and why)**:
In order to perform a datacenter switch, we need to be able to isolate Cassandra clients to a specific datacenter ("local").  The DCAwareRR client ensures that we do not try to route requests to the "remote" datacenter.

(Copied from comment below): I believe that the equivalent of this for Thrift is already practically implemented by the local host filtering in the CassandraService: https://github.com/palantir/atlasdb/blob/develop/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java#L303

This change is not required for correctness, especially since we will disable the client interfaces on the remote DC. Instead, it's meant to gently urge the clients to behave correctly the first time, to minimize churn and make it easier to reason about queries.

**Implementation Description (bullets)**:

Use the Datastax DCAwareRR policy.

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

I don't believe that we rely on the existing implementation for anything important, please correct me if I am wrong.

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
