### PR TITLE
[LW] Improve performance for long running transactions

### DIFF
--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/InterruptibleFileLogCollector.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/InterruptibleFileLogCollector.java
@@ -31,7 +31,6 @@ import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import org.apache.commons.lang3.Validate;
 
 @SuppressFBWarnings("SLF4J_ILLEGAL_PASSED_CLASS")
 public class InterruptibleFileLogCollector implements LogCollector {
@@ -46,7 +45,11 @@ public class InterruptibleFileLogCollector implements LogCollector {
     public InterruptibleFileLogCollector(File logDirectory) {
         Preconditions.checkArgument(!logDirectory.isFile(), "Log directory cannot be a file");
         if (!logDirectory.exists()) {
-            Validate.isTrue(logDirectory.mkdirs(), "Error making log directory: " + logDirectory.getAbsolutePath());
+            boolean successfullyCreated = logDirectory.mkdirs();
+            Preconditions.checkState(
+                    successfullyCreated,
+                    "Error making log directory",
+                    SafeArg.of("logDirectory", logDirectory.getAbsolutePath()));
         }
         this.logDirectory = logDirectory;
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/SnapshotStoreImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/SnapshotStoreImpl.java
@@ -111,7 +111,8 @@ final class SnapshotStoreImpl implements SnapshotStore {
         return Optional.ofNullable(snapshotMap.get(sequence));
     }
 
-    private void retentionSnapshots() {
+    @VisibleForTesting
+    void retentionSnapshots() {
         Set<Sequence> currentLiveSequences = liveSequences.keySet();
         int nonEssentialSnapshotCount = snapshotMap.size() - currentLiveSequences.size();
         if (nonEssentialSnapshotCount > minimumSize) {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/SnapshotStoreImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/SnapshotStoreImplTest.java
@@ -19,6 +19,7 @@ package com.palantir.atlasdb.keyvalue.api.cache;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Streams;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.CellReference;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
@@ -27,6 +28,9 @@ import com.palantir.atlasdb.keyvalue.api.watch.StartTimestamp;
 import com.palantir.atlasdb.util.MetricsManagers;
 import io.vavr.collection.HashMap;
 import io.vavr.collection.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
 import java.util.stream.Stream;
 import org.assertj.core.api.OptionalAssert;
 import org.junit.Before;
@@ -98,12 +102,13 @@ public final class SnapshotStoreImplTest {
         assertSnapshotsEqualForTimestamp(SNAPSHOT_2, TIMESTAMP_4);
         assertThat(snapshotStore.getSnapshot(TIMESTAMP_1)).isEmpty();
 
+        forceRunSnapshotRetention();
         assertThat(snapshotStore.getSnapshotForSequence(SEQUENCE_1)).isEmpty();
     }
 
     @Test
     public void removeTimestampOnlyRetentionsDownToMinimumSize() {
-        snapshotStore = new SnapshotStoreImpl(2, 20_000, CACHE_METRICS);
+        snapshotStore = new SnapshotStoreImpl(1, 20_000, CACHE_METRICS);
         snapshotStore.storeSnapshot(SEQUENCE_1, ImmutableSet.of(TIMESTAMP_1), SNAPSHOT_1);
         snapshotStore.storeSnapshot(SEQUENCE_2, ImmutableSet.of(TIMESTAMP_2), SNAPSHOT_2);
         snapshotStore.storeSnapshot(SEQUENCE_3, ImmutableSet.of(TIMESTAMP_3), SNAPSHOT_3);
@@ -114,20 +119,71 @@ public final class SnapshotStoreImplTest {
         assertSnapshotsEqualForTimestamp(SNAPSHOT_3, TIMESTAMP_3);
         assertSnapshotsEqualForTimestamp(SNAPSHOT_4, TIMESTAMP_4);
 
-        removeSnapshotAndAssert(TIMESTAMP_1, SEQUENCE_1).isEmpty();
-        removeSnapshotAndAssert(TIMESTAMP_2, SEQUENCE_2).isEmpty();
-        removeSnapshotAndAssert(TIMESTAMP_3, SEQUENCE_3).hasValue(SNAPSHOT_3);
-        removeSnapshotAndAssert(TIMESTAMP_4, SEQUENCE_4).hasValue(SNAPSHOT_4);
+        removeSnapshotAndAssert(TIMESTAMP_2, SEQUENCE_2)
+                .as("snapshot is the latest non-essential and thus kept")
+                .hasValue(SNAPSHOT_2);
+
+        removeSnapshotAndAssert(TIMESTAMP_1, SEQUENCE_1)
+                .as("snapshot is not the latest and thus removed")
+                .isEmpty();
+
+        removeSnapshotAndAssert(TIMESTAMP_4, SEQUENCE_4)
+                .as("snapshot is the latest non-essential and thus kept")
+                .hasValue(SNAPSHOT_4);
+
+        removeSnapshotAndAssert(TIMESTAMP_3, SEQUENCE_3)
+                .as("snapshot is not the latest and thus removed")
+                .isEmpty();
 
         snapshotStore.storeSnapshot(SEQUENCE_5, ImmutableSet.of(TIMESTAMP_5), SNAPSHOT_5);
-        removeSnapshotAndAssert(TIMESTAMP_5, SEQUENCE_5).hasValue(SNAPSHOT_5);
-        assertThat(snapshotStore.getSnapshotForSequence(SEQUENCE_3)).isEmpty();
+        removeSnapshotAndAssert(TIMESTAMP_5, SEQUENCE_5)
+                .as("snapshot is the latest non-essential and thus kept")
+                .hasValue(SNAPSHOT_5);
+
+        assertThat(snapshotStore.getSnapshotForSequence(SEQUENCE_4))
+                .as("snapshot is no longer latest and thus removed")
+                .isEmpty();
+    }
+
+    @Test
+    public void retentionIsNotRunOnEveryRemoval() {
+        snapshotStore = new SnapshotStoreImpl(0, 20_000, CACHE_METRICS);
+        long numEntries = 100L;
+        List<Sequence> sequences =
+                LongStream.range(0, numEntries).mapToObj(Sequence::of).collect(Collectors.toList());
+        List<StartTimestamp> timestamps =
+                LongStream.range(0, numEntries).mapToObj(StartTimestamp::of).collect(Collectors.toList());
+
+        Streams.forEachPair(
+                sequences.stream(),
+                timestamps.stream(),
+                (sequence, timestamp) -> snapshotStore.storeSnapshot(sequence, ImmutableSet.of(timestamp), SNAPSHOT_1));
+
+        timestamps.forEach(timestamp -> assertSnapshotsEqualForTimestamp(SNAPSHOT_1, timestamp));
+        timestamps.forEach(timestamp -> snapshotStore.removeTimestamp(timestamp));
+        timestamps.forEach(
+                timestamp -> assertThat(snapshotStore.getSnapshot(timestamp)).isEmpty());
+        assertThat(anySnapshotPresentForSequences(sequences)).isTrue();
+        forceRunSnapshotRetention();
+        assertThat(anySnapshotPresentForSequences(sequences)).isFalse();
+    }
+
+    private boolean anySnapshotPresentForSequences(List<Sequence> sequences) {
+        return sequences.stream()
+                .anyMatch(sequence ->
+                        snapshotStore.getSnapshotForSequence(sequence).isPresent());
     }
 
     private OptionalAssert<ValueCacheSnapshot> removeSnapshotAndAssert(StartTimestamp timestamp, Sequence sequence) {
         snapshotStore.removeTimestamp(timestamp);
+        forceRunSnapshotRetention();
         assertThat(snapshotStore.getSnapshot(timestamp)).isEmpty();
         return assertThat(snapshotStore.getSnapshotForSequence(sequence));
+    }
+
+    private void forceRunSnapshotRetention() {
+        // retention is now rate-limited, so we must bypass if we want to guarantee the removal of a snapshot
+        ((SnapshotStoreImpl) snapshotStore).retentionSnapshots();
     }
 
     private void assertSnapshotsEqualForTimestamp(ValueCacheSnapshot expectedValue, StartTimestamp... timestamps) {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/SnapshotStoreImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/SnapshotStoreImplTest.java
@@ -158,9 +158,9 @@ public final class SnapshotStoreImplTest {
         assertSnapshotsEqualForTimestamp(SNAPSHOT_3, TIMESTAMP_3);
         assertSnapshotsEqualForTimestamp(SNAPSHOT_4, TIMESTAMP_4);
 
-        removeSnapshotAndAssert(TIMESTAMP_3, SEQUENCE_3)
+        removeSnapshotAndAssert(TIMESTAMP_4, SEQUENCE_4)
                 .as("snapshot is the latest non-essential and thus kept")
-                .hasValue(SNAPSHOT_3);
+                .hasValue(SNAPSHOT_4);
 
         removeSnapshotAndAssert(TIMESTAMP_2, SEQUENCE_2)
                 .as("snapshot is not the latest and thus removed")
@@ -171,7 +171,7 @@ public final class SnapshotStoreImplTest {
                 .hasValue(SNAPSHOT_1);
 
         assertThat(snapshotStore.getSnapshotForSequence(SEQUENCE_4))
-                .as("new snapshot is kept around as it has a live timestamp")
+                .as("new snapshot is kept around as is the latest")
                 .hasValue(SNAPSHOT_4);
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -123,8 +123,7 @@ allprojects {
                 'StaticAssignmentInConstructor',
                 'StrictUnusedVariable',
                 'ThreadPriorityCheck',
-                'TooManyArguments',
-                'ValidateConstantMessage'
+                'TooManyArguments'
     }
 }
 


### PR DESCRIPTION
**Goals (and why)**:
The snapshot store stores three mappings in memory:
1. Snapshot map: this maps `Sequence` to `ValueCacheSnapshot`, and may be updated once a transaction is complete. Snapshots are loaded by transactions as the basis for their transaction scoped cache. We've found issues in the past with desynchronisation in the past if we do not keep a few extra of these caches around, and of course we must keep these around for the active transactions.
2. Live sequences: this tracks the current live sequences for the purpose of retention.
3. Timestamp map: effectively the inverse of the live sequences map, and is used to retrieve the current sequence for a transaction.

The issue for long running transactions under the current implementation is this: we keep at least 1000 snapshots, and throw at 20,000. However, for the sake of retention, we stop retentioning any snapshot that is after the earliest live transaction, and so any long-running transaction causes us to retain many snapshots. Additionally, high write-rates cause us to do a lot of retentioning (which is synchronised), and thus causes a lot of lock contention.

**Implementation Description (bullets)**:
* Retain only the _latest_ 1000 snapshots, as well as any active ones (instead of at least 1000 snapshots, never retentioning after the earliest live transaction).
* Only retention snapshots every second, or if we reach the maximum size.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Amended tests, and added new ones.

**Concerns (what feedback would you like?)**:
* Do we violate any correctness? I'm thinking no: technically, we maintain correctness with no additional caches.
* Do we compromise performance? I'd also argue no: we're improving it by reducing contention (via rate limiting).
* Will this cause us to miss snapshots repeatedly? Again, should not as we're still keeping 1000 around.

**Where should we start reviewing?**:
`SnapshotStoreImpl`

**Priority (whenever / two weeks / yesterday)**:
Whenever - I think we probably shouldn't merge this before Christmas.
