### PR TITLE
ABR 10a: Unit tests for RangeFetcher classes

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/backup/CassandraRepairHelper.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/backup/CassandraRepairHelper.java
@@ -35,6 +35,7 @@ import com.palantir.common.streams.KeyedStream;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
+
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.time.Duration;
@@ -87,8 +88,6 @@ public class CassandraRepairHelper {
         CqlCluster cqlCluster = cqlClusters.get(namespace);
         KeyedStream.of(getTableNamesToRepair(kvs))
                 .map(tableName -> getRangesToRepair(cqlCluster, namespace, tableName))
-                // TODO(gs): this will do repairs serially, instead of batched. Is this fine? Port batching from
-                //   internal product?
                 .forEach(repairTable);
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/backup/CassandraRepairHelper.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/backup/CassandraRepairHelper.java
@@ -35,7 +35,6 @@ import com.palantir.common.streams.KeyedStream;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
-
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.time.Duration;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/backup/CqlMetadata.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/backup/CqlMetadata.java
@@ -16,7 +16,6 @@
 
 package com.palantir.atlasdb.cassandra.backup;
 
-import com.datastax.driver.core.Host;
 import com.datastax.driver.core.KeyspaceMetadata;
 import com.datastax.driver.core.Metadata;
 import com.datastax.driver.core.Token;
@@ -27,6 +26,7 @@ import com.google.common.collect.Range;
 import com.palantir.atlasdb.keyvalue.cassandra.LightweightOppToken;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
+import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -76,8 +76,10 @@ public class CqlMetadata {
         }
     }
 
-    public Set<Host> getReplicas(String keyspace, Range<LightweightOppToken> range) {
-        return metadata.getReplicas(quotedKeyspace(keyspace), toTokenRange(range));
+    public Set<InetSocketAddress> getReplicas(String keyspace, Range<LightweightOppToken> range) {
+        return metadata.getReplicas(quotedKeyspace(keyspace), toTokenRange(range)).stream()
+                .map(host -> host.getEndPoint().resolve())
+                .collect(Collectors.toSet());
     }
 
     @VisibleForTesting

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/BackupTestUtils.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/BackupTestUtils.java
@@ -28,7 +28,6 @@ import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.CassandraServersConfigs;
 import com.palantir.atlasdb.cassandra.ImmutableCqlCapableConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.LightweightOppToken;
-import com.palantir.atlasdb.transaction.impl.TransactionConstants;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.List;
@@ -50,9 +49,6 @@ final class BackupTestUtils {
     static final Range<LightweightOppToken> RANGE_1_TO_2 = Range.openClosed(TOKEN_1, TOKEN_2);
     static final Range<LightweightOppToken> RANGE_2_TO_3 = Range.openClosed(TOKEN_2, TOKEN_3);
     static final Range<LightweightOppToken> RANGE_GREATER_THAN_3 = Range.greaterThan(TOKEN_3);
-
-    static final String TXN_1 = TransactionConstants.TRANSACTION_TABLE.getTableName();
-    static final String TXN_2 = TransactionConstants.TRANSACTIONS2_TABLE.getTableName();
 
     private BackupTestUtils() {
         // utility

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/BackupTestUtils.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/BackupTestUtils.java
@@ -1,0 +1,26 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.cassandra.backup;
+
+import com.palantir.atlasdb.keyvalue.cassandra.LightweightOppToken;
+import javax.xml.bind.DatatypeConverter;
+
+public class BackupTestUtils {
+    public static LightweightOppToken lightweightOppToken(String hexString) {
+        return new LightweightOppToken(DatatypeConverter.parseHexBinary(hexString));
+    }
+}

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/BackupTestUtils.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/BackupTestUtils.java
@@ -77,15 +77,18 @@ final class BackupTestUtils {
         when(config.getKeyspaceOrThrow()).thenReturn(KEYSPACE_NAME);
     }
 
-    static void mockMetadata(CqlMetadata cqlMetadata, String... tableNames) {
-        KeyspaceMetadata keyspaceMetadata = mock(KeyspaceMetadata.class);
-        when(keyspaceMetadata.getName()).thenReturn(KEYSPACE_NAME);
+    static List<TableMetadata> mockTableMetadatas(KeyspaceMetadata keyspaceMetadata, String... tableNames) {
         List<TableMetadata> tableMetadatas = Arrays.stream(tableNames)
                 .map(tableName -> mockTableMetadata(keyspaceMetadata, tableName))
                 .collect(Collectors.toList());
-        when(keyspaceMetadata.getTables()).thenReturn(tableMetadatas);
+        return tableMetadatas;
+    }
 
+    static KeyspaceMetadata mockKeyspaceMetadata(CqlMetadata cqlMetadata) {
+        KeyspaceMetadata keyspaceMetadata = mock(KeyspaceMetadata.class);
+        when(keyspaceMetadata.getName()).thenReturn(KEYSPACE_NAME);
         when(cqlMetadata.getKeyspaceMetadata(KEYSPACE_NAME)).thenReturn(keyspaceMetadata);
+        return keyspaceMetadata;
     }
 
     private static TableMetadata mockTableMetadata(KeyspaceMetadata keyspaceMetadata, String tableName) {

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/BackupTestUtils.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/BackupTestUtils.java
@@ -16,11 +16,82 @@
 
 package com.palantir.atlasdb.cassandra.backup;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.datastax.driver.core.KeyspaceMetadata;
+import com.datastax.driver.core.TableMetadata;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Range;
+import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
+import com.palantir.atlasdb.cassandra.CassandraServersConfigs;
+import com.palantir.atlasdb.cassandra.ImmutableCqlCapableConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.LightweightOppToken;
+import com.palantir.atlasdb.transaction.impl.TransactionConstants;
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 import javax.xml.bind.DatatypeConverter;
 
-public class BackupTestUtils {
-    public static LightweightOppToken lightweightOppToken(String hexString) {
+final class BackupTestUtils {
+    static final InetSocketAddress HOST_1 = new InetSocketAddress("cassandra-1", 9042);
+    static final InetSocketAddress HOST_2 = new InetSocketAddress("cassandra-2", 9042);
+    static final InetSocketAddress HOST_3 = new InetSocketAddress("cassandra-3", 9042);
+    static final ImmutableList<InetSocketAddress> HOSTS = ImmutableList.of(HOST_1, HOST_2, HOST_3);
+    static final String KEYSPACE_NAME = "keyspace";
+
+    static final LightweightOppToken TOKEN_1 = BackupTestUtils.lightweightOppToken("1111");
+    static final LightweightOppToken TOKEN_2 = BackupTestUtils.lightweightOppToken("5555");
+    static final LightweightOppToken TOKEN_3 = BackupTestUtils.lightweightOppToken("9999");
+
+    static final Range<LightweightOppToken> RANGE_AT_MOST_1 = Range.atMost(TOKEN_1);
+    static final Range<LightweightOppToken> RANGE_1_TO_2 = Range.openClosed(TOKEN_1, TOKEN_2);
+    static final Range<LightweightOppToken> RANGE_2_TO_3 = Range.openClosed(TOKEN_2, TOKEN_3);
+    static final Range<LightweightOppToken> RANGE_GREATER_THAN_3 = Range.greaterThan(TOKEN_3);
+
+    static final String TXN_1 = TransactionConstants.TRANSACTION_TABLE.getTableName();
+    static final String TXN_2 = TransactionConstants.TRANSACTIONS2_TABLE.getTableName();
+
+    private BackupTestUtils() {
+        // utility
+    }
+
+    static LightweightOppToken lightweightOppToken(String hexString) {
         return new LightweightOppToken(DatatypeConverter.parseHexBinary(hexString));
+    }
+
+    static void mockTokenRanges(CqlSession cqlSession, CqlMetadata cqlMetadata) {
+        when(cqlMetadata.getTokenRanges())
+                .thenReturn(ImmutableSet.of(RANGE_AT_MOST_1, RANGE_1_TO_2, RANGE_2_TO_3, RANGE_GREATER_THAN_3));
+        when(cqlSession.getMetadata()).thenReturn(cqlMetadata);
+    }
+
+    static void mockConfig(CassandraKeyValueServiceConfig config) {
+        CassandraServersConfigs.CqlCapableConfig cqlCapableConfig = ImmutableCqlCapableConfig.builder()
+                .addAllCqlHosts(HOSTS)
+                .addAllThriftHosts(HOSTS)
+                .build();
+        when(config.servers()).thenReturn(cqlCapableConfig);
+        when(config.getKeyspaceOrThrow()).thenReturn(KEYSPACE_NAME);
+    }
+
+    static void mockMetadata(CqlMetadata cqlMetadata, String... tableNames) {
+        KeyspaceMetadata keyspaceMetadata = mock(KeyspaceMetadata.class);
+        when(keyspaceMetadata.getName()).thenReturn(KEYSPACE_NAME);
+        List<TableMetadata> tableMetadatas = Arrays.stream(tableNames)
+                .map(tableName -> mockTableMetadata(keyspaceMetadata, tableName))
+                .collect(Collectors.toList());
+        when(keyspaceMetadata.getTables()).thenReturn(tableMetadatas);
+
+        when(cqlMetadata.getKeyspaceMetadata(KEYSPACE_NAME)).thenReturn(keyspaceMetadata);
+    }
+
+    private static TableMetadata mockTableMetadata(KeyspaceMetadata keyspaceMetadata, String tableName) {
+        TableMetadata tableMetadata = mock(TableMetadata.class);
+        when(tableMetadata.getKeyspace()).thenReturn(keyspaceMetadata);
+        when(tableMetadata.getName()).thenReturn(tableName);
+        return tableMetadata;
     }
 }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/BackupTestUtils.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/BackupTestUtils.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import javax.xml.bind.DatatypeConverter;
 
+@SuppressWarnings("DnsLookup")
 final class BackupTestUtils {
     static final InetSocketAddress HOST_1 = new InetSocketAddress("cassandra-1", 9042);
     static final InetSocketAddress HOST_2 = new InetSocketAddress("cassandra-2", 9042);

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/RepairRangeFetcherTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/RepairRangeFetcherTest.java
@@ -35,6 +35,7 @@ import com.palantir.atlasdb.cassandra.backup.transaction.Transactions2TableInter
 import com.palantir.atlasdb.cassandra.backup.transaction.Transactions3TableInteraction;
 import com.palantir.atlasdb.cassandra.backup.transaction.TransactionsTableInteraction;
 import com.palantir.atlasdb.keyvalue.cassandra.LightweightOppToken;
+import com.palantir.atlasdb.transaction.impl.TransactionConstants;
 import com.palantir.timestamp.FullyBoundedTimestampRange;
 import java.net.InetSocketAddress;
 import java.util.List;
@@ -50,6 +51,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class RepairRangeFetcherTest {
     static final LightweightOppToken OTHER_TOKEN = BackupTestUtils.lightweightOppToken("7777");
     static final DefaultRetryPolicy POLICY = DefaultRetryPolicy.INSTANCE;
+    static final String TXN_1 = TransactionConstants.TRANSACTION_TABLE.getTableName();
+    static final String TXN_2 = TransactionConstants.TRANSACTIONS2_TABLE.getTableName();
 
     @Mock
     private CqlSession cqlSession;
@@ -65,8 +68,7 @@ public class RepairRangeFetcherTest {
     @Before
     public void setUp() {
         KeyspaceMetadata keyspaceMetadata = BackupTestUtils.mockKeyspaceMetadata(cqlMetadata);
-        List<TableMetadata> tableMetadatas =
-                BackupTestUtils.mockTableMetadatas(keyspaceMetadata, BackupTestUtils.TXN_1, BackupTestUtils.TXN_2);
+        List<TableMetadata> tableMetadatas = BackupTestUtils.mockTableMetadatas(keyspaceMetadata, TXN_1, TXN_2);
         when(keyspaceMetadata.getTables()).thenReturn(tableMetadatas);
 
         BackupTestUtils.mockTokenRanges(cqlSession, cqlMetadata);
@@ -87,7 +89,7 @@ public class RepairRangeFetcherTest {
 
         Map<String, Map<InetSocketAddress, RangeSet<LightweightOppToken>>> rangesForRepair =
                 repairRangeFetcher.getTransactionTableRangesForRepair(interactions);
-        assertThat(rangesForRepair.keySet()).containsExactly(BackupTestUtils.TXN_1);
+        assertThat(rangesForRepair.keySet()).containsExactly(TXN_1);
     }
 
     @Test
@@ -96,7 +98,7 @@ public class RepairRangeFetcherTest {
                 ImmutableList.of(new Transactions2TableInteraction(range(1L, 10_000_000L), POLICY));
         Map<String, Map<InetSocketAddress, RangeSet<LightweightOppToken>>> rangesForRepair =
                 repairRangeFetcher.getTransactionTableRangesForRepair(interactions);
-        assertThat(rangesForRepair.keySet()).containsExactly(BackupTestUtils.TXN_2);
+        assertThat(rangesForRepair.keySet()).containsExactly(TXN_2);
     }
 
     @Test
@@ -107,7 +109,7 @@ public class RepairRangeFetcherTest {
                 repairRangeFetcher.getTransactionTableRangesForRepair(interactions);
 
         // Transactions3 is backed by Transactions2 under the hood, so this is the table that will be repaired.
-        assertThat(rangesForRepair.keySet()).containsExactly(BackupTestUtils.TXN_2);
+        assertThat(rangesForRepair.keySet()).containsExactly(TXN_2);
     }
 
     @Test
@@ -118,7 +120,7 @@ public class RepairRangeFetcherTest {
 
         Map<String, Map<InetSocketAddress, RangeSet<LightweightOppToken>>> rangesForRepair =
                 repairRangeFetcher.getTransactionTableRangesForRepair(interactions);
-        assertThat(rangesForRepair.keySet()).containsExactlyInAnyOrder(BackupTestUtils.TXN_1, BackupTestUtils.TXN_2);
+        assertThat(rangesForRepair.keySet()).containsExactlyInAnyOrder(TXN_1, TXN_2);
     }
 
     @Test
@@ -131,7 +133,7 @@ public class RepairRangeFetcherTest {
 
         Map<String, Map<InetSocketAddress, RangeSet<LightweightOppToken>>> rangesForRepair =
                 repairRangeFetcher.getTransactionTableRangesForRepair(interactions);
-        assertThat(rangesForRepair.keySet()).containsExactlyInAnyOrder(BackupTestUtils.TXN_1, BackupTestUtils.TXN_2);
+        assertThat(rangesForRepair.keySet()).containsExactlyInAnyOrder(TXN_1, TXN_2);
     }
 
     @Test
@@ -141,10 +143,7 @@ public class RepairRangeFetcherTest {
         Map<String, Map<InetSocketAddress, RangeSet<LightweightOppToken>>> rangesForRepair =
                 repairRangeFetcher.getTransactionTableRangesForRepair(interactions);
 
-        assertThat(rangesForRepair
-                        .get(BackupTestUtils.TXN_2)
-                        .get(BackupTestUtils.HOST_1)
-                        .asRanges())
+        assertThat(rangesForRepair.get(TXN_2).get(BackupTestUtils.HOST_1).asRanges())
                 .containsExactlyInAnyOrder(
                         Range.atMost(BackupTestUtils.TOKEN_1),
                         Range.openClosed(BackupTestUtils.TOKEN_2, OTHER_TOKEN),
@@ -158,7 +157,7 @@ public class RepairRangeFetcherTest {
         Map<String, Map<InetSocketAddress, RangeSet<LightweightOppToken>>> rangesForRepair =
                 repairRangeFetcher.getTransactionTableRangesForRepair(interactions);
 
-        assertThat(rangesForRepair.get(BackupTestUtils.TXN_2).keySet())
+        assertThat(rangesForRepair.get(TXN_2).keySet())
                 .containsExactlyInAnyOrder(BackupTestUtils.HOST_1, BackupTestUtils.HOST_2, BackupTestUtils.HOST_3);
     }
 
@@ -171,7 +170,7 @@ public class RepairRangeFetcherTest {
         Map<String, Map<InetSocketAddress, RangeSet<LightweightOppToken>>> rangesForRepair =
                 repairRangeFetcher.getTransactionTableRangesForRepair(interactions);
 
-        assertThat(rangesForRepair.get(BackupTestUtils.TXN_2).keySet())
+        assertThat(rangesForRepair.get(TXN_2).keySet())
                 .containsExactlyInAnyOrder(BackupTestUtils.HOST_1, BackupTestUtils.HOST_2);
     }
 

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/RepairRangeFetcherTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/RepairRangeFetcherTest.java
@@ -16,42 +16,47 @@
 
 package com.palantir.atlasdb.cassandra.backup;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import com.datastax.driver.core.KeyspaceMetadata;
 import com.datastax.driver.core.TableMetadata;
+import com.datastax.driver.core.policies.DefaultRetryPolicy;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.CassandraServersConfigs;
 import com.palantir.atlasdb.cassandra.ImmutableCqlCapableConfig;
+import com.palantir.atlasdb.cassandra.backup.transaction.Transactions1TableInteraction;
+import com.palantir.atlasdb.cassandra.backup.transaction.TransactionsTableInteraction;
 import com.palantir.atlasdb.keyvalue.cassandra.LightweightOppToken;
-import java.net.InetSocketAddress;
-import java.nio.charset.StandardCharsets;
-import java.util.Map;
+import com.palantir.atlasdb.transaction.impl.TransactionConstants;
+import com.palantir.timestamp.FullyBoundedTimestampRange;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+// TODO(gs): deduplicate mockery
 @RunWith(MockitoJUnitRunner.class)
-@SuppressWarnings({"DnsLookup", "UnstableApiUsage"})
-public class TokenRangeFetcherTest {
+public class RepairRangeFetcherTest {
     private static final InetSocketAddress HOST_1 = new InetSocketAddress("cassandra-1", 9042);
     private static final InetSocketAddress HOST_2 = new InetSocketAddress("cassandra-2", 9042);
     private static final InetSocketAddress HOST_3 = new InetSocketAddress("cassandra-3", 9042);
     private static final ImmutableList<InetSocketAddress> HOSTS = ImmutableList.of(HOST_1, HOST_2, HOST_3);
     private static final String KEYSPACE_NAME = "keyspace";
-    private static final String TABLE_NAME = "table";
+    private static final DefaultRetryPolicy POLICY = DefaultRetryPolicy.INSTANCE;
+    private static final String TXN_1 = TransactionConstants.TRANSACTION_TABLE.getTableName();
 
     private static final LightweightOppToken TOKEN_1 = new LightweightOppToken("1111".getBytes(StandardCharsets.UTF_8));
     private static final LightweightOppToken TOKEN_2 = new LightweightOppToken("2222".getBytes(StandardCharsets.UTF_8));
@@ -71,23 +76,26 @@ public class TokenRangeFetcherTest {
     @Mock
     private CassandraKeyValueServiceConfig config;
 
-    private TokenRangeFetcher tokenRangeFetcher;
+    private RepairRangeFetcher repairRangeFetcher;
 
     @Before
     public void setUp() {
-        TableMetadata tableMetadata = mock(TableMetadata.class);
+        TableMetadata txn1Metadata = mock(TableMetadata.class);
 
         KeyspaceMetadata keyspaceMetadata = mock(KeyspaceMetadata.class);
         when(keyspaceMetadata.getName()).thenReturn(KEYSPACE_NAME);
-        when(keyspaceMetadata.getTable(TABLE_NAME)).thenReturn(tableMetadata);
-        when(tableMetadata.getKeyspace()).thenReturn(keyspaceMetadata);
-        when(tableMetadata.getName()).thenReturn(TABLE_NAME);
+        when(keyspaceMetadata.getTables()).thenReturn(ImmutableList.of(txn1Metadata));
+        when(txn1Metadata.getKeyspace()).thenReturn(keyspaceMetadata);
+        when(txn1Metadata.getName()).thenReturn(TXN_1);
         when(cqlMetadata.getKeyspaceMetadata(KEYSPACE_NAME)).thenReturn(keyspaceMetadata);
 
+        when(cqlSession.getMetadata()).thenReturn(cqlMetadata);
         when(cqlSession.retrieveRowKeysAtConsistencyAll(anyList()))
-                .thenReturn(ImmutableSet.of(TOKEN_1, TOKEN_2, TOKEN_3));
+                .thenReturn(ImmutableSet.of(token("1111"), token("5555")));
+
         when(cqlMetadata.getTokenRanges())
                 .thenReturn(ImmutableSet.of(RANGE_AT_MOST_1, RANGE_1_TO_2, RANGE_2_TO_3, RANGE_GREATER_THAN_3));
+        when(cqlMetadata.getReplicas(eq(KEYSPACE_NAME), any())).thenReturn(ImmutableSet.copyOf(HOSTS));
         when(cqlSession.getMetadata()).thenReturn(cqlMetadata);
 
         CassandraServersConfigs.CqlCapableConfig cqlCapableConfig = ImmutableCqlCapableConfig.builder()
@@ -97,31 +105,25 @@ public class TokenRangeFetcherTest {
         when(config.servers()).thenReturn(cqlCapableConfig);
         when(config.getKeyspaceOrThrow()).thenReturn(KEYSPACE_NAME);
 
-        tokenRangeFetcher = new TokenRangeFetcher(cqlSession, config);
+        repairRangeFetcher = new RepairRangeFetcher(cqlSession, config);
     }
 
     @Test
-    public void allNodesGetAllRangesWithThreeNodesAndRF3() {
-        when(cqlMetadata.getReplicas(eq(KEYSPACE_NAME), any())).thenReturn(ImmutableSet.copyOf(HOSTS));
+    public void testRepairOnlyTxn1() {
+        List<TransactionsTableInteraction> interactions =
+                ImmutableList.of(new Transactions1TableInteraction(range(1L, 10_000_000L), POLICY));
 
-        Map<InetSocketAddress, RangeSet<LightweightOppToken>> tokenRange = tokenRangeFetcher.getTokenRange(TABLE_NAME);
-        assertThat(tokenRange.keySet()).containsExactlyInAnyOrder(HOST_1, HOST_2, HOST_3);
-        HOSTS.forEach(host -> assertThat(tokenRange.get(host)).isEqualTo(ImmutableRangeSet.of(Range.all())));
+        Map<String, Map<InetSocketAddress, RangeSet<LightweightOppToken>>> rangesForRepair =
+                repairRangeFetcher.getTransactionTableRangesForRepair(interactions);
+        assertThat(rangesForRepair.keySet()).containsExactly(TXN_1);
     }
 
-    @Test
-    public void testGetTokenRangesWithRF2() {
-        when(cqlMetadata.getReplicas(KEYSPACE_NAME, RANGE_AT_MOST_1)).thenReturn(ImmutableSet.of(HOST_3, HOST_1));
-        when(cqlMetadata.getReplicas(KEYSPACE_NAME, RANGE_GREATER_THAN_3)).thenReturn(ImmutableSet.of(HOST_3, HOST_1));
-        when(cqlMetadata.getReplicas(KEYSPACE_NAME, RANGE_1_TO_2)).thenReturn(ImmutableSet.of(HOST_1, HOST_2));
-        when(cqlMetadata.getReplicas(KEYSPACE_NAME, RANGE_2_TO_3)).thenReturn(ImmutableSet.of(HOST_2, HOST_3));
+    private static FullyBoundedTimestampRange range(long lower, long upper) {
+        return FullyBoundedTimestampRange.of(Range.closed(lower, upper));
+    }
 
-        Map<InetSocketAddress, RangeSet<LightweightOppToken>> tokenRange = tokenRangeFetcher.getTokenRange(TABLE_NAME);
-        assertThat(tokenRange.keySet()).containsExactlyInAnyOrder(HOST_1, HOST_2, HOST_3);
-        assertThat(tokenRange.get(HOST_1).asRanges())
-                .containsExactly(Range.atMost(TOKEN_2), Range.greaterThan(TOKEN_3));
-        assertThat(tokenRange.get(HOST_2).asRanges()).containsExactly(Range.openClosed(TOKEN_1, TOKEN_3));
-        assertThat(tokenRange.get(HOST_3).asRanges())
-                .containsExactly(Range.atMost(TOKEN_1), Range.greaterThan(TOKEN_2));
+    // TODO(gs): refine/unify test token generation?
+    private static LightweightOppToken token(String hexString) {
+        return new LightweightOppToken(hexString.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/RepairRangeFetcherTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/RepairRangeFetcherTest.java
@@ -22,6 +22,8 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+import com.datastax.driver.core.KeyspaceMetadata;
+import com.datastax.driver.core.TableMetadata;
 import com.datastax.driver.core.policies.DefaultRetryPolicy;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -62,7 +64,11 @@ public class RepairRangeFetcherTest {
 
     @Before
     public void setUp() {
-        BackupTestUtils.mockMetadata(cqlMetadata, BackupTestUtils.TXN_1, BackupTestUtils.TXN_2);
+        KeyspaceMetadata keyspaceMetadata = BackupTestUtils.mockKeyspaceMetadata(cqlMetadata);
+        List<TableMetadata> tableMetadatas =
+                BackupTestUtils.mockTableMetadatas(keyspaceMetadata, BackupTestUtils.TXN_1, BackupTestUtils.TXN_2);
+        when(keyspaceMetadata.getTables()).thenReturn(tableMetadatas);
+
         BackupTestUtils.mockTokenRanges(cqlSession, cqlMetadata);
         BackupTestUtils.mockConfig(config);
 

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/RepairRangeFetcherTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/RepairRangeFetcherTest.java
@@ -16,6 +16,13 @@
 
 package com.palantir.atlasdb.cassandra.backup;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import com.datastax.driver.core.KeyspaceMetadata;
 import com.datastax.driver.core.TableMetadata;
 import com.datastax.driver.core.policies.DefaultRetryPolicy;
@@ -31,21 +38,15 @@ import com.palantir.atlasdb.cassandra.backup.transaction.TransactionsTableIntera
 import com.palantir.atlasdb.keyvalue.cassandra.LightweightOppToken;
 import com.palantir.atlasdb.transaction.impl.TransactionConstants;
 import com.palantir.timestamp.FullyBoundedTimestampRange;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import java.net.InetSocketAddress;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 // TODO(gs): deduplicate mockery
 @RunWith(MockitoJUnitRunner.class)

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/TokenRangeFetcherTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/TokenRangeFetcherTest.java
@@ -35,7 +35,6 @@ import com.palantir.atlasdb.cassandra.CassandraServersConfigs;
 import com.palantir.atlasdb.cassandra.ImmutableCqlCapableConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.LightweightOppToken;
 import java.net.InetSocketAddress;
-import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
@@ -53,9 +52,9 @@ public class TokenRangeFetcherTest {
     private static final String KEYSPACE_NAME = "keyspace";
     private static final String TABLE_NAME = "table";
 
-    private static final LightweightOppToken TOKEN_1 = new LightweightOppToken("1111".getBytes(StandardCharsets.UTF_8));
-    private static final LightweightOppToken TOKEN_2 = new LightweightOppToken("2222".getBytes(StandardCharsets.UTF_8));
-    private static final LightweightOppToken TOKEN_3 = new LightweightOppToken("3333".getBytes(StandardCharsets.UTF_8));
+    private static final LightweightOppToken TOKEN_1 = BackupTestUtils.lightweightOppToken("1111");
+    private static final LightweightOppToken TOKEN_2 = BackupTestUtils.lightweightOppToken("2222");
+    private static final LightweightOppToken TOKEN_3 = BackupTestUtils.lightweightOppToken("3333");
 
     private static final Range<LightweightOppToken> RANGE_AT_MOST_1 = Range.atMost(TOKEN_1);
     private static final Range<LightweightOppToken> RANGE_1_TO_2 = Range.openClosed(TOKEN_1, TOKEN_2);

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/TokenRangeFetcherTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/TokenRangeFetcherTest.java
@@ -1,0 +1,128 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.cassandra.backup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.datastax.driver.core.KeyspaceMetadata;
+import com.datastax.driver.core.TableMetadata;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableRangeSet;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Range;
+import com.google.common.collect.RangeSet;
+import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
+import com.palantir.atlasdb.cassandra.CassandraServersConfigs;
+import com.palantir.atlasdb.cassandra.ImmutableCqlCapableConfig;
+import com.palantir.atlasdb.keyvalue.cassandra.LightweightOppToken;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+@SuppressWarnings({"DnsLookup", "UnstableApiUsage"})
+public class TokenRangeFetcherTest {
+    private static final InetSocketAddress HOST_1 = new InetSocketAddress("cassandra-1", 9042);
+    private static final InetSocketAddress HOST_2 = new InetSocketAddress("cassandra-2", 9042);
+    private static final InetSocketAddress HOST_3 = new InetSocketAddress("cassandra-3", 9042);
+    private static final ImmutableList<InetSocketAddress> HOSTS = ImmutableList.of(HOST_1, HOST_2, HOST_3);
+    private static final String KEYSPACE_NAME = "keyspace";
+    private static final String TABLE_NAME = "table";
+
+    private static final LightweightOppToken TOKEN_1 = new LightweightOppToken("1111".getBytes(StandardCharsets.UTF_8));
+    private static final LightweightOppToken TOKEN_2 = new LightweightOppToken("2222".getBytes(StandardCharsets.UTF_8));
+    private static final LightweightOppToken TOKEN_3 = new LightweightOppToken("3333".getBytes(StandardCharsets.UTF_8));
+
+    private static final Range<LightweightOppToken> RANGE_AT_MOST_1 = Range.atMost(TOKEN_1);
+    private static final Range<LightweightOppToken> RANGE_1_TO_2 = Range.openClosed(TOKEN_1, TOKEN_2);
+    private static final Range<LightweightOppToken> RANGE_2_TO_3 = Range.openClosed(TOKEN_2, TOKEN_3);
+    private static final Range<LightweightOppToken> RANGE_GREATER_THAN_3 = Range.greaterThan(TOKEN_3);
+
+    @Mock
+    private CqlSession cqlSession;
+
+    @Mock
+    private CqlMetadata cqlMetadata;
+
+    @Mock
+    private CassandraKeyValueServiceConfig config;
+
+    private TokenRangeFetcher tokenRangeFetcher;
+
+    @Before
+    public void setUp() {
+        TableMetadata tableMetadata = mock(TableMetadata.class);
+
+        KeyspaceMetadata keyspaceMetadata = mock(KeyspaceMetadata.class);
+        when(keyspaceMetadata.getName()).thenReturn(KEYSPACE_NAME);
+        when(keyspaceMetadata.getTable(TABLE_NAME)).thenReturn(tableMetadata);
+        when(tableMetadata.getKeyspace()).thenReturn(keyspaceMetadata);
+        when(tableMetadata.getName()).thenReturn(TABLE_NAME);
+        when(cqlMetadata.getKeyspaceMetadata(KEYSPACE_NAME)).thenReturn(keyspaceMetadata);
+
+        when(cqlSession.retrieveRowKeysAtConsistencyAll(anyList()))
+                .thenReturn(ImmutableSet.of(TOKEN_1, TOKEN_2, TOKEN_3));
+        when(cqlMetadata.getTokenRanges())
+                .thenReturn(ImmutableSet.of(RANGE_AT_MOST_1, RANGE_1_TO_2, RANGE_2_TO_3, RANGE_GREATER_THAN_3));
+        when(cqlSession.getMetadata()).thenReturn(cqlMetadata);
+
+        CassandraServersConfigs.CqlCapableConfig cqlCapableConfig = ImmutableCqlCapableConfig.builder()
+                .addAllCqlHosts(HOSTS)
+                .addAllThriftHosts(HOSTS)
+                .build();
+        when(config.servers()).thenReturn(cqlCapableConfig);
+        when(config.getKeyspaceOrThrow()).thenReturn(KEYSPACE_NAME);
+
+        tokenRangeFetcher = new TokenRangeFetcher(cqlSession, config);
+    }
+
+    // TODO(gs): takes a long time. Need to mock more?
+    @Test
+    public void allNodesGetAllRangesWithThreeNodesAndRF3() {
+        when(cqlMetadata.getReplicas(eq(KEYSPACE_NAME), any())).thenReturn(ImmutableSet.copyOf(HOSTS));
+
+        Map<InetSocketAddress, RangeSet<LightweightOppToken>> tokenRange = tokenRangeFetcher.getTokenRange(TABLE_NAME);
+        assertThat(tokenRange.keySet()).containsExactlyInAnyOrder(HOST_1, HOST_2, HOST_3);
+        HOSTS.forEach(host -> assertThat(tokenRange.get(host)).isEqualTo(ImmutableRangeSet.of(Range.all())));
+    }
+
+    @Test
+    public void testGetTokenRangesWithRF2() {
+        when(cqlMetadata.getReplicas(KEYSPACE_NAME, RANGE_AT_MOST_1)).thenReturn(ImmutableSet.of(HOST_3, HOST_1));
+        when(cqlMetadata.getReplicas(KEYSPACE_NAME, RANGE_GREATER_THAN_3)).thenReturn(ImmutableSet.of(HOST_3, HOST_1));
+        when(cqlMetadata.getReplicas(KEYSPACE_NAME, RANGE_1_TO_2)).thenReturn(ImmutableSet.of(HOST_1, HOST_2));
+        when(cqlMetadata.getReplicas(KEYSPACE_NAME, RANGE_2_TO_3)).thenReturn(ImmutableSet.of(HOST_2, HOST_3));
+
+        Map<InetSocketAddress, RangeSet<LightweightOppToken>> tokenRange = tokenRangeFetcher.getTokenRange(TABLE_NAME);
+        assertThat(tokenRange.keySet()).containsExactlyInAnyOrder(HOST_1, HOST_2, HOST_3);
+        assertThat(tokenRange.get(HOST_1).asRanges())
+                .containsExactly(Range.atMost(TOKEN_2), Range.greaterThan(TOKEN_3));
+        assertThat(tokenRange.get(HOST_2).asRanges()).containsExactly(Range.openClosed(TOKEN_1, TOKEN_3));
+        assertThat(tokenRange.get(HOST_3).asRanges())
+                .containsExactly(Range.atMost(TOKEN_1), Range.greaterThan(TOKEN_2));
+    }
+}

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/TokenRangeFetcherTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/TokenRangeFetcherTest.java
@@ -41,7 +41,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-@SuppressWarnings({"DnsLookup", "UnstableApiUsage"})
+@SuppressWarnings("UnstableApiUsage")
 public class TokenRangeFetcherTest {
     private static final String TABLE_NAME = "table";
 

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/TokenRangeFetcherTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/TokenRangeFetcherTest.java
@@ -22,13 +22,17 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+import com.datastax.driver.core.KeyspaceMetadata;
+import com.datastax.driver.core.TableMetadata;
 import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.LightweightOppToken;
 import java.net.InetSocketAddress;
+import java.util.List;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
@@ -54,7 +58,10 @@ public class TokenRangeFetcherTest {
 
     @Before
     public void setUp() {
-        BackupTestUtils.mockMetadata(cqlMetadata, TABLE_NAME);
+        KeyspaceMetadata keyspaceMetadata = BackupTestUtils.mockKeyspaceMetadata(cqlMetadata);
+        List<TableMetadata> tableMetadatas = BackupTestUtils.mockTableMetadatas(keyspaceMetadata, TABLE_NAME);
+        when(keyspaceMetadata.getTable(TABLE_NAME)).thenReturn(Iterables.getOnlyElement(tableMetadatas));
+
         BackupTestUtils.mockConfig(config);
         BackupTestUtils.mockTokenRanges(cqlSession, cqlMetadata);
 

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/TokenRangeFetcherTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/TokenRangeFetcherTest.java
@@ -20,19 +20,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.datastax.driver.core.KeyspaceMetadata;
-import com.datastax.driver.core.TableMetadata;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
-import com.palantir.atlasdb.cassandra.CassandraServersConfigs;
-import com.palantir.atlasdb.cassandra.ImmutableCqlCapableConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.LightweightOppToken;
 import java.net.InetSocketAddress;
 import java.util.Map;
@@ -45,21 +39,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 @SuppressWarnings({"DnsLookup", "UnstableApiUsage"})
 public class TokenRangeFetcherTest {
-    private static final InetSocketAddress HOST_1 = new InetSocketAddress("cassandra-1", 9042);
-    private static final InetSocketAddress HOST_2 = new InetSocketAddress("cassandra-2", 9042);
-    private static final InetSocketAddress HOST_3 = new InetSocketAddress("cassandra-3", 9042);
-    private static final ImmutableList<InetSocketAddress> HOSTS = ImmutableList.of(HOST_1, HOST_2, HOST_3);
-    private static final String KEYSPACE_NAME = "keyspace";
     private static final String TABLE_NAME = "table";
-
-    private static final LightweightOppToken TOKEN_1 = BackupTestUtils.lightweightOppToken("1111");
-    private static final LightweightOppToken TOKEN_2 = BackupTestUtils.lightweightOppToken("2222");
-    private static final LightweightOppToken TOKEN_3 = BackupTestUtils.lightweightOppToken("3333");
-
-    private static final Range<LightweightOppToken> RANGE_AT_MOST_1 = Range.atMost(TOKEN_1);
-    private static final Range<LightweightOppToken> RANGE_1_TO_2 = Range.openClosed(TOKEN_1, TOKEN_2);
-    private static final Range<LightweightOppToken> RANGE_2_TO_3 = Range.openClosed(TOKEN_2, TOKEN_3);
-    private static final Range<LightweightOppToken> RANGE_GREATER_THAN_3 = Range.greaterThan(TOKEN_3);
 
     @Mock
     private CqlSession cqlSession;
@@ -74,53 +54,47 @@ public class TokenRangeFetcherTest {
 
     @Before
     public void setUp() {
-        TableMetadata tableMetadata = mock(TableMetadata.class);
-
-        KeyspaceMetadata keyspaceMetadata = mock(KeyspaceMetadata.class);
-        when(keyspaceMetadata.getName()).thenReturn(KEYSPACE_NAME);
-        when(keyspaceMetadata.getTable(TABLE_NAME)).thenReturn(tableMetadata);
-        when(tableMetadata.getKeyspace()).thenReturn(keyspaceMetadata);
-        when(tableMetadata.getName()).thenReturn(TABLE_NAME);
-        when(cqlMetadata.getKeyspaceMetadata(KEYSPACE_NAME)).thenReturn(keyspaceMetadata);
+        BackupTestUtils.mockMetadata(cqlMetadata, TABLE_NAME);
+        BackupTestUtils.mockConfig(config);
+        BackupTestUtils.mockTokenRanges(cqlSession, cqlMetadata);
 
         when(cqlSession.retrieveRowKeysAtConsistencyAll(anyList()))
-                .thenReturn(ImmutableSet.of(TOKEN_1, TOKEN_2, TOKEN_3));
-        when(cqlMetadata.getTokenRanges())
-                .thenReturn(ImmutableSet.of(RANGE_AT_MOST_1, RANGE_1_TO_2, RANGE_2_TO_3, RANGE_GREATER_THAN_3));
-        when(cqlSession.getMetadata()).thenReturn(cqlMetadata);
-
-        CassandraServersConfigs.CqlCapableConfig cqlCapableConfig = ImmutableCqlCapableConfig.builder()
-                .addAllCqlHosts(HOSTS)
-                .addAllThriftHosts(HOSTS)
-                .build();
-        when(config.servers()).thenReturn(cqlCapableConfig);
-        when(config.getKeyspaceOrThrow()).thenReturn(KEYSPACE_NAME);
+                .thenReturn(ImmutableSet.of(BackupTestUtils.TOKEN_1, BackupTestUtils.TOKEN_2, BackupTestUtils.TOKEN_3));
 
         tokenRangeFetcher = new TokenRangeFetcher(cqlSession, config);
     }
 
     @Test
     public void allNodesGetAllRangesWithThreeNodesAndRF3() {
-        when(cqlMetadata.getReplicas(eq(KEYSPACE_NAME), any())).thenReturn(ImmutableSet.copyOf(HOSTS));
+        when(cqlMetadata.getReplicas(eq(BackupTestUtils.KEYSPACE_NAME), any()))
+                .thenReturn(ImmutableSet.copyOf(BackupTestUtils.HOSTS));
 
         Map<InetSocketAddress, RangeSet<LightweightOppToken>> tokenRange = tokenRangeFetcher.getTokenRange(TABLE_NAME);
-        assertThat(tokenRange.keySet()).containsExactlyInAnyOrder(HOST_1, HOST_2, HOST_3);
-        HOSTS.forEach(host -> assertThat(tokenRange.get(host)).isEqualTo(ImmutableRangeSet.of(Range.all())));
+        assertThat(tokenRange.keySet())
+                .containsExactlyInAnyOrder(BackupTestUtils.HOST_1, BackupTestUtils.HOST_2, BackupTestUtils.HOST_3);
+        BackupTestUtils.HOSTS.forEach(
+                host -> assertThat(tokenRange.get(host)).isEqualTo(ImmutableRangeSet.of(Range.all())));
     }
 
     @Test
     public void testGetTokenRangesWithRF2() {
-        when(cqlMetadata.getReplicas(KEYSPACE_NAME, RANGE_AT_MOST_1)).thenReturn(ImmutableSet.of(HOST_3, HOST_1));
-        when(cqlMetadata.getReplicas(KEYSPACE_NAME, RANGE_GREATER_THAN_3)).thenReturn(ImmutableSet.of(HOST_3, HOST_1));
-        when(cqlMetadata.getReplicas(KEYSPACE_NAME, RANGE_1_TO_2)).thenReturn(ImmutableSet.of(HOST_1, HOST_2));
-        when(cqlMetadata.getReplicas(KEYSPACE_NAME, RANGE_2_TO_3)).thenReturn(ImmutableSet.of(HOST_2, HOST_3));
+        when(cqlMetadata.getReplicas(BackupTestUtils.KEYSPACE_NAME, BackupTestUtils.RANGE_AT_MOST_1))
+                .thenReturn(ImmutableSet.of(BackupTestUtils.HOST_3, BackupTestUtils.HOST_1));
+        when(cqlMetadata.getReplicas(BackupTestUtils.KEYSPACE_NAME, BackupTestUtils.RANGE_GREATER_THAN_3))
+                .thenReturn(ImmutableSet.of(BackupTestUtils.HOST_3, BackupTestUtils.HOST_1));
+        when(cqlMetadata.getReplicas(BackupTestUtils.KEYSPACE_NAME, BackupTestUtils.RANGE_1_TO_2))
+                .thenReturn(ImmutableSet.of(BackupTestUtils.HOST_1, BackupTestUtils.HOST_2));
+        when(cqlMetadata.getReplicas(BackupTestUtils.KEYSPACE_NAME, BackupTestUtils.RANGE_2_TO_3))
+                .thenReturn(ImmutableSet.of(BackupTestUtils.HOST_2, BackupTestUtils.HOST_3));
 
         Map<InetSocketAddress, RangeSet<LightweightOppToken>> tokenRange = tokenRangeFetcher.getTokenRange(TABLE_NAME);
-        assertThat(tokenRange.keySet()).containsExactlyInAnyOrder(HOST_1, HOST_2, HOST_3);
-        assertThat(tokenRange.get(HOST_1).asRanges())
-                .containsExactly(Range.atMost(TOKEN_2), Range.greaterThan(TOKEN_3));
-        assertThat(tokenRange.get(HOST_2).asRanges()).containsExactly(Range.openClosed(TOKEN_1, TOKEN_3));
-        assertThat(tokenRange.get(HOST_3).asRanges())
-                .containsExactly(Range.atMost(TOKEN_1), Range.greaterThan(TOKEN_2));
+        assertThat(tokenRange.keySet())
+                .containsExactlyInAnyOrder(BackupTestUtils.HOST_1, BackupTestUtils.HOST_2, BackupTestUtils.HOST_3);
+        assertThat(tokenRange.get(BackupTestUtils.HOST_1).asRanges())
+                .containsExactly(Range.atMost(BackupTestUtils.TOKEN_2), Range.greaterThan(BackupTestUtils.TOKEN_3));
+        assertThat(tokenRange.get(BackupTestUtils.HOST_2).asRanges())
+                .containsExactly(Range.openClosed(BackupTestUtils.TOKEN_1, BackupTestUtils.TOKEN_3));
+        assertThat(tokenRange.get(BackupTestUtils.HOST_3).asRanges())
+                .containsExactly(Range.atMost(BackupTestUtils.TOKEN_1), Range.greaterThan(BackupTestUtils.TOKEN_2));
     }
 }


### PR DESCRIPTION
**Goals (and why)**: Add unit test coverage before ABR rollout

**Implementation Description (bullets)**:
- Added TokenRangeFetcherTest
- Added RepairRangeFetcherTest
- Actually fixed a couple of small bugs along the way (specifically, making the token ranges more closely match those given by Cassandra, including the "wraparound range". 

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added a bunch of unit tests 🚀 

These tests are very similar to those in CassandraRepairEteTest - my main reason for not removing them yet is that the ones in CRET also cover some type-massaging code from CassandraRepairHelper - I'll probably cover that code and remove the ETE tests in a later PR.

**Concerns (what feedback would you like?)**: Any test cases missing? (check TokenRangeFetcher and RepairRangeFetcher)

**Where should we start reviewing?**: TokenRangeFetcherTest and RepairRangeFetcherTest most likely.

**Priority (whenever / two weeks / yesterday)**: would like this to merge this week, but after ABR9.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
