### PR TITLE
ABR 19: Fix restore

### DIFF
--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -345,10 +345,15 @@ public class TimeLockAgent {
 
         registrar.accept(resource);
 
-        Function<String, AsyncTimelockService> asyncTimelockServiceGetter =
-                namespace -> namespaces.get(namespace).getTimelockService();
         Function<String, LockService> lockServiceGetter =
                 namespace -> namespaces.get(namespace).getLockService();
+        Function<String, AsyncTimelockService> asyncTimelockServiceGetter =
+                namespace -> namespaces.get(namespace).getTimelockService();
+
+        // TODO(gs): use BackupTimeLockServiceView?
+        // strictly for restore operations
+        Function<String, AsyncTimelockService> asyncTimelockServiceGetterIgnoringDisabled =
+                namespace -> namespaces.getIgnoringDisabled(namespace).getTimelockService();
 
         AuthHeaderValidator authHeaderValidator = getAuthHeaderValidator();
         RedirectRetryTargeter redirectRetryTargeter = redirectRetryTargeter();
@@ -375,7 +380,7 @@ public class TimeLockAgent {
             registerCorruptionHandlerWrappedService(
                     presentUndertowRegistrar,
                     AtlasRestoreResource.undertow(
-                            authHeaderValidator, redirectRetryTargeter, asyncTimelockServiceGetter));
+                            authHeaderValidator, redirectRetryTargeter, asyncTimelockServiceGetterIgnoringDisabled));
             registerCorruptionHandlerWrappedService(
                     presentUndertowRegistrar,
                     DisabledNamespacesUpdaterResource.undertow(authHeaderValidator, redirectRetryTargeter, namespaces));
@@ -389,7 +394,7 @@ public class TimeLockAgent {
             registrar.accept(
                     AtlasBackupResource.jersey(authHeaderValidator, redirectRetryTargeter, asyncTimelockServiceGetter));
             registrar.accept(AtlasRestoreResource.jersey(
-                    authHeaderValidator, redirectRetryTargeter, asyncTimelockServiceGetter));
+                    authHeaderValidator, redirectRetryTargeter, asyncTimelockServiceGetterIgnoringDisabled));
             registrar.accept(
                     DisabledNamespacesUpdaterResource.jersey(authHeaderValidator, redirectRetryTargeter, namespaces));
         }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimelockNamespaces.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimelockNamespaces.java
@@ -83,6 +83,10 @@ public final class TimelockNamespaces {
         return timeLockServices;
     }
 
+    public BackupTimeLockServiceView getForRestore(String namespace) {
+        return getIgnoringDisabled(namespace).getTimelockService();
+    }
+
     public TimeLockServices getIgnoringDisabled(String namespace) {
         return services.computeIfAbsent(namespace, ns -> createNewClient(ns, true));
     }


### PR DESCRIPTION
**Goals (and why)**:
Restore was failing in internal testing as it attempted to fetch a timelock service without ignoring that it's disabled

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Allow AtlasRestoreService to communicate with TimeLock while the namespace is disabled.
==COMMIT_MSG==

