### PR TITLE
Don't publish docs from tag builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ jobs:
       - run:
           command: |
             # hack - notion of "owners" isn't supported in Circle 2
-            if [ $CIRCLE_PROJECT_USERNAME = 'palantir' ] && [ -z $CIRCLE_PR_NUMBER ]; then
+            if [ $CIRCLE_PROJECT_USERNAME = 'palantir' ] && [ -z $CIRCLE_PR_NUMBER ] && [ -z $CIRCLE_TAG ]; then
               ./scripts/circle-ci/publish-github-page.sh
               # Internal publishing from an external CircleCI is... not a thing.
               # curl -s --fail $DOCS_URL | bash -s -- -r docs/requirements.txt $CIRCLE_BRANCH

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,17 +116,17 @@ jobs:
       - run:
           command: |
             # hack - notion of "owners" isn't supported in Circle 2
-            if [ $CIRCLE_PROJECT_USERNAME = 'palantir' ] && [ -z $CIRCLE_PR_NUMBER ] && [ -z $CIRCLE_TAG ]; then
-              ./scripts/circle-ci/publish-github-page.sh
-              # Internal publishing from an external CircleCI is... not a thing.
-              # curl -s --fail $DOCS_URL | bash -s -- -r docs/requirements.txt $CIRCLE_BRANCH
+            if [ $CIRCLE_PROJECT_USERNAME = 'palantir' ] && [ -z $CIRCLE_PR_NUMBER ]; then
+              git status
+              ./gradlew --profile --stacktrace --continue publish
             fi
       - run:
           command: |
             # hack - notion of "owners" isn't supported in Circle 2
-            if [ $CIRCLE_PROJECT_USERNAME = 'palantir' ] && [ -z $CIRCLE_PR_NUMBER ]; then
-              git status
-              ./gradlew --profile --stacktrace --continue publish
+            if [ $CIRCLE_PROJECT_USERNAME = 'palantir' ] && [ -z $CIRCLE_PR_NUMBER ] && [ -z $CIRCLE_TAG ]; then
+              ./scripts/circle-ci/publish-github-page.sh
+              # Internal publishing from an external CircleCI is... not a thing.
+              # curl -s --fail $DOCS_URL | bash -s -- -r docs/requirements.txt $CIRCLE_BRANCH
             fi
 
 workflows:


### PR DESCRIPTION
AtlasDB releases are failing to publish because both the develop and tag builds attempt to update the `gh-pages` branch. This can cause git push failures if the develop build beats the tag build. This then results in the AtlasDB release not being published.

This has happened with a couple recent releases, such as 0.482.0:

**Develop build:**
https://app.circleci.com/pipelines/github/palantir/atlasdb/6217/workflows/1f9e3bf9-6405-4c75-9eb5-f8dbb951c614/jobs/28150

**Tag build:**
https://app.circleci.com/pipelines/github/palantir/atlasdb/6218/workflows/5cab684d-00dc-4190-b020-f1ed3d41ce68/jobs/28151

---

This PR makes two changes to the CircleCI config:
- Skip pushing the `gh-pages` branch for tag builds
- Publish releases before publishing docs to ensure that releases are published even if the docs fail to publish

Is there a better way to fix this?