### PR TITLE
Remove replication factor specified check

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.CassandraServersConfigs.CassandraServersConfig;
@@ -39,6 +40,7 @@ import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import org.apache.cassandra.thrift.EndpointDetails;
@@ -344,8 +346,18 @@ public final class CassandraVerifier {
     }
 
     static void sanityCheckReplicationFactor(KsDef ks, CassandraKeyValueServiceConfig config, Set<String> dcs) {
+        Set<String> scopedDownDcs = checkRfsSpecifiedAndScopeDownDcs(dcs, ks.getStrategy_options());
+        checkRfsMatchConfig(ks, config, scopedDownDcs, ks.getStrategy_options());
+    }
+
+    private static Set<String> checkRfsSpecifiedAndScopeDownDcs(Set<String> dcs, Map<String, String> strategyOptions) {
+        return Sets.intersection(dcs, strategyOptions.keySet());
+    }
+
+    private static void checkRfsMatchConfig(
+            KsDef ks, CassandraKeyValueServiceConfig config, Set<String> dcs, Map<String, String> strategyOptions) {
         for (String datacenter : dcs) {
-            if (Integer.parseInt(ks.getStrategy_options().get(datacenter)) != config.replicationFactor()) {
+            if (Integer.parseInt(strategyOptions.get(datacenter)) != config.replicationFactor()) {
                 throw new UnsupportedOperationException("Your current Cassandra keyspace (" + ks.getName()
                         + ") has a replication factor not matching your Atlas Cassandra configuration."
                         + " Change them to match, but be mindful of what steps you'll need to"

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -39,7 +39,6 @@ import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import org.apache.cassandra.thrift.EndpointDetails;
@@ -345,26 +344,8 @@ public final class CassandraVerifier {
     }
 
     static void sanityCheckReplicationFactor(KsDef ks, CassandraKeyValueServiceConfig config, Set<String> dcs) {
-        checkRfsSpecified(config, dcs, ks.getStrategy_options());
-        checkRfsMatchConfig(ks, config, dcs, ks.getStrategy_options());
-    }
-
-    private static void checkRfsSpecified(
-            CassandraKeyValueServiceConfig config, Set<String> dcs, Map<String, String> strategyOptions) {
         for (String datacenter : dcs) {
-            if (strategyOptions.get(datacenter) == null) {
-                logErrorOrThrow(
-                        "The datacenter for this cassandra cluster is invalid. " + " failed dc: " + datacenter
-                                + "  strategyOptions: " + strategyOptions,
-                        config.ignoreDatacenterConfigurationChecks());
-            }
-        }
-    }
-
-    private static void checkRfsMatchConfig(
-            KsDef ks, CassandraKeyValueServiceConfig config, Set<String> dcs, Map<String, String> strategyOptions) {
-        for (String datacenter : dcs) {
-            if (Integer.parseInt(strategyOptions.get(datacenter)) != config.replicationFactor()) {
+            if (Integer.parseInt(ks.getStrategy_options().get(datacenter)) != config.replicationFactor()) {
                 throw new UnsupportedOperationException("Your current Cassandra keyspace (" + ks.getName()
                         + ") has a replication factor not matching your Atlas Cassandra configuration."
                         + " Change them to match, but be mindful of what steps you'll need to"

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifierTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifierTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.ImmutableDefaultConfig;
@@ -225,15 +224,6 @@ public class CassandraVerifierTest {
 
         ksDef = CassandraVerifier.checkAndSetReplicationFactor(client, ksDef, config);
         assertThat(ksDef.strategy_options).isEqualTo(strategyOptions);
-    }
-
-    @Test
-    public void noStrategyForDcThrows() {
-        KsDef ksDef = new KsDef("test", CassandraConstants.SIMPLE_STRATEGY, ImmutableList.of());
-        ksDef.setStrategy_options(ImmutableMap.of(DC_1, "1"));
-        assertThatThrownBy(() ->
-                        CassandraVerifier.sanityCheckReplicationFactor(ksDef, config, ImmutableSet.of(DC_1, DC_2)))
-                .isInstanceOf(IllegalStateException.class);
     }
 
     @Test

--- a/changelog/@unreleased/pr-5874.v2.yml
+++ b/changelog/@unreleased/pr-5874.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: Remove a Cassandra verification check that effectively verifies that
+    the datacenters have not been changed for a keyspace when compared against the
+    `SAMPLE_RF_KEYSPACE` as this invariant cannot be broken through AtlasDB and would
+    require direct Cassandra modification.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5874


### PR DESCRIPTION
**Goals (and why)**:
==COMMIT_MSG==
Remove a Cassandra verification check that effectively verifies that the datacenters have not been changed for a keyspace when compared against the `SAMPLE_RF_KEYSPACE` as this invariant cannot be broken through AtlasDB and would require direct Cassandra modification.
==COMMIT_MSG==

**Implementation Description (bullets)**:
Since strategy options can contain things other than the DCs, we still need a way of getting them. This is _super_ hacky, but maybe it provides something (although the general check is definitely weakened).

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added a fun test.

**Concerns (what feedback would you like?)**:
Do we modify the strategy options _anywhere_ in AtlasDB?

**Where should we start reviewing?**:
Diff

**Priority (whenever / two weeks / yesterday)**:
ASAP
