### PR TITLE
[LW] KVS Reads are no longer synchronised

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/TransactionScopedCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/TransactionScopedCacheImpl.java
@@ -82,7 +82,7 @@ final class TransactionScopedCacheImpl implements TransactionScopedCache {
     }
 
     @Override
-    public synchronized ListenableFuture<Map<Cell, byte[]>> getAsync(
+    public ListenableFuture<Map<Cell, byte[]>> getAsync(
             TableReference tableReference,
             Set<Cell> cells,
             Function<Set<Cell>, ListenableFuture<Map<Cell, byte[]>>> valueLoader) {


### PR DESCRIPTION
**Goals (and why)**:
==COMMIT_MSG==
Reads that go through the lock-watch backed cache are no longer in a synchronised block.
==COMMIT_MSG==

**Implementation Description (bullets)**:
When using the _validating_ cache, we perform all KVS reads up front, then read from those when we miss. These KVS reads are not done in a synchronised block, and thus can be concurrent (within the given transaction).

However, when we do _not_ validate, the whole `getAsync` method (which we use for `get`) is synchronised, **including** the read from the KVS. As a result, this dramatically reduces the possible concurrency within a transaction. The reason this isn't immediately obvious is that the value loader appears to return a future, but actually that future is always immediate and thus the computation is performed immediately.

Removing `synchronised` on this method obviously resolves this, but I also argue that this method is thread-safe without any further modification:

1. `isWatched` doesn't change within a transaction, and thus is thread-safe.
2. `valueLoader.apply` is thread-safe: it's the regular read path from `SnapshotTransaction`.
3. `cacheLookup` goes to a synchronised block, which is critical for correctness: we cannot have concurrent reads and writes going to the `TransactionCacheValueStore`. Note that we could feasibly wrap TCVS with a read-write lock instead of synchronised methods for the same result.
4. If everything is hit, then we're obviously safe to return
5. Else, processing remote reads is synchronised. Note that if a different request modifies the cache in between our lookup and processing the remote reads, the options are:
A) it was doing reads: the values should end up being the same
B) it was doing writes: writes do `put`, whereas reads do `putIfAbsent`, so these should not overwrite them anyway
Note that `processRemoteReads` is synchronised, too.

**Testing (What was existing testing like?  What have you done to improve it?)**:
We have concurrency / stress tests already at the integration layer; I think trying to force some weird interleaving might just be too difficult.

**Concerns (what feedback would you like?)**:
Does my proof make sense?
Do we think we'll get enough of a gain by going for a read-write lock over a synchronised one at this point? If so, should we go ahead and make that change too? (I'd argue that should be in a separate PR though).

**Where should we start reviewing?**:
Diff. There's a one word change.

**Priority (whenever / two weeks / yesterday)**:
ASAP. I want to get this soaking.
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
