### PR TITLE
[Transactions3] ResilientCommitTimestampPutUnlessExistsTableIntegrationTest

### DIFF
--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/pue/CassandraImitatingConsensusForgettingStore.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/pue/CassandraImitatingConsensusForgettingStore.java
@@ -140,7 +140,11 @@ public class CassandraImitatingConsensusForgettingStore implements ConsensusForg
      */
     @Override
     public ListenableFuture<Optional<byte[]>> get(Cell cell) {
-        return Futures.immediateFuture(getInternal(cell, getQuorumNodes()).map(BytesAndTimestamp::bytes));
+        try {
+            return Futures.immediateFuture(getInternal(cell, getQuorumNodes()).map(BytesAndTimestamp::bytes));
+        } catch (RuntimeException e) {
+            return Futures.immediateFailedFuture(e);
+        }
     }
 
     @Override

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/pue/ResilientCommitTimestampPutUnlessExistsTableIntegrationTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/pue/ResilientCommitTimestampPutUnlessExistsTableIntegrationTest.java
@@ -87,8 +87,12 @@ public class ResilientCommitTimestampPutUnlessExistsTableIntegrationTest {
                 .isTrue();
 
         timestampReaders.forEach((_startTimestamp, reader) -> reader.close());
-        timestampReaders.forEach(ResilientCommitTimestampPutUnlessExistsTableIntegrationTest::validateIndividualReaderHadRepeatableReads);
-        timestampReaders.asMap().forEach((_startTimestamp, readers) -> validateConsistencyObservedAcrossReaders(readers));
+        timestampReaders.forEach(
+                ResilientCommitTimestampPutUnlessExistsTableIntegrationTest
+                        ::validateIndividualReaderHadRepeatableReads);
+        timestampReaders
+                .asMap()
+                .forEach((_startTimestamp, readers) -> validateConsistencyObservedAcrossReaders(readers));
     }
 
     private static void validateIndividualReaderHadRepeatableReads(Long startTimestamp, TimestampReader reader) {
@@ -98,12 +102,9 @@ public class ResilientCommitTimestampPutUnlessExistsTableIntegrationTest {
                 .as("can only read at most 2 distinct values: empty and a single fixed value")
                 .hasSizeLessThanOrEqualTo(2);
         if (readSet.size() == 2) {
-            Set<OptionalLong> valuesRead = readSet.stream()
-                    .filter(OptionalLong::isPresent)
-                    .collect(Collectors.toSet());
-            assertThat(valuesRead)
-                    .as("can only read at most 1 fixed value")
-                    .hasSize(1);
+            Set<OptionalLong> valuesRead =
+                    readSet.stream().filter(OptionalLong::isPresent).collect(Collectors.toSet());
+            assertThat(valuesRead).as("can only read at most 1 fixed value").hasSize(1);
 
             OptionalLong concreteValue = Iterables.getOnlyElement(valuesRead);
             assertThat(reads.subList(0, reads.indexOf(concreteValue)))
@@ -116,7 +117,8 @@ public class ResilientCommitTimestampPutUnlessExistsTableIntegrationTest {
     }
 
     private Multimap<Long, TimestampReader> createStartedTimestampReaders() {
-        Multimap<Long, TimestampReader> timestampReaders = MultimapBuilder.hashKeys().arrayListValues().build();
+        Multimap<Long, TimestampReader> timestampReaders =
+                MultimapBuilder.hashKeys().arrayListValues().build();
         for (long startTimestamp = 1; startTimestamp <= MAXIMUM_EVALUATED_TIMESTAMP; startTimestamp++) {
             for (int concurrentReader = 1; concurrentReader <= 5; concurrentReader++) {
                 timestampReaders.put(startTimestamp, new TimestampReader(startTimestamp, pueTable));
@@ -144,9 +146,7 @@ public class ResilientCommitTimestampPutUnlessExistsTableIntegrationTest {
         private final List<OptionalLong> timestampReads;
         private final ScheduledExecutorService scheduledExecutorService;
 
-        private TimestampReader(
-                long startTimestamp,
-                PutUnlessExistsTable<Long, Long> pueTable) {
+        private TimestampReader(long startTimestamp, PutUnlessExistsTable<Long, Long> pueTable) {
             this.startTimestamp = startTimestamp;
             this.pueTable = pueTable;
             this.timestampReads = new ArrayList<>();

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/pue/ResilientCommitTimestampPutUnlessExistsTableIntegrationTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/pue/ResilientCommitTimestampPutUnlessExistsTableIntegrationTest.java
@@ -1,0 +1,168 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.pue;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.MultimapBuilder;
+import com.google.common.util.concurrent.Uninterruptibles;
+import com.palantir.atlasdb.transaction.encoding.TwoPhaseEncodingStrategy;
+import com.palantir.common.concurrent.PTExecutors;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import org.immutables.value.Value;
+import org.junit.Test;
+
+public class ResilientCommitTimestampPutUnlessExistsTableIntegrationTest {
+    private static final double WRITE_FAILURE_PROBABILITY = 0.1;
+
+    private final ConsensusForgettingStore forgettingStore =
+            new CassandraImitatingConsensusForgettingStore(WRITE_FAILURE_PROBABILITY);
+    private final PutUnlessExistsTable<Long, Long> pueTable =
+            new ResilientCommitTimestampPutUnlessExistsTable(forgettingStore, TwoPhaseEncodingStrategy.INSTANCE);
+
+    @Test
+    public void repeatableReads() throws InterruptedException {
+        ExecutorService executorService = Executors.newCachedThreadPool();
+        List<Future<Object>> writerFutures = new ArrayList<>();
+        List<Future<TimestampPair>> readFutures = new ArrayList<>();
+        CountDownLatch writeExecutionLatch = new CountDownLatch(1);
+
+        for (long startTimestamp = 1; startTimestamp <= 50; startTimestamp++) {
+            for (int concurrentWriter = 1; concurrentWriter <= 10; concurrentWriter++) {
+                int finalConcurrentWriter = concurrentWriter;
+                long finalStartTimestamp = startTimestamp;
+
+                Future<Object> writerFuture = executorService.submit(() -> {
+                    try {
+                        writeExecutionLatch.await();
+                        Uninterruptibles.sleepUninterruptibly(
+                                ThreadLocalRandom.current().nextInt(10), TimeUnit.MILLISECONDS);
+                        pueTable.putUnlessExists(finalStartTimestamp, finalStartTimestamp + finalConcurrentWriter);
+                    } catch (RuntimeException e) {
+                        // Expected - some failures will happen as part of our test.
+                    }
+                    return null;
+                });
+                writerFutures.add(writerFuture);
+            }
+        }
+
+        Multimap<Long, TimestampReader> timestampReaders = MultimapBuilder.hashKeys().arrayListValues().build();
+        for (long startTimestamp = 1; startTimestamp <= 50; startTimestamp++) {
+            for (int concurrentReader = 1; concurrentReader <= 10; concurrentReader++) {
+                timestampReaders.put(startTimestamp, new TimestampReader(startTimestamp, pueTable));
+            }
+        }
+        timestampReaders.forEach((_startTimestamp, reader) -> reader.start());
+
+        writeExecutionLatch.countDown();
+        executorService.shutdown();
+        executorService.awaitTermination(3, TimeUnit.SECONDS);
+
+        writerFutures.forEach(future -> {
+            try {
+                future.get();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                // Expected - some failures will happen as part of our test.
+            } catch (ExecutionException e) {
+                // Expected - some failures will happen as part of our test.
+            }
+        });
+        timestampReaders.forEach((_startTimestamp, reader) -> reader.close());
+        timestampReaders.forEach((startTimestamp, reader) -> System.out.println(reader.getTimestampReads()));
+    }
+
+    static <T> Optional<T> exceptionSwallowingGet(Future<T> future) {
+        try {
+            T element = future.get();
+            if (element != null) {
+                return Optional.of(element);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            // Expected - some failures will happen as part of our test.
+        } catch (ExecutionException e) {
+            // Expected - some failures will happen as part of our test.
+        }
+        return Optional.empty();
+    }
+
+    private static class TimestampReader implements AutoCloseable {
+        private final long startTimestamp;
+        private final PutUnlessExistsTable<Long, Long> pueTable;
+        private final List<OptionalLong> timestampReads;
+        private final ScheduledExecutorService scheduledExecutorService;
+
+        private TimestampReader(
+                long startTimestamp,
+                PutUnlessExistsTable<Long, Long> pueTable) {
+            this.startTimestamp = startTimestamp;
+            this.pueTable = pueTable;
+            this.timestampReads = new ArrayList<>();
+            this.scheduledExecutorService = PTExecutors.newSingleThreadScheduledExecutor();
+        }
+
+        public List<OptionalLong> getTimestampReads() {
+            return ImmutableList.copyOf(timestampReads);
+        }
+
+        public void start() {
+            scheduledExecutorService.scheduleAtFixedRate(this::readOneIteration, 0, 10, TimeUnit.MILLISECONDS);
+        }
+
+        public void readOneIteration() {
+            try {
+                Long rawRead = pueTable.get(startTimestamp).get();
+                if (rawRead == null) {
+                    timestampReads.add(OptionalLong.empty());
+                } else {
+                    timestampReads.add(OptionalLong.of(rawRead));
+                }
+            } catch (Exception e) {
+                // Expected - some failures will happen as part of our test.
+            }
+        }
+
+        @Override
+        public void close() {
+            scheduledExecutorService.shutdown();
+        }
+    }
+
+    @Value.Immutable
+    interface TimestampPair {
+        long startTimestamp();
+
+        OptionalLong commitTimestamp();
+
+        static ImmutableTimestampPair.Builder builder() {
+            return ImmutableTimestampPair.builder();
+        }
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/pue/ResilientCommitTimestampPutUnlessExistsTableIntegrationTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/pue/ResilientCommitTimestampPutUnlessExistsTableIntegrationTest.java
@@ -34,12 +34,10 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import org.immutables.value.Value;
 import org.junit.Test;
 
 public class ResilientCommitTimestampPutUnlessExistsTableIntegrationTest {
@@ -55,7 +53,6 @@ public class ResilientCommitTimestampPutUnlessExistsTableIntegrationTest {
     public void repeatableReads() throws InterruptedException {
         Multimap<Long, TimestampReader> timestampReaders = createStartedTimestampReaders();
 
-        List<Future<Object>> writerFutures = new ArrayList<>();
         CountDownLatch writeExecutionLatch = new CountDownLatch(1);
         ExecutorService writeExecutor = Executors.newCachedThreadPool();
 
@@ -64,7 +61,7 @@ public class ResilientCommitTimestampPutUnlessExistsTableIntegrationTest {
                 int finalConcurrentWriter = concurrentWriter;
                 long finalStartTimestamp = startTimestamp;
 
-                Future<Object> writerFuture = writeExecutor.submit(() -> {
+                writeExecutor.submit(() -> {
                     try {
                         writeExecutionLatch.await();
                         Uninterruptibles.sleepUninterruptibly(
@@ -75,7 +72,6 @@ public class ResilientCommitTimestampPutUnlessExistsTableIntegrationTest {
                     }
                     return null;
                 });
-                writerFutures.add(writerFuture);
             }
         }
 
@@ -177,17 +173,6 @@ public class ResilientCommitTimestampPutUnlessExistsTableIntegrationTest {
         @Override
         public void close() {
             scheduledExecutorService.shutdown();
-        }
-    }
-
-    @Value.Immutable
-    interface TimestampPair {
-        long startTimestamp();
-
-        OptionalLong commitTimestamp();
-
-        static ImmutableTimestampPair.Builder builder() {
-            return ImmutableTimestampPair.builder();
         }
     }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/pue/ResilientCommitTimestampPutUnlessExistsTableIntegrationTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/pue/ResilientCommitTimestampPutUnlessExistsTableIntegrationTest.java
@@ -136,7 +136,7 @@ public class ResilientCommitTimestampPutUnlessExistsTableIntegrationTest {
                 .hasSizeLessThanOrEqualTo(1);
     }
 
-    private static class TimestampReader implements AutoCloseable {
+    private static final class TimestampReader implements AutoCloseable {
         private final long startTimestamp;
         private final PutUnlessExistsTable<Long, Long> pueTable;
         private final List<OptionalLong> timestampReads;

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/pue/ResilientCommitTimestampPutUnlessExistsTableIntegrationTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/pue/ResilientCommitTimestampPutUnlessExistsTableIntegrationTest.java
@@ -79,10 +79,7 @@ public class ResilientCommitTimestampPutUnlessExistsTableIntegrationTest {
     }
 
     private void submitWriteTask(
-            CountDownLatch writeExecutionLatch,
-            ExecutorService writeExecutor,
-            long startTimestamp,
-            int writerIndex) {
+            CountDownLatch writeExecutionLatch, ExecutorService writeExecutor, long startTimestamp, int writerIndex) {
         writeExecutor.submit(() -> {
             try {
                 writeExecutionLatch.await();
@@ -160,7 +157,8 @@ public class ResilientCommitTimestampPutUnlessExistsTableIntegrationTest {
 
         public void readOneIteration() {
             try {
-                timestampReads.add(Optional.ofNullable(pueTable.get(startTimestamp).get()));
+                timestampReads.add(
+                        Optional.ofNullable(pueTable.get(startTimestamp).get()));
             } catch (Exception e) {
                 // Expected - some failures will happen as part of our test.
             }


### PR DESCRIPTION
**Goals (and why)**:
- Add integration nondeterministic test wiring together a PutUnlessExistsTable and the forgetting store

**Implementation Description (bullets)**:
- Wire things together
- Add test checking invariants

**Testing (What was existing testing like?  What have you done to improve it?)**:
This PR focuses on tests

**Concerns (what feedback would you like?)**:
Are there more cases we need to add? It feels lighter than I expected

**Where should we start reviewing?**: ResilientCommitTimestampPutUnlessExistsTableIntegrationTest

**Priority (whenever / two weeks / yesterday)**: this week
