### PR TITLE
Don't perform async initialization on calling thread

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/async/initializer/AsyncInitializer.java
+++ b/atlasdb-commons/src/main/java/com/palantir/async/initializer/AsyncInitializer.java
@@ -21,6 +21,7 @@ import com.palantir.exception.NotInitializedException;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
+import java.time.Duration;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -51,7 +52,7 @@ public abstract class AsyncInitializer {
         initializationStartTime = System.currentTimeMillis();
 
         if (initializeAsync) {
-            scheduleInitialization(0);
+            scheduleInitialization(Duration.ZERO);
         } else {
             tryInitializeInternal();
         }
@@ -86,13 +87,13 @@ public abstract class AsyncInitializer {
                         SafeArg.of("initializationDuration", System.currentTimeMillis() - initializationStartTime),
                         cleanupThrowable);
             }
-            scheduleInitialization(sleepIntervalInMillis());
+            scheduleInitialization(sleepInterval());
         }
     }
 
     // Not final for tests.
-    void scheduleInitialization(long delayMillis) {
-        singleThreadedExecutor.schedule(this::tryInitializationLoop, delayMillis, TimeUnit.MILLISECONDS);
+    void scheduleInitialization(Duration delay) {
+        singleThreadedExecutor.schedule(this::tryInitializationLoop, delay.toMillis(), TimeUnit.MILLISECONDS);
     }
 
     // Not final for tests
@@ -110,8 +111,8 @@ public abstract class AsyncInitializer {
         }
     }
 
-    protected int sleepIntervalInMillis() {
-        return 10_000;
+    protected Duration sleepInterval() {
+        return Duration.ofSeconds(10);
     }
 
     /**

--- a/atlasdb-commons/src/test/java/com/palantir/async/initializer/AsyncInitializerTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/async/initializer/AsyncInitializerTest.java
@@ -17,7 +17,7 @@ package com.palantir.async.initializer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.time.Duration;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -47,8 +48,8 @@ public class AsyncInitializerTest {
         }
 
         @Override
-        protected int sleepIntervalInMillis() {
-            return ASYNC_INIT_DELAY;
+        protected Duration sleepInterval() {
+            return Duration.ofMillis(10);
         }
 
         @Override
@@ -80,7 +81,7 @@ public class AsyncInitializerTest {
                 .isInstanceOf(RuntimeException.class)
                 .hasMessage("Failed initializing");
         verify(initializer).tryInitialize();
-        verify(initializer, never()).scheduleInitialization(anyLong());
+        verify(initializer, never()).scheduleInitialization(any());
     }
 
     @Test
@@ -89,7 +90,7 @@ public class AsyncInitializerTest {
 
         initializer.initialize(true);
         verify(initializer, never()).tryInitialize();
-        verify(initializer).scheduleInitialization(anyLong());
+        verify(initializer).scheduleInitialization(any());
     }
 
     @Test
@@ -241,7 +242,7 @@ public class AsyncInitializerTest {
         AsyncInitializer initializer = mock(AsyncInitializer.class, Mockito.CALLS_REAL_METHODS);
         doNothing().when(initializer).assertNeverCalledInitialize();
         doThrow(new RuntimeException("Failed initializing")).when(initializer).tryInitialize();
-        doNothing().when(initializer).scheduleInitialization(anyLong());
+        doNothing().when(initializer).scheduleInitialization(any());
         return initializer;
     }
 

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/keyvalue/impl/AsyncInitializeableInMemoryKvs.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/keyvalue/impl/AsyncInitializeableInMemoryKvs.java
@@ -21,6 +21,7 @@ import com.palantir.atlasdb.keyvalue.api.AutoDelegate_KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.CheckAndSetCompatibility;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.logsafe.Preconditions;
+import java.time.Duration;
 
 public final class AsyncInitializeableInMemoryKvs extends AsyncInitializer implements AutoDelegate_KeyValueService {
     private final InMemoryKeyValueService delegate;
@@ -70,8 +71,8 @@ public final class AsyncInitializeableInMemoryKvs extends AsyncInitializer imple
     }
 
     @Override
-    protected int sleepIntervalInMillis() {
-        return 1_000;
+    protected Duration sleepInterval() {
+        return Duration.ofSeconds(1);
     }
 
     @Override

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/memory/AsyncInitializeableInMemoryTimestampService.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/memory/AsyncInitializeableInMemoryTimestampService.java
@@ -23,6 +23,7 @@ import com.palantir.timestamp.AutoDelegate_TimestampService;
 import com.palantir.timestamp.InMemoryTimestampService;
 import com.palantir.timestamp.ManagedTimestampService;
 import com.palantir.timestamp.TimestampService;
+import java.time.Duration;
 
 public final class AsyncInitializeableInMemoryTimestampService extends AsyncInitializer
         implements AutoDelegate_TimestampService, ManagedTimestampService {
@@ -63,8 +64,8 @@ public final class AsyncInitializeableInMemoryTimestampService extends AsyncInit
     }
 
     @Override
-    protected int sleepIntervalInMillis() {
-        return 1_000;
+    protected Duration sleepInterval() {
+        return Duration.ofSeconds(1);
     }
 
     @Override

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/memory/InMemoryAsyncAtlasDbFactoryTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/memory/InMemoryAsyncAtlasDbFactoryTest.java
@@ -60,7 +60,7 @@ public class InMemoryAsyncAtlasDbFactoryTest {
     public void asyncInitTimestampServiceWithReadyKvsSynchronous() {
         KeyValueService kvs = createRawKeyValueService(false);
         TimestampService timestampService = factory.createManagedTimestampService(kvs, Optional.empty(), true);
-        assertThat(timestampService.isInitialized()).isTrue();
+        Awaitility.await().atMost(Duration.ofSeconds(2)).until(timestampService::isInitialized);
         assertThat(timestampService.getFreshTimestamp()).isEqualTo(1L);
     }
 

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/memory/InMemoryAsyncAtlasDbFactoryTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/memory/InMemoryAsyncAtlasDbFactoryTest.java
@@ -17,11 +17,9 @@
 package com.palantir.atlasdb.memory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.spi.AtlasDbFactory;
-import com.palantir.exception.NotInitializedException;
 import com.palantir.refreshable.Refreshable;
 import com.palantir.timestamp.TimestampService;
 import java.time.Duration;
@@ -35,6 +33,7 @@ public class InMemoryAsyncAtlasDbFactoryTest {
     @Test
     public void syncInitKvs() {
         KeyValueService kvs = createRawKeyValueService(false);
+
         assertThat(kvs.isInitialized()).isTrue();
         assertThat(kvs.getAllTableNames()).isEmpty();
     }
@@ -42,8 +41,6 @@ public class InMemoryAsyncAtlasDbFactoryTest {
     @Test
     public void asyncInitKvs() {
         KeyValueService kvs = createRawKeyValueService(true);
-        assertThat(kvs.isInitialized()).isFalse();
-        assertThatThrownBy(kvs::getAllTableNames).isInstanceOf(NotInitializedException.class);
 
         Awaitility.await().atMost(Duration.ofSeconds(2)).until(kvs::isInitialized);
         assertThat(kvs.getAllTableNames()).isEmpty();
@@ -53,6 +50,7 @@ public class InMemoryAsyncAtlasDbFactoryTest {
     public void syncInitTimestampService() {
         KeyValueService kvs = createRawKeyValueService(false);
         TimestampService timestampService = factory.createManagedTimestampService(kvs, Optional.empty(), false);
+
         assertThat(timestampService.isInitialized()).isTrue();
         assertThat(timestampService.getFreshTimestamp()).isEqualTo(1L);
     }
@@ -61,8 +59,6 @@ public class InMemoryAsyncAtlasDbFactoryTest {
     public void asyncInitTimestampService() {
         KeyValueService kvs = createRawKeyValueService(false);
         TimestampService timestampService = factory.createManagedTimestampService(kvs, Optional.empty(), true);
-        assertThat(timestampService.isInitialized()).isFalse();
-        assertThatThrownBy(timestampService::getFreshTimestamp).isInstanceOf(NotInitializedException.class);
 
         Awaitility.await().atMost(Duration.ofSeconds(2)).until(timestampService::isInitialized);
         assertThat(timestampService.getFreshTimestamp()).isEqualTo(1L);

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/memory/InMemoryAsyncAtlasDbFactoryTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/memory/InMemoryAsyncAtlasDbFactoryTest.java
@@ -33,14 +33,14 @@ public class InMemoryAsyncAtlasDbFactoryTest {
     private final AtlasDbFactory<?> factory = new InMemoryAsyncAtlasDbFactory();
 
     @Test
-    public void syncInitKvsSynchronous() {
+    public void syncInitKvs() {
         KeyValueService kvs = createRawKeyValueService(false);
         assertThat(kvs.isInitialized()).isTrue();
         assertThat(kvs.getAllTableNames()).isEmpty();
     }
 
     @Test
-    public void asyncInitKvsAsynchronous() {
+    public void asyncInitKvs() {
         KeyValueService kvs = createRawKeyValueService(true);
         assertThat(kvs.isInitialized()).isFalse();
         assertThatThrownBy(kvs::getAllTableNames).isInstanceOf(NotInitializedException.class);
@@ -50,29 +50,21 @@ public class InMemoryAsyncAtlasDbFactoryTest {
     }
 
     @Test
-    public void syncInitTimestampServiceSynchronous() {
-        TimestampService timestampService = factory.createManagedTimestampService(null, Optional.empty(), false);
+    public void syncInitTimestampService() {
+        KeyValueService kvs = createRawKeyValueService(false);
+        TimestampService timestampService = factory.createManagedTimestampService(kvs, Optional.empty(), false);
         assertThat(timestampService.isInitialized()).isTrue();
         assertThat(timestampService.getFreshTimestamp()).isEqualTo(1L);
     }
 
     @Test
-    public void asyncInitTimestampServiceWithReadyKvsSynchronous() {
+    public void asyncInitTimestampService() {
         KeyValueService kvs = createRawKeyValueService(false);
         TimestampService timestampService = factory.createManagedTimestampService(kvs, Optional.empty(), true);
-        Awaitility.await().atMost(Duration.ofSeconds(2)).until(timestampService::isInitialized);
-        assertThat(timestampService.getFreshTimestamp()).isEqualTo(1L);
-    }
-
-    @Test
-    public void asyncInitTimestampServiceWithAsyncKvsAsynchronous() {
-        KeyValueService kvs = createRawKeyValueService(true);
-        TimestampService timestampService = factory.createManagedTimestampService(kvs, Optional.empty(), true);
-
         assertThat(timestampService.isInitialized()).isFalse();
         assertThatThrownBy(timestampService::getFreshTimestamp).isInstanceOf(NotInitializedException.class);
 
-        Awaitility.await().atMost(Duration.ofSeconds(3)).until(timestampService::isInitialized);
+        Awaitility.await().atMost(Duration.ofSeconds(2)).until(timestampService::isInitialized);
         assertThat(timestampService.getFreshTimestamp()).isEqualTo(1L);
     }
 

--- a/changelog/@unreleased/pr-5746.v2.yml
+++ b/changelog/@unreleased/pr-5746.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Initialization always happens asynchronously when `initializeAsync`
+    is true.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5746


### PR DESCRIPTION
**Goals (and why)**:

Enable faster server initialization when using `initializeAsync`

In large internal authentication service, we've noticed that some installations take up to 4 minutes for the server to be initialized. Logs indicate that `CassandraClientPoolImpl` initialization is happening before the server is initialized and takes a majority of those 4 minutes.

**Implementation Description (bullets)**:

Before this PR, when `initializeAsync` is true, AtlasDB attempts to initialize components synchronously on the calling thread. If the initialization takes a long time (like it does for `CassandraClientPoolImpl`), then this will block other initialization work.

After this PR, when `initializeAsync` is true, AtlasDB will schedule the initialization to run immediately on the executor thread. This way other initialization can continue while the AtlasDB initialization happens in the background.

This seems to be more intuitive behavior for a flag named `initializeAsync`.

**Testing (What was existing testing like?  What have you done to improve it?)**:

I've updated `AsyncInitializerTest` to verify this behavior. I've also refactored this test class to make it a bit more readable.