### PR TITLE
[WIP] Separate hosts by datacenter

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Range;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.containers.CassandraResource;
+import com.palantir.atlasdb.keyvalue.cassandra.pool.DcAwareHost;
 import com.palantir.atlasdb.keyvalue.cassandra.pool.HostLocation;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.atlasdb.util.MetricsManagers;
@@ -97,7 +98,7 @@ public class CassandraClientPoolIntegrationTest {
         CassandraClientPoolImpl clientPoolWithLocation = CassandraClientPoolImpl.createImplForTest(
                 metricsManager, configHostWithLocation, CassandraClientPoolImpl.StartupChecks.RUN, blacklist);
 
-        return clientPoolWithLocation.getLocalHosts();
+        return DcAwareHost.addresses(clientPoolWithLocation.getLocalHosts());
     }
 
     @Test

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/Blacklist.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/Blacklist.java
@@ -19,11 +19,11 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
+import com.palantir.atlasdb.keyvalue.cassandra.pool.DcAwareHost;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
-import java.net.InetSocketAddress;
 import java.time.Clock;
 import java.util.Collection;
 import java.util.Iterator;
@@ -41,7 +41,7 @@ public class Blacklist {
     private final CassandraKeyValueServiceConfig config;
     private final Clock clock;
 
-    private Map<InetSocketAddress, Long> blacklist;
+    private Map<DcAwareHost, Long> blacklist;
 
     public Blacklist(CassandraKeyValueServiceConfig config) {
         this(config, Clock.systemUTC());
@@ -54,14 +54,14 @@ public class Blacklist {
         this.clock = clock;
     }
 
-    void checkAndUpdate(Map<InetSocketAddress, CassandraClientPoolingContainer> pools) {
+    void checkAndUpdate(Map<DcAwareHost, CassandraClientPoolingContainer> pools) {
         // Check blacklist and re-integrate or continue to wait as necessary
-        Iterator<Entry<InetSocketAddress, Long>> blacklistIterator =
+        Iterator<Entry<DcAwareHost, Long>> blacklistIterator =
                 blacklist.entrySet().iterator();
         while (blacklistIterator.hasNext()) {
-            Map.Entry<InetSocketAddress, Long> blacklistedEntry = blacklistIterator.next();
+            Map.Entry<DcAwareHost, Long> blacklistedEntry = blacklistIterator.next();
             if (coolOffPeriodExpired(blacklistedEntry)) {
-                InetSocketAddress host = blacklistedEntry.getKey();
+                DcAwareHost host = blacklistedEntry.getKey();
                 if (!pools.containsKey(host)) {
                     // Probably the pool changed underneath us
                     blacklistIterator.remove();
@@ -78,7 +78,7 @@ public class Blacklist {
         }
     }
 
-    private boolean coolOffPeriodExpired(Map.Entry<InetSocketAddress, Long> blacklistedEntry) {
+    private boolean coolOffPeriodExpired(Map.Entry<DcAwareHost, Long> blacklistedEntry) {
         long backoffTimeMillis = TimeUnit.SECONDS.toMillis(config.unresponsiveHostBackoffTimeSeconds());
         return blacklistedEntry.getValue() + backoffTimeMillis < clock.millis();
     }
@@ -92,7 +92,7 @@ public class Blacklist {
             log.info(
                     "We tried to add blacklisted host '{}' back into the pool, but got an exception"
                             + " that caused us to distrust this host further. Exception message was: {} : {}",
-                    SafeArg.of("host", CassandraLogHelper.host(container.getHost())),
+                    SafeArg.of("host", CassandraLogHelper.host(container.getDcAwareHost())),
                     SafeArg.of("exceptionClass", e.getClass().getCanonicalName()),
                     UnsafeArg.of("exceptionMessage", e.getMessage()),
                     e);
@@ -100,24 +100,24 @@ public class Blacklist {
         }
     }
 
-    public Set<InetSocketAddress> filterBlacklistedHostsFrom(Collection<InetSocketAddress> potentialHosts) {
+    public Set<DcAwareHost> filterBlacklistedHostsFrom(Collection<DcAwareHost> potentialHosts) {
         return Sets.difference(ImmutableSet.copyOf(potentialHosts), blacklist.keySet());
     }
 
-    boolean contains(InetSocketAddress host) {
+    boolean contains(DcAwareHost host) {
         return blacklist.containsKey(host);
     }
 
-    public void add(InetSocketAddress host) {
+    public void add(DcAwareHost host) {
         blacklist.put(host, clock.millis());
         log.info("Blacklisted host '{}'", SafeArg.of("badHost", CassandraLogHelper.host(host)));
     }
 
-    void addAll(Set<InetSocketAddress> hosts) {
+    void addAll(Set<DcAwareHost> hosts) {
         hosts.forEach(this::add);
     }
 
-    public void remove(InetSocketAddress host) {
+    public void remove(DcAwareHost host) {
         blacklist.remove(host);
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientImpl.java
@@ -82,7 +82,6 @@ public class CassandraClientImpl implements CassandraClient {
             ConsistencyLevel consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, TException {
         ColumnParent colFam = getColumnParent(tableRef);
-
         return executeHandlingExceptions(() -> client.multiget_slice(keys, colFam, predicate, consistency_level));
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
@@ -15,28 +15,28 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
+import com.palantir.atlasdb.keyvalue.cassandra.pool.DcAwareHost;
 import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.processors.AutoDelegate;
-import java.net.InetSocketAddress;
 import java.util.Map;
 
 @AutoDelegate
 public interface CassandraClientPool {
     FunctionCheckedException<CassandraClient, Void, Exception> getValidatePartitioner();
 
-    <V, K extends Exception> V runOnHost(
-            InetSocketAddress specifiedHost, FunctionCheckedException<CassandraClient, V, K> fn) throws K;
+    <V, K extends Exception> V runOnHost(DcAwareHost specifiedHost, FunctionCheckedException<CassandraClient, V, K> fn)
+            throws K;
 
     <V, K extends Exception> V run(FunctionCheckedException<CassandraClient, V, K> fn) throws K;
 
     <V, K extends Exception> V runWithRetryOnHost(
-            InetSocketAddress specifiedHost, FunctionCheckedException<CassandraClient, V, K> fn) throws K;
+            DcAwareHost specifiedHost, FunctionCheckedException<CassandraClient, V, K> fn) throws K;
 
     <V, K extends Exception> V runWithRetry(FunctionCheckedException<CassandraClient, V, K> fn) throws K;
 
-    InetSocketAddress getRandomHostForKey(byte[] key);
+    DcAwareHost getRandomHostForKey(byte[] key);
 
-    Map<InetSocketAddress, CassandraClientPoolingContainer> getCurrentPools();
+    Map<DcAwareHost, CassandraClientPoolingContainer> getCurrentPools();
 
     void shutdown();
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -22,6 +22,7 @@ import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraClientPoolHostLevelMetric;
 import com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraClientPoolMetrics;
+import com.palantir.atlasdb.keyvalue.cassandra.pool.DcAwareHost;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.common.concurrent.ThreadNames;
@@ -57,6 +58,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Cassand
     private static final SafeLogger log = SafeLoggerFactory.get(CassandraClientPoolingContainer.class);
 
     private final InetSocketAddress host;
+    private final DcAwareHost dcAwareHost;
     private final CassandraKeyValueServiceConfig config;
     private final MetricsManager metricsManager;
     private final AtomicLong count = new AtomicLong();
@@ -68,12 +70,13 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Cassand
 
     public CassandraClientPoolingContainer(
             MetricsManager metricsManager,
-            InetSocketAddress host,
+            DcAwareHost dcAwareHost,
             CassandraKeyValueServiceConfig config,
             int poolNumber,
             CassandraClientPoolMetrics poolMetrics) {
         this.metricsManager = metricsManager;
-        this.host = host;
+        this.host = dcAwareHost.address();
+        this.dcAwareHost = dcAwareHost;
         this.config = config;
         this.poolNumber = poolNumber;
         this.poolMetrics = poolMetrics;
@@ -83,6 +86,10 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Cassand
 
     public InetSocketAddress getHost() {
         return host;
+    }
+
+    public DcAwareHost getDcAwareHost() {
+        return dcAwareHost;
     }
 
     /**

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandler.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandler.java
@@ -17,12 +17,12 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.palantir.atlasdb.keyvalue.api.InsufficientConsistencyException;
+import com.palantir.atlasdb.keyvalue.cassandra.pool.DcAwareHost;
 import com.palantir.common.exception.AtlasDbDependencyException;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
-import java.net.InetSocketAddress;
 import java.net.SocketTimeoutException;
 import java.time.Duration;
 import java.util.NoSuchElementException;
@@ -71,7 +71,7 @@ class CassandraRequestExceptionHandler {
 
     @SuppressWarnings("unchecked")
     <K extends Exception> void handleExceptionFromRequest(
-            RetryableCassandraRequest<?, K> req, InetSocketAddress hostTried, Exception ex) throws K {
+            RetryableCassandraRequest<?, K> req, DcAwareHost hostTried, Exception ex) throws K {
         if (!isRetryable(ex)) {
             throw (K) ex;
         }
@@ -146,7 +146,7 @@ class CassandraRequestExceptionHandler {
 
     private <K extends Exception> void handleBackoff(
             RetryableCassandraRequest<?, K> req,
-            InetSocketAddress hostTried,
+            DcAwareHost hostTried,
             Exception ex,
             RequestExceptionHandlerStrategy strategy) {
         if (!shouldBackoff(ex, strategy)) {
@@ -175,7 +175,7 @@ class CassandraRequestExceptionHandler {
 
     private <K extends Exception> void handleRetryOnDifferentHosts(
             RetryableCassandraRequest<?, K> req,
-            InetSocketAddress hostTried,
+            DcAwareHost hostTried,
             Exception ex,
             RequestExceptionHandlerStrategy strategy) {
         if (shouldRetryOnDifferentHost(ex, req.getNumberOfAttemptsOnHost(hostTried), strategy)) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellDeleter.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellDeleter.java
@@ -21,10 +21,10 @@ import com.google.common.collect.Ordering;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.RetryLimitReachedException;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.cassandra.pool.DcAwareHost;
 import com.palantir.atlasdb.keyvalue.cassandra.thrift.MutationMap;
 import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.common.base.Throwables;
-import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Collections;
@@ -54,17 +54,15 @@ class CellDeleter {
     }
 
     void delete(TableReference tableRef, Multimap<Cell, Long> keys) {
-        Map<InetSocketAddress, Map<Cell, Collection<Long>>> keysByHost =
+        Map<DcAwareHost, Map<Cell, Collection<Long>>> keysByHost =
                 HostPartitioner.partitionMapByHost(clientPool, keys.asMap().entrySet());
-        for (Map.Entry<InetSocketAddress, Map<Cell, Collection<Long>>> entry : keysByHost.entrySet()) {
+        for (Map.Entry<DcAwareHost, Map<Cell, Collection<Long>>> entry : keysByHost.entrySet()) {
             deleteOnSingleHost(entry.getKey(), tableRef, entry.getValue());
         }
     }
 
     private void deleteOnSingleHost(
-            final InetSocketAddress host,
-            final TableReference tableRef,
-            final Map<Cell, Collection<Long>> cellVersionsMap) {
+            final DcAwareHost host, final TableReference tableRef, final Map<Cell, Collection<Long>> cellVersionsMap) {
         try {
             clientPool.runWithRetryOnHost(host, new FunctionCheckedException<CassandraClient, Void, Exception>() {
                 private int numVersions = 0;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoadingBatcher.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoadingBatcher.java
@@ -25,7 +25,7 @@ import com.google.common.primitives.UnsignedBytes;
 import com.palantir.atlasdb.cassandra.CassandraCellLoadingConfig;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
-import java.net.InetSocketAddress;
+import com.palantir.atlasdb.keyvalue.cassandra.pool.DcAwareHost;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -60,7 +60,7 @@ final class CellLoadingBatcher {
     }
 
     List<List<Cell>> partitionIntoBatches(
-            Collection<Cell> cellsToPartition, InetSocketAddress host, TableReference tableReference) {
+            Collection<Cell> cellsToPartition, DcAwareHost host, TableReference tableReference) {
         CassandraCellLoadingConfig config = loadingConfigSupplier.get();
 
         ListMultimap<byte[], Cell> cellsByColumn = indexCellsByColumnName(cellsToPartition);
@@ -82,10 +82,7 @@ final class CellLoadingBatcher {
     }
 
     private List<List<Cell>> partitionBySingleQueryLoadBatchLimit(
-            List<Cell> cells,
-            CassandraCellLoadingConfig config,
-            InetSocketAddress host,
-            TableReference tableReference) {
+            List<Cell> cells, CassandraCellLoadingConfig config, DcAwareHost host, TableReference tableReference) {
         if (cells.size() > config.singleQueryLoadBatchLimit()) {
             rebatchingManyRowsForColumnCallback.consume(host, tableReference, cells.size());
             return Lists.partition(cells, config.singleQueryLoadBatchLimit());
@@ -110,6 +107,6 @@ final class CellLoadingBatcher {
 
     @FunctionalInterface
     interface BatchCallback {
-        void consume(InetSocketAddress host, TableReference tableReference, int numRows);
+        void consume(DcAwareHost host, TableReference tableReference, int numRows);
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
@@ -79,7 +79,7 @@ public class CassandraService implements AutoCloseable {
     private final CassandraClientPoolMetrics poolMetrics;
 
     private volatile RangeMap<LightweightOppToken, List<InetSocketAddress>> tokenMap = ImmutableRangeMap.of();
-    private final Map<InetSocketAddress, CassandraClientPoolingContainer> currentPools = new ConcurrentHashMap<>();
+    private final Map<DcAwareHost, CassandraClientPoolingContainer> currentPools = new ConcurrentHashMap<>();
 
     private List<InetSocketAddress> cassandraHosts;
 
@@ -272,11 +272,10 @@ public class CassandraService implements AutoCloseable {
         return tokenMap.get(new LightweightOppToken(key));
     }
 
-    public Optional<CassandraClientPoolingContainer> getRandomGoodHostForPredicate(
-            Predicate<InetSocketAddress> predicate) {
-        Map<InetSocketAddress, CassandraClientPoolingContainer> pools = currentPools;
+    public Optional<CassandraClientPoolingContainer> getRandomGoodHostForPredicate(Predicate<DcAwareHost> predicate) {
+        Map<DcAwareHost, CassandraClientPoolingContainer> pools = currentPools;
 
-        Set<InetSocketAddress> filteredHosts =
+        Set<DcAwareHost> filteredHosts =
                 pools.keySet().stream().filter(predicate).collect(Collectors.toSet());
         if (filteredHosts.isEmpty()) {
             log.info("No hosts match the provided predicate.");

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/DcAwareHost.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/DcAwareHost.java
@@ -17,6 +17,9 @@
 package com.palantir.atlasdb.keyvalue.cassandra.pool;
 
 import java.net.InetSocketAddress;
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -30,5 +33,9 @@ public interface DcAwareHost {
                 .datacenter(datacenter)
                 .address(address)
                 .build();
+    }
+
+    static Set<InetSocketAddress> addresses(Collection<DcAwareHost> hosts) {
+        return hosts.stream().map(DcAwareHost::address).collect(Collectors.toSet());
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/DcAwareHost.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/DcAwareHost.java
@@ -1,0 +1,34 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra.pool;
+
+import java.net.InetSocketAddress;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface DcAwareHost {
+    String datacenter();
+
+    InetSocketAddress address();
+
+    static DcAwareHost of(String datacenter, InetSocketAddress address) {
+        return ImmutableDcAwareHost.builder()
+                .datacenter(datacenter)
+                .address(address)
+                .build();
+    }
+}

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoadingBatcherTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoadingBatcherTest.java
@@ -30,6 +30,7 @@ import com.palantir.atlasdb.cassandra.ImmutableCassandraCellLoadingConfig;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.cassandra.pool.DcAwareHost;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -52,7 +53,7 @@ public class CellLoadingBatcherTest {
             .singleQueryLoadBatchLimit(SINGLE_QUERY_LIMIT)
             .build();
 
-    private static final InetSocketAddress ADDRESS = new InetSocketAddress(42);
+    private static final DcAwareHost ADDRESS = DcAwareHost.of("the-answer-is", new InetSocketAddress(42));
     private static final TableReference TABLE_REFERENCE = TableReference.createFromFullyQualifiedName("a.b");
     private static final int SEED = 1;
 

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/RetryableCassandraRequestTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/RetryableCassandraRequestTest.java
@@ -17,6 +17,7 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.palantir.atlasdb.keyvalue.cassandra.pool.DcAwareHost;
 import com.palantir.common.base.FunctionCheckedException;
 import java.net.InetSocketAddress;
 import org.junit.Before;
@@ -26,8 +27,10 @@ public class RetryableCassandraRequestTest {
     private static final int DEFAULT_PORT = 5000;
     private static final String HOSTNAME_1 = "1.0.0.0";
     private static final String HOSTNAME_2 = "2.0.0.0";
-    private static final InetSocketAddress HOST_1 = InetSocketAddress.createUnresolved(HOSTNAME_1, DEFAULT_PORT);
-    private static final InetSocketAddress HOST_2 = InetSocketAddress.createUnresolved(HOSTNAME_2, DEFAULT_PORT);
+    private static final DcAwareHost HOST_1 =
+            DcAwareHost.of("foo", InetSocketAddress.createUnresolved(HOSTNAME_1, DEFAULT_PORT));
+    private static final DcAwareHost HOST_2 =
+            DcAwareHost.of("foo", InetSocketAddress.createUnresolved(HOSTNAME_2, DEFAULT_PORT));
 
     private RetryableCassandraRequest<Void, RuntimeException> request;
 
@@ -75,7 +78,7 @@ public class RetryableCassandraRequestTest {
         assertThat(request.getNumberOfAttempts()).isEqualTo(expected);
     }
 
-    private void assertNumberOfAttemptsOnHost(int expected, InetSocketAddress host) {
+    private void assertNumberOfAttemptsOnHost(int expected, DcAwareHost host) {
         assertThat(request.getNumberOfAttemptsOnHost(host)).isEqualTo(expected);
     }
 


### PR DESCRIPTION
**Goals (and why)**:
==COMMIT_MSG==
When retrying Cassandra calls, retries will attempt to use hosts with a different datacenter to the one that failed.
==COMMIT_MSG==

**Implementation Description (bullets)**:
* Change the current pools map in `CassandraService` to use a key that is aware of both the host and the datacenter
WIP

**Testing (What was existing testing like?  What have you done to improve it?)**:
WIP

**Concerns (what feedback would you like?)**:
WIP - although also concerns about datacenters missing from the config

**Where should we start reviewing?**:
WIP

**Priority (whenever / two weeks / yesterday)**:
As soon as this is done