### PR TITLE
[Jank] Remember oldest timestamp after TS has been running

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -80,6 +80,7 @@ import com.palantir.atlasdb.sweep.SweepTaskRunner;
 import com.palantir.atlasdb.sweep.SweeperServiceImpl;
 import com.palantir.atlasdb.sweep.metrics.LegacySweepMetrics;
 import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
+import com.palantir.atlasdb.sweep.queue.OldestTargetedSweepTrackedTimestamp;
 import com.palantir.atlasdb.sweep.queue.TargetedSweeper;
 import com.palantir.atlasdb.sweep.queue.clear.SafeTableClearerKeyValueService;
 import com.palantir.atlasdb.sweep.queue.config.TargetedSweepInstallConfig;
@@ -416,6 +417,15 @@ public abstract class TransactionManagers {
                     return ValidatingQueryRewritingKeyValueService.create(kvs);
                 },
                 closeables);
+
+        if (config().targetedSweep().enableSweepQueueWrites()) {
+            initializeCloseable(
+                    () -> OldestTargetedSweepTrackedTimestamp.track(
+                            keyValueService,
+                            lockAndTimestampServices.timestamp(),
+                            PTExecutors.newSingleThreadScheduledExecutor()),
+                    closeables);
+        }
 
         TransactionManagersInitializer initializer = TransactionManagersInitializer.createInitialTables(
                 keyValueService, schemas(), config().initializeAsync(), allSafeForLogging());

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -111,6 +111,7 @@ import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.atlasdb.versions.AtlasDbVersion;
 import com.palantir.common.annotation.Output;
 import com.palantir.common.annotations.ImmutablesStyles.StagedBuilderStyle;
+import com.palantir.common.concurrent.NamedThreadFactory;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.common.time.Clock;
 import com.palantir.conjure.java.api.config.service.ServicesConfigBlock;
@@ -420,10 +421,11 @@ public abstract class TransactionManagers {
 
         if (config().targetedSweep().enableSweepQueueWrites()) {
             initializeCloseable(
-                    () -> OldestTargetedSweepTrackedTimestamp.track(
+                    () -> OldestTargetedSweepTrackedTimestamp.createStarted(
                             keyValueService,
                             lockAndTimestampServices.timestamp(),
-                            PTExecutors.newSingleThreadScheduledExecutor()),
+                            PTExecutors.newSingleThreadScheduledExecutor(
+                                    new NamedThreadFactory("OldestTargetedSweepTrackedTimestamp", true))),
                     closeables);
         }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/OldestTargetedSweepTrackedTimestamp.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/OldestTargetedSweepTrackedTimestamp.java
@@ -1,0 +1,94 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.queue;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.sweep.queue.config.TargetedSweepInstallConfig;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import com.palantir.timestamp.TimestampService;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
+
+/**
+ * WARNING: The correctness of using this information depends on
+ * {@link TargetedSweepInstallConfig#enableSweepQueueWrites()} being true on every service node since the moment
+ * this is first scheduled.
+ */
+public class OldestTargetedSweepTrackedTimestamp implements AutoCloseable {
+    private static final SafeLogger log = SafeLoggerFactory.get(OldestTargetedSweepTrackedTimestamp.class);
+
+    private final ShardProgress shardProgress;
+    private final LongSupplier timestampService;
+    private final ScheduledExecutorService executor;
+
+    private volatile OptionalLong oldestTimestamp = OptionalLong.empty();
+
+    @VisibleForTesting
+    OldestTargetedSweepTrackedTimestamp(
+            KeyValueService kvs, LongSupplier timestampService, ScheduledExecutorService executor) {
+        this.shardProgress = new ShardProgress(kvs);
+        this.timestampService = timestampService;
+        this.executor = executor;
+    }
+
+    public static OldestTargetedSweepTrackedTimestamp track(
+            KeyValueService kvs, TimestampService timestampService, ScheduledExecutorService executor) {
+        OldestTargetedSweepTrackedTimestamp timestampTracker =
+                new OldestTargetedSweepTrackedTimestamp(kvs, timestampService::getFreshTimestamp, executor);
+        timestampTracker.run();
+        return timestampTracker;
+    }
+
+    public OptionalLong getOldestTimestamp() {
+        return shardProgress.getOldestSeenTimestamp().map(OptionalLong::of).orElseGet(OptionalLong::empty);
+    }
+
+    @VisibleForTesting
+    void run() {
+        executor.scheduleAtFixedRate(this::tryToPersist, 0, 1, TimeUnit.SECONDS);
+    }
+
+    private void tryToPersist() {
+        try {
+            if (oldestTimestamp.isEmpty()) {
+                oldestTimestamp = OptionalLong.of(timestampService.getAsLong());
+            }
+            persist();
+            executor.shutdownNow();
+        } catch (Exception e) {
+            log.info("Failed to persist timestamp", SafeArg.of("oldestSeenTs", oldestTimestamp), e);
+        }
+    }
+
+    private void persist() {
+        Optional<Long> persisted = shardProgress.getOldestSeenTimestamp();
+        if (persisted.map(actual -> actual > oldestTimestamp.getAsLong()).orElse(true)) {
+            shardProgress.tryUpdateOldestSeenTimestamp(persisted, oldestTimestamp.getAsLong());
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        executor.shutdownNow();
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/OldestTargetedSweepTrackedTimestampTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/OldestTargetedSweepTrackedTimestampTest.java
@@ -1,0 +1,124 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.queue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
+import com.palantir.atlasdb.table.description.TableMetadata;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.LongSupplier;
+import org.jmock.lib.concurrent.DeterministicScheduler;
+import org.junit.Test;
+
+public class OldestTargetedSweepTrackedTimestampTest {
+    private final InMemoryKeyValueService kvs = new InMemoryKeyValueService(true);
+    private final LongSupplier timestampSupplier = mock(LongSupplier.class);
+    private final AtomicBoolean schedulerShutDown = new AtomicBoolean(false);
+    private final DeterministicScheduler deterministicScheduler = new DeterministicScheduler() {
+        @Override
+        public List<Runnable> shutdownNow() {
+            schedulerShutDown.set(true);
+            return ImmutableList.of();
+        }
+    };
+    private final OldestTargetedSweepTrackedTimestamp tracker =
+            new OldestTargetedSweepTrackedTimestamp(kvs, timestampSupplier, deterministicScheduler);
+
+    @Test
+    public void persistsValidTimestampAndShutsDown() {
+        when(timestampSupplier.getAsLong()).thenReturn(42L);
+
+        tracker.run();
+        deterministicScheduler.tick(0, TimeUnit.SECONDS);
+
+        assertThat(tracker.getOldestTimestamp()).hasValue(42L);
+        assertThat(schedulerShutDown).isTrue();
+    }
+
+    @Test
+    public void resilientToTimestampThrowing() {
+        when(timestampSupplier.getAsLong()).thenThrow(new RuntimeException()).thenReturn(17L);
+
+        tracker.run();
+        deterministicScheduler.tick(0, TimeUnit.SECONDS);
+
+        assertThat(tracker.getOldestTimestamp()).isEmpty();
+
+        deterministicScheduler.tick(1, TimeUnit.SECONDS);
+        assertThat(tracker.getOldestTimestamp()).hasValue(17L);
+        assertThat(schedulerShutDown).isTrue();
+    }
+
+    @Test
+    public void doesNotIncreaseExistingTimestamp() {
+        OldestTargetedSweepTrackedTimestamp otherTracker =
+                new OldestTargetedSweepTrackedTimestamp(kvs, () -> 1L, deterministicScheduler);
+
+        otherTracker.run();
+        deterministicScheduler.tick(0, TimeUnit.SECONDS);
+
+        assertThat(tracker.getOldestTimestamp()).hasValue(1L);
+
+        when(timestampSupplier.getAsLong()).thenReturn(100L);
+        tracker.run();
+        deterministicScheduler.tick(1, TimeUnit.SECONDS);
+
+        assertThat(tracker.getOldestTimestamp()).hasValue(1L);
+    }
+
+    @Test
+    public void doesReduceExistingTimestamp() {
+        OldestTargetedSweepTrackedTimestamp otherTracker =
+                new OldestTargetedSweepTrackedTimestamp(kvs, () -> 100L, deterministicScheduler);
+
+        otherTracker.run();
+        deterministicScheduler.tick(0, TimeUnit.SECONDS);
+
+        assertThat(tracker.getOldestTimestamp()).hasValue(100L);
+
+        when(timestampSupplier.getAsLong()).thenReturn(13L);
+        tracker.run();
+        deterministicScheduler.tick(1, TimeUnit.SECONDS);
+
+        assertThat(tracker.getOldestTimestamp()).hasValue(13L);
+    }
+
+    @Test
+    public void resilientToKvsFailures() {
+        KeyValueService nonInitialisedKvs = new InMemoryKeyValueService(false);
+        OldestTargetedSweepTrackedTimestamp otherTracker =
+                new OldestTargetedSweepTrackedTimestamp(nonInitialisedKvs, () -> 1L, deterministicScheduler);
+
+        otherTracker.run();
+        deterministicScheduler.tick(1, TimeUnit.SECONDS);
+
+        assertThatThrownBy(otherTracker::getOldestTimestamp).isInstanceOf(RuntimeException.class);
+
+        nonInitialisedKvs.createTable(
+                ShardProgress.TABLE_REF, TableMetadata.allDefault().persistToBytes());
+        deterministicScheduler.tick(1, TimeUnit.SECONDS);
+        assertThat(otherTracker.getOldestTimestamp()).hasValue(1L);
+    }
+}

--- a/changelog/@unreleased/pr-5772.v2.yml
+++ b/changelog/@unreleased/pr-5772.v2.yml
@@ -1,0 +1,7 @@
+type: feature
+feature:
+  description: AtlasDB now tracks the lowest timestamp guaranteed to be included in
+    the targeted sweep queue. This may be used in the future to avoid transactions
+    table lookups.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5772


### PR DESCRIPTION
**Goals (and why)**:
This can be used in the future to avoid having to look into transactions table and even clean it up.

**Implementation Description (bullets)**:
Uses the ShardProgress table to persist this info, which a) makes sense, and b) avoids creating a new table. It does add another magic row, but that is probably ok.
Uses a fresh timestamp as oldest locally seen then CASs the persisted if it's less instead of some more complicated mechanism -- I see no real benefit to complicating this.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Unit tests

**Concerns (what feedback would you like?)**:
This can go bad really fast if we decide to use the information, and someone decides to stop writing to the TS queue at any point. Do we want to make this non-configurable going forward? We can try to build in-protection where we flip another magic switch if we detect this or some such method, but this is super tricky and we need to account for versions of atlasdb before this change etc...

Another concern to remember in the future is tables with sweep strategy nothing, but that has nothing to do with this PR
