### PR TITLE
[LW] Keep additional snapshots around

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
@@ -61,7 +61,7 @@ public final class LockWatchValueScopingCacheImpl implements LockWatchValueScopi
             CacheMetrics metrics) {
         this.eventCache = eventCache;
         this.valueStore = new ValueStoreImpl(watchedTablesFromSchema, maxCacheSize, metrics);
-        this.snapshotStore = new SnapshotStoreImpl();
+        this.snapshotStore = SnapshotStoreImpl.create();
         this.cacheStore =
                 new CacheStoreImpl(snapshotStore, validationProbability, failureCallback, metrics, MAX_CACHE_COUNT);
     }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/CacheStoreImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/CacheStoreImplTest.java
@@ -40,7 +40,7 @@ public final class CacheStoreImplTest {
 
     @Test
     public void updatesToSnapshotStoreReflectedInCacheStore() {
-        SnapshotStore snapshotStore = new SnapshotStoreImpl();
+        SnapshotStore snapshotStore = SnapshotStoreImpl.create();
         CacheStore cacheStore = new CacheStoreImpl(snapshotStore, VALIDATION_PROBABILITY, () -> {}, metrics, 100);
 
         cacheStore.createCache(TIMESTAMP_1);
@@ -57,7 +57,7 @@ public final class CacheStoreImplTest {
 
     @Test
     public void multipleCallsToGetReturnsTheSameCache() {
-        SnapshotStore snapshotStore = new SnapshotStoreImpl();
+        SnapshotStore snapshotStore = SnapshotStoreImpl.create();
         CacheStore cacheStore = new CacheStoreImpl(snapshotStore, VALIDATION_PROBABILITY, () -> {}, metrics, 100);
         snapshotStore.storeSnapshot(
                 Sequence.of(5L),
@@ -75,7 +75,7 @@ public final class CacheStoreImplTest {
 
     @Test
     public void cachesExceedingMaximumCountThrows() {
-        SnapshotStore snapshotStore = new SnapshotStoreImpl();
+        SnapshotStore snapshotStore = SnapshotStoreImpl.create();
         CacheStore cacheStore = new CacheStoreImpl(snapshotStore, VALIDATION_PROBABILITY, () -> {}, metrics, 1);
 
         StartTimestamp timestamp = StartTimestamp.of(22222L);
@@ -95,7 +95,7 @@ public final class CacheStoreImplTest {
 
     @Test
     public void getCacheDoesNotPersistAnything() {
-        SnapshotStore snapshotStore = new SnapshotStoreImpl();
+        SnapshotStore snapshotStore = SnapshotStoreImpl.create();
         CacheStore cacheStore = new CacheStoreImpl(snapshotStore, VALIDATION_PROBABILITY, () -> {}, metrics, 100);
         snapshotStore.storeSnapshot(
                 Sequence.of(5L),
@@ -110,7 +110,7 @@ public final class CacheStoreImplTest {
 
     @Test
     public void noOpCachesAreNotStored() {
-        SnapshotStore snapshotStore = new SnapshotStoreImpl();
+        SnapshotStore snapshotStore = SnapshotStoreImpl.create();
         CacheStore cacheStore = new CacheStoreImpl(snapshotStore, VALIDATION_PROBABILITY, () -> {}, metrics, 0);
 
         cacheStore.createCache(TIMESTAMP_1);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/SnapshotStoreImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/SnapshotStoreImplTest.java
@@ -27,32 +27,33 @@ import com.palantir.atlasdb.keyvalue.api.watch.StartTimestamp;
 import io.vavr.collection.HashMap;
 import io.vavr.collection.HashSet;
 import java.util.stream.Stream;
+import org.assertj.core.api.OptionalAssert;
 import org.junit.Before;
 import org.junit.Test;
 
 public final class SnapshotStoreImplTest {
     private static final Sequence SEQUENCE_1 = Sequence.of(1337L);
     private static final Sequence SEQUENCE_2 = Sequence.of(8284L);
+    private static final Sequence SEQUENCE_3 = Sequence.of(9999L);
+    private static final Sequence SEQUENCE_4 = Sequence.of(31337L);
+    private static final Sequence SEQUENCE_5 = Sequence.of(88888L);
     private static final StartTimestamp TIMESTAMP_1 = StartTimestamp.of(42L);
     private static final StartTimestamp TIMESTAMP_2 = StartTimestamp.of(31415925635L);
     private static final StartTimestamp TIMESTAMP_3 = StartTimestamp.of(404L);
     private static final StartTimestamp TIMESTAMP_4 = StartTimestamp.of(10110101L);
+    private static final StartTimestamp TIMESTAMP_5 = StartTimestamp.of(500);
     private static final ValueCacheSnapshot SNAPSHOT_1 =
             ValueCacheSnapshotImpl.of(HashMap.empty(), HashSet.empty(), ImmutableSet.of());
-    private static final ValueCacheSnapshot SNAPSHOT_2 = ValueCacheSnapshotImpl.of(
-            HashMap.<CellReference, CacheEntry>empty()
-                    .put(
-                            CellReference.of(
-                                    TableReference.createFromFullyQualifiedName("t.table"),
-                                    Cell.create(new byte[] {1}, new byte[] {1})),
-                            CacheEntry.locked()),
-            HashSet.empty(),
-            ImmutableSet.of());
+    private static final ValueCacheSnapshot SNAPSHOT_2 = createSnapshot(2);
+    private static final ValueCacheSnapshot SNAPSHOT_3 = createSnapshot(3);
+    private static final ValueCacheSnapshot SNAPSHOT_4 = createSnapshot(4);
+    private static final ValueCacheSnapshot SNAPSHOT_5 = createSnapshot(5);
+
     private SnapshotStore snapshotStore;
 
     @Before
     public void before() {
-        snapshotStore = new SnapshotStoreImpl();
+        snapshotStore = SnapshotStoreImpl.create();
     }
 
     @Test
@@ -77,6 +78,7 @@ public final class SnapshotStoreImplTest {
 
     @Test
     public void removeTimestampRemovesSnapshotWhenThereAreNoMoreLiveTimestampsForSequence() {
+        snapshotStore = new SnapshotStoreImpl(0, 20_000);
         snapshotStore.storeSnapshot(SEQUENCE_1, ImmutableSet.of(TIMESTAMP_1, TIMESTAMP_2, TIMESTAMP_3), SNAPSHOT_1);
         snapshotStore.storeSnapshot(SEQUENCE_2, ImmutableSet.of(TIMESTAMP_4), SNAPSHOT_2);
 
@@ -97,8 +99,50 @@ public final class SnapshotStoreImplTest {
         assertThat(snapshotStore.getSnapshotForSequence(SEQUENCE_1)).isEmpty();
     }
 
+    @Test
+    public void removeTimestampOnlyRetentionsDownToMinimumSize() {
+        snapshotStore = new SnapshotStoreImpl(2, 20_000);
+        snapshotStore.storeSnapshot(SEQUENCE_1, ImmutableSet.of(TIMESTAMP_1), SNAPSHOT_1);
+        snapshotStore.storeSnapshot(SEQUENCE_2, ImmutableSet.of(TIMESTAMP_2), SNAPSHOT_2);
+        snapshotStore.storeSnapshot(SEQUENCE_3, ImmutableSet.of(TIMESTAMP_3), SNAPSHOT_3);
+        snapshotStore.storeSnapshot(SEQUENCE_4, ImmutableSet.of(TIMESTAMP_4), SNAPSHOT_4);
+
+        assertSnapshotsEqualForTimestamp(SNAPSHOT_1, TIMESTAMP_1);
+        assertSnapshotsEqualForTimestamp(SNAPSHOT_2, TIMESTAMP_2);
+        assertSnapshotsEqualForTimestamp(SNAPSHOT_3, TIMESTAMP_3);
+        assertSnapshotsEqualForTimestamp(SNAPSHOT_4, TIMESTAMP_4);
+
+        removeSnapshotAndAssert(TIMESTAMP_1, SEQUENCE_1).isEmpty();
+        removeSnapshotAndAssert(TIMESTAMP_2, SEQUENCE_2).isEmpty();
+        removeSnapshotAndAssert(TIMESTAMP_3, SEQUENCE_3).hasValue(SNAPSHOT_3);
+        removeSnapshotAndAssert(TIMESTAMP_4, SEQUENCE_4).hasValue(SNAPSHOT_4);
+
+        snapshotStore.storeSnapshot(SEQUENCE_5, ImmutableSet.of(TIMESTAMP_5), SNAPSHOT_5);
+        removeSnapshotAndAssert(TIMESTAMP_5, SEQUENCE_5).hasValue(SNAPSHOT_5);
+        assertThat(snapshotStore.getSnapshotForSequence(SEQUENCE_3)).isEmpty();
+    }
+
+    private OptionalAssert<ValueCacheSnapshot> removeSnapshotAndAssert(StartTimestamp timestamp, Sequence sequence) {
+        snapshotStore.removeTimestamp(timestamp);
+        assertThat(snapshotStore.getSnapshot(timestamp)).isEmpty();
+        return assertThat(snapshotStore.getSnapshotForSequence(sequence));
+    }
+
     private void assertSnapshotsEqualForTimestamp(ValueCacheSnapshot expectedValue, StartTimestamp... timestamps) {
         Stream.of(timestamps).map(snapshotStore::getSnapshot).forEach(snapshot -> assertThat(snapshot)
                 .hasValue(expectedValue));
+    }
+
+    private static ValueCacheSnapshot createSnapshot(int value) {
+        byte byteValue = (byte) value;
+        return ValueCacheSnapshotImpl.of(
+                HashMap.<CellReference, CacheEntry>empty()
+                        .put(
+                                CellReference.of(
+                                        TableReference.createFromFullyQualifiedName("t.table"),
+                                        Cell.create(new byte[] {byteValue}, new byte[] {byteValue})),
+                                CacheEntry.locked()),
+                HashSet.empty(),
+                ImmutableSet.of());
     }
 }

--- a/changelog/@unreleased/pr-5673.v2.yml
+++ b/changelog/@unreleased/pr-5673.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Retain a minimum number of lock watch snapshots in memory to reduce
+    the chance of old updates failing when starting transactions.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5673


### PR DESCRIPTION
**Goals (and why)**:
There is a rare case where the aggressive snapshot retention causes starting transactions to repeatedly fail:

1. Transactions started, return lock watch version N -> N + X; update not yet gone through cache
2. Other update received; cache now on version N + Y (where Y < X), and has retentioned all snapshots before N + Y.
3. Update from 1. is processed; this throws if there are no snapshots for every version from N to N + X.
4. Transaction retried

This shouldn't reoccur often, but it seems to be for some services.

**Implementation Description (bullets)**:
Keep a minimum number of snapshots in memory. This will mitigate the chances of the above happening significantly, as the retention won't be so aggressive.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Add new tests around this edge case.

**Concerns (what feedback would you like?)**:
Memory impact should be small (only 1000 additional snapshots at most). I just want to ensure that my use of fancy map types is fine.

**Where should we start reviewing?**:
SnapshotStoreImpl

**Priority (whenever / two weeks / yesterday)**:
Today


