### PR TITLE
Get the retry policies right

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/backup/transaction/Transactions3TableInteraction.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/backup/transaction/Transactions3TableInteraction.java
@@ -23,7 +23,6 @@ import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.TableMetadata;
 import com.datastax.driver.core.policies.DefaultRetryPolicy;
-import com.datastax.driver.core.policies.RetryPolicy;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.datastax.driver.core.utils.Bytes;
 import com.palantir.atlasdb.cassandra.backup.CqlSession;
@@ -41,11 +40,9 @@ import java.util.stream.Collectors;
 
 public class Transactions3TableInteraction implements TransactionsTableInteraction {
     private final FullyBoundedTimestampRange timestampRange;
-    private final RetryPolicy abortRetryPolicy;
 
-    public Transactions3TableInteraction(FullyBoundedTimestampRange timestampRange, RetryPolicy abortRetryPolicy) {
+    public Transactions3TableInteraction(FullyBoundedTimestampRange timestampRange) {
         this.timestampRange = timestampRange;
-        this.abortRetryPolicy = abortRetryPolicy;
     }
 
     @Override
@@ -121,8 +118,7 @@ public class Transactions3TableInteraction implements TransactionsTableInteracti
         return bound.setConsistencyLevel(ConsistencyLevel.QUORUM)
                 .setSerialConsistencyLevel(ConsistencyLevel.SERIAL)
                 .setReadTimeoutMillis(LONG_READ_TIMEOUT_MS)
-                .setIdempotent(true) // by default CAS operations are not idempotent in case of multiple clients
-                .setRetryPolicy(abortRetryPolicy);
+                .setRetryPolicy(DefaultRetryPolicy.INSTANCE);
     }
 
     @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/backup/transaction/TransactionsTableInteraction.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/backup/transaction/TransactionsTableInteraction.java
@@ -61,16 +61,16 @@ public interface TransactionsTableInteraction {
     }
 
     static List<TransactionsTableInteraction> getTransactionTableInteractions(
-            Map<FullyBoundedTimestampRange, Integer> coordinationMap, RetryPolicy abortRetryPolicy) {
+            Map<FullyBoundedTimestampRange, Integer> coordinationMap, RetryPolicy casRetryPolicy) {
         return coordinationMap.entrySet().stream()
                 .map(entry -> {
                     switch (entry.getValue()) {
                         case TransactionConstants.DIRECT_ENCODING_TRANSACTIONS_SCHEMA_VERSION:
-                            return new Transactions1TableInteraction(entry.getKey(), abortRetryPolicy);
+                            return new Transactions1TableInteraction(entry.getKey(), casRetryPolicy);
                         case TransactionConstants.TICKETS_ENCODING_TRANSACTIONS_SCHEMA_VERSION:
-                            return new Transactions2TableInteraction(entry.getKey(), abortRetryPolicy);
+                            return new Transactions2TableInteraction(entry.getKey(), casRetryPolicy);
                         case TransactionConstants.TWO_STAGE_ENCODING_TRANSACTIONS_SCHEMA_VERSION:
-                            return new Transactions3TableInteraction(entry.getKey(), abortRetryPolicy);
+                            return new Transactions3TableInteraction(entry.getKey());
                         default:
                             throw new SafeIllegalArgumentException(
                                     "Found unsupported transactions schema version",

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/RepairRangeFetcherTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/RepairRangeFetcherTest.java
@@ -104,7 +104,7 @@ public class RepairRangeFetcherTest {
     @Test
     public void testRepairTxn3() {
         List<TransactionsTableInteraction> interactions =
-                ImmutableList.of(new Transactions3TableInteraction(range(1L, 10_000_000L), POLICY));
+                ImmutableList.of(new Transactions3TableInteraction(range(1L, 10_000_000L)));
         Map<String, Map<InetSocketAddress, RangeSet<LightweightOppToken>>> rangesForRepair =
                 repairRangeFetcher.getTransactionTableRangesForRepair(interactions);
 

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/transaction/Transactions3TableInteractionTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/transaction/Transactions3TableInteractionTest.java
@@ -48,7 +48,7 @@ public class Transactions3TableInteractionTest {
     private static final String KEYSPACE = "keyspace";
 
     private final RetryPolicy mockPolicy = mock(RetryPolicy.class);
-    private final TransactionsTableInteraction interaction = new Transactions3TableInteraction(RANGE, mockPolicy);
+    private final TransactionsTableInteraction interaction = new Transactions3TableInteraction(RANGE);
     private final TableMetadata tableMetadata = mock(TableMetadata.class, RETURNS_DEEP_STUBS);
 
     @Before
@@ -95,7 +95,7 @@ public class Transactions3TableInteractionTest {
     public void getAllRowsInPartition() {
         Range<Long> rangeWithinOnePartition = Range.closed(100L, 1000L);
         Transactions3TableInteraction txnInteraction =
-                new Transactions3TableInteraction(FullyBoundedTimestampRange.of(rangeWithinOnePartition), mockPolicy);
+                new Transactions3TableInteraction(FullyBoundedTimestampRange.of(rangeWithinOnePartition));
         List<Statement> selects = txnInteraction.createSelectStatementsForScanningFullTimestampRange(tableMetadata);
         List<String> correctSelects = createSelectStatement(0L, ROWS_PER_QUANTUM - 1);
         assertThat(selects)
@@ -107,7 +107,7 @@ public class Transactions3TableInteractionTest {
     public void getsRowsInAllSpannedPartitions() {
         Range<Long> rangeWithinOnePartition = Range.closed(100L, PARTITIONING_QUANTUM + 1000000);
         Transactions3TableInteraction txnInteraction =
-                new Transactions3TableInteraction(FullyBoundedTimestampRange.of(rangeWithinOnePartition), mockPolicy);
+                new Transactions3TableInteraction(FullyBoundedTimestampRange.of(rangeWithinOnePartition));
         List<Statement> selects = txnInteraction.createSelectStatementsForScanningFullTimestampRange(tableMetadata);
         List<String> correctSelects = createSelectStatement(0, 2 * ROWS_PER_QUANTUM - 1);
         assertThat(selects)
@@ -119,7 +119,7 @@ public class Transactions3TableInteractionTest {
     public void doesntGetNextPartitionIfOpenBounded() {
         Range<Long> rangeWithinOnePartition = Range.closedOpen(100L, 25000000L);
         Transactions3TableInteraction txnInteraction =
-                new Transactions3TableInteraction(FullyBoundedTimestampRange.of(rangeWithinOnePartition), mockPolicy);
+                new Transactions3TableInteraction(FullyBoundedTimestampRange.of(rangeWithinOnePartition));
         List<Statement> selects = txnInteraction.createSelectStatementsForScanningFullTimestampRange(tableMetadata);
         List<String> correctSelects = createSelectStatement(0L, 15L);
         assertThat(selects)

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/CassandraRepairEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/CassandraRepairEteTest.java
@@ -142,7 +142,7 @@ public final class CassandraRepairEteTest {
         BiConsumer<String, RangesForRepair> repairer = (table, _unused) -> tablesRepaired.add(table);
 
         List<TransactionsTableInteraction> interactions =
-                ImmutableList.of(new Transactions3TableInteraction(range(1L, 10_000_000L), POLICY));
+                ImmutableList.of(new Transactions3TableInteraction(range(1L, 10_000_000L)));
         cassandraRepairHelper.repairTransactionsTables(NAMESPACE, interactions, repairer);
 
         // Transactions3 is backed by Transactions2 under the hood, so this is the table that will be repaired.


### PR DESCRIPTION
**Goals (and why)**:
Use the correct retry policy

**Implementation Description (bullets)**:
Hardcode the default policy in the abort statement for transactions3. When we tested this, we were using the constructor, so we could do it in the internal product, but normally we go through the TTI static method.

**Priority (whenever / two weeks / yesterday)**:
🔥 