### PR TITLE
Handle null ConflictDetectionManagers + fix ancient ConflictDetectionManagers bug

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ConflictDetectionManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ConflictDetectionManager.java
@@ -22,7 +22,6 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import java.util.Map;
 import java.util.Optional;
-import javax.annotation.Nullable;
 
 public class ConflictDetectionManager {
     private final LoadingCache<TableReference, Optional<ConflictHandler>> cache;
@@ -51,7 +50,6 @@ public class ConflictDetectionManager {
         return cache.asMap();
     }
 
-    @Nullable
     public Optional<ConflictHandler> get(TableReference tableReference) {
         return cache.getUnchecked(tableReference);
     }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ConflictDetectionManagers.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ConflictDetectionManagers.java
@@ -69,7 +69,7 @@ public final class ConflictDetectionManagers {
             @Override
             public Optional<ConflictHandler> load(TableReference tableReference) throws Exception {
                 byte[] metadata = kvs.getMetadataForTable(tableReference);
-                if (metadata == null) {
+                if (metadata.length == 0) {
                     log.error(
                             "Tried to make a transaction over a table that has no metadata: {}.",
                             LoggingArgs.tableRef("tableReference", tableReference));

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -426,8 +426,8 @@ public class SerializableTransaction extends SnapshotTransaction {
     boolean isSerializableTable(TableReference table) {
         // If the metadata is null, we assume that the conflict handler is not SERIALIZABLE.
         // In that case the transaction will fail on commit if it has writes.
-        ConflictHandler conflictHandler = conflictDetectionManager.get(table);
-        return conflictHandler != null && conflictHandler.checkReadWriteConflicts();
+        Optional<ConflictHandler> conflictHandler = conflictDetectionManager.get(table);
+        return conflictHandler.map(ConflictHandler::checkReadWriteConflicts).orElse(false);
     }
 
     /**

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -427,7 +427,7 @@ public class SerializableTransaction extends SnapshotTransaction {
         // If the metadata is null, we assume that the conflict handler is not SERIALIZABLE.
         // In that case the transaction will fail on commit if it has writes.
         ConflictHandler conflictHandler = conflictDetectionManager.get(table);
-        return conflictHandler.checkReadWriteConflicts();
+        return conflictHandler != null && conflictHandler.checkReadWriteConflicts();
     }
 
     /**

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -131,6 +131,7 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import com.palantir.logsafe.exceptions.SafeNullPointerException;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
@@ -1927,10 +1928,12 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     }
 
     protected ConflictHandler getConflictHandlerForTable(TableReference tableRef) {
-        return com.google.common.base.Preconditions.checkNotNull(
-                conflictDetectionManager.get(tableRef),
-                "Not a valid table for this transaction. Make sure this table name exists or has a valid namespace: %s",
-                tableRef);
+        return conflictDetectionManager
+                .get(tableRef)
+                .orElseThrow(() -> new SafeNullPointerException(
+                        "Not a valid table for this transaction. Make sure this table name exists or has a valid "
+                                + "namespace.",
+                        LoggingArgs.tableRef(tableRef)));
     }
 
     private String getExpiredLocksErrorString(@Nullable LockToken commitLocksToken, Set<LockToken> expiredLocks) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionConflictDetectionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionConflictDetectionManager.java
@@ -24,7 +24,6 @@ import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import javax.annotation.Nullable;
 
 public final class TransactionConflictDetectionManager {
 
@@ -67,8 +66,7 @@ public final class TransactionConflictDetectionManager {
         }
     }
 
-    @Nullable
-    public ConflictHandler get(TableReference tableReference) {
-        return conflictHandlers.computeIfAbsent(tableReference, delegate::get).orElse(null);
+    public Optional<ConflictHandler> get(TableReference tableReference) {
+        return conflictHandlers.computeIfAbsent(tableReference, delegate::get);
     }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/TransactionConflictDetectionManagerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/TransactionConflictDetectionManagerTest.java
@@ -121,7 +121,7 @@ public final class TransactionConflictDetectionManagerTest {
 
     private void testDisableReadWriteConflict(ConflictHandler initial, ConflictHandler overriden) throws Exception {
         whenDisableReadWriteConflict(initial);
-        assertThat(conflictDetectionManager.get(TABLE_REFERENCE)).isEqualTo(overriden);
+        assertThat(conflictDetectionManager.get(TABLE_REFERENCE)).contains(overriden);
     }
 
     private void testDisableReadWriteConflictThrowsUnsupported(ConflictHandler initial) {

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
@@ -1466,6 +1466,20 @@ public abstract class AbstractSerializableTransactionTest extends AbstractTransa
         });
     }
 
+    @Test
+    public void testChecksIfTablesAreSerializable() {
+        createManager().runTaskThrowOnConflict(tx -> {
+            SerializableTransaction serializable = (SerializableTransaction) tx;
+            assertThat(serializable.isSerializableTable(TEST_TABLE_SERIALIZABLE))
+                    .isTrue();
+            assertThat(serializable.isSerializableTable(TEST_TABLE)).isFalse();
+            assertThat(serializable.isSerializableTable(
+                            TableReference.createFromFullyQualifiedName("i.amrandom" + UUID.randomUUID())))
+                    .isFalse();
+            return null;
+        });
+    }
+
     @Override
     protected void put(Transaction txn, String rowName, String columnName, String value) {
         put(txn, TEST_TABLE_SERIALIZABLE, rowName, columnName, value);

--- a/changelog/@unreleased/pr-5821.v2.yml
+++ b/changelog/@unreleased/pr-5821.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: We now return correct results for queries to the conflict handler of
+    a non-existent table or table with empty metadata. Previously, we would have thrown
+    `NullPointerException` or a deserialization-related exception respectively.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5821


### PR DESCRIPTION
**Goals (and why)**:
- We should behave correctly if trying to load the conflict detection strategy for a table that does not exist.

**Implementation Description (bullets)**:
- Fix the check of isTableSerializable in SerializableTransaction to follow its spec
- Fix ConflictDetectionManagers to perform the correct test for empty tables - the implementer of `ConflictDetectionManagers` made an error when investigating the spec of `getMetadataForTable(...)`.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added tests that would fail if either of the bugs were not addressed.

**Concerns (what feedback would you like?)**: Not much

**Where should we start reviewing?**: it's small

**Priority (whenever / two weeks / yesterday)**: before EOY please 😅 