### PR TITLE
Coalesce

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ReadConsistencyProvider.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ReadConsistencyProvider.java
@@ -38,8 +38,7 @@ public final class ReadConsistencyProvider {
 
     public ConsistencyLevel getConsistency(TableReference tableReference) {
         if (AtlasDbConstants.SERIAL_CONSISTENCY_ATOMIC_TABLES.contains(tableReference)) {
-            // todo (gmaretic): figure out if we can make this serial without killing users
-            return DEFAULT_CONSISTENCY;
+            return ConsistencyLevel.LOCAL_SERIAL;
         }
         return defaultReadConsistency.get();
     }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/ReadConsistencyProviderTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/ReadConsistencyProviderTest.java
@@ -47,16 +47,16 @@ public class ReadConsistencyProviderTest {
     }
 
     @Test
-    public void consistencyForAtomicSerialTablesIsActuallyQuorum() {
+    public void consistencyForAtomicSerialTablesIsLocalSerial() {
         AtlasDbConstants.SERIAL_CONSISTENCY_ATOMIC_TABLES.forEach(tableReference ->
-                assertThat(provider.getConsistency(tableReference)).isEqualTo(ConsistencyLevel.LOCAL_QUORUM));
+                assertThat(provider.getConsistency(tableReference)).isEqualTo(ConsistencyLevel.LOCAL_SERIAL));
     }
 
     @Test
-    public void consistencyForAtomicSerialTablesRemainsLocalQuorumlEvenAfterBroadConsistencyDowngrade() {
+    public void consistencyForAtomicSerialTablesRemainsLocalSeriallEvenAfterBroadConsistencyDowngrade() {
         provider.lowerConsistencyLevelToOne();
         AtlasDbConstants.SERIAL_CONSISTENCY_ATOMIC_TABLES.forEach(tableReference ->
-                assertThat(provider.getConsistency(tableReference)).isEqualTo(ConsistencyLevel.LOCAL_QUORUM));
+                assertThat(provider.getConsistency(tableReference)).isEqualTo(ConsistencyLevel.LOCAL_SERIAL));
     }
 
     @Test

--- a/changelog/@unreleased/pr-5817.v2.yml
+++ b/changelog/@unreleased/pr-5817.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Reads from the coordination store are now using serial consistency
+    but are being coalesced to avoid doing many parallel serial reads.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5817


### PR DESCRIPTION
**Goals (and why)**:
Avoid doing unbounded serial reads at the same time

**Implementation Description (bullets)**:
Coalesce calls to read from the coordiantion store

**Testing (What was existing testing like?  What have you done to improve it?)**:
relax

**Concerns (what feedback would you like?)**:
We have to avoid nesting coalescing suppliers, but it is ok, the two suppliers that we have are

- We coalesce calls in `CoordinationService.getValueForTimestamp` when we call `readLatestValueFromStore`
- We also coalesce calls in `TransactionSchemaManager.tryInstallNewTransactionsSchemaVersion` when we call `CoordinationService.tryTransformCurrentValue`

These do call some of the same methods, like `store.getAgreedValue` and updating the cache, but they do not call each other

**Where should we start reviewing?**:
small

**Priority (whenever / two weeks / yesterday)**:
Today?
