### PR TITLE
[Transactions3] Read Coordination Service at ReadConsistency.SERIAL

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -694,7 +694,10 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
 
                         Map<ByteBuffer, List<List<ColumnOrSuperColumn>>> results =
                                 wrappingQueryRunner.multiget_multislice(
-                                        "getRows", client, tableRef, query,
+                                        "getRows",
+                                        client,
+                                        tableRef,
+                                        query,
                                         readConsistencyProvider.getConsistency(tableRef));
 
                         return Maps.transformValues(results, lists -> Lists.newArrayList(Iterables.concat(lists)));
@@ -741,7 +744,13 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         }
 
         StartTsResultsCollector collector = new StartTsResultsCollector(metricsManager, startTs);
-        cellLoader.loadWithTs("getRows", tableRef, cells, startTs, false, collector,
+        cellLoader.loadWithTs(
+                "getRows",
+                tableRef,
+                cells,
+                startTs,
+                false,
+                collector,
                 readConsistencyProvider.getConsistency(tableRef));
         return collector.getCollectedResults();
     }
@@ -780,7 +789,13 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             for (long ts : cellsByTs.keySet()) {
                 StartTsResultsCollector collector = new StartTsResultsCollector(metricsManager, ts);
                 try (CloseableTracer tracer = CloseableTracer.startSpan("loadWithTs")) {
-                    cellLoader.loadWithTs("get", tableRef, cellsByTs.get(ts), ts, false, collector,
+                    cellLoader.loadWithTs(
+                            "get",
+                            tableRef,
+                            cellsByTs.get(ts),
+                            ts,
+                            false,
+                            collector,
                             readConsistencyProvider.getConsistency(tableRef));
                 }
                 builder.putAll(collector.getCollectedResults());
@@ -796,7 +811,12 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         StartTsResultsCollector collector = new StartTsResultsCollector(metricsManager, maxTimestampExclusive);
         try (CloseableTracer tracer = CloseableTracer.startSpan("loadWithTs")) {
             cellLoader.loadWithTs(
-                    kvsMethodName, tableRef, cells, maxTimestampExclusive, false, collector,
+                    kvsMethodName,
+                    tableRef,
+                    cells,
+                    maxTimestampExclusive,
+                    false,
+                    collector,
                     readConsistencyProvider.getConsistency(tableRef));
         }
         return collector.getCollectedResults();
@@ -932,7 +952,11 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                             SlicePredicate pred = SlicePredicates.create(range, limit);
 
                             Map<ByteBuffer, List<ColumnOrSuperColumn>> results = wrappingQueryRunner.multiget(
-                                    "getRowsColumnRange", client, tableRef, wrap(rows), pred,
+                                    "getRowsColumnRange",
+                                    client,
+                                    tableRef,
+                                    wrap(rows),
+                                    pred,
                                     readConsistencyProvider.getConsistency(tableRef));
 
                             RowColumnRangeExtractor extractor = new RowColumnRangeExtractor(metricsManager);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -214,7 +214,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     private final CassandraKeyValueServiceConfig config;
     private final CassandraClientPool clientPool;
 
-    private ConsistencyLevel readConsistency = ConsistencyLevel.LOCAL_QUORUM;
+    private final ReadConsistencyProvider readConsistencyProvider = new ReadConsistencyProvider();
 
     private final TracingQueryRunner queryRunner;
     private final WrappingQueryRunner wrappingQueryRunner;
@@ -428,7 +428,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         this.cassandraTables = new CassandraTables(clientPool, config);
         this.taskRunner = new TaskRunner(executor);
         this.cellLoader = CellLoader.create(clientPool, wrappingQueryRunner, taskRunner, runtimeConfigSupplier);
-        this.rangeLoader = new RangeLoader(clientPool, queryRunner, metricsManager, readConsistency);
+        this.rangeLoader = new RangeLoader(clientPool, queryRunner, metricsManager, readConsistencyProvider);
         this.cellValuePutter = new CellValuePutter(
                 config,
                 clientPool,
@@ -556,8 +556,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                     if (currentRf == config.replicationFactor()) {
                         if (currentRf == 2 && config.clusterMeetsNormalConsistencyGuarantees()) {
                             log.info("Setting Read Consistency to ONE, as cluster has only one datacenter at RF2.");
-                            readConsistency = ConsistencyLevel.ONE;
-                            rangeLoader.setConsistencyLevel(readConsistency);
+                            readConsistencyProvider.lowerConsistencyLevelToOne();
                         }
                     }
                 }
@@ -695,7 +694,8 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
 
                         Map<ByteBuffer, List<List<ColumnOrSuperColumn>>> results =
                                 wrappingQueryRunner.multiget_multislice(
-                                        "getRows", client, tableRef, query, readConsistency);
+                                        "getRows", client, tableRef, query,
+                                        readConsistencyProvider.getConsistency(tableRef));
 
                         return Maps.transformValues(results, lists -> Lists.newArrayList(Iterables.concat(lists)));
                     }
@@ -741,7 +741,8 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         }
 
         StartTsResultsCollector collector = new StartTsResultsCollector(metricsManager, startTs);
-        cellLoader.loadWithTs("getRows", tableRef, cells, startTs, false, collector, readConsistency);
+        cellLoader.loadWithTs("getRows", tableRef, cells, startTs, false, collector,
+                readConsistencyProvider.getConsistency(tableRef));
         return collector.getCollectedResults();
     }
 
@@ -779,7 +780,8 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             for (long ts : cellsByTs.keySet()) {
                 StartTsResultsCollector collector = new StartTsResultsCollector(metricsManager, ts);
                 try (CloseableTracer tracer = CloseableTracer.startSpan("loadWithTs")) {
-                    cellLoader.loadWithTs("get", tableRef, cellsByTs.get(ts), ts, false, collector, readConsistency);
+                    cellLoader.loadWithTs("get", tableRef, cellsByTs.get(ts), ts, false, collector,
+                            readConsistencyProvider.getConsistency(tableRef));
                 }
                 builder.putAll(collector.getCollectedResults());
             }
@@ -794,7 +796,8 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         StartTsResultsCollector collector = new StartTsResultsCollector(metricsManager, maxTimestampExclusive);
         try (CloseableTracer tracer = CloseableTracer.startSpan("loadWithTs")) {
             cellLoader.loadWithTs(
-                    kvsMethodName, tableRef, cells, maxTimestampExclusive, false, collector, readConsistency);
+                    kvsMethodName, tableRef, cells, maxTimestampExclusive, false, collector,
+                    readConsistencyProvider.getConsistency(tableRef));
         }
         return collector.getCollectedResults();
     }
@@ -929,7 +932,8 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                             SlicePredicate pred = SlicePredicates.create(range, limit);
 
                             Map<ByteBuffer, List<ColumnOrSuperColumn>> results = wrappingQueryRunner.multiget(
-                                    "getRowsColumnRange", client, tableRef, wrap(rows), pred, readConsistency);
+                                    "getRowsColumnRange", client, tableRef, wrap(rows), pred,
+                                    readConsistencyProvider.getConsistency(tableRef));
 
                             RowColumnRangeExtractor extractor = new RowColumnRangeExtractor(metricsManager);
                             extractor.extractResults(rows, results, startTs);
@@ -995,7 +999,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                                                         tableRef,
                                                         ImmutableList.of(rowByteBuffer),
                                                         pred,
-                                                        readConsistency);
+                                                        readConsistencyProvider.getConsistency(tableRef));
 
                                         if (results.isEmpty()) {
                                             return SimpleTokenBackedResultsPage.create(

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/RangeLoader.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/RangeLoader.java
@@ -50,8 +50,7 @@ public class RangeLoader {
     }
 
     public ClosableIterator<RowResult<Value>> getRange(TableReference tableRef, RangeRequest rangeRequest, long ts) {
-        return getRangeWithPageCreator(
-                tableRef, rangeRequest, ts, () -> ValueExtractor.create(metricsManager));
+        return getRangeWithPageCreator(tableRef, rangeRequest, ts, () -> ValueExtractor.create(metricsManager));
     }
 
     private <T> ClosableIterator<RowResult<T>> getRangeWithPageCreator(
@@ -68,8 +67,8 @@ public class RangeLoader {
             // each column. note that if no columns are specified, it's a special case that means all columns
             predicate = SlicePredicates.create(SlicePredicates.Range.ALL, SlicePredicates.Limit.NO_LIMIT);
         }
-        RowGetter rowGetter = new RowGetter(clientPool, queryRunner, readConsistencyProvider.getConsistency(tableRef),
-                tableRef);
+        RowGetter rowGetter =
+                new RowGetter(clientPool, queryRunner, readConsistencyProvider.getConsistency(tableRef), tableRef);
         ColumnGetter columnGetter = new ThriftColumnGetter();
 
         return getRangeWithPageCreator(rowGetter, predicate, columnGetter, rangeRequest, resultsExtractor, startTs);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ReadConsistencyProvider.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ReadConsistencyProvider.java
@@ -34,8 +34,7 @@ public final class ReadConsistencyProvider {
 
     private static final ConsistencyLevel DEFAULT_CONSISTENCY = ConsistencyLevel.LOCAL_QUORUM;
 
-    private final AtomicReference<ConsistencyLevel> defaultReadConsistency =
-            new AtomicReference<>(DEFAULT_CONSISTENCY);
+    private final AtomicReference<ConsistencyLevel> defaultReadConsistency = new AtomicReference<>(DEFAULT_CONSISTENCY);
 
     public ConsistencyLevel getConsistency(TableReference tableReference) {
         if (AtlasDbConstants.SERIAL_CONSISTENCY_ATOMIC_TABLES.contains(tableReference)) {
@@ -48,7 +47,8 @@ public final class ReadConsistencyProvider {
         while (defaultReadConsistency.get() != ConsistencyLevel.ONE) {
             boolean update = defaultReadConsistency.compareAndSet(DEFAULT_CONSISTENCY, ConsistencyLevel.ONE);
             if (update) {
-                log.info("Lowering read consistency level to ONE.",
+                log.info(
+                        "Lowering read consistency level to ONE.",
                         SafeArg.of("originalReadConsistency", DEFAULT_CONSISTENCY),
                         new SafeRuntimeException("I exist to show you the stack trace."));
             }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ReadConsistencyProvider.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ReadConsistencyProvider.java
@@ -44,14 +44,22 @@ public final class ReadConsistencyProvider {
     }
 
     public void lowerConsistencyLevelToOne() {
-        while (defaultReadConsistency.get() != ConsistencyLevel.ONE) {
+        if (defaultReadConsistency.get() != ConsistencyLevel.ONE) {
             boolean update = defaultReadConsistency.compareAndSet(DEFAULT_CONSISTENCY, ConsistencyLevel.ONE);
             if (update) {
                 log.info(
                         "Lowering read consistency level to ONE.",
                         SafeArg.of("originalReadConsistency", DEFAULT_CONSISTENCY),
                         new SafeRuntimeException("I exist to show you the stack trace."));
+            } else {
+                log.info(
+                        "Could not lower read consistency level to ONE.",
+                        SafeArg.of("currentReadConsistency", defaultReadConsistency.get()),
+                        SafeArg.of("defaultReadConsistency", DEFAULT_CONSISTENCY),
+                        new SafeRuntimeException("I exist to show you the stack trace."));
             }
+        } else {
+            log.info("Did not lower read consistency to ONE because it was already ONE.");
         }
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ReadConsistencyProvider.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ReadConsistencyProvider.java
@@ -1,0 +1,57 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.cassandra.thrift.ConsistencyLevel;
+
+/**
+ * Indicates to other Cassandra operations what consistency read operations should be performed at.
+ * Notice that this may differ by table.
+ */
+public final class ReadConsistencyProvider {
+    private static final SafeLogger log = SafeLoggerFactory.get(ReadConsistencyProvider.class);
+
+    private static final ConsistencyLevel DEFAULT_CONSISTENCY = ConsistencyLevel.LOCAL_QUORUM;
+
+    private final AtomicReference<ConsistencyLevel> defaultReadConsistency =
+            new AtomicReference<>(DEFAULT_CONSISTENCY);
+
+    public ConsistencyLevel getConsistency(TableReference tableReference) {
+        if (AtlasDbConstants.SERIAL_CONSISTENCY_ATOMIC_TABLES.contains(tableReference)) {
+            return ConsistencyLevel.LOCAL_SERIAL;
+        }
+        return defaultReadConsistency.get();
+    }
+
+    public void lowerConsistencyLevelToOne() {
+        while (defaultReadConsistency.get() != ConsistencyLevel.ONE) {
+            boolean update = defaultReadConsistency.compareAndSet(DEFAULT_CONSISTENCY, ConsistencyLevel.ONE);
+            if (update) {
+                log.info("Lowering read consistency level to ONE.",
+                        SafeArg.of("originalReadConsistency", DEFAULT_CONSISTENCY),
+                        new SafeRuntimeException("I exist to show you the stack trace."));
+            }
+        }
+    }
+}

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/ReadConsistencyProviderTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/ReadConsistencyProviderTest.java
@@ -93,6 +93,7 @@ public class ReadConsistencyProviderTest {
         executorService.shutdown();
         boolean successfulShutdown = executorService.awaitTermination(5, TimeUnit.SECONDS);
         assertThat(successfulShutdown).isTrue();
-        consistencyLevelLoweringFutures.forEach(future -> assertThat(future.isDone()).isTrue());
+        consistencyLevelLoweringFutures.forEach(
+                future -> assertThat(future.isDone()).isTrue());
     }
 }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/ReadConsistencyProviderTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/ReadConsistencyProviderTest.java
@@ -1,0 +1,71 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import org.apache.cassandra.thrift.ConsistencyLevel;
+import org.junit.Test;
+
+public class ReadConsistencyProviderTest {
+    private static final TableReference TABLE_1 = TableReference.createFromFullyQualifiedName("bobby.tables");
+    private static final TableReference TABLE_2 = TableReference.createFromFullyQualifiedName("robert.tische");
+
+    private final ReadConsistencyProvider provider = new ReadConsistencyProvider();
+
+    @Test
+    public void defaultReadConsistencyIsLocalQuorum() {
+        assertThat(provider.getConsistency(TABLE_1)).isEqualTo(ConsistencyLevel.LOCAL_QUORUM);
+        assertThat(provider.getConsistency(TABLE_2)).isEqualTo(ConsistencyLevel.LOCAL_QUORUM);
+    }
+
+    @Test
+    public void consistencyForAtomicSerialTablesIsLocalSerial() {
+        AtlasDbConstants.SERIAL_CONSISTENCY_ATOMIC_TABLES.forEach(tableReference ->
+                assertThat(provider.getConsistency(tableReference)).isEqualTo(ConsistencyLevel.LOCAL_SERIAL));
+    }
+
+    @Test
+    public void consistencyForAtomicSerialTablesRemainsLocalSerialEvenAfterBroadConsistencyDowngrade() {
+        provider.lowerConsistencyLevelToOne();
+        AtlasDbConstants.SERIAL_CONSISTENCY_ATOMIC_TABLES.forEach(tableReference ->
+                assertThat(provider.getConsistency(tableReference)).isEqualTo(ConsistencyLevel.LOCAL_SERIAL));
+    }
+
+    @Test
+    public void consistencyForNonAtomicSerialTablesIsLocalSerial() {
+        AtlasDbConstants.NON_SERIAL_CONSISTENCY_ATOMIC_TABLES.forEach(tableReference ->
+                assertThat(provider.getConsistency(tableReference)).isEqualTo(ConsistencyLevel.LOCAL_QUORUM));
+    }
+
+    @Test
+    public void canLowerConsistencyToOne() {
+        assertThat(provider.getConsistency(TABLE_1)).isEqualTo(ConsistencyLevel.LOCAL_QUORUM);
+        provider.lowerConsistencyLevelToOne();
+        assertThat(provider.getConsistency(TABLE_1)).isEqualTo(ConsistencyLevel.ONE);
+    }
+
+    @Test
+    public void separateProvidersHaveSeparateLifecycles() {
+        ReadConsistencyProvider anotherProvider = new ReadConsistencyProvider();
+        anotherProvider.lowerConsistencyLevelToOne();
+        assertThat(anotherProvider.getConsistency(TABLE_1)).isEqualTo(ConsistencyLevel.ONE);
+        assertThat(provider.getConsistency(TABLE_1)).isEqualTo(ConsistencyLevel.LOCAL_QUORUM);
+    }
+}

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/ReadConsistencyProviderTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/ReadConsistencyProviderTest.java
@@ -19,14 +19,18 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
+import com.google.common.util.concurrent.Futures;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.common.concurrent.PTExecutors;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.apache.cassandra.thrift.ConsistencyLevel;
 import org.junit.Test;
 
@@ -84,15 +88,43 @@ public class ReadConsistencyProviderTest {
     }
 
     @Test
-    public void concurrentUpdatePermitted() throws InterruptedException {
+    public void concurrentUpdatesAndReadsPermitted() throws InterruptedException {
         ExecutorService executorService = PTExecutors.newCachedThreadPool();
+        List<Future<ConsistencyLevel>> readFutures = new ArrayList<>();
         List<Future<?>> consistencyLevelLoweringFutures = new ArrayList<>();
+        CountDownLatch latchBlockedOnFiftyCompletedReads = new CountDownLatch(50);
         for (int index = 0; index < 100; index++) {
-            consistencyLevelLoweringFutures.add(executorService.submit(provider::lowerConsistencyLevelToOne));
+            readFutures.add(executorService.submit(() -> {
+                ConsistencyLevel level = provider.getConsistency(TABLE_1);
+                latchBlockedOnFiftyCompletedReads.countDown();
+                return level;
+            }));
+        }
+        for (int index = 0; index < 5; index++) {
+            consistencyLevelLoweringFutures.add(executorService.submit(() -> {
+                try {
+                    latchBlockedOnFiftyCompletedReads.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+                provider.lowerConsistencyLevelToOne();
+            }));
         }
         executorService.shutdown();
         boolean successfulShutdown = executorService.awaitTermination(5, TimeUnit.SECONDS);
         assertThat(successfulShutdown).isTrue();
+
+        Map<ConsistencyLevel, Long> consistencyLevelReadCount = readFutures.stream()
+                .map(Futures::getUnchecked)
+                .collect(Collectors.groupingBy(x -> x, Collectors.counting()));
+        assertThat(consistencyLevelReadCount.keySet())
+                .containsExactlyInAnyOrder(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.ONE);
+        assertThat(consistencyLevelReadCount.get(ConsistencyLevel.LOCAL_QUORUM)).isGreaterThanOrEqualTo(50);
+        assertThat(consistencyLevelReadCount.get(ConsistencyLevel.ONE)).isLessThanOrEqualTo(50);
+        assertThat(consistencyLevelReadCount.values().stream().mapToLong(x -> x).sum())
+                .isEqualTo(100);
+
         consistencyLevelLoweringFutures.forEach(
                 future -> assertThat(future.isDone()).isTrue());
     }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/ReadConsistencyProviderTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/ReadConsistencyProviderTest.java
@@ -56,7 +56,7 @@ public class ReadConsistencyProviderTest {
     }
 
     @Test
-    public void consistencyForNonAtomicSerialTablesIsLocalSerial() {
+    public void consistencyForNonSerialAtomicTablesIsLocalQuorum() {
         AtlasDbConstants.NON_SERIAL_CONSISTENCY_ATOMIC_TABLES.forEach(tableReference ->
                 assertThat(provider.getConsistency(tableReference)).isEqualTo(ConsistencyLevel.LOCAL_QUORUM));
     }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -140,9 +140,11 @@ public final class AtlasDbConstants {
      * is to ensure that decisions are made the set of {@link #ATOMIC_TABLES}.
      */
     public static final ImmutableSet<TableReference> NON_SERIAL_CONSISTENCY_ATOMIC_TABLES = ImmutableSet.of(
-            NAMESPACE_TABLE, // Used for KvTableMappingService, only by Oracle
             TransactionConstants.TRANSACTION_TABLE, // Bankruptcy
-            TransactionConstants.TRANSACTIONS2_TABLE); // Bankruptcy for Transactions2, handled for Transactions3
+            TransactionConstants.TRANSACTIONS2_TABLE, // Bankruptcy for Transactions2, handled for Transactions3
+            NAMESPACE_TABLE, // Used for KvTableMappingService, only by Oracle
+            PERSISTED_LOCKS_TABLE // Maintained for legacy purposes
+    );
 
     public static final ImmutableSet<TableReference> TABLES_KNOWN_TO_BE_POORLY_DESIGNED =
             ImmutableSet.of(TableReference.createWithEmptyNamespace("resync_object"));

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -132,8 +132,8 @@ public final class AtlasDbConstants {
      * critical. See ResilientCommitTimestampPutUnlessExistsTable for an example of how to work around such
      * limitations for the {@link TransactionConstants#TRANSACTIONS2_TABLE}.
      */
-    public static final ImmutableSet<TableReference> SERIAL_CONSISTENCY_ATOMIC_TABLES = ImmutableSet.of(
-            COORDINATION_TABLE);
+    public static final ImmutableSet<TableReference> SERIAL_CONSISTENCY_ATOMIC_TABLES =
+            ImmutableSet.of(COORDINATION_TABLE);
 
     /**
      * These tables are atomic tables, but are not intended to be read in a high-cost mode. The intention of this set
@@ -144,7 +144,7 @@ public final class AtlasDbConstants {
             TransactionConstants.TRANSACTIONS2_TABLE, // Bankruptcy for Transactions2, handled for Transactions3
             NAMESPACE_TABLE, // Used for KvTableMappingService, only by Oracle
             PERSISTED_LOCKS_TABLE // Maintained for legacy purposes
-    );
+            );
 
     public static final ImmutableSet<TableReference> TABLES_KNOWN_TO_BE_POORLY_DESIGNED =
             ImmutableSet.of(TableReference.createWithEmptyNamespace("resync_object"));

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -122,6 +122,28 @@ public final class AtlasDbConstants {
             PERSISTED_LOCKS_TABLE,
             COORDINATION_TABLE);
 
+    /**
+     * Some key-value services may support atomic put unless exists and check and touch operations, but fail to
+     * guarantee repeatable reads in the general case. They may offer (potentially more costly) options for reading
+     * cells that do support repeatable reads.
+     *
+     * Where applicable, tables in this set should ideally not be read frequently. Implementers are encouraged to
+     * provide alternative solutions in cases where the tables are read frequently and/or read performance is
+     * critical. See ResilientCommitTimestampPutUnlessExistsTable for an example of how to work around such
+     * limitations for the {@link TransactionConstants#TRANSACTIONS2_TABLE}.
+     */
+    public static final ImmutableSet<TableReference> SERIAL_CONSISTENCY_ATOMIC_TABLES = ImmutableSet.of(
+            COORDINATION_TABLE);
+
+    /**
+     * These tables are atomic tables, but are not intended to be read in a high-cost mode. The intention of this set
+     * is to ensure that decisions are made the set of {@link #ATOMIC_TABLES}.
+     */
+    public static final ImmutableSet<TableReference> NON_SERIAL_CONSISTENCY_ATOMIC_TABLES = ImmutableSet.of(
+            NAMESPACE_TABLE, // Used for KvTableMappingService, only by Oracle
+            TransactionConstants.TRANSACTION_TABLE, // Bankruptcy
+            TransactionConstants.TRANSACTIONS2_TABLE); // Bankruptcy for Transactions2, handled for Transactions3
+
     public static final ImmutableSet<TableReference> TABLES_KNOWN_TO_BE_POORLY_DESIGNED =
             ImmutableSet.of(TableReference.createWithEmptyNamespace("resync_object"));
 

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/AtlasDbConstantsTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/AtlasDbConstantsTest.java
@@ -25,8 +25,8 @@ public class AtlasDbConstantsTest {
     @Test
     public void allAtomicTablesHaveExplicitReadConsistencyDecision() {
         assertThat(Sets.union(
-                AtlasDbConstants.NON_SERIAL_CONSISTENCY_ATOMIC_TABLES,
-                AtlasDbConstants.SERIAL_CONSISTENCY_ATOMIC_TABLES))
+                        AtlasDbConstants.NON_SERIAL_CONSISTENCY_ATOMIC_TABLES,
+                        AtlasDbConstants.SERIAL_CONSISTENCY_ATOMIC_TABLES))
                 .isEqualTo(AtlasDbConstants.ATOMIC_TABLES);
     }
 }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/AtlasDbConstantsTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/AtlasDbConstantsTest.java
@@ -1,0 +1,32 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.Sets;
+import org.junit.Test;
+
+public class AtlasDbConstantsTest {
+    @Test
+    public void allAtomicTablesHaveExplicitReadConsistencyDecision() {
+        assertThat(Sets.union(
+                AtlasDbConstants.NON_SERIAL_CONSISTENCY_ATOMIC_TABLES,
+                AtlasDbConstants.SERIAL_CONSISTENCY_ATOMIC_TABLES))
+                .isEqualTo(AtlasDbConstants.ATOMIC_TABLES);
+    }
+}

--- a/changelog/@unreleased/pr-5794.v2.yml
+++ b/changelog/@unreleased/pr-5794.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: AtlasDB now reads the coordination service's tables at ReadConsistency.LOCAL_SERIAL.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5794


### PR DESCRIPTION
**Goals (and why)**:
- In general, CAS tables where we don't have protection are vulnerable to the same issue as the transactions table. We want to minimise our risk in these cases (while, at the same time, we do not have a broad solution).

**Implementation Description (bullets)**:
- Two main things. Factoring out a ReadConsistencyProvider, and introducing a concept of serial atomic tables.

**Testing (What was existing testing like?  What have you done to improve it?)**: New components are properly tested.

**Concerns (what feedback would you like?)**:
- Does the concept of serial tables make sense more broadly / should this be a thing that _only_ lives in Cassandra? Given that we have the notion of CAS consistency, this doesn't seem too unreasonable but I'm not 100% certain.

**Where should we start reviewing?**: ReadConsistencyProvider

**Priority (whenever / two weeks / yesterday)**: this week