### PR TITLE
Allow datacenter configuration error to be disabled

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -358,10 +358,12 @@ public final class CassandraVerifier {
             KsDef ks, CassandraKeyValueServiceConfig config, Set<String> dcs, Map<String, String> strategyOptions) {
         for (String datacenter : dcs) {
             if (Integer.parseInt(strategyOptions.get(datacenter)) != config.replicationFactor()) {
-                throw new UnsupportedOperationException("Your current Cassandra keyspace (" + ks.getName()
-                        + ") has a replication factor not matching your Atlas Cassandra configuration."
-                        + " Change them to match, but be mindful of what steps you'll need to"
-                        + " take to correctly repair or cleanup existing data in your cluster.");
+                logErrorOrThrow(
+                        "Your current Cassandra keyspace (" + ks.getName()
+                                + ") has a replication factor not matching your Atlas Cassandra configuration."
+                                + " Change them to match, but be mindful of what steps you'll need to"
+                                + " take to correctly repair or cleanup existing data in your cluster.",
+                        config.ignoreDatacenterConfigurationChecks());
             }
         }
     }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifierTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifierTest.java
@@ -249,7 +249,7 @@ public class CassandraVerifierTest {
         when(config.replicationFactor()).thenReturn(1);
         assertThatThrownBy(() -> CassandraVerifier.sanityCheckReplicationFactor(
                         ksDef, config, ImmutableSortedSet.of(DC_1, DC_2)))
-                .isInstanceOf(UnsupportedOperationException.class);
+                .isInstanceOf(IllegalStateException.class);
     }
 
     private void setTopology(EndpointDetails... details) throws TException {

--- a/changelog/@unreleased/pr-5901.v2.yml
+++ b/changelog/@unreleased/pr-5901.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Allow datacenter configuration error to be disabled via config
+  links:
+  - https://github.com/palantir/atlasdb/pull/5901


### PR DESCRIPTION
**Goals (and why)**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Allow datacenter configuration error to be disabled via config
==COMMIT_MSG==

**Implementation Description (bullets)**:
This is a tiny one, but we don't actually use `ignoreDatacenterConfigurationChecks` anywhere.  We would prefer that our backup service does not fail on this check, so we would like to take advantage of that config point.

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
