### PR TITLE
ABR 16: Accept lockId as string

### DIFF
--- a/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/AtlasRestoreService.java
+++ b/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/AtlasRestoreService.java
@@ -163,7 +163,7 @@ public class AtlasRestoreService {
      * Completes the restore process for the requested namespaces.
      * This includes fast-forwarding the timestamp, and then re-enabling the TimeLock namespaces.
      *
-     * @param request the request object, which must include the lock ID returned by {@link #prepareRestore(Set)}
+     * @param request the request object, which must include the lock ID given to {@link #prepareRestore(Set, String)}
      * @return the set of namespaces that were successfully fast-forwarded and re-enabled.
      */
     @NonIdempotent

--- a/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/AtlasRestoreService.java
+++ b/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/AtlasRestoreService.java
@@ -104,13 +104,14 @@ public class AtlasRestoreService {
 
     /**
      * Disables TimeLock on all nodes for the given namespaces.
-     * Should be called exactly once prior to a restore operation. Calling this on multiple nodes will cause conflicts.
+     * This will fail if any namespace is already disabled, unless it was disabled with the provided backupId.
+     * Namespaces for which we don't have a recorded backup will be ignored.
      *
-     * @param namespaces the namespaces to disable
+     * @param namespaces the namespaces to disable.
+     * @param backupId a unique identifier for this request (uniquely identifies the backup to which we're restoring)
      *
      * @return the namespaces successfully disabled.
      */
-    @NonIdempotent // TODO(gs): disable twice with same ID should be acceptable
     public Set<Namespace> prepareRestore(Set<Namespace> namespaces, String backupId) {
         Map<Namespace, CompletedBackup> completedBackups = getCompletedBackups(namespaces);
         Set<Namespace> namespacesToRestore = completedBackups.keySet();

--- a/changelog/@unreleased/pr-5898.v2.yml
+++ b/changelog/@unreleased/pr-5898.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: prepareRestore now accepts a backup ID, enabling retries of failed
+    restores without having to deconflict.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5898

--- a/timelock-api/src/main/conjure/timelock-management-api.yml
+++ b/timelock-api/src/main/conjure/timelock-management-api.yml
@@ -11,10 +11,10 @@ types:
       DisableNamespacesRequest:
         fields:
           namespaces: set<api.Namespace>
-          lockId: uuid
+          lockId: string
       SuccessfulDisableNamespacesResponse:
         fields:
-          lockId: uuid
+          lockId: string
       UnsuccessfulDisableNamespacesResponse:
         fields:
           consistentlyDisabledNamespaces:
@@ -32,7 +32,7 @@ types:
       ReenableNamespacesRequest:
         fields:
           namespaces: set<api.Namespace>
-          lockId: uuid
+          lockId: string
       SuccessfulReenableNamespacesResponse:
         alias: boolean
       UnsuccessfulReenableNamespacesResponse:
@@ -106,7 +106,7 @@ services:
       disableTimelock:
         http: POST /disable
         args:
-          request: set<api.Namespace>
+          request: DisableNamespacesRequest
         returns: DisableNamespacesResponse
         docs: |
           Disables the TimeLock server in a persistant way for the specified namespaces. This includes invalidating

--- a/timelock-api/src/main/java/com/palantir/atlasdb/timelock/api/SingleNodeUpdateResponse.java
+++ b/timelock-api/src/main/java/com/palantir/atlasdb/timelock/api/SingleNodeUpdateResponse.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.palantir.paxos.PaxosResponse;
 import java.util.Map;
-import java.util.UUID;
 import org.immutables.value.Value;
 
 @JsonDeserialize(as = ImmutableSingleNodeUpdateResponse.class)
@@ -30,13 +29,13 @@ public interface SingleNodeUpdateResponse extends PaxosResponse {
     /**
      * other namespaces will not have been disabled/re-enabled (the transaction will not complete).
      */
-    Map<Namespace, UUID> lockedNamespaces();
+    Map<Namespace, String> lockedNamespaces();
 
     static SingleNodeUpdateResponse successful() {
         return ImmutableSingleNodeUpdateResponse.builder().isSuccessful(true).build();
     }
 
-    static SingleNodeUpdateResponse failed(Map<Namespace, UUID> lockedNamespaces) {
+    static SingleNodeUpdateResponse failed(Map<Namespace, String> lockedNamespaces) {
         return ImmutableSingleNodeUpdateResponse.builder()
                 .isSuccessful(false)
                 .lockedNamespaces(lockedNamespaces)

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimelockNamespaces.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimelockNamespaces.java
@@ -35,7 +35,6 @@ import com.palantir.logsafe.logger.SafeLoggerFactory;
 import com.palantir.paxos.Client;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
@@ -129,7 +128,8 @@ public final class TimelockNamespaces {
         }
     }
 
-    public Map<Namespace, UUID> getNamespacesLockedWithDifferentLockId(Set<Namespace> namespaces, UUID expectedLockId) {
+    public Map<Namespace, String> getNamespacesLockedWithDifferentLockId(
+            Set<Namespace> namespaces, String expectedLockId) {
         return disabledNamespaces.getNamespacesLockedWithDifferentLockId(namespaces, expectedLockId);
     }
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/DisableNamespaceResponses.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/DisableNamespaceResponses.java
@@ -23,7 +23,6 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.util.Set;
-import java.util.UUID;
 
 final class DisableNamespaceResponses {
     private static final SafeLogger log = SafeLoggerFactory.get(DisableNamespaceResponses.class);
@@ -54,7 +53,7 @@ final class DisableNamespaceResponses {
     }
 
     static DisableNamespacesResponse unsuccessfulButRolledBack(
-            Set<Namespace> partiallyDisabledNamespaces, UUID lockId) {
+            Set<Namespace> partiallyDisabledNamespaces, String lockId) {
         log.error(
                 "Failed to disable all namespaces. However, we successfully rolled back our changes.",
                 SafeArg.of("partiallyDisabledNamespaces", partiallyDisabledNamespaces),
@@ -64,7 +63,7 @@ final class DisableNamespaceResponses {
                 .build());
     }
 
-    static DisableNamespacesResponse unsuccessfulAndRollBackFailed(Set<Namespace> namespaces, UUID lockId) {
+    static DisableNamespacesResponse unsuccessfulAndRollBackFailed(Set<Namespace> namespaces, String lockId) {
         log.error(
                 "Failed to disable all namespaces, and we may have failed to roll back some namespaces."
                         + " These may need to be force-re-enabled in order to return Timelock to a consistent state.",

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/DisabledNamespaces.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/DisabledNamespaces.java
@@ -93,7 +93,7 @@ public class DisabledNamespaces {
     }
 
     public SingleNodeUpdateResponse reEnable(ReenableNamespacesRequest request) {
-        String lockId = request.getLockId().toString(); // TODO(gs): RNR -> String
+        String lockId = request.getLockId();
         SingleNodeUpdateResponse response = execute(dao -> dao.reEnableAll(request.getNamespaces(), lockId));
         if (!response.isSuccessful()) {
             Map<Namespace, String> conflictingNamespaces = response.lockedNamespaces();

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/TimeLockManagementResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/TimeLockManagementResource.java
@@ -25,8 +25,8 @@ import com.palantir.atlasdb.http.RedirectRetryTargeter;
 import com.palantir.atlasdb.keyvalue.api.TimestampSeries;
 import com.palantir.atlasdb.timelock.ConjureResourceExceptionHandler;
 import com.palantir.atlasdb.timelock.TimelockNamespaces;
+import com.palantir.atlasdb.timelock.api.DisableNamespacesRequest;
 import com.palantir.atlasdb.timelock.api.DisableNamespacesResponse;
-import com.palantir.atlasdb.timelock.api.Namespace;
 import com.palantir.atlasdb.timelock.api.ReenableNamespacesRequest;
 import com.palantir.atlasdb.timelock.api.ReenableNamespacesResponse;
 import com.palantir.atlasdb.timelock.api.management.TimeLockManagementService;
@@ -150,20 +150,20 @@ public final class TimeLockManagementResource implements UndertowTimeLockManagem
 
     @Override
     public ListenableFuture<DisableNamespacesResponse> disableTimelock(
-            AuthHeader authHeader, Set<Namespace> namespaces) {
+            AuthHeader authHeader, DisableNamespacesRequest request) {
         if (!authHeaderValidator.suppliedTokenIsValid(authHeader)) {
             log.error(
                     "Attempted to disable TimeLock with an invalid auth header. "
                             + "The provided token must match the configured permitted-backup-token.",
-                    SafeArg.of("namespaces", namespaces));
+                    SafeArg.of("namespaces", request.getNamespaces()));
             throw new ServiceException(ErrorType.PERMISSION_DENIED);
         }
-        return handleExceptions(() -> disableInternal(authHeader, namespaces));
+        return handleExceptions(() -> disableInternal(authHeader, request));
     }
 
     private ListenableFuture<DisableNamespacesResponse> disableInternal(
-            AuthHeader authHeader, Set<Namespace> namespaces) {
-        return Futures.immediateFuture(allNodesDisabledNamespacesUpdater.disableOnAllNodes(authHeader, namespaces));
+            AuthHeader authHeader, DisableNamespacesRequest request) {
+        return Futures.immediateFuture(allNodesDisabledNamespacesUpdater.disableOnAllNodes(authHeader, request));
     }
 
     @Override
@@ -237,7 +237,7 @@ public final class TimeLockManagementResource implements UndertowTimeLockManagem
         }
 
         @Override
-        public DisableNamespacesResponse disableTimelock(AuthHeader authHeader, Set<Namespace> request) {
+        public DisableNamespacesResponse disableTimelock(AuthHeader authHeader, DisableNamespacesRequest request) {
             return unwrap(resource.disableTimelock(authHeader, request));
         }
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/UpdateFailureRecord.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/UpdateFailureRecord.java
@@ -17,16 +17,15 @@
 package com.palantir.atlasdb.timelock.management;
 
 import java.util.Set;
-import java.util.UUID;
 import org.immutables.value.Value;
 
 @Value.Modifiable
 interface UpdateFailureRecord {
     int failureCount();
 
-    Set<UUID> lockIds();
+    Set<String> lockIds();
 
-    static ModifiableUpdateFailureRecord of(UUID lockId) {
+    static ModifiableUpdateFailureRecord of(String lockId) {
         return ModifiableUpdateFailureRecord.create().setFailureCount(1).addLockIds(lockId);
     }
 

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/TimelockNamespacesTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/TimelockNamespacesTest.java
@@ -206,7 +206,7 @@ public class TimelockNamespacesTest {
         String client = uniqueClient();
         TimeLockServices services = namespaces.get(client);
 
-        UUID lockId = UUID.randomUUID();
+        String lockId = "lockId";
         when(disabledNamespaces.disable(any())).thenReturn(SingleNodeUpdateResponse.successful());
 
         namespaces.disable(DisableNamespacesRequest.of(ImmutableSet.of(Namespace.of(client)), lockId));
@@ -219,8 +219,8 @@ public class TimelockNamespacesTest {
         TimeLockServices services = namespaces.get(client);
 
         ImmutableSet<Namespace> namespacesToDisable = ImmutableSet.of(Namespace.of(client));
-        UUID lockId = UUID.randomUUID();
-        Map<Namespace, UUID> lockedNamespace = ImmutableMap.of(Namespace.of(client), lockId);
+        String lockId = "lockId";
+        Map<Namespace, String> lockedNamespace = ImmutableMap.of(Namespace.of(client), lockId);
         when(disabledNamespaces.disable(any())).thenReturn(SingleNodeUpdateResponse.failed(lockedNamespace));
 
         namespaces.disable(DisableNamespacesRequest.of(namespacesToDisable, lockId));

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/management/DisabledNamespacesTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/management/DisabledNamespacesTest.java
@@ -78,28 +78,41 @@ public class DisabledNamespacesTest {
     }
 
     @Test
-    public void disableFailsIfAlreadyDisabled() {
+    public void disableFailsIfAlreadyDisabledWithDifferentId() {
         SingleNodeUpdateResponse firstResponse = disabledNamespaces.disable(disableNamespacesRequest(FIRST));
         assertThat(firstResponse).isEqualTo(successfulResponse());
 
-        SingleNodeUpdateResponse secondResponse = disabledNamespaces.disable(disableNamespacesRequest(FIRST));
+        SingleNodeUpdateResponse secondResponse =
+                disabledNamespaces.disable(DisableNamespacesRequest.of(ImmutableSet.of(FIRST), "otherLockId"));
         assertThat(secondResponse).isEqualTo(unsuccessfulResponse());
     }
 
     @Test
-    public void disableFailsIfPartiallyDisabled() {
+    public void disableSucceedsIfAlreadyDisabledWithTheSameId() {
         SingleNodeUpdateResponse firstResponse = disabledNamespaces.disable(disableNamespacesRequest(FIRST));
+        assertThat(firstResponse).isEqualTo(successfulResponse());
+
+        SingleNodeUpdateResponse secondResponse = disabledNamespaces.disable(disableNamespacesRequest(FIRST));
+        assertThat(secondResponse).isEqualTo(successfulResponse());
+    }
+
+    @Test
+    public void disableFailsIfPartiallyDisabledWithOtherLockId() {
+        String otherLockId = "otherLockId";
+        SingleNodeUpdateResponse firstResponse =
+                disabledNamespaces.disable(DisableNamespacesRequest.of(ImmutableSet.of(FIRST), otherLockId));
+
         assertThat(firstResponse).isEqualTo(successfulResponse());
 
         SingleNodeUpdateResponse secondResponse = disabledNamespaces.disable(disableNamespacesRequest(SECOND, FIRST));
 
         assertThat(disabledNamespaces.isDisabled(SECOND)).isFalse();
-        assertThat(secondResponse).isEqualTo(unsuccessfulResponse());
+        assertThat(secondResponse).isEqualTo(unsuccessfulResponse(otherLockId));
 
         SingleNodeUpdateResponse thirdResponse = disabledNamespaces.disable(disableNamespacesRequest(FIRST, SECOND));
 
         assertThat(disabledNamespaces.isDisabled(SECOND)).isFalse();
-        assertThat(thirdResponse).isEqualTo(unsuccessfulResponse());
+        assertThat(thirdResponse).isEqualTo(unsuccessfulResponse(otherLockId));
     }
 
     @Test
@@ -159,6 +172,10 @@ public class DisabledNamespacesTest {
     }
 
     private SingleNodeUpdateResponse unsuccessfulResponse() {
-        return SingleNodeUpdateResponse.failed(ImmutableMap.of(FIRST, LOCK_ID));
+        return unsuccessfulResponse(LOCK_ID);
+    }
+
+    private SingleNodeUpdateResponse unsuccessfulResponse(String lockId) {
+        return SingleNodeUpdateResponse.failed(ImmutableMap.of(FIRST, lockId));
     }
 }

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/management/DisabledNamespacesTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/management/DisabledNamespacesTest.java
@@ -33,8 +33,8 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 public class DisabledNamespacesTest {
-    private static final UUID LOCK_ID = new UUID(13, 52);
-    private static final UUID OTHER_LOCK_ID = new UUID(123, 45);
+    private static final String LOCK_ID = new UUID(13, 52).toString();
+    private static final String OTHER_LOCK_ID = new UUID(123, 45).toString();
 
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();


### PR DESCRIPTION
**Goals (and why)**:
Make prepareRestore idempotent, by tying the lock ID to the backup ID.
We have protection internally that prevents us from having multiple simultaneous restores, so conflicts are less of a concern than idempotence - i.e. if we prepareRestore, and fail during restore, we want to be able to start from prepareRestore again without having to deconflict ourselves.

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
prepareRestore now accepts a backup ID, enabling retries of failed restores without having to deconflict. 
==COMMIT_MSG==

**Implementation Description (bullets)**:
- Add `String backupId` to the signature of prepareRestore
- Propagate this change to the DB (so backupId is stored as String, not UUID)
- Alter signature of `completeRestore` to be consistent with `prepareRestore` (and the backup-flavoured counterparts)

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Added a test to show that disableNamespaces is now idempotent.

**Concerns (what feedback would you like?)**: none really, this is what we agreed on yesterday

**Where should we start reviewing?**: where you're sitting now is good

**Priority (whenever / two weeks / yesterday)**: ASAP

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
