### PR TITLE
[AtlasDB Proxy & Oracle] Part 2: Allow Dollar Suffixes For Table Prefixes

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfig.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfig.java
@@ -128,11 +128,13 @@ public abstract class OracleDdlConfig extends DdlConfig {
         Preconditions.checkState(tablePrefix() != null, "Oracle 'tablePrefix' cannot be null.");
         Preconditions.checkState(!tablePrefix().isEmpty(), "Oracle 'tablePrefix' must not be an empty string.");
         Preconditions.checkState(!tablePrefix().startsWith("_"), "Oracle 'tablePrefix' cannot begin with underscore.");
-        Preconditions.checkState(tablePrefix().endsWith("_"), "Oracle 'tablePrefix' must end with an underscore.");
+        Preconditions.checkState(tablePrefix().endsWith("_") || tablePrefix().endsWith("$"), "Oracle 'tablePrefix' "
+                + "must end with an underscore or a dollar sign.");
         Preconditions.checkState(
                 !overflowTablePrefix().startsWith("_"), "Oracle 'overflowTablePrefix' cannot begin with underscore.");
         Preconditions.checkState(
-                overflowTablePrefix().endsWith("_"), "Oracle 'overflowTablePrefix' must end with an underscore.");
+                overflowTablePrefix().endsWith("_") || overflowTablePrefix().endsWith("$"), "Oracle "
+                        + "'overflowTablePrefix' must end with an underscore or a dollar sign.");
 
         checkTablePrefixLengthLimits();
 

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfigTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfigTest.java
@@ -41,10 +41,13 @@ public class OracleDdlConfigTest {
     }
 
     @Test
-    public void tablePrefixesMustEndWithUnderscore() {
+    public void tablePrefixesMustEndWithUnderscoreOrDollarSign() {
         assertThatThrownBy(() -> createLegacyCompatibleOracleConfigWithPrefixes("a", ACCEPTED_OVERFLOW_PREFIX))
                 .isInstanceOf(SafeIllegalStateException.class)
-                .hasMessageContaining("'tablePrefix' must end with an underscore");
+                .hasMessageContaining("'tablePrefix' must end with an underscore or a dollar sign");
+        assertThatCode(() ->
+                createLegacyCompatibleOracleConfigWithPrefixes("a$", ACCEPTED_OVERFLOW_PREFIX))
+                .doesNotThrowAnyException();
     }
 
     @Test
@@ -55,10 +58,13 @@ public class OracleDdlConfigTest {
     }
 
     @Test
-    public void overflowTablePrefixesMustEndWithUnderscore() {
+    public void overflowTablePrefixesMustEndWithUnderscoreOrDollarSign() {
         assertThatThrownBy(() -> createLegacyCompatibleOracleConfigWithPrefixes(ACCEPTED_PREFIX, "ao"))
                 .isInstanceOf(SafeIllegalStateException.class)
-                .hasMessageContaining("'overflowTablePrefix' must end with an underscore");
+                .hasMessageContaining("'overflowTablePrefix' must end with an underscore or a dollar sign");
+        assertThatCode(() ->
+                createLegacyCompatibleOracleConfigWithPrefixes(ACCEPTED_PREFIX, "b$"))
+                .doesNotThrowAnyException();
     }
 
     @Test


### PR DESCRIPTION
**Goals (and why)**:
- Consider the way in which internal storage proxy produces names. These consist of a namespace which we plan to populate the table prefix with and a table name. With underscores, it's possible (if awkward) for users to have tables resolve to exactly the same value: a scheme of `namespace_tablename` will not work because namespaces are of the form `A_B_C` and tables arbitrary strings `D`, and thus there is a risk that `A_B1_C1_B2_C2_E` resolves to `A_B1_C1 . B2_C2_E` *or* `A_B1_C1_B2_C2 . E`.
- We thus introduce the novel character of a dollar sign.
==COMMIT_MSG==
Dollar signs are now permitted as a suffix to a table prefix in DbKVS.
==COMMIT_MSG==

**Implementation Description (bullets)**:
- Permit dollar signs to end table prefixes.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Added tests for this specific case.

**Concerns (what feedback would you like?)**:
- Might this end up getting misused?

**Where should we start reviewing?**: small

**Priority (whenever / two weeks / yesterday)**: this week