### PR TITLE
TimeLockAdjudication: allow green node to back off if it restarts

### DIFF
--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/SinglePingableLeaderTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/SinglePingableLeaderTest.java
@@ -151,7 +151,7 @@ public class SinglePingableLeaderTest {
                 () -> RemotingClientConfigs.DEFAULT,
                 ServiceCreator.createTrustContext(Optional.of(SSL_CONFIGURATION)),
                 USER_AGENT);
-        return SingleLeaderPinger.create(
+        return SingleLeaderPinger.createForTests(
                 ImmutableMap.of(otherLeaders.get(0), new CheckedRejectionExecutorService(executorService)),
                 Duration.ofSeconds(5),
                 LOCAL_UUID,

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/SinglePingableLeaderTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/SinglePingableLeaderTest.java
@@ -151,7 +151,7 @@ public class SinglePingableLeaderTest {
                 () -> RemotingClientConfigs.DEFAULT,
                 ServiceCreator.createTrustContext(Optional.of(SSL_CONFIGURATION)),
                 USER_AGENT);
-        return new SingleLeaderPinger(
+        return SingleLeaderPinger.create(
                 ImmutableMap.of(otherLeaders.get(0), new CheckedRejectionExecutorService(executorService)),
                 Duration.ofSeconds(5),
                 LOCAL_UUID,

--- a/leader-election-impl/src/main/java/com/palantir/paxos/DbGreenNodeLeadershipPrioritiser.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/DbGreenNodeLeadershipPrioritiser.java
@@ -1,0 +1,61 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.paxos;
+
+import com.palantir.common.time.Clock;
+import com.palantir.sls.versions.OrderableSlsVersion;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+public class DbGreenNodeLeadershipPrioritiser implements GreenNodeLeadershipPrioritiser {
+    private final Optional<OrderableSlsVersion> timeLockVersion;
+    private final Supplier<Duration> leadershipAttemptBackoff;
+    private final GreenNodeLeadershipState greenNodeLeadershipState;
+    private final Clock clock;
+
+    public DbGreenNodeLeadershipPrioritiser(
+            Optional<OrderableSlsVersion> timeLockVersion,
+            Supplier<Duration> leadershipAttemptBackoff,
+            GreenNodeLeadershipState greenNodeLeadershipState,
+            Clock clock) {
+        this.timeLockVersion = timeLockVersion;
+        this.leadershipAttemptBackoff = leadershipAttemptBackoff;
+        this.greenNodeLeadershipState = greenNodeLeadershipState;
+        this.clock = clock;
+    }
+
+    @Override
+    public boolean shouldGreeningNodeBecomeLeader() {
+        OrderableSlsVersion currentVersion = timeLockVersion.orElse(null);
+        Optional<Long> latestAttemptTime = greenNodeLeadershipState.getLatestAttemptTime(currentVersion);
+        if (latestAttemptTime.isEmpty()) {
+            greenNodeLeadershipState.setLatestAttemptTime(currentVersion, clock.getTimeMillis());
+            return true;
+        }
+
+        long latestAttemptMillis = latestAttemptTime.get();
+        long currentTime = clock.getTimeMillis();
+        long backoffMillis = leadershipAttemptBackoff.get().toMillis();
+        if (currentTime - latestAttemptMillis > backoffMillis) {
+            greenNodeLeadershipState.setLatestAttemptTime(currentVersion, currentTime);
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/leader-election-impl/src/main/java/com/palantir/paxos/DbGreenNodeLeadershipPrioritiser.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/DbGreenNodeLeadershipPrioritiser.java
@@ -17,10 +17,12 @@
 package com.palantir.paxos;
 
 import com.palantir.common.time.Clock;
+import com.palantir.common.time.SystemClock;
 import com.palantir.sls.versions.OrderableSlsVersion;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.function.Supplier;
+import javax.sql.DataSource;
 
 public class DbGreenNodeLeadershipPrioritiser implements GreenNodeLeadershipPrioritiser {
     private final Optional<OrderableSlsVersion> timeLockVersion;
@@ -37,6 +39,15 @@ public class DbGreenNodeLeadershipPrioritiser implements GreenNodeLeadershipPrio
         this.leadershipAttemptBackoff = leadershipAttemptBackoff;
         this.greenNodeLeadershipState = greenNodeLeadershipState;
         this.clock = clock;
+    }
+
+    public static DbGreenNodeLeadershipPrioritiser create(
+            Optional<OrderableSlsVersion> timeLockVersion,
+            Supplier<Duration> leadershipAttemptBackoff,
+            DataSource sqliteDataSource) {
+        GreenNodeLeadershipState greenNodeLeadershipState = GreenNodeLeadershipState.create(sqliteDataSource);
+        return new DbGreenNodeLeadershipPrioritiser(
+                timeLockVersion, leadershipAttemptBackoff, greenNodeLeadershipState, new SystemClock());
     }
 
     @Override

--- a/leader-election-impl/src/main/java/com/palantir/paxos/GreenNodeLeadershipPrioritiser.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/GreenNodeLeadershipPrioritiser.java
@@ -1,0 +1,21 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.paxos;
+
+interface GreenNodeLeadershipPrioritiser {
+    boolean shouldGreeningNodeBecomeLeader();
+}

--- a/leader-election-impl/src/main/java/com/palantir/paxos/GreenNodeLeadershipState.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/GreenNodeLeadershipState.java
@@ -27,7 +27,7 @@ import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 
-public class GreenNodeLeadershipState {
+public final class GreenNodeLeadershipState {
     private static final int NODE_ID = 0;
 
     private final Jdbi jdbi;

--- a/leader-election-impl/src/main/java/com/palantir/paxos/GreenNodeLeadershipState.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/GreenNodeLeadershipState.java
@@ -28,6 +28,9 @@ import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 
 public final class GreenNodeLeadershipState {
+    // We use a constant node_id to ensure the table takes up a constant amount of space.
+    // Latest attempts for previous versions are not relevant once we start upgrading to a new version, so
+    // we don't want to keep them around.
     private static final int NODE_ID = 0;
 
     private final Jdbi jdbi;

--- a/leader-election-impl/src/main/java/com/palantir/paxos/GreenNodeLeadershipState.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/GreenNodeLeadershipState.java
@@ -1,0 +1,79 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.paxos;
+
+import com.palantir.sls.versions.OrderableSlsVersion;
+import java.util.Optional;
+import java.util.function.Function;
+import javax.sql.DataSource;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.mapper.immutables.JdbiImmutables;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+
+public class GreenNodeLeadershipState {
+    private static final int NODE_ID = 0;
+
+    private final Jdbi jdbi;
+
+    private GreenNodeLeadershipState(Jdbi jdbi) {
+        this.jdbi = jdbi;
+    }
+
+    public static GreenNodeLeadershipState create(DataSource dataSource) {
+        Jdbi jdbi = Jdbi.create(dataSource).installPlugin(new SqlObjectPlugin());
+        jdbi.getConfig(JdbiImmutables.class).registerImmutable(Client.class);
+        GreenNodeLeadershipState state = new GreenNodeLeadershipState(jdbi);
+        state.initialise();
+        return state;
+    }
+
+    private void initialise() {
+        execute(Queries::createGreenNodeLeadershipStateTable);
+    }
+
+    public Optional<Long> getLatestAttemptTime(OrderableSlsVersion currentVersion) {
+        return execute(dao -> dao.getLatestAttemptTime(NODE_ID, currentVersion.getValue()));
+    }
+
+    public boolean setLatestAttemptTime(OrderableSlsVersion currentVersion, Long attemptTimeMillis) {
+        return execute(dao -> dao.updateLatestAttemptTime(NODE_ID, currentVersion.getValue(), attemptTimeMillis));
+    }
+
+    private <T> T execute(Function<GreenNodeLeadershipState.Queries, T> call) {
+        return jdbi.withExtension(GreenNodeLeadershipState.Queries.class, call::apply);
+    }
+
+    public interface Queries {
+        @SqlUpdate("CREATE TABLE IF NOT EXISTS greenNodeLeadershipState (nodeId INTEGER, productVersion TEXT, "
+                + "attemptTime BIGINT, PRIMARY KEY(nodeId))")
+        boolean createGreenNodeLeadershipStateTable();
+
+        @SqlUpdate("INSERT OR REPLACE INTO greenNodeLeadershipState (node, productVersion, attemptTime) VALUES "
+                + "(:nodeId, :productVersion, :attemptTime)")
+        boolean updateLatestAttemptTime(
+                @Bind("nodeId") int nodeId,
+                @Bind("productVersion") String productVersion,
+                @Bind("attemptTime") long attemptTime);
+
+        @SqlQuery("SELECT attemptTime FROM greenNodeLeadershipState "
+                + "WHERE nodeId = :nodeId AND productVersion = :productVersion")
+        Optional<Long> getLatestAttemptTime(@Bind("nodeId") int nodeId, @Bind("productVersion") String productVersion);
+    }
+}

--- a/leader-election-impl/src/main/java/com/palantir/paxos/RateLimitedGreenNodeLeadershipPrioritiser.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/RateLimitedGreenNodeLeadershipPrioritiser.java
@@ -1,0 +1,28 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.paxos;
+
+import com.google.common.util.concurrent.RateLimiter;
+
+class RateLimitedGreenNodeLeadershipPrioritiser implements GreenNodeLeadershipPrioritiser {
+    private final RateLimiter greeningNodeShouldBecomeLeaderRateLimiter = RateLimiter.create(1.0 / (10 * 60));
+
+    @Override
+    public boolean shouldGreeningNodeBecomeLeader() {
+        return greeningNodeShouldBecomeLeaderRateLimiter.tryAcquire();
+    }
+}

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderPinger.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderPinger.java
@@ -16,7 +16,6 @@
 
 package com.palantir.paxos;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.RateLimiter;
@@ -48,7 +47,7 @@ import java.util.function.BooleanSupplier;
 import javax.annotation.Nullable;
 import javax.sql.DataSource;
 
-public class SingleLeaderPinger implements LeaderPinger {
+public final class SingleLeaderPinger implements LeaderPinger {
     private static final SafeLogger log = SafeLoggerFactory.get(SingleLeaderPinger.class);
 
     private final ConcurrentMap<UUID, LeaderPingerContext<PingableLeader>> uuidToServiceCache =
@@ -78,7 +77,7 @@ public class SingleLeaderPinger implements LeaderPinger {
         this.greenNodeLeadershipPrioritiser = greenNodeLeadershipPrioritiser;
     }
 
-    @VisibleForTesting
+    // VisibleForTesting
     public static SingleLeaderPinger createForTests(
             Map<LeaderPingerContext<PingableLeader>, CheckedRejectionExecutorService> otherPingableExecutors,
             Duration leaderPingResponseWait,

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderPinger.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderPinger.java
@@ -95,6 +95,7 @@ public class SingleLeaderPinger implements LeaderPinger {
                 greenNodeLeadershipPrioritiser);
     }
 
+    // TODO(gs): add tests that use the DbGreenNodeLeadershipPrioritiser
     public static SingleLeaderPinger create(
             Map<LeaderPingerContext<PingableLeader>, CheckedRejectionExecutorService> otherPingableExecutors,
             DataSource sqliteDataSource,

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderPinger.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderPinger.java
@@ -62,7 +62,7 @@ public class SingleLeaderPinger implements LeaderPinger {
 
     private Map<LeaderPingerContext<PingableLeader>, Boolean> pingV2StatusOnRemotes = new HashMap<>();
 
-    public SingleLeaderPinger(
+    private SingleLeaderPinger(
             Map<LeaderPingerContext<PingableLeader>, CheckedRejectionExecutorService> otherPingableExecutors,
             Duration leaderPingResponseWait,
             UUID localUuid,
@@ -73,6 +73,16 @@ public class SingleLeaderPinger implements LeaderPinger {
         this.localUuid = localUuid;
         this.cancelRemainingCalls = cancelRemainingCalls;
         this.timeLockVersion = timeLockVersion;
+    }
+
+    public static SingleLeaderPinger create(
+            Map<LeaderPingerContext<PingableLeader>, CheckedRejectionExecutorService> otherPingableExecutors,
+            Duration leaderPingResponseWait,
+            UUID localUuid,
+            boolean cancelRemainingCalls,
+            Optional<OrderableSlsVersion> timeLockVersion) {
+        return new SingleLeaderPinger(
+                otherPingableExecutors, leaderPingResponseWait, localUuid, cancelRemainingCalls, timeLockVersion);
     }
 
     public static SingleLeaderPinger createLegacy(

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderPinger.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderPinger.java
@@ -16,6 +16,7 @@
 
 package com.palantir.paxos;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.RateLimiter;
@@ -77,8 +78,8 @@ public class SingleLeaderPinger implements LeaderPinger {
         this.greenNodeLeadershipPrioritiser = greenNodeLeadershipPrioritiser;
     }
 
-    // TODO(gs): remove this factory method
-    public static SingleLeaderPinger create(
+    @VisibleForTesting
+    public static SingleLeaderPinger createForTests(
             Map<LeaderPingerContext<PingableLeader>, CheckedRejectionExecutorService> otherPingableExecutors,
             Duration leaderPingResponseWait,
             UUID localUuid,

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderPinger.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderPinger.java
@@ -44,6 +44,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import javax.sql.DataSource;
 
@@ -102,8 +103,11 @@ public final class SingleLeaderPinger implements LeaderPinger {
             UUID localUuid,
             boolean cancelRemainingCalls,
             Optional<OrderableSlsVersion> timeLockVersion) {
-        GreenNodeLeadershipPrioritiser greenNodeLeadershipPrioritiser = DbGreenNodeLeadershipPrioritiser.create(
-                timeLockVersion, () -> Duration.ofMinutes(30L), sqliteDataSource);
+        // TODO(gs): extract runtime config for this
+        Supplier<Duration> leadershipAttemptBackoff = () -> Duration.ofMinutes(30L);
+
+        GreenNodeLeadershipPrioritiser greenNodeLeadershipPrioritiser =
+                DbGreenNodeLeadershipPrioritiser.create(timeLockVersion, leadershipAttemptBackoff, sqliteDataSource);
         return new SingleLeaderPinger(
                 otherPingableExecutors,
                 leaderPingResponseWait,

--- a/leader-election-impl/src/test/java/com/palantir/leader/PaxosLeaderEventsTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/PaxosLeaderEventsTest.java
@@ -131,7 +131,7 @@ public class PaxosLeaderEventsTest {
     }
 
     private LeaderPinger pingerWithTimeout(Duration leaderPingResponseWait) {
-        return SingleLeaderPinger.create(
+        return SingleLeaderPinger.createForTests(
                 ImmutableMap.of(
                         ImmutableLeaderPingerContext.of(pingableLeader, HOST_AND_PORT),
                         new CheckedRejectionExecutorService(executorService)),
@@ -142,7 +142,7 @@ public class PaxosLeaderEventsTest {
     }
 
     private LeaderPinger pingerWithVersion(OrderableSlsVersion version) {
-        return SingleLeaderPinger.create(
+        return SingleLeaderPinger.createForTests(
                 ImmutableMap.of(
                         ImmutableLeaderPingerContext.of(pingableLeader, HOST_AND_PORT),
                         new CheckedRejectionExecutorService(executorService)),

--- a/leader-election-impl/src/test/java/com/palantir/leader/PaxosLeaderEventsTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/PaxosLeaderEventsTest.java
@@ -131,7 +131,7 @@ public class PaxosLeaderEventsTest {
     }
 
     private LeaderPinger pingerWithTimeout(Duration leaderPingResponseWait) {
-        return new SingleLeaderPinger(
+        return SingleLeaderPinger.create(
                 ImmutableMap.of(
                         ImmutableLeaderPingerContext.of(pingableLeader, HOST_AND_PORT),
                         new CheckedRejectionExecutorService(executorService)),
@@ -142,7 +142,7 @@ public class PaxosLeaderEventsTest {
     }
 
     private LeaderPinger pingerWithVersion(OrderableSlsVersion version) {
-        return new SingleLeaderPinger(
+        return SingleLeaderPinger.create(
                 ImmutableMap.of(
                         ImmutableLeaderPingerContext.of(pingableLeader, HOST_AND_PORT),
                         new CheckedRejectionExecutorService(executorService)),

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosConsensusTestUtils.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosConsensusTestUtils.java
@@ -102,7 +102,7 @@ public final class PaxosConsensusTestUtils {
                     .knowledge(ourLearner)
                     .acceptorClient(acceptorNetworkClient)
                     .learnerClient(learnerNetworkClient)
-                    .leaderPinger(SingleLeaderPinger.create(
+                    .leaderPinger(SingleLeaderPinger.createForTests(
                             ImmutableMap.of(), Duration.ZERO, leaderUuid, true, Optional.empty()))
                     .build();
             leaders.add(SimulatingFailingServerProxy.newProxyInstance(

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosConsensusTestUtils.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosConsensusTestUtils.java
@@ -102,7 +102,7 @@ public final class PaxosConsensusTestUtils {
                     .knowledge(ourLearner)
                     .acceptorClient(acceptorNetworkClient)
                     .learnerClient(learnerNetworkClient)
-                    .leaderPinger(new SingleLeaderPinger(
+                    .leaderPinger(SingleLeaderPinger.create(
                             ImmutableMap.of(), Duration.ZERO, leaderUuid, true, Optional.empty()))
                     .build();
             leaders.add(SimulatingFailingServerProxy.newProxyInstance(

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/Dependencies.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/Dependencies.java
@@ -25,6 +25,7 @@ import com.palantir.timelock.config.PaxosRuntimeConfiguration;
 import java.time.Duration;
 import java.util.UUID;
 import java.util.function.Supplier;
+import javax.sql.DataSource;
 
 public interface Dependencies {
 
@@ -50,6 +51,8 @@ public interface Dependencies {
         Duration leaderPingRate();
 
         Duration leaderPingResponseWait();
+
+        DataSource dataSource();
     }
 
     interface NetworkClientFactories {

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/Factories.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/Factories.java
@@ -82,6 +82,7 @@ public interface Factories {
         SingleLeaderPinger pinger() {
             return SingleLeaderPinger.create(
                     WithDedicatedExecutor.convert(remoteClients().nonBatchPingableLeadersWithContext()),
+                    dataSource(),
                     leaderPingResponseWait(),
                     leaderUuid(),
                     PaxosConstants.CANCEL_REMAINING_CALLS,

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/Factories.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/Factories.java
@@ -80,7 +80,7 @@ public interface Factories {
 
         @Value.Derived
         SingleLeaderPinger pinger() {
-            return new SingleLeaderPinger(
+            return SingleLeaderPinger.create(
                     WithDedicatedExecutor.convert(remoteClients().nonBatchPingableLeadersWithContext()),
                     leaderPingResponseWait(),
                     leaderUuid(),

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipContextFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipContextFactory.java
@@ -29,6 +29,7 @@ import com.palantir.timelock.paxos.HealthCheckPinger;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.UUID;
+import javax.sql.DataSource;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -100,6 +101,12 @@ public abstract class LeadershipContextFactory
     @Value.Derived
     public Duration leaderPingRate() {
         return runtime().get().pingRate();
+    }
+
+    @Override
+    @Value.Derived
+    public DataSource dataSource() {
+        return install().sqliteDataSource();
     }
 
     @Value.Derived


### PR DESCRIPTION
**Goals (and why)**: Leadership thrashing can happen if a green node repeatedly restarts, because it will always try to gain leadership.

**Implementation Description (bullets)**:
- Factor out a class for green node leadership prioritisation logic
- Keep the rate limited logic for legacy and most tests
- Introduce DbGreenNodeLeadershipPrioritiser, which will store the version and timestamp locally in sqlite. On startup, the green node will only attempt to gain leadership if it did not already do so within the last $LEADERSHIP_ATTEMPT_BACKOFF_DURATION.

**Testing (What was existing testing like?  What have you done to improve it?)**: testing - TODO

**Concerns (what feedback would you like?)**: Am I going along the right lines here? Any obvious problems?

**Where should we start reviewing?**: GreenNodeLeadershipState and DbGreenNodeLeadershipPrioritiser

**Priority (whenever / two weeks / yesterday)**: today (for first look), this week (for merge)

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
