### PR TITLE
[transactions3] Reworking CheckAndSetCompatibilities

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/CheckAndSetCompatibility.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/CheckAndSetCompatibility.java
@@ -16,7 +16,6 @@
 
 package com.palantir.atlasdb.keyvalue.api;
 
-import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/CheckAndSetCompatibility.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/CheckAndSetCompatibility.java
@@ -16,43 +16,31 @@
 
 package com.palantir.atlasdb.keyvalue.api;
 
-import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.immutables.value.Value;
 
 /**
  * Indicates whether a {@link KeyValueService} supports check and set (CAS) and put unless exists (PUE) operations, and
  * if so the granularity with which it can provide feedback.
  */
-public enum CheckAndSetCompatibility {
+public interface CheckAndSetCompatibility {
     /**
-     * This is the only value that is allowed if a {@link KeyValueService} does NOT support check and set.
+     * If false, this {@link KeyValueService} does not support check and set operations.
      */
-    NO_DETAIL_CONSISTENT_ON_FAILURE(false, true),
-
-    SUPPORTS_DETAIL_CONSISTENT_ON_FAILURE(true, true),
-
-    SUPPORTS_DETAIL_NOT_CONSISTENT_ON_FAILURE(true, false),
-
-    NO_DETAIL_NOT_CONSISTENT_ON_FAILURE(false, false);
-
-    private final boolean supportsDetailOnFailure;
-    private final boolean consistentOnFailure;
-
-    CheckAndSetCompatibility(boolean supportsDetailOnFailure, boolean consistentOnFailure) {
-        this.supportsDetailOnFailure = supportsDetailOnFailure;
-        this.consistentOnFailure = consistentOnFailure;
-    }
+    boolean supportsCheckAndSetOperations();
 
     /**
      * If false, there are no guarantees that a {@link CheckAndSetException#getActualValues()} or
      * {@link KeyAlreadyExistsException#getExistingKeys()} from exceptions thrown by the the {@link KeyValueService}
      * will actually return any meaningful data (other than the fact that the operation failed).
+     *
+     * This method should only be called if {@link CheckAndSetCompatibility#supportsCheckAndSetOperations()} is true.
+     * If it is not true, behaviour is undefined.
      */
-    public boolean supportsDetailOnFailure() {
-        return supportsDetailOnFailure;
-    }
+    boolean supportsDetailOnFailure();
 
     /**
      *  If true, on CAS or PUE failure other than a {@link CheckAndSetException} or a
@@ -60,20 +48,63 @@ public enum CheckAndSetCompatibility {
      *  be consistent: any subsequent reads will be repeatable. If false, the value may have been persisted
      *  in a way that subsequent reads are not repeatable: if a read before the operation could have returned values
      *  from a set S, it can non-deterministically return a value from S U {newValue} afterwards.
+     *
+     * This method should only be called if {@link CheckAndSetCompatibility#supportsCheckAndSetOperations()} is true.
+     * If it is not true, behaviour is undefined.
      */
-    public boolean consistentOnFailure() {
-        return consistentOnFailure;
-    }
+    boolean consistentOnFailure();
 
-    public static CheckAndSetCompatibility intersect(Stream<CheckAndSetCompatibility> compatibilities) {
+    static CheckAndSetCompatibility intersect(Stream<CheckAndSetCompatibility> compatibilities) {
         Set<CheckAndSetCompatibility> presentCompatibilities = compatibilities.collect(Collectors.toSet());
+
+        boolean supported =
+                presentCompatibilities.stream().allMatch(CheckAndSetCompatibility::supportsCheckAndSetOperations);
+        if (!supported) {
+            return Unsupported.INSTANCE;
+        }
         boolean detail = presentCompatibilities.stream().allMatch(CheckAndSetCompatibility::supportsDetailOnFailure);
         boolean consistency = presentCompatibilities.stream().allMatch(CheckAndSetCompatibility::consistentOnFailure);
 
-        return Stream.of(CheckAndSetCompatibility.values())
-                .filter(compatibility -> compatibility.supportsDetailOnFailure() == detail)
-                .filter(compatibility -> compatibility.consistentOnFailure() == consistency)
-                .findFirst()
-                .orElseThrow(() -> new SafeIllegalArgumentException("min requires at least 1 element, but 0 provided"));
+        return supportedBuilder()
+                .supportsDetailOnFailure(detail)
+                .consistentOnFailure(consistency)
+                .build();
+    }
+
+    static CheckAndSetCompatibility unsupported() {
+        return Unsupported.INSTANCE;
+    }
+
+    static ImmutableSupported.Builder supportedBuilder() {
+        return ImmutableSupported.builder();
+    }
+
+    enum Unsupported implements CheckAndSetCompatibility {
+        INSTANCE;
+
+        @Override
+        public boolean supportsCheckAndSetOperations() {
+            return false;
+        }
+
+        @Override
+        public boolean supportsDetailOnFailure() {
+            throw new SafeIllegalStateException("Should not check a KVS that does not support CAS operations for "
+                    + "detail");
+        }
+
+        @Override
+        public boolean consistentOnFailure() {
+            throw new SafeIllegalStateException("Should not check a KVS that does not support CAS operations for "
+                    + "consistency");
+        }
+    }
+
+    @Value.Immutable
+    abstract class Supported implements CheckAndSetCompatibility {
+        @Override
+        public boolean supportsCheckAndSetOperations() {
+            return true;
+        }
     }
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/CheckAndSetCompatibility.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/CheckAndSetCompatibility.java
@@ -90,13 +90,13 @@ public interface CheckAndSetCompatibility {
         @Override
         public boolean supportsDetailOnFailure() {
             throw new SafeIllegalStateException(
-                    "Should not check a KVS that does not support CAS operations for " + "detail");
+                    "Should not check a KVS that does not support CAS operations for detail");
         }
 
         @Override
         public boolean consistentOnFailure() {
             throw new SafeIllegalStateException(
-                    "Should not check a KVS that does not support CAS operations for " + "consistency");
+                    "Should not check a KVS that does not support CAS operations for consistency");
         }
     }
 

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/CheckAndSetCompatibility.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/CheckAndSetCompatibility.java
@@ -89,14 +89,14 @@ public interface CheckAndSetCompatibility {
 
         @Override
         public boolean supportsDetailOnFailure() {
-            throw new SafeIllegalStateException("Should not check a KVS that does not support CAS operations for "
-                    + "detail");
+            throw new SafeIllegalStateException(
+                    "Should not check a KVS that does not support CAS operations for " + "detail");
         }
 
         @Override
         public boolean consistentOnFailure() {
-            throw new SafeIllegalStateException("Should not check a KVS that does not support CAS operations for "
-                    + "consistency");
+            throw new SafeIllegalStateException(
+                    "Should not check a KVS that does not support CAS operations for " + "consistency");
         }
     }
 

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/CheckAndSetCompatibility.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/CheckAndSetCompatibility.java
@@ -89,13 +89,13 @@ public interface CheckAndSetCompatibility {
 
         @Override
         public boolean supportsDetailOnFailure() {
-            throw new SafeIllegalStateException(
+            throw new UnsupportedOperationException(
                     "Should not check a KVS that does not support CAS operations for detail");
         }
 
         @Override
         public boolean consistentOnFailure() {
-            throw new SafeIllegalStateException(
+            throw new UnsupportedOperationException(
                     "Should not check a KVS that does not support CAS operations for consistency");
         }
     }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -258,14 +258,13 @@ public interface KeyValueService extends AutoCloseable, AsyncKeyValueService {
      */
     @DoDelegate
     default boolean supportsCheckAndSet() {
-        return getCheckAndSetCompatibility() != CheckAndSetCompatibility.NO_DETAIL_CONSISTENT_ON_FAILURE;
+        return getCheckAndSetCompatibility().supportsCheckAndSetOperations();
     }
 
     /**
      * Get the {@link CheckAndSetCompatibility} that this {@link KeyValueService} exhibits.
      *
-     * This method should be consistent with {@link KeyValueService#supportsCheckAndSet()} - this method should
-     * return {@link CheckAndSetCompatibility#NO_DETAIL_CONSISTENT_ON_FAILURE} if and only if that method returns false.
+     * This method should be consistent with {@link KeyValueService#supportsCheckAndSet()}.
      *
      * @return check and set compatibility
      */

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -264,7 +264,7 @@ public interface KeyValueService extends AutoCloseable, AsyncKeyValueService {
     /**
      * Get the {@link CheckAndSetCompatibility} that this {@link KeyValueService} exhibits.
      *
-     * This method should be consistent with {@link KeyValueService#supportsCheckAndSet()}.
+     * This method must be consistent with {@link KeyValueService#supportsCheckAndSet()}.
      *
      * @return check and set compatibility
      */

--- a/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/CheckAndSetCompatibilityTest.java
+++ b/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/CheckAndSetCompatibilityTest.java
@@ -17,53 +17,112 @@
 package com.palantir.atlasdb.keyvalue.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.stream.Stream;
 import org.junit.Test;
 
 public class CheckAndSetCompatibilityTest {
+    private static final CheckAndSetCompatibility SUPPORTS_DETAIL_NOT_CONSISTENT_ON_FAILURE =
+            CheckAndSetCompatibility.supportedBuilder()
+                    .supportsDetailOnFailure(true)
+                    .consistentOnFailure(false)
+                    .build();
+    private static final CheckAndSetCompatibility NO_DETAIL_CONSISTENT_ON_FAILURE =
+            CheckAndSetCompatibility.supportedBuilder()
+                    .supportsDetailOnFailure(false)
+                    .consistentOnFailure(true)
+                    .build();
+    private static final CheckAndSetCompatibility SUPPORTS_DETAIL_CONSISTENT_ON_FAILURE =
+            CheckAndSetCompatibility.supportedBuilder()
+                    .supportsDetailOnFailure(true)
+                    .consistentOnFailure(true)
+                    .build();
+
+    @Test
+    public void checkingDetailSupportedOnUnsupportedThrows() {
+        assertThatThrownBy(() -> CheckAndSetCompatibility.unsupported().supportsDetailOnFailure())
+                .isInstanceOf(SafeIllegalStateException.class)
+                .hasMessageContaining("Should not check a KVS that does not support CAS operations for detail");
+    }
+
+    @Test
+    public void checkingConsistencyOnUnsupportedThrows() {
+        assertThatThrownBy(() -> CheckAndSetCompatibility.unsupported().consistentOnFailure())
+                .isInstanceOf(SafeIllegalStateException.class)
+                .hasMessageContaining("Should not check a KVS that does not support CAS operations for consistency");
+    }
+
+    @Test
+    public void unsupportedDoesNotSupportCheckAndSetOperations() {
+        assertThat(CheckAndSetCompatibility.unsupported().supportsCheckAndSetOperations()).isFalse();
+    }
+
+    @Test
+    public void supportedBuilderSupportsCheckAndSetOperations() {
+        assertThat(CheckAndSetCompatibility.supportedBuilder()
+                .supportsDetailOnFailure(false)
+                .consistentOnFailure(false)
+                .build()
+                .supportsCheckAndSetOperations()).isTrue();
+    }
+
     @Test
     public void intersectReturnsLeastRestrictiveWhenNoCompatibilitiesProvided() {
-        CheckAndSetCompatibility minCompatibility = intersectCompatibility();
-        assertThat(minCompatibility.supportsDetailOnFailure()).isTrue();
-        assertThat(minCompatibility.consistentOnFailure()).isTrue();
+        CheckAndSetCompatibility intersection = intersectCompatibility();
+        assertThat(intersection.supportsCheckAndSetOperations()).isTrue();
+        assertThat(intersection.supportsDetailOnFailure()).isTrue();
+        assertThat(intersection.consistentOnFailure()).isTrue();
     }
 
     @Test
     public void intersectAppliesToBothProperties() {
-        CheckAndSetCompatibility minCompatibility = intersectCompatibility(
-                CheckAndSetCompatibility.SUPPORTS_DETAIL_NOT_CONSISTENT_ON_FAILURE,
-                CheckAndSetCompatibility.NO_DETAIL_CONSISTENT_ON_FAILURE,
-                CheckAndSetCompatibility.SUPPORTS_DETAIL_CONSISTENT_ON_FAILURE);
-        assertThat(minCompatibility.supportsDetailOnFailure()).isFalse();
-        assertThat(minCompatibility.consistentOnFailure()).isFalse();
+        CheckAndSetCompatibility intersection = intersectCompatibility(
+                SUPPORTS_DETAIL_NOT_CONSISTENT_ON_FAILURE,
+                NO_DETAIL_CONSISTENT_ON_FAILURE,
+                SUPPORTS_DETAIL_CONSISTENT_ON_FAILURE);
+        assertThat(intersection.supportsCheckAndSetOperations()).isTrue();
+        assertThat(intersection.supportsDetailOnFailure()).isFalse();
+        assertThat(intersection.consistentOnFailure()).isFalse();
     }
 
     @Test
     public void intersectReturnsDetailSupportedWhenAllSupport() {
-        CheckAndSetCompatibility minCompatibility = intersectCompatibility(
-                CheckAndSetCompatibility.SUPPORTS_DETAIL_NOT_CONSISTENT_ON_FAILURE,
-                CheckAndSetCompatibility.SUPPORTS_DETAIL_CONSISTENT_ON_FAILURE);
-        assertThat(minCompatibility.supportsDetailOnFailure()).isTrue();
-        assertThat(minCompatibility.consistentOnFailure()).isFalse();
+        CheckAndSetCompatibility intersection = intersectCompatibility(
+                SUPPORTS_DETAIL_NOT_CONSISTENT_ON_FAILURE,
+                SUPPORTS_DETAIL_CONSISTENT_ON_FAILURE);
+        assertThat(intersection.supportsCheckAndSetOperations()).isTrue();
+        assertThat(intersection.supportsDetailOnFailure()).isTrue();
+        assertThat(intersection.consistentOnFailure()).isFalse();
     }
 
     @Test
     public void intersectReturnsConsistentWhenAllConsistent() {
-        CheckAndSetCompatibility minCompatibility = intersectCompatibility(
-                CheckAndSetCompatibility.SUPPORTS_DETAIL_CONSISTENT_ON_FAILURE,
-                CheckAndSetCompatibility.NO_DETAIL_CONSISTENT_ON_FAILURE);
-        assertThat(minCompatibility.supportsDetailOnFailure()).isFalse();
-        assertThat(minCompatibility.consistentOnFailure()).isTrue();
+        CheckAndSetCompatibility intersection = intersectCompatibility(
+                SUPPORTS_DETAIL_CONSISTENT_ON_FAILURE,
+                NO_DETAIL_CONSISTENT_ON_FAILURE);
+        assertThat(intersection.supportsCheckAndSetOperations()).isTrue();
+        assertThat(intersection.supportsDetailOnFailure()).isFalse();
+        assertThat(intersection.consistentOnFailure()).isTrue();
     }
 
     @Test
     public void intersectDoesNotRestrictUnnecessarily() {
-        CheckAndSetCompatibility minCompatibility = intersectCompatibility(
-                CheckAndSetCompatibility.SUPPORTS_DETAIL_CONSISTENT_ON_FAILURE,
-                CheckAndSetCompatibility.SUPPORTS_DETAIL_CONSISTENT_ON_FAILURE);
-        assertThat(minCompatibility.supportsDetailOnFailure()).isTrue();
-        assertThat(minCompatibility.consistentOnFailure()).isTrue();
+        CheckAndSetCompatibility intersection = intersectCompatibility(
+                SUPPORTS_DETAIL_CONSISTENT_ON_FAILURE,
+                SUPPORTS_DETAIL_CONSISTENT_ON_FAILURE);
+        assertThat(intersection.supportsCheckAndSetOperations()).isTrue();
+        assertThat(intersection.supportsDetailOnFailure()).isTrue();
+        assertThat(intersection.consistentOnFailure()).isTrue();
+    }
+
+    @Test
+    public void intersectWithUnsupportedIsUnsupported() {
+        CheckAndSetCompatibility intersection = intersectCompatibility(
+                SUPPORTS_DETAIL_CONSISTENT_ON_FAILURE,
+                CheckAndSetCompatibility.unsupported());
+        assertThat(intersection.supportsCheckAndSetOperations()).isFalse();
     }
 
     private CheckAndSetCompatibility intersectCompatibility(CheckAndSetCompatibility... compatibilities) {

--- a/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/CheckAndSetCompatibilityTest.java
+++ b/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/CheckAndSetCompatibilityTest.java
@@ -43,14 +43,14 @@ public class CheckAndSetCompatibilityTest {
     @Test
     public void checkingDetailSupportedOnUnsupportedThrows() {
         assertThatThrownBy(() -> CheckAndSetCompatibility.unsupported().supportsDetailOnFailure())
-                .isInstanceOf(SafeIllegalStateException.class)
+                .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessageContaining("Should not check a KVS that does not support CAS operations for detail");
     }
 
     @Test
     public void checkingConsistencyOnUnsupportedThrows() {
         assertThatThrownBy(() -> CheckAndSetCompatibility.unsupported().consistentOnFailure())
-                .isInstanceOf(SafeIllegalStateException.class)
+                .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessageContaining("Should not check a KVS that does not support CAS operations for consistency");
     }
 

--- a/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/CheckAndSetCompatibilityTest.java
+++ b/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/CheckAndSetCompatibilityTest.java
@@ -56,16 +56,18 @@ public class CheckAndSetCompatibilityTest {
 
     @Test
     public void unsupportedDoesNotSupportCheckAndSetOperations() {
-        assertThat(CheckAndSetCompatibility.unsupported().supportsCheckAndSetOperations()).isFalse();
+        assertThat(CheckAndSetCompatibility.unsupported().supportsCheckAndSetOperations())
+                .isFalse();
     }
 
     @Test
     public void supportedBuilderSupportsCheckAndSetOperations() {
         assertThat(CheckAndSetCompatibility.supportedBuilder()
-                .supportsDetailOnFailure(false)
-                .consistentOnFailure(false)
-                .build()
-                .supportsCheckAndSetOperations()).isTrue();
+                        .supportsDetailOnFailure(false)
+                        .consistentOnFailure(false)
+                        .build()
+                        .supportsCheckAndSetOperations())
+                .isTrue();
     }
 
     @Test
@@ -90,8 +92,7 @@ public class CheckAndSetCompatibilityTest {
     @Test
     public void intersectReturnsDetailSupportedWhenAllSupport() {
         CheckAndSetCompatibility intersection = intersectCompatibility(
-                SUPPORTS_DETAIL_NOT_CONSISTENT_ON_FAILURE,
-                SUPPORTS_DETAIL_CONSISTENT_ON_FAILURE);
+                SUPPORTS_DETAIL_NOT_CONSISTENT_ON_FAILURE, SUPPORTS_DETAIL_CONSISTENT_ON_FAILURE);
         assertThat(intersection.supportsCheckAndSetOperations()).isTrue();
         assertThat(intersection.supportsDetailOnFailure()).isTrue();
         assertThat(intersection.consistentOnFailure()).isFalse();
@@ -99,9 +100,8 @@ public class CheckAndSetCompatibilityTest {
 
     @Test
     public void intersectReturnsConsistentWhenAllConsistent() {
-        CheckAndSetCompatibility intersection = intersectCompatibility(
-                SUPPORTS_DETAIL_CONSISTENT_ON_FAILURE,
-                NO_DETAIL_CONSISTENT_ON_FAILURE);
+        CheckAndSetCompatibility intersection =
+                intersectCompatibility(SUPPORTS_DETAIL_CONSISTENT_ON_FAILURE, NO_DETAIL_CONSISTENT_ON_FAILURE);
         assertThat(intersection.supportsCheckAndSetOperations()).isTrue();
         assertThat(intersection.supportsDetailOnFailure()).isFalse();
         assertThat(intersection.consistentOnFailure()).isTrue();
@@ -109,9 +109,8 @@ public class CheckAndSetCompatibilityTest {
 
     @Test
     public void intersectDoesNotRestrictUnnecessarily() {
-        CheckAndSetCompatibility intersection = intersectCompatibility(
-                SUPPORTS_DETAIL_CONSISTENT_ON_FAILURE,
-                SUPPORTS_DETAIL_CONSISTENT_ON_FAILURE);
+        CheckAndSetCompatibility intersection =
+                intersectCompatibility(SUPPORTS_DETAIL_CONSISTENT_ON_FAILURE, SUPPORTS_DETAIL_CONSISTENT_ON_FAILURE);
         assertThat(intersection.supportsCheckAndSetOperations()).isTrue();
         assertThat(intersection.supportsDetailOnFailure()).isTrue();
         assertThat(intersection.consistentOnFailure()).isTrue();
@@ -119,9 +118,8 @@ public class CheckAndSetCompatibilityTest {
 
     @Test
     public void intersectWithUnsupportedIsUnsupported() {
-        CheckAndSetCompatibility intersection = intersectCompatibility(
-                SUPPORTS_DETAIL_CONSISTENT_ON_FAILURE,
-                CheckAndSetCompatibility.unsupported());
+        CheckAndSetCompatibility intersection =
+                intersectCompatibility(SUPPORTS_DETAIL_CONSISTENT_ON_FAILURE, CheckAndSetCompatibility.unsupported());
         assertThat(intersection.supportsCheckAndSetOperations()).isFalse();
     }
 

--- a/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/CheckAndSetCompatibilityTest.java
+++ b/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/CheckAndSetCompatibilityTest.java
@@ -19,7 +19,6 @@ package com.palantir.atlasdb.keyvalue.api;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.stream.Stream;
 import org.junit.Test;
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -1884,7 +1884,10 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
 
     @Override
     public CheckAndSetCompatibility getCheckAndSetCompatibility() {
-        return CheckAndSetCompatibility.SUPPORTS_DETAIL_NOT_CONSISTENT_ON_FAILURE;
+        return CheckAndSetCompatibility.supportedBuilder()
+                .supportsDetailOnFailure(true)
+                .consistentOnFailure(false)
+                .build();
     }
 
     /**

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueService.java
@@ -83,7 +83,10 @@ public abstract class AbstractKeyValueService implements KeyValueService {
 
     @Override
     public CheckAndSetCompatibility getCheckAndSetCompatibility() {
-        return CheckAndSetCompatibility.NO_DETAIL_CONSISTENT_ON_FAILURE;
+        return CheckAndSetCompatibility.supportedBuilder()
+                .consistentOnFailure(true)
+                .supportsDetailOnFailure(false)
+                .build();
     }
 
     @Override

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/InMemoryKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/InMemoryKeyValueService.java
@@ -431,7 +431,10 @@ public class InMemoryKeyValueService extends AbstractKeyValueService {
 
     @Override
     public CheckAndSetCompatibility getCheckAndSetCompatibility() {
-        return CheckAndSetCompatibility.SUPPORTS_DETAIL_NOT_CONSISTENT_ON_FAILURE;
+        return CheckAndSetCompatibility.supportedBuilder()
+                .supportsDetailOnFailure(true)
+                .consistentOnFailure(true)
+                .build();
     }
 
     @Override

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/InMemoryKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/InMemoryKeyValueService.java
@@ -431,9 +431,10 @@ public class InMemoryKeyValueService extends AbstractKeyValueService {
 
     @Override
     public CheckAndSetCompatibility getCheckAndSetCompatibility() {
+        // We advertise inconsistency on failure, for the purposes of test re-usability.
         return CheckAndSetCompatibility.supportedBuilder()
                 .supportsDetailOnFailure(true)
-                .consistentOnFailure(true)
+                .consistentOnFailure(false)
                 .build();
     }
 

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/DualWriteKeyValueServiceTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/DualWriteKeyValueServiceTest.java
@@ -34,13 +34,14 @@ public class DualWriteKeyValueServiceTest {
 
     @Test
     public void checkAndSetCompatibilityIsBasedOnTheFirstDelegate() {
-        when(delegate1.getCheckAndSetCompatibility())
-                .thenReturn(CheckAndSetCompatibility.SUPPORTS_DETAIL_NOT_CONSISTENT_ON_FAILURE);
-        when(delegate2.getCheckAndSetCompatibility())
-                .thenReturn(CheckAndSetCompatibility.NO_DETAIL_CONSISTENT_ON_FAILURE);
+        CheckAndSetCompatibility firstDelegateCompatibility = CheckAndSetCompatibility.supportedBuilder()
+                .supportsDetailOnFailure(true)
+                .consistentOnFailure(false)
+                .build();
+        when(delegate1.getCheckAndSetCompatibility()).thenReturn(firstDelegateCompatibility);
+        when(delegate2.getCheckAndSetCompatibility()).thenReturn(CheckAndSetCompatibility.unsupported());
 
-        assertThat(dualWriteService.getCheckAndSetCompatibility())
-                .isEqualTo(CheckAndSetCompatibility.SUPPORTS_DETAIL_NOT_CONSISTENT_ON_FAILURE);
+        assertThat(dualWriteService.getCheckAndSetCompatibility()).isEqualTo(firstDelegateCompatibility);
         verify(delegate1).getCheckAndSetCompatibility();
         verifyNoMoreInteractions(delegate1, delegate2);
     }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -55,6 +55,7 @@ import com.palantir.atlasdb.internalschema.TransactionSchemaInstaller;
 import com.palantir.atlasdb.internalschema.TransactionSchemaManager;
 import com.palantir.atlasdb.internalschema.metrics.MetadataCoordinationServiceMetrics;
 import com.palantir.atlasdb.internalschema.persistence.CoordinationServices;
+import com.palantir.atlasdb.keyvalue.api.CheckAndSetCompatibility;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.impl.ProfilingKeyValueService;
@@ -687,7 +688,8 @@ public abstract class TransactionManagers {
             KeyValueService keyValueService,
             Supplier<AtlasDbRuntimeConfig> runtimeConfigSupplier,
             TransactionSchemaManager transactionSchemaManager) {
-        if (keyValueService.getCheckAndSetCompatibility().supportsDetailOnFailure()) {
+        CheckAndSetCompatibility compatibility = keyValueService.getCheckAndSetCompatibility();
+        if (compatibility.supportsCheckAndSetOperations() && compatibility.supportsDetailOnFailure()) {
             return Optional.of(
                     initializeTransactionSchemaInstaller(closeables, runtimeConfigSupplier, transactionSchemaManager));
         }

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/keyvalue/impl/AsyncInitializeableInMemoryKvs.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/keyvalue/impl/AsyncInitializeableInMemoryKvs.java
@@ -67,7 +67,10 @@ public final class AsyncInitializeableInMemoryKvs extends AsyncInitializer imple
 
     @Override
     public CheckAndSetCompatibility getCheckAndSetCompatibility() {
-        return CheckAndSetCompatibility.SUPPORTS_DETAIL_CONSISTENT_ON_FAILURE;
+        return CheckAndSetCompatibility.supportedBuilder()
+                .consistentOnFailure(true)
+                .supportsDetailOnFailure(true)
+                .build();
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/TransactionServices.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/TransactionServices.java
@@ -23,6 +23,7 @@ import com.palantir.atlasdb.internalschema.InternalSchemaMetadata;
 import com.palantir.atlasdb.internalschema.ReadOnlyTransactionSchemaManager;
 import com.palantir.atlasdb.internalschema.TransactionSchemaManager;
 import com.palantir.atlasdb.internalschema.persistence.CoordinationServices;
+import com.palantir.atlasdb.keyvalue.api.CheckAndSetCompatibility;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.transaction.impl.TransactionConstants;
 import com.palantir.atlasdb.util.MetricsManager;
@@ -38,7 +39,8 @@ public final class TransactionServices {
 
     public static TransactionService createTransactionService(
             KeyValueService keyValueService, TransactionSchemaManager transactionSchemaManager) {
-        if (keyValueService.getCheckAndSetCompatibility().supportsDetailOnFailure()) {
+        CheckAndSetCompatibility compatibility = keyValueService.getCheckAndSetCompatibility();
+        if (compatibility.supportsCheckAndSetOperations() && compatibility.supportsDetailOnFailure()) {
             return createSplitKeyTransactionService(keyValueService, transactionSchemaManager);
         }
         return createV1TransactionService(keyValueService);

--- a/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueService.java
+++ b/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueService.java
@@ -510,7 +510,13 @@ public final class JdbcKeyValueService implements KeyValueService {
 
     @Override
     public CheckAndSetCompatibility getCheckAndSetCompatibility() {
-        return CheckAndSetCompatibility.unsupported();
+        // Lies, blatant lies.
+        // JDBC KVS supports PUE but not CAS. Given that this KVS is not used in production, though, and
+        // all current uses of CAS are in the context of Targeted Sweep or Transactions 3
+        return CheckAndSetCompatibility.supportedBuilder()
+                .consistentOnFailure(false)
+                .supportsDetailOnFailure(false)
+                .build();
     }
 
     @Override

--- a/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueService.java
+++ b/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueService.java
@@ -510,13 +510,7 @@ public final class JdbcKeyValueService implements KeyValueService {
 
     @Override
     public CheckAndSetCompatibility getCheckAndSetCompatibility() {
-        // Lies, blatant lies.
-        // JDBC KVS supports PUE but not CAS. Given that this KVS is not used in production, though, and
-        // all current uses of CAS are in the context of Targeted Sweep or Transactions 3
-        return CheckAndSetCompatibility.supportedBuilder()
-                .consistentOnFailure(false)
-                .supportsDetailOnFailure(false)
-                .build();
+        return CheckAndSetCompatibility.unsupported();
     }
 
     @Override

--- a/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueService.java
+++ b/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueService.java
@@ -510,10 +510,7 @@ public final class JdbcKeyValueService implements KeyValueService {
 
     @Override
     public CheckAndSetCompatibility getCheckAndSetCompatibility() {
-        return CheckAndSetCompatibility.supportedBuilder()
-                .consistentOnFailure(true)
-                .supportsDetailOnFailure(false)
-                .build();
+        return CheckAndSetCompatibility.unsupported();
     }
 
     @Override

--- a/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueService.java
+++ b/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueService.java
@@ -510,7 +510,10 @@ public final class JdbcKeyValueService implements KeyValueService {
 
     @Override
     public CheckAndSetCompatibility getCheckAndSetCompatibility() {
-        return CheckAndSetCompatibility.NO_DETAIL_CONSISTENT_ON_FAILURE;
+        return CheckAndSetCompatibility.supportedBuilder()
+                .consistentOnFailure(true)
+                .supportsDetailOnFailure(false)
+                .build();
     }
 
     @Override

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
@@ -1543,7 +1543,7 @@ public abstract class AbstractKeyValueServiceTest {
 
     @Test
     public void putUnlessExistsDecodesCellsCorrectlyIfSupported() {
-        assumeTrue(keyValueService.getCheckAndSetCompatibility().supportsDetailOnFailure());
+        assumeDetailOnFailureSupported();
 
         keyValueService.putUnlessExists(TEST_TABLE, ImmutableMap.of(TEST_CELL, val(0, 0)));
 
@@ -1994,5 +1994,10 @@ public abstract class AbstractKeyValueServiceTest {
         return LongStream.rangeClosed(1L, numberOfTimestamps)
                 .mapToObj(timestamp -> Value.create(data, timestamp))
                 .collect(Collectors.toList());
+    }
+
+    private void assumeDetailOnFailureSupported() {
+        assumeTrue(checkAndSetSupported());
+        assumeTrue(keyValueService.getCheckAndSetCompatibility().supportsDetailOnFailure());
     }
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/TableSplittingKeyValueServiceTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/TableSplittingKeyValueServiceTest.java
@@ -136,20 +136,29 @@ public class TableSplittingKeyValueServiceTest {
     }
 
     @Test
-    public void evaluatesCheckAndSetCompatibilityCorrectly() {
+    public void defensivelyEvaluatesCheckAndSetCompatibility() {
         TableSplittingKeyValueService splittingKvs = TableSplittingKeyValueService.create(
                 ImmutableList.of(defaultKvs, tableDelegate), ImmutableMap.of(TABLE, tableDelegate));
 
         mockery.checking(new Expectations() {
             {
                 oneOf(defaultKvs).getCheckAndSetCompatibility();
-                will(returnValue(CheckAndSetCompatibility.SUPPORTS_DETAIL_NOT_CONSISTENT_ON_FAILURE));
+                will(returnValue(CheckAndSetCompatibility.supportedBuilder()
+                        .consistentOnFailure(true)
+                        .supportsDetailOnFailure(false)
+                        .build()));
                 oneOf(tableDelegate).getCheckAndSetCompatibility();
-                will(returnValue(CheckAndSetCompatibility.SUPPORTS_DETAIL_CONSISTENT_ON_FAILURE));
+                will(returnValue(CheckAndSetCompatibility.supportedBuilder()
+                        .consistentOnFailure(false)
+                        .supportsDetailOnFailure(true)
+                        .build()));
             }
         });
         assertThat(splittingKvs.getCheckAndSetCompatibility())
-                .isEqualTo(CheckAndSetCompatibility.SUPPORTS_DETAIL_NOT_CONSISTENT_ON_FAILURE);
+                .isEqualTo(CheckAndSetCompatibility.supportedBuilder()
+                        .consistentOnFailure(false)
+                        .supportsDetailOnFailure(false)
+                        .build());
     }
 
     private Map<TableReference, byte[]> merge(


### PR DESCRIPTION
**Goals (and why)**:
- Have a multi-dimensional way of expressing whether a KVS is able to perform the check-and-set (CAS) operation, and how well it can or cannot do so.

**Implementation Description (bullets)**:
- Make CASC have three booleans (supported, detailOnFailure, consistentOnFailure)
- Provide suitable interfaces to ensure users only build sensible configurations

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Refined existing tests for CASC, and patched ones where necessary.

**Concerns (what feedback would you like?)**:
- I decided to make `unsupported()` _throw_ if one attempts to query the more precise detailed methods. Is this overly aggressive?

**Where should we start reviewing?**: CheckAndSetCompatibility itself

**Priority (whenever / two weeks / yesterday)**: today or tomorrow would be ideal