### PR TITLE
Configurable GzipCompressingInputStream compression buffer size

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/common/compression/GzipCompressingInputStream.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/compression/GzipCompressingInputStream.java
@@ -52,11 +52,16 @@ public final class GzipCompressingInputStream {
     }
 
     public static InputStream compress(InputStream uncompressed) {
+        return compress(uncompressed, StreamCompression.DEFAULT_BLOCK_SIZE);
+    }
+
+    public static InputStream compress(InputStream uncompressed, int bufferSize) {
         InputStream header = createHeaderStream();
         CountingInputStream counting = new CountingInputStream(uncompressed);
         CRC32 crc = new CRC32();
         CheckedInputStream checked = new CheckedInputStream(counting, crc);
-        InputStream content = new DeflaterInputStream(checked, new Deflater(Deflater.DEFAULT_COMPRESSION, true));
+        InputStream content =
+                new DeflaterInputStream(checked, new Deflater(Deflater.DEFAULT_COMPRESSION, true), bufferSize);
         List<Supplier<InputStream>> allStreams =
                 ImmutableList.of(() -> header, () -> content, () -> trailerStream(counting.getCount(), crc));
         return new SequenceInputStream(Collections.enumeration(Lists.transform(allStreams, Supplier::get)));

--- a/atlasdb-commons/src/main/java/com/palantir/common/compression/StreamCompression.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/compression/StreamCompression.java
@@ -38,7 +38,7 @@ public enum StreamCompression {
     public InputStream compress(InputStream stream) {
         switch (this) {
             case GZIP:
-                return GzipCompressingInputStream.compress(stream, DEFAULT_BLOCK_SIZE);
+                return GzipCompressingInputStream.compress(stream);
             case LZ4:
                 return new LZ4CompressingInputStream(stream);
             case NONE:

--- a/atlasdb-commons/src/test/java/com/palantir/common/compression/StreamCompressionTests.java
+++ b/atlasdb-commons/src/test/java/com/palantir/common/compression/StreamCompressionTests.java
@@ -37,7 +37,6 @@ public class StreamCompressionTests {
     private static final byte SINGLE_VALUE = 42;
     private static final int BLOCK_SIZE = 1 << 16; // 64 KB
 
-    private ByteArrayInputStream uncompressedStream;
     private InputStream compressingStream;
     private InputStream decompressingStream;
 
@@ -47,7 +46,7 @@ public class StreamCompressionTests {
         this.compression = compression;
     }
 
-    @Parameterized.Parameters
+    @Parameterized.Parameters(name = "{index} {0} compression")
     public static Object[] parameters() {
         return StreamCompression.values();
     }
@@ -125,9 +124,9 @@ public class StreamCompressionTests {
         fillWithIncompressibleData(uncompressedData);
         initializeStreams(uncompressedData);
 
-        for (int i = 0; i < uncompressedData.length; ++i) {
+        for (byte uncompressedDatum : uncompressedData) {
             int value = decompressingStream.read();
-            assertThat(value).isEqualTo(uncompressedData[i] & 0xFF);
+            assertThat(value).isEqualTo(uncompressedDatum & 0xFF);
         }
         assertStreamIsEmpty(decompressingStream);
     }
@@ -159,16 +158,16 @@ public class StreamCompressionTests {
     }
 
     private void initializeStreams(byte[] uncompressedData) {
-        uncompressedStream = new ByteArrayInputStream(uncompressedData);
+        ByteArrayInputStream uncompressedStream = new ByteArrayInputStream(uncompressedData);
         compressingStream = compression.compress(uncompressedStream);
         decompressingStream = compression.decompress(compressingStream);
     }
 
-    private void fillWithCompressibleData(byte[] data) {
+    private static void fillWithCompressibleData(byte[] data) {
         Arrays.fill(data, SINGLE_VALUE);
     }
 
-    private void fillWithIncompressibleData(byte[] data) {
+    private static void fillWithIncompressibleData(byte[] data) {
         new Random(0).nextBytes(data);
     }
 
@@ -179,7 +178,7 @@ public class StreamCompressionTests {
         assertStreamIsEmpty(decompressingStream);
     }
 
-    private void assertStreamIsEmpty(InputStream stream) throws IOException {
+    private static void assertStreamIsEmpty(InputStream stream) throws IOException {
         assertThat(stream.read()).isEqualTo(-1);
     }
 }

--- a/changelog/@unreleased/pr-5848.v2.yml
+++ b/changelog/@unreleased/pr-5848.v2.yml
@@ -1,0 +1,27 @@
+type: improvement
+improvement:
+  description: |-
+    Configurable GzipCompressingInputStream compression buffer size
+
+    **Goals (and why)**:
+    `GzipCompressingInputStream` did not allow configuring compression buffer size, leading to suboptimal compression with default `DeflaterInputStream` buffer size of 512 bytes.
+
+    **Implementation Description (bullets)**:
+    Allow configuring the GZIP compression buffer size. Increase default compression buffer size to 64 KiB.
+
+    **Testing (What was existing testing like?  What have you done to improve it?)**:
+    StreamCompressionTests
+
+    **Concerns (what feedback would you like?)**: Is 64 KiB too large default? My sense is no, and that's the current default for LZ4 block size.
+
+    **Where should we start reviewing?**: GzipCompressingInputStream
+
+    **Priority (whenever / two weeks / yesterday)**: this week
+
+    <!---
+    Please remember to:
+    - Add any necessary release notes (including breaking changes)
+    - Make sure the documentation is up to date for your change
+    --->
+  links:
+  - https://github.com/palantir/atlasdb/pull/5848

--- a/changelog/@unreleased/pr-5848.v2.yml
+++ b/changelog/@unreleased/pr-5848.v2.yml
@@ -1,6 +1,6 @@
 type: improvement
 improvement:
   description: |-
-    Added a configurable GzipCompressingInputStream compression buffer size. Increased the default compression buffer size to 64 KiB.
+    Added a configurable GzipCompressingInputStream compression level and buffer size. Increased the default compression buffer size to 64 KiB.
   links:
   - https://github.com/palantir/atlasdb/pull/5848

--- a/changelog/@unreleased/pr-5848.v2.yml
+++ b/changelog/@unreleased/pr-5848.v2.yml
@@ -1,27 +1,6 @@
 type: improvement
 improvement:
   description: |-
-    Configurable GzipCompressingInputStream compression buffer size
-
-    **Goals (and why)**:
-    `GzipCompressingInputStream` did not allow configuring compression buffer size, leading to suboptimal compression with default `DeflaterInputStream` buffer size of 512 bytes.
-
-    **Implementation Description (bullets)**:
-    Allow configuring the GZIP compression buffer size. Increase default compression buffer size to 64 KiB.
-
-    **Testing (What was existing testing like?  What have you done to improve it?)**:
-    StreamCompressionTests
-
-    **Concerns (what feedback would you like?)**: Is 64 KiB too large default? My sense is no, and that's the current default for LZ4 block size.
-
-    **Where should we start reviewing?**: GzipCompressingInputStream
-
-    **Priority (whenever / two weeks / yesterday)**: this week
-
-    <!---
-    Please remember to:
-    - Add any necessary release notes (including breaking changes)
-    - Make sure the documentation is up to date for your change
-    --->
+    Added a configurable GzipCompressingInputStream compression buffer size. Increased the default compression buffer size to 64 KiB.
   links:
   - https://github.com/palantir/atlasdb/pull/5848


### PR DESCRIPTION
**Goals (and why)**:
`GzipCompressingInputStream` did not allow configuring compression buffer size, leading to suboptimal compression with default `DeflaterInputStream` buffer size of 512 bytes.

**Implementation Description (bullets)**:
Allow configuring the GZIP compression buffer size. Increase default compression buffer size to 64 KiB.

**Testing (What was existing testing like?  What have you done to improve it?)**:
StreamCompressionTests

**Concerns (what feedback would you like?)**: Is 64 KiB too large default? My sense is no, and that's the current default for LZ4 block size.

**Where should we start reviewing?**: GzipCompressingInputStream

**Priority (whenever / two weeks / yesterday)**: this week

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
