### PR TITLE
ABR 16: Persist restore lock ID

### DIFF
--- a/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/BackupPersister.java
+++ b/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/BackupPersister.java
@@ -21,6 +21,7 @@ import com.palantir.atlasdb.backup.api.InProgressBackupToken;
 import com.palantir.atlasdb.internalschema.InternalSchemaMetadataState;
 import com.palantir.atlasdb.timelock.api.Namespace;
 import java.util.Optional;
+import java.util.UUID;
 
 interface BackupPersister {
     void storeSchemaMetadata(Namespace namespace, InternalSchemaMetadataState internalSchemaMetadataState);
@@ -34,4 +35,8 @@ interface BackupPersister {
     void storeImmutableTimestamp(InProgressBackupToken inProgressBackupToken);
 
     Optional<Long> getImmutableTimestamp(Namespace namespace);
+
+    void storeRestoreLockId(Namespace namespace, UUID lockId);
+
+    Optional<UUID> getRestoreLockId(Namespace namespace);
 }

--- a/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/ExternalBackupPersister.java
+++ b/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/ExternalBackupPersister.java
@@ -31,6 +31,7 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.function.Function;
 
 public class ExternalBackupPersister implements BackupPersister {
@@ -41,6 +42,7 @@ public class ExternalBackupPersister implements BackupPersister {
     private static final String BACKUP_TIMESTAMP_FILE_NAME = "backup.timestamp";
     private static final String IMMUTABLE_TIMESTAMP_FILE_NAME = "immutable.timestamp";
     private static final String FAST_FORWARD_TIMESTAMP_FILE_NAME = "fast-forward.timestamp";
+    private static final String RESTORE_LOCK_ID_FILE_NAME = "restore.lock";
 
     private final Function<Namespace, Path> pathFactory;
 
@@ -94,6 +96,16 @@ public class ExternalBackupPersister implements BackupPersister {
         return loadFromFile(namespace, getImmutableTimestampFile(namespace), Long.class);
     }
 
+    @Override
+    public void storeRestoreLockId(Namespace namespace, UUID lockId) {
+        writeToFile(namespace, getRestoreLockIdFile(namespace), lockId);
+    }
+
+    @Override
+    public Optional<UUID> getRestoreLockId(Namespace namespace) {
+        return loadFromFile(namespace, getRestoreLockIdFile(namespace), UUID.class);
+    }
+
     private File getSchemaMetadataFile(Namespace namespace) {
         return getFile(namespace, SCHEMA_METADATA_FILE_NAME);
     }
@@ -108,6 +120,10 @@ public class ExternalBackupPersister implements BackupPersister {
 
     private File getFastForwardTimestampFile(Namespace namespace) {
         return getFile(namespace, FAST_FORWARD_TIMESTAMP_FILE_NAME);
+    }
+
+    private File getRestoreLockIdFile(Namespace namespace) {
+        return getFile(namespace, RESTORE_LOCK_ID_FILE_NAME);
     }
 
     private File getFile(Namespace namespace, String fileName) {

--- a/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/InMemoryBackupPersister.java
+++ b/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/InMemoryBackupPersister.java
@@ -22,17 +22,20 @@ import com.palantir.atlasdb.internalschema.InternalSchemaMetadataState;
 import com.palantir.atlasdb.timelock.api.Namespace;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 class InMemoryBackupPersister implements BackupPersister {
     private final Map<Namespace, Long> immutableTimestamps;
     private final Map<Namespace, InternalSchemaMetadataState> schemaMetadatas;
     private final Map<Namespace, CompletedBackup> completedBackups;
+    private final Map<Namespace, UUID> restoreLockIds;
 
     InMemoryBackupPersister() {
         schemaMetadatas = new ConcurrentHashMap<>();
         completedBackups = new ConcurrentHashMap<>();
         immutableTimestamps = new ConcurrentHashMap<>();
+        restoreLockIds = new ConcurrentHashMap<>();
     }
 
     @Override
@@ -63,5 +66,15 @@ class InMemoryBackupPersister implements BackupPersister {
     @Override
     public Optional<Long> getImmutableTimestamp(Namespace namespace) {
         return Optional.ofNullable(immutableTimestamps.get(namespace));
+    }
+
+    @Override
+    public void storeRestoreLockId(Namespace namespace, UUID lockId) {
+        restoreLockIds.put(namespace, lockId);
+    }
+
+    @Override
+    public Optional<UUID> getRestoreLockId(Namespace namespace) {
+        return Optional.ofNullable(restoreLockIds.get(namespace));
     }
 }

--- a/atlasdb-backup/src/test/java/com/palantir/atlasdb/backup/ExternalBackupPersisterTest.java
+++ b/atlasdb-backup/src/test/java/com/palantir/atlasdb/backup/ExternalBackupPersisterTest.java
@@ -98,6 +98,18 @@ public class ExternalBackupPersisterTest {
         assertThat(externalBackupPersister.getCompletedBackup(NAMESPACE)).contains(completedBackup);
     }
 
+    @Test
+    public void getRestoreLockIdWhenEmpty() {
+        assertThat(externalBackupPersister.getRestoreLockId(NAMESPACE)).isEmpty();
+    }
+
+    @Test
+    public void putAndGetRestoreLockId() {
+        UUID lockId = UUID.randomUUID();
+        externalBackupPersister.storeRestoreLockId(NAMESPACE, lockId);
+        assertThat(externalBackupPersister.getRestoreLockId(NAMESPACE)).contains(lockId);
+    }
+
     private Path getPath(Namespace namespace) {
         try {
             return getOrCreateFolder(namespace).toPath();

--- a/changelog/@unreleased/pr-5897.v2.yml
+++ b/changelog/@unreleased/pr-5897.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: AtlasDB now persists the lock ID produced when preparing a restore
+    operation.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5897


### PR DESCRIPTION
**Goals (and why)**:
In previous parts, we persisted backup information (e.g. timestamps) ourselves, so that external consumers do not depend on these internal details. However, the restore process was incongruent, as it required the lock ID, generated in the prepare restore phase, to be resupplied in the complete restore phase.


**Implementation Description (bullets)**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
AtlasDB now persists the lock ID produced when preparing a restore operation.
==COMMIT_MSG==
- Added fourth option to BackupPersister
- Used this in prepare and complete restore

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added tests in BackupPersisterTest and AtlasRestoreServiceTest.

**Concerns (what feedback would you like?)**: We simplify here by assuming that all namespaces were locked at the same time. This is true now, but in the future might change - is this good enough for now?

**Where should we start reviewing?**: AtlasRestoreService is the most interesting part

**Priority (whenever / two weeks / yesterday)**: ASAP, want to use this elsewhere
