### PR TITLE
[TS] More aggressive backoff for TS when a Cassandra node is down

### DIFF
--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/ScalingSweepTaskSchedulerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/ScalingSweepTaskSchedulerTest.java
@@ -90,11 +90,12 @@ public class ScalingSweepTaskSchedulerTest {
         when(sweepIteration.call())
                 .thenReturn(
                         SweepIterationResults.insufficientConsistency(),
+                        SUCCESS_MEDIUM,
                         SweepIterationResults.insufficientConsistency(),
                         SUCCESS_MEDIUM);
 
         schedulerWithDelay.start(2);
-        runSweepIterations(2, SweepDelay.BACKOFF);
+        runSweepIterations(2, SweepDelay.MIN_BACKOFF);
         runSweepIterations(5, DELAY);
 
         verify(sweepIteration, times(7 * 2)).call();

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepDelayTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepDelayTest.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.sweep.queue;
 
 import static com.palantir.atlasdb.sweep.queue.SweepDelay.BATCH_CELLS_LOW_THRESHOLD;
 import static com.palantir.atlasdb.sweep.queue.SweepDelay.DEFAULT_MAX_PAUSE_MILLIS;
+import static com.palantir.atlasdb.sweep.queue.SweepDelay.ITERATIONS_TO_REACH_MAX_BACKOFF;
 import static com.palantir.atlasdb.sweep.queue.SweepDelay.MAX_BACKOFF;
 import static com.palantir.atlasdb.sweep.queue.SweepDelay.MIN_BACKOFF;
 import static com.palantir.atlasdb.sweep.queue.SweepDelay.MIN_PAUSE_MILLIS;
@@ -95,7 +96,7 @@ public class SweepDelayTest {
         assertThat(delay.getNextPause(SweepIterationResults.insufficientConsistency()))
                 .isGreaterThan(secondPause);
 
-        IntStream.range(0, 100)
+        IntStream.range(0, ITERATIONS_TO_REACH_MAX_BACKOFF)
                 .mapToObj(_ignore -> delay.getNextPause(SweepIterationResults.insufficientConsistency()))
                 .forEach(pause -> assertThat(pause).isLessThanOrEqualTo(MAX_BACKOFF));
 

--- a/changelog/@unreleased/pr-5786.v2.yml
+++ b/changelog/@unreleased/pr-5786.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Targeted sweep will now back off more aggressively when it detects
+    insufficient consistency for deletes.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5786

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceTransactionIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceTransactionIntegrationTest.java
@@ -88,6 +88,11 @@ public class AsyncTimelockServiceTransactionIntegrationTest extends AbstractAsyn
     }
 
     @Test
+    public void bestTest() {
+        System.out.println(txnManager.getLockService().getLockServerOptions());
+    }
+
+    @Test
     public void canCommitWritesWithExclusiveAdvisoryLocks() throws ExecutionException, InterruptedException {
         AtomicBoolean isExecuting = new AtomicBoolean(false);
 

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceTransactionIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceTransactionIntegrationTest.java
@@ -88,11 +88,6 @@ public class AsyncTimelockServiceTransactionIntegrationTest extends AbstractAsyn
     }
 
     @Test
-    public void bestTest() {
-        System.out.println(txnManager.getLockService().getLockServerOptions());
-    }
-
-    @Test
     public void canCommitWritesWithExclusiveAdvisoryLocks() throws ExecutionException, InterruptedException {
         AtomicBoolean isExecuting = new AtomicBoolean(false);
 


### PR DESCRIPTION
**Goals (and why)**:
Prevent excessively eager TS from writing too many tombstones
