### PR TITLE
[Transactions3/ABR] Hard delete things to be aborted in Transactions3

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/backup/transaction/Transactions3TableInteraction.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/backup/transaction/Transactions3TableInteraction.java
@@ -69,7 +69,8 @@ public class Transactions3TableInteraction implements TransactionsTableInteracti
                 .and(QueryBuilder.eq(CassandraConstants.COLUMN, QueryBuilder.bindMarker()))
                 .and(QueryBuilder.eq(CassandraConstants.TIMESTAMP, CassandraConstants.ENCODED_CAS_TABLE_TIMESTAMP))
                 .using(QueryBuilder.timestamp(CellValuePutter.SET_TIMESTAMP + 1));
-        // if you change this to CAS then you must update RetryPolicy
+        // abortRetryPolicy must match the type of operation of the abort statement
+        // so if the statement is changed TO a CAS, callers will need to change their policy
         return session.prepare(abortStatement);
     }
 

--- a/changelog/@unreleased/pr-5853.v2.yml
+++ b/changelog/@unreleased/pr-5853.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Transactions3 table interaction now correctly aborts transactions.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5853


### PR DESCRIPTION
**Goals (and why)**:
==COMMIT_MSG==
Transactions3 table interaction now correctly aborts transactions.
==COMMIT_MSG==

**Implementation Description (bullets)**:
- Put things to be aborted, rather than doing a CAS that will succeed but actually not work because of writetime.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Existing tests.

**Concerns (what feedback would you like?)**:
- Is this too aggressive?

**Where should we start reviewing?**: small

**Priority (whenever / two weeks / yesterday)**: ASAP 🔥 