### PR TITLE
Read serial at quorum because that's how we roll

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ReadConsistencyProvider.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ReadConsistencyProvider.java
@@ -38,7 +38,8 @@ public final class ReadConsistencyProvider {
 
     public ConsistencyLevel getConsistency(TableReference tableReference) {
         if (AtlasDbConstants.SERIAL_CONSISTENCY_ATOMIC_TABLES.contains(tableReference)) {
-            return ConsistencyLevel.LOCAL_SERIAL;
+            // todo (gmaretic): figure out if we can make this serial without killing users
+            return DEFAULT_CONSISTENCY;
         }
         return defaultReadConsistency.get();
     }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/ReadConsistencyProviderTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/ReadConsistencyProviderTest.java
@@ -47,16 +47,16 @@ public class ReadConsistencyProviderTest {
     }
 
     @Test
-    public void consistencyForAtomicSerialTablesIsLocalSerial() {
+    public void consistencyForAtomicSerialTablesIsActuallyQuorum() {
         AtlasDbConstants.SERIAL_CONSISTENCY_ATOMIC_TABLES.forEach(tableReference ->
-                assertThat(provider.getConsistency(tableReference)).isEqualTo(ConsistencyLevel.LOCAL_SERIAL));
+                assertThat(provider.getConsistency(tableReference)).isEqualTo(ConsistencyLevel.LOCAL_QUORUM));
     }
 
     @Test
-    public void consistencyForAtomicSerialTablesRemainsLocalSerialEvenAfterBroadConsistencyDowngrade() {
+    public void consistencyForAtomicSerialTablesRemainsLocalQuorumlEvenAfterBroadConsistencyDowngrade() {
         provider.lowerConsistencyLevelToOne();
         AtlasDbConstants.SERIAL_CONSISTENCY_ATOMIC_TABLES.forEach(tableReference ->
-                assertThat(provider.getConsistency(tableReference)).isEqualTo(ConsistencyLevel.LOCAL_SERIAL));
+                assertThat(provider.getConsistency(tableReference)).isEqualTo(ConsistencyLevel.LOCAL_QUORUM));
     }
 
     @Test

--- a/changelog/@unreleased/pr-5816.v2.yml
+++ b/changelog/@unreleased/pr-5816.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Reads from the coordination table are now using consistency quorum
+    again instead of serial which was causing perf issues.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5816


### PR DESCRIPTION
**Goals (and why)**:
Reading coordination table at serial was killing a cassandra cluster. Let's downgrade this to quorum until we can figure out a way this can be done more safely -- why are we doing so many reads?

**Implementation Description (bullets)**:
Trivial

**Concerns (what feedback would you like?)**:
This was the behaviour until recently anyway so not overly concerning

**Priority (whenever / two weeks / yesterday)**:
Now