### PR TITLE
[LW] Add some more logging

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/ResilientLockWatchProxy.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/ResilientLockWatchProxy.java
@@ -98,6 +98,7 @@ public final class ResilientLockWatchProxy<T> extends AbstractInvocationHandler 
     }
 
     public void fallback() {
+        log.warn("Falling back to fallback cache");
         delegate = fallbackCache;
         failureCallback.run();
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ValidatingTransactionScopedCache.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ValidatingTransactionScopedCache.java
@@ -34,6 +34,7 @@ import com.palantir.lock.watch.CommitUpdate;
 import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.util.Arrays;
@@ -194,10 +195,12 @@ final class ValidatingTransactionScopedCache implements TransactionScopedCache {
     }
 
     private void failAndLog(Arg<?>... args) {
+        SafeRuntimeException runtimeException = new SafeRuntimeException("I exist to show you the stacktrace");
         log.error(
                 "Reading from lock watch cache returned a different result to a remote read - this indicates there "
                         + "is a corruption bug in the caching logic",
-                Arrays.stream(args).collect(Collectors.toList()));
+                Arrays.stream(args).collect(Collectors.toList()),
+                runtimeException);
         failureCallback.run();
         throw new TransactionLockWatchFailedException(
                 "Failed lock watch cache validation - will retry without caching");

--- a/changelog/@unreleased/pr-5861.v2.yml
+++ b/changelog/@unreleased/pr-5861.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Add additional logging when the lock watch cache falls back due to
+    validation failures
+  links:
+  - https://github.com/palantir/atlasdb/pull/5861


### PR DESCRIPTION
**Goals (and why)**:
==COMMIT_MSG==
Add additional logging when the lock watch cache falls back due to validation failures
==COMMIT_MSG==

**Implementation Description (bullets)**:
* add a stacktrace for when the validation fails
* add a logline for the fallback (which can be called by itself instead of by catching an exception, and thus there isn't always a guaranteed logline present currently).

**Concerns (what feedback would you like?)**:
While we're at it, anything else we should probably add?

**Priority (whenever / two weeks / yesterday)**:
ASAP
