### PR TITLE
[LW] Fix Validation for getRows

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/TransactionScopedCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/TransactionScopedCacheImpl.java
@@ -44,7 +44,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.concurrent.ThreadSafe;
 import org.immutables.value.Value;
-a
+
 @ThreadSafe
 final class TransactionScopedCacheImpl implements TransactionScopedCache {
     private final TransactionCacheValueStore valueStore;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/TransactionScopedCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/TransactionScopedCacheImpl.java
@@ -44,7 +44,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.concurrent.ThreadSafe;
 import org.immutables.value.Value;
-
+a
 @ThreadSafe
 final class TransactionScopedCacheImpl implements TransactionScopedCache {
     private final TransactionCacheValueStore valueStore;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/TransactionScopedCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/TransactionScopedCacheImpl.java
@@ -167,7 +167,8 @@ final class TransactionScopedCacheImpl implements TransactionScopedCache {
 
     @Override
     public TransactionScopedCache createReadOnlyCache(CommitUpdate commitUpdate) {
-        return new TransactionScopedCacheImpl(valueStore.createWithFilteredSnapshot(commitUpdate), metrics);
+        return ReadOnlyTransactionScopedCache.create(
+                new TransactionScopedCacheImpl(valueStore.createWithFilteredSnapshot(commitUpdate), metrics));
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/util/ByteArrayUtilities.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/util/ByteArrayUtilities.java
@@ -76,7 +76,10 @@ public final class ByteArrayUtilities {
                     .map(RowResult::getColumns)
                     .orElseGet(ImmutableSortedMap::of);
 
-            return areByteMapsEqual(firstColumns, secondColumns);
+            boolean mapsEqual = areByteMapsEqual(firstColumns, secondColumns);
+            if (!mapsEqual) {
+                return false;
+            }
         }
         return true;
     }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/util/ByteArrayUtilitiesTests.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/util/ByteArrayUtilitiesTests.java
@@ -1,0 +1,50 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.primitives.UnsignedBytes;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.RowResult;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import org.junit.Test;
+
+public final class ByteArrayUtilitiesTests {
+
+    @Test
+    public void getRowsCompareAllEntries() {
+        NavigableMap<byte[], RowResult<byte[]>> first = new TreeMap<>(UnsignedBytes.lexicographicalComparator());
+        NavigableMap<byte[], RowResult<byte[]>> second = new TreeMap<>(UnsignedBytes.lexicographicalComparator());
+
+        // These are *not* extracted into common variables to make sure that we are comparing based on the values,
+        // not the references.
+        first.put(new byte[] {1, 2, 3, 4}, RowResult.of(Cell.create(new byte[] {5, 6}, new byte[] {7, 8}), new byte[] {9
+        }));
+        second.put(
+                new byte[] {1, 2, 3, 4},
+                RowResult.of(Cell.create(new byte[] {5, 6}, new byte[] {7, 8}), new byte[] {9}));
+        first.put(
+                new byte[] {1, 2, 3, 5},
+                RowResult.of(Cell.create(new byte[] {5, 6}, new byte[] {7, 8}), new byte[] {111}));
+        second.put(
+                new byte[] {1, 2, 3, 5},
+                RowResult.of(Cell.create(new byte[] {5, 6}, new byte[] {7, 8}), new byte[] {9}));
+        assertThat(ByteArrayUtilities.areRowResultsEqual(first, second)).isFalse();
+    }
+}

--- a/changelog/@unreleased/pr-5867.v2.yml
+++ b/changelog/@unreleased/pr-5867.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: The lock watch validation check now correctly checks all read rows,
+    instead of just the first row.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5867

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/LockWatchValueIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/LockWatchValueIntegrationTest.java
@@ -553,7 +553,7 @@ public final class LockWatchValueIntegrationTest {
                 transaction.get(60, TimeUnit.SECONDS);
             } catch (ExecutionException e) {
                 if (!(e.getCause() instanceof TransactionFailedRetriableException)) {
-                    fail("Encountered nonretriable exception");
+                    fail("Encountered nonretriable exception", e);
                 }
             } catch (InterruptedException | TimeoutException e) {
                 fail("Transaction took too long", e);


### PR DESCRIPTION
**Goals (and why)**:
==COMMIT_MSG==
The lock watch validation check now correctly checks all read rows, instead of just the first row.
==COMMIT_MSG==

**Implementation Description (bullets)**:
Fix it. Also fixed a place where we forgot to wrap with the read only cache properly.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Add a test. I didn't test the whole thing at this point, just wanted to get a fix out.

**Concerns (what feedback would you like?)**:
Is this actually right this time?

**Where should we start reviewing?**:
Diff

**Priority (whenever / two weeks / yesterday)**:
Yesterday 🔥 