### PR TITLE
Tasks which rename threads avoid updating the OS thread

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -24,6 +24,7 @@ import com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraClientPoolHostLevel
 import com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraClientPoolMetrics;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.common.base.FunctionCheckedException;
+import com.palantir.common.concurrent.ThreadNames;
 import com.palantir.common.pooling.PoolingContainer;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
@@ -108,8 +109,9 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Cassand
     public <V, K extends Exception> V runWithPooledResource(FunctionCheckedException<CassandraClient, V, K> fn)
             throws K {
         final String origName = Thread.currentThread().getName();
-        Thread.currentThread()
-                .setName(origName
+        ThreadNames.setThreadName(
+                Thread.currentThread(),
+                origName
                         + " calling cassandra host " + host
                         + " started at " + DateTimeFormatter.ISO_INSTANT.format(Instant.now())
                         + " - " + count.getAndIncrement());
@@ -133,7 +135,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Cassand
             throw t;
         } finally {
             openRequests.getAndDecrement();
-            Thread.currentThread().setName(origName);
+            ThreadNames.setThreadName(Thread.currentThread(), origName);
         }
     }
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/AnnotatedCallable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/AnnotatedCallable.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.util;
 
+import com.palantir.common.concurrent.ThreadNames;
 import java.util.concurrent.Callable;
 
 /**
@@ -49,14 +50,14 @@ public final class AnnotatedCallable<T> implements Callable<T> {
     @Override
     public T call() throws Exception {
         final String oldName = Thread.currentThread().getName();
-        Thread.currentThread().setName(type.join(name, oldName));
+        ThreadNames.setThreadName(Thread.currentThread(), type.join(name, oldName));
         try {
             return delegate.call();
         } catch (Throwable throwable) {
             throwable.addSuppressed(SuppressedException.from(throwable));
             throw throwable;
         } finally {
-            Thread.currentThread().setName(oldName);
+            ThreadNames.setThreadName(Thread.currentThread(), oldName);
         }
     }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/AnnotatedRunnable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/AnnotatedRunnable.java
@@ -15,6 +15,8 @@
  */
 package com.palantir.atlasdb.util;
 
+import com.palantir.common.concurrent.ThreadNames;
+
 /**
  * Whenever this runnable is run, for the duration of the call we will have a new thread name.
  * <p>
@@ -47,14 +49,14 @@ public final class AnnotatedRunnable implements Runnable {
     @Override
     public void run() {
         final String oldName = Thread.currentThread().getName();
-        Thread.currentThread().setName(type.join(name, oldName));
+        ThreadNames.setThreadName(Thread.currentThread(), type.join(name, oldName));
         try {
             delegate.run();
         } catch (Throwable throwable) {
             throwable.addSuppressed(SuppressedException.from(throwable));
             throw throwable;
         } finally {
-            Thread.currentThread().setName(oldName);
+            ThreadNames.setThreadName(Thread.currentThread(), oldName);
         }
     }
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
@@ -92,6 +92,7 @@ import com.palantir.common.base.ClosableIterators;
 import com.palantir.common.base.Throwables;
 import com.palantir.common.collect.Maps2;
 import com.palantir.common.concurrent.PTExecutors;
+import com.palantir.common.concurrent.ThreadNames;
 import com.palantir.exception.PalantirSqlException;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
@@ -414,12 +415,13 @@ public final class DbKvs extends AbstractKeyValueService implements DbKeyValueSe
             for (final List<Map.Entry<Cell, byte[]>> p : partitions) {
                 callables.add(() -> {
                     String originalName = Thread.currentThread().getName();
-                    Thread.currentThread().setName("Atlas multiPut of " + p.size() + " cells into " + table);
+                    ThreadNames.setThreadName(
+                            Thread.currentThread(), "Atlas multiPut of " + p.size() + " cells into " + table);
                     try {
                         put(table, Maps2.fromEntries(p), timestamp);
                         return null;
                     } finally {
-                        Thread.currentThread().setName(originalName);
+                        ThreadNames.setThreadName(Thread.currentThread(), originalName);
                     }
                 });
             }

--- a/changelog/@unreleased/pr-5877.v2.yml
+++ b/changelog/@unreleased/pr-5877.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Tasks which rename threads avoid updating the OS thread
+  links:
+  - https://github.com/palantir/atlasdb/pull/5877

--- a/commons-api/src/main/java/com/palantir/common/concurrent/ThreadNamingCallable.java
+++ b/commons-api/src/main/java/com/palantir/common/concurrent/ThreadNamingCallable.java
@@ -53,11 +53,11 @@ public class ThreadNamingCallable<T> implements Callable<T> {
     @Override
     public T call() throws Exception {
         final String oldName = Thread.currentThread().getName();
-        Thread.currentThread().setName(getNewName(oldName));
+        ThreadNames.setThreadName(Thread.currentThread(), getNewName(oldName));
         try {
             return delegate.call();
         } finally {
-            Thread.currentThread().setName(oldName);
+            ThreadNames.setThreadName(Thread.currentThread(), oldName);
         }
     }
 

--- a/commons-db/src/main/java/com/palantir/nexus/db/sql/BasicSQL.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/sql/BasicSQL.java
@@ -19,6 +19,7 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.palantir.common.base.Throwables;
 import com.palantir.common.concurrent.PTExecutors;
+import com.palantir.common.concurrent.ThreadNames;
 import com.palantir.common.concurrent.ThreadNamingCallable;
 import com.palantir.db.oracle.JdbcHandler;
 import com.palantir.db.oracle.JdbcHandler.BlobHandler;
@@ -491,7 +492,8 @@ public abstract class BasicSQL {
         long startTime = System.currentTimeMillis();
         final String oldName = Thread.currentThread().getName();
         final String currentTimestamp = DateTimeFormat.forPattern("HH:mm:ss").print(System.currentTimeMillis());
-        Thread.currentThread().setName(oldName + " blocking on " + threadString + " started at " + currentTimestamp);
+        ThreadNames.setThreadName(
+                Thread.currentThread(), oldName + " blocking on " + threadString + " started at " + currentTimestamp);
         try {
             rs = result.get();
             return visitor.visit(rs);
@@ -508,7 +510,7 @@ public abstract class BasicSQL {
         } catch (ExecutionException ee) {
             throw handleInterruptions(startTime, ee);
         } finally {
-            Thread.currentThread().setName(oldName);
+            ThreadNames.setThreadName(Thread.currentThread(), oldName);
             if (rs != null && autoClose == AutoClose.TRUE) {
                 ResultSets.close(rs);
             }

--- a/commons-db/src/main/java/com/palantir/nexus/db/sql/BasicSQLUtils.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/sql/BasicSQLUtils.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.nexus.db.sql;
 
+import com.palantir.common.concurrent.ThreadNames;
 import com.palantir.common.concurrent.ThreadNamingCallable;
 import com.palantir.exception.PalantirSqlException;
 import com.palantir.logsafe.Preconditions;
@@ -293,7 +294,8 @@ public class BasicSQLUtils {
         T result = null;
         final String oldName = Thread.currentThread().getName();
         final String currentTimestamp = DateTimeFormat.forPattern("HH:mm:ss").print(System.currentTimeMillis());
-        Thread.currentThread().setName(oldName + " blocking on " + threadString + " started at " + currentTimestamp);
+        ThreadNames.setThreadName(
+                Thread.currentThread(), oldName + " blocking on " + threadString + " started at " + currentTimestamp);
         try {
             long startTime = System.currentTimeMillis();
             while (true) {
@@ -308,7 +310,7 @@ public class BasicSQLUtils {
                 }
             }
         } finally {
-            Thread.currentThread().setName(oldName);
+            ThreadNames.setThreadName(Thread.currentThread(), oldName);
             if (interrupted) {
                 Thread.currentThread().interrupt();
             }

--- a/commons-executors/src/main/java/com/palantir/common/concurrent/AtlasRenamingExecutorService.java
+++ b/commons-executors/src/main/java/com/palantir/common/concurrent/AtlasRenamingExecutorService.java
@@ -86,13 +86,13 @@ final class AtlasRenamingExecutorService extends AbstractExecutorService {
         public void run() {
             final Thread currentThread = Thread.currentThread();
             final String originalName = currentThread.getName();
-            currentThread.setName(nameSupplier.get());
+            ThreadNames.setThreadName(currentThread, nameSupplier.get());
             try {
                 command.run();
             } catch (Throwable t) {
                 handler.uncaughtException(currentThread, t);
             } finally {
-                currentThread.setName(originalName);
+                ThreadNames.setThreadName(currentThread, originalName);
             }
         }
     }

--- a/commons-executors/src/main/java/com/palantir/common/concurrent/ThreadNames.java
+++ b/commons-executors/src/main/java/com/palantir/common/concurrent/ThreadNames.java
@@ -21,7 +21,7 @@ import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.lang.reflect.Field;
 import java.security.PrivilegedAction;
 
-@SuppressWarnings("UnnecessarilyQualified") // Internal classes should not be imported
+@SuppressWarnings({"UnnecessarilyQualified", "deprecation", "removal"}) // Internal classes should not be imported
 public final class ThreadNames {
 
     private static final sun.misc.Unsafe unsafe = initUnsafe();

--- a/commons-executors/src/main/java/com/palantir/common/concurrent/ThreadNames.java
+++ b/commons-executors/src/main/java/com/palantir/common/concurrent/ThreadNames.java
@@ -1,0 +1,67 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.common.concurrent;
+
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import java.lang.reflect.Field;
+import java.security.PrivilegedAction;
+
+@SuppressWarnings("UnnecessarilyQualified") // Internal classes should not be imported
+public final class ThreadNames {
+
+    private static final sun.misc.Unsafe unsafe = initUnsafe();
+
+    private static final long threadNameOffset;
+
+    static {
+        try {
+            threadNameOffset = unsafe.objectFieldOffset(Thread.class.getDeclaredField("name"));
+        } catch (NoSuchFieldException e) {
+            throw new SafeIllegalStateException("Failed to find the Thread.name field", e);
+        }
+    }
+
+    /**
+     * Sets the name of a thread without native overhead to rename the OS thread.
+     * Note that unlike {@link Thread#setName(String)} this implementation may not
+     * synchronize on the {@code thread} object.
+     *
+     * @see <a href="https://github.com/palantir/atlasdb/pull/5796>atlasdb#5796</a>
+     */
+    public static void setThreadName(Thread thread, String name) {
+        Preconditions.checkNotNull(thread, "Thread is required");
+        Preconditions.checkNotNull(name, "Thread name is required");
+        unsafe.putObjectVolatile(thread, threadNameOffset, name);
+    }
+
+    // prevent avoidable failures in spark/etc where security manager is used
+    @SuppressWarnings("removal")
+    private static sun.misc.Unsafe initUnsafe() {
+        return java.security.AccessController.doPrivileged((PrivilegedAction<sun.misc.Unsafe>) () -> {
+            try {
+                Field field = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+                field.setAccessible(true);
+                return (sun.misc.Unsafe) field.get(null);
+            } catch (ReflectiveOperationException e) {
+                throw new SafeIllegalStateException("Failed to load Unsafe", e);
+            }
+        });
+    }
+
+    private ThreadNames() {}
+}

--- a/commons-executors/src/test/java/com/palantir/common/concurrent/ThreadNamesTest.java
+++ b/commons-executors/src/test/java/com/palantir/common/concurrent/ThreadNamesTest.java
@@ -1,0 +1,65 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.common.concurrent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.io.ByteStreams;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import org.junit.Test;
+
+public final class ThreadNamesTest {
+
+    @Test
+    public void testRenameCurrentThread() {
+        Thread current = Thread.currentThread();
+        String originalName = current.getName();
+        try {
+            String newName = UUID.randomUUID().toString();
+            ThreadNames.setThreadName(current, newName);
+            assertThat(current.getName()).isEqualTo(newName);
+        } finally {
+            current.setName(originalName);
+        }
+        assertThat(current.getName()).isEqualTo(originalName);
+    }
+
+    @Test
+    public void testRenameAppearsInThreadDump() throws Exception {
+        Thread current = Thread.currentThread();
+        String originalName = current.getName();
+        try {
+            String newName = UUID.randomUUID().toString();
+            ThreadNames.setThreadName(current, newName);
+            assertThat(current.getName()).isEqualTo(newName);
+
+            Process process = Runtime.getRuntime().exec(new String[] {
+                "jstack", Long.toString(ProcessHandle.current().pid())
+            });
+            String jstackOutput;
+            try (InputStream data = process.getInputStream()) {
+                jstackOutput = new String(ByteStreams.toByteArray(data), StandardCharsets.UTF_8);
+            }
+            assertThat(jstackOutput).contains('"' + newName + "\" ");
+        } finally {
+            current.setName(originalName);
+        }
+        assertThat(current.getName()).isEqualTo(originalName);
+    }
+}


### PR DESCRIPTION
Instead only the java representation is updated, which provides
observability upsides without potentially unknown cost of os
thread renaming based on the environment configuration.

==COMMIT_MSG==
Tasks which rename threads avoid updating the OS thread
==COMMIT_MSG==

Internal benchmark results:
```
Benchmark                                 Mode  Cnt    Score     Error  Units
ThreadNamesBenchmark.threadSetName        avgt    4  610.446 ± 193.203  ns/op
ThreadNamesBenchmark.unsafeSetThreadName  avgt    4   31.699 ±   0.305  ns/op
```