### PR TITLE
Change retry of TSI to 3 days

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/TransactionSchemaInstaller.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/TransactionSchemaInstaller.java
@@ -34,7 +34,7 @@ public final class TransactionSchemaInstaller implements AutoCloseable {
     private static final SafeLogger log = SafeLoggerFactory.get(TransactionSchemaInstaller.class);
 
     @VisibleForTesting
-    static final Duration POLLING_INTERVAL = Duration.ofDays(10);
+    static final Duration POLLING_INTERVAL = Duration.ofDays(3);
 
     private final TransactionSchemaManager manager;
     private final Supplier<Optional<Integer>> versionToInstall;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/TransactionSchemaInstaller.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/TransactionSchemaInstaller.java
@@ -34,7 +34,7 @@ public final class TransactionSchemaInstaller implements AutoCloseable {
     private static final SafeLogger log = SafeLoggerFactory.get(TransactionSchemaInstaller.class);
 
     @VisibleForTesting
-    static final Duration POLLING_INTERVAL = Duration.ofMinutes(10);
+    static final Duration POLLING_INTERVAL = Duration.ofDays(10);
 
     private final TransactionSchemaManager manager;
     private final Supplier<Optional<Integer>> versionToInstall;

--- a/changelog/@unreleased/pr-5840.v2.yml
+++ b/changelog/@unreleased/pr-5840.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: Transaction schema versions are now only installed by a running service
+    once on startup, and thereafter once every three days to avoid excessive contention
+    during blue-green deployments. If you would like the new schema version to be
+    installed more quickly, please bounce one of the nodes of your service.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5840


### PR DESCRIPTION
**Goals (and why)**:
- Avoid flip-flopping *too* quickly between versions when internal services do blue-green deployment

**Implementation Description (bullets)**:
- Change the polling interval for installing a new schema version from 10 minutes to 3 days.

**Testing (What was existing testing like?  What have you done to improve it?)**:
None beyond existing tests.

**Concerns (what feedback would you like?)**:
- The reason I didn't want to set this to infinity (i.e., run task once on startup) is that the contract is that we eventually set it to be the agreed on value, and we've seen stacks where no bounce happens for 3 days. Does this make sense?

**Where should we start reviewing?**: +1-1

**Priority (whenever / two weeks / yesterday)**: ASAP