### PR TITLE
Allow more shards in TS

### DIFF
--- a/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/TargetedSweepMetadataTest.java
+++ b/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/TargetedSweepMetadataTest.java
@@ -35,7 +35,7 @@ public class TargetedSweepMetadataTest {
     private static final TargetedSweepMetadata ALL_ONE_METADATA = ImmutableTargetedSweepMetadata.builder()
             .conservative(true)
             .dedicatedRow(true)
-            .shard(255)
+            .shard(1023)
             .dedicatedRowNumber(63)
             .build();
 
@@ -88,10 +88,22 @@ public class TargetedSweepMetadataTest {
     }
 
     @Test
+    public void persistAndHydrateWith512Shards() {
+        TargetedSweepMetadata metadata = ImmutableTargetedSweepMetadata.builder()
+                .conservative(true)
+                .dedicatedRow(true)
+                .shard(512)
+                .dedicatedRowNumber(1)
+                .build();
+        assertThat(TargetedSweepMetadata.BYTES_HYDRATOR.hydrateFromBytes(metadata.persistToBytes()))
+                .isEqualTo(metadata);
+    }
+
+    @Test
     public void testIllegalShardSize() {
         ImmutableTargetedSweepMetadata.Builder builder =
                 ImmutableTargetedSweepMetadata.builder().from(ALL_ZERO_METADATA);
-        assertThatThrownBy(() -> builder.shard(300).build()).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> builder.shard(3000).build()).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/changelog/@unreleased/pr-5894.v2.yml
+++ b/changelog/@unreleased/pr-5894.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Targeted sweep now supports configuring up to 1024 shards
+  links:
+  - https://github.com/palantir/atlasdb/pull/5894


### PR DESCRIPTION
**Goals (and why)**:
==COMMIT_MSG==
Targeted sweep now supports configuring up to 1024 shards
==COMMIT_MSG==

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
