### PR TITLE
Reduce MNPTLSIT flakes

### DIFF
--- a/atlasdb-commons/src/test/java/com/palantir/util/SafeShutdownRunnerTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/util/SafeShutdownRunnerTest.java
@@ -79,9 +79,8 @@ public class SafeShutdownRunnerTest {
         runner.shutdownSafely(blockingUninterruptibleRunnable);
         runner.shutdownSafely(blockingUninterruptibleRunnable);
 
-        verify(blockingUninterruptibleRunnable, times(2)).run();
-
         closeAndAssertNumberOfTimeouts(runner, 2);
+        verify(blockingUninterruptibleRunnable, times(2)).run();
     }
 
     @Test

--- a/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/suiteTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -82,11 +82,14 @@ import java.util.stream.Stream;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
 import org.junit.runners.Parameterized;
 
 @RunWith(Parameterized.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING) // This test flakes in parallel execution, the ordering should fix it
 public class MultiNodePaxosTimeLockServerIntegrationTest {
 
     @ClassRule


### PR DESCRIPTION
**Goals (and why)**:
This test flakes an incredible amount, and this deeply impacts our ability to roll out features on AtlasDB.

**Implementation Description (bullets)**:
Force the test to run each case sequentially. This will hopefully prevent errors around the SQLite DB being locked (which is one such issue).

**Concerns (what feedback would you like?)**:
This will slow down tests. Is this acceptable?

**Where should we start reviewing?**:
Diff

**Priority (whenever / two weeks / yesterday)**:
ASAP if you want tests to pass (provided this works...)
