### PR TITLE
No db lookup when checking for disabled namespaces

### DIFF
--- a/changelog/@unreleased/pr-5922.v2.yml
+++ b/changelog/@unreleased/pr-5922.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Avoid refetching disabled namespaces on every request.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5922

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/DisabledNamespaces.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/DisabledNamespaces.java
@@ -47,7 +47,7 @@ public class DisabledNamespaces {
 
     private Set<Namespace> disabledNamespaces;
 
-    public DisabledNamespaces(Jdbi jdbi) {
+    private DisabledNamespaces(Jdbi jdbi) {
         this.jdbi = jdbi;
     }
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/DisabledNamespaces.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/DisabledNamespaces.java
@@ -26,7 +26,6 @@ import com.palantir.common.streams.KeyedStream;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -41,6 +40,7 @@ import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.sqlobject.transaction.Transaction;
 
+@SuppressWarnings("FinalClass") // mocked in tests
 public class DisabledNamespaces {
     private static final SafeLogger log = SafeLoggerFactory.get(DisabledNamespaces.class);
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/DisabledNamespaces.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/DisabledNamespaces.java
@@ -76,7 +76,7 @@ public class DisabledNamespaces {
     Set<Namespace> disabledNamespaces() {
         return execute(Queries::getAllStates).stream()
                 .map(Namespace::of)
-                .collect(Collectors.toCollection(HashSet::new));
+                .collect(Collectors.toCollection(Sets::newConcurrentHashSet));
     }
 
     public Map<Namespace, String> getNamespacesLockedWithDifferentLockId(


### PR DESCRIPTION
**Goals (and why)**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Avoid refetching disabled namespaces on every request.
==COMMIT_MSG==

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**: 🔥 

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
