### PR TITLE
[Transactions3] Resolve accidental flakes around concurrentUpdatesAndReadsPermitted

### DIFF
--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/ReadConsistencyProviderTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/ReadConsistencyProviderTest.java
@@ -128,10 +128,8 @@ public class ReadConsistencyProviderTest {
                 .collect(Collectors.groupingBy(x -> x, Collectors.counting()));
         assertThat(consistencyLevelReadCount.keySet())
                 .containsExactlyInAnyOrder(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.ONE);
-        assertThat(consistencyLevelReadCount.get(ConsistencyLevel.LOCAL_QUORUM))
-                .isGreaterThanOrEqualTo(30);
-        assertThat(consistencyLevelReadCount.get(ConsistencyLevel.ONE))
-                .isGreaterThanOrEqualTo(50);
+        assertThat(consistencyLevelReadCount.get(ConsistencyLevel.LOCAL_QUORUM)).isGreaterThanOrEqualTo(30);
+        assertThat(consistencyLevelReadCount.get(ConsistencyLevel.ONE)).isGreaterThanOrEqualTo(50);
         assertThat(consistencyLevelReadCount.values().stream().mapToLong(x -> x).sum())
                 .isEqualTo(100);
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -376,8 +376,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
             assertThat(t.getTimestamp()).isLessThan(timestampService.getFreshTimestamp());
             return t.getTimestamp();
         });
-        assertThat(firstTs).isLessThan(txManager.getImmutableTimestamp());
-        assertThat(startTs).isLessThan(txManager.getImmutableTimestamp());
+        assertThat(firstTs).isLessThan(txManager.getImmutableTimestamp()); // pass
+        assertThat(startTs).isLessThan(txManager.getImmutableTimestamp()); // startTs = 4, immutableTs = 3, failed
     }
 
     // If lock happens concurrent with get, we aren't sure that we can rollback the transaction

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -376,8 +376,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
             assertThat(t.getTimestamp()).isLessThan(timestampService.getFreshTimestamp());
             return t.getTimestamp();
         });
-        assertThat(firstTs).isLessThan(txManager.getImmutableTimestamp()); // pass
-        assertThat(startTs).isLessThan(txManager.getImmutableTimestamp()); // startTs = 4, immutableTs = 3, failed
+        assertThat(firstTs).isLessThan(txManager.getImmutableTimestamp());
+        assertThat(startTs).isLessThan(txManager.getImmutableTimestamp());
     }
 
     // If lock happens concurrent with get, we aren't sure that we can rollback the transaction


### PR DESCRIPTION
**Goals (and why)**:
- Resolve an edge case with concurrentUpdatesAndReadsPermitted that could result in an assertion getting violated.
- Flakes are bad

**Implementation Description (bullets)**:
- Force some things to wait

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Only reworking one test

**Concerns (what feedback would you like?)**:
- Flake rate

**Where should we start reviewing?**: whenever

**Priority (whenever / two weeks / yesterday)**: yesterday