### PR TITLE
ABR3: Backup persistence

### DIFF
--- a/atlasdb-backup/build.gradle
+++ b/atlasdb-backup/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     implementation project(':timelock-api:timelock-api-objects')
 
     implementation 'com.palantir.safe-logging:safe-logging'
+    implementation 'com.palantir.conjure.java.runtime:conjure-java-jackson-serialization'
 
     testImplementation 'org.mockito:mockito-core'
 

--- a/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/AtlasBackupService.java
+++ b/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/AtlasBackupService.java
@@ -89,6 +89,7 @@ public final class AtlasBackupService {
 
     private void storeBackupToken(InProgressBackupToken backupToken) {
         inProgressBackups.put(backupToken.getNamespace(), backupToken);
+        backupPersister.storeImmutableTimestamp(backupToken);
     }
 
     public Set<Namespace> completeBackup(Set<Namespace> namespaces) {

--- a/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/BackupPersister.java
+++ b/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/BackupPersister.java
@@ -17,6 +17,7 @@
 package com.palantir.atlasdb.backup;
 
 import com.palantir.atlasdb.backup.api.CompletedBackup;
+import com.palantir.atlasdb.backup.api.InProgressBackupToken;
 import com.palantir.atlasdb.internalschema.InternalSchemaMetadataState;
 import com.palantir.atlasdb.timelock.api.Namespace;
 import java.util.Optional;
@@ -29,4 +30,8 @@ interface BackupPersister {
     void storeCompletedBackup(CompletedBackup completedBackup);
 
     Optional<CompletedBackup> getCompletedBackup(Namespace namespace);
+
+    void storeImmutableTimestamp(InProgressBackupToken inProgressBackupToken);
+
+    Optional<Long> getImmutableTimestamp(Namespace namespace);
 }

--- a/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/ExternalBackupPersister.java
+++ b/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/ExternalBackupPersister.java
@@ -1,0 +1,122 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.backup;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.palantir.atlasdb.backup.api.CompletedBackup;
+import com.palantir.atlasdb.internalschema.InternalSchemaMetadataState;
+import com.palantir.atlasdb.timelock.api.Namespace;
+import com.palantir.conjure.java.serialization.ObjectMappers;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.function.Function;
+
+public class ExternalBackupPersister implements BackupPersister {
+    private static final SafeLogger log = SafeLoggerFactory.get(ExternalBackupPersister.class);
+
+    private static final ObjectMapper OBJECT_MAPPER = ObjectMappers.newClientObjectMapper();
+    private static final String SCHEMA_METADATA_FILE_NAME = "schemaMetadata";
+    private static final String COMPLETED_BACKUP_FILE_NAME = "completedBackup";
+
+    private final Function<Namespace, Path> pathFactory;
+
+    public ExternalBackupPersister(Function<Namespace, Path> pathFactory) {
+        this.pathFactory = pathFactory;
+    }
+
+    @Override
+    public void storeSchemaMetadata(Namespace namespace, InternalSchemaMetadataState internalSchemaMetadataState) {
+        File schemaMetadataFile = getSchemaMetadataFile(namespace);
+        writeToFile(namespace, schemaMetadataFile, internalSchemaMetadataState);
+    }
+
+    @Override
+    public Optional<InternalSchemaMetadataState> getSchemaMetadata(Namespace namespace) {
+        return loadFromFile(namespace, getSchemaMetadataFile(namespace), InternalSchemaMetadataState.class);
+    }
+
+    @Override
+    public void storeCompletedBackup(CompletedBackup completedBackup) {
+        Namespace namespace = completedBackup.getNamespace();
+        File completedBackupFile = getCompletedBackupFile(namespace);
+        writeToFile(namespace, completedBackupFile, completedBackup);
+    }
+
+    @Override
+    public Optional<CompletedBackup> getCompletedBackup(Namespace namespace) {
+        return loadFromFile(namespace, getCompletedBackupFile(namespace), CompletedBackup.class);
+    }
+
+    private File getSchemaMetadataFile(Namespace namespace) {
+        return getFile(namespace, SCHEMA_METADATA_FILE_NAME);
+    }
+
+    private File getCompletedBackupFile(Namespace namespace) {
+        return getFile(namespace, COMPLETED_BACKUP_FILE_NAME);
+    }
+
+    private File getFile(Namespace namespace, String fileName) {
+        return new File(pathFactory.apply(namespace).toFile(), fileName);
+    }
+
+    private void writeToFile(Namespace namespace, File file, Object data) {
+        try (OutputStream os = Files.newOutputStream(file.toPath())) {
+            os.write(OBJECT_MAPPER.writeValueAsBytes(data));
+            os.flush();
+        } catch (IOException e) {
+            log.error(
+                    "Failed to store file",
+                    SafeArg.of("fileName", file.getName()),
+                    SafeArg.of("namespace", namespace),
+                    e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private <T> Optional<T> loadFromFile(Namespace namespace, File file, Class<T> clazz) {
+        if (!file.exists()) {
+            log.info(
+                    "Tried to load file, but it did not exist",
+                    SafeArg.of("fileType", file.getName()),
+                    SafeArg.of("namespace", namespace));
+            return Optional.empty();
+        }
+
+        try {
+            T state = OBJECT_MAPPER.readValue(file, clazz);
+            log.info(
+                    "Successfully loaded file",
+                    SafeArg.of("fileType", file.getName()),
+                    SafeArg.of("namespace", namespace));
+            return Optional.of(state);
+        } catch (IOException e) {
+            log.warn(
+                    "Failed to read file",
+                    SafeArg.of("fileType", file.getName()),
+                    SafeArg.of("namespace", namespace),
+                    e);
+            return Optional.empty();
+        }
+    }
+}

--- a/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/ExternalBackupPersister.java
+++ b/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/ExternalBackupPersister.java
@@ -50,8 +50,7 @@ public class ExternalBackupPersister implements BackupPersister {
 
     @Override
     public void storeSchemaMetadata(Namespace namespace, InternalSchemaMetadataState internalSchemaMetadataState) {
-        File schemaMetadataFile = getSchemaMetadataFile(namespace);
-        writeToFile(namespace, schemaMetadataFile, internalSchemaMetadataState);
+        writeToFile(namespace, getSchemaMetadataFile(namespace), internalSchemaMetadataState);
     }
 
     @Override

--- a/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/ExternalBackupPersister.java
+++ b/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/ExternalBackupPersister.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.backup;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.palantir.atlasdb.backup.api.CompletedBackup;
+import com.palantir.atlasdb.backup.api.InProgressBackupToken;
 import com.palantir.atlasdb.internalschema.InternalSchemaMetadataState;
 import com.palantir.atlasdb.timelock.api.Namespace;
 import com.palantir.conjure.java.serialization.ObjectMappers;
@@ -81,8 +82,23 @@ public class ExternalBackupPersister implements BackupPersister {
                 .build());
     }
 
+    @Override
+    public void storeImmutableTimestamp(InProgressBackupToken inProgressBackupToken) {
+        Namespace namespace = inProgressBackupToken.getNamespace();
+        writeToFile(namespace, getImmutableTimestampFile(namespace), inProgressBackupToken.getImmutableTimestamp());
+    }
+
+    @Override
+    public Optional<Long> getImmutableTimestamp(Namespace namespace) {
+        return loadFromFile(namespace, getImmutableTimestampFile(namespace), Long.class);
+    }
+
     private File getSchemaMetadataFile(Namespace namespace) {
         return getFile(namespace, SCHEMA_METADATA_FILE_NAME);
+    }
+
+    private File getImmutableTimestampFile(Namespace namespace) {
+        return getFile(namespace, IMMUTABLE_TIMESTAMP_FILE_NAME);
     }
 
     private File getBackupTimestampFile(Namespace namespace) {

--- a/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/ExternalBackupPersister.java
+++ b/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/ExternalBackupPersister.java
@@ -33,7 +33,6 @@ import java.nio.file.Path;
 import java.util.Optional;
 import java.util.function.Function;
 
-// TODO(gs): store immutable ts
 public class ExternalBackupPersister implements BackupPersister {
     private static final SafeLogger log = SafeLoggerFactory.get(ExternalBackupPersister.class);
 
@@ -131,7 +130,7 @@ public class ExternalBackupPersister implements BackupPersister {
         if (!file.exists()) {
             log.info(
                     "Tried to load file, but it did not exist",
-                    SafeArg.of("fileType", file.getName()),
+                    SafeArg.of("fileName", file.getName()),
                     SafeArg.of("namespace", namespace));
             return Optional.empty();
         }
@@ -140,13 +139,13 @@ public class ExternalBackupPersister implements BackupPersister {
             T state = OBJECT_MAPPER.readValue(file, clazz);
             log.info(
                     "Successfully loaded file",
-                    SafeArg.of("fileType", file.getName()),
+                    SafeArg.of("fileName", file.getName()),
                     SafeArg.of("namespace", namespace));
             return Optional.of(state);
         } catch (IOException e) {
             log.warn(
                     "Failed to read file",
-                    SafeArg.of("fileType", file.getName()),
+                    SafeArg.of("fileName", file.getName()),
                     SafeArg.of("namespace", namespace),
                     e);
             return Optional.empty();

--- a/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/InMemoryBackupPersister.java
+++ b/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/InMemoryBackupPersister.java
@@ -17,6 +17,7 @@
 package com.palantir.atlasdb.backup;
 
 import com.palantir.atlasdb.backup.api.CompletedBackup;
+import com.palantir.atlasdb.backup.api.InProgressBackupToken;
 import com.palantir.atlasdb.internalschema.InternalSchemaMetadataState;
 import com.palantir.atlasdb.timelock.api.Namespace;
 import java.util.Map;
@@ -24,12 +25,14 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 class InMemoryBackupPersister implements BackupPersister {
+    private final Map<Namespace, Long> immutableTimestamps;
     private final Map<Namespace, InternalSchemaMetadataState> schemaMetadatas;
     private final Map<Namespace, CompletedBackup> completedBackups;
 
     InMemoryBackupPersister() {
         schemaMetadatas = new ConcurrentHashMap<>();
         completedBackups = new ConcurrentHashMap<>();
+        immutableTimestamps = new ConcurrentHashMap<>();
     }
 
     @Override
@@ -50,5 +53,15 @@ class InMemoryBackupPersister implements BackupPersister {
     @Override
     public Optional<CompletedBackup> getCompletedBackup(Namespace namespace) {
         return Optional.ofNullable(completedBackups.get(namespace));
+    }
+
+    @Override
+    public void storeImmutableTimestamp(InProgressBackupToken inProgressBackupToken) {
+        immutableTimestamps.put(inProgressBackupToken.getNamespace(), inProgressBackupToken.getImmutableTimestamp());
+    }
+
+    @Override
+    public Optional<Long> getImmutableTimestamp(Namespace namespace) {
+        return Optional.ofNullable(immutableTimestamps.get(namespace));
     }
 }

--- a/atlasdb-backup/src/test/java/com/palantir/atlasdb/backup/ExternalBackupPersisterTest.java
+++ b/atlasdb-backup/src/test/java/com/palantir/atlasdb/backup/ExternalBackupPersisterTest.java
@@ -1,0 +1,92 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.backup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.atlasdb.backup.api.BackupId;
+import com.palantir.atlasdb.backup.api.CompletedBackup;
+import com.palantir.atlasdb.coordination.ValueAndBound;
+import com.palantir.atlasdb.internalschema.InternalSchemaMetadata;
+import com.palantir.atlasdb.internalschema.InternalSchemaMetadataState;
+import com.palantir.atlasdb.timelock.api.Namespace;
+import java.io.IOException;
+import java.nio.file.Path;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class ExternalBackupPersisterTest {
+    private static final BackupId BACKUP_ID = BackupId.of("back_when_stuff_worked");
+    private static final Namespace NAMESPACE = Namespace.of("broken_namespace");
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    private ExternalBackupPersister externalBackupPersister;
+
+    @Before
+    public void setUp() {
+        externalBackupPersister = new ExternalBackupPersister(this::getPath);
+    }
+
+    @Test
+    public void getSchemaMetadataWhenEmpty() {
+        assertThat(externalBackupPersister.getSchemaMetadata(BACKUP_ID, NAMESPACE))
+                .isEmpty();
+    }
+
+    @Test
+    public void putAndGetSchemaMetadata() {
+        InternalSchemaMetadata internalSchemaMetadata = InternalSchemaMetadata.defaultValue();
+        InternalSchemaMetadataState state =
+                InternalSchemaMetadataState.of(ValueAndBound.of(internalSchemaMetadata, 100L));
+        externalBackupPersister.storeSchemaMetadata(BACKUP_ID, NAMESPACE, state);
+
+        assertThat(externalBackupPersister.getSchemaMetadata(BACKUP_ID, NAMESPACE))
+                .contains(state);
+    }
+
+    @Test
+    public void getCompletedBackupWhenEmpty() {
+        assertThat(externalBackupPersister.getCompletedBackup(BACKUP_ID, NAMESPACE))
+                .isEmpty();
+    }
+
+    @Test
+    public void putAndGetCompletedBackup() {
+        CompletedBackup completedBackup = CompletedBackup.builder()
+                .backupId(BACKUP_ID)
+                .namespace(NAMESPACE)
+                .backupStartTimestamp(1L)
+                .backupEndTimestamp(2L)
+                .build();
+        externalBackupPersister.storeCompletedBackup(completedBackup);
+
+        assertThat(externalBackupPersister.getCompletedBackup(BACKUP_ID, NAMESPACE))
+                .contains(completedBackup);
+    }
+
+    private Path getPath(BackupId backupId, Namespace namespace) {
+        try {
+            return tempFolder.newFolder(backupId.get(), namespace.get()).toPath();
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/changelog/@unreleased/pr-5771.v2.yml
+++ b/changelog/@unreleased/pr-5771.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: |
+    The AtlasBackupService will now persist backup metadata in the same way as in the internal backup product.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5771


### PR DESCRIPTION
**Goals (and why)**: Persist backup metadata in the same way as in the internal backup product.

**Implementation Description (bullets)**:
- Add ExternalBackupPersister
- Wiring to AtlasBackupService

**Testing (What was existing testing like?  What have you done to improve it?)**: Added ExternalBackupPersisterTest

**Concerns (what feedback would you like?)**: Storing the immutable timestamp seems a little janky - it appears to be used during the restore process though, so it would be needed at least for back-compatibility.

**Where should we start reviewing?**: ExternalBackupPersister

**Priority (whenever / two weeks / yesterday)**: today 🙏 

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
