### PR TITLE
[Migrate to Gradle 7] | Remove testCompile

### DIFF
--- a/atlasdb-api/build.gradle
+++ b/atlasdb-api/build.gradle
@@ -48,7 +48,7 @@ dependencies {
   annotationProcessor 'org.derive4j:derive4j'
   compileOnly 'org.derive4j:derive4j-annotation'
 
-  testCompile group: 'junit', name: 'junit'
-  testCompile group: 'org.assertj', name: 'assertj-core'
-  testCompile group: 'org.mockito', name: 'mockito-core'
+  testImplementation group: 'junit', name: 'junit'
+  testImplementation group: 'org.assertj', name: 'assertj-core'
+  testImplementation group: 'org.mockito', name: 'mockito-core'
 }

--- a/atlasdb-autobatch/build.gradle
+++ b/atlasdb-autobatch/build.gradle
@@ -29,12 +29,12 @@ dependencies {
     testAnnotationProcessor group: 'org.immutables', name: 'value'
     testCompileOnly 'org.immutables:value::annotations'
 
-    testCompile group: 'junit', name: 'junit'
-    testCompile group: 'org.assertj', name: 'assertj-core'
-    testCompile group: 'org.awaitility', name: 'awaitility'
+    testImplementation group: 'junit', name: 'junit'
+    testImplementation group: 'org.assertj', name: 'assertj-core'
+    testImplementation group: 'org.awaitility', name: 'awaitility'
     testCompile(group: 'org.jmock', name: 'jmock') {
       exclude group: 'org.hamcrest'
     }
-    testCompile group: 'org.mockito', name: 'mockito-core'
-    testCompile group: 'com.palantir.tracing', name: 'tracing-test-utils'
+    testImplementation group: 'org.mockito', name: 'mockito-core'
+    testImplementation group: 'com.palantir.tracing', name: 'tracing-test-utils'
 }

--- a/atlasdb-autobatch/build.gradle
+++ b/atlasdb-autobatch/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     testImplementation group: 'junit', name: 'junit'
     testImplementation group: 'org.assertj', name: 'assertj-core'
     testImplementation group: 'org.awaitility', name: 'awaitility'
-    testCompile(group: 'org.jmock', name: 'jmock') {
+    testImplementation(group: 'org.jmock', name: 'jmock') {
       exclude group: 'org.hamcrest'
     }
     testImplementation group: 'org.mockito', name: 'mockito-core'

--- a/atlasdb-cassandra-integration-tests/build.gradle
+++ b/atlasdb-cassandra-integration-tests/build.gradle
@@ -18,32 +18,32 @@ dependencies {
     testImplementation project(':atlasdb-impl-shared')
     testImplementation project(':timestamp-api')
 
-    testCompile project(":atlasdb-cassandra")
-    testCompile project(":atlasdb-cli")
-    testCompile project(":atlasdb-tests-shared")
-    testCompile project(":atlasdb-container-test-utils")
-    testCompile project(":atlasdb-ete-test-utils")
-    testCompile project(":timelock-impl")
+    testImplementation project(":atlasdb-cassandra")
+    testImplementation project(":atlasdb-cli")
+    testImplementation project(":atlasdb-tests-shared")
+    testImplementation project(":atlasdb-container-test-utils")
+    testImplementation project(":atlasdb-ete-test-utils")
+    testImplementation project(":timelock-impl")
 
     testCompile('com.palantir.cassandra:cassandra-all:' + libVersions.palantir_cassandra_thrift) {
         exclude module: 'junit'
 
       exclude group: 'org.apache.httpcomponents'
   }
-  testCompile ('com.palantir.cassandra:cassandra-thrift:' + libVersions.palantir_cassandra_thrift) {
+  testImplementation ('com.palantir.cassandra:cassandra-thrift:' + libVersions.palantir_cassandra_thrift) {
     exclude module: 'junit'
 
     exclude group: 'org.apache.httpcomponents'
   }
 
-    testCompile project(':flake-rule')
+    testImplementation project(':flake-rule')
 
     testCompile('com.datastax.cassandra:cassandra-driver-core:' + libVersions.cassandra_driver_core) {
         exclude(group: 'com.codahale.metrics', module: 'metrics-core')
     }
 
-    testCompile group: 'org.mockito', name: 'mockito-core'
-    testCompile group: 'com.palantir.docker.compose', name: 'docker-compose-rule-core'
+    testImplementation group: 'org.mockito', name: 'mockito-core'
+    testImplementation group: 'com.palantir.docker.compose', name: 'docker-compose-rule-core'
 }
 
 task longTest(type: Test) {

--- a/atlasdb-cassandra-integration-tests/build.gradle
+++ b/atlasdb-cassandra-integration-tests/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     testImplementation project(":atlasdb-ete-test-utils")
     testImplementation project(":timelock-impl")
 
-    testCompile('com.palantir.cassandra:cassandra-all:' + libVersions.palantir_cassandra_thrift) {
+    testImplementation('com.palantir.cassandra:cassandra-all:' + libVersions.palantir_cassandra_thrift) {
         exclude module: 'junit'
 
       exclude group: 'org.apache.httpcomponents'
@@ -38,7 +38,7 @@ dependencies {
 
     testImplementation project(':flake-rule')
 
-    testCompile('com.datastax.cassandra:cassandra-driver-core:' + libVersions.cassandra_driver_core) {
+    testImplementation('com.datastax.cassandra:cassandra-driver-core:' + libVersions.cassandra_driver_core) {
         exclude(group: 'com.codahale.metrics', module: 'metrics-core')
     }
 

--- a/atlasdb-cassandra-multinode-tests/build.gradle
+++ b/atlasdb-cassandra-multinode-tests/build.gradle
@@ -9,21 +9,21 @@ dependencies {
     testImplementation project(':atlasdb-client')
     testImplementation project(':atlasdb-commons')
 
-    testCompile project(":atlasdb-cassandra")
-    testCompile project(":atlasdb-tests-shared")
-    testCompile project(":atlasdb-container-test-utils")
-    testCompile project(":atlasdb-ete-test-utils")
-    testCompile project(":flake-rule")
+    testImplementation project(":atlasdb-cassandra")
+    testImplementation project(":atlasdb-tests-shared")
+    testImplementation project(":atlasdb-container-test-utils")
+    testImplementation project(":atlasdb-ete-test-utils")
+    testImplementation project(":flake-rule")
 
-    testCompile ('com.palantir.cassandra:cassandra-thrift:' + libVersions.palantir_cassandra_thrift) {
+    testImplementation ('com.palantir.cassandra:cassandra-thrift:' + libVersions.palantir_cassandra_thrift) {
        exclude module: 'junit'
 
        exclude group: 'org.apache.httpcomponents'
     }
-    testCompile 'com.datastax.cassandra:cassandra-driver-core:' + libVersions.cassandra_driver_core
+    testImplementation 'com.datastax.cassandra:cassandra-driver-core:' + libVersions.cassandra_driver_core
 
-    testCompile group: 'com.palantir.docker.compose', name: 'docker-compose-rule-core'
-    testCompile group: 'org.assertj', name: 'assertj-core'
+    testImplementation group: 'com.palantir.docker.compose', name: 'docker-compose-rule-core'
+    testImplementation group: 'org.assertj', name: 'assertj-core'
 
     test {
         include '**/CassandraSchemaLockTest.class'

--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -48,7 +48,7 @@ dependencies {
   testImplementation group: 'org.assertj', name: 'assertj-core'
   testImplementation group: 'org.awaitility', name: 'awaitility'
   testImplementation group: 'uk.org.lidalia', name: 'slf4j-test', version: '1.1.0'
-  testCompile(group: 'org.jmock', name: 'jmock') {
+  testImplementation(group: 'org.jmock', name: 'jmock') {
       exclude group: 'org.hamcrest'
   }
 

--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -41,13 +41,13 @@ dependencies {
 
   explicitShadow group: 'org.jboss.marshalling', name: 'jboss-marshalling', version: '1.4.11.Final'
 
-  testCompile project(path: ":atlasdb-client", configuration: "testArtifacts")
-  testCompile project(":atlasdb-config")
-  testCompile group: 'com.palantir.safe-logging', name: 'preconditions-assertj'
-  testCompile group: 'org.mockito', name: 'mockito-core'
-  testCompile group: 'org.assertj', name: 'assertj-core'
-  testCompile group: 'org.awaitility', name: 'awaitility'
-  testCompile group: 'uk.org.lidalia', name: 'slf4j-test', version: '1.1.0'
+  testImplementation project(path: ":atlasdb-client", configuration: "testArtifacts")
+  testImplementation project(":atlasdb-config")
+  testImplementation group: 'com.palantir.safe-logging', name: 'preconditions-assertj'
+  testImplementation group: 'org.mockito', name: 'mockito-core'
+  testImplementation group: 'org.assertj', name: 'assertj-core'
+  testImplementation group: 'org.awaitility', name: 'awaitility'
+  testImplementation group: 'uk.org.lidalia', name: 'slf4j-test', version: '1.1.0'
   testCompile(group: 'org.jmock', name: 'jmock') {
       exclude group: 'org.hamcrest'
   }

--- a/atlasdb-cli/build.gradle
+++ b/atlasdb-cli/build.gradle
@@ -47,6 +47,6 @@ dependencies {
     compileOnly 'org.immutables:value::annotations'
     testCompileOnly 'org.immutables:value::annotations'
 
-    testCompile group: 'org.assertj', name: 'assertj-core'
-    testCompile group: 'org.mockito', name: 'mockito-core'
+    testImplementation group: 'org.assertj', name: 'assertj-core'
+    testImplementation group: 'org.mockito', name: 'mockito-core'
 }

--- a/atlasdb-client/build.gradle
+++ b/atlasdb-client/build.gradle
@@ -82,7 +82,7 @@ dependencies {
 
   testImplementation group: 'junit', name: 'junit'
   testImplementation group: 'org.mockito', name: 'mockito-core'
-  testCompile(group: 'org.jmock', name: 'jmock') {
+  testImplementation(group: 'org.jmock', name: 'jmock') {
       exclude group: 'org.hamcrest'
   }
   testImplementation group: 'ch.qos.logback', name: 'logback-classic'

--- a/atlasdb-client/build.gradle
+++ b/atlasdb-client/build.gradle
@@ -80,14 +80,14 @@ dependencies {
   compileOnly 'org.immutables:value::annotations'
   testCompileOnly 'org.immutables:value::annotations'
 
-  testCompile group: 'junit', name: 'junit'
-  testCompile group: 'org.mockito', name: 'mockito-core'
+  testImplementation group: 'junit', name: 'junit'
+  testImplementation group: 'org.mockito', name: 'mockito-core'
   testCompile(group: 'org.jmock', name: 'jmock') {
       exclude group: 'org.hamcrest'
   }
-  testCompile group: 'ch.qos.logback', name: 'logback-classic'
-  testCompile group: 'org.assertj', name: 'assertj-core'
-  testCompile group: 'org.awaitility', name: 'awaitility'
+  testImplementation group: 'ch.qos.logback', name: 'logback-classic'
+  testImplementation group: 'org.assertj', name: 'assertj-core'
+  testImplementation group: 'org.awaitility', name: 'awaitility'
 
   integrationInputCompile project(":atlasdb-client")
 

--- a/atlasdb-commons/build.gradle
+++ b/atlasdb-commons/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 
     testImplementation group: 'junit', name: 'junit'
     testImplementation group: 'org.assertj', name: 'assertj-core'
-    testCompile(group: 'org.jmock', name: 'jmock') {
+    testImplementation(group: 'org.jmock', name: 'jmock') {
       exclude group: 'org.hamcrest'
     }
     testImplementation group: 'org.mockito', name: 'mockito-core'

--- a/atlasdb-commons/build.gradle
+++ b/atlasdb-commons/build.gradle
@@ -31,11 +31,11 @@ dependencies {
     testAnnotationProcessor group: 'org.immutables', name: 'value'
     testCompileOnly 'org.immutables:value::annotations'
 
-    testCompile group: 'junit', name: 'junit'
-    testCompile group: 'org.assertj', name: 'assertj-core'
+    testImplementation group: 'junit', name: 'junit'
+    testImplementation group: 'org.assertj', name: 'assertj-core'
     testCompile(group: 'org.jmock', name: 'jmock') {
       exclude group: 'org.hamcrest'
     }
-    testCompile group: 'org.mockito', name: 'mockito-core'
-    testCompile group: 'org.awaitility', name: 'awaitility'
+    testImplementation group: 'org.mockito', name: 'mockito-core'
+    testImplementation group: 'org.awaitility', name: 'awaitility'
 }

--- a/atlasdb-config/build.gradle
+++ b/atlasdb-config/build.gradle
@@ -79,15 +79,15 @@ dependencies {
     testAnnotationProcessor group: 'org.immutables', name: 'value'
     testCompileOnly 'org.immutables:value::annotations'
 
-    testCompile project(path: ":atlasdb-client", configuration: "testArtifacts")
+    testImplementation project(path: ":atlasdb-client", configuration: "testArtifacts")
     testCompile(group: 'org.jmock', name: 'jmock') {
       exclude group: 'org.hamcrest'
     }
-    testCompile group: 'org.mockito', name: 'mockito-core'
-    testCompile group: 'com.github.tomakehurst', name: 'wiremock-standalone'
-    testCompile group: 'org.assertj', name: 'assertj-core'
-    testCompile group: 'org.awaitility', name: 'awaitility'
-    testCompile group: 'com.github.stefanbirkner', name: 'system-rules'
+    testImplementation group: 'org.mockito', name: 'mockito-core'
+    testImplementation group: 'com.github.tomakehurst', name: 'wiremock-standalone'
+    testImplementation group: 'org.assertj', name: 'assertj-core'
+    testImplementation group: 'org.awaitility', name: 'awaitility'
+    testImplementation group: 'com.github.stefanbirkner', name: 'system-rules'
     // Needed for Jersey Response-based tests
-    testCompile group: 'org.glassfish.jersey.core', name: 'jersey-common'
+    testImplementation group: 'org.glassfish.jersey.core', name: 'jersey-common'
 }

--- a/atlasdb-config/build.gradle
+++ b/atlasdb-config/build.gradle
@@ -80,7 +80,7 @@ dependencies {
     testCompileOnly 'org.immutables:value::annotations'
 
     testImplementation project(path: ":atlasdb-client", configuration: "testArtifacts")
-    testCompile(group: 'org.jmock', name: 'jmock') {
+    testImplementation(group: 'org.jmock', name: 'jmock') {
       exclude group: 'org.hamcrest'
     }
     testImplementation group: 'org.mockito', name: 'mockito-core'

--- a/atlasdb-conjure/build.gradle
+++ b/atlasdb-conjure/build.gradle
@@ -34,7 +34,7 @@ dependencies {
   annotationProcessor group: 'org.immutables', name: 'value'
   compileOnly 'org.immutables:value::annotations'
 
-  testCompile group: 'junit', name: 'junit'
-  testCompile group: 'org.assertj', name: 'assertj-core'
-  testCompile group: 'org.mockito', name: 'mockito-core'
+  testImplementation group: 'junit', name: 'junit'
+  testImplementation group: 'org.assertj', name: 'assertj-core'
+  testImplementation group: 'org.mockito', name: 'mockito-core'
 }

--- a/atlasdb-console/build.gradle
+++ b/atlasdb-console/build.gradle
@@ -27,10 +27,10 @@ dependencies {
     testImplementation 'org.codehaus.groovy:groovy-test'
     testImplementation project(':atlasdb-client')
 
-    testCompile(group: 'org.jmock', name: 'jmock-legacy') {
+    testImplementation(group: 'org.jmock', name: 'jmock-legacy') {
         exclude group: 'org.hamcrest'
     }
-    testCompile(group: 'org.jmock', name: 'jmock') {
+    testImplementation(group: 'org.jmock', name: 'jmock') {
       exclude group: 'org.hamcrest'
     }
     testImplementation 'org.gmock:gmock:0.8.3'

--- a/atlasdb-console/build.gradle
+++ b/atlasdb-console/build.gradle
@@ -33,5 +33,5 @@ dependencies {
     testCompile(group: 'org.jmock', name: 'jmock') {
       exclude group: 'org.hamcrest'
     }
-    testCompile 'org.gmock:gmock:0.8.3'
+    testImplementation 'org.gmock:gmock:0.8.3'
 }

--- a/atlasdb-container-test-utils/build.gradle
+++ b/atlasdb-container-test-utils/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     annotationProcessor group: 'org.immutables', name: 'value'
     compileOnly 'org.immutables:value::annotations'
 
-    testCompile group: 'com.github.stefanbirkner', name: 'system-rules'
-    testCompile group: 'org.assertj', name: 'assertj-core'
-    testCompile group: 'org.mockito', name: 'mockito-core'
+    testImplementation group: 'com.github.stefanbirkner', name: 'system-rules'
+    testImplementation group: 'org.assertj', name: 'assertj-core'
+    testImplementation group: 'org.mockito', name: 'mockito-core'
 }

--- a/atlasdb-coordination-impl/build.gradle
+++ b/atlasdb-coordination-impl/build.gradle
@@ -23,7 +23,7 @@ dependencies {
   annotationProcessor group: 'org.immutables', name: 'value'
   compileOnly 'org.immutables:value::annotations'
 
-  testCompile group: 'org.assertj', name: 'assertj-core'
-  testCompile group: 'org.mockito', name: 'mockito-core'
-  testCompile 'com.palantir.conjure.java.runtime:conjure-java-jackson-serialization'
+  testImplementation group: 'org.assertj', name: 'assertj-core'
+  testImplementation group: 'org.mockito', name: 'mockito-core'
+  testImplementation 'com.palantir.conjure.java.runtime:conjure-java-jackson-serialization'
 }

--- a/atlasdb-dbkvs-tests/build.gradle
+++ b/atlasdb-dbkvs-tests/build.gradle
@@ -28,9 +28,9 @@ dependencies {
   testImplementation project(':commons-db')
   testImplementation project(':timestamp-api')
 
-  testCompile group: 'org.mockito', name: 'mockito-core'
-  testCompile group: 'com.palantir.docker.compose', name: 'docker-compose-rule-junit4'
-  testCompile group: 'junit', name: 'junit'
+  testImplementation group: 'org.mockito', name: 'mockito-core'
+  testImplementation group: 'com.palantir.docker.compose', name: 'docker-compose-rule-junit4'
+  testImplementation group: 'junit', name: 'junit'
 }
 
 task postgresTest(type: Test) {

--- a/atlasdb-dbkvs/build.gradle
+++ b/atlasdb-dbkvs/build.gradle
@@ -36,9 +36,9 @@ dependencies {
   testImplementation 'org.slf4j:slf4j-api'
   testImplementation project(':atlasdb-commons')
 
-  testCompile project(':atlasdb-config')
-  testCompile project(path: ":atlasdb-client", configuration: "testArtifacts")
-  testCompile group: 'org.mockito', name: 'mockito-core'
+  testImplementation project(':atlasdb-config')
+  testImplementation project(path: ":atlasdb-client", configuration: "testArtifacts")
+  testImplementation group: 'org.mockito', name: 'mockito-core'
 
   annotationProcessor group: 'org.immutables', name: 'value'
   compileOnly 'org.immutables:value::annotations'

--- a/atlasdb-ete-tests/build.gradle
+++ b/atlasdb-ete-tests/build.gradle
@@ -75,16 +75,16 @@ dependencies {
     annotationProcessor project(':atlasdb-processors')
     compileOnly project(':atlasdb-processors')
 
-    testCompile project(':atlasdb-container-test-utils')
-    testCompile project(':atlasdb-ete-test-utils')
-    testCompile project(':flake-rule')
+    testImplementation project(':atlasdb-container-test-utils')
+    testImplementation project(':atlasdb-ete-test-utils')
+    testImplementation project(':flake-rule')
 
     testAnnotationProcessor group: 'org.immutables', name: 'value'
     testCompileOnly 'org.immutables:value::annotations'
 
-    testCompile group: 'com.palantir.docker.compose', name: 'docker-compose-rule-core'
-    testCompile group: 'io.dropwizard', name: 'dropwizard-testing'
-    testCompile group: 'org.assertj', name: 'assertj-core'
+    testImplementation group: 'com.palantir.docker.compose', name: 'docker-compose-rule-core'
+    testImplementation group: 'io.dropwizard', name: 'dropwizard-testing'
+    testImplementation group: 'org.assertj', name: 'assertj-core'
 }
 
 task prepareForEteTests(type: Copy, dependsOn: 'distTar') {

--- a/atlasdb-impl-shared/build.gradle
+++ b/atlasdb-impl-shared/build.gradle
@@ -96,14 +96,14 @@ dependencies {
   testAnnotationProcessor group: 'org.immutables', name: 'value'
   testCompileOnly 'org.immutables:value::annotations'
 
-  testCompile group: 'com.palantir.conjure.java.runtime', name: 'client-config'
-  testCompile group: 'com.palantir.conjure.java.runtime', name: 'conjure-java-jaxrs-client'
-  testCompile group: 'com.palantir.conjure.java.runtime', name: 'keystores'
-  testCompile group: 'com.palantir.safe-logging', name: 'preconditions-assertj'
-  testCompile group: 'io.dropwizard', name: 'dropwizard-testing'
-  testCompile group: 'org.assertj', name: 'assertj-core'
-  testCompile group: 'org.mockito', name: 'mockito-core'
-  testCompile group: 'org.awaitility', name: 'awaitility'
+  testImplementation group: 'com.palantir.conjure.java.runtime', name: 'client-config'
+  testImplementation group: 'com.palantir.conjure.java.runtime', name: 'conjure-java-jaxrs-client'
+  testImplementation group: 'com.palantir.conjure.java.runtime', name: 'keystores'
+  testImplementation group: 'com.palantir.safe-logging', name: 'preconditions-assertj'
+  testImplementation group: 'io.dropwizard', name: 'dropwizard-testing'
+  testImplementation group: 'org.assertj', name: 'assertj-core'
+  testImplementation group: 'org.mockito', name: 'mockito-core'
+  testImplementation group: 'org.awaitility', name: 'awaitility'
   testCompile(group: 'org.jmock', name: 'jmock') {
     exclude group: 'org.hamcrest'
     exclude group: 'org.ow2.asm'
@@ -112,7 +112,7 @@ dependencies {
   testRuntime group: 'ch.qos.logback', name: 'logback-classic'
 }
 
-configurations.testCompile {
+configurations.testImplementation {
   resolutionStrategy {
     // It sucks, but at least we can validate only on test
     force 'io.dropwizard.metrics:metrics-jmx:4.1.5'

--- a/atlasdb-impl-shared/build.gradle
+++ b/atlasdb-impl-shared/build.gradle
@@ -104,7 +104,7 @@ dependencies {
   testImplementation group: 'org.assertj', name: 'assertj-core'
   testImplementation group: 'org.mockito', name: 'mockito-core'
   testImplementation group: 'org.awaitility', name: 'awaitility'
-  testCompile(group: 'org.jmock', name: 'jmock') {
+  testImplementation(group: 'org.jmock', name: 'jmock') {
     exclude group: 'org.hamcrest'
     exclude group: 'org.ow2.asm'
   }

--- a/atlasdb-jdbc-tests/build.gradle
+++ b/atlasdb-jdbc-tests/build.gradle
@@ -1,9 +1,9 @@
 apply from: "../gradle/shared.gradle"
 
 dependencies {
-  testCompile project(":atlasdb-jdbc")
-  testCompile project(":atlasdb-tests-shared")
-  testCompile project(":atlasdb-hikari")
+  testImplementation project(":atlasdb-jdbc")
+  testImplementation project(":atlasdb-tests-shared")
+  testImplementation project(":atlasdb-hikari")
 
   implementation 'com.fasterxml.jackson.core:jackson-annotations'
   implementation 'com.google.errorprone:error_prone_annotations'
@@ -27,6 +27,6 @@ dependencies {
   testImplementation project(':atlasdb-api')
   testImplementation project(':timestamp-api')
 
-  testCompile "com.h2database:h2:1.4.190"
+  testImplementation "com.h2database:h2:1.4.190"
 }
 

--- a/atlasdb-jepsen-tests/build.gradle
+++ b/atlasdb-jepsen-tests/build.gradle
@@ -60,8 +60,8 @@ dependencies {
     annotationProcessor group: 'org.immutables', name: 'value'
     compileOnly 'org.immutables:value::annotations'
 
-    testCompile group: 'org.assertj', name: 'assertj-core'
-    testCompile group: 'org.mockito', name: 'mockito-core'
+    testImplementation group: 'org.assertj', name: 'assertj-core'
+    testImplementation group: 'org.mockito', name: 'mockito-core'
 }
 
 shadowJar {

--- a/atlasdb-perf/build.gradle
+++ b/atlasdb-perf/build.gradle
@@ -54,8 +54,8 @@ dependencies {
     testImplementation 'com.google.guava:guava'
     testImplementation 'org.apache.commons:commons-math3'
 
-    testCompile group: 'org.assertj', name: 'assertj-core'
-    testCompile group: 'org.mockito', name: 'mockito-core'
+    testImplementation group: 'org.assertj', name: 'assertj-core'
+    testImplementation group: 'org.mockito', name: 'mockito-core'
 
     compile group: 'org.openjdk.jmh', name: 'jmh-core', version: '1.13'
     annotationProcessor group: 'org.immutables', name: 'value'

--- a/atlasdb-processors-tests/build.gradle
+++ b/atlasdb-processors-tests/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     annotationProcessor project(":atlasdb-processors")
     compileOnly project(":atlasdb-processors")
 
-    testCompile group: 'com.google.guava', name: 'guava'
-    testCompile group: 'org.assertj', name: 'assertj-core'
-    testCompile group: 'org.mockito', name: 'mockito-core'
+    testImplementation group: 'com.google.guava', name: 'guava'
+    testImplementation group: 'org.assertj', name: 'assertj-core'
+    testImplementation group: 'org.mockito', name: 'mockito-core'
 }

--- a/atlasdb-remoting-api/build.gradle
+++ b/atlasdb-remoting-api/build.gradle
@@ -22,7 +22,7 @@ dependencies {
 
   testImplementation group: 'junit', name: 'junit'
   testImplementation group: 'org.assertj', name: 'assertj-core'
-  testCompile(group: 'org.jmock', name: 'jmock') {
+  testImplementation(group: 'org.jmock', name: 'jmock') {
     exclude group: 'org.hamcrest'
   }
   testImplementation group: 'org.mockito', name: 'mockito-core'

--- a/atlasdb-remoting-api/build.gradle
+++ b/atlasdb-remoting-api/build.gradle
@@ -20,10 +20,10 @@ dependencies {
   annotationProcessor group: 'org.immutables', name: 'value'
   compileOnly 'org.immutables:value::annotations'
 
-  testCompile group: 'junit', name: 'junit'
-  testCompile group: 'org.assertj', name: 'assertj-core'
+  testImplementation group: 'junit', name: 'junit'
+  testImplementation group: 'org.assertj', name: 'assertj-core'
   testCompile(group: 'org.jmock', name: 'jmock') {
     exclude group: 'org.hamcrest'
   }
-  testCompile group: 'org.mockito', name: 'mockito-core'
+  testImplementation group: 'org.mockito', name: 'mockito-core'
 }

--- a/atlasdb-service/build.gradle
+++ b/atlasdb-service/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compile project(':atlasdb-config')
     compile group: 'jakarta.inject', name: 'jakarta.inject-api'
 
-    testCompile group: 'org.mockito', name: 'mockito-core'
+    testImplementation group: 'org.mockito', name: 'mockito-core'
 
     implementation 'com.fasterxml.jackson.core:jackson-annotations'
     implementation 'com.fasterxml.jackson.core:jackson-core'
@@ -29,5 +29,5 @@ dependencies {
     testImplementation project(':atlasdb-client')
 
     // Needed for Jersey Response-based tests
-    testCompile group: 'org.glassfish.jersey.core', name: 'jersey-common'
+    testImplementation group: 'org.glassfish.jersey.core', name: 'jersey-common'
 }

--- a/atlasdb-tests-shared/build.gradle
+++ b/atlasdb-tests-shared/build.gradle
@@ -7,9 +7,9 @@ schemas = [
 
 dependencies {
   compile project(":atlasdb-config")
-  testCompile project(":atlasdb-config")
+  testImplementation project(":atlasdb-config")
 
-  testCompile project(":commons-api")
+  testImplementation project(":commons-api")
 
   compile group: 'com.palantir.tracing', name: 'tracing'
   compile group: 'com.palantir.tritium', name: 'tritium-lib'
@@ -68,7 +68,7 @@ dependencies {
   compileOnly 'org.immutables:value::annotations'
   testCompileOnly 'org.immutables:value::annotations'
 
-  testCompile project(path: ":atlasdb-client", configuration: "testArtifacts")
+  testImplementation project(path: ":atlasdb-client", configuration: "testArtifacts")
   testCompile(group: 'org.jmock', name: 'jmock') {
       exclude group: 'org.hamcrest'
   }

--- a/atlasdb-tests-shared/build.gradle
+++ b/atlasdb-tests-shared/build.gradle
@@ -69,7 +69,7 @@ dependencies {
   testCompileOnly 'org.immutables:value::annotations'
 
   testImplementation project(path: ":atlasdb-client", configuration: "testArtifacts")
-  testCompile(group: 'org.jmock', name: 'jmock') {
+  testImplementation(group: 'org.jmock', name: 'jmock') {
       exclude group: 'org.hamcrest'
   }
 }

--- a/changelog/@unreleased/pr-5720.v2.yml
+++ b/changelog/@unreleased/pr-5720.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Replace usages of `testCompile` by `testImplementation` in preparation
+    for Gradle 7
+  links:
+  - https://github.com/palantir/atlasdb/pull/5720

--- a/commons-db/build.gradle
+++ b/commons-db/build.gradle
@@ -36,7 +36,7 @@ dependencies {
   testImplementation 'org.slf4j:slf4j-api'
   testImplementation project(':atlasdb-commons')
 
-  testCompile group: 'junit', name: 'junit'
-  testCompile group: 'org.mockito', name: 'mockito-core'
-  testCompile group: 'org.assertj', name: 'assertj-core'
+  testImplementation group: 'junit', name: 'junit'
+  testImplementation group: 'org.mockito', name: 'mockito-core'
+  testImplementation group: 'org.assertj', name: 'assertj-core'
 }

--- a/commons-executors/build.gradle
+++ b/commons-executors/build.gradle
@@ -15,6 +15,6 @@ dependencies {
     testImplementation 'com.palantir.tritium:tritium-registry'
     testImplementation 'io.dropwizard.metrics:metrics-core'
 
-    testCompile group: 'com.google.guava', name: 'guava'
+    testImplementation group: 'com.google.guava', name: 'guava'
     testCompileOnly 'org.immutables:value::annotations'
 }

--- a/examples/profile-client/build.gradle
+++ b/examples/profile-client/build.gradle
@@ -29,7 +29,7 @@ dependencies {
   testImplementation project(':atlasdb-impl-shared')
   testImplementation project(':atlasdb-remoting-api')
 
-  testCompile project(":atlasdb-config")
-  testCompile project(":atlasdb-tests-shared")
-  testCompile project(":timelock-impl")
+  testImplementation project(":atlasdb-config")
+  testImplementation project(":atlasdb-tests-shared")
+  testImplementation project(":timelock-impl")
 }

--- a/flake-rule/build.gradle
+++ b/flake-rule/build.gradle
@@ -5,7 +5,7 @@ dependencies {
   compile group: 'org.slf4j', name: 'slf4j-api'
   compile group: 'com.google.guava', name: 'guava'
 
-  testCompile group: 'ch.qos.logback', name: 'logback-classic'
-  testCompile group: 'org.assertj', name: 'assertj-core'
-  testCompile group: 'org.mockito', name: 'mockito-core'
+  testImplementation group: 'ch.qos.logback', name: 'logback-classic'
+  testImplementation group: 'org.assertj', name: 'assertj-core'
+  testImplementation group: 'org.mockito', name: 'mockito-core'
 }

--- a/gradle/shared.gradle
+++ b/gradle/shared.gradle
@@ -33,8 +33,8 @@ dependencies {
 
     implementation 'com.palantir.safe-logging:logger'
 
-    testCompile group: 'junit', name: 'junit'
-    testCompile group: 'org.assertj', name: 'assertj-core'
+    testImplementation group: 'junit', name: 'junit'
+    testImplementation group: 'org.assertj', name: 'assertj-core'
 }
 
 apply from: rootProject.file('gradle/javadoc.gradle'), to: javadoc

--- a/leader-election-impl/build.gradle
+++ b/leader-election-impl/build.gradle
@@ -48,10 +48,10 @@ dependencies {
     exclude group: 'org.hamcrest'
     exclude group: 'org.ow2.asm'
   }
-  testCompile group: 'org.assertj', name: 'assertj-core'
-  testCompile group: 'org.awaitility', name: 'awaitility'
-  testCompile group: 'org.mockito', name: 'mockito-core'
-  testCompile group: 'com.palantir.tracing', name: 'tracing-test-utils'
+  testImplementation group: 'org.assertj', name: 'assertj-core'
+  testImplementation group: 'org.awaitility', name: 'awaitility'
+  testImplementation group: 'org.mockito', name: 'mockito-core'
+  testImplementation group: 'com.palantir.tracing', name: 'tracing-test-utils'
 }
 
 configurations {

--- a/leader-election-impl/build.gradle
+++ b/leader-election-impl/build.gradle
@@ -44,7 +44,7 @@ dependencies {
   annotationProcessor 'org.derive4j:derive4j'
   compileOnly 'org.derive4j:derive4j-annotation'
 
-  testCompile(group: 'org.jmock', name: 'jmock') {
+  testImplementation(group: 'org.jmock', name: 'jmock') {
     exclude group: 'org.hamcrest'
     exclude group: 'org.ow2.asm'
   }

--- a/lock-api/build.gradle
+++ b/lock-api/build.gradle
@@ -55,12 +55,12 @@ dependencies {
     testAnnotationProcessor group: 'org.immutables', name: 'value'
     testCompileOnly 'org.immutables:value::annotations'
 
-    testCompile group: 'com.palantir.conjure.java.runtime', name: 'conjure-java-jackson-serialization'
-    testCompile group: 'junit', name: 'junit'
-    testCompile group: 'org.assertj', name: 'assertj-core'
-    testCompile group: 'org.awaitility', name: 'awaitility'
+    testImplementation group: 'com.palantir.conjure.java.runtime', name: 'conjure-java-jackson-serialization'
+    testImplementation group: 'junit', name: 'junit'
+    testImplementation group: 'org.assertj', name: 'assertj-core'
+    testImplementation group: 'org.awaitility', name: 'awaitility'
     testCompile(group: 'org.jmock', name: 'jmock') {
       exclude group: 'org.hamcrest'
     }
-    testCompile group: 'org.mockito', name: 'mockito-core'
+    testImplementation group: 'org.mockito', name: 'mockito-core'
 }

--- a/lock-api/build.gradle
+++ b/lock-api/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     testImplementation group: 'junit', name: 'junit'
     testImplementation group: 'org.assertj', name: 'assertj-core'
     testImplementation group: 'org.awaitility', name: 'awaitility'
-    testCompile(group: 'org.jmock', name: 'jmock') {
+    testImplementation(group: 'org.jmock', name: 'jmock') {
       exclude group: 'org.hamcrest'
     }
     testImplementation group: 'org.mockito', name: 'mockito-core'

--- a/lock-impl/build.gradle
+++ b/lock-impl/build.gradle
@@ -36,7 +36,7 @@ dependencies {
   testImplementation project(":flake-rule")
   testImplementation group: 'uk.org.lidalia', name: 'slf4j-test', version: '1.1.0'
   testImplementation group: 'org.assertj', name: 'assertj-core'
-  testCompile(group: 'org.jmock', name: 'jmock') {
+  testImplementation(group: 'org.jmock', name: 'jmock') {
     exclude group: 'org.hamcrest'
   }
   testImplementation group: 'org.mockito', name: 'mockito-core'

--- a/lock-impl/build.gradle
+++ b/lock-impl/build.gradle
@@ -33,11 +33,11 @@ dependencies {
   compileOnly 'org.immutables:value::annotations'
   testCompileOnly 'org.immutables:value::annotations'
 
-  testCompile project(":flake-rule")
-  testCompile group: 'uk.org.lidalia', name: 'slf4j-test', version: '1.1.0'
-  testCompile group: 'org.assertj', name: 'assertj-core'
+  testImplementation project(":flake-rule")
+  testImplementation group: 'uk.org.lidalia', name: 'slf4j-test', version: '1.1.0'
+  testImplementation group: 'org.assertj', name: 'assertj-core'
   testCompile(group: 'org.jmock', name: 'jmock') {
     exclude group: 'org.hamcrest'
   }
-  testCompile group: 'org.mockito', name: 'mockito-core'
+  testImplementation group: 'org.mockito', name: 'mockito-core'
 }

--- a/timelock-agent/build.gradle
+++ b/timelock-agent/build.gradle
@@ -62,11 +62,11 @@ dependencies {
     compileOnly 'org.immutables:value::annotations'
     testCompileOnly 'org.immutables:value::annotations'
 
-    testCompile group: 'org.assertj', name: 'assertj-core'
-    testCompile (group: 'org.mockito', name: 'mockito-core') {
+    testImplementation group: 'org.assertj', name: 'assertj-core'
+    testImplementation (group: 'org.mockito', name: 'mockito-core') {
         // Mockito version doesn't agree with our JUnit version
         exclude group: 'org.hamcrest', module: 'hamcrest-core'
     }
 
-    testCompile group: 'com.palantir.conjure.java.runtime', name: 'conjure-java-jackson-serialization'
+    testImplementation group: 'com.palantir.conjure.java.runtime', name: 'conjure-java-jackson-serialization'
 }

--- a/timelock-corruption-detection/build.gradle
+++ b/timelock-corruption-detection/build.gradle
@@ -55,8 +55,8 @@ dependencies {
     testAnnotationProcessor group: 'org.immutables', name: 'value'
     testCompileOnly 'org.immutables:value::annotations'
 
-    testCompile group: 'org.assertj', name: 'assertj-core'
-    testCompile group: 'org.mockito', name: 'mockito-core'
+    testImplementation group: 'org.assertj', name: 'assertj-core'
+    testImplementation group: 'org.mockito', name: 'mockito-core'
 }
 
 subprojects {

--- a/timelock-impl/build.gradle
+++ b/timelock-impl/build.gradle
@@ -87,12 +87,12 @@ dependencies {
     annotationProcessor 'org.derive4j:derive4j'
     compileOnly 'org.derive4j:derive4j-annotation'
 
-    testCompile project(path: ":leader-election-impl", configuration: "testArtifacts")
+    testImplementation project(path: ":leader-election-impl", configuration: "testArtifacts")
 
-    testCompile group: 'com.palantir.safe-logging', name: 'preconditions-assertj'
-    testCompile group: 'com.palantir.conjure.java.api', name: 'test-utils'
-    testCompile group: 'org.assertj', name: 'assertj-core'
-    testCompile group: 'org.mockito', name: 'mockito-core'
+    testImplementation group: 'com.palantir.safe-logging', name: 'preconditions-assertj'
+    testImplementation group: 'com.palantir.conjure.java.api', name: 'test-utils'
+    testImplementation group: 'org.assertj', name: 'assertj-core'
+    testImplementation group: 'org.mockito', name: 'mockito-core'
 
     testAnnotationProcessor group: 'org.immutables', name: 'value'
     testCompileOnly 'org.immutables:value::annotations'

--- a/timelock-server/build.gradle
+++ b/timelock-server/build.gradle
@@ -103,7 +103,7 @@ dependencies {
     }
     testImplementation project(":flake-rule")
     testImplementation group: 'org.assertj', name: 'assertj-core'
-    testCompile(group: 'org.jmock', name: 'jmock') {
+    testImplementation(group: 'org.jmock', name: 'jmock') {
         exclude group: 'org.hamcrest'
         exclude group: 'org.ow2.asm'
     }

--- a/timelock-server/build.gradle
+++ b/timelock-server/build.gradle
@@ -89,29 +89,29 @@ dependencies {
     // TODO:   runtime "org.postgresql:postgresql:${postgresJdbcDriverVersion}"
     // TODO:   add runtime depencency on the dbkvs-oracle-driver internally
 
-    testCompile (project(":atlasdb-tests-shared")) {
+    testImplementation (project(":atlasdb-tests-shared")) {
         exclude group: 'com.fasterxml.jackson.jaxrs'
     }
 
-    testCompile group: 'com.palantir.conjure.java.runtime', name: 'client-config'
-    testCompile project(":atlasdb-container-test-utils")
-    testCompile project(":atlasdb-tests-shared")
-    testCompile project(":atlasdb-dbkvs")
-    testCompile (project(":atlasdb-cassandra")) {
+    testImplementation group: 'com.palantir.conjure.java.runtime', name: 'client-config'
+    testImplementation project(":atlasdb-container-test-utils")
+    testImplementation project(":atlasdb-tests-shared")
+    testImplementation project(":atlasdb-dbkvs")
+    testImplementation (project(":atlasdb-cassandra")) {
         exclude(module:'log4j-over-slf4j')
         exclude(module:'jcl-over-slf4j')
     }
-    testCompile project(":flake-rule")
-    testCompile group: 'org.assertj', name: 'assertj-core'
+    testImplementation project(":flake-rule")
+    testImplementation group: 'org.assertj', name: 'assertj-core'
     testCompile(group: 'org.jmock', name: 'jmock') {
         exclude group: 'org.hamcrest'
         exclude group: 'org.ow2.asm'
     }
-    testCompile group: 'org.mockito', name: 'mockito-core'
-    testCompile group: 'com.github.tomakehurst', name: 'wiremock-standalone'
+    testImplementation group: 'org.mockito', name: 'mockito-core'
+    testImplementation group: 'com.github.tomakehurst', name: 'wiremock-standalone'
 
-    testCompile group: 'com.palantir.docker.compose', name: 'docker-compose-rule-core'
-    testCompile group: 'com.palantir.docker.compose', name: 'docker-compose-rule-junit4'
+    testImplementation group: 'com.palantir.docker.compose', name: 'docker-compose-rule-core'
+    testImplementation group: 'com.palantir.docker.compose', name: 'docker-compose-rule-junit4'
 
     testImplementation 'com.google.guava:guava'
     testImplementation 'io.dropwizard.metrics:metrics-core'

--- a/timestamp-api/build.gradle
+++ b/timestamp-api/build.gradle
@@ -8,5 +8,5 @@ dependencies {
     annotationProcessor project(':atlasdb-processors')
     compileOnly project(':atlasdb-processors')
 
-    testCompile group: 'org.assertj', name: 'assertj-core'
+    testImplementation group: 'org.assertj', name: 'assertj-core'
 }

--- a/timestamp-client/build.gradle
+++ b/timestamp-client/build.gradle
@@ -22,8 +22,8 @@ dependencies {
   testAnnotationProcessor group: 'org.immutables', name: 'value'
   testCompileOnly 'org.immutables:value::annotations'
 
-  testCompile group: 'com.palantir.tracing', name: 'tracing'
-  testCompile group: 'junit', name: 'junit'
-  testCompile group: 'org.assertj', name: 'assertj-core'
-  testCompile group: 'org.mockito', name: 'mockito-core'
+  testImplementation group: 'com.palantir.tracing', name: 'tracing'
+  testImplementation group: 'junit', name: 'junit'
+  testImplementation group: 'org.assertj', name: 'assertj-core'
+  testImplementation group: 'org.mockito', name: 'mockito-core'
 }

--- a/timestamp-impl/build.gradle
+++ b/timestamp-impl/build.gradle
@@ -22,10 +22,10 @@ dependencies {
   annotationProcessor project(":atlasdb-processors")
   compileOnly project(":atlasdb-processors")
 
-  testCompile group: 'junit', name: 'junit'
+  testImplementation group: 'junit', name: 'junit'
   testCompile(group: 'org.jmock', name: 'jmock') {
       exclude group: 'org.hamcrest'
   }
-  testCompile group: 'org.awaitility', name: 'awaitility'
-  testCompile group: 'org.mockito', name: 'mockito-core'
+  testImplementation group: 'org.awaitility', name: 'awaitility'
+  testImplementation group: 'org.mockito', name: 'mockito-core'
 }

--- a/timestamp-impl/build.gradle
+++ b/timestamp-impl/build.gradle
@@ -23,7 +23,7 @@ dependencies {
   compileOnly project(":atlasdb-processors")
 
   testImplementation group: 'junit', name: 'junit'
-  testCompile(group: 'org.jmock', name: 'jmock') {
+  testImplementation(group: 'org.jmock', name: 'jmock') {
       exclude group: 'org.hamcrest'
   }
   testImplementation group: 'org.awaitility', name: 'awaitility'


### PR DESCRIPTION
**Goals (and why)**:
Replace usages of `testCompile` by `testImplementation` in preparation for Gradle 7

**Priority (whenever / two weeks / yesterday)**:
Before EOD is ideal

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
