### PR TITLE
Fix NPE caused by txn commit race condition

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/pue/ResilientCommitTimestampPutUnlessExistsTable.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/pue/ResilientCommitTimestampPutUnlessExistsTable.java
@@ -102,6 +102,8 @@ public class ResilientCommitTimestampPutUnlessExistsTable implements PutUnlessEx
                         SafeArg.of("kvsValue", kvsValue),
                         SafeArg.of("stagingValue", currentValue));
             } finally {
+                // If we got here after catching CheckAndSetException, then some other thread committed this
+                // transaction, and we must therefore return the commit timestamp.
                 resultBuilder.put(startTs, commitTs);
             }
         }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/pue/ResilientCommitTimestampPutUnlessExistsTable.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/pue/ResilientCommitTimestampPutUnlessExistsTable.java
@@ -91,6 +91,7 @@ public class ResilientCommitTimestampPutUnlessExistsTable implements PutUnlessEx
             // if we reach here, actual is guaranteed to be a staging value
             try {
                 store.checkAndTouch(cell, actual);
+                checkAndTouch.put(cell, actual);
             } catch (CheckAndSetException e) {
                 PutUnlessExistsValue<Long> kvsValue = encodingStrategy.decodeValueAsCommitTimestamp(
                         startTs, Iterables.getOnlyElement(e.getActualValues()));
@@ -100,10 +101,9 @@ public class ResilientCommitTimestampPutUnlessExistsTable implements PutUnlessEx
                                 + "was found in the KVS",
                         SafeArg.of("kvsValue", kvsValue),
                         SafeArg.of("stagingValue", currentValue));
-                continue;
+            } finally {
+                resultBuilder.put(startTs, commitTs);
             }
-            checkAndTouch.put(cell, actual);
-            resultBuilder.put(startTs, commitTs);
         }
         store.put(KeyedStream.stream(checkAndTouch)
                 .map(encodingStrategy::transformStagingToCommitted)

--- a/changelog/@unreleased/pr-5940.v2.yml
+++ b/changelog/@unreleased/pr-5940.v2.yml
@@ -1,6 +1,8 @@
 type: fix
 fix:
-  description: Fixed a race condition where if a transaction was just committed by
-    another thread, we may return null values from TransactionService.get.
+  description: 'Fixed a race condition where if a transaction was just committed by
+    another thread, users would receive null values from TransactionService.get. This
+    caused users to observe that a completed transaction was still running, but did
+    not lead to any correctness issue. '
   links:
   - https://github.com/palantir/atlasdb/pull/5940

--- a/changelog/@unreleased/pr-5940.v2.yml
+++ b/changelog/@unreleased/pr-5940.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fixed a race condition where if a transaction was just committed by
+    another thread, we may return null values from TransactionService.get.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5940


### PR DESCRIPTION
**Goals (and why)**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixed a race condition where if a transaction was just committed by another thread, we may return null values from TransactionService.get.
==COMMIT_MSG==

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Added a unit test that failed without the first commit

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**: today

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
