### PR TITLE
Fix race condition causing 'pool not open' errors

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
@@ -399,15 +399,16 @@ public class CassandraService implements AutoCloseable {
 
     public void removePool(InetSocketAddress removedServerAddress) {
         blacklist.remove(removedServerAddress);
+        CassandraClientPoolingContainer containerToRemove = currentPools.get(removedServerAddress);
+        currentPools.remove(removedServerAddress);
         try {
-            currentPools.get(removedServerAddress).shutdownPooling();
+            containerToRemove.shutdownPooling();
         } catch (Exception e) {
             log.warn(
                     "While removing a host ({}) from the pool, we were unable to gently cleanup resources.",
                     SafeArg.of("removedServerAddress", CassandraLogHelper.host(removedServerAddress)),
                     e);
         }
-        currentPools.remove(removedServerAddress);
     }
 
     public void cacheInitialCassandraHosts() {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
@@ -399,10 +399,9 @@ public class CassandraService implements AutoCloseable {
 
     public void removePool(InetSocketAddress removedServerAddress) {
         blacklist.remove(removedServerAddress);
-        CassandraClientPoolingContainer containerToRemove = currentPools.get(removedServerAddress);
-        currentPools.remove(removedServerAddress);
+        CassandraClientPoolingContainer removedContainer = currentPools.remove(removedServerAddress);
         try {
-            containerToRemove.shutdownPooling();
+            removedContainer.shutdownPooling();
         } catch (Exception e) {
             log.warn(
                     "While removing a host ({}) from the pool, we were unable to gently cleanup resources.",

--- a/changelog/@unreleased/pr-5882.v2.yml
+++ b/changelog/@unreleased/pr-5882.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fixed a race condition where we would potentially attempt to use a
+    Cassandra client pool that we had already closed.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5882


### PR DESCRIPTION
**Goals (and why)**:
In PDS-239577, we had a report of various failures, and the 'pool not open' error was a common theme. We know of a race condition where, on removing a host from the client pool, we shut down the pooling container _before_ removing the host from the map. This means that there exists a short time when hosts can be present in the pool, but closed (and thus unable to serve requests).

==COMMIT_MSG==
Fixed a race condition where we would potentially attempt to use a Cassandra client pool that we had already closed.
==COMMIT_MSG==

**Implementation Description (bullets)**:
- Fix race condition
- Drive-by improvement to logging

**Testing (What was existing testing like?  What have you done to improve it?)**: Tricky to test for this; we would expect to see a reduction in failure frequency once this has rolled out.

**Concerns (what feedback would you like?)**: Is there more we can do to avoid thrashing of client pools?

**Where should we start reviewing?**: +14/-5

**Priority (whenever / two weeks / yesterday)**: yesterday
