### PR TITLE
[LW] Add memory metrics

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbMetricNames.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbMetricNames.java
@@ -107,4 +107,7 @@ public final class AtlasDbMetricNames {
     public static final String LW_EVENT_CACHE_FALLBACK_COUNT = "lockWatchEventCacheFallbackCount";
     public static final String LW_VALUE_CACHE_FALLBACK_COUNT = "lockWatchValueCacheFallbackCount";
     public static final String LW_TRANSACTION_CACHE_INSTANCE_COUNT = "lockWatchTransactionCacheInstanceCount";
+    public static final String LW_EVENTS_HELD_IN_MEMORY = "lockWatchEventsHeldInMemory";
+    public static final String LW_SNAPSHOTS_HELD_IN_MEMORY = "lockWatchSnapshotsHeldInMemory";
+    public static final String LW_SEQUENCE_DIFFERENCE = "lockWatchSequenceDifference";
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/CacheMetrics.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/CacheMetrics.java
@@ -64,10 +64,8 @@ public final class CacheMetrics {
                         CacheMetrics.class, AtlasDbMetricNames.LW_CACHE_GET_ROWS_CELLS_LOADED),
                 metricsManager.registerOrGetCounter(
                         CacheMetrics.class, AtlasDbMetricNames.LW_CACHE_GET_ROWS_ROWS_LOADED),
-                metricsManager.registerOrGetGauge(
-                        CacheMetrics.class, AtlasDbMetricNames.LW_EVENT_CACHE_FALLBACK_COUNT, CurrentValueMetric::new),
-                metricsManager.registerOrGetGauge(
-                        CacheMetrics.class, AtlasDbMetricNames.LW_VALUE_CACHE_FALLBACK_COUNT, CurrentValueMetric::new),
+                registerCurrentValueMetric(metricsManager, AtlasDbMetricNames.LW_EVENT_CACHE_FALLBACK_COUNT),
+                registerCurrentValueMetric(metricsManager, AtlasDbMetricNames.LW_VALUE_CACHE_FALLBACK_COUNT),
                 metricsManager);
     }
 
@@ -121,5 +119,26 @@ public final class CacheMetrics {
     public void setTransactionCacheInstanceCountGauge(Gauge<Integer> getCacheMapCount) {
         metricsManager.registerOrGetGauge(
                 CacheMetrics.class, AtlasDbMetricNames.LW_TRANSACTION_CACHE_INSTANCE_COUNT, () -> getCacheMapCount);
+    }
+
+    public void setEventsHeldInMemory(Gauge<Integer> eventsGauge) {
+        metricsManager.registerOrGetGauge(
+                CacheMetrics.class, AtlasDbMetricNames.LW_EVENTS_HELD_IN_MEMORY, () -> eventsGauge);
+    }
+
+    public void setSnapshotsHeldInMemory(Gauge<Integer> snapshotGauge) {
+        metricsManager.registerOrGetGauge(
+                CacheMetrics.class, AtlasDbMetricNames.LW_SNAPSHOTS_HELD_IN_MEMORY, () -> snapshotGauge);
+    }
+
+    public void setSequenceDifference(Gauge<Long> differenceGauge) {
+        metricsManager.registerOrGetGauge(
+                CacheMetrics.class, AtlasDbMetricNames.LW_SEQUENCE_DIFFERENCE, () -> differenceGauge);
+    }
+
+    private static CurrentValueMetric<Integer> registerCurrentValueMetric(
+            MetricsManager metricsManager, String lwEventCacheFallbackCount) {
+        return metricsManager.registerOrGetGauge(
+                CacheMetrics.class, lwEventCacheFallbackCount, CurrentValueMetric::new);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/CacheMetrics.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/CacheMetrics.java
@@ -137,8 +137,7 @@ public final class CacheMetrics {
     }
 
     private static CurrentValueMetric<Integer> registerCurrentValueMetric(
-            MetricsManager metricsManager, String lwEventCacheFallbackCount) {
-        return metricsManager.registerOrGetGauge(
-                CacheMetrics.class, lwEventCacheFallbackCount, CurrentValueMetric::new);
+            MetricsManager metricsManager, String metricName) {
+        return metricsManager.registerOrGetGauge(CacheMetrics.class, metricName, CurrentValueMetric::new);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/CacheMetrics.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/CacheMetrics.java
@@ -110,34 +110,34 @@ public final class CacheMetrics {
     }
 
     public void setMaximumCacheSize(long maximumCacheSize) {
-        metricsManager.registerOrGetGauge(
+        metricsManager.registerMetric(
                 CacheMetrics.class,
                 AtlasDbMetricNames.LW_CACHE_RATIO_USED,
-                () -> () -> cacheSize.getCount() / (double) maximumCacheSize);
+                () -> cacheSize.getCount() / (double) maximumCacheSize);
     }
 
     public void setTransactionCacheInstanceCountGauge(Gauge<Integer> getCacheMapCount) {
-        metricsManager.registerOrGetGauge(
+        metricsManager.registerMetric(
                 CacheMetrics.class, AtlasDbMetricNames.LW_TRANSACTION_CACHE_INSTANCE_COUNT, () -> getCacheMapCount);
     }
 
     public void setEventsHeldInMemory(Gauge<Integer> eventsGauge) {
-        metricsManager.registerOrGetGauge(
-                CacheMetrics.class, AtlasDbMetricNames.LW_EVENTS_HELD_IN_MEMORY, () -> eventsGauge);
+        metricsManager.registerMetric(CacheMetrics.class, AtlasDbMetricNames.LW_EVENTS_HELD_IN_MEMORY, eventsGauge);
     }
 
     public void setSnapshotsHeldInMemory(Gauge<Integer> snapshotGauge) {
-        metricsManager.registerOrGetGauge(
-                CacheMetrics.class, AtlasDbMetricNames.LW_SNAPSHOTS_HELD_IN_MEMORY, () -> snapshotGauge);
+        metricsManager.registerMetric(
+                CacheMetrics.class, AtlasDbMetricNames.LW_SNAPSHOTS_HELD_IN_MEMORY, snapshotGauge);
     }
 
     public void setSequenceDifference(Gauge<Long> differenceGauge) {
-        metricsManager.registerOrGetGauge(
-                CacheMetrics.class, AtlasDbMetricNames.LW_SEQUENCE_DIFFERENCE, () -> differenceGauge);
+        metricsManager.registerMetric(CacheMetrics.class, AtlasDbMetricNames.LW_SEQUENCE_DIFFERENCE, differenceGauge);
     }
 
     private static CurrentValueMetric<Integer> registerCurrentValueMetric(
             MetricsManager metricsManager, String metricName) {
-        return metricsManager.registerOrGetGauge(CacheMetrics.class, metricName, CurrentValueMetric::new);
+        CurrentValueMetric<Integer> metric = new CurrentValueMetric<>();
+        metricsManager.registerMetric(CacheMetrics.class, metricName, metric);
+        return metric;
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
@@ -84,7 +84,7 @@ public final class LockWatchValueScopingCacheImpl implements LockWatchValueScopi
                 maxCacheSize,
                 validationProbability,
                 watchedTablesFromSchema,
-                SnapshotStoreImpl.create(),
+                SnapshotStoreImpl.create(metrics),
                 proxyFactory::fallback,
                 metrics);
         proxyFactory.setDelegate(defaultCache);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheImpl.java
@@ -45,7 +45,7 @@ public final class LockWatchEventCacheImpl implements LockWatchEventCache {
 
     public static LockWatchEventCache create(CacheMetrics metrics) {
         return ResilientLockWatchProxy.newEventCacheProxy(
-                new LockWatchEventCacheImpl(LockWatchEventLog.create(MIN_EVENTS, MAX_EVENTS)),
+                new LockWatchEventCacheImpl(LockWatchEventLog.create(metrics, MIN_EVENTS, MAX_EVENTS)),
                 NoOpLockWatchEventCache.create(),
                 metrics);
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLog.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLog.java
@@ -41,7 +41,7 @@ final class LockWatchEventLog {
 
     private LockWatchEventLog(ClientLockWatchSnapshot snapshot, CacheMetrics metrics, int minEvents, int maxEvents) {
         this.snapshot = snapshot;
-        this.eventStore = new VersionedEventStore(minEvents, maxEvents, metrics);
+        this.eventStore = new VersionedEventStore(metrics, minEvents, maxEvents);
     }
 
     CacheUpdate processUpdate(LockWatchStateUpdate update) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLog.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLog.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.keyvalue.api.watch;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.palantir.atlasdb.keyvalue.api.cache.CacheMetrics;
 import com.palantir.atlasdb.transaction.api.TransactionLockWatchFailedException;
 import com.palantir.lock.watch.LockWatchCreatedEvent;
 import com.palantir.lock.watch.LockWatchEvent;
@@ -34,13 +35,13 @@ final class LockWatchEventLog {
     private final VersionedEventStore eventStore;
     private Optional<LockWatchVersion> latestVersion = Optional.empty();
 
-    static LockWatchEventLog create(int minEvents, int maxEvents) {
-        return new LockWatchEventLog(ClientLockWatchSnapshot.create(), minEvents, maxEvents);
+    static LockWatchEventLog create(CacheMetrics metrics, int minEvents, int maxEvents) {
+        return new LockWatchEventLog(ClientLockWatchSnapshot.create(), metrics, minEvents, maxEvents);
     }
 
-    private LockWatchEventLog(ClientLockWatchSnapshot snapshot, int minEvents, int maxEvents) {
+    private LockWatchEventLog(ClientLockWatchSnapshot snapshot, CacheMetrics metrics, int minEvents, int maxEvents) {
         this.snapshot = snapshot;
-        this.eventStore = new VersionedEventStore(minEvents, maxEvents);
+        this.eventStore = new VersionedEventStore(minEvents, maxEvents, metrics);
     }
 
     CacheUpdate processUpdate(LockWatchStateUpdate update) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStore.java
@@ -39,7 +39,7 @@ final class VersionedEventStore {
     private final int maxEvents;
     private final NavigableMap<Sequence, LockWatchEvent> eventMap = new TreeMap<>();
 
-    VersionedEventStore(int minEvents, int maxEvents, CacheMetrics cacheMetrics) {
+    VersionedEventStore(CacheMetrics cacheMetrics, int minEvents, int maxEvents) {
         Preconditions.checkArgument(minEvents > 0, "minEvents must be positive", SafeArg.of("minEvents", minEvents));
         Preconditions.checkArgument(
                 maxEvents >= minEvents,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStore.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.keyvalue.api.watch;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.palantir.atlasdb.keyvalue.api.cache.CacheMetrics;
 import com.palantir.lock.watch.LockWatchEvent;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
@@ -38,7 +39,7 @@ final class VersionedEventStore {
     private final int maxEvents;
     private final NavigableMap<Sequence, LockWatchEvent> eventMap = new TreeMap<>();
 
-    VersionedEventStore(int minEvents, int maxEvents) {
+    VersionedEventStore(int minEvents, int maxEvents, CacheMetrics cacheMetrics) {
         Preconditions.checkArgument(minEvents > 0, "minEvents must be positive", SafeArg.of("minEvents", minEvents));
         Preconditions.checkArgument(
                 maxEvents >= minEvents,
@@ -47,6 +48,7 @@ final class VersionedEventStore {
                 SafeArg.of("maxEvents", maxEvents));
         this.maxEvents = maxEvents;
         this.minEvents = minEvents;
+        cacheMetrics.setEventsHeldInMemory(eventMap::size);
     }
 
     Collection<LockWatchEvent> getEventsBetweenVersionsInclusive(Optional<Long> maybeStartVersion, long endVersion) {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/CacheStoreImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/CacheStoreImplTest.java
@@ -40,7 +40,7 @@ public final class CacheStoreImplTest {
 
     @Test
     public void updatesToSnapshotStoreReflectedInCacheStore() {
-        SnapshotStore snapshotStore = SnapshotStoreImpl.create();
+        SnapshotStore snapshotStore = SnapshotStoreImpl.create(metrics);
         CacheStore cacheStore = new CacheStoreImpl(snapshotStore, VALIDATION_PROBABILITY, () -> {}, metrics, 100);
 
         cacheStore.createCache(TIMESTAMP_1);
@@ -57,7 +57,7 @@ public final class CacheStoreImplTest {
 
     @Test
     public void multipleCallsToGetReturnsTheSameCache() {
-        SnapshotStore snapshotStore = SnapshotStoreImpl.create();
+        SnapshotStore snapshotStore = SnapshotStoreImpl.create(metrics);
         CacheStore cacheStore = new CacheStoreImpl(snapshotStore, VALIDATION_PROBABILITY, () -> {}, metrics, 100);
         snapshotStore.storeSnapshot(
                 Sequence.of(5L),
@@ -75,7 +75,7 @@ public final class CacheStoreImplTest {
 
     @Test
     public void cachesExceedingMaximumCountThrows() {
-        SnapshotStore snapshotStore = SnapshotStoreImpl.create();
+        SnapshotStore snapshotStore = SnapshotStoreImpl.create(metrics);
         CacheStore cacheStore = new CacheStoreImpl(snapshotStore, VALIDATION_PROBABILITY, () -> {}, metrics, 1);
 
         StartTimestamp timestamp = StartTimestamp.of(22222L);
@@ -95,7 +95,7 @@ public final class CacheStoreImplTest {
 
     @Test
     public void getCacheDoesNotPersistAnything() {
-        SnapshotStore snapshotStore = SnapshotStoreImpl.create();
+        SnapshotStore snapshotStore = SnapshotStoreImpl.create(metrics);
         CacheStore cacheStore = new CacheStoreImpl(snapshotStore, VALIDATION_PROBABILITY, () -> {}, metrics, 100);
         snapshotStore.storeSnapshot(
                 Sequence.of(5L),
@@ -110,7 +110,7 @@ public final class CacheStoreImplTest {
 
     @Test
     public void noOpCachesAreNotStored() {
-        SnapshotStore snapshotStore = SnapshotStoreImpl.create();
+        SnapshotStore snapshotStore = SnapshotStoreImpl.create(metrics);
         CacheStore cacheStore = new CacheStoreImpl(snapshotStore, VALIDATION_PROBABILITY, () -> {}, metrics, 0);
 
         cacheStore.createCache(TIMESTAMP_1);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImplTest.java
@@ -102,7 +102,7 @@ public final class LockWatchValueScopingCacheImplTest {
 
     @Before
     public void before() {
-        snapshotStore = SnapshotStoreImpl.create();
+        snapshotStore = SnapshotStoreImpl.create(metrics);
         eventCache = LockWatchEventCacheImpl.create(metrics);
         valueCache = new LockWatchValueScopingCacheImpl(
                 eventCache, 20_000, 0.0, ImmutableSet.of(TABLE), snapshotStore, () -> {}, metrics);
@@ -432,7 +432,7 @@ public final class LockWatchValueScopingCacheImplTest {
 
     @Test
     public void missingSnapshotsForSequenceDoesNotThrowWhenNoTablesAreWatched() {
-        snapshotStore = new SnapshotStoreImpl(0, 20_000);
+        snapshotStore = new SnapshotStoreImpl(0, 20_000, metrics);
         valueCache = new LockWatchValueScopingCacheImpl(
                 eventCache, 20_000, 0.0, ImmutableSet.of(TABLE), snapshotStore, () -> {}, metrics);
 
@@ -458,7 +458,7 @@ public final class LockWatchValueScopingCacheImplTest {
 
     @Test
     public void missingSnapshotsForSequenceThrowsWhenTablesAreWatched() {
-        snapshotStore = new SnapshotStoreImpl(0, 20_000);
+        snapshotStore = new SnapshotStoreImpl(0, 20_000, metrics);
         valueCache = new LockWatchValueScopingCacheImpl(
                 eventCache, 20_000, 0.0, ImmutableSet.of(TABLE), snapshotStore, () -> {}, metrics);
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/SnapshotStoreImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/SnapshotStoreImplTest.java
@@ -24,6 +24,7 @@ import com.palantir.atlasdb.keyvalue.api.CellReference;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.watch.Sequence;
 import com.palantir.atlasdb.keyvalue.api.watch.StartTimestamp;
+import com.palantir.atlasdb.util.MetricsManagers;
 import io.vavr.collection.HashMap;
 import io.vavr.collection.HashSet;
 import java.util.stream.Stream;
@@ -48,12 +49,13 @@ public final class SnapshotStoreImplTest {
     private static final ValueCacheSnapshot SNAPSHOT_3 = createSnapshot(3);
     private static final ValueCacheSnapshot SNAPSHOT_4 = createSnapshot(4);
     private static final ValueCacheSnapshot SNAPSHOT_5 = createSnapshot(5);
+    private static final CacheMetrics CACHE_METRICS = CacheMetrics.create(MetricsManagers.createForTests());
 
     private SnapshotStore snapshotStore;
 
     @Before
     public void before() {
-        snapshotStore = SnapshotStoreImpl.create();
+        snapshotStore = SnapshotStoreImpl.create(CACHE_METRICS);
     }
 
     @Test
@@ -78,7 +80,7 @@ public final class SnapshotStoreImplTest {
 
     @Test
     public void removeTimestampRemovesSnapshotWhenThereAreNoMoreLiveTimestampsForSequence() {
-        snapshotStore = new SnapshotStoreImpl(0, 20_000);
+        snapshotStore = new SnapshotStoreImpl(0, 20_000, CACHE_METRICS);
         snapshotStore.storeSnapshot(SEQUENCE_1, ImmutableSet.of(TIMESTAMP_1, TIMESTAMP_2, TIMESTAMP_3), SNAPSHOT_1);
         snapshotStore.storeSnapshot(SEQUENCE_2, ImmutableSet.of(TIMESTAMP_4), SNAPSHOT_2);
 
@@ -101,7 +103,7 @@ public final class SnapshotStoreImplTest {
 
     @Test
     public void removeTimestampOnlyRetentionsDownToMinimumSize() {
-        snapshotStore = new SnapshotStoreImpl(2, 20_000);
+        snapshotStore = new SnapshotStoreImpl(2, 20_000, CACHE_METRICS);
         snapshotStore.storeSnapshot(SEQUENCE_1, ImmutableSet.of(TIMESTAMP_1), SNAPSHOT_1);
         snapshotStore.storeSnapshot(SEQUENCE_2, ImmutableSet.of(TIMESTAMP_2), SNAPSHOT_2);
         snapshotStore.storeSnapshot(SEQUENCE_3, ImmutableSet.of(TIMESTAMP_3), SNAPSHOT_3);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheIntegrationTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheIntegrationTest.java
@@ -29,8 +29,10 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import com.palantir.atlasdb.keyvalue.api.cache.CacheMetrics;
 import com.palantir.atlasdb.timelock.api.ConjureLockToken;
 import com.palantir.atlasdb.transaction.api.TransactionLockWatchFailedException;
+import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.common.time.NanoTime;
 import com.palantir.lock.AtlasRowLockDescriptor;
 import com.palantir.lock.LockDescriptor;
@@ -107,6 +109,8 @@ public class LockWatchEventCacheIntegrationTest {
             .build());
     private static final ImmutableSet<Long> TIMESTAMPS = ImmutableSet.of(START_TS_1);
     private static final ImmutableSet<Long> TIMESTAMPS_2 = ImmutableSet.of(START_TS_2);
+
+    private static final CacheMetrics CACHE_METRICS = CacheMetrics.create(MetricsManagers.createForTests());
     private static final String BASE = "src/test/resources/lockwatch-event-cache-output/";
     private static final Mode MODE = Mode.CI;
 
@@ -617,7 +621,7 @@ public class LockWatchEventCacheIntegrationTest {
 
     private void createEventCache(int minSize, int maxSize) {
         fakeCache = NoOpLockWatchEventCache.create();
-        realEventCache = new LockWatchEventCacheImpl(LockWatchEventLog.create(minSize, maxSize));
+        realEventCache = new LockWatchEventCacheImpl(LockWatchEventLog.create(CACHE_METRICS, minSize, maxSize));
         eventCache = new DuplicatingLockWatchEventCache(realEventCache, fakeCache);
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStoreTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStoreTest.java
@@ -19,6 +19,8 @@ package com.palantir.atlasdb.keyvalue.api.watch;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableSet;
+import com.palantir.atlasdb.keyvalue.api.cache.CacheMetrics;
+import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.lock.watch.LockWatchEvent;
 import com.palantir.lock.watch.UnlockEvent;
 import java.util.Optional;
@@ -41,12 +43,13 @@ public final class VersionedEventStoreTest {
     private static final Sequence SEQ_2 = Sequence.of(2L);
     private static final Sequence SEQ_3 = Sequence.of(3L);
     private static final Sequence SEQ_4 = Sequence.of(4L);
+    private static final CacheMetrics CACHE_METRICS = CacheMetrics.create(MetricsManagers.createForTests());
 
     private VersionedEventStore eventStore;
 
     @Before
     public void before() {
-        eventStore = new VersionedEventStore(2, 20);
+        eventStore = new VersionedEventStore(2, 20, CACHE_METRICS);
     }
 
     @Test
@@ -85,7 +88,7 @@ public final class VersionedEventStoreTest {
 
     @Test
     public void retentionEventsClearsEventsOverMaxBound() {
-        eventStore = new VersionedEventStore(1, 3);
+        eventStore = new VersionedEventStore(1, 3, CACHE_METRICS);
         eventStore.putAll(makeEvents(EVENT_1, EVENT_2, EVENT_3, EVENT_4));
         assertThat(eventStore.retentionEvents(Optional.of(SEQ_MIN)).events().stream()
                         .map(LockWatchEvent::sequence))

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStoreTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStoreTest.java
@@ -49,7 +49,7 @@ public final class VersionedEventStoreTest {
 
     @Before
     public void before() {
-        eventStore = new VersionedEventStore(2, 20, CACHE_METRICS);
+        eventStore = new VersionedEventStore(CACHE_METRICS, 2, 20);
     }
 
     @Test
@@ -88,7 +88,7 @@ public final class VersionedEventStoreTest {
 
     @Test
     public void retentionEventsClearsEventsOverMaxBound() {
-        eventStore = new VersionedEventStore(1, 3, CACHE_METRICS);
+        eventStore = new VersionedEventStore(CACHE_METRICS, 1, 3);
         eventStore.putAll(makeEvents(EVENT_1, EVENT_2, EVENT_3, EVENT_4));
         assertThat(eventStore.retentionEvents(Optional.of(SEQ_MIN)).events().stream()
                         .map(LockWatchEvent::sequence))

--- a/changelog/@unreleased/pr-5685.v2.yml
+++ b/changelog/@unreleased/pr-5685.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add metrics around lock-watch memory usage.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5685

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/LockWatchValueIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/LockWatchValueIntegrationTest.java
@@ -434,6 +434,8 @@ public final class LockWatchValueIntegrationTest {
                     startTs.set(txn.getTimestamp());
                     lwCache.set(((LockWatchManagerInternal) txnManager.getLockWatchManager()).getCache());
 
+                    txnManager.getTimestampManagementService().fastForwardTimestamp(txn.getTimestamp() + 1_000_000);
+
                     txn.get(TABLE_REF, ImmutableSet.of(CELL_1));
                     // A write forces this to go through serializable conflict checking
                     txn.put(TABLE_REF, ImmutableMap.of(CELL_2, DATA_1));


### PR DESCRIPTION
**Goals (and why)**:
Need to assess the amount of memory that various LW datastructures are using so that we can gauge whether it is feasible to store more snapshots in memory. For context, atlasdb-proxy-client's implementation stores a snapshot for every sequence, whether there is a transaction pointing to it or not.

**Implementation Description (bullets)**:
Add metrics around events held in memory, snapshots held in memory, and the version difference between the oldest and newest snapshot. This last one represents how many snapshots _could_ be stored in memory if we stored a snapshot per sequence.

**Testing (What was existing testing like?  What have you done to improve it?)**:
No testing added.

**Priority (whenever / two weeks / yesterday)**:
Sooner rather than later - we want to get a fix out for this soon.