### PR TITLE
Streamline SQL BLOB cleanup

### DIFF
--- a/changelog/@unreleased/pr-5933.v2.yml
+++ b/changelog/@unreleased/pr-5933.v2.yml
@@ -1,0 +1,10 @@
+type: improvement
+improvement:
+  description: |-
+    Streamline SQL BLOB cleanup
+
+    Avoid wrapping prepared statements to handle BLOB cleanup when there are
+    no BLOBs that need cleanup. Refactor to reuse BLOB temporary cleanup
+    logic and avoid iterable allocation overhead when no BLOBs are used.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5933


### PR DESCRIPTION
**Goals (and why)**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Streamline SQL BLOB cleanup

Avoid wrapping prepared statements to handle BLOB cleanup when there are
no BLOBs that need cleanup. Refactor to reuse BLOB temporary cleanup
logic and avoid iterable allocation overhead when no BLOBs are used.
==COMMIT_MSG==

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
