### PR TITLE
Avoid exposing com.palantir.common:streams to consumers

### DIFF
--- a/atlasdb-client/build.gradle
+++ b/atlasdb-client/build.gradle
@@ -45,7 +45,6 @@ dependencies {
   api group: "com.google.code.findbugs", name: "jsr305"
   api group: "com.google.guava", name: "guava"
   api group: "com.google.protobuf", name: "protobuf-java"
-  api group: "com.palantir.common", name: "streams"
   api group: "jakarta.annotation", name: "jakarta.annotation-api"
   api group: "org.slf4j", name: "slf4j-api"
 
@@ -77,6 +76,7 @@ dependencies {
   implementation group: 'com.squareup.okio', name: 'okio'
   implementation group: 'org.hdrhistogram', name: 'HdrHistogram'
   implementation group: 'com.github.rholder', name: 'guava-retrying'
+  implementation group: 'com.palantir.common', name: 'streams'
   implementation group: 'org.rocksdb', name: 'rocksdbjni'
 
   implementation group: 'com.squareup', name:'javapoet'

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
@@ -932,7 +932,6 @@ public class StreamStoreRenderer {
                 line("import com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata;");
                 line("import com.palantir.atlasdb.table.description.ValueType;");
                 line("import com.palantir.atlasdb.transaction.api.Transaction;");
-                line("import com.palantir.common.streams.KeyedStream;");
                 line("import com.palantir.logsafe.SafeArg;");
 
                 if (streamIdType == ValueType.SHA256HASH) {
@@ -991,9 +990,9 @@ public class StreamStoreRenderer {
                     line("        = indexTable.getRowsColumnRangeIterator(indexRows,");
                     line("                BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY,"
                             + " PtBytes.EMPTY_BYTE_ARRAY, 1));");
-                    line("return KeyedStream.stream(referenceIteratorByStream)");
-                    line("        .filter(valueIterator -> !valueIterator.hasNext())");
-                    line("        .keys() // (authorized)"); // required for large internal product
+                    line("return referenceIteratorByStream.entrySet().stream()");
+                    line("        .filter(entry -> !entry.getValue().hasNext())");
+                    line("        .map(Map.Entry::getKey)");
                     line("        .map(", StreamIndexRow, "::getId)");
                     line("        .map(", StreamMetadataRow, "::of)");
                     line("        .collect(Collectors.toSet());");


### PR DESCRIPTION
`KeyedStream` is only used in a single place in generated code. This usage can easily be replaced with JDK methods to allow us to avoid exposing this dependency to consumer's compile classpaths.