### PR TITLE
[Transactions3] Wiring ETE Tests To Use Transactions3

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTransactionIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTransactionIntegrationTest.java
@@ -32,7 +32,6 @@ import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.transaction.service.WriteBatchingTransactionService;
 import com.palantir.flake.FlakeRetryingRule;
 import com.palantir.flake.ShouldRetry;
-import com.palantir.timestamp.ManagedTimestampService;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTransactionIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTransactionIntegrationTest.java
@@ -117,7 +117,7 @@ public class CassandraKeyValueServiceTransactionIntegrationTest extends Abstract
     private void installTransactionsVersion() {
         keyValueService.truncateTable(AtlasDbConstants.COORDINATION_TABLE);
         TransactionSchemaVersionEnforcement.ensureTransactionsGoingForwardHaveSchemaVersion(
-                transactionSchemaManager, (ManagedTimestampService) timestampService, transactionsSchemaVersion);
+                transactionSchemaManager, timestampService, timestampManagementService, transactionsSchemaVersion);
     }
 
     @Test

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsSerializableTransactionTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsSerializableTransactionTest.java
@@ -29,7 +29,6 @@ import com.palantir.atlasdb.transaction.impl.AbstractSerializableTransactionTest
 import com.palantir.atlasdb.transaction.impl.GetAsyncDelegate;
 import com.palantir.atlasdb.transaction.impl.TransactionConstants;
 import com.palantir.atlasdb.transaction.impl.TransactionSchemaVersionEnforcement;
-import com.palantir.timestamp.ManagedTimestampService;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.UnaryOperator;

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsSerializableTransactionTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsSerializableTransactionTest.java
@@ -77,7 +77,7 @@ public class CassandraKvsSerializableTransactionTest extends AbstractSerializabl
     public void before() {
         keyValueService.truncateTable(AtlasDbConstants.COORDINATION_TABLE);
         TransactionSchemaVersionEnforcement.ensureTransactionsGoingForwardHaveSchemaVersion(
-                transactionSchemaManager, (ManagedTimestampService) timestampService, transactionsSchemaVersion);
+                transactionSchemaManager, timestampService, timestampManagementService, transactionsSchemaVersion);
     }
 
     @Override

--- a/atlasdb-ete-tests/build.gradle
+++ b/atlasdb-ete-tests/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation project(':atlasdb-client-protobufs')
     implementation project(':atlasdb-commons')
     implementation project(':atlasdb-impl-shared')
+    implementation project(':atlasdb-tests-shared')
     implementation project(':lock-api')
     implementation project(':lock-api-objects')
     implementation project(':timestamp-api')

--- a/atlasdb-ete-tests/docker/conf/atlasdb-ete.no-leader.cassandra.yml
+++ b/atlasdb-ete-tests/docker/conf/atlasdb-ete.no-leader.cassandra.yml
@@ -29,6 +29,8 @@ atlasdb:
     enableSweepQueueWrites: true
 
 atlasDbRuntime:
+  internalSchema:
+    targetTransactionsSchemaVersion: 3
   sweep:
     enabled: false
   targetedSweep:

--- a/atlasdb-ete-tests/docker/conf/atlasdb-ete.timelock.cassandra.yml
+++ b/atlasdb-ete-tests/docker/conf/atlasdb-ete.timelock.cassandra.yml
@@ -29,6 +29,8 @@ atlasdb:
   namespace: atlasete
 
 atlasDbRuntime:
+  internalSchema:
+    targetTransactionsSchemaVersion: 3
   sweep:
     enabled: false
   targetedSweep:

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
@@ -55,7 +55,6 @@ import com.palantir.conjure.java.server.jersey.ConjureJerseyFeature;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
-import com.palantir.timestamp.ManagedTimestampService;
 import com.palantir.tritium.metrics.registry.SharedTaggedMetricRegistries;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import io.dropwizard.Application;
@@ -133,7 +132,10 @@ public class AtlasDbEteServer extends Application<AtlasDbEteConfiguration> {
                 .targetTransactionsSchemaVersion()
                 .get();
         TransactionSchemaVersionEnforcement.ensureTransactionsGoingForwardHaveSchemaVersion(
-                manager, (ManagedTimestampService) transactionManager.getTimestampService(), targetSchemaVersion);
+                manager,
+                transactionManager.getTimestampService(),
+                transactionManager.getTimestampManagementService(),
+                targetSchemaVersion);
     }
 
     private TransactionManager tryToCreateTransactionManager(

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
@@ -15,7 +15,6 @@
  */
 package com.palantir.atlasdb;
 
-import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.SharedMetricRegistries;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.base.Stopwatch;
@@ -27,9 +26,13 @@ import com.palantir.atlasdb.cleaner.CleanupFollower;
 import com.palantir.atlasdb.cleaner.Follower;
 import com.palantir.atlasdb.config.AtlasDbConfig;
 import com.palantir.atlasdb.config.AtlasDbRuntimeConfig;
+import com.palantir.atlasdb.coordination.CoordinationService;
 import com.palantir.atlasdb.coordination.SimpleCoordinationResource;
 import com.palantir.atlasdb.factory.TransactionManagers;
 import com.palantir.atlasdb.http.NotInitializedExceptionMapper;
+import com.palantir.atlasdb.internalschema.InternalSchemaMetadata;
+import com.palantir.atlasdb.internalschema.TransactionSchemaManager;
+import com.palantir.atlasdb.internalschema.persistence.CoordinationServices;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.lock.SimpleLockResource;
 import com.palantir.atlasdb.sweep.CellsSweeper;
@@ -43,10 +46,9 @@ import com.palantir.atlasdb.todo.SimpleTodoResource;
 import com.palantir.atlasdb.todo.TodoClient;
 import com.palantir.atlasdb.todo.TodoSchema;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
-import com.palantir.atlasdb.transaction.impl.SweepStrategyManager;
-import com.palantir.atlasdb.transaction.impl.SweepStrategyManagers;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.transaction.service.TransactionServices;
+import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.server.jersey.ConjureJerseyFeature;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
@@ -92,9 +94,10 @@ public class AtlasDbEteServer extends Application<AtlasDbEteConfiguration> {
         TaggedMetricRegistry taggedMetrics = SharedTaggedMetricRegistries.getSingleton();
         TransactionManager txManager = tryToCreateTransactionManager(config, environment, taggedMetrics);
         Supplier<SweepTaskRunner> sweepTaskRunner =
-                Suppliers.memoize(() -> getSweepTaskRunner(txManager, environment.metrics(), taggedMetrics));
+                Suppliers.memoize(() -> getSweepTaskRunner(txManager));
         TargetedSweeper sweeper = TargetedSweeper.createUninitializedForTest(() -> 1);
         Supplier<TargetedSweeper> sweeperSupplier = Suppliers.memoize(() -> initializeAndGet(sweeper, txManager));
+        ensureTransactionSchemaVersionInstalled(txManager);
         environment
                 .jersey()
                 .register(new SimpleTodoResource(new TodoClient(txManager, sweepTaskRunner, sweeperSupplier)));
@@ -104,6 +107,17 @@ public class AtlasDbEteServer extends Application<AtlasDbEteConfiguration> {
         environment.jersey().register(new SimpleEteTimestampResource(txManager));
         environment.jersey().register(new SimpleLockResource(txManager));
         environment.jersey().register(new EmptyOptionalTo204ExceptionMapper());
+    }
+
+    private void ensureTransactionSchemaVersionInstalled(
+            AtlasDbConfig config, TransactionManager transactionManager) {
+        CoordinationService<InternalSchemaMetadata> coordinationService = CoordinationServices.createDefault(
+                transactionManager.getKeyValueService(),
+                transactionManager.getTimestampService(),
+                MetricsManagers.createForTests(),
+                config.initializeAsync());
+        TransactionSchemaManager manager = new TransactionSchemaManager(coordinationService);
+        
     }
 
     private TransactionManager tryToCreateTransactionManager(
@@ -119,14 +133,11 @@ public class AtlasDbEteServer extends Application<AtlasDbEteConfiguration> {
     }
 
     private SweepTaskRunner getSweepTaskRunner(
-            TransactionManager transactionManager,
-            MetricRegistry metricRegistry,
-            TaggedMetricRegistry taggedMetricRegistry) {
+            TransactionManager transactionManager) {
         KeyValueService kvs = transactionManager.getKeyValueService();
         LongSupplier ts = transactionManager.getTimestampService()::getFreshTimestamp;
         TransactionService txnService =
                 TransactionServices.createRaw(kvs, transactionManager.getTimestampService(), false);
-        SweepStrategyManager ssm = SweepStrategyManagers.completelyConservative(); // maybe createDefault
         CleanupFollower follower = CleanupFollower.create(ETE_SCHEMAS);
         CellsSweeper cellsSweeper = new CellsSweeper(transactionManager, kvs, ImmutableList.of(follower));
         return new SweepTaskRunner(kvs, ts, ts, txnService, cellsSweeper);

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionSchemaVersionEnforcement.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionSchemaVersionEnforcement.java
@@ -20,7 +20,8 @@ import com.palantir.atlasdb.internalschema.TransactionSchemaManager;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
-import com.palantir.timestamp.ManagedTimestampService;
+import com.palantir.timestamp.TimestampManagementService;
+import com.palantir.timestamp.TimestampService;
 
 public final class TransactionSchemaVersionEnforcement {
     private static final SafeLogger log = SafeLoggerFactory.get(TransactionSchemaVersionEnforcement.class);
@@ -34,14 +35,15 @@ public final class TransactionSchemaVersionEnforcement {
 
     public static void ensureTransactionsGoingForwardHaveSchemaVersion(
             TransactionSchemaManager transactionSchemaManager,
-            ManagedTimestampService timestampManagementService,
+            TimestampService timestampService,
+            TimestampManagementService timestampManagementService,
             int targetSchemaVersion) {
         for (int attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
             transactionSchemaManager.tryInstallNewTransactionsSchemaVersion(targetSchemaVersion);
-            advanceTimestamp(timestampManagementService);
+            advanceTimestamp(timestampService, timestampManagementService);
 
             int currentSchemaVersion = transactionSchemaManager.getTransactionsSchemaVersion(
-                    timestampManagementService.getFreshTimestamp());
+                    timestampService.getFreshTimestamp());
             if (currentSchemaVersion == targetSchemaVersion) {
                 log.info(
                         "Enforced schema version to the target.",
@@ -54,7 +56,8 @@ public final class TransactionSchemaVersionEnforcement {
                 SafeArg.of("numAttempts", MAX_ATTEMPTS));
     }
 
-    private static void advanceTimestamp(ManagedTimestampService timestampManagementService) {
-        timestampManagementService.fastForwardTimestamp(timestampManagementService.getFreshTimestamp() + ONE_BILLION);
+    private static void advanceTimestamp(TimestampService timestampService,
+            TimestampManagementService timestampManagementService) {
+        timestampManagementService.fastForwardTimestamp(timestampService.getFreshTimestamp() + ONE_BILLION);
     }
 }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionSchemaVersionEnforcement.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionSchemaVersionEnforcement.java
@@ -42,8 +42,8 @@ public final class TransactionSchemaVersionEnforcement {
             transactionSchemaManager.tryInstallNewTransactionsSchemaVersion(targetSchemaVersion);
             advanceTimestamp(timestampService, timestampManagementService);
 
-            int currentSchemaVersion = transactionSchemaManager.getTransactionsSchemaVersion(
-                    timestampService.getFreshTimestamp());
+            int currentSchemaVersion =
+                    transactionSchemaManager.getTransactionsSchemaVersion(timestampService.getFreshTimestamp());
             if (currentSchemaVersion == targetSchemaVersion) {
                 log.info(
                         "Enforced schema version to the target.",
@@ -56,8 +56,8 @@ public final class TransactionSchemaVersionEnforcement {
                 SafeArg.of("numAttempts", MAX_ATTEMPTS));
     }
 
-    private static void advanceTimestamp(TimestampService timestampService,
-            TimestampManagementService timestampManagementService) {
+    private static void advanceTimestamp(
+            TimestampService timestampService, TimestampManagementService timestampManagementService) {
         timestampManagementService.fastForwardTimestamp(timestampService.getFreshTimestamp() + ONE_BILLION);
     }
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/MemorySerializableTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/MemorySerializableTransactionTest.java
@@ -56,6 +56,6 @@ public class MemorySerializableTransactionTest extends AbstractSerializableTrans
     public void before() {
         keyValueService.truncateTable(AtlasDbConstants.COORDINATION_TABLE);
         TransactionSchemaVersionEnforcement.ensureTransactionsGoingForwardHaveSchemaVersion(
-                transactionSchemaManager, (ManagedTimestampService) timestampService, transactionsSchemaVersion);
+                transactionSchemaManager, timestampService, timestampManagementService, transactionsSchemaVersion);
     }
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/MemorySerializableTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/MemorySerializableTransactionTest.java
@@ -20,7 +20,6 @@ import com.palantir.atlasdb.keyvalue.impl.TestResourceManager;
 import com.palantir.atlasdb.transaction.impl.AbstractSerializableTransactionTest;
 import com.palantir.atlasdb.transaction.impl.TransactionConstants;
 import com.palantir.atlasdb.transaction.impl.TransactionSchemaVersionEnforcement;
-import com.palantir.timestamp.ManagedTimestampService;
 import java.util.Arrays;
 import java.util.Collection;
 import org.junit.Before;

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/MemoryTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/MemoryTransactionTest.java
@@ -63,7 +63,7 @@ public class MemoryTransactionTest extends AbstractTransactionTest {
     public void before() {
         keyValueService.truncateTable(AtlasDbConstants.COORDINATION_TABLE);
         TransactionSchemaVersionEnforcement.ensureTransactionsGoingForwardHaveSchemaVersion(
-                transactionSchemaManager, (ManagedTimestampService) timestampService, transactionsSchemaVersion);
+                transactionSchemaManager, timestampService, timestampManagementService, transactionsSchemaVersion);
     }
 
     @Test

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/MemoryTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/MemoryTransactionTest.java
@@ -23,7 +23,6 @@ import com.palantir.atlasdb.keyvalue.impl.TestResourceManager;
 import com.palantir.atlasdb.transaction.impl.AbstractTransactionTest;
 import com.palantir.atlasdb.transaction.impl.TransactionConstants;
 import com.palantir.atlasdb.transaction.impl.TransactionSchemaVersionEnforcement;
-import com.palantir.timestamp.ManagedTimestampService;
 import java.util.Arrays;
 import java.util.Collection;
 import org.junit.Before;

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/TransactionSchemaVersionEnforcementTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/TransactionSchemaVersionEnforcementTest.java
@@ -16,8 +16,6 @@
 
 package com.palantir.atlasdb.transaction.impl;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.palantir.atlasdb.internalschema.TransactionSchemaManager;
 import com.palantir.atlasdb.internalschema.persistence.CoordinationServices;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
@@ -25,6 +23,8 @@ import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
 import com.palantir.timestamp.InMemoryTimestampService;
 import com.palantir.timestamp.ManagedTimestampService;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TransactionSchemaVersionEnforcementTest {
     private final KeyValueService keyValueService = new InMemoryKeyValueService(true);
@@ -36,16 +36,16 @@ public class TransactionSchemaVersionEnforcementTest {
     public void canEnforceSchemaVersions() {
         long oldTimestamp = managedTimestampService.getFreshTimestamp();
         TransactionSchemaVersionEnforcement.ensureTransactionsGoingForwardHaveSchemaVersion(
-                schemaManager, managedTimestampService, 2);
+                schemaManager, managedTimestampService, managedTimestampService, 2);
         assertThat(schemaManager.getTransactionsSchemaVersion(oldTimestamp)).isEqualTo(1);
         assertThat(schemaManager.getTransactionsSchemaVersion(managedTimestampService.getFreshTimestamp()))
                 .isEqualTo(2);
         TransactionSchemaVersionEnforcement.ensureTransactionsGoingForwardHaveSchemaVersion(
-                schemaManager, managedTimestampService, 3);
+                schemaManager, managedTimestampService, managedTimestampService, 3);
         assertThat(schemaManager.getTransactionsSchemaVersion(managedTimestampService.getFreshTimestamp()))
                 .isEqualTo(3);
         TransactionSchemaVersionEnforcement.ensureTransactionsGoingForwardHaveSchemaVersion(
-                schemaManager, managedTimestampService, 2);
+                schemaManager, managedTimestampService, managedTimestampService, 2);
         assertThat(schemaManager.getTransactionsSchemaVersion(managedTimestampService.getFreshTimestamp()))
                 .isEqualTo(2);
     }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/TransactionSchemaVersionEnforcementTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/TransactionSchemaVersionEnforcementTest.java
@@ -16,6 +16,8 @@
 
 package com.palantir.atlasdb.transaction.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.palantir.atlasdb.internalschema.TransactionSchemaManager;
 import com.palantir.atlasdb.internalschema.persistence.CoordinationServices;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
@@ -23,8 +25,6 @@ import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
 import com.palantir.timestamp.InMemoryTimestampService;
 import com.palantir.timestamp.ManagedTimestampService;
 import org.junit.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class TransactionSchemaVersionEnforcementTest {
     private final KeyValueService keyValueService = new InMemoryKeyValueService(true);


### PR DESCRIPTION
**Goals (and why)**:
- Have ETE tests use transactions3

**Implementation Description (bullets)**:
- Set this up and ensure the server enforces the relevant versions

**Testing (What was existing testing like?  What have you done to improve it?)**:
Not much. These are tests

**Concerns (what feedback would you like?)**:
Will this affect runtimes too much?

**Where should we start reviewing?**: AtlasDbEteServer

**Priority (whenever / two weeks / yesterday)**: 3 days?