### PR TITLE
ABR15: "clear locks task" wiring

### DIFF
--- a/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/AtlasRestoreService.java
+++ b/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/AtlasRestoreService.java
@@ -53,7 +53,6 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-// TODO(gs): retry logic for disable/re-enable
 public class AtlasRestoreService {
     private static final SafeLogger log = SafeLoggerFactory.get(AtlasRestoreService.class);
 
@@ -160,11 +159,12 @@ public class AtlasRestoreService {
             return ImmutableSet.of();
         }
 
+        // Fast forward timestamps
         CompleteRestoreResponse response =
                 atlasRestoreClientBlocking.completeRestore(authHeader, CompleteRestoreRequest.of(completedBackups));
-
-        // TODO(gs): what to do about failed namespaces?
         Set<Namespace> successfulNamespaces = response.getSuccessfulNamespaces();
+
+        // Re-enable timelock
         timeLockManagementService.reenableTimelock(
                 authHeader, ReenableNamespacesRequest.of(successfulNamespaces, request.getLockId()));
 

--- a/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/AtlasRestoreService.java
+++ b/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/AtlasRestoreService.java
@@ -139,11 +139,12 @@ public class AtlasRestoreService {
      *
      * @return the set of namespaces for which we issued a repair command via the provided Consumer.
      */
-    // TODO(gs): response object?
-    public void repairInternalTables(Set<Namespace> namespaces, BiConsumer<String, RangesForRepair> repairTable) {
+    public Set<Namespace> repairInternalTables(
+            Set<Namespace> namespaces, BiConsumer<String, RangesForRepair> repairTable) {
         Map<Namespace, CompletedBackup> completedBackups = getCompletedBackups(namespaces);
         Set<Namespace> namespacesToRepair = completedBackups.keySet();
         restoreTables(repairTable, completedBackups, namespacesToRepair);
+        return namespacesToRepair;
     }
 
     public Set<Namespace> completeRestore(ReenableNamespacesRequest request) {

--- a/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/AtlasRestoreService.java
+++ b/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/AtlasRestoreService.java
@@ -30,6 +30,7 @@ import com.palantir.atlasdb.cassandra.backup.transaction.TransactionsTableIntera
 import com.palantir.atlasdb.internalschema.InternalSchemaMetadataState;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.timelock.api.Namespace;
+import com.palantir.atlasdb.timelock.api.management.TimeLockManagementServiceBlocking;
 import com.palantir.common.streams.KeyedStream;
 import com.palantir.conjure.java.api.config.service.ServicesConfigBlock;
 import com.palantir.dialogue.clients.DialogueClients;
@@ -52,6 +53,7 @@ public class AtlasRestoreService {
 
     private final AuthHeader authHeader;
     private final AtlasRestoreClientBlocking atlasRestoreClientBlocking;
+    private final TimeLockManagementServiceBlocking timeLockManagementService;
     private final BackupPersister backupPersister;
     private final CassandraRepairHelper cassandraRepairHelper;
 
@@ -59,10 +61,12 @@ public class AtlasRestoreService {
     AtlasRestoreService(
             AuthHeader authHeader,
             AtlasRestoreClientBlocking atlasRestoreClientBlocking,
+            TimeLockManagementServiceBlocking timeLockManagementService,
             BackupPersister backupPersister,
             CassandraRepairHelper cassandraRepairHelper) {
         this.authHeader = authHeader;
         this.atlasRestoreClientBlocking = atlasRestoreClientBlocking;
+        this.timeLockManagementService = timeLockManagementService;
         this.backupPersister = backupPersister;
         this.cassandraRepairHelper = cassandraRepairHelper;
     }
@@ -77,10 +81,17 @@ public class AtlasRestoreService {
         DialogueClients.ReloadingFactory reloadingFactory = DialogueClients.create(servicesConfigBlock);
         AtlasRestoreClientBlocking atlasRestoreClientBlocking =
                 reloadingFactory.get(AtlasRestoreClientBlocking.class, serviceName);
+        TimeLockManagementServiceBlocking timeLockManagementService =
+                reloadingFactory.get(TimeLockManagementServiceBlocking.class, serviceName);
 
         CassandraRepairHelper cassandraRepairHelper =
                 new CassandraRepairHelper(keyValueServiceConfigFactory, keyValueServiceFactory);
-        return new AtlasRestoreService(authHeader, atlasRestoreClientBlocking, backupPersister, cassandraRepairHelper);
+        return new AtlasRestoreService(
+                authHeader,
+                atlasRestoreClientBlocking,
+                timeLockManagementService,
+                backupPersister,
+                cassandraRepairHelper);
     }
 
     /**

--- a/atlasdb-backup/src/test/java/com/palantir/atlasdb/backup/AtlasRestoreServiceTest.java
+++ b/atlasdb-backup/src/test/java/com/palantir/atlasdb/backup/AtlasRestoreServiceTest.java
@@ -59,7 +59,6 @@ public class AtlasRestoreServiceTest {
     private static final long BACKUP_START_TIMESTAMP = 2L;
     private static final UUID LOCK_ID = new UUID(12, 9);
 
-    // TODO(gs): auth header tests
     @Mock
     private AuthHeader authHeader;
 
@@ -95,7 +94,6 @@ public class AtlasRestoreServiceTest {
         backupPersister.storeCompletedBackup(completedBackup);
     }
 
-    // TODO(gs): should return namespaces too
     @Test
     public void prepareReturnsOnlyCompletedBackups() {
         DisableNamespacesResponse successfulDisable =
@@ -124,7 +122,9 @@ public class AtlasRestoreServiceTest {
     public void repairsOnlyWhenBackupPresentAndDisableSuccessful() {
         BiConsumer<String, RangesForRepair> doNothingConsumer = (_unused1, _unused2) -> {};
 
-        atlasRestoreService.repairInternalTables(ImmutableSet.of(WITH_BACKUP, NO_BACKUP), doNothingConsumer);
+        Set<Namespace> repairedNamespaces =
+                atlasRestoreService.repairInternalTables(ImmutableSet.of(WITH_BACKUP, NO_BACKUP), doNothingConsumer);
+        assertThat(repairedNamespaces).containsExactly(WITH_BACKUP);
 
         verify(cassandraRepairHelper).repairInternalTables(WITH_BACKUP, doNothingConsumer);
         verify(cassandraRepairHelper).repairTransactionsTables(eq(WITH_BACKUP), anyList(), eq(doNothingConsumer));

--- a/atlasdb-backup/src/test/java/com/palantir/atlasdb/backup/AtlasRestoreServiceTest.java
+++ b/atlasdb-backup/src/test/java/com/palantir/atlasdb/backup/AtlasRestoreServiceTest.java
@@ -32,6 +32,7 @@ import com.palantir.atlasdb.backup.api.CompletedBackup;
 import com.palantir.atlasdb.cassandra.backup.CassandraRepairHelper;
 import com.palantir.atlasdb.cassandra.backup.RangesForRepair;
 import com.palantir.atlasdb.timelock.api.Namespace;
+import com.palantir.atlasdb.timelock.api.management.TimeLockManagementServiceBlocking;
 import com.palantir.tokens.auth.AuthHeader;
 import java.util.Optional;
 import java.util.Set;
@@ -57,6 +58,9 @@ public class AtlasRestoreServiceTest {
     private AtlasRestoreClientBlocking atlasRestoreClient;
 
     @Mock
+    private TimeLockManagementServiceBlocking timeLockManagementService;
+
+    @Mock
     private CassandraRepairHelper cassandraRepairHelper;
 
     private AtlasRestoreService atlasRestoreService;
@@ -65,8 +69,8 @@ public class AtlasRestoreServiceTest {
     @Before
     public void setup() {
         backupPersister = new InMemoryBackupPersister();
-        atlasRestoreService =
-                new AtlasRestoreService(authHeader, atlasRestoreClient, backupPersister, cassandraRepairHelper);
+        atlasRestoreService = new AtlasRestoreService(
+                authHeader, atlasRestoreClient, timeLockManagementService, backupPersister, cassandraRepairHelper);
 
         storeCompletedBackup(WITH_BACKUP);
         storeCompletedBackup(FAILING_NAMESPACE);

--- a/changelog/@unreleased/pr-5892.v2.yml
+++ b/changelog/@unreleased/pr-5892.v2.yml
@@ -1,0 +1,7 @@
+type: feature
+feature:
+  description: Added AtlasRestoreService methods `prepareRestore` and `completeRestore`,
+    which will respectively disable and re-enable TimeLock, and should be called during
+    the restore process.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5892

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/management/AllNodesDisabledNamespacesUpdaterFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/management/AllNodesDisabledNamespacesUpdaterFactory.java
@@ -27,19 +27,16 @@ import com.palantir.atlasdb.timelock.paxos.WithDedicatedExecutor;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.common.concurrent.CheckedRejectionExecutorService;
 import com.palantir.common.streams.KeyedStream;
-import com.palantir.tokens.auth.AuthHeader;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 public final class AllNodesDisabledNamespacesUpdaterFactory {
-    private final AuthHeader authHeader;
     private final TimelockPaxosInstallationContext install;
     private final MetricsManager metricsManager;
 
     public AllNodesDisabledNamespacesUpdaterFactory(
-            AuthHeader authHeader, TimelockPaxosInstallationContext install, MetricsManager metricsManager) {
-        this.authHeader = authHeader;
+            TimelockPaxosInstallationContext install, MetricsManager metricsManager) {
         this.install = install;
         this.metricsManager = metricsManager;
     }
@@ -60,6 +57,6 @@ public final class AllNodesDisabledNamespacesUpdaterFactory {
         ImmutableList<DisabledNamespacesUpdaterService> remoteServices = ImmutableList.copyOf(
                 remoteUpdaters.stream().map(WithDedicatedExecutor::service).collect(Collectors.toList()));
 
-        return AllNodesDisabledNamespacesUpdater.create(authHeader, remoteServices, remoteExecutors, localNamespaces);
+        return AllNodesDisabledNamespacesUpdater.create(remoteServices, remoteExecutors, localNamespaces);
     }
 }

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/management/AllNodesDisabledNamespacesUpdaterFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/management/AllNodesDisabledNamespacesUpdaterFactory.java
@@ -49,8 +49,7 @@ public final class AllNodesDisabledNamespacesUpdaterFactory {
 
         List<WithDedicatedExecutor<DisabledNamespacesUpdaterService>> remoteUpdaters = remoteClients.updaters();
 
-        // TODO(gs): include local one here??
-        Map<DisabledNamespacesUpdaterService, CheckedRejectionExecutorService> executorMap =
+        Map<DisabledNamespacesUpdaterService, CheckedRejectionExecutorService> remoteExecutors =
                 ImmutableMap.<DisabledNamespacesUpdaterService, CheckedRejectionExecutorService>builder()
                         .putAll(KeyedStream.of(remoteUpdaters)
                                 .mapKeys(WithDedicatedExecutor::service)
@@ -58,9 +57,9 @@ public final class AllNodesDisabledNamespacesUpdaterFactory {
                                 .collectToMap())
                         .build();
 
-        ImmutableList<DisabledNamespacesUpdaterService> services = ImmutableList.copyOf(
+        ImmutableList<DisabledNamespacesUpdaterService> remoteServices = ImmutableList.copyOf(
                 remoteUpdaters.stream().map(WithDedicatedExecutor::service).collect(Collectors.toList()));
 
-        return AllNodesDisabledNamespacesUpdater.create(authHeader, services, executorMap, localNamespaces);
+        return AllNodesDisabledNamespacesUpdater.create(authHeader, remoteServices, remoteExecutors, localNamespaces);
     }
 }

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/management/AllNodesDisabledNamespacesUpdaterFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/management/AllNodesDisabledNamespacesUpdaterFactory.java
@@ -1,0 +1,66 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.management;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.palantir.atlasdb.timelock.TimelockNamespaces;
+import com.palantir.atlasdb.timelock.api.DisabledNamespacesUpdaterService;
+import com.palantir.atlasdb.timelock.paxos.ImmutablePaxosRemoteClients;
+import com.palantir.atlasdb.timelock.paxos.PaxosRemoteClients;
+import com.palantir.atlasdb.timelock.paxos.PaxosResourcesFactory.TimelockPaxosInstallationContext;
+import com.palantir.atlasdb.timelock.paxos.WithDedicatedExecutor;
+import com.palantir.atlasdb.util.MetricsManager;
+import com.palantir.common.concurrent.CheckedRejectionExecutorService;
+import com.palantir.common.streams.KeyedStream;
+import com.palantir.tokens.auth.AuthHeader;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public final class AllNodesDisabledNamespacesUpdaterFactory {
+    private final AuthHeader authHeader;
+    private final TimelockPaxosInstallationContext install;
+    private final MetricsManager metricsManager;
+
+    public AllNodesDisabledNamespacesUpdaterFactory(
+            AuthHeader authHeader, TimelockPaxosInstallationContext install, MetricsManager metricsManager) {
+        this.authHeader = authHeader;
+        this.install = install;
+        this.metricsManager = metricsManager;
+    }
+
+    public AllNodesDisabledNamespacesUpdater create(TimelockNamespaces localNamespaces) {
+        PaxosRemoteClients remoteClients = ImmutablePaxosRemoteClients.of(install, metricsManager);
+
+        List<WithDedicatedExecutor<DisabledNamespacesUpdaterService>> remoteUpdaters = remoteClients.updaters();
+
+        // TODO(gs): include local one here??
+        Map<DisabledNamespacesUpdaterService, CheckedRejectionExecutorService> executorMap =
+                ImmutableMap.<DisabledNamespacesUpdaterService, CheckedRejectionExecutorService>builder()
+                        .putAll(KeyedStream.of(remoteUpdaters)
+                                .mapKeys(WithDedicatedExecutor::service)
+                                .map(WithDedicatedExecutor::executor)
+                                .collectToMap())
+                        .build();
+
+        ImmutableList<DisabledNamespacesUpdaterService> services = ImmutableList.copyOf(
+                remoteUpdaters.stream().map(WithDedicatedExecutor::service).collect(Collectors.toList()));
+
+        return AllNodesDisabledNamespacesUpdater.create(authHeader, services, executorMap, localNamespaces);
+    }
+}

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClients.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosRemoteClients.java
@@ -19,6 +19,7 @@ package com.palantir.atlasdb.timelock.paxos;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HostAndPort;
 import com.palantir.atlasdb.AtlasDbMetricNames;
+import com.palantir.atlasdb.timelock.api.DisabledNamespacesUpdaterService;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.common.concurrent.CheckedRejectionExecutorService;
@@ -119,6 +120,12 @@ public abstract class PaxosRemoteClients {
     @Value.Derived
     public List<WithDedicatedExecutor<BatchPaxosLearnerRpcClient>> batchLearner() {
         return createInstrumentedRemoteProxiesAndAssignDedicatedPaxosExecutors(BatchPaxosLearnerRpcClient.class, true);
+    }
+
+    @Value.Derived
+    public List<WithDedicatedExecutor<DisabledNamespacesUpdaterService>> updaters() {
+        return createInstrumentedRemoteProxiesAndAssignDedicatedPaxosExecutors(
+                DisabledNamespacesUpdaterService.class, true);
     }
 
     @Value.Derived

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -51,6 +51,7 @@ import com.palantir.atlasdb.timelock.batch.MultiClientConjureTimelockResource;
 import com.palantir.atlasdb.timelock.lock.LockLog;
 import com.palantir.atlasdb.timelock.lock.v1.ConjureLockV1Resource;
 import com.palantir.atlasdb.timelock.management.DisabledNamespaces;
+import com.palantir.atlasdb.timelock.management.DisabledNamespacesUpdaterResource;
 import com.palantir.atlasdb.timelock.management.PersistentNamespaceContexts;
 import com.palantir.atlasdb.timelock.management.ServiceLifecycleController;
 import com.palantir.atlasdb.timelock.management.TimeLockManagementResource;
@@ -367,6 +368,9 @@ public class TimeLockAgent {
                     presentUndertowRegistrar,
                     AtlasRestoreResource.undertow(
                             permittedBackupToken, redirectRetryTargeter, asyncTimelockServiceGetter));
+            registerCorruptionHandlerWrappedService(
+                    presentUndertowRegistrar,
+                    DisabledNamespacesUpdaterResource.undertow(redirectRetryTargeter, namespaces));
         } else {
             registrar.accept(ConjureTimelockResource.jersey(redirectRetryTargeter, asyncTimelockServiceGetter));
             registrar.accept(ConjureLockWatchingResource.jersey(redirectRetryTargeter, asyncTimelockServiceGetter));
@@ -378,6 +382,7 @@ public class TimeLockAgent {
                     permittedBackupToken, redirectRetryTargeter, asyncTimelockServiceGetter));
             registrar.accept(AtlasRestoreResource.jersey(
                     permittedBackupToken, redirectRetryTargeter, asyncTimelockServiceGetter));
+            registrar.accept(DisabledNamespacesUpdaterResource.jersey(redirectRetryTargeter, namespaces));
         }
     }
 

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -177,6 +177,8 @@ public class TimeLockAgent {
                 metricsManager,
                 Suppliers.compose(TimeLockRuntimeConfiguration::paxos, restrictedRuntime::get));
 
+        // TODO(gs): set up AllNodesUpdater
+
         TimeLockAgent agent = new TimeLockAgent(
                 metricsManager,
                 install,

--- a/timelock-api/src/main/conjure/timelock-management-api.yml
+++ b/timelock-api/src/main/conjure/timelock-management-api.yml
@@ -101,7 +101,7 @@ services:
           operation is atomic for each namespace (e.g. users will not see two different lock services servicing the
           same startTransactions request), but not atomic as a whole. Additionally, if this method throws, it is
           nondeterministic which, if any, namespaces have been invalidated; some may even be invalidated only on a
-          subset od nodes. This state can be cleared by re-enabling all namespaces.
+          subset of nodes. This state can be cleared by re-enabling all namespaces.
 
       disableTimelock:
         http: POST /disable

--- a/timelock-api/src/main/conjure/timelock-management-api.yml
+++ b/timelock-api/src/main/conjure/timelock-management-api.yml
@@ -101,7 +101,23 @@ services:
           operation is atomic for each namespace (e.g. users will not see two different lock services servicing the
           same startTransactions request), but not atomic as a whole. Additionally, if this method throws, it is
           nondeterministic which, if any, namespaces have been invalidated; some may even be invalidated only on a
-          subset of nodes. This state can be cleared by re-enabling all namespaces.
+          subset od nodes. This state can be cleared by re-enabling all namespaces.
+
+      disableTimelock:
+        http: POST /disable
+        args:
+          request: set<api.Namespace>
+        returns: DisableNamespacesResponse
+        docs: |
+          Disables the TimeLock server in a persistant way for the specified namespaces. This includes invalidating
+          all currently held locks, all lock watch state, as well as refusing to serve new requests.
+      reenableTimelock:
+        http: POST /reenable
+        args:
+          request: ReenableNamespacesRequest
+        returns: ReenableNamespacesResponse
+        docs: |
+          Allows the TimeLock server to once again serve requests for these namespaces.
 
       getServerLifecycleId:
         http: POST /getServerLifecycleId

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/backup/AtlasBackupResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/backup/AtlasBackupResource.java
@@ -45,7 +45,6 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import com.palantir.tokens.auth.AuthHeader;
-import com.palantir.tokens.auth.BearerToken;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -56,34 +55,34 @@ import java.util.stream.Collectors;
 public class AtlasBackupResource implements UndertowAtlasBackupClient {
     private static final SafeLogger log = SafeLoggerFactory.get(AtlasBackupResource.class);
 
-    private final Supplier<Optional<BearerToken>> permittedBackupToken;
+    private final AuthHeaderValidator authHeaderValidator;
     private final Function<String, AsyncTimelockService> timelockServices;
     private final ConjureResourceExceptionHandler exceptionHandler;
 
     @VisibleForTesting
     AtlasBackupResource(
-            Supplier<Optional<BearerToken>> permittedBackupToken,
+            AuthHeaderValidator authHeaderValidator,
             RedirectRetryTargeter redirectRetryTargeter,
             Function<String, AsyncTimelockService> timelockServices) {
-        this.permittedBackupToken = permittedBackupToken;
+        this.authHeaderValidator = authHeaderValidator;
         this.exceptionHandler = new ConjureResourceExceptionHandler(redirectRetryTargeter);
         this.timelockServices = timelockServices;
     }
 
     public static UndertowService undertow(
-            Supplier<Optional<BearerToken>> permittedAuthHeader,
+            AuthHeaderValidator authHeaderValidator,
             RedirectRetryTargeter redirectRetryTargeter,
             Function<String, AsyncTimelockService> timelockServices) {
         return AtlasBackupClientEndpoints.of(
-                new AtlasBackupResource(permittedAuthHeader, redirectRetryTargeter, timelockServices));
+                new AtlasBackupResource(authHeaderValidator, redirectRetryTargeter, timelockServices));
     }
 
     public static AtlasBackupClient jersey(
-            Supplier<Optional<BearerToken>> permittedAuthHeader,
+            AuthHeaderValidator authHeaderValidator,
             RedirectRetryTargeter redirectRetryTargeter,
             Function<String, AsyncTimelockService> timelockServices) {
         return new JerseyAtlasBackupClientAdapter(
-                new AtlasBackupResource(permittedAuthHeader, redirectRetryTargeter, timelockServices));
+                new AtlasBackupResource(authHeaderValidator, redirectRetryTargeter, timelockServices));
     }
 
     @Override
@@ -92,7 +91,7 @@ public class AtlasBackupResource implements UndertowAtlasBackupClient {
     }
 
     private PrepareBackupResponse prepareBackupInternal(AuthHeader authHeader, PrepareBackupRequest request) {
-        if (!suppliedTokenIsValid(authHeader)) {
+        if (!authHeaderValidator.suppliedTokenIsValid(authHeader)) {
             log.error(
                     "Attempted to prepare backup with an invalid auth header. "
                             + "The provided token must match the configured permitted-backup-token.",
@@ -127,7 +126,7 @@ public class AtlasBackupResource implements UndertowAtlasBackupClient {
     @SuppressWarnings("ConstantConditions")
     private ListenableFuture<CompleteBackupResponse> completeBackupInternal(
             AuthHeader authHeader, CompleteBackupRequest request) {
-        if (!suppliedTokenIsValid(authHeader)) {
+        if (!authHeaderValidator.suppliedTokenIsValid(authHeader)) {
             log.error(
                     "Attempted to complete backup with an invalid auth header. "
                             + "The provided token must match the configured permitted-backup-token.",
@@ -171,13 +170,6 @@ public class AtlasBackupResource implements UndertowAtlasBackupClient {
                 .backupStartTimestamp(backupToken.getBackupStartTimestamp())
                 .backupEndTimestamp(fastForwardTimestamp)
                 .build();
-    }
-
-    private Boolean suppliedTokenIsValid(AuthHeader suppliedAuthHeader) {
-        return permittedBackupToken
-                .get()
-                .map(token -> token.equals(suppliedAuthHeader.getBearerToken()))
-                .orElse(false);
     }
 
     private AsyncTimelockService timelock(Namespace namespace) {

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/backup/AtlasRestoreResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/backup/AtlasRestoreResource.java
@@ -39,7 +39,6 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import com.palantir.tokens.auth.AuthHeader;
-import com.palantir.tokens.auth.BearerToken;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -55,28 +54,28 @@ public class AtlasRestoreResource implements UndertowAtlasRestoreClient {
 
     @VisibleForTesting
     AtlasRestoreResource(
-            Supplier<Optional<BearerToken>> permittedToken,
+            AuthHeaderValidator authHeaderValidator,
             RedirectRetryTargeter redirectRetryTargeter,
             Function<String, AsyncTimelockService> timelockServices) {
-        this.authHeaderValidator = new AuthHeaderValidator(permittedToken);
+        this.authHeaderValidator = authHeaderValidator;
         this.exceptionHandler = new ConjureResourceExceptionHandler(redirectRetryTargeter);
         this.timelockServices = timelockServices;
     }
 
     public static UndertowService undertow(
-            Supplier<Optional<BearerToken>> permittedToken,
+            AuthHeaderValidator authHeaderValidator,
             RedirectRetryTargeter redirectRetryTargeter,
             Function<String, AsyncTimelockService> timelockServices) {
         return AtlasRestoreClientEndpoints.of(
-                new AtlasRestoreResource(permittedToken, redirectRetryTargeter, timelockServices));
+                new AtlasRestoreResource(authHeaderValidator, redirectRetryTargeter, timelockServices));
     }
 
     public static AtlasRestoreClient jersey(
-            Supplier<Optional<BearerToken>> permittedToken,
+            AuthHeaderValidator authHeaderValidator,
             RedirectRetryTargeter redirectRetryTargeter,
             Function<String, AsyncTimelockService> timelockServices) {
         return new JerseyAtlasRestoreClientAdapter(
-                new AtlasRestoreResource(permittedToken, redirectRetryTargeter, timelockServices));
+                new AtlasRestoreResource(authHeaderValidator, redirectRetryTargeter, timelockServices));
     }
 
     @Override

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/backup/AuthHeaderValidator.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/backup/AuthHeaderValidator.java
@@ -1,0 +1,37 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.backup;
+
+import com.palantir.tokens.auth.AuthHeader;
+import com.palantir.tokens.auth.BearerToken;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+public final class AuthHeaderValidator {
+    private final Supplier<Optional<BearerToken>> permittedToken;
+
+    public AuthHeaderValidator(Supplier<Optional<BearerToken>> permittedToken) {
+        this.permittedToken = permittedToken;
+    }
+
+    public boolean suppliedTokenIsValid(AuthHeader suppliedAuthHeader) {
+        return permittedToken
+                .get()
+                .map(token -> token.equals(suppliedAuthHeader.getBearerToken()))
+                .orElse(false);
+    }
+}

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/AllNodesDisabledNamespacesUpdater.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/AllNodesDisabledNamespacesUpdater.java
@@ -55,7 +55,6 @@ import org.immutables.value.Value;
 public class AllNodesDisabledNamespacesUpdater {
     private static final SafeLogger log = SafeLoggerFactory.get(AllNodesDisabledNamespacesUpdater.class);
 
-    private final AuthHeader authHeader;
     private final ImmutableList<DisabledNamespacesUpdaterService> remoteUpdaters;
     private final Map<DisabledNamespacesUpdaterService, CheckedRejectionExecutorService> remoteExecutors;
     private final TimelockNamespaces localUpdater;
@@ -64,12 +63,10 @@ public class AllNodesDisabledNamespacesUpdater {
 
     @VisibleForTesting
     AllNodesDisabledNamespacesUpdater(
-            AuthHeader authHeader,
             ImmutableList<DisabledNamespacesUpdaterService> remoteUpdaters,
             Map<DisabledNamespacesUpdaterService, CheckedRejectionExecutorService> remoteExecutors,
             TimelockNamespaces localUpdater,
             Supplier<UUID> lockIdSupplier) {
-        this.authHeader = authHeader;
         this.remoteUpdaters = remoteUpdaters;
         this.remoteExecutors = remoteExecutors;
         this.localUpdater = localUpdater;
@@ -78,12 +75,10 @@ public class AllNodesDisabledNamespacesUpdater {
     }
 
     public static AllNodesDisabledNamespacesUpdater create(
-            AuthHeader authHeader,
             ImmutableList<DisabledNamespacesUpdaterService> remoteUpdaters,
             Map<DisabledNamespacesUpdaterService, CheckedRejectionExecutorService> remoteExecutors,
             TimelockNamespaces localUpdater) {
-        return new AllNodesDisabledNamespacesUpdater(
-                authHeader, remoteUpdaters, remoteExecutors, localUpdater, UUID::randomUUID);
+        return new AllNodesDisabledNamespacesUpdater(remoteUpdaters, remoteExecutors, localUpdater, UUID::randomUUID);
     }
 
     /**
@@ -101,13 +96,13 @@ public class AllNodesDisabledNamespacesUpdater {
      *  If we fail to roll back for some node (e.g. it becomes unreachable), then we're left in an inconsistent state
      *  which will need manual remediation.
      */
-    public DisableNamespacesResponse disableOnAllNodes(Set<Namespace> namespaces) {
-        if (anyNodeIsUnreachable()) {
+    public DisableNamespacesResponse disableOnAllNodes(AuthHeader authHeader, Set<Namespace> namespaces) {
+        if (anyNodeIsUnreachable(authHeader)) {
             return DisableNamespaceResponses.unsuccessfulDueToPingFailure(namespaces);
         }
 
         UUID lockId = lockIdSupplier.get();
-        AllNodesUpdateResponse responses = disableNamespacesOnAllNodes(namespaces, lockId);
+        AllNodesUpdateResponse responses = disableNamespacesOnAllNodes(authHeader, namespaces, lockId);
         if (updateWasSuccessfulOnAllNodes(responses.allResponses())) {
             return DisableNamespacesResponse.successful(SuccessfulDisableNamespacesResponse.of(lockId));
         }
@@ -129,7 +124,7 @@ public class AllNodesDisabledNamespacesUpdater {
                         || remoteResponses.get(node).isSuccessful())
                 .collect(Collectors.toList());
 
-        boolean rollbackSuccess = attemptReEnableOnNodes(namespaces, lockId, successfulOrUnreachableNodes);
+        boolean rollbackSuccess = attemptReEnableOnNodes(authHeader, namespaces, lockId, successfulOrUnreachableNodes);
         if (rollbackSuccess) {
             return DisableNamespaceResponses.unsuccessfulButRolledBack(namespaces, lockId);
         }
@@ -142,9 +137,9 @@ public class AllNodesDisabledNamespacesUpdater {
      * If some namespaces are locked with a different lock ID, then these namespaces will remain disabled, however
      * we will still re-enable those that were locked with the provided lock ID.
      */
-    public ReenableNamespacesResponse reEnableOnAllNodes(ReenableNamespacesRequest request) {
+    public ReenableNamespacesResponse reEnableOnAllNodes(AuthHeader authHeader, ReenableNamespacesRequest request) {
         List<SingleNodeUpdateResponse> responses =
-                reEnableNamespacesOnAllNodes(request).allResponses();
+                reEnableNamespacesOnAllNodes(authHeader, request).allResponses();
         if (updateWasSuccessfulOnAllNodes(responses)) {
             return ReenableNamespacesResponse.successful(SuccessfulReenableNamespacesResponse.of(true));
         }
@@ -160,7 +155,7 @@ public class AllNodesDisabledNamespacesUpdater {
     }
 
     // Ping
-    private boolean anyNodeIsUnreachable() {
+    private boolean anyNodeIsUnreachable(AuthHeader authHeader) {
         return !isSuccessfulOnAllRemoteNodes(service -> new BooleanPaxosResponse(service.ping(authHeader)));
     }
 
@@ -171,7 +166,8 @@ public class AllNodesDisabledNamespacesUpdater {
     }
 
     // Disable
-    private AllNodesUpdateResponse disableNamespacesOnAllNodes(Set<Namespace> namespaces, UUID lockId) {
+    private AllNodesUpdateResponse disableNamespacesOnAllNodes(
+            AuthHeader authHeader, Set<Namespace> namespaces, UUID lockId) {
         DisableNamespacesRequest request = DisableNamespacesRequest.of(namespaces, lockId);
         Function<DisabledNamespacesUpdaterService, SingleNodeUpdateResponse> update =
                 service -> service.disable(authHeader, request);
@@ -182,16 +178,21 @@ public class AllNodesDisabledNamespacesUpdater {
 
     // ReEnable
     private boolean attemptReEnableOnNodes(
-            Set<Namespace> namespaces, UUID lockId, List<DisabledNamespacesUpdaterService> successfulNodes) {
+            AuthHeader authHeader,
+            Set<Namespace> namespaces,
+            UUID lockId,
+            List<DisabledNamespacesUpdaterService> successfulNodes) {
         ReenableNamespacesRequest request = ReenableNamespacesRequest.builder()
                 .namespaces(namespaces)
                 .lockId(lockId)
                 .build();
-        Collection<SingleNodeUpdateResponse> responses = reEnableNamespacesOnRemoteNodes(request, successfulNodes);
+        Collection<SingleNodeUpdateResponse> responses =
+                reEnableNamespacesOnRemoteNodes(authHeader, request, successfulNodes);
         return responses.stream().filter(SingleNodeUpdateResponse::isSuccessful).count() == successfulNodes.size();
     }
 
-    private AllNodesUpdateResponse reEnableNamespacesOnAllNodes(ReenableNamespacesRequest request) {
+    private AllNodesUpdateResponse reEnableNamespacesOnAllNodes(
+            AuthHeader authHeader, ReenableNamespacesRequest request) {
         Set<Namespace> namespaces = request.getNamespaces();
         UUID lockId = request.getLockId();
         Function<DisabledNamespacesUpdaterService, SingleNodeUpdateResponse> update =
@@ -202,7 +203,7 @@ public class AllNodesDisabledNamespacesUpdater {
     }
 
     private Collection<SingleNodeUpdateResponse> reEnableNamespacesOnRemoteNodes(
-            ReenableNamespacesRequest request, List<DisabledNamespacesUpdaterService> nodes) {
+            AuthHeader authHeader, ReenableNamespacesRequest request, List<DisabledNamespacesUpdaterService> nodes) {
         Function<DisabledNamespacesUpdaterService, SingleNodeUpdateResponse> update =
                 node -> node.reenable(authHeader, request);
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/AllNodesDisabledNamespacesUpdater.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/AllNodesDisabledNamespacesUpdater.java
@@ -79,10 +79,11 @@ public class AllNodesDisabledNamespacesUpdater {
 
     public static AllNodesDisabledNamespacesUpdater create(
             AuthHeader authHeader,
-            ImmutableList<DisabledNamespacesUpdaterService> updaters,
-            Map<DisabledNamespacesUpdaterService, CheckedRejectionExecutorService> executors,
+            ImmutableList<DisabledNamespacesUpdaterService> remoteUpdaters,
+            Map<DisabledNamespacesUpdaterService, CheckedRejectionExecutorService> remoteExecutors,
             TimelockNamespaces localUpdater) {
-        return new AllNodesDisabledNamespacesUpdater(authHeader, updaters, executors, localUpdater, UUID::randomUUID);
+        return new AllNodesDisabledNamespacesUpdater(
+                authHeader, remoteUpdaters, remoteExecutors, localUpdater, UUID::randomUUID);
     }
 
     /**

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/TimeLockManagementResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/TimeLockManagementResource.java
@@ -24,6 +24,11 @@ import com.palantir.atlasdb.http.RedirectRetryTargeter;
 import com.palantir.atlasdb.keyvalue.api.TimestampSeries;
 import com.palantir.atlasdb.timelock.ConjureResourceExceptionHandler;
 import com.palantir.atlasdb.timelock.TimelockNamespaces;
+import com.palantir.atlasdb.timelock.api.DisableNamespacesResponse;
+import com.palantir.atlasdb.timelock.api.Namespace;
+import com.palantir.atlasdb.timelock.api.ReenableNamespacesRequest;
+import com.palantir.atlasdb.timelock.api.ReenableNamespacesResponse;
+import com.palantir.atlasdb.timelock.api.UnsuccessfulDisableNamespacesResponse;
 import com.palantir.atlasdb.timelock.api.management.TimeLockManagementService;
 import com.palantir.atlasdb.timelock.api.management.TimeLockManagementServiceEndpoints;
 import com.palantir.atlasdb.timelock.api.management.UndertowTimeLockManagementService;
@@ -117,6 +122,29 @@ public final class TimeLockManagementResource implements UndertowTimeLockManagem
     }
 
     @Override
+    public ListenableFuture<DisableNamespacesResponse> disableTimelock(
+            AuthHeader authHeader, Set<Namespace> namespaces) {
+        return handleExceptions(() -> disableInternal(namespaces));
+    }
+
+    private ListenableFuture<DisableNamespacesResponse> disableInternal(Set<Namespace> namespaces) {
+        // todo(gs): wire up ANDNU
+        return Futures.immediateFuture(
+                DisableNamespacesResponse.unsuccessful(UnsuccessfulDisableNamespacesResponse.of(ImmutableSet.of())));
+    }
+
+    @Override
+    public ListenableFuture<ReenableNamespacesResponse> reenableTimelock(
+            AuthHeader authHeader, ReenableNamespacesRequest request) {
+        return handleExceptions(() -> reenableInternal(request));
+    }
+
+    public ListenableFuture<ReenableNamespacesResponse> reenableInternal(ReenableNamespacesRequest request) {
+        // todo(gs): wire up ANDNU
+        return Futures.immediateFuture(ReenableNamespacesResponse.builder().build());
+    }
+
+    @Override
     public ListenableFuture<UUID> getServerLifecycleId(AuthHeader authHeader) {
         return Futures.immediateFuture(serviceLifecycleController.getServerId());
     }
@@ -166,6 +194,16 @@ public final class TimeLockManagementResource implements UndertowTimeLockManagem
         @Override
         public void invalidateResources(AuthHeader authHeader, Set<String> namespaces) {
             unwrap(resource.invalidateResources(authHeader, namespaces));
+        }
+
+        @Override
+        public DisableNamespacesResponse disableTimelock(AuthHeader authHeader, Set<Namespace> request) {
+            return unwrap(resource.disableTimelock(authHeader, request));
+        }
+
+        @Override
+        public ReenableNamespacesResponse reenableTimelock(AuthHeader authHeader, ReenableNamespacesRequest request) {
+            return unwrap(resource.reenableTimelock(authHeader, request));
         }
 
         @Override

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/TimeLockManagementResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/TimeLockManagementResource.java
@@ -158,11 +158,12 @@ public final class TimeLockManagementResource implements UndertowTimeLockManagem
                     SafeArg.of("namespaces", namespaces));
             throw new ServiceException(ErrorType.PERMISSION_DENIED);
         }
-        return handleExceptions(() -> disableInternal(namespaces));
+        return handleExceptions(() -> disableInternal(authHeader, namespaces));
     }
 
-    private ListenableFuture<DisableNamespacesResponse> disableInternal(Set<Namespace> namespaces) {
-        return Futures.immediateFuture(allNodesDisabledNamespacesUpdater.disableOnAllNodes(namespaces));
+    private ListenableFuture<DisableNamespacesResponse> disableInternal(
+            AuthHeader authHeader, Set<Namespace> namespaces) {
+        return Futures.immediateFuture(allNodesDisabledNamespacesUpdater.disableOnAllNodes(authHeader, namespaces));
     }
 
     @Override
@@ -175,11 +176,12 @@ public final class TimeLockManagementResource implements UndertowTimeLockManagem
                     SafeArg.of("request", request));
             throw new ServiceException(ErrorType.PERMISSION_DENIED);
         }
-        return handleExceptions(() -> reenableInternal(request));
+        return handleExceptions(() -> reenableInternal(authHeader, request));
     }
 
-    public ListenableFuture<ReenableNamespacesResponse> reenableInternal(ReenableNamespacesRequest request) {
-        return Futures.immediateFuture(allNodesDisabledNamespacesUpdater.reEnableOnAllNodes(request));
+    public ListenableFuture<ReenableNamespacesResponse> reenableInternal(
+            AuthHeader authHeader, ReenableNamespacesRequest request) {
+        return Futures.immediateFuture(allNodesDisabledNamespacesUpdater.reEnableOnAllNodes(authHeader, request));
     }
 
     @Override

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/backup/AuthHeaderValidatorTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/backup/AuthHeaderValidatorTest.java
@@ -1,0 +1,50 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.backup;
+
+import static com.palantir.logsafe.testing.Assertions.assertThat;
+
+import com.palantir.tokens.auth.AuthHeader;
+import com.palantir.tokens.auth.BearerToken;
+import java.util.Optional;
+import org.junit.Test;
+
+public class AuthHeaderValidatorTest {
+    private static final BearerToken BEARER_TOKEN = BearerToken.valueOf("bear");
+    private static final BearerToken WRONG_TOKEN = BearerToken.valueOf("tiger");
+
+    private final AuthHeaderValidator authHeaderValidator = new AuthHeaderValidator(() -> Optional.of(BEARER_TOKEN));
+
+    @Test
+    public void succeedsWithMatchingHeader() {
+        assertThat(authHeaderValidator.suppliedTokenIsValid(AuthHeader.of(BEARER_TOKEN)))
+                .isTrue();
+    }
+
+    @Test
+    public void failsWithWrongHeader() {
+        assertThat(authHeaderValidator.suppliedTokenIsValid(AuthHeader.of(WRONG_TOKEN)))
+                .isFalse();
+    }
+
+    @Test
+    public void failsIfSupplierYieldsEmpty() {
+        AuthHeaderValidator emptyValidator = new AuthHeaderValidator(Optional::empty);
+        assertThat(emptyValidator.suppliedTokenIsValid(AuthHeader.of(BEARER_TOKEN)))
+                .isFalse();
+    }
+}

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/management/AllNodesDisabledNamespacesUpdaterTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/management/AllNodesDisabledNamespacesUpdaterTest.java
@@ -95,7 +95,7 @@ public final class AllNodesDisabledNamespacesUpdaterTest {
         when(remote2.reenable(any(), any())).thenReturn(SUCCESSFUL_SINGLE_NODE_UPDATE);
         when(localUpdater.reEnable(any())).thenReturn(SUCCESSFUL_SINGLE_NODE_UPDATE);
 
-        updater = new AllNodesDisabledNamespacesUpdater(AUTH_HEADER, remotes, executors, localUpdater, () -> LOCK_ID);
+        updater = new AllNodesDisabledNamespacesUpdater(remotes, executors, localUpdater, () -> LOCK_ID);
     }
 
     @Test
@@ -104,7 +104,7 @@ public final class AllNodesDisabledNamespacesUpdaterTest {
         when(remote2.disable(any(), any())).thenReturn(SUCCESSFUL_SINGLE_NODE_UPDATE);
         when(localUpdater.disable(any(DisableNamespacesRequest.class))).thenReturn(SUCCESSFUL_SINGLE_NODE_UPDATE);
 
-        DisableNamespacesResponse response = updater.disableOnAllNodes(ImmutableSet.of(NAMESPACE));
+        DisableNamespacesResponse response = updater.disableOnAllNodes(AUTH_HEADER, ImmutableSet.of(NAMESPACE));
 
         assertThat(response).isEqualTo(successfulDisableResponse());
     }
@@ -113,7 +113,7 @@ public final class AllNodesDisabledNamespacesUpdaterTest {
     public void doesNotDisableIfPingFailsOnOneNode() {
         when(remote2.ping(any())).thenThrow(new SafeRuntimeException("unreachable"));
 
-        DisableNamespacesResponse response = updater.disableOnAllNodes(ImmutableSet.of(NAMESPACE));
+        DisableNamespacesResponse response = updater.disableOnAllNodes(AUTH_HEADER, ImmutableSet.of(NAMESPACE));
 
         assertThat(response).isEqualTo(DISABLE_FAILED_SUCCESSFULLY);
         verify(remote1, never()).disable(any(), any());
@@ -132,7 +132,7 @@ public final class AllNodesDisabledNamespacesUpdaterTest {
 
         when(localUpdater.getNamespacesLockedWithDifferentLockId(any(), any())).thenReturn(ImmutableMap.of());
 
-        DisableNamespacesResponse response = updater.disableOnAllNodes(BOTH_NAMESPACES);
+        DisableNamespacesResponse response = updater.disableOnAllNodes(AUTH_HEADER, BOTH_NAMESPACES);
 
         ReenableNamespacesRequest rollbackRequest = ReenableNamespacesRequest.of(BOTH_NAMESPACES, LOCK_ID);
         verify(remote1).reenable(AUTH_HEADER, rollbackRequest);
@@ -151,7 +151,7 @@ public final class AllNodesDisabledNamespacesUpdaterTest {
         when(localUpdater.disable(DisableNamespacesRequest.of(BOTH_NAMESPACES, LOCK_ID)))
                 .thenReturn(singleNodeUpdateFailure(failedNamespaces));
 
-        DisableNamespacesResponse response = updater.disableOnAllNodes(BOTH_NAMESPACES);
+        DisableNamespacesResponse response = updater.disableOnAllNodes(AUTH_HEADER, BOTH_NAMESPACES);
 
         assertThat(response).isEqualTo(partiallyDisabled(BOTH_NAMESPACES));
         ReenableNamespacesRequest rollbackRequest = ReenableNamespacesRequest.of(BOTH_NAMESPACES, LOCK_ID);
@@ -176,7 +176,7 @@ public final class AllNodesDisabledNamespacesUpdaterTest {
         when(localUpdater.getNamespacesLockedWithDifferentLockId(any(), any()))
                 .thenReturn(unsuccessfulResponse.lockedNamespaces());
 
-        DisableNamespacesResponse response = updater.disableOnAllNodes(BOTH_NAMESPACES);
+        DisableNamespacesResponse response = updater.disableOnAllNodes(AUTH_HEADER, BOTH_NAMESPACES);
 
         assertThat(response).isEqualTo(consistentlyDisabled(disabledNamespaces));
 
@@ -202,7 +202,8 @@ public final class AllNodesDisabledNamespacesUpdaterTest {
 
         when(localUpdater.getNamespacesLockedWithDifferentLockId(any(), any())).thenReturn(ImmutableMap.of());
 
-        DisableNamespacesResponse response = updater.disableOnAllNodes(ImmutableSet.of(NAMESPACE, OTHER_NAMESPACE));
+        DisableNamespacesResponse response =
+                updater.disableOnAllNodes(AUTH_HEADER, ImmutableSet.of(NAMESPACE, OTHER_NAMESPACE));
 
         ReenableNamespacesRequest rollbackRequest = ReenableNamespacesRequest.of(BOTH_NAMESPACES, LOCK_ID);
         verify(remote1, never()).reenable(any(), any());
@@ -232,7 +233,7 @@ public final class AllNodesDisabledNamespacesUpdaterTest {
         when(localUpdater.getNamespacesLockedWithDifferentLockId(any(), any()))
                 .thenReturn(lockedWithYetAnotherLock.lockedNamespaces());
 
-        DisableNamespacesResponse response = updater.disableOnAllNodes(namespaces);
+        DisableNamespacesResponse response = updater.disableOnAllNodes(AUTH_HEADER, namespaces);
         verify(remote1, never()).reenable(any(), any());
         verify(remote2).reenable(any(), any());
         assertThat(response).isEqualTo(partiallyDisabled(namespaces));
@@ -258,7 +259,7 @@ public final class AllNodesDisabledNamespacesUpdaterTest {
         when(localUpdater.reEnable(any())).thenReturn(lockedWithYetAnotherLock);
 
         ReenableNamespacesResponse reenableResponse =
-                updater.reEnableOnAllNodes(ReenableNamespacesRequest.of(namespaces, LOCK_ID));
+                updater.reEnableOnAllNodes(AUTH_HEADER, ReenableNamespacesRequest.of(namespaces, LOCK_ID));
         assertThat(reenableResponse).isEqualTo(partiallyLocked(namespaces));
         verify(remote1, never()).disable(any(), any());
         verify(remote2, never()).disable(any(), any());
@@ -275,7 +276,7 @@ public final class AllNodesDisabledNamespacesUpdaterTest {
 
         when(remote1.reenable(any(), any())).thenReturn(singleNodeUpdateFailure(failedNamespaces));
 
-        DisableNamespacesResponse response = updater.disableOnAllNodes(BOTH_NAMESPACES);
+        DisableNamespacesResponse response = updater.disableOnAllNodes(AUTH_HEADER, BOTH_NAMESPACES);
 
         verify(remote1).reenable(any(), any());
         verify(remote2, never()).reenable(any(), any());
@@ -293,7 +294,7 @@ public final class AllNodesDisabledNamespacesUpdaterTest {
 
         when(localUpdater.getNamespacesLockedWithDifferentLockId(any(), any())).thenReturn(ImmutableMap.of());
 
-        DisableNamespacesResponse response = updater.disableOnAllNodes(BOTH_NAMESPACES);
+        DisableNamespacesResponse response = updater.disableOnAllNodes(AUTH_HEADER, BOTH_NAMESPACES);
 
         // We don't know if the request succeeded or failed on remote2, so we should try our best to roll back
         verify(remote2).reenable(any(), any());
@@ -311,7 +312,7 @@ public final class AllNodesDisabledNamespacesUpdaterTest {
         when(localUpdater.reEnable(any())).thenReturn(SUCCESSFUL_SINGLE_NODE_UPDATE);
 
         ReenableNamespacesRequest request = ReenableNamespacesRequest.of(BOTH_NAMESPACES, LOCK_ID);
-        ReenableNamespacesResponse response = updater.reEnableOnAllNodes(request);
+        ReenableNamespacesResponse response = updater.reEnableOnAllNodes(AUTH_HEADER, request);
 
         assertThat(response).isEqualTo(partiallyLocked(ImmutableSet.of()));
     }
@@ -323,7 +324,7 @@ public final class AllNodesDisabledNamespacesUpdaterTest {
         when(remote2.reenable(AUTH_HEADER, request)).thenReturn(SUCCESSFUL_SINGLE_NODE_UPDATE);
         when(localUpdater.reEnable(request)).thenReturn(SUCCESSFUL_SINGLE_NODE_UPDATE);
 
-        ReenableNamespacesResponse response = updater.reEnableOnAllNodes(request);
+        ReenableNamespacesResponse response = updater.reEnableOnAllNodes(AUTH_HEADER, request);
         assertThat(response).isEqualTo(REENABLED_SUCCESSFULLY);
     }
 
@@ -337,7 +338,7 @@ public final class AllNodesDisabledNamespacesUpdaterTest {
         when(remote2.reenable(AUTH_HEADER, request)).thenReturn(singleNodeUpdateFailure(oneNamespace));
         when(localUpdater.reEnable(request)).thenReturn(SingleNodeUpdateResponse.successful());
 
-        ReenableNamespacesResponse response = updater.reEnableOnAllNodes(request);
+        ReenableNamespacesResponse response = updater.reEnableOnAllNodes(AUTH_HEADER, request);
         assertThat(response).isEqualTo(partiallyLocked(oneNamespace));
         // verify we still unlocked locally
         verify(localUpdater).reEnable(request);
@@ -354,7 +355,7 @@ public final class AllNodesDisabledNamespacesUpdaterTest {
         when(localUpdater.reEnable(any())).thenReturn(unsuccessfulResponse);
 
         ReenableNamespacesResponse response =
-                updater.reEnableOnAllNodes(ReenableNamespacesRequest.of(BOTH_NAMESPACES, LOCK_ID));
+                updater.reEnableOnAllNodes(AUTH_HEADER, ReenableNamespacesRequest.of(BOTH_NAMESPACES, LOCK_ID));
 
         assertThat(response).isEqualTo(consistentlyLocked(disabledNamespaces));
     }

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/management/DiskNamespaceLoaderTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/management/DiskNamespaceLoaderTest.java
@@ -78,6 +78,7 @@ public class DiskNamespaceLoaderTest {
         timeLockManagementResource = TimeLockManagementResource.create(
                 persistentNamespaceContext,
                 namespaces,
+                mock(AllNodesDisabledNamespacesUpdater.class),
                 redirectRetryTargeter,
                 new ServiceLifecycleController(serviceStopper, PTExecutors.newSingleThreadScheduledExecutor()));
 

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/management/TimeLockManagementResourceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/management/TimeLockManagementResourceTest.java
@@ -16,23 +16,33 @@
 
 package com.palantir.atlasdb.timelock.management;
 
+import static com.palantir.conjure.java.api.testing.Assertions.assertThatServiceExceptionThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.palantir.atlasdb.backup.AuthHeaderValidator;
+import com.palantir.atlasdb.futures.AtlasFutures;
 import com.palantir.atlasdb.http.RedirectRetryTargeter;
 import com.palantir.atlasdb.timelock.TimeLockServices;
 import com.palantir.atlasdb.timelock.TimelockNamespaces;
+import com.palantir.atlasdb.timelock.api.Namespace;
+import com.palantir.atlasdb.timelock.api.ReenableNamespacesRequest;
 import com.palantir.atlasdb.timelock.paxos.PaxosTimeLockConstants;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.common.concurrent.PTExecutors;
+import com.palantir.conjure.java.api.errors.ErrorType;
 import com.palantir.paxos.SqliteConnections;
 import com.palantir.tokens.auth.AuthHeader;
+import com.palantir.tokens.auth.BearerToken;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -40,12 +50,23 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
-public class DiskNamespaceLoaderTest {
+@RunWith(MockitoJUnitRunner.class)
+public class TimeLockManagementResourceTest {
     private static final String NAMESPACE_1 = "namespace_1";
     private static final String NAMESPACE_2 = "namespace_2";
-    private static final AuthHeader AUTH_HEADER = AuthHeader.valueOf("Bearer omitted");
+    private static final Set<Namespace> NAMESPACES =
+            ImmutableSet.of(Namespace.of(NAMESPACE_1), Namespace.of(NAMESPACE_2));
+    private static final BearerToken BEARER_TOKEN = BearerToken.valueOf("bear");
+    private static final BearerToken WRONG_BEARER_TOKEN = BearerToken.valueOf("tiger");
+    private static final AuthHeader AUTH_HEADER = AuthHeader.of(BEARER_TOKEN);
+    private static final AuthHeader WRONG_AUTH_HEADER = AuthHeader.of(WRONG_BEARER_TOKEN);
+
+    @Mock
+    private AuthHeaderValidator authHeaderValidator;
 
     @Mock
     private Function<String, TimeLockServices> serviceFactory;
@@ -75,15 +96,34 @@ public class DiskNamespaceLoaderTest {
         TimelockNamespaces namespaces =
                 new TimelockNamespaces(metricsManager, serviceFactory, maxNumberOfClientsSupplier, disabledNamespaces);
 
+        when(authHeaderValidator.suppliedTokenIsValid(AUTH_HEADER)).thenReturn(true);
+        when(authHeaderValidator.suppliedTokenIsValid(WRONG_AUTH_HEADER)).thenReturn(false);
         timeLockManagementResource = TimeLockManagementResource.create(
                 persistentNamespaceContext,
                 namespaces,
                 mock(AllNodesDisabledNamespacesUpdater.class),
+                authHeaderValidator,
                 redirectRetryTargeter,
                 new ServiceLifecycleController(serviceStopper, PTExecutors.newSingleThreadScheduledExecutor()));
 
         createDirectoryForLeaderForEachClientUseCase(NAMESPACE_1);
         createDirectoryInRootDataDirectory(NAMESPACE_2);
+    }
+
+    @Test
+    public void disableTimeLockThrowsIfAuthHeaderIsWrong() {
+        assertThatServiceExceptionThrownBy(() -> AtlasFutures.getUnchecked(
+                        timeLockManagementResource.disableTimelock(WRONG_AUTH_HEADER, NAMESPACES)))
+                .hasType(ErrorType.PERMISSION_DENIED);
+    }
+    // TODO(gs): dis/reenable tests with valid auth header
+
+    @Test
+    public void reEnableTimeLockThrowsIfAuthHeaderIsWrong() {
+        ReenableNamespacesRequest request = ReenableNamespacesRequest.of(NAMESPACES, UUID.randomUUID());
+        assertThatServiceExceptionThrownBy(() -> AtlasFutures.getUnchecked(
+                        timeLockManagementResource.reenableTimelock(WRONG_AUTH_HEADER, request)))
+                .hasType(ErrorType.PERMISSION_DENIED);
     }
 
     @Test

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/management/TimeLockManagementResourceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/management/TimeLockManagementResourceTest.java
@@ -126,7 +126,7 @@ public class TimeLockManagementResourceTest {
     @Test
     public void disableTimeLockCallsUpdater() {
         timeLockManagementResource.disableTimelock(AUTH_HEADER, NAMESPACES);
-        verify(allNodesDisabledNamespacesUpdater).disableOnAllNodes(NAMESPACES);
+        verify(allNodesDisabledNamespacesUpdater).disableOnAllNodes(AUTH_HEADER, NAMESPACES);
     }
 
     @Test
@@ -142,7 +142,7 @@ public class TimeLockManagementResourceTest {
     public void reEnableTimeLockCallsUpdater() {
         ReenableNamespacesRequest request = ReenableNamespacesRequest.of(NAMESPACES, UUID.randomUUID());
         timeLockManagementResource.reenableTimelock(AUTH_HEADER, request);
-        verify(allNodesDisabledNamespacesUpdater).reEnableOnAllNodes(request);
+        verify(allNodesDisabledNamespacesUpdater).reEnableOnAllNodes(AUTH_HEADER, request);
     }
 
     @Test

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/management/TimeLockManagementResourceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/management/TimeLockManagementResourceTest.java
@@ -60,7 +60,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class TimeLockManagementResourceTest {
     private static final String NAMESPACE_1 = "namespace_1";
     private static final String NAMESPACE_2 = "namespace_2";
-    private static final Set<Namespace> NAMESPACES =
+    private static final ImmutableSet<Namespace> NAMESPACES =
             ImmutableSet.of(Namespace.of(NAMESPACE_1), Namespace.of(NAMESPACE_2));
     private static final BearerToken BEARER_TOKEN = BearerToken.valueOf("bear");
     private static final BearerToken WRONG_BEARER_TOKEN = BearerToken.valueOf("tiger");


### PR DESCRIPTION
**Goals (and why)**:
Final part of the production code for Atlas Backup/Restore work stream.
Wires up the AllNodesDisabledNamespacesUpdater, added in #5876, to the TimeLockManagementResource, and adds new public methods in AtlasRestoreService.

==COMMIT_MSG==
Added AtlasRestoreService methods `prepareRestore` and `completeRestore`, which will respectively disable and re-enable TimeLock, and should be called during the restore process.
==COMMIT_MSG==

**Implementation Description (bullets)**:
- Wired up new endpoints
- Pulled out a small AuthHeaderValidator class for reuse of auth validation logic added in #5890.
- Added javadoc for new methods

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Moved some validation tests to AuthHeaderValidatorTest

**Concerns (what feedback would you like?)**:
Do we want to take the time to add retry logic now? These methods should now work end-to-end, although flakes may require manual action.

**Where should we start reviewing?**: AtlasRestoreService

**Priority (whenever / two weeks / yesterday)**: ASAP, the next parts are blocked on this piece.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
