### PR TITLE
[LW] Relax conditions on start transaction flow

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/FilteringValueCacheSnapshot.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/FilteringValueCacheSnapshot.java
@@ -60,6 +60,11 @@ final class FilteringValueCacheSnapshot implements ValueCacheSnapshot {
         return delegate.isWatched(tableReference);
     }
 
+    @Override
+    public boolean hasAnyTablesWatched() {
+        return delegate.hasAnyTablesWatched();
+    }
+
     private static LockedCells toLockedCells(CommitUpdate commitUpdate) {
         return commitUpdate.accept(new Visitor<LockedCells>() {
             @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
@@ -25,7 +25,6 @@ import com.palantir.atlasdb.keyvalue.api.ResilientLockWatchProxy;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.watch.Sequence;
 import com.palantir.atlasdb.keyvalue.api.watch.StartTimestamp;
-import com.palantir.atlasdb.transaction.api.TransactionLockWatchFailedException;
 import com.palantir.common.streams.KeyedStream;
 import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.watch.CommitUpdate;
@@ -203,8 +202,6 @@ public final class LockWatchValueScopingCacheImpl implements LockWatchValueScopi
                 .startTsToSequence()
                 .keySet()
                 .forEach(timestamp -> cacheStore.createCache(StartTimestamp.of(timestamp)));
-
-        //        assertNoSnapshotsMissing(reversedMap.keySet());
     }
 
     private synchronized boolean isNewEvent(LockWatchEvent event) {
@@ -212,13 +209,6 @@ public final class LockWatchValueScopingCacheImpl implements LockWatchValueScopi
                 .map(LockWatchVersion::version)
                 .map(current -> current < event.sequence())
                 .orElse(true);
-    }
-
-    private synchronized void assertNoSnapshotsMissing(Set<Sequence> sequences) {
-        if (sequences.stream().map(snapshotStore::getSnapshotForSequence).anyMatch(Optional::isEmpty)) {
-            throw new TransactionLockWatchFailedException("snapshots were not taken for all sequences; this update "
-                    + "must have been lost and is now too old to process. Transactions should be retried.");
-        }
     }
 
     private synchronized void updateCurrentVersion(TransactionsLockWatchUpdate updateForTransactions) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
@@ -119,32 +119,31 @@ public final class LockWatchValueScopingCacheImpl implements LockWatchValueScopi
         cache.finalise();
 
         Map<CellReference, CacheValue> cachedValues = cache.getValueDigest().loadedValues();
-        if (cachedValues.isEmpty()) {
-            return;
+        if (!cachedValues.isEmpty()) {
+
+            CommitUpdate commitUpdate = eventCache.getEventUpdate(startTimestamp);
+            commitUpdate.accept(new CommitUpdate.Visitor<Void>() {
+                @Override
+                public Void invalidateAll() {
+                    // This might happen due to an election or if we exceeded the maximum number of events held in
+                    // memory. Either way, the values are just not pushed to the central cache. If it needs to throw
+                    // because of read-write conflicts, that is handled in the PreCommitCondition.
+                    return null;
+                }
+
+                @Override
+                public Void invalidateSome(Set<LockDescriptor> invalidatedLocks) {
+                    Set<CellReference> invalidatedCells = invalidatedLocks.stream()
+                            .map(AtlasLockDescriptorUtils::candidateCells)
+                            .flatMap(List::stream)
+                            .collect(Collectors.toSet());
+                    KeyedStream.stream(cachedValues)
+                            .filterKeys(cellReference -> !invalidatedCells.contains(cellReference))
+                            .forEach(valueStore::putValue);
+                    return null;
+                }
+            });
         }
-
-        CommitUpdate commitUpdate = eventCache.getEventUpdate(startTimestamp);
-        commitUpdate.accept(new CommitUpdate.Visitor<Void>() {
-            @Override
-            public Void invalidateAll() {
-                // This might happen due to an election or if we exceeded the maximum number of events held in
-                // memory. Either way, the values are just not pushed to the central cache. If it needs to throw
-                // because of read-write conflicts, that is handled in the PreCommitCondition.
-                return null;
-            }
-
-            @Override
-            public Void invalidateSome(Set<LockDescriptor> invalidatedLocks) {
-                Set<CellReference> invalidatedCells = invalidatedLocks.stream()
-                        .map(AtlasLockDescriptorUtils::candidateCells)
-                        .flatMap(List::stream)
-                        .collect(Collectors.toSet());
-                KeyedStream.stream(cachedValues)
-                        .filterKeys(cellReference -> !invalidatedCells.contains(cellReference))
-                        .forEach(valueStore::putValue);
-                return null;
-            }
-        });
         ensureStateRemoved(startTimestamp);
     }
 
@@ -205,7 +204,7 @@ public final class LockWatchValueScopingCacheImpl implements LockWatchValueScopi
                 .keySet()
                 .forEach(timestamp -> cacheStore.createCache(StartTimestamp.of(timestamp)));
 
-        assertNoSnapshotsMissing(reversedMap.keySet());
+        //        assertNoSnapshotsMissing(reversedMap.keySet());
     }
 
     private synchronized boolean isNewEvent(LockWatchEvent event) {
@@ -216,9 +215,7 @@ public final class LockWatchValueScopingCacheImpl implements LockWatchValueScopi
     }
 
     private synchronized void assertNoSnapshotsMissing(Set<Sequence> sequences) {
-        if (sequences.stream()
-                .map(snapshotStore::getSnapshotForSequence)
-                .anyMatch(maybeSnapshot -> !maybeSnapshot.isPresent())) {
+        if (sequences.stream().map(snapshotStore::getSnapshotForSequence).anyMatch(Optional::isEmpty)) {
             throw new TransactionLockWatchFailedException("snapshots were not taken for all sequences; this update "
                     + "must have been lost and is now too old to process. Transactions should be retried.");
         }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ValueCacheSnapshot.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ValueCacheSnapshot.java
@@ -26,4 +26,6 @@ public interface ValueCacheSnapshot {
     boolean isUnlocked(CellReference cellReference);
 
     boolean isWatched(TableReference tableReference);
+
+    boolean hasAnyTablesWatched();
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ValueCacheSnapshotImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ValueCacheSnapshotImpl.java
@@ -53,6 +53,11 @@ public interface ValueCacheSnapshotImpl extends ValueCacheSnapshot {
         return enabledTables().contains(tableReference);
     }
 
+    @Override
+    default boolean hasAnyTablesWatched() {
+        return !enabledTables().isEmpty();
+    }
+
     static ValueCacheSnapshot of(
             Map<CellReference, CacheEntry> values,
             Set<TableReference> enabledTables,

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImplTest.java
@@ -464,9 +464,10 @@ public final class LockWatchValueScopingCacheImplTest {
 
         // This should cause the cache to progress to version 1 but without a snapshot stored at version 0
         processStartTransactionsUpdate(LOCK_WATCH_SNAPSHOT, TIMESTAMP_1);
-        processStartTransactionsUpdate(LOCK_WATCH_LOCK_SUCCESS, 99L);
+        long timestamp4 = 99L;
+        processStartTransactionsUpdate(LOCK_WATCH_LOCK_SUCCESS, timestamp4);
         processSuccessfulCommit(TIMESTAMP_1, 1L);
-        processSuccessfulCommit(99L, 1L);
+        processSuccessfulCommit(timestamp4, 1L);
 
         // There are timestamps at version 0 (before we have a snapshot) and at version 1; this would previously throw,
         // but now it just causes the transaction to not cache.

--- a/changelog/@unreleased/pr-5677.v2.yml
+++ b/changelog/@unreleased/pr-5677.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Relax a lock-watch-based constraint when starting transactions. The
+    impact of this change is that starting transactions should succeed more often,
+    but some transactions may not be eligible to use the cache.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5677


### PR DESCRIPTION
**Goals (and why)**:
For whatever reason, the check that every start timestamp has a corresponding snapshot available fails surprisingly frequently on the odd internal service (yet appears fine for most). However, this is not a mandatory check: if it fails, it just means that some transactions cannot cache. Thus, instead of restarting the batch, just remove the constraint so that some of the transactions (but absolutely not all) will use no-op caches.

**Implementation Description (bullets)**:
* Remove constraint
* Fix a bug when removing state (note that a finally block was saving us in the production codepath)

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added a test that threw prior to this change.

**Concerns (what feedback would you like?)**:
Should we be concerned that we are semi-frequently hitting this issue in production at all?

**Where should we start reviewing?**:
Diff

**Priority (whenever / two weeks / yesterday)**:
Today - this was causing fairly significant issues internally!
