### PR TITLE
Disable TL adjudication flag

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/TimeLockClientConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/TimeLockClientConfig.java
@@ -35,6 +35,11 @@ public abstract class TimeLockClientConfig {
     @Deprecated
     public abstract Optional<String> client();
 
+    @Value.Default
+    public boolean shouldGiveFeedbackToTimeLockServer() {
+        return true;
+    }
+
     @JsonIgnore
     @Value.Lazy
     public String getClientOrThrow() {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -571,7 +571,7 @@ public abstract class TransactionManagers {
             @Output List<AutoCloseable> closeables,
             AtlasDbConfig config,
             Refreshable<AtlasDbRuntimeConfig> runtimeConfig) {
-        if (isUsingTimeLock(config, runtimeConfig.current())) {
+        if (isUsingTimeLock(config, runtimeConfig.current()) && shouldGiveFeedbackToServer(config)) {
             Refreshable<List<TimeLockClientFeedbackService>> refreshableTimeLockClientFeedbackServices =
                     getTimeLockClientFeedbackServices(config, runtimeConfig, userAgent(), reloadingFactory());
             return Optional.of(initializeCloseable(
@@ -903,6 +903,12 @@ public abstract class TransactionManagers {
     static boolean isUsingTimeLock(AtlasDbConfig atlasDbConfig, AtlasDbRuntimeConfig runtimeConfig) {
         return atlasDbConfig.timelock().isPresent()
                 || runtimeConfig.timelockRuntime().isPresent();
+    }
+
+    private boolean shouldGiveFeedbackToServer(AtlasDbConfig config) {
+        return config.timelock()
+                .map(TimeLockClientConfig::shouldGiveFeedbackToTimeLockServer)
+                .orElse(false);
     }
 
     /**

--- a/changelog/@unreleased/pr-5810.v2.yml
+++ b/changelog/@unreleased/pr-5810.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: 'We can now disable client side feedback sent to TimeLock server for
+    adjudication purposes. '
+  links:
+  - https://github.com/palantir/atlasdb/pull/5810


### PR DESCRIPTION
**Goals (and why)**:
See https://github.com/palantir/atlasdb/pull/5809
TimeLock is seeing issues with connections on k8s. We suspect the adjudication feedback calls could be the root of the issue.

**Priority (whenever / two weeks / yesterday)**:
Today please

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
