### PR TITLE
[AtlasDB Proxy & DbKVS] Part 6: Deserialisable Internal Configs

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/spi/LocalConnectionConfig.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/spi/LocalConnectionConfig.java
@@ -16,9 +16,11 @@
 
 package com.palantir.atlasdb.spi;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.immutables.value.Value;
 
 @Value.Immutable
+@JsonDeserialize(as = ImmutableLocalConnectionConfig.class)
 public interface LocalConnectionConfig {
     int poolSize();
 

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/spi/SharedResourcesConfig.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/spi/SharedResourcesConfig.java
@@ -16,9 +16,11 @@
 
 package com.palantir.atlasdb.spi;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.immutables.value.Value;
 
 @Value.Immutable
+@JsonDeserialize(as = ImmutableSharedResourcesConfig.class)
 public interface SharedResourcesConfig {
     int sharedGetRangesPoolSize();
 

--- a/changelog/@unreleased/pr-5941.v2.yml
+++ b/changelog/@unreleased/pr-5941.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: '`LocalConnectionConfig` and `SharedResourcesConfig` may now be deserialised
+    from config.'
+  links:
+  - https://github.com/palantir/atlasdb/pull/5941


### PR DESCRIPTION
**Goals (and why)**:
==COMMIT_MSG==
`LocalConnectionConfig` and `SharedResourcesConfig` may now be deserialised from config.
==COMMIT_MSG==

**Implementation Description (bullets)**:
- Add JsonDeserialize annotations

**Testing (What was existing testing like?  What have you done to improve it?)**:
None. It's awkward to do so as the in memory config works differently from expected.

**Concerns (what feedback would you like?)**:
- Am I missing some other classes somewhere?

**Where should we start reviewing?**: small

**Priority (whenever / two weeks / yesterday)**: yesterday 🔥 
