### PR TITLE
Exclusion Advent-ure: suppressing ThreadPriorityCheck

### DIFF
--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -443,6 +443,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
         mockery.assertIsSatisfied();
     }
 
+    @SuppressWarnings("ThreadPriorityCheck")
     @Test
     public void testTransactionAtomicity() throws Exception {
         // This test runs multiple transactions in parallel, with KeyValueService.put calls throwing

--- a/build.gradle
+++ b/build.gradle
@@ -115,7 +115,6 @@ allprojects {
                 'Slf4jLogsafeArgs',
                 'StaticAssignmentInConstructor',
                 'StrictUnusedVariable',
-                'ThreadPriorityCheck',
                 'TooManyArguments'
     }
 }

--- a/commons-executors/src/main/java/com/palantir/common/concurrent/PTExecutors.java
+++ b/commons-executors/src/main/java/com/palantir/common/concurrent/PTExecutors.java
@@ -773,6 +773,7 @@ public final class PTExecutors {
         return new NamedThreadFactory(computeBaseThreadName(classToIgnore), isDaemon);
     }
 
+    @SuppressWarnings("ThreadPriorityCheck") // Used internally
     public static ThreadFactory newThreadFactory(final String prefix, final int priority, final boolean isDaemon) {
         ThreadFactory threadFactory = new ThreadFactory() {
             private final AtomicInteger nextThreadId = new AtomicInteger();

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockServerLock.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockServerLock.java
@@ -107,6 +107,7 @@ public class LockServerLock implements ClientAwareReadWriteLock {
             sync.acquireSharedInterruptibly(clientIndex);
         }
 
+        @SuppressWarnings("ThreadPriorityCheck") // not changing legacy code
         @Override
         public LockClient tryLock() {
             while (true) {
@@ -189,6 +190,7 @@ public class LockServerLock implements ClientAwareReadWriteLock {
             sync.acquireInterruptibly(clientIndex);
         }
 
+        @SuppressWarnings("ThreadPriorityCheck") // not changing legacy code
         @Override
         public LockClient tryLock() {
             while (true) {


### PR DESCRIPTION
**Goals (and why)**: Exclusion hunting

**Implementation Description (bullets)**: Suppressed the instances, because in most cases this is very old code that has obviously been battle-tested, but changing how we mess around with thread priorities seems risky.

