### PR TITLE
Make CachedTransformingSupplier exception safe

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/util/CachedTransformingSupplier.java
+++ b/atlasdb-commons/src/main/java/com/palantir/util/CachedTransformingSupplier.java
@@ -49,8 +49,8 @@ public class CachedTransformingSupplier<T, U> implements Supplier<U> {
             return cachedOutput;
         }
 
-        cachedInput = currentInput;
         cachedOutput = outputFunction.apply(cachedInput);
+        cachedInput = currentInput;
         return cachedOutput;
     }
 }

--- a/atlasdb-commons/src/main/java/com/palantir/util/CachedTransformingSupplier.java
+++ b/atlasdb-commons/src/main/java/com/palantir/util/CachedTransformingSupplier.java
@@ -49,7 +49,7 @@ public class CachedTransformingSupplier<T, U> implements Supplier<U> {
             return cachedOutput;
         }
 
-        cachedOutput = outputFunction.apply(cachedInput);
+        cachedOutput = outputFunction.apply(currentInput);
         cachedInput = currentInput;
         return cachedOutput;
     }

--- a/atlasdb-commons/src/test/java/com/palantir/util/CachedTransformingSupplierTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/util/CachedTransformingSupplierTest.java
@@ -59,15 +59,22 @@ public class CachedTransformingSupplierTest {
     }
 
     @Test
-    public void throwsIfSupplierThrows() {
-        RuntimeException ex = new RuntimeException();
-        when(STRING_SUPPLIER.get()).thenThrow(ex);
-        assertThatThrownBy(TRANSFORMING_SUPPLIER::get).isEqualTo(ex);
+    public void throwsAndRetriesIfSupplierThrows() {
+        RuntimeException ex1 = new RuntimeException();
+        RuntimeException ex2 = new RuntimeException();
+        when(STRING_SUPPLIER.get()).thenThrow(ex1).thenThrow(ex2);
+        assertThatThrownBy(TRANSFORMING_SUPPLIER::get).isEqualTo(ex1);
+        assertThatThrownBy(TRANSFORMING_SUPPLIER::get).isEqualTo(ex2);
+
+        verify(STRING_SUPPLIER, times(2)).get();
     }
 
     @Test
-    public void throwsIfMappingFunctionThrows() {
+    public void throwsAndRetriesIfMappingFunctionThrows() {
         when(STRING_SUPPLIER.get()).thenReturn("42!)*()");
         assertThatThrownBy(TRANSFORMING_SUPPLIER::get).isInstanceOf(NumberFormatException.class);
+        assertThatThrownBy(TRANSFORMING_SUPPLIER::get).isInstanceOf(NumberFormatException.class);
+
+        verify(STRING_SUPPLIER, times(2)).get();
     }
 }

--- a/changelog/@unreleased/pr-5656.v2.yml
+++ b/changelog/@unreleased/pr-5656.v2.yml
@@ -1,0 +1,16 @@
+type: fix
+fix:
+  description: |-
+    Make CachedTransformingSupplier exception safe
+
+    If `outputFunction.apply` throws an exception, the supplier will be
+    stuck in a broken state until the input changes again. Swapping the
+    order of assignment will only update the input if the output computation
+    succeeds, forcing the supplier to recompute the output every call until
+    it does not error.
+
+    This makes it so that errors in `outputFunction` show up in error
+    stacktraces, instead of getting a mysterious `NullPointerException`
+    after the first failure when calling `CachedTransformingSupplier#get`.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5656


### PR DESCRIPTION
If `outputFunction.apply` throws an exception, the supplier will be stuck in a broken state until the input changes again. Swapping the order of assignment will only update the input if the output computation succeeds, forcing the supplier to recompute the output every call until it does not error.

This makes it so that errors in `outputFunction` show up in error stacktraces, instead of getting a mysterious `NullPointerException` after the first failure when calling `CachedTransformingSupplier#get`.