### PR TITLE
[Transactions3] Integration tests, meet transactions3.

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTransactionIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTransactionIntegrationTest.java
@@ -117,7 +117,7 @@ public class CassandraKeyValueServiceTransactionIntegrationTest extends Abstract
     private void installTransactionsVersion() {
         keyValueService.truncateTable(AtlasDbConstants.COORDINATION_TABLE);
         TransactionSchemaVersionEnforcement.ensureTransactionsGoingForwardHaveSchemaVersion(
-                transactionSchemaManager, ((ManagedTimestampService) timestampService), transactionsSchemaVersion);
+                transactionSchemaManager, (ManagedTimestampService) timestampService, transactionsSchemaVersion);
     }
 
     @Test

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsSerializableTransactionTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsSerializableTransactionTest.java
@@ -17,6 +17,7 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 
 import static org.mockito.Mockito.mock;
 
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.containers.CassandraResource;
 import com.palantir.atlasdb.sweep.metrics.TargetedSweepMetrics;
 import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
@@ -26,9 +27,13 @@ import com.palantir.atlasdb.sweep.queue.TargetedSweeper;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.impl.AbstractSerializableTransactionTest;
 import com.palantir.atlasdb.transaction.impl.GetAsyncDelegate;
+import com.palantir.atlasdb.transaction.impl.TransactionConstants;
+import com.palantir.atlasdb.transaction.impl.TransactionSchemaVersionEnforcement;
+import com.palantir.timestamp.ManagedTimestampService;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.UnaryOperator;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -38,23 +43,41 @@ public class CassandraKvsSerializableTransactionTest extends AbstractSerializabl
     @ClassRule
     public static final CassandraResource CASSANDRA = new CassandraResource();
 
-    private static final String SYNC = "sync";
-    private static final String ASYNC = "async";
+    private static final String SYNC_TRANSACTIONS_1 = "sync, transactions1";
+    private static final String ASYNC_TRANSACTIONS_3 = "async, transactions3";
 
     @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> data() {
         Object[][] data = new Object[][] {
-            {SYNC, UnaryOperator.identity()},
-            {ASYNC, (UnaryOperator<Transaction>) GetAsyncDelegate::new}
+            {
+                SYNC_TRANSACTIONS_1,
+                UnaryOperator.identity(),
+                TransactionConstants.DIRECT_ENCODING_TRANSACTIONS_SCHEMA_VERSION
+            },
+            {
+                ASYNC_TRANSACTIONS_3,
+                (UnaryOperator<Transaction>) GetAsyncDelegate::new,
+                TransactionConstants.TWO_STAGE_ENCODING_TRANSACTIONS_SCHEMA_VERSION
+            }
         };
         return Arrays.asList(data);
     }
 
     private final UnaryOperator<Transaction> transactionWrapper;
+    private final int transactionsSchemaVersion;
 
-    public CassandraKvsSerializableTransactionTest(String name, UnaryOperator<Transaction> transactionWrapper) {
+    public CassandraKvsSerializableTransactionTest(
+            String name, UnaryOperator<Transaction> transactionWrapper, int transactionsSchemaVersion) {
         super(CASSANDRA, CASSANDRA);
         this.transactionWrapper = transactionWrapper;
+        this.transactionsSchemaVersion = transactionsSchemaVersion;
+    }
+
+    @Before
+    public void before() {
+        keyValueService.truncateTable(AtlasDbConstants.COORDINATION_TABLE);
+        TransactionSchemaVersionEnforcement.ensureTransactionsGoingForwardHaveSchemaVersion(
+                transactionSchemaManager, (ManagedTimestampService) timestampService, transactionsSchemaVersion);
     }
 
     @Override

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionSchemaVersionEnforcement.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionSchemaVersionEnforcement.java
@@ -1,0 +1,57 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl;
+
+import com.palantir.atlasdb.internalschema.TransactionSchemaManager;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import com.palantir.timestamp.ManagedTimestampService;
+
+public final class TransactionSchemaVersionEnforcement {
+    private static final SafeLogger log = SafeLoggerFactory.get(TransactionSchemaVersionEnforcement.class);
+
+    private static final int MAX_ATTEMPTS = 50;
+    private static final long ONE_BILLION = 1_000_000_000L;
+
+    private TransactionSchemaVersionEnforcement() {
+        // utility
+    }
+
+    public static void ensureTransactionsGoingForwardHaveSchemaVersion(
+            TransactionSchemaManager transactionSchemaManager,
+            ManagedTimestampService timestampManagementService,
+            int targetSchemaVersion) {
+        for (int attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+            transactionSchemaManager.tryInstallNewTransactionsSchemaVersion(targetSchemaVersion);
+            advanceTimestamp(timestampManagementService);
+
+            int currentSchemaVersion = transactionSchemaManager.getTransactionsSchemaVersion(
+                    timestampManagementService.getFreshTimestamp());
+            if (currentSchemaVersion == targetSchemaVersion) {
+                return;
+            }
+        }
+        log.error(
+                "Could not enforce the desired schema version in spite of repeated retries.",
+                SafeArg.of("numAttempts", MAX_ATTEMPTS));
+    }
+
+    private static void advanceTimestamp(ManagedTimestampService timestampManagementService) {
+        timestampManagementService.fastForwardTimestamp(timestampManagementService.getFreshTimestamp() + ONE_BILLION);
+    }
+}

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionSchemaVersionEnforcement.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionSchemaVersionEnforcement.java
@@ -43,6 +43,9 @@ public final class TransactionSchemaVersionEnforcement {
             int currentSchemaVersion = transactionSchemaManager.getTransactionsSchemaVersion(
                     timestampManagementService.getFreshTimestamp());
             if (currentSchemaVersion == targetSchemaVersion) {
+                log.info(
+                        "Enforced schema version to the target.",
+                        SafeArg.of("targetSchemaVersion", targetSchemaVersion));
                 return;
             }
         }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTestSetup.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTestSetup.java
@@ -15,12 +15,18 @@
  */
 package com.palantir.atlasdb.transaction.impl;
 
+import static com.palantir.atlasdb.transaction.service.TransactionServices.createTransactionService;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.atlasdb.ComparingTimestampCache;
 import com.palantir.atlasdb.cache.TimestampCache;
+import com.palantir.atlasdb.coordination.CoordinationService;
 import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.internalschema.InternalSchemaMetadata;
+import com.palantir.atlasdb.internalschema.TransactionSchemaManager;
+import com.palantir.atlasdb.internalschema.persistence.CoordinationServices;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
@@ -40,7 +46,6 @@ import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.atlasdb.transaction.service.TransactionService;
-import com.palantir.atlasdb.transaction.service.TransactionServices;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.lock.LockClient;
@@ -66,6 +71,12 @@ import org.junit.rules.TemporaryFolder;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 
+/**
+ * Expectations for semantics of tests that are run as part of this class (not that the author thinks these
+ * assumptions are ideal, but this is documentation of the current state):
+ * - The timestamp and lock services are disjoint across individual tests.
+ * - The key value services may not be disjoint across individual tests.
+ */
 public abstract class TransactionTestSetup {
     @ClassRule
     public static final TemporaryFolder PERSISTENT_STORAGE_FOLDER = new TemporaryFolder();
@@ -103,6 +114,7 @@ public abstract class TransactionTestSetup {
     protected KeyValueService keyValueService;
     protected TimestampService timestampService;
     protected TimestampManagementService timestampManagementService;
+    protected TransactionSchemaManager transactionSchemaManager;
     protected TransactionService transactionService;
     protected ConflictDetectionManager conflictDetectionManager;
     protected SweepStrategyManager sweepStrategyManager;
@@ -165,7 +177,11 @@ public abstract class TransactionTestSetup {
         timestampManagementService = inMemoryTimelockServices.getTimestampManagementService();
         timelockService = inMemoryTimelockServices.getLegacyTimelockService();
         lockWatchManager = NoOpLockWatchManager.create();
-        transactionService = TransactionServices.createRaw(keyValueService, timestampService, false);
+
+        CoordinationService<InternalSchemaMetadata> coordinationService = CoordinationServices.createDefault(
+                keyValueService, timestampService, metricsManager, false);
+        transactionSchemaManager = new TransactionSchemaManager(coordinationService);
+        transactionService = createTransactionService(keyValueService, transactionSchemaManager);
         conflictDetectionManager = ConflictDetectionManagers.createWithoutWarmingCache(keyValueService);
         sweepStrategyManager = SweepStrategyManagers.createDefault(keyValueService);
         txMgr = getManager();

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTestSetup.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTestSetup.java
@@ -178,8 +178,8 @@ public abstract class TransactionTestSetup {
         timelockService = inMemoryTimelockServices.getLegacyTimelockService();
         lockWatchManager = NoOpLockWatchManager.create();
 
-        CoordinationService<InternalSchemaMetadata> coordinationService = CoordinationServices.createDefault(
-                keyValueService, timestampService, metricsManager, false);
+        CoordinationService<InternalSchemaMetadata> coordinationService =
+                CoordinationServices.createDefault(keyValueService, timestampService, metricsManager, false);
         transactionSchemaManager = new TransactionSchemaManager(coordinationService);
         transactionService = createTransactionService(keyValueService, transactionSchemaManager);
         conflictDetectionManager = ConflictDetectionManagers.createWithoutWarmingCache(keyValueService);

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/MemorySerializableTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/MemorySerializableTransactionTest.java
@@ -25,8 +25,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+@RunWith(Parameterized.class)
 public class MemorySerializableTransactionTest extends AbstractSerializableTransactionTest {
     @ClassRule
     public static final TestResourceManager TRM = TestResourceManager.inMemory();

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/MemorySerializableTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/MemorySerializableTransactionTest.java
@@ -15,15 +15,45 @@
  */
 package com.palantir.atlasdb.keyvalue;
 
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.impl.TestResourceManager;
 import com.palantir.atlasdb.transaction.impl.AbstractSerializableTransactionTest;
+import com.palantir.atlasdb.transaction.impl.TransactionConstants;
+import com.palantir.atlasdb.transaction.impl.TransactionSchemaVersionEnforcement;
+import com.palantir.timestamp.ManagedTimestampService;
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.runners.Parameterized;
 
 public class MemorySerializableTransactionTest extends AbstractSerializableTransactionTest {
     @ClassRule
     public static final TestResourceManager TRM = TestResourceManager.inMemory();
 
-    public MemorySerializableTransactionTest() {
+    private static final String TRANSACTIONS_1 = "transactions1";
+    private static final String TRANSACTIONS_3 = "transactions3";
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> data() {
+        Object[][] data = new Object[][] {
+            {TRANSACTIONS_1, TransactionConstants.DIRECT_ENCODING_TRANSACTIONS_SCHEMA_VERSION},
+            {TRANSACTIONS_3, TransactionConstants.TWO_STAGE_ENCODING_TRANSACTIONS_SCHEMA_VERSION}
+        };
+        return Arrays.asList(data);
+    }
+
+    private final int transactionsSchemaVersion;
+
+    public MemorySerializableTransactionTest(String name, int transactionsSchemaVersion) {
         super(TRM, TRM);
+        this.transactionsSchemaVersion = transactionsSchemaVersion;
+    }
+
+    @Before
+    public void before() {
+        keyValueService.truncateTable(AtlasDbConstants.COORDINATION_TABLE);
+        TransactionSchemaVersionEnforcement.ensureTransactionsGoingForwardHaveSchemaVersion(
+                transactionSchemaManager, (ManagedTimestampService) timestampService, transactionsSchemaVersion);
     }
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/MemoryTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/MemoryTransactionTest.java
@@ -17,12 +17,22 @@ package com.palantir.atlasdb.keyvalue;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.impl.TestResourceManager;
 import com.palantir.atlasdb.transaction.impl.AbstractTransactionTest;
+import com.palantir.atlasdb.transaction.impl.TransactionConstants;
+import com.palantir.atlasdb.transaction.impl.TransactionSchemaVersionEnforcement;
+import com.palantir.timestamp.ManagedTimestampService;
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+@RunWith(Parameterized.class)
 public class MemoryTransactionTest extends AbstractTransactionTest {
     @ClassRule
     public static final TestResourceManager TRM = TestResourceManager.inMemory();
@@ -30,8 +40,30 @@ public class MemoryTransactionTest extends AbstractTransactionTest {
     private static final byte[] ROW_1 = PtBytes.toBytes("row1");
     private static final byte[] ZERO = new byte[0];
 
-    public MemoryTransactionTest() {
+    private static final String TRANSACTIONS_1 = "transactions1";
+    private static final String TRANSACTIONS_3 = "transactions3";
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> data() {
+        Object[][] data = new Object[][] {
+            {TRANSACTIONS_1, TransactionConstants.DIRECT_ENCODING_TRANSACTIONS_SCHEMA_VERSION},
+            {TRANSACTIONS_3, TransactionConstants.TWO_STAGE_ENCODING_TRANSACTIONS_SCHEMA_VERSION}
+        };
+        return Arrays.asList(data);
+    }
+
+    private final int transactionsSchemaVersion;
+
+    public MemoryTransactionTest(String name, int transactionsSchemaVersion) {
         super(TRM, TRM);
+        this.transactionsSchemaVersion = transactionsSchemaVersion;
+    }
+
+    @Before
+    public void before() {
+        keyValueService.truncateTable(AtlasDbConstants.COORDINATION_TABLE);
+        TransactionSchemaVersionEnforcement.ensureTransactionsGoingForwardHaveSchemaVersion(
+                transactionSchemaManager, (ManagedTimestampService) timestampService, transactionsSchemaVersion);
     }
 
     @Test

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/TransactionSchemaVersionEnforcementTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/TransactionSchemaVersionEnforcementTest.java
@@ -1,0 +1,52 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.atlasdb.internalschema.TransactionSchemaManager;
+import com.palantir.atlasdb.internalschema.persistence.CoordinationServices;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
+import com.palantir.timestamp.InMemoryTimestampService;
+import com.palantir.timestamp.ManagedTimestampService;
+import org.junit.Test;
+
+public class TransactionSchemaVersionEnforcementTest {
+    private final KeyValueService keyValueService = new InMemoryKeyValueService(true);
+    private final ManagedTimestampService managedTimestampService = new InMemoryTimestampService();
+    private final TransactionSchemaManager schemaManager = new TransactionSchemaManager(
+            CoordinationServices.createDefault(keyValueService, managedTimestampService::getFreshTimestamp, false));
+
+    @Test
+    public void canEnforceSchemaVersions() {
+        long oldTimestamp = managedTimestampService.getFreshTimestamp();
+        TransactionSchemaVersionEnforcement.ensureTransactionsGoingForwardHaveSchemaVersion(
+                schemaManager, managedTimestampService, 2);
+        assertThat(schemaManager.getTransactionsSchemaVersion(oldTimestamp)).isEqualTo(1);
+        assertThat(schemaManager.getTransactionsSchemaVersion(managedTimestampService.getFreshTimestamp()))
+                .isEqualTo(2);
+        TransactionSchemaVersionEnforcement.ensureTransactionsGoingForwardHaveSchemaVersion(
+                schemaManager, managedTimestampService, 3);
+        assertThat(schemaManager.getTransactionsSchemaVersion(managedTimestampService.getFreshTimestamp()))
+                .isEqualTo(3);
+        TransactionSchemaVersionEnforcement.ensureTransactionsGoingForwardHaveSchemaVersion(
+                schemaManager, managedTimestampService, 2);
+        assertThat(schemaManager.getTransactionsSchemaVersion(managedTimestampService.getFreshTimestamp()))
+                .isEqualTo(2);
+    }
+}


### PR DESCRIPTION
**Goals (and why)**:
- Run existing integration tests for Cassandra and Memory with transactions3

**Implementation Description (bullets)**:
- For Cassandra tests, add parameters to run in the configurations (sync/1, async/3) and for one set of tests (async/2). 
- For in memory tests, run in the configurations 1 and 3.

**Testing (What was existing testing like?  What have you done to improve it?)**:
This PR focuses primarily on adding tests

**Concerns (what feedback would you like?)**:
- Is it ok to not test transactions2, and for the Cassandra KVS only test the sync/Transactions1 and async/Transactions3 pairs?
- Does this make the tests too much longer?

**Where should we start reviewing?**: TransactionSchemaVersionEnforcement

**Priority (whenever / two weeks / yesterday)**: 2 days please
