### PR TITLE
ABR13: Validate auth headers

### DIFF
--- a/atlasdb-tests-shared/src/main/java/com/palantir/timelock/paxos/InMemoryTimelockServices.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/timelock/paxos/InMemoryTimelockServices.java
@@ -56,6 +56,7 @@ import com.palantir.timelock.config.TimeLockRuntimeConfiguration;
 import com.palantir.timestamp.ManagedTimestampService;
 import com.palantir.timestamp.TimestampManagementService;
 import com.palantir.timestamp.TimestampService;
+import com.palantir.tokens.auth.BearerToken;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
@@ -71,6 +72,7 @@ public final class InMemoryTimelockServices extends ExternalResource implements 
     private static final String USER_AGENT_NAME = "user-agent";
     private static final String USER_AGENT_VERSION = "3.1415926.5358979";
     private static final UserAgent USER_AGENT = UserAgent.of(UserAgent.Agent.of(USER_AGENT_NAME, USER_AGENT_VERSION));
+    private static final BearerToken BEARER_TOKEN = BearerToken.valueOf("test-token");
     private static final int THREAD_POOL_SIZE = 128;
     private static final int BLOCKING_TIMEOUT_MS = 60 * 800; // 0.8 mins to ms
 
@@ -118,6 +120,7 @@ public final class InMemoryTimelockServices extends ExternalResource implements 
                 .cluster(PartialServiceConfiguration.of(List.of("local"), Optional.empty()))
                 .build();
         TimeLockRuntimeConfiguration runtime = ImmutableTimeLockRuntimeConfiguration.builder()
+                .permittedBackupToken(BEARER_TOKEN)
                 .clusterSnapshot(clusterConfig)
                 .build();
 

--- a/changelog/@unreleased/pr-5890.v2.yml
+++ b/changelog/@unreleased/pr-5890.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Added AuthHeader validation to the backup and restore endpoints.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5890

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/RestrictedTimeLockRuntimeConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/RestrictedTimeLockRuntimeConfiguration.java
@@ -32,7 +32,7 @@ public class RestrictedTimeLockRuntimeConfiguration extends TimeLockRuntimeConfi
     }
 
     @Override
-    public BearerToken permittedBackupToken() {
+    public Optional<BearerToken> permittedBackupToken() {
         return runtime.permittedBackupToken();
     }
 

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/RestrictedTimeLockRuntimeConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/RestrictedTimeLockRuntimeConfiguration.java
@@ -16,6 +16,7 @@
 
 package com.palantir.timelock.config;
 
+import com.palantir.tokens.auth.BearerToken;
 import java.util.Optional;
 
 public class RestrictedTimeLockRuntimeConfiguration extends TimeLockRuntimeConfiguration {
@@ -28,6 +29,11 @@ public class RestrictedTimeLockRuntimeConfiguration extends TimeLockRuntimeConfi
     @Override
     public PaxosRuntimeConfiguration paxos() {
         return runtime.paxos();
+    }
+
+    @Override
+    public BearerToken permittedBackupToken() {
+        return runtime.permittedBackupToken();
     }
 
     @Override

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockRuntimeConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockRuntimeConfiguration.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Preconditions;
+import com.palantir.tokens.auth.BearerToken;
 import java.util.Optional;
 import org.immutables.value.Value;
 
@@ -38,6 +39,12 @@ public abstract class TimeLockRuntimeConfiguration {
     public PaxosRuntimeConfiguration paxos() {
         return ImmutablePaxosRuntimeConfiguration.builder().build();
     }
+
+    /**
+     *  The token required by other services to use backup and restore-related endpoints.
+     */
+    @JsonProperty("permitted-backup-token")
+    public abstract BearerToken permittedBackupToken();
 
     /**
      * As of now, TimeLock is not equipped to handle live-changes in the cluster configuration. For this reason,

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockRuntimeConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockRuntimeConfiguration.java
@@ -44,7 +44,7 @@ public abstract class TimeLockRuntimeConfiguration {
      *  The token required by other services to use backup and restore-related endpoints.
      */
     @JsonProperty("permitted-backup-token")
-    public abstract BearerToken permittedBackupToken();
+    public abstract Optional<BearerToken> permittedBackupToken();
 
     /**
      * As of now, TimeLock is not equipped to handle live-changes in the cluster configuration. For this reason,

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -338,7 +338,8 @@ public class TimeLockAgent {
         Function<String, LockService> lockServiceGetter =
                 namespace -> namespaces.get(namespace).getLockService();
 
-        Refreshable<BearerToken> permittedBackupToken = runtime.map(TimeLockRuntimeConfiguration::permittedBackupToken);
+        Refreshable<Optional<BearerToken>> permittedBackupToken =
+                runtime.map(TimeLockRuntimeConfiguration::permittedBackupToken);
         RedirectRetryTargeter redirectRetryTargeter = redirectRetryTargeter();
         if (undertowRegistrar.isPresent()) {
             Consumer<UndertowService> presentUndertowRegistrar = undertowRegistrar.get();

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -358,7 +358,8 @@ public class TimeLockAgent {
                     MultiClientConjureTimelockResource.undertow(redirectRetryTargeter, asyncTimelockServiceGetter));
             registerCorruptionHandlerWrappedService(
                     presentUndertowRegistrar,
-                    AtlasBackupResource.undertow(redirectRetryTargeter, asyncTimelockServiceGetter));
+                    AtlasBackupResource.undertow(
+                            permittedBackupToken, redirectRetryTargeter, asyncTimelockServiceGetter));
             registerCorruptionHandlerWrappedService(
                     presentUndertowRegistrar,
                     AtlasRestoreResource.undertow(
@@ -370,7 +371,8 @@ public class TimeLockAgent {
             registrar.accept(TimeLockPaxosHistoryProviderResource.jersey(corruptionComponents.localHistoryLoader()));
             registrar.accept(
                     MultiClientConjureTimelockResource.jersey(redirectRetryTargeter, asyncTimelockServiceGetter));
-            registrar.accept(AtlasBackupResource.jersey(redirectRetryTargeter, asyncTimelockServiceGetter));
+            registrar.accept(AtlasBackupResource.jersey(
+                    permittedBackupToken, redirectRetryTargeter, asyncTimelockServiceGetter));
             registrar.accept(AtlasRestoreResource.jersey(
                     permittedBackupToken, redirectRetryTargeter, asyncTimelockServiceGetter));
         }

--- a/timelock-agent/src/test/java/com/palantir/timelock/config/TimeLockRuntimeConfigurationTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/config/TimeLockRuntimeConfigurationTest.java
@@ -47,7 +47,6 @@ public class TimeLockRuntimeConfigurationTest {
     @Test
     public void canSpecifyPositiveLockLoggerTimeout() {
         ImmutableTimeLockRuntimeConfiguration.builder()
-                .permittedBackupToken(BEARER_TOKEN)
                 .clusterSnapshot(CLUSTER_CONFIG)
                 .slowLockLogTriggerMillis(1L)
                 .build();
@@ -56,7 +55,6 @@ public class TimeLockRuntimeConfigurationTest {
     @Test
     public void throwOnNegativeLeaderPingResponseWait() {
         assertThatThrownBy(() -> ImmutableTimeLockRuntimeConfiguration.builder()
-                        .permittedBackupToken(BEARER_TOKEN)
                         .clusterSnapshot(CLUSTER_CONFIG)
                         .slowLockLogTriggerMillis(-1L)
                         .build())
@@ -66,7 +64,6 @@ public class TimeLockRuntimeConfigurationTest {
     @Test
     public void newNodeInExistingServiceRecognisedAsNew() {
         assertThat(ImmutableTimeLockRuntimeConfiguration.builder()
-                        .permittedBackupToken(BEARER_TOKEN)
                         .clusterSnapshot(ImmutableDefaultClusterConfiguration.builder()
                                 .localServer(SERVER_A)
                                 .cluster(PartialServiceConfiguration.of(

--- a/timelock-agent/src/test/java/com/palantir/timelock/config/TimeLockRuntimeConfigurationTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/config/TimeLockRuntimeConfigurationTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.java.api.config.service.PartialServiceConfiguration;
+import com.palantir.tokens.auth.BearerToken;
 import java.util.Optional;
 import org.junit.Test;
 
@@ -33,10 +34,12 @@ public class TimeLockRuntimeConfigurationTest {
                     ImmutableList.of(SERVER_A, SERVER_B, "the-mane-event:3456"), Optional.empty()))
             .addKnownNewServers(SERVER_B)
             .build();
+    private static final BearerToken BEARER_TOKEN = BearerToken.valueOf("quit-horsing-around");
 
     @Test
     public void canCreateWithZeroClients() {
         ImmutableTimeLockRuntimeConfiguration.builder()
+                .permittedBackupToken(BEARER_TOKEN)
                 .clusterSnapshot(CLUSTER_CONFIG)
                 .build();
     }
@@ -44,6 +47,7 @@ public class TimeLockRuntimeConfigurationTest {
     @Test
     public void canSpecifyPositiveLockLoggerTimeout() {
         ImmutableTimeLockRuntimeConfiguration.builder()
+                .permittedBackupToken(BEARER_TOKEN)
                 .clusterSnapshot(CLUSTER_CONFIG)
                 .slowLockLogTriggerMillis(1L)
                 .build();
@@ -52,6 +56,7 @@ public class TimeLockRuntimeConfigurationTest {
     @Test
     public void throwOnNegativeLeaderPingResponseWait() {
         assertThatThrownBy(() -> ImmutableTimeLockRuntimeConfiguration.builder()
+                        .permittedBackupToken(BEARER_TOKEN)
                         .clusterSnapshot(CLUSTER_CONFIG)
                         .slowLockLogTriggerMillis(-1L)
                         .build())
@@ -61,6 +66,7 @@ public class TimeLockRuntimeConfigurationTest {
     @Test
     public void newNodeInExistingServiceRecognisedAsNew() {
         assertThat(ImmutableTimeLockRuntimeConfiguration.builder()
+                        .permittedBackupToken(BEARER_TOKEN)
                         .clusterSnapshot(ImmutableDefaultClusterConfiguration.builder()
                                 .localServer(SERVER_A)
                                 .cluster(PartialServiceConfiguration.of(

--- a/timelock-agent/src/test/java/com/palantir/timelock/paxos/TimeLockAgentTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/paxos/TimeLockAgentTest.java
@@ -38,7 +38,6 @@ import com.palantir.timelock.config.ImmutableTimeLockRuntimeConfiguration;
 import com.palantir.timelock.config.PaxosInstallConfiguration;
 import com.palantir.timelock.config.TimeLockInstallConfiguration;
 import com.palantir.timelock.config.TsBoundPersisterRuntimeConfiguration;
-import com.palantir.tokens.auth.BearerToken;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -61,7 +60,6 @@ public class TimeLockAgentTest {
                     ImmutableList.of(SERVER_A, SERVER_B, "the-mane-event:3456"), Optional.empty()))
             .addKnownNewServers(SERVER_B)
             .build();
-    private static final BearerToken BEARER_TOKEN = BearerToken.valueOf("neigh-friend-and-enter");
 
     private final PersistedSchemaVersion schemaVersion = mock(PersistedSchemaVersion.class);
 
@@ -106,7 +104,6 @@ public class TimeLockAgentTest {
     public void getKeyValueServiceRuntimeConfigThrowsIfConfiguredToNotUseDatabase() {
         assertThatThrownBy(() ->
                         TimeLockAgent.getKeyValueServiceRuntimeConfig(ImmutableTimeLockRuntimeConfiguration.builder()
-                                .permittedBackupToken(BEARER_TOKEN)
                                 .timestampBoundPersistence(mock(TsBoundPersisterRuntimeConfiguration.class))
                                 .clusterSnapshot(CLUSTER_CONFIG)
                                 .build()))
@@ -117,7 +114,6 @@ public class TimeLockAgentTest {
     @Test
     public void getKeyValueServiceRuntimeConfigReturnsEmptyIfNotProvided() {
         assertThat(TimeLockAgent.getKeyValueServiceRuntimeConfig(ImmutableTimeLockRuntimeConfiguration.builder()
-                        .permittedBackupToken(BEARER_TOKEN)
                         .clusterSnapshot(CLUSTER_CONFIG)
                         .build()))
                 .isEmpty();
@@ -130,7 +126,6 @@ public class TimeLockAgentTest {
         when(runtimeConfig.type()).thenReturn("relational");
 
         assertThat(TimeLockAgent.getKeyValueServiceRuntimeConfig(ImmutableTimeLockRuntimeConfiguration.builder()
-                        .permittedBackupToken(BEARER_TOKEN)
                         .timestampBoundPersistence(ImmutableDatabaseTsBoundPersisterRuntimeConfiguration.builder()
                                 .keyValueServiceRuntimeConfig(runtimeConfig)
                                 .build())

--- a/timelock-agent/src/test/java/com/palantir/timelock/paxos/TimeLockAgentTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/paxos/TimeLockAgentTest.java
@@ -38,6 +38,7 @@ import com.palantir.timelock.config.ImmutableTimeLockRuntimeConfiguration;
 import com.palantir.timelock.config.PaxosInstallConfiguration;
 import com.palantir.timelock.config.TimeLockInstallConfiguration;
 import com.palantir.timelock.config.TsBoundPersisterRuntimeConfiguration;
+import com.palantir.tokens.auth.BearerToken;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -60,6 +61,7 @@ public class TimeLockAgentTest {
                     ImmutableList.of(SERVER_A, SERVER_B, "the-mane-event:3456"), Optional.empty()))
             .addKnownNewServers(SERVER_B)
             .build();
+    private static final BearerToken BEARER_TOKEN = BearerToken.valueOf("neigh-friend-and-enter");
 
     private final PersistedSchemaVersion schemaVersion = mock(PersistedSchemaVersion.class);
 
@@ -104,6 +106,7 @@ public class TimeLockAgentTest {
     public void getKeyValueServiceRuntimeConfigThrowsIfConfiguredToNotUseDatabase() {
         assertThatThrownBy(() ->
                         TimeLockAgent.getKeyValueServiceRuntimeConfig(ImmutableTimeLockRuntimeConfiguration.builder()
+                                .permittedBackupToken(BEARER_TOKEN)
                                 .timestampBoundPersistence(mock(TsBoundPersisterRuntimeConfiguration.class))
                                 .clusterSnapshot(CLUSTER_CONFIG)
                                 .build()))
@@ -114,6 +117,7 @@ public class TimeLockAgentTest {
     @Test
     public void getKeyValueServiceRuntimeConfigReturnsEmptyIfNotProvided() {
         assertThat(TimeLockAgent.getKeyValueServiceRuntimeConfig(ImmutableTimeLockRuntimeConfiguration.builder()
+                        .permittedBackupToken(BEARER_TOKEN)
                         .clusterSnapshot(CLUSTER_CONFIG)
                         .build()))
                 .isEmpty();
@@ -126,6 +130,7 @@ public class TimeLockAgentTest {
         when(runtimeConfig.type()).thenReturn("relational");
 
         assertThat(TimeLockAgent.getKeyValueServiceRuntimeConfig(ImmutableTimeLockRuntimeConfiguration.builder()
+                        .permittedBackupToken(BEARER_TOKEN)
                         .timestampBoundPersistence(ImmutableDatabaseTsBoundPersisterRuntimeConfiguration.builder()
                                 .keyValueServiceRuntimeConfig(runtimeConfig)
                                 .build())

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/backup/AtlasBackupResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/backup/AtlasBackupResource.java
@@ -92,8 +92,8 @@ public class AtlasBackupResource implements UndertowAtlasBackupClient {
     }
 
     private PrepareBackupResponse prepareBackupInternal(AuthHeader authHeader, PrepareBackupRequest request) {
-        if (!permittedBackupToken.get().equals(authHeader.getBearerToken())) {
-            log.error("Attempted to complete restore with an invalid auth header", SafeArg.of("request", request));
+        if (permittedBackupToken.get() != null && !permittedBackupToken.get().equals(authHeader.getBearerToken())) {
+            log.error("Attempted to prepare backup with an invalid auth header", SafeArg.of("request", request));
             throw new ServiceException(ErrorType.PERMISSION_DENIED);
         }
 
@@ -124,8 +124,8 @@ public class AtlasBackupResource implements UndertowAtlasBackupClient {
     @SuppressWarnings("ConstantConditions")
     private ListenableFuture<CompleteBackupResponse> completeBackupInternal(
             AuthHeader authHeader, CompleteBackupRequest request) {
-        if (!permittedBackupToken.get().equals(authHeader.getBearerToken())) {
-            log.error("Attempted to complete restore with an invalid auth header", SafeArg.of("request", request));
+        if (permittedBackupToken.get() != null && !permittedBackupToken.get().equals(authHeader.getBearerToken())) {
+            log.error("Attempted to complete backup with an invalid auth header", SafeArg.of("request", request));
             throw new ServiceException(ErrorType.PERMISSION_DENIED);
         }
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/backup/AtlasBackupResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/backup/AtlasBackupResource.java
@@ -93,7 +93,10 @@ public class AtlasBackupResource implements UndertowAtlasBackupClient {
 
     private PrepareBackupResponse prepareBackupInternal(AuthHeader authHeader, PrepareBackupRequest request) {
         if (!suppliedTokenIsValid(authHeader)) {
-            log.error("Attempted to prepare backup with an invalid auth header", SafeArg.of("request", request));
+            log.error(
+                    "Attempted to prepare backup with an invalid auth header. "
+                            + "The provided token must match the configured permitted-backup-token.",
+                    SafeArg.of("request", request));
             throw new ServiceException(ErrorType.PERMISSION_DENIED);
         }
 
@@ -125,7 +128,10 @@ public class AtlasBackupResource implements UndertowAtlasBackupClient {
     private ListenableFuture<CompleteBackupResponse> completeBackupInternal(
             AuthHeader authHeader, CompleteBackupRequest request) {
         if (!suppliedTokenIsValid(authHeader)) {
-            log.error("Attempted to complete backup with an invalid auth header", SafeArg.of("request", request));
+            log.error(
+                    "Attempted to complete backup with an invalid auth header. "
+                            + "The provided token must match the configured permitted-backup-token.",
+                    SafeArg.of("request", request));
             throw new ServiceException(ErrorType.PERMISSION_DENIED);
         }
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/backup/AtlasBackupResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/backup/AtlasBackupResource.java
@@ -35,11 +35,17 @@ import com.palantir.atlasdb.http.RedirectRetryTargeter;
 import com.palantir.atlasdb.timelock.AsyncTimelockService;
 import com.palantir.atlasdb.timelock.ConjureResourceExceptionHandler;
 import com.palantir.atlasdb.timelock.api.Namespace;
+import com.palantir.conjure.java.api.errors.ErrorType;
+import com.palantir.conjure.java.api.errors.ServiceException;
 import com.palantir.conjure.java.undertow.lib.UndertowService;
 import com.palantir.lock.v2.IdentifiedTimeLockRequest;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
 import com.palantir.lock.v2.LockToken;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
 import com.palantir.tokens.auth.AuthHeader;
+import com.palantir.tokens.auth.BearerToken;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -48,32 +54,49 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 public class AtlasBackupResource implements UndertowAtlasBackupClient {
+    private static final SafeLogger log = SafeLoggerFactory.get(AtlasBackupResource.class);
+
+    private final Supplier<BearerToken> permittedBackupToken;
     private final Function<String, AsyncTimelockService> timelockServices;
     private final ConjureResourceExceptionHandler exceptionHandler;
 
     @VisibleForTesting
     AtlasBackupResource(
-            RedirectRetryTargeter redirectRetryTargeter, Function<String, AsyncTimelockService> timelockServices) {
+            Supplier<BearerToken> permittedBackupToken,
+            RedirectRetryTargeter redirectRetryTargeter,
+            Function<String, AsyncTimelockService> timelockServices) {
+        this.permittedBackupToken = permittedBackupToken;
         this.exceptionHandler = new ConjureResourceExceptionHandler(redirectRetryTargeter);
         this.timelockServices = timelockServices;
     }
 
     public static UndertowService undertow(
-            RedirectRetryTargeter redirectRetryTargeter, Function<String, AsyncTimelockService> timelockServices) {
-        return AtlasBackupClientEndpoints.of(new AtlasBackupResource(redirectRetryTargeter, timelockServices));
+            Supplier<BearerToken> permittedAuthHeader,
+            RedirectRetryTargeter redirectRetryTargeter,
+            Function<String, AsyncTimelockService> timelockServices) {
+        return AtlasBackupClientEndpoints.of(
+                new AtlasBackupResource(permittedAuthHeader, redirectRetryTargeter, timelockServices));
     }
 
     public static AtlasBackupClient jersey(
-            RedirectRetryTargeter redirectRetryTargeter, Function<String, AsyncTimelockService> timelockServices) {
-        return new JerseyAtlasBackupClientAdapter(new AtlasBackupResource(redirectRetryTargeter, timelockServices));
+            Supplier<BearerToken> permittedAuthHeader,
+            RedirectRetryTargeter redirectRetryTargeter,
+            Function<String, AsyncTimelockService> timelockServices) {
+        return new JerseyAtlasBackupClientAdapter(
+                new AtlasBackupResource(permittedAuthHeader, redirectRetryTargeter, timelockServices));
     }
 
     @Override
     public ListenableFuture<PrepareBackupResponse> prepareBackup(AuthHeader authHeader, PrepareBackupRequest request) {
-        return handleExceptions(() -> Futures.immediateFuture(prepareBackupInternal(request)));
+        return handleExceptions(() -> Futures.immediateFuture(prepareBackupInternal(authHeader, request)));
     }
 
-    private PrepareBackupResponse prepareBackupInternal(PrepareBackupRequest request) {
+    private PrepareBackupResponse prepareBackupInternal(AuthHeader authHeader, PrepareBackupRequest request) {
+        if (!permittedBackupToken.get().equals(authHeader.getBearerToken())) {
+            log.error("Attempted to complete restore with an invalid auth header", SafeArg.of("request", request));
+            throw new ServiceException(ErrorType.PERMISSION_DENIED);
+        }
+
         Set<InProgressBackupToken> preparedBackups =
                 request.getNamespaces().stream().map(this::prepareBackup).collect(Collectors.toSet());
         return PrepareBackupResponse.of(preparedBackups);
@@ -95,11 +118,17 @@ public class AtlasBackupResource implements UndertowAtlasBackupClient {
     @Override
     public ListenableFuture<CompleteBackupResponse> completeBackup(
             AuthHeader authHeader, CompleteBackupRequest request) {
-        return handleExceptions(() -> completeBackupInternal(request));
+        return handleExceptions(() -> completeBackupInternal(authHeader, request));
     }
 
     @SuppressWarnings("ConstantConditions")
-    private ListenableFuture<CompleteBackupResponse> completeBackupInternal(CompleteBackupRequest request) {
+    private ListenableFuture<CompleteBackupResponse> completeBackupInternal(
+            AuthHeader authHeader, CompleteBackupRequest request) {
+        if (!permittedBackupToken.get().equals(authHeader.getBearerToken())) {
+            log.error("Attempted to complete restore with an invalid auth header", SafeArg.of("request", request));
+            throw new ServiceException(ErrorType.PERMISSION_DENIED);
+        }
+
         Map<InProgressBackupToken, ListenableFuture<Optional<CompletedBackup>>> futureMap =
                 request.getBackupTokens().stream().collect(Collectors.toMap(token -> token, this::completeBackupAsync));
         ListenableFuture<Map<InProgressBackupToken, CompletedBackup>> singleFuture =

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/backup/AtlasRestoreResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/backup/AtlasRestoreResource.java
@@ -88,7 +88,10 @@ public class AtlasRestoreResource implements UndertowAtlasRestoreClient {
     private ListenableFuture<CompleteRestoreResponse> completeRestoreInternal(
             AuthHeader authHeader, CompleteRestoreRequest request) {
         if (!suppliedTokenIsValid(authHeader)) {
-            log.error("Attempted to complete restore with an invalid auth header", SafeArg.of("request", request));
+            log.error(
+                    "Attempted to complete restore with an invalid auth header. "
+                            + "The provided token must match the configured permitted-backup-token.",
+                    SafeArg.of("request", request));
             throw new ServiceException(ErrorType.PERMISSION_DENIED);
         }
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/backup/AtlasRestoreResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/backup/AtlasRestoreResource.java
@@ -87,7 +87,7 @@ public class AtlasRestoreResource implements UndertowAtlasRestoreClient {
 
     private ListenableFuture<CompleteRestoreResponse> completeRestoreInternal(
             AuthHeader authHeader, CompleteRestoreRequest request) {
-        if (!permittedToken.get().equals(authHeader.getBearerToken())) {
+        if (permittedBackupToken.get() != null && !permittedToken.get().equals(authHeader.getBearerToken())) {
             log.error("Attempted to complete restore with an invalid auth header", SafeArg.of("request", request));
             throw new ServiceException(ErrorType.PERMISSION_DENIED);
         }

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/backup/AtlasBackupResourceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/backup/AtlasBackupResourceTest.java
@@ -87,6 +87,19 @@ public class AtlasBackupResourceTest {
     }
 
     @Test
+    public void emptyBearerTokenInConfigWillCauseBackupOperationsToFail() {
+        AtlasBackupResource emptyTokenResource = new AtlasBackupResource(
+                Optional::empty, TARGETER, str -> str.equals("test") ? mockTimelock : otherTimelock);
+
+        assertThatServiceExceptionThrownBy(() -> AtlasFutures.getUnchecked(
+                        emptyTokenResource.prepareBackup(AUTH_HEADER, PREPARE_BACKUP_REQUEST)))
+                .hasType(ErrorType.PERMISSION_DENIED);
+        assertThatServiceExceptionThrownBy(() -> AtlasFutures.getUnchecked(
+                        emptyTokenResource.completeBackup(AUTH_HEADER, completeBackupRequest(validBackupToken()))))
+                .hasType(ErrorType.PERMISSION_DENIED);
+    }
+
+    @Test
     public void preparesBackupSuccessfully() {
         LockToken lockToken = lockToken();
         when(mockTimelock.lockImmutableTimestamp(any()))

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/backup/AtlasBackupResourceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/backup/AtlasBackupResourceTest.java
@@ -16,6 +16,7 @@
 
 package com.palantir.atlasdb.backup;
 
+import static com.palantir.conjure.java.api.testing.Assertions.assertThatServiceExceptionThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -34,9 +35,11 @@ import com.palantir.atlasdb.http.RedirectRetryTargeter;
 import com.palantir.atlasdb.timelock.AsyncTimelockService;
 import com.palantir.atlasdb.timelock.api.Namespace;
 import com.palantir.atlasdb.util.TimelockTestUtils;
+import com.palantir.conjure.java.api.errors.ErrorType;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
 import com.palantir.lock.v2.LockToken;
 import com.palantir.tokens.auth.AuthHeader;
+import com.palantir.tokens.auth.BearerToken;
 import java.net.URL;
 import java.util.List;
 import java.util.Set;
@@ -49,7 +52,8 @@ public class AtlasBackupResourceTest {
     private static final URL REMOTE = TimelockTestUtils.url("https://localhost:" + REMOTE_PORT);
     private static final RedirectRetryTargeter TARGETER = RedirectRetryTargeter.create(LOCAL, List.of(LOCAL, REMOTE));
 
-    private static final AuthHeader AUTH_HEADER = AuthHeader.valueOf("header");
+    private static final BearerToken BEARER_TOKEN = BearerToken.valueOf("bear");
+    private static final AuthHeader AUTH_HEADER = AuthHeader.of(BEARER_TOKEN);
     private static final Namespace NAMESPACE = Namespace.of("test");
     private static final Namespace OTHER_NAMESPACE = Namespace.of("other");
     private static final PrepareBackupRequest PREPARE_BACKUP_REQUEST =
@@ -63,8 +67,24 @@ public class AtlasBackupResourceTest {
     private final AsyncTimelockService mockTimelock = mock(AsyncTimelockService.class);
     private final AsyncTimelockService otherTimelock = mock(AsyncTimelockService.class);
 
-    private final AtlasBackupResource atlasBackupService =
-            new AtlasBackupResource(TARGETER, str -> str.equals("test") ? mockTimelock : otherTimelock);
+    private final AtlasBackupResource atlasBackupService = new AtlasBackupResource(
+            () -> BEARER_TOKEN, TARGETER, str -> str.equals("test") ? mockTimelock : otherTimelock);
+
+    @Test
+    public void prepareBackupThrowsIfAuthHeaderIsWrong() {
+        AuthHeader wrongHeader = AuthHeader.of(BearerToken.valueOf("imposter"));
+        assertThatServiceExceptionThrownBy(() -> AtlasFutures.getUnchecked(
+                        atlasBackupService.prepareBackup(wrongHeader, PREPARE_BACKUP_REQUEST)))
+                .hasType(ErrorType.PERMISSION_DENIED);
+    }
+
+    @Test
+    public void completeBackupThrowsIfAuthHeaderIsWrong() {
+        AuthHeader wrongHeader = AuthHeader.of(BearerToken.valueOf("imposter"));
+        assertThatServiceExceptionThrownBy(() -> AtlasFutures.getUnchecked(
+                        atlasBackupService.completeBackup(wrongHeader, completeBackupRequest(validBackupToken()))))
+                .hasType(ErrorType.PERMISSION_DENIED);
+    }
 
     @Test
     public void preparesBackupSuccessfully() {

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/backup/AtlasBackupResourceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/backup/AtlasBackupResourceTest.java
@@ -54,6 +54,7 @@ public class AtlasBackupResourceTest {
 
     private static final BearerToken BEARER_TOKEN = BearerToken.valueOf("bear");
     private static final AuthHeader AUTH_HEADER = AuthHeader.of(BEARER_TOKEN);
+    private static final AuthHeader WRONG_AUTH_HEADER = AuthHeader.of(BearerToken.valueOf("imposter"));
     private static final Namespace NAMESPACE = Namespace.of("test");
     private static final Namespace OTHER_NAMESPACE = Namespace.of("other");
     private static final PrepareBackupRequest PREPARE_BACKUP_REQUEST =
@@ -72,17 +73,15 @@ public class AtlasBackupResourceTest {
 
     @Test
     public void prepareBackupThrowsIfAuthHeaderIsWrong() {
-        AuthHeader wrongHeader = AuthHeader.of(BearerToken.valueOf("imposter"));
         assertThatServiceExceptionThrownBy(() -> AtlasFutures.getUnchecked(
-                        atlasBackupService.prepareBackup(wrongHeader, PREPARE_BACKUP_REQUEST)))
+                        atlasBackupService.prepareBackup(WRONG_AUTH_HEADER, PREPARE_BACKUP_REQUEST)))
                 .hasType(ErrorType.PERMISSION_DENIED);
     }
 
     @Test
     public void completeBackupThrowsIfAuthHeaderIsWrong() {
-        AuthHeader wrongHeader = AuthHeader.of(BearerToken.valueOf("imposter"));
-        assertThatServiceExceptionThrownBy(() -> AtlasFutures.getUnchecked(
-                        atlasBackupService.completeBackup(wrongHeader, completeBackupRequest(validBackupToken()))))
+        assertThatServiceExceptionThrownBy(() -> AtlasFutures.getUnchecked(atlasBackupService.completeBackup(
+                        WRONG_AUTH_HEADER, completeBackupRequest(validBackupToken()))))
                 .hasType(ErrorType.PERMISSION_DENIED);
     }
 

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/backup/AtlasBackupResourceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/backup/AtlasBackupResourceTest.java
@@ -42,6 +42,7 @@ import com.palantir.tokens.auth.AuthHeader;
 import com.palantir.tokens.auth.BearerToken;
 import java.net.URL;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import org.junit.Test;
@@ -69,7 +70,7 @@ public class AtlasBackupResourceTest {
     private final AsyncTimelockService otherTimelock = mock(AsyncTimelockService.class);
 
     private final AtlasBackupResource atlasBackupService = new AtlasBackupResource(
-            () -> BEARER_TOKEN, TARGETER, str -> str.equals("test") ? mockTimelock : otherTimelock);
+            () -> Optional.of(BEARER_TOKEN), TARGETER, str -> str.equals("test") ? mockTimelock : otherTimelock);
 
     @Test
     public void prepareBackupThrowsIfAuthHeaderIsWrong() {

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/backup/AtlasRestoreResourceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/backup/AtlasRestoreResourceTest.java
@@ -34,6 +34,7 @@ import com.palantir.tokens.auth.AuthHeader;
 import com.palantir.tokens.auth.BearerToken;
 import java.net.URL;
 import java.util.List;
+import java.util.Optional;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -58,7 +59,7 @@ public class AtlasRestoreResourceTest {
     private AsyncTimelockService otherTimelock;
 
     private final AtlasRestoreResource atlasRestoreResource = new AtlasRestoreResource(
-            () -> BEARER_TOKEN, TARGETER, str -> str.equals("test") ? mockTimelock : otherTimelock);
+            () -> Optional.of(BEARER_TOKEN), TARGETER, str -> str.equals("test") ? mockTimelock : otherTimelock);
 
     @Test
     public void throwsIfWrongAuthHeaderIsProvided() {

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/backup/AtlasRestoreResourceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/backup/AtlasRestoreResourceTest.java
@@ -72,7 +72,7 @@ public class AtlasRestoreResourceTest {
     }
 
     @Test
-    public void emptyBearerTokenInConfigWillCauseBackupOperationsToFail() {
+    public void emptyBearerTokenInConfigWillCauseRestoreOperationsToFail() {
         AtlasRestoreResource emptyTokenResource = new AtlasRestoreResource(
                 Optional::empty, TARGETER, str -> str.equals("test") ? mockTimelock : otherTimelock);
 

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/backup/AtlasRestoreResourceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/backup/AtlasRestoreResourceTest.java
@@ -72,6 +72,18 @@ public class AtlasRestoreResourceTest {
     }
 
     @Test
+    public void emptyBearerTokenInConfigWillCauseBackupOperationsToFail() {
+        AtlasRestoreResource emptyTokenResource = new AtlasRestoreResource(
+                Optional::empty, TARGETER, str -> str.equals("test") ? mockTimelock : otherTimelock);
+
+        CompletedBackup completedBackup = completedBackup();
+        CompleteRestoreRequest request = CompleteRestoreRequest.of(ImmutableSet.of(completedBackup));
+        assertThatServiceExceptionThrownBy(
+                        () -> AtlasFutures.getUnchecked(emptyTokenResource.completeRestore(AUTH_HEADER, request)))
+                .hasType(ErrorType.PERMISSION_DENIED);
+    }
+
+    @Test
     public void completesRestoreSuccessfully() {
         CompletedBackup completedBackup = completedBackup();
         CompleteRestoreResponse response = AtlasFutures.getUnchecked(atlasRestoreResource.completeRestore(


### PR DESCRIPTION
**Goals (and why)**:
Only those with the super-secret permitted auth header should be able to perform backup and restore tasks
==COMMIT_MSG==
Added AuthHeader validation to the backup and restore endpoints.
==COMMIT_MSG==

**Implementation Description (bullets)**:
- Add permitted token to runtime config
- Check provided AuthHeaders against this token

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added unit tests

**Concerns (what feedback would you like?)**:
None really, followed prior art in internal products

**Where should we start reviewing?**:
Anywhere

**Priority (whenever / two weeks / yesterday)**:
ASAP, want to ship this and use internally

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
