### PR TITLE
Clean up some things that I missed in the review

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/atlasdb/futures/AtlasFutures.java
+++ b/atlasdb-commons/src/main/java/com/palantir/atlasdb/futures/AtlasFutures.java
@@ -85,9 +85,9 @@ public final class AtlasFutures {
         }
     }
 
-    public static <R> R getUnchecked(Future<R> listenableFuture) {
+    public static <R> R getUnchecked(Future<R> future) {
         try {
-            return listenableFuture.get();
+            return future.get();
         } catch (ExecutionException e) {
             throw Throwables.rewrapAndThrowUncheckedException(e.getCause());
         } catch (Exception e) {


### PR DESCRIPTION
**Goals (and why)**:
Catching InterruptedException without resetting the interrupted flag should be avoided. Also, `tryUnlock` is allowed to be async so we can avoid worrying about exceptions. 
