### PR TITLE
[PDS-247002] Don't Throw CheckAndSetException Out Of Transactions

### DIFF
--- a/changelog/@unreleased/pr-5912.v2.yml
+++ b/changelog/@unreleased/pr-5912.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: AtlasDB no longer throws `CheckAndSetException` out of transactional
+    gets. This could happen for Transactions3 users, because gets may require a user
+    to touch a value atomically, and if this touch fails then the aforementioned exception
+    will be thrown.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5912


### PR DESCRIPTION
**Goals (and why)**:
==COMMIT_MSG==
AtlasDB no longer throws `CheckAndSetException` out of transactional gets. This could happen for Transactions3 users, because gets may require a user to touch a value atomically, and if this touch fails then the aforementioned exception will be thrown.
==COMMIT_MSG==

**Implementation Description (bullets)**:
- Catch `CheckAndSetExceptions` if they arise from gets to the transaction service inside SnapshotTransaction, and convert them to a `TransactionFailedRetryableException`.

**Testing (What was existing testing like?  What have you done to improve it?)**: relying on existing tests.

**Concerns (what feedback would you like?)**:
Is failing correct / should we re-read the value and try again?

**Where should we start reviewing?**: small-ish

**Priority (whenever / two weeks / yesterday)**: this week
