### PR TITLE
[Transactions3/ABR] Need to abort at the put timestamp or higher

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/backup/transaction/Transactions3TableInteraction.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/backup/transaction/Transactions3TableInteraction.java
@@ -68,7 +68,7 @@ public class Transactions3TableInteraction implements TransactionsTableInteracti
                 .where(QueryBuilder.eq(CassandraConstants.ROW, QueryBuilder.bindMarker()))
                 .and(QueryBuilder.eq(CassandraConstants.COLUMN, QueryBuilder.bindMarker()))
                 .and(QueryBuilder.eq(CassandraConstants.TIMESTAMP, CassandraConstants.ENCODED_CAS_TABLE_TIMESTAMP))
-                .using(QueryBuilder.timestamp(CellValuePutter.SET_TIMESTAMP))
+                .using(QueryBuilder.timestamp(CellValuePutter.SET_TIMESTAMP + 1))
                 .onlyIf(QueryBuilder.eq(CassandraConstants.VALUE, QueryBuilder.bindMarker()));
         // if you change this from CAS then you must update RetryPolicy
         return session.prepare(abortStatement.toString());

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/backup/transaction/Transactions3TableInteraction.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/backup/transaction/Transactions3TableInteraction.java
@@ -124,7 +124,6 @@ public class Transactions3TableInteraction implements TransactionsTableInteracti
         BoundStatement bound = preparedAbortStatement.bind(rowKeyBb, columnNameBb, valueBb);
         return bound.setConsistencyLevel(ConsistencyLevel.QUORUM)
                 .setSerialConsistencyLevel(ConsistencyLevel.SERIAL)
-                .setDefaultTimestamp(CellValuePutter.SET_TIMESTAMP + 1)
                 .setReadTimeoutMillis(LONG_READ_TIMEOUT_MS)
                 .setIdempotent(true) // by default CAS operations are not idempotent in case of multiple clients
                 .setRetryPolicy(abortRetryPolicy);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/backup/transaction/Transactions3TableInteraction.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/backup/transaction/Transactions3TableInteraction.java
@@ -68,6 +68,7 @@ public class Transactions3TableInteraction implements TransactionsTableInteracti
                 .where(QueryBuilder.eq(CassandraConstants.ROW, QueryBuilder.bindMarker()))
                 .and(QueryBuilder.eq(CassandraConstants.COLUMN, QueryBuilder.bindMarker()))
                 .and(QueryBuilder.eq(CassandraConstants.TIMESTAMP, CassandraConstants.ENCODED_CAS_TABLE_TIMESTAMP))
+                .using(QueryBuilder.timestamp(CellValuePutter.SET_TIMESTAMP))
                 .onlyIf(QueryBuilder.eq(CassandraConstants.VALUE, QueryBuilder.bindMarker()));
         // if you change this from CAS then you must update RetryPolicy
         return session.prepare(abortStatement.toString());

--- a/changelog/@unreleased/pr-5847.v2.yml
+++ b/changelog/@unreleased/pr-5847.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: We now abort values in Transactions3 for purposes of cleaning the transactions
+    range correctly when restoring from backup. Normal users are not affected.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5847


### PR DESCRIPTION
**Goals (and why)**:
- Abort values correctly in Transactions3 for the cleanup task

**Implementation Description (bullets)**:
- Aborts didn't seem to be happening at a high enough value.

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:
to investigate: this looks like it's set lower down, why doesn't it work already?

**Where should we start reviewing?**: small

**Priority (whenever / two weeks / yesterday)**: this week please, blocks transactions3 _and_ ABR rollouts!