### PR TITLE
[Transactions3] Automatically install transactions3 if (using inconsistent KVS AND not on transactions3)

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionConstants.java
@@ -50,6 +50,8 @@ public final class TransactionConstants {
             DIRECT_ENCODING_TRANSACTIONS_SCHEMA_VERSION,
             TICKETS_ENCODING_TRANSACTIONS_SCHEMA_VERSION,
             TWO_STAGE_ENCODING_TRANSACTIONS_SCHEMA_VERSION);
+    public static final ImmutableSet<Integer> SUPPORTED_TRANSACTION_SCHEMA_VERSIONS_FOR_CAS_INCONSISTENT_KVSES =
+            ImmutableSet.of(TWO_STAGE_ENCODING_TRANSACTIONS_SCHEMA_VERSION);
 
     public static byte[] getValueForTimestamp(long transactionTimestamp) {
         return EncodingUtils.encodeVarLong(transactionTimestamp);

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -703,8 +703,10 @@ public abstract class TransactionManagers {
             TransactionSchemaManager transactionSchemaManager) {
         CheckAndSetCompatibility compatibility = keyValueService.getCheckAndSetCompatibility();
         if (compatibility.supportsCheckAndSetOperations() && compatibility.supportsDetailOnFailure()) {
+            TransactionSchemaVersionSelector versionSelector = new TransactionSchemaVersionSelector(compatibility,
+                    () -> runtimeConfigSupplier.get().internalSchema().targetTransactionsSchemaVersion());
             return Optional.of(
-                    initializeTransactionSchemaInstaller(closeables, runtimeConfigSupplier, transactionSchemaManager));
+                    initializeTransactionSchemaInstaller(closeables, versionSelector, transactionSchemaManager));
         }
         runtimeConfigSupplier
                 .get()
@@ -721,12 +723,12 @@ public abstract class TransactionManagers {
 
     private static TransactionSchemaInstaller initializeTransactionSchemaInstaller(
             @Output List<AutoCloseable> closeables,
-            Supplier<AtlasDbRuntimeConfig> runtimeConfigSupplier,
+            TransactionSchemaVersionSelector versionSelector,
             TransactionSchemaManager transactionSchemaManager) {
         return initializeCloseable(
                 () -> TransactionSchemaInstaller.createStarted(
                         transactionSchemaManager,
-                        () -> runtimeConfigSupplier.get().internalSchema().targetTransactionsSchemaVersion()),
+                        versionSelector),
                 closeables);
     }
 

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -703,7 +703,8 @@ public abstract class TransactionManagers {
             TransactionSchemaManager transactionSchemaManager) {
         CheckAndSetCompatibility compatibility = keyValueService.getCheckAndSetCompatibility();
         if (compatibility.supportsCheckAndSetOperations() && compatibility.supportsDetailOnFailure()) {
-            TransactionSchemaVersionSelector versionSelector = new TransactionSchemaVersionSelector(compatibility,
+            TransactionSchemaVersionSelector versionSelector = new TransactionSchemaVersionSelector(
+                    compatibility,
                     () -> runtimeConfigSupplier.get().internalSchema().targetTransactionsSchemaVersion());
             return Optional.of(
                     initializeTransactionSchemaInstaller(closeables, versionSelector, transactionSchemaManager));
@@ -726,10 +727,7 @@ public abstract class TransactionManagers {
             TransactionSchemaVersionSelector versionSelector,
             TransactionSchemaManager transactionSchemaManager) {
         return initializeCloseable(
-                () -> TransactionSchemaInstaller.createStarted(
-                        transactionSchemaManager,
-                        versionSelector),
-                closeables);
+                () -> TransactionSchemaInstaller.createStarted(transactionSchemaManager, versionSelector), closeables);
     }
 
     private CoordinationService<InternalSchemaMetadata> getSchemaMetadataCoordinationService(

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionSchemaVersionSelector.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionSchemaVersionSelector.java
@@ -33,8 +33,7 @@ public class TransactionSchemaVersionSelector implements Supplier<Optional<Integ
     private final Supplier<Optional<Integer>> userProvidedExplicitSupplier;
 
     public TransactionSchemaVersionSelector(
-            CheckAndSetCompatibility compatibility,
-            Supplier<Optional<Integer>> userProvidedExplicitSupplier) {
+            CheckAndSetCompatibility compatibility, Supplier<Optional<Integer>> userProvidedExplicitSupplier) {
         this.compatibility = compatibility;
         this.userProvidedExplicitSupplier = userProvidedExplicitSupplier;
     }
@@ -42,7 +41,7 @@ public class TransactionSchemaVersionSelector implements Supplier<Optional<Integ
     @Override
     public Optional<Integer> get() {
         Optional<Integer> userValue = userProvidedExplicitSupplier.get();
-        
+
         if (!compatibility.consistentOnFailure()) {
             return recommendVersionForInconsistentCasKeyValueServices(userValue);
         }
@@ -51,15 +50,17 @@ public class TransactionSchemaVersionSelector implements Supplier<Optional<Integ
 
     private Optional<Integer> recommendVersionForInconsistentCasKeyValueServices(Optional<Integer> userValue) {
         if (userValue.isEmpty()) {
-            log.info("User is using a KVS that may be inconsistent on failure, and has not specified a transaction"
-                    + " schema version. Recommending a minimum version, to avoid said inconsistency.",
+            log.info(
+                    "User is using a KVS that may be inconsistent on failure, and has not specified a transaction"
+                            + " schema version. Recommending a minimum version, to avoid said inconsistency.",
                     SafeArg.of("recommendedVersion", MIN_ACCEPTABLE_VERSION_FOR_INCONSISTENT_CAS_KVSES));
             return MIN_ACCEPTABLE_VERSION_FOR_INCONSISTENT_CAS_KVSES;
         }
         int userSpecifiedVersion = userValue.get();
-        if (userSpecifiedVersion == TransactionConstants.DIRECT_ENCODING_TRANSACTIONS_SCHEMA_VERSION ||
-                userSpecifiedVersion == TransactionConstants.TICKETS_ENCODING_TRANSACTIONS_SCHEMA_VERSION) {
-            log.warn("User is using a KVS that may be inconsistent on failure, and has explicitly specified a"
+        if (userSpecifiedVersion == TransactionConstants.DIRECT_ENCODING_TRANSACTIONS_SCHEMA_VERSION
+                || userSpecifiedVersion == TransactionConstants.TICKETS_ENCODING_TRANSACTIONS_SCHEMA_VERSION) {
+            log.warn(
+                    "User is using a KVS that may be inconsistent on failure, and has explicitly specified a"
                             + " transaction schema version not known to handle such inconsistencies."
                             + " Recommending a minimum version, to avoid said inconsistency.",
                     SafeArg.of("userSpecifiedVersion", userSpecifiedVersion),

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionSchemaVersionSelector.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionSchemaVersionSelector.java
@@ -1,0 +1,71 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.factory;
+
+import com.palantir.atlasdb.keyvalue.api.CheckAndSetCompatibility;
+import com.palantir.atlasdb.transaction.impl.TransactionConstants;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+public class TransactionSchemaVersionSelector implements Supplier<Optional<Integer>> {
+    private static final SafeLogger log = SafeLoggerFactory.get(TransactionSchemaVersionSelector.class);
+    private static final Optional<Integer> MIN_ACCEPTABLE_VERSION_FOR_INCONSISTENT_CAS_KVSES =
+            Optional.of(TransactionConstants.TWO_STAGE_ENCODING_TRANSACTIONS_SCHEMA_VERSION);
+
+    private final CheckAndSetCompatibility compatibility;
+    private final Supplier<Optional<Integer>> userProvidedExplicitSupplier;
+
+    public TransactionSchemaVersionSelector(
+            CheckAndSetCompatibility compatibility,
+            Supplier<Optional<Integer>> userProvidedExplicitSupplier) {
+        this.compatibility = compatibility;
+        this.userProvidedExplicitSupplier = userProvidedExplicitSupplier;
+    }
+
+    @Override
+    public Optional<Integer> get() {
+        Optional<Integer> userValue = userProvidedExplicitSupplier.get();
+        
+        if (!compatibility.consistentOnFailure()) {
+            return recommendVersionForInconsistentCasKeyValueServices(userValue);
+        }
+        return userValue;
+    }
+
+    private Optional<Integer> recommendVersionForInconsistentCasKeyValueServices(Optional<Integer> userValue) {
+        if (userValue.isEmpty()) {
+            log.info("User is using a KVS that may be inconsistent on failure, and has not specified a transaction"
+                    + " schema version. Recommending a minimum version, to avoid said inconsistency.",
+                    SafeArg.of("recommendedVersion", MIN_ACCEPTABLE_VERSION_FOR_INCONSISTENT_CAS_KVSES));
+            return MIN_ACCEPTABLE_VERSION_FOR_INCONSISTENT_CAS_KVSES;
+        }
+        int userSpecifiedVersion = userValue.get();
+        if (userSpecifiedVersion == TransactionConstants.DIRECT_ENCODING_TRANSACTIONS_SCHEMA_VERSION ||
+                userSpecifiedVersion == TransactionConstants.TICKETS_ENCODING_TRANSACTIONS_SCHEMA_VERSION) {
+            log.warn("User is using a KVS that may be inconsistent on failure, and has explicitly specified a"
+                            + " transaction schema version not known to handle such inconsistencies."
+                            + " Recommending a minimum version, to avoid said inconsistency.",
+                    SafeArg.of("userSpecifiedVersion", userSpecifiedVersion),
+                    SafeArg.of("recommendedVersion", MIN_ACCEPTABLE_VERSION_FOR_INCONSISTENT_CAS_KVSES));
+            return MIN_ACCEPTABLE_VERSION_FOR_INCONSISTENT_CAS_KVSES;
+        }
+        return userValue;
+    }
+}

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionSchemaVersionSelectorTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionSchemaVersionSelectorTest.java
@@ -1,0 +1,92 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.factory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.collect.Sets;
+import com.palantir.atlasdb.keyvalue.api.CheckAndSetCompatibility;
+import com.palantir.atlasdb.transaction.impl.TransactionConstants;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
+
+public class TransactionSchemaVersionSelectorTest {
+    private final AtomicReference<Optional<Integer>> userVersion = new AtomicReference<>(Optional.empty());
+    private final TransactionSchemaVersionSelector consistentKvsBackedSelector = new TransactionSchemaVersionSelector(
+            CheckAndSetCompatibility.supportedBuilder()
+                    .consistentOnFailure(true)
+                    .supportsDetailOnFailure(false)
+                    .build(),
+            userVersion::get);
+    private final TransactionSchemaVersionSelector inconsistentKvsBackedSelector = new TransactionSchemaVersionSelector(
+            CheckAndSetCompatibility.supportedBuilder()
+                    .consistentOnFailure(false)
+                    .supportsDetailOnFailure(true)
+                    .build(),
+            userVersion::get);
+
+    @Test
+    public void passesThroughEmptyForConsistentKeyValueServices() {
+        assertThat(consistentKvsBackedSelector.get()).isEmpty();
+    }
+
+    @Test
+    public void passesThroughUserChoiceForConsistentKeyValueServices() {
+        TransactionConstants.SUPPORTED_TRANSACTIONS_SCHEMA_VERSIONS.forEach(version -> {
+            userVersion.set(Optional.of(version));
+            assertThat(consistentKvsBackedSelector.get()).hasValue(version);
+        });
+    }
+
+    @Test
+    public void recommendsTwoStageEncodingForEmptyAndInconsistentKeyValueServices() {
+        assertThat(inconsistentKvsBackedSelector.get())
+                .contains(TransactionConstants.TWO_STAGE_ENCODING_TRANSACTIONS_SCHEMA_VERSION);
+    }
+
+    @Test
+    public void recommendsTwoStageEncodingForNonInconsistentSupportedAndInconsistentKeyValueServices() {
+        Sets.difference(
+                        TransactionConstants.SUPPORTED_TRANSACTIONS_SCHEMA_VERSIONS,
+                        TransactionConstants.SUPPORTED_TRANSACTION_SCHEMA_VERSIONS_FOR_CAS_INCONSISTENT_KVSES)
+                .forEach(version -> {
+                    userVersion.set(Optional.of(version));
+                    assertThat(inconsistentKvsBackedSelector.get())
+                            .hasValue(TransactionConstants.TWO_STAGE_ENCODING_TRANSACTIONS_SCHEMA_VERSION);
+                });
+    }
+
+    @Test
+    public void passesThroughUserChoiceForInonsistentKeyValueServicesIfSupported() {
+        TransactionConstants.SUPPORTED_TRANSACTION_SCHEMA_VERSIONS_FOR_CAS_INCONSISTENT_KVSES.forEach(version -> {
+            userVersion.set(Optional.of(version));
+            assertThat(inconsistentKvsBackedSelector.get()).hasValue(version);
+        });
+    }
+
+    @Test
+    public void throwsForKeyValueServicesNotSupportingCheckAndSet() {
+        assertThatThrownBy(() ->
+                        new TransactionSchemaVersionSelector(CheckAndSetCompatibility.unsupported(), userVersion::get))
+                .isInstanceOf(SafeIllegalStateException.class)
+                .hasMessageContaining(
+                        "Should not determine transaction schema versions on a KVS not supporting check" + " and set");
+    }
+}

--- a/changelog/@unreleased/pr-5839.v2.yml
+++ b/changelog/@unreleased/pr-5839.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Users on key-value-services that may not exhibit CAS consistency will
+    now automatically have a version that _does_ exhibit said consistency installed.
+    Please contact the AtlasDB team if you believe this to be an issue.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5839

--- a/changelog/@unreleased/pr-5839.v2.yml
+++ b/changelog/@unreleased/pr-5839.v2.yml
@@ -1,7 +1,9 @@
 type: improvement
 improvement:
   description: Users on key-value-services that may not exhibit CAS consistency will
-    now automatically have a version that _does_ exhibit said consistency installed.
-    Please contact the AtlasDB team if you believe this to be an issue.
+    now automatically have a transaction schema version that _does_ exhibit said consistency
+    installed, even if no target schema version or a specific schema version that
+    is vulnerable to said inconsistency was configured. Please contact the AtlasDB
+    team if you believe this to be an issue.
   links:
   - https://github.com/palantir/atlasdb/pull/5839

--- a/docs/source/configuration/internal_schemas.rst
+++ b/docs/source/configuration/internal_schemas.rst
@@ -21,7 +21,8 @@ Target Transactions Schema Version
 .. warning::
 
    Schema versions 1 and 2 are vulnerable to a Cassandra consistency issue. Cassandra users should use
-   schema version 3. Users of other key-value-services are not affected by this issue.
+   schema version 3. Users of other key-value-services are not affected by this issue. If you are configured to use
+   Cassandra and are on schema version 1 or 2, we will automatically install schema version 3.
 
 AtlasDB needs to persist information about the start and commit timestamps of transactions that have committed.
 This may be done in various ways, and is configurable. We currently support three strategies:


### PR DESCRIPTION
**Goals (and why)**:
- Ensure that users on Cassandra move to transactions3.

**Implementation Description (bullets)**:
- Forcibly install transaction schema version (TSV) 3, if the user is not on TSV3 and hasn't specified anything _or_ has specified TSV1 or TSV2.
- Log at INFO if the user hasn't specified a TSV, and log at WARN if the user has explicitly specified TSV1 or TSV2 (because we're overriding what they've said)

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Added tests for the new code.

**Concerns (what feedback would you like?)**:
- Is this _too_ abusive of the coupling between CASCs and Cassandra?
- Are there legitimate use cases where a Cassandra user might actually want to be on TSV1 or 2?

**Where should we start reviewing?**: TransactionSchemaVersionSelector

**Priority (whenever / two weeks / yesterday)**: next week? This will be useful when burning down transactions3.