### PR TITLE
Remove PDS-146088 magic

### DIFF
--- a/changelog/@unreleased/pr-5872.v2.yml
+++ b/changelog/@unreleased/pr-5872.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: We do a costly thread dump when failing to evict an object from the
+    Cassandra client pool. This was necessary as part of PDS-146088, but since we
+    fixed that in commons pool, it's not needed any more.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5872


### PR DESCRIPTION
**Goals (and why)**:
==COMMIT_MSG==
We do a costly thread dump when failing to evict an object from the Cassandra client pool. This was necessary as part of PDS-146088, but since we fixed that in commons pool, it's not needed any more.
==COMMIT_MSG==

**Implementation Description (bullets)**:
- Remove PDS-146088's expensive thread dump.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Relying on existing tests.

**Concerns (what feedback would you like?)**:
- I didn't want to disturb any logic, so the implementation of `TaskContext.runnable(thingy, () -> {})` might not be the neatest way to do something, but would go ahead with this first.

**Where should we start reviewing?**: small

**Priority (whenever / two weeks / yesterday)**: whenever