### PR TITLE
Use singleton for default table factory

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/TableFactoryRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/TableFactoryRenderer.java
@@ -122,6 +122,7 @@ public final class TableFactoryRenderer {
                 ClassName.get(Function.class), WildcardTypeName.supertypeOf(Transaction.class), sharedTriggersType);
 
         results.add(getDefaultNamespaceField());
+        results.add(getDefaultTableFactoryField());
         results.add(FieldSpec.builder(
                         ParameterizedTypeName.get(ClassName.get(List.class), functionOfTransactionAndTriggersType),
                         "sharedTriggers")
@@ -165,19 +166,11 @@ public final class TableFactoryRenderer {
 
         results.add(factoryBaseBuilder()
                 .addParameter(Namespace.class, "namespace")
-                .addStatement(
-                        "return of($T.<$T>of(), $L)",
-                        ImmutableList.class,
-                        functionOfTransactionAndTriggersType,
-                        "namespace")
+                .addStatement("return of($T.of(), $L)", ImmutableList.class, "namespace")
                 .build());
 
         results.add(factoryBaseBuilder()
-                .addStatement(
-                        "return of($T.<$T>of(), $L)",
-                        ImmutableList.class,
-                        functionOfTransactionAndTriggersType,
-                        "defaultNamespace")
+                .addStatement("return $L", "defaultTableFactory")
                 .build());
 
         results.add(MethodSpec.constructorBuilder()
@@ -317,5 +310,12 @@ public final class TableFactoryRenderer {
                     "$T.create($S, $T.UNCHECKED_NAME)", Namespace.class, defaultNamespaceName, Namespace.class);
         }
         return namespaceFieldBuilder.build();
+    }
+
+    private FieldSpec getDefaultTableFactoryField() {
+        return FieldSpec.builder(tableFactoryType, "defaultTableFactory")
+                .addModifiers(Modifier.PRIVATE, Modifier.FINAL, Modifier.STATIC)
+                .initializer("of($T.of(), $L)", ImmutableList.class, "defaultNamespace")
+                .build();
     }
 }

--- a/changelog/@unreleased/pr-5843.v2.yml
+++ b/changelog/@unreleased/pr-5843.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: The default table factory is now a singleton.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5843


### PR DESCRIPTION
## Goals
Allows callers to use `MyTableFactory.of()` directly and rely on the value being cached so they don't have to create constants themselves.

## Implementation Description

**Before**
```java
public final class MyTableFactory {
    public static MyTableFactory of() {
        return of(ImmutableList.of(), defaultNamespace);
    }
}
```

**After**
```java
public final class MyTableFactory {
    private static final MyTableFactory defaultTableFactory = of(ImmutableList.of(), defaultNamespace);
    
    public static MyTableFactory of() {
        return defaultTableFactory;
    }
}
```

## Testing
I tested this locally and verified that the generated code looks as expected and compiles.
