### PR TITLE
Do not fail if someone already committed our value

### DIFF
--- a/atlasdb-cassandra-integration-tests/build.gradle
+++ b/atlasdb-cassandra-integration-tests/build.gradle
@@ -45,17 +45,11 @@ dependencies {
     testImplementation group: 'com.palantir.docker.compose', name: 'docker-compose-rule-core'
 }
 
-task longTest(type: Test) {
-    include '**/CassandraKeyValueServiceTransactionIntegrationTest.class'
-}
-
 task memorySensitiveTest(type: Test) {
     include '**/CassandraKeyValueServiceSweepTaskRunnerIntegrationTest.class'
 }
 
 test {
-    dependsOn longTest
-    exclude '**/CassandraKeyValueServiceTransactionIntegrationTest.class'
     exclude '**/CassandraKeyValueServiceSweepTaskRunnerIntegrationTest.class'
 }
 

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraBackedPueTableTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraBackedPueTableTest.java
@@ -82,10 +82,7 @@ public class CassandraBackedPueTableTest {
 
             List<ListenableFuture<Map<Long, Long>>> reads = new ArrayList<>();
             for (int i = 0; i < singlePartition.size(); i++) {
-                reads.add(Futures.transform(
-                        readExecutors.submit(() -> pueTable.get(singlePartition)),
-                        Futures::getUnchecked,
-                        MoreExecutors.directExecutor()));
+                reads.add(Futures.submitAsync(() -> pueTable.get(singlePartition), readExecutors));
             }
             Futures.allAsList(reads).get().forEach(singleResult -> {
                 for (long ts : singlePartition) {

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraBackedPueTableTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraBackedPueTableTest.java
@@ -1,0 +1,90 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.atlasdb.containers.CassandraResource;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.pue.ConsensusForgettingStore;
+import com.palantir.atlasdb.pue.KvsConsensusForgettingStore;
+import com.palantir.atlasdb.pue.PutUnlessExistsTable;
+import com.palantir.atlasdb.pue.ResilientCommitTimestampPutUnlessExistsTable;
+import com.palantir.atlasdb.table.description.TableMetadata;
+import com.palantir.atlasdb.transaction.encoding.TwoPhaseEncodingStrategy;
+import com.palantir.atlasdb.transaction.impl.TransactionConstants;
+import com.palantir.common.concurrent.PTExecutors;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class CassandraBackedPueTableTest {
+    private KeyValueService kvs = CASSANDRA.getDefaultKvs();
+    private ConsensusForgettingStore store =
+            new KvsConsensusForgettingStore(kvs, TransactionConstants.TRANSACTIONS2_TABLE);
+    private PutUnlessExistsTable<Long, Long> pueTable =
+            new ResilientCommitTimestampPutUnlessExistsTable(store, TwoPhaseEncodingStrategy.INSTANCE);
+
+    @ClassRule
+    public static final CassandraResource CASSANDRA = new CassandraResource();
+
+    @Before
+    public void setup() {
+        kvs.createTable(
+                TransactionConstants.TRANSACTIONS2_TABLE,
+                TableMetadata.allDefault().persistToBytes());
+    }
+
+    @Test
+    public void getDoesNotLeakExceptionsInRaceConditions() throws ExecutionException, InterruptedException {
+        ExecutorService writeExecutor = PTExecutors.newFixedThreadPool(1);
+        ExecutorService readExecutors = PTExecutors.newFixedThreadPool(10);
+
+        List<Long> timestamps = LongStream.range(0, 500).mapToObj(x -> x * 100).collect(Collectors.toList());
+        Iterable<List<Long>> partitionedStartTimestamps = Iterables.partition(timestamps, 20);
+        for (List<Long> singlePartition : partitionedStartTimestamps) {
+            singlePartition.forEach(
+                    timestamp -> writeExecutor.submit(() -> pueTable.putUnlessExists(timestamp, timestamp)));
+
+            List<Future<ListenableFuture<Map<Long, Long>>>> reads = new ArrayList<>();
+            for (int i = 0; i < singlePartition.size(); i++) {
+                reads.add(readExecutors.submit(() -> pueTable.get(singlePartition)));
+            }
+            for (Future<ListenableFuture<Map<Long, Long>>> oneFuture : reads) {
+                Map<Long, Long> result = oneFuture.get().get();
+                for (long ts : singlePartition) {
+                    assertCommitTimestampAbsentOrEqualToStartTimestamp(result, ts);
+                }
+            }
+        }
+    }
+
+    private static void assertCommitTimestampAbsentOrEqualToStartTimestamp(Map<Long, Long> result, long ts) {
+        Optional.ofNullable(result.get(ts)).ifPresent(commitTs -> assertThat(ts).isEqualTo(commitTs));
+    }
+}

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraBackedPueTableTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraBackedPueTableTest.java
@@ -82,6 +82,9 @@ public class CassandraBackedPueTableTest {
                 }
             }
         }
+
+        writeExecutor.shutdownNow();
+        readExecutors.shutdownNow();
     }
 
     private static void assertCommitTimestampAbsentOrEqualToStartTimestamp(Map<Long, Long> result, long ts) {

--- a/changelog/@unreleased/pr-5915.v2.yml
+++ b/changelog/@unreleased/pr-5915.v2.yml
@@ -1,6 +1,5 @@
 type: fix
 fix:
-  description: Fixed a race condition in _transactions3 where a race condition could
-    cause reads to throw a CheckAndSetException.
+  description: Fixed a race condition in _transactions3 where reads could throw a CheckAndSetException.
   links:
   - https://github.com/palantir/atlasdb/pull/5915

--- a/changelog/@unreleased/pr-5915.v2.yml
+++ b/changelog/@unreleased/pr-5915.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fixed a race condition in _transactions3 where a race condition could
+    cause reads to throw a CheckAndSetException.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5915


### PR DESCRIPTION
**Goals (and why)**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixed a race condition in _transactions3 where a race condition could cause reads to throw a CheckAndSetException.
==COMMIT_MSG==

**Implementation Description (bullets)**:
We know from the proof in the ADR that this failure can only happen if someone committed the commit timestamp that we wanted to CAS as staging. We therefore verify everything is as expected and carry on.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added a Cassandra integration test that was failing before the fix

**Concerns (what feedback would you like?)**:
Note that doing CAS one by one is not a regression -- this was already the case before in the happy path
Also incidentally fixed some weirdness in the build.gradle -- this longTest is actually not referred anywhere I can tell, but for some reason it was making me unable to run tests locally.

**Where should we start reviewing?**:
small

**Priority (whenever / two weeks / yesterday)**:
🔥 
