### PR TITLE
Log number of lock descriptors

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -2272,6 +2272,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                     "Timed out waiting while acquiring commit locks. Timeout was {} ms. "
                             + "First ten required locks were {}.",
                     SafeArg.of("acquireTimeoutMs", lockAcquireTimeoutMillis),
+                    SafeArg.of("numberOfDescriptors", lockDescriptors.size()),
                     UnsafeArg.of("firstTenLockDescriptors", Iterables.limit(lockDescriptors, 10)));
             throw new TransactionLockAcquisitionTimeoutException("Timed out while acquiring commit locks.");
         }
@@ -2355,6 +2356,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                     "Timed out waiting for commits to complete. Timeout was {} ms. First ten locks were {}.",
                     SafeArg.of("requestId", request.getRequestId()),
                     SafeArg.of("acquireTimeoutMs", lockAcquireTimeoutMillis),
+                    SafeArg.of("numberOfDescriptors", lockDescriptors.size()),
                     UnsafeArg.of("firstTenLockDescriptors", Iterables.limit(lockDescriptors, 10)));
             throw new TransactionLockAcquisitionTimeoutException("Timed out waiting for commits to complete.");
         }

--- a/changelog/@unreleased/pr-5869.v2.yml
+++ b/changelog/@unreleased/pr-5869.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Log number of lock descriptors when failing to acquire or wait for
+    commit locks.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5869


### PR DESCRIPTION
**Goals (and why)**:
==COMMIT_MSG==
Log number of lock descriptors when failing to acquire or wait for commit locks.
==COMMIT_MSG==

**Implementation Description (bullets)**:
Log number of descriptors safely (so we can determine whether this is a huge request or not).

**Priority (whenever / two weeks / yesterday)**:
Today please!
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
