### PR TITLE
TLA: fix log-spam

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/util/RateLimitedLogger.java
+++ b/atlasdb-commons/src/main/java/com/palantir/util/RateLimitedLogger.java
@@ -1,0 +1,37 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.util;
+
+import com.google.common.util.concurrent.RateLimiter;
+import com.palantir.logsafe.logger.SafeLogger;
+
+@SuppressWarnings("UnstableApiUsage")
+public class RateLimitedLogger {
+    private final SafeLogger delegate;
+    private final RateLimiter rateLimiter;
+
+    public RateLimitedLogger(SafeLogger delegate, double permitsPerSecond) {
+        this.delegate = delegate;
+        this.rateLimiter = RateLimiter.create(permitsPerSecond);
+    }
+
+    public void debug(String message) {
+        if (rateLimiter.tryAcquire()) {
+            delegate.debug(message);
+        }
+    }
+}

--- a/atlasdb-commons/src/main/java/com/palantir/util/RateLimitedLogger.java
+++ b/atlasdb-commons/src/main/java/com/palantir/util/RateLimitedLogger.java
@@ -18,6 +18,7 @@ package com.palantir.util;
 
 import com.google.common.util.concurrent.RateLimiter;
 import com.palantir.logsafe.logger.SafeLogger;
+import java.util.function.Consumer;
 
 @SuppressWarnings("UnstableApiUsage")
 public class RateLimitedLogger {
@@ -29,9 +30,9 @@ public class RateLimitedLogger {
         this.rateLimiter = RateLimiter.create(permitsPerSecond);
     }
 
-    public void debug(String message) {
+    public void log(Consumer<SafeLogger> loggingFunction) {
         if (rateLimiter.tryAcquire()) {
-            delegate.debug(message);
+            loggingFunction.accept(delegate);
         }
     }
 }

--- a/leader-election-impl/src/main/java/com/palantir/leader/LeadershipEvents.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/LeadershipEvents.java
@@ -29,9 +29,9 @@ import org.slf4j.LoggerFactory;
 
 @ThreadSafe
 class LeadershipEvents {
-
     private static final String LEADER_LOG_NAME = "leadership";
 
+    // TODO(gs): replace with RateLimitedLogger
     @SuppressWarnings("PreferSafeLogger") // Some refactoring required
     private static final Logger leaderLog = LoggerFactory.getLogger(LEADER_LOG_NAME);
 

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
@@ -22,7 +22,6 @@ import com.google.common.net.HostAndPort;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
-import com.google.common.util.concurrent.RateLimiter;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
@@ -39,6 +38,7 @@ import com.palantir.paxos.PaxosResponses;
 import com.palantir.paxos.PaxosRoundFailureException;
 import com.palantir.paxos.PaxosUpdate;
 import com.palantir.paxos.PaxosValue;
+import com.palantir.util.RateLimitedLogger;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.UUID;
@@ -54,6 +54,7 @@ import org.immutables.value.Value;
  */
 public class PaxosLeaderElectionService implements LeaderElectionService {
     private static final SafeLogger log = SafeLoggerFactory.get(PaxosLeaderElectionService.class);
+    private static final RateLimitedLogger leaderEligibilityLogger = new RateLimitedLogger(log, 1);
 
     // stored here to be consistent when proposing to take over leadership
     private static final byte[] LEADERSHIP_PROPOSAL_VALUE = null;
@@ -73,7 +74,6 @@ public class PaxosLeaderElectionService implements LeaderElectionService {
     private final PaxosLeaderElectionEventRecorder eventRecorder;
 
     private final AtomicBoolean leaderEligible = new AtomicBoolean(true);
-    private final RateLimiter leaderEligibilityLoggingRateLimiter = RateLimiter.create(1);
 
     private final Cache<UUID, HostAndPort> leaderAddressCache;
 
@@ -130,9 +130,7 @@ public class PaxosLeaderElectionService implements LeaderElectionService {
 
     private void proposeLeadershipOrWaitForBackoff(LeadershipState currentState) throws InterruptedException {
         if (!leaderEligible.get()) {
-            if (leaderEligibilityLoggingRateLimiter.tryAcquire()) {
-                log.debug("Not eligible for leadership");
-            }
+            leaderEligibilityLogger.debug("Not eligible for leadership");
             throw new InterruptedException("leader no longer eligible");
         }
 

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
@@ -130,7 +130,7 @@ public class PaxosLeaderElectionService implements LeaderElectionService {
 
     private void proposeLeadershipOrWaitForBackoff(LeadershipState currentState) throws InterruptedException {
         if (!leaderEligible.get()) {
-            leaderEligibilityLogger.debug("Not eligible for leadership");
+            leaderEligibilityLogger.log(logger -> logger.debug("Not eligible for leadership"));
             throw new InterruptedException("leader no longer eligible");
         }
 


### PR DESCRIPTION
**Goals (and why)**: Reduce log-spam when the green node knows the leader is on an older version, but isn't going to propose leadership yet (example [here](https://apollo.palantircloud.com/aries/logDetails/v2/%7B%22columns%22%3A%5B%7B%22propertyKey%22%3A%22time%22%7D%2C%7B%22propertyKey%22%3A%22traceId%22%7D%2C%7B%22propertyKey%22%3A%22level%22%7D%2C%7B%22propertyKey%22%3A%22message%22%7D%2C%7B%22propertyKey%22%3A%22params%22%7D%2C%7B%22propertyKey%22%3A%22origin%22%7D%2C%7B%22propertyKey%22%3A%22stacktrace%22%7D%2C%7B%22propertyKey%22%3A%22host%22%7D%5D%2C%22endTime%22%3A%222021-11-09T17%3A00%3A47.816%22%2C%22queryStrings%22%3A%5B%22origin%3A%5C%22com.palantir.paxos.PersistedRateLimitingLeadershipPrioritiser%5C%22%22%5D%2C%22startTime%22%3A%222021-11-09T12%3A00%3A47.816%22%2C%22serviceLocators%22%3A%5B%7B%22environmentId%22%3A%223fb69f84-1b80-42dc-997a-d56c1bccda42%22%2C%22logType%22%3A%22SERVICE_LOG%22%2C%22blueGreenGroupId%22%3A%22gotham%7Ctimelock-server%22%7D%5D%7D)).

**Implementation Description (bullets)**:
- Extracted a utility class for rate-limited logging, as I've seen this pattern in a few places
- Use the new class in PersistentRateLimitedLeadershipPrioritiser

**Testing (What was existing testing like?  What have you done to improve it?)**: none

**Concerns (what feedback would you like?)**: is it worth adding tests to the RateLimitingLogger? It seemed fairly trivial to me.

**Where should we start reviewing?**:  RateLimitedLogger

**Priority (whenever / two weeks / yesterday)**: this week (small PR)

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
