### PR TITLE
ABR8: Pull out session-scoped classes

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraServersConfigs.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraServersConfigs.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.net.InetSocketAddress;
@@ -154,6 +155,12 @@ public final class CassandraServersConfigs {
         public <T> T accept(Visitor<T> visitor) {
             return visitor.visit(this);
         }
+    }
+
+    public static Set<InetSocketAddress> getCqlHosts(CassandraKeyValueServiceConfig config) {
+        return CassandraServersConfigs.getCqlCapableConfigIfValid(config)
+                .map(CassandraServersConfigs.CqlCapableConfig::cqlHosts)
+                .orElseThrow(() -> new SafeIllegalStateException("Attempting to get CQL hosts with thrift config!"));
     }
 
     public static Optional<CqlCapableConfig> getCqlCapableConfigIfValid(CassandraKeyValueServiceConfig config) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/backup/CqlCluster.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/backup/CqlCluster.java
@@ -23,8 +23,6 @@ import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.TableMetadata;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Multimap;
-import com.google.common.collect.Multimaps;
 import com.google.common.collect.RangeSet;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.CassandraServersConfigs;
@@ -33,21 +31,17 @@ import com.palantir.atlasdb.cassandra.backup.transaction.TransactionsTableIntera
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraConstants;
 import com.palantir.atlasdb.keyvalue.cassandra.LightweightOppToken;
 import com.palantir.atlasdb.keyvalue.cassandra.async.client.creation.ClusterFactory;
-import com.palantir.common.streams.KeyedStream;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
-import com.palantir.timestamp.FullyBoundedTimestampRange;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 public final class CqlCluster implements Closeable {
     private static final SafeLogger log = SafeLoggerFactory.get(CqlCluster.class);
@@ -83,8 +77,8 @@ public final class CqlCluster implements Closeable {
 
     public Map<InetSocketAddress, RangeSet<LightweightOppToken>> getTokenRanges(String tableName) {
         try (CqlSession session = new CqlSession(cluster.connect())) {
-            CqlMetadata metadata = session.getMetadata();
             String keyspaceName = config.getKeyspaceOrThrow();
+            CqlMetadata metadata = session.getMetadata();
             KeyspaceMetadata keyspace = metadata.getKeyspaceMetadata(keyspaceName);
             TableMetadata tableMetadata = keyspace.getTable(tableName);
             Set<LightweightOppToken> partitionTokens = getPartitionTokens(session, tableMetadata);
@@ -111,72 +105,8 @@ public final class CqlCluster implements Closeable {
     public Map<String, Map<InetSocketAddress, RangeSet<LightweightOppToken>>> getTransactionsTableRangesForRepair(
             List<TransactionsTableInteraction> transactionsTableInteractions) {
         try (CqlSession session = new CqlSession(cluster.connect())) {
-            String keyspaceName = config.getKeyspaceOrThrow();
-            CqlMetadata metadata = session.getMetadata();
-
-            Map<String, Set<LightweightOppToken>> partitionKeysByTable =
-                    getPartitionTokensByTable(session, transactionsTableInteractions, keyspaceName, metadata);
-
-            maybeLogTokenRanges(transactionsTableInteractions, partitionKeysByTable);
-
-            Set<InetSocketAddress> hosts = getHosts(config);
-            return KeyedStream.stream(partitionKeysByTable)
-                    .map(ranges -> ClusterMetadataUtils.getTokenMapping(hosts, metadata, keyspaceName, ranges))
-                    .collectToMap();
-        }
-    }
-
-    private static Map<String, Set<LightweightOppToken>> getPartitionTokensByTable(
-            CqlSession cqlSession,
-            List<TransactionsTableInteraction> transactionsTableInteractions,
-            String keyspaceName,
-            CqlMetadata metadata) {
-        Multimap<String, TransactionsTableInteraction> interactionsByTable =
-                Multimaps.index(transactionsTableInteractions, TransactionsTableInteraction::getTransactionsTableName);
-        return KeyedStream.stream(interactionsByTable.asMap())
-                .map(interactionsForTable -> getPartitionsTokenForSingleTransactionsTable(
-                        cqlSession, keyspaceName, metadata, interactionsForTable))
-                .collectToMap();
-    }
-
-    private static Set<LightweightOppToken> getPartitionsTokenForSingleTransactionsTable(
-            CqlSession cqlSession,
-            String keyspaceName,
-            CqlMetadata metadata,
-            Collection<TransactionsTableInteraction> interactions) {
-        return interactions.stream()
-                .map(interaction ->
-                        getPartitionTokensForTransactionsTable(cqlSession, keyspaceName, metadata, interaction))
-                .flatMap(Collection::stream)
-                .collect(Collectors.toSet());
-    }
-
-    private static Set<LightweightOppToken> getPartitionTokensForTransactionsTable(
-            CqlSession cqlSession,
-            String keyspaceName,
-            CqlMetadata metadata,
-            TransactionsTableInteraction interaction) {
-        TableMetadata transactionsTableMetadata =
-                ClusterMetadataUtils.getTableMetadata(metadata, keyspaceName, interaction.getTransactionsTableName());
-        List<Statement> selectStatements =
-                interaction.createSelectStatementsForScanningFullTimestampRange(transactionsTableMetadata);
-        return cqlSession.retrieveRowKeysAtConsistencyAll(selectStatements);
-    }
-
-    private static void maybeLogTokenRanges(
-            List<TransactionsTableInteraction> transactionsTableInteractions,
-            Map<String, Set<LightweightOppToken>> partitionKeysByTable) {
-        if (log.isDebugEnabled()) {
-            Multimap<String, TransactionsTableInteraction> indexedInteractions = Multimaps.index(
-                    transactionsTableInteractions, TransactionsTableInteraction::getTransactionsTableName);
-            Multimap<String, FullyBoundedTimestampRange> loggableTableRanges =
-                    Multimaps.transformValues(indexedInteractions, TransactionsTableInteraction::getTimestampRange);
-            Map<String, Integer> numPartitionKeysByTable =
-                    KeyedStream.stream(partitionKeysByTable).map(Set::size).collectToMap();
-            log.debug(
-                    "Identified token ranges requiring repair in the following transactions tables",
-                    SafeArg.of("transactionsTablesWithRanges", loggableTableRanges),
-                    SafeArg.of("numPartitionKeysByTable", numPartitionKeysByTable));
+            return new RepairRangeFetcher(session, config)
+                    .getTransactionTableRangesForRepair(transactionsTableInteractions);
         }
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/backup/CqlCluster.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/backup/CqlCluster.java
@@ -17,39 +17,18 @@
 package com.palantir.atlasdb.cassandra.backup;
 
 import com.datastax.driver.core.Cluster;
-import com.datastax.driver.core.ConsistencyLevel;
-import com.datastax.driver.core.KeyspaceMetadata;
-import com.datastax.driver.core.Statement;
-import com.datastax.driver.core.TableMetadata;
-import com.datastax.driver.core.querybuilder.QueryBuilder;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.RangeSet;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
-import com.palantir.atlasdb.cassandra.CassandraServersConfigs;
-import com.palantir.atlasdb.cassandra.CassandraServersConfigs.CqlCapableConfig;
 import com.palantir.atlasdb.cassandra.backup.transaction.TransactionsTableInteraction;
-import com.palantir.atlasdb.keyvalue.cassandra.CassandraConstants;
 import com.palantir.atlasdb.keyvalue.cassandra.LightweightOppToken;
 import com.palantir.atlasdb.keyvalue.cassandra.async.client.creation.ClusterFactory;
-import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.exceptions.SafeIllegalStateException;
-import com.palantir.logsafe.logger.SafeLogger;
-import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 public final class CqlCluster implements Closeable {
-    private static final SafeLogger log = SafeLoggerFactory.get(CqlCluster.class);
-
-    private static final int LONG_READ_TIMEOUT_MS = (int) TimeUnit.MINUTES.toMillis(2);
-    // reduce this from default because we run RepairTableTask across N keyspaces at the same time
-    private static final int SELECT_FETCH_SIZE = 1_000;
-
     private final Cluster cluster;
     private final CassandraKeyValueServiceConfig config;
 
@@ -69,36 +48,9 @@ public final class CqlCluster implements Closeable {
         cluster.close();
     }
 
-    private static Set<InetSocketAddress> getHosts(CassandraKeyValueServiceConfig config) {
-        return CassandraServersConfigs.getCqlCapableConfigIfValid(config)
-                .map(CqlCapableConfig::cqlHosts)
-                .orElseThrow(() -> new SafeIllegalStateException("Attempting to get token ranges with thrift config!"));
-    }
-
     public Map<InetSocketAddress, RangeSet<LightweightOppToken>> getTokenRanges(String tableName) {
         try (CqlSession session = new CqlSession(cluster.connect())) {
-            String keyspaceName = config.getKeyspaceOrThrow();
-            CqlMetadata metadata = session.getMetadata();
-            KeyspaceMetadata keyspace = metadata.getKeyspaceMetadata(keyspaceName);
-            TableMetadata tableMetadata = keyspace.getTable(tableName);
-            Set<LightweightOppToken> partitionTokens = getPartitionTokens(session, tableMetadata);
-            Map<InetSocketAddress, RangeSet<LightweightOppToken>> tokenRangesByNode =
-                    ClusterMetadataUtils.getTokenMapping(getHosts(config), metadata, keyspaceName, partitionTokens);
-
-            if (!partitionTokens.isEmpty() && log.isDebugEnabled()) {
-                int numTokenRanges = tokenRangesByNode.values().stream()
-                        .mapToInt(ranges -> ranges.asRanges().size())
-                        .sum();
-
-                log.debug(
-                        "Identified token ranges requiring repair",
-                        SafeArg.of("keyspace", keyspace),
-                        SafeArg.of("table", tableName),
-                        SafeArg.of("numPartitionKeys", partitionTokens.size()),
-                        SafeArg.of("numTokenRanges", numTokenRanges));
-            }
-
-            return tokenRangesByNode;
+            return new TokenRangeFetcher(session, config).getTokenRange(tableName);
         }
     }
 
@@ -108,23 +60,5 @@ public final class CqlCluster implements Closeable {
             return new RepairRangeFetcher(session, config)
                     .getTransactionTableRangesForRepair(transactionsTableInteractions);
         }
-    }
-
-    private static Set<LightweightOppToken> getPartitionTokens(CqlSession session, TableMetadata tableMetadata) {
-        return session.retrieveRowKeysAtConsistencyAll(createSelectStatements(tableMetadata));
-    }
-
-    private static List<Statement> createSelectStatements(TableMetadata table) {
-        return ImmutableList.of(createSelectStatement(table));
-    }
-
-    private static Statement createSelectStatement(TableMetadata table) {
-        return QueryBuilder.select(CassandraConstants.ROW)
-                // only returns the column that we need instead of all of them, otherwise we get a timeout
-                .distinct()
-                .from(table)
-                .setConsistencyLevel(ConsistencyLevel.ALL)
-                .setFetchSize(SELECT_FETCH_SIZE)
-                .setReadTimeoutMillis(LONG_READ_TIMEOUT_MS);
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/backup/RepairRangeFetcher.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/backup/RepairRangeFetcher.java
@@ -1,0 +1,120 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.cassandra.backup;
+
+import com.datastax.driver.core.Statement;
+import com.datastax.driver.core.TableMetadata;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.RangeSet;
+import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
+import com.palantir.atlasdb.cassandra.CassandraServersConfigs;
+import com.palantir.atlasdb.cassandra.backup.transaction.TransactionsTableInteraction;
+import com.palantir.atlasdb.keyvalue.cassandra.LightweightOppToken;
+import com.palantir.common.streams.KeyedStream;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import com.palantir.timestamp.FullyBoundedTimestampRange;
+import java.net.InetSocketAddress;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+class RepairRangeFetcher {
+    private static final SafeLogger log = SafeLoggerFactory.get(RepairRangeFetcher.class);
+
+    private final CqlSession cqlSession;
+    private final CassandraKeyValueServiceConfig config;
+
+    public RepairRangeFetcher(CqlSession cqlSession, CassandraKeyValueServiceConfig config) {
+        this.cqlSession = cqlSession;
+        this.config = config;
+    }
+
+    public Map<String, Map<InetSocketAddress, RangeSet<LightweightOppToken>>> getTransactionTableRangesForRepair(
+            List<TransactionsTableInteraction> transactionsTableInteractions) {
+        String keyspaceName = config.getKeyspaceOrThrow();
+        CqlMetadata metadata = cqlSession.getMetadata();
+
+        Map<String, Set<LightweightOppToken>> partitionKeysByTable =
+                getPartitionTokensByTable(transactionsTableInteractions, keyspaceName, metadata);
+
+        maybeLogTokenRanges(transactionsTableInteractions, partitionKeysByTable);
+
+        Set<InetSocketAddress> hosts = getHosts(config);
+        return KeyedStream.stream(partitionKeysByTable)
+                .map(ranges -> ClusterMetadataUtils.getTokenMapping(hosts, metadata, keyspaceName, ranges))
+                .collectToMap();
+    }
+
+    private Map<String, Set<LightweightOppToken>> getPartitionTokensByTable(
+            List<TransactionsTableInteraction> transactionsTableInteractions,
+            String keyspaceName,
+            CqlMetadata metadata) {
+        Multimap<String, TransactionsTableInteraction> interactionsByTable =
+                Multimaps.index(transactionsTableInteractions, TransactionsTableInteraction::getTransactionsTableName);
+        return KeyedStream.stream(interactionsByTable.asMap())
+                .map(interactionsForTable ->
+                        getPartitionsTokenForSingleTransactionsTable(keyspaceName, metadata, interactionsForTable))
+                .collectToMap();
+    }
+
+    private Set<LightweightOppToken> getPartitionsTokenForSingleTransactionsTable(
+            String keyspaceName, CqlMetadata metadata, Collection<TransactionsTableInteraction> interactions) {
+        return interactions.stream()
+                .map(interaction -> getPartitionTokensForTransactionsTable(keyspaceName, metadata, interaction))
+                .flatMap(Collection::stream)
+                .collect(Collectors.toSet());
+    }
+
+    private Set<LightweightOppToken> getPartitionTokensForTransactionsTable(
+            String keyspaceName, CqlMetadata metadata, TransactionsTableInteraction interaction) {
+        TableMetadata transactionsTableMetadata =
+                ClusterMetadataUtils.getTableMetadata(metadata, keyspaceName, interaction.getTransactionsTableName());
+        List<Statement> selectStatements =
+                interaction.createSelectStatementsForScanningFullTimestampRange(transactionsTableMetadata);
+        return cqlSession.retrieveRowKeysAtConsistencyAll(selectStatements);
+    }
+
+    private static void maybeLogTokenRanges(
+            List<TransactionsTableInteraction> transactionsTableInteractions,
+            Map<String, Set<LightweightOppToken>> partitionKeysByTable) {
+        if (log.isDebugEnabled()) {
+            Multimap<String, TransactionsTableInteraction> indexedInteractions = Multimaps.index(
+                    transactionsTableInteractions, TransactionsTableInteraction::getTransactionsTableName);
+            Multimap<String, FullyBoundedTimestampRange> loggableTableRanges =
+                    Multimaps.transformValues(indexedInteractions, TransactionsTableInteraction::getTimestampRange);
+            Map<String, Integer> numPartitionKeysByTable =
+                    KeyedStream.stream(partitionKeysByTable).map(Set::size).collectToMap();
+            log.debug(
+                    "Identified token ranges requiring repair in the following transactions tables",
+                    SafeArg.of("transactionsTablesWithRanges", loggableTableRanges),
+                    SafeArg.of("numPartitionKeysByTable", numPartitionKeysByTable));
+        }
+    }
+
+    // TODO(gs): move to CassandraServersConfigs
+    private static Set<InetSocketAddress> getHosts(CassandraKeyValueServiceConfig config) {
+        return CassandraServersConfigs.getCqlCapableConfigIfValid(config)
+                .map(CassandraServersConfigs.CqlCapableConfig::cqlHosts)
+                .orElseThrow(() -> new SafeIllegalStateException("Attempting to get token ranges with thrift config!"));
+    }
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/backup/RepairRangeFetcher.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/backup/RepairRangeFetcher.java
@@ -38,7 +38,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-class RepairRangeFetcher {
+final class RepairRangeFetcher {
     private static final SafeLogger log = SafeLoggerFactory.get(RepairRangeFetcher.class);
 
     private final CqlSession cqlSession;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/backup/TokenRangeFetcher.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/backup/TokenRangeFetcher.java
@@ -31,7 +31,6 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.net.InetSocketAddress;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -78,14 +77,10 @@ final class TokenRangeFetcher {
     }
 
     private Set<LightweightOppToken> getPartitionTokens(TableMetadata tableMetadata) {
-        return cqlSession.retrieveRowKeysAtConsistencyAll(createSelectStatements(tableMetadata));
+        return cqlSession.retrieveRowKeysAtConsistencyAll(ImmutableList.of(selectDistinctRowKeys(tableMetadata)));
     }
 
-    private static List<Statement> createSelectStatements(TableMetadata table) {
-        return ImmutableList.of(createSelectStatement(table));
-    }
-
-    private static Statement createSelectStatement(TableMetadata table) {
+    private static Statement selectDistinctRowKeys(TableMetadata table) {
         return QueryBuilder.select(CassandraConstants.ROW)
                 // only returns the column that we need instead of all of them, otherwise we get a timeout
                 .distinct()

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/backup/TokenRangeFetcher.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/backup/TokenRangeFetcher.java
@@ -1,0 +1,104 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.cassandra.backup;
+
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.KeyspaceMetadata;
+import com.datastax.driver.core.Statement;
+import com.datastax.driver.core.TableMetadata;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.RangeSet;
+import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
+import com.palantir.atlasdb.cassandra.CassandraServersConfigs;
+import com.palantir.atlasdb.keyvalue.cassandra.CassandraConstants;
+import com.palantir.atlasdb.keyvalue.cassandra.LightweightOppToken;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+final class TokenRangeFetcher {
+    private static final SafeLogger log = SafeLoggerFactory.get(TokenRangeFetcher.class);
+
+    private static final int LONG_READ_TIMEOUT_MS = (int) TimeUnit.MINUTES.toMillis(2);
+    // reduce this from default because we run RepairTableTask across N keyspaces at the same time
+    private static final int SELECT_FETCH_SIZE = 1_000;
+
+    private final CqlSession cqlSession;
+    private final CassandraKeyValueServiceConfig config;
+
+    public TokenRangeFetcher(CqlSession cqlSession, CassandraKeyValueServiceConfig config) {
+        this.cqlSession = cqlSession;
+        this.config = config;
+    }
+
+    public Map<InetSocketAddress, RangeSet<LightweightOppToken>> getTokenRange(String tableName) {
+        String keyspaceName = config.getKeyspaceOrThrow();
+        CqlMetadata metadata = cqlSession.getMetadata();
+        KeyspaceMetadata keyspace = metadata.getKeyspaceMetadata(keyspaceName);
+        TableMetadata tableMetadata = keyspace.getTable(tableName);
+        Set<LightweightOppToken> partitionTokens = getPartitionTokens(cqlSession, tableMetadata);
+        Map<InetSocketAddress, RangeSet<LightweightOppToken>> tokenRangesByNode =
+                ClusterMetadataUtils.getTokenMapping(getHosts(config), metadata, keyspaceName, partitionTokens);
+
+        if (!partitionTokens.isEmpty() && log.isDebugEnabled()) {
+            int numTokenRanges = tokenRangesByNode.values().stream()
+                    .mapToInt(ranges -> ranges.asRanges().size())
+                    .sum();
+
+            log.debug(
+                    "Identified token ranges requiring repair",
+                    SafeArg.of("keyspace", keyspace),
+                    SafeArg.of("table", tableName),
+                    SafeArg.of("numPartitionKeys", partitionTokens.size()),
+                    SafeArg.of("numTokenRanges", numTokenRanges));
+        }
+
+        return tokenRangesByNode;
+    }
+
+    private static Set<LightweightOppToken> getPartitionTokens(CqlSession session, TableMetadata tableMetadata) {
+        return session.retrieveRowKeysAtConsistencyAll(createSelectStatements(tableMetadata));
+    }
+
+    private static List<Statement> createSelectStatements(TableMetadata table) {
+        return ImmutableList.of(createSelectStatement(table));
+    }
+
+    private static Statement createSelectStatement(TableMetadata table) {
+        return QueryBuilder.select(CassandraConstants.ROW)
+                // only returns the column that we need instead of all of them, otherwise we get a timeout
+                .distinct()
+                .from(table)
+                .setConsistencyLevel(ConsistencyLevel.ALL)
+                .setFetchSize(SELECT_FETCH_SIZE)
+                .setReadTimeoutMillis(LONG_READ_TIMEOUT_MS);
+    }
+
+    // TODO(gs): move to CassandraServersConfigs
+    private static Set<InetSocketAddress> getHosts(CassandraKeyValueServiceConfig config) {
+        return CassandraServersConfigs.getCqlCapableConfigIfValid(config)
+                .map(CassandraServersConfigs.CqlCapableConfig::cqlHosts)
+                .orElseThrow(() -> new SafeIllegalStateException("Attempting to get token ranges with thrift config!"));
+    }
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/client/creation/ClusterFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/client/creation/ClusterFactory.java
@@ -32,10 +32,8 @@ import com.datastax.driver.core.policies.TokenAwarePolicy;
 import com.datastax.driver.core.policies.WhiteListPolicy;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.CassandraServersConfigs;
-import com.palantir.atlasdb.cassandra.CassandraServersConfigs.CqlCapableConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraConstants;
 import com.palantir.conjure.java.config.ssl.SslSocketFactories;
-import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.net.InetSocketAddress;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -49,7 +47,7 @@ public class ClusterFactory {
     }
 
     public Cluster constructCluster(CassandraKeyValueServiceConfig config) {
-        Set<InetSocketAddress> hosts = getHosts(config);
+        Set<InetSocketAddress> hosts = CassandraServersConfigs.getCqlHosts(config);
         return constructCluster(hosts, config);
     }
 
@@ -72,13 +70,6 @@ public class ClusterFactory {
         clusterBuilder = withSocketOptions(clusterBuilder, config);
 
         return clusterBuilder.build();
-    }
-
-    private static Set<InetSocketAddress> getHosts(CassandraKeyValueServiceConfig config) {
-        return CassandraServersConfigs.getCqlCapableConfigIfValid(config)
-                .map(CqlCapableConfig::cqlHosts)
-                .orElseThrow(
-                        () -> new SafeIllegalStateException("Attempting to set up CqlCluster with thrift config!"));
     }
 
     private static Cluster.Builder withSocketOptions(

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/client/creation/DefaultCqlClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/client/creation/DefaultCqlClientFactory.java
@@ -21,8 +21,6 @@ import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.CassandraServersConfigs;
 import com.palantir.atlasdb.keyvalue.cassandra.async.CqlClient;
 import com.palantir.atlasdb.keyvalue.cassandra.async.CqlClientImpl;
-import com.palantir.logsafe.logger.SafeLogger;
-import com.palantir.logsafe.logger.SafeLoggerFactory;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.net.InetSocketAddress;
 import java.util.Optional;
@@ -31,8 +29,6 @@ import java.util.function.Supplier;
 
 public class DefaultCqlClientFactory implements CqlClientFactory {
     public static final CqlClientFactory DEFAULT = new DefaultCqlClientFactory();
-
-    private static final SafeLogger log = SafeLoggerFactory.get(DefaultCqlClientFactory.class);
 
     private final Supplier<Cluster.Builder> cqlClusterBuilderFactory;
 


### PR DESCRIPTION
**Goals (and why)**:
- The CqlCluster class was becoming bloated
- Want to make the restore tasks individually testable 

**Implementation Description (bullets)**:
- Pull out classes from CqlCluster
- Deduped a method

**Testing (What was existing testing like?  What have you done to improve it?)**:
Tests for these tasks are covered in ETE tests, but in a later PR, I can convert these to unit tests.
I'd like to focus on delivering the final part (CleanTransactionsTables) before doing this conversion, and that part depends on this branch.

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**: Probably CqlCluster side-by-side with the new classes - it should be a fairly clean copy.

**Priority (whenever / two weeks / yesterday)**: today 🙏 

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
