### PR TITLE
[LW] Refactor value loader to not use table reference

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/NoOpTransactionScopedCache.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/NoOpTransactionScopedCache.java
@@ -28,7 +28,6 @@ import com.palantir.lock.watch.CommitUpdate;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Set;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 
 public final class NoOpTransactionScopedCache implements TransactionScopedCache {
@@ -48,7 +47,7 @@ public final class NoOpTransactionScopedCache implements TransactionScopedCache 
     public Map<Cell, byte[]> get(
             TableReference tableReference,
             Set<Cell> cells,
-            BiFunction<TableReference, Set<Cell>, ListenableFuture<Map<Cell, byte[]>>> valueLoader) {
+            Function<Set<Cell>, ListenableFuture<Map<Cell, byte[]>>> valueLoader) {
         return AtlasFutures.getUnchecked(getAsync(tableReference, cells, valueLoader));
     }
 
@@ -56,8 +55,8 @@ public final class NoOpTransactionScopedCache implements TransactionScopedCache 
     public ListenableFuture<Map<Cell, byte[]>> getAsync(
             TableReference tableReference,
             Set<Cell> cells,
-            BiFunction<TableReference, Set<Cell>, ListenableFuture<Map<Cell, byte[]>>> valueLoader) {
-        return valueLoader.apply(tableReference, cells);
+            Function<Set<Cell>, ListenableFuture<Map<Cell, byte[]>>> valueLoader) {
+        return valueLoader.apply(cells);
     }
 
     @Override

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ReadOnlyTransactionScopedCache.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ReadOnlyTransactionScopedCache.java
@@ -25,7 +25,6 @@ import com.palantir.lock.watch.CommitUpdate;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Set;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 
 public final class ReadOnlyTransactionScopedCache implements TransactionScopedCache {
@@ -53,7 +52,7 @@ public final class ReadOnlyTransactionScopedCache implements TransactionScopedCa
     public Map<Cell, byte[]> get(
             TableReference tableReference,
             Set<Cell> cells,
-            BiFunction<TableReference, Set<Cell>, ListenableFuture<Map<Cell, byte[]>>> valueLoader) {
+            Function<Set<Cell>, ListenableFuture<Map<Cell, byte[]>>> valueLoader) {
         return delegate.get(tableReference, cells, valueLoader);
     }
 
@@ -61,7 +60,7 @@ public final class ReadOnlyTransactionScopedCache implements TransactionScopedCa
     public ListenableFuture<Map<Cell, byte[]>> getAsync(
             TableReference tableReference,
             Set<Cell> cells,
-            BiFunction<TableReference, Set<Cell>, ListenableFuture<Map<Cell, byte[]>>> valueLoader) {
+            Function<Set<Cell>, ListenableFuture<Map<Cell, byte[]>>> valueLoader) {
         return delegate.getAsync(tableReference, cells, valueLoader);
     }
 

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/TransactionScopedCache.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/TransactionScopedCache.java
@@ -26,7 +26,6 @@ import com.palantir.lock.watch.CommitUpdate;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Set;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 
 /**
@@ -59,12 +58,12 @@ public interface TransactionScopedCache {
     Map<Cell, byte[]> get(
             TableReference tableReference,
             Set<Cell> cells,
-            BiFunction<TableReference, Set<Cell>, ListenableFuture<Map<Cell, byte[]>>> valueLoader);
+            Function<Set<Cell>, ListenableFuture<Map<Cell, byte[]>>> valueLoader);
 
     ListenableFuture<Map<Cell, byte[]>> getAsync(
             TableReference tableReference,
             Set<Cell> cells,
-            BiFunction<TableReference, Set<Cell>, ListenableFuture<Map<Cell, byte[]>>> valueLoader);
+            Function<Set<Cell>, ListenableFuture<Map<Cell, byte[]>>> valueLoader);
 
     /**
      * The cache will try to fulfil as much of the request as possible with cached values. In the case where some of the

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ValidatingTransactionScopedCache.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ValidatingTransactionScopedCache.java
@@ -45,7 +45,6 @@ import java.util.Random;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -85,7 +84,7 @@ final class ValidatingTransactionScopedCache implements TransactionScopedCache {
     public Map<Cell, byte[]> get(
             TableReference tableReference,
             Set<Cell> cells,
-            BiFunction<TableReference, Set<Cell>, ListenableFuture<Map<Cell, byte[]>>> valueLoader) {
+            Function<Set<Cell>, ListenableFuture<Map<Cell, byte[]>>> valueLoader) {
         return AtlasFutures.getUnchecked(getAsync(tableReference, cells, valueLoader));
     }
 
@@ -93,13 +92,13 @@ final class ValidatingTransactionScopedCache implements TransactionScopedCache {
     public ListenableFuture<Map<Cell, byte[]>> getAsync(
             TableReference tableReference,
             Set<Cell> cells,
-            BiFunction<TableReference, Set<Cell>, ListenableFuture<Map<Cell, byte[]>>> valueLoader) {
+            Function<Set<Cell>, ListenableFuture<Map<Cell, byte[]>>> valueLoader) {
         if (shouldValidate()) {
-            ListenableFuture<Map<Cell, byte[]>> remoteReads = valueLoader.apply(tableReference, cells);
+            ListenableFuture<Map<Cell, byte[]>> remoteReads = valueLoader.apply(cells);
             ListenableFuture<Map<Cell, byte[]>> cacheReads = delegate.getAsync(
                     tableReference,
                     cells,
-                    (table, cellsToRead) -> Futures.transform(
+                    cellsToRead -> Futures.transform(
                             remoteReads, reads -> getCells(reads, cellsToRead), MoreExecutors.directExecutor()));
 
             return Futures.transform(

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -799,7 +799,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                 .get(
                         tableRef,
                         cells,
-                        (table, uncached) -> getInternal(
+                        uncached -> getInternal(
                                 "get", tableRef, uncached, immediateKeyValueService, immediateTransactionService));
     }
 
@@ -810,7 +810,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                 .getAsync(
                         tableRef,
                         cells,
-                        (table, uncached) -> getInternal(
+                        uncached -> getInternal(
                                 "getAsync", tableRef, uncached, keyValueService, defaultTransactionService)));
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImplTest.java
@@ -318,7 +318,7 @@ public final class LockWatchValueScopingCacheImplTest {
         TransactionScopedCache scopedCache1 = valueCache.getTransactionScopedCache(TIMESTAMP_1);
         assertThat(getRemotelyReadCells(scopedCache1, TABLE, CELL_1)).containsExactlyInAnyOrder(CELL_1);
         assertThatThrownBy(() -> scopedCache1.get(
-                        TABLE, ImmutableSet.of(CELL_1), (_table, _cells) -> Futures.immediateFuture(ImmutableMap.of())))
+                        TABLE, ImmutableSet.of(CELL_1), _cells -> Futures.immediateFuture(ImmutableMap.of())))
                 .isExactlyInstanceOf(TransactionLockWatchFailedException.class)
                 .hasMessage("Failed lock watch cache validation - will retry without caching");
 
@@ -409,7 +409,7 @@ public final class LockWatchValueScopingCacheImplTest {
 
     private static Set<Cell> getRemotelyReadCells(TransactionScopedCache cache, TableReference table, Cell... cells) {
         Set<Cell> remoteReads = new HashSet<>();
-        cache.get(table, Stream.of(cells).collect(Collectors.toSet()), (_unused, cellsToRead) -> {
+        cache.get(table, Stream.of(cells).collect(Collectors.toSet()), cellsToRead -> {
             remoteReads.addAll(cellsToRead);
             return remoteRead(cellsToRead);
         });


### PR DESCRIPTION
**Goals (and why)**:
* `get` implementations in the cache used a `BiFunction` of `(table, cell) -> values`, although the table isn't really necessary since those that create the lambdas will also have the table present.
* For comparison, `getRows` was using essentially the same function but was just a `Function` of `cell -> values`.

**Implementation Description (bullets)**:
* Change `BiFunction` to `Function`

**Testing (What was existing testing like?  What have you done to improve it?)**:
Update tests, and add in a couple of missing things.

**Where should we start reviewing?**:
`TransactionScopedCache`

**Priority (whenever / two weeks / yesterday)**:
This week ideally.
