### PR TITLE
Weaken Overly-Strong Assertions in Tests Assuming Eager Unlocking

### DIFF
--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweepTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweepTest.java
@@ -176,12 +176,30 @@ public class TargetedSweepTest extends AtlasDbTestCase {
         long startTs = putWriteAndFailOnPreCommitConditionReturningStartTimestamp(SINGLE_WRITE);
 
         serializableTxManager.setUnreadableTimestamp(startTs + 1);
+        waitForImmutableTimestampToBeStrictlyGreaterThan(startTs);
+        sweepNextBatch(ShardAndStrategy.conservative(0));
+        assertNoEntryForCellInKvs(TABLE_CONS, TEST_CELL);
+    }
+
+    /**
+     * After this method returns successfully, there has existed some point in time when the immutable timestamp from
+     * the {@link #serializableTxManager} was strictly greater than the timestamp parameter that was passed. In the
+     * absence of concurrent transaction starts, this also means that the immutable timestamp will be
+     * strictly greater than the timestamp parameter going forward.
+     *
+     * Note that in the general case, this does not guarantee that the immutable timestamp is currently greater than
+     * the timestamp parameter in the presence of concurrent transaction starts, since under certain scheduling
+     * conditions it may go backwards.
+     *
+     * The purpose of this method is to ensure that, for tests that assert that Sweep has deleted values written in a
+     * given transaction, that that transaction has released its immutable timestamp lock. This happens
+     * asynchronously, and thus an explicit wait is needed to avoid race conditions.
+     */
+    private void waitForImmutableTimestampToBeStrictlyGreaterThan(long timestampToBePassed) {
         Awaitility.await()
                 .atMost(5, TimeUnit.SECONDS)
                 .pollInterval(10, TimeUnit.MILLISECONDS)
-                .until(() -> startTs < serializableTxManager.getImmutableTimestamp());
-        sweepNextBatch(ShardAndStrategy.conservative(0));
-        assertNoEntryForCellInKvs(TABLE_CONS, TEST_CELL);
+                .until(() -> timestampToBePassed < serializableTxManager.getImmutableTimestamp());
     }
 
     @Test

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweepTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweepTest.java
@@ -320,7 +320,7 @@ public class TargetedSweepTest extends AtlasDbTestCase {
     /**
      * After this method returns successfully, we know that there has existed some point in time when the immutable
      * timestamp from the {@link #serializableTxManager} was strictly greater than the timestamp parameter that was
-     * passed. ote that in the general case, this does not guarantee that the immutable timestamp is currently
+     * passed. Note that in the general case, this does not guarantee that the immutable timestamp is currently
      * greater than the timestamp parameter in the presence of concurrent transaction starts. This is because it may
      * go backwards under certain (non-deterministic) scheduling conditions. Writers of sweep tests must ensure that
      * this is the case when writing their tests.


### PR DESCRIPTION
**Goals (and why)**:
- In #5695, we switched in-memory timestamp and lock services to use `InMemoryTimelockServices`. This introduced a small (and generally positive) behavioural change: the implementation of `tryUnlock(LockToken)` used to synchronously perform an unlock, while now it performs it asynchronously. However, this has implications for tests that make assertions relating to Sweep and/or getImmutableTimestamp().

**Implementation Description (bullets)**:
- Introduce appropriate awaits in tests to check the immutable timestamp had advanced.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Does this flake as much?

**Concerns (what feedback would you like?)**:
- Are there other tests where we should add something like this?
- An alternative design is for us to introduce a delegating layer that ensures unlock is blocking, but I don't think that's good (we should test code in a way that's as similar to production as possible).

**Where should we start reviewing?**: it's small

**Priority (whenever / two weeks / yesterday)**: this week please