### PR TITLE
[AtlasDB Proxy & DbKVS] Part 7: Allow Namespace Overrides for Oracle Connection Config

### DIFF
--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/OracleConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/OracleConnectionConfig.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
-import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import com.palantir.nexus.db.DBType;
@@ -31,7 +30,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
 import org.immutables.value.Value;
 
 @JsonDeserialize(as = ImmutableOracleConnectionConfig.class)
@@ -74,16 +72,11 @@ public abstract class OracleConnectionConfig extends ConnectionConfig {
     @Value.Derived
     @JsonIgnore
     public Optional<String> namespace() {
-        return Stream.of(
-                        namespaceOverride(),
-                        getSid(),
-                        serviceNameConfiguration().map(ServiceNameConfiguration::namespaceOverride))
-                .filter(Optional::isPresent)
-                .findFirst()
-                .orElseThrow(() -> new SafeIllegalStateException("Could not determine namespace for Oracle config"));
+        if (getSid().isPresent()) {
+            return getSid();
+        }
+        return serviceNameConfiguration().map(ServiceNameConfiguration::namespaceOverride);
     }
-
-    public abstract Optional<String> namespaceOverride();
 
     @Override
     @Value.Default

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/OracleConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/OracleConnectionConfig.java
@@ -78,6 +78,7 @@ public abstract class OracleConnectionConfig extends ConnectionConfig {
                         namespaceOverride(),
                         getSid(),
                         serviceNameConfiguration().map(ServiceNameConfiguration::namespaceOverride))
+                .filter(Optional::isPresent)
                 .findFirst()
                 .orElseThrow(() -> new SafeIllegalStateException("Could not determine namespace for Oracle config"));
     }

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/OracleConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/OracleConnectionConfig.java
@@ -15,7 +15,6 @@
  */
 package com.palantir.nexus.db.pool.config;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -69,8 +68,7 @@ public abstract class OracleConnectionConfig extends ConnectionConfig {
     }
 
     @Override
-    @Value.Derived
-    @JsonIgnore
+    @Value.Default
     public Optional<String> namespace() {
         if (getSid().isPresent()) {
             return getSid();

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/OracleConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/OracleConnectionConfig.java
@@ -15,12 +15,14 @@
  */
 package com.palantir.nexus.db.pool.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import com.palantir.nexus.db.DBType;
@@ -29,6 +31,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 import org.immutables.value.Value;
 
 @JsonDeserialize(as = ImmutableOracleConnectionConfig.class)
@@ -68,12 +71,18 @@ public abstract class OracleConnectionConfig extends ConnectionConfig {
     }
 
     @Override
+    @Value.Derived
+    @JsonIgnore
     public Optional<String> namespace() {
-        if (getSid().isPresent()) {
-            return getSid();
-        }
-        return serviceNameConfiguration().map(ServiceNameConfiguration::namespaceOverride);
+        return Stream.of(
+                        namespaceOverride(),
+                        getSid(),
+                        serviceNameConfiguration().map(ServiceNameConfiguration::namespaceOverride))
+                .findFirst()
+                .orElseThrow(() -> new SafeIllegalStateException("Could not determine namespace for Oracle config"));
     }
+
+    public abstract Optional<String> namespaceOverride();
 
     @Override
     @Value.Default

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/OracleConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/OracleConnectionConfig.java
@@ -68,7 +68,6 @@ public abstract class OracleConnectionConfig extends ConnectionConfig {
     }
 
     @Override
-    @Value.Default
     public Optional<String> namespace() {
         if (getSid().isPresent()) {
             return getSid();

--- a/atlasdb-dbkvs-hikari/src/test/java/com/palantir/nexus/db/pool/config/OracleConnectionConfigTest.java
+++ b/atlasdb-dbkvs-hikari/src/test/java/com/palantir/nexus/db/pool/config/OracleConnectionConfigTest.java
@@ -26,7 +26,6 @@ import com.palantir.nexus.db.pool.config.OracleConnectionConfig.ServiceNameConfi
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 import org.junit.Test;
 
@@ -37,7 +36,7 @@ public class OracleConnectionConfigTest {
     private static final int PORT = 42;
     private static final MaskedValue PASSWORD = ImmutableMaskedValue.of("password");
     private static final String SID = "sid";
-    private static final Optional<String> NAMESPACE = Optional.of("namespace");
+    private static final String NAMESPACE = "namespace";
     private static final ServiceNameConfiguration SERVICE_NAME_CONFIGURATION = new ServiceNameConfiguration.Builder()
             .serviceName("serviceName")
             .namespaceOverride("namespaceOverride")
@@ -88,16 +87,16 @@ public class OracleConnectionConfigTest {
     }
 
     @Test
-    public void namespaceCanBeManuallyOverridden() {
+    public void namespaceManualOverrideTakesPrecedence() {
         OracleConnectionConfig sidBasedConfig =
-                getBaseBuilder().sid(SID).namespace(NAMESPACE).build();
-        assertThat(sidBasedConfig.namespace()).isEqualTo(NAMESPACE);
+                getBaseBuilder().sid(SID).namespaceOverride(NAMESPACE).build();
+        assertThat(sidBasedConfig.namespace()).contains(NAMESPACE);
 
         OracleConnectionConfig serviceNameConfigurationBasedConfig = getBaseBuilder()
                 .serviceNameConfiguration(SERVICE_NAME_CONFIGURATION)
-                .namespace(NAMESPACE)
+                .namespaceOverride(NAMESPACE)
                 .build();
-        assertThat(serviceNameConfigurationBasedConfig.namespace()).isEqualTo(NAMESPACE);
+        assertThat(serviceNameConfigurationBasedConfig.namespace()).contains(NAMESPACE);
     }
 
     @Test

--- a/atlasdb-dbkvs-hikari/src/test/java/com/palantir/nexus/db/pool/config/OracleConnectionConfigTest.java
+++ b/atlasdb-dbkvs-hikari/src/test/java/com/palantir/nexus/db/pool/config/OracleConnectionConfigTest.java
@@ -26,6 +26,7 @@ import com.palantir.nexus.db.pool.config.OracleConnectionConfig.ServiceNameConfi
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import org.junit.Test;
 
@@ -36,6 +37,7 @@ public class OracleConnectionConfigTest {
     private static final int PORT = 42;
     private static final MaskedValue PASSWORD = ImmutableMaskedValue.of("password");
     private static final String SID = "sid";
+    private static final Optional<String> NAMESPACE = Optional.of("namespace");
     private static final ServiceNameConfiguration SERVICE_NAME_CONFIGURATION = new ServiceNameConfiguration.Builder()
             .serviceName("serviceName")
             .namespaceOverride("namespaceOverride")
@@ -72,17 +74,30 @@ public class OracleConnectionConfigTest {
     }
 
     @Test
-    public void namespaceIsSidIfPresent() {
+    public void namespaceDefaultsToSidIfPresent() {
         OracleConnectionConfig connectionConfig = getBaseBuilder().sid(SID).build();
         assertThat(connectionConfig.namespace()).contains(SID);
     }
 
     @Test
-    public void namespaceIsNamespaceOverrideIfServiceNameConfigurationSpecified() {
+    public void namespaceDefaultsToNamespaceOverrideIfServiceNameConfigurationSpecified() {
         OracleConnectionConfig connectionConfig = getBaseBuilder()
                 .serviceNameConfiguration(SERVICE_NAME_CONFIGURATION)
                 .build();
         assertThat(connectionConfig.namespace()).contains(SERVICE_NAME_CONFIGURATION.namespaceOverride());
+    }
+
+    @Test
+    public void namespaceCanBeManuallyOverridden() {
+        OracleConnectionConfig sidBasedConfig =
+                getBaseBuilder().sid(SID).namespace(NAMESPACE).build();
+        assertThat(sidBasedConfig.namespace()).isEqualTo(NAMESPACE);
+
+        OracleConnectionConfig serviceNameConfigurationBasedConfig = getBaseBuilder()
+                .serviceNameConfiguration(SERVICE_NAME_CONFIGURATION)
+                .namespace(NAMESPACE)
+                .build();
+        assertThat(serviceNameConfigurationBasedConfig.namespace()).isEqualTo(NAMESPACE);
     }
 
     @Test

--- a/atlasdb-dbkvs-hikari/src/test/java/com/palantir/nexus/db/pool/config/OracleConnectionConfigTest.java
+++ b/atlasdb-dbkvs-hikari/src/test/java/com/palantir/nexus/db/pool/config/OracleConnectionConfigTest.java
@@ -73,30 +73,17 @@ public class OracleConnectionConfigTest {
     }
 
     @Test
-    public void namespaceDefaultsToSidIfPresent() {
+    public void namespaceIsSidIfPresent() {
         OracleConnectionConfig connectionConfig = getBaseBuilder().sid(SID).build();
         assertThat(connectionConfig.namespace()).contains(SID);
     }
 
     @Test
-    public void namespaceDefaultsToNamespaceOverrideIfServiceNameConfigurationSpecified() {
+    public void namespaceIsNamespaceOverrideIfServiceNameConfigurationSpecified() {
         OracleConnectionConfig connectionConfig = getBaseBuilder()
                 .serviceNameConfiguration(SERVICE_NAME_CONFIGURATION)
                 .build();
         assertThat(connectionConfig.namespace()).contains(SERVICE_NAME_CONFIGURATION.namespaceOverride());
-    }
-
-    @Test
-    public void namespaceManualOverrideTakesPrecedence() {
-        OracleConnectionConfig sidBasedConfig =
-                getBaseBuilder().sid(SID).namespaceOverride(NAMESPACE).build();
-        assertThat(sidBasedConfig.namespace()).contains(NAMESPACE);
-
-        OracleConnectionConfig serviceNameConfigurationBasedConfig = getBaseBuilder()
-                .serviceNameConfiguration(SERVICE_NAME_CONFIGURATION)
-                .namespaceOverride(NAMESPACE)
-                .build();
-        assertThat(serviceNameConfigurationBasedConfig.namespace()).contains(NAMESPACE);
     }
 
     @Test

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/DbKeyValueServiceConfig.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/DbKeyValueServiceConfig.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.keyvalue.dbkvs;
 import static com.palantir.logsafe.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -44,8 +45,11 @@ public abstract class DbKeyValueServiceConfig implements KeyValueServiceConfig {
     @JsonIgnore
     @Value.Derived
     public Optional<String> namespace() {
-        return connection().namespace();
+        return namespaceOverride().or(() -> connection().namespace());
     }
+
+    @JsonProperty("namespace")
+    public abstract Optional<String> namespaceOverride();
 
     @Override
     public final String type() {

--- a/atlasdb-ete-tests/docker/conf/atlasdb-ete.timelock.dbkvs.yml
+++ b/atlasdb-ete-tests/docker/conf/atlasdb-ete.timelock.dbkvs.yml
@@ -12,6 +12,7 @@ server:
 atlasdb:
   keyValueService:
     type: relational
+    namespace: globeete
     ddl:
       type: postgres
     connection:
@@ -22,7 +23,7 @@ atlasdb:
       dbLogin: palantir
       dbPassword: palantir
 
-  namespace: atlasete
+  namespace: globeete
 
 atlasDbRuntime:
   timelockRuntime:

--- a/docs/source/configuration/key_value_service_configs/db_key_value_services_config.rst
+++ b/docs/source/configuration/key_value_service_configs/db_key_value_services_config.rst
@@ -1,0 +1,28 @@
+.. _db_key_value_services_config:
+
+===========================
+DB KVS Shared Configuration
+===========================
+
+.. note::
+   Please read the documentation for configuration of the specific flavour of DbKVS (Oracle or Postgres) that you are
+   using as well. This document discusses concepts that are shared across the relational key-value-service
+   configurations that we support.
+
+Namespaces
+----------
+
+.. danger::
+
+   Changing the namespace of an individual service, or explicitly specifying the namespace of a service that previously
+   did not have namespace overrides without taking suitable mitigating measures may result in
+   **SEVERE DATA CORRUPTION**! Please contact the AtlasDB team before attempting such a migration.
+
+*Namespaces* are a mechanism by which an AtlasDB application using a relational KVS may identify itself to TimeLock.
+This can be useful in situations where a DB instance is shared between services. This should be a unique value per
+user service, and must not be changed without a migration.
+
+By default, this is determined by the connection configuration. In Oracle this is determined from either the ``sid``
+or the ``serviceNameConfiguration``; in Postgres, this is determined from the ``dbName``. However, in cases where a
+single application needs to be responsible for multiple AtlasDB instances connecting to the same Oracle instance under
+the same user, setting ``namespace`` accordingly allows for interactions with TimeLock to be handled properly.

--- a/docs/source/configuration/key_value_service_configs/index.rst
+++ b/docs/source/configuration/key_value_service_configs/index.rst
@@ -11,6 +11,7 @@ The configurations for supported key value services can be found below.
    :titlesonly:
 
    cassandra_key_value_service_config
+   db_key_value_services_config
    postgres_key_value_service_config
    oracle_key_value_service_config
 

--- a/docs/source/configuration/key_value_service_configs/oracle_key_value_service_config.rst
+++ b/docs/source/configuration/key_value_service_configs/oracle_key_value_service_config.rst
@@ -46,6 +46,7 @@ A minimal AtlasDB configuration for running against Oracle will look like the be
           sid: palantir
           dbLogin: palantir
           dbPassword: palpal
+        namespace: myAppAtlas # must be unique per product
 
       leader:
         # This should be at least half the number of nodes in your cluster
@@ -69,9 +70,10 @@ For more details on the leader block, see :ref:`Leader Configuration <leader-con
 Configuration Parameters
 ========================
 
-The Oracle Configuration has 2 major blocks:
+The Oracle Configuration has 2 major blocks.
 
-The DDL Config Block:
+DDL parameters
+--------------
 
 .. list-table::
     :widths: 5 40 15
@@ -172,6 +174,24 @@ These are the required parameters:
     *    - dbPassword
          - The Oracle DB password.
          - Yes
+
+Namespaces
+----------
+
+.. danger::
+
+   Changing the namespace of an individual service, or explicitly specifying the namespace of a service that previously
+   did not have namespace overrides without taking suitable mitigating measures may result in
+   **SEVERE DATA CORRUPTION**! Please contact the AtlasDB team before attempting such a migration.
+
+*Namespaces* are a mechanism by which an AtlasDB application using Oracle may identify itself to TimeLock. This can
+be useful in situations where an Oracle instance is shared between services. This should be a unique value per
+user service, and must not be changed without a migration.
+
+By default, this is determined by the connection configuration (either from ``sid`` or ``serviceNameConfiguration``).
+However, in cases where a single application needs to be responsible for multiple AtlasDB instances connecting to
+the same Oracle instance under the same user, setting ``namespace`` accordingly allows for interactions with TimeLock
+to be handled properly.
 
 Migrating Connection Methods
 ----------------------------

--- a/docs/source/configuration/key_value_service_configs/oracle_key_value_service_config.rst
+++ b/docs/source/configuration/key_value_service_configs/oracle_key_value_service_config.rst
@@ -175,24 +175,6 @@ These are the required parameters:
          - The Oracle DB password.
          - Yes
 
-Namespaces
-----------
-
-.. danger::
-
-   Changing the namespace of an individual service, or explicitly specifying the namespace of a service that previously
-   did not have namespace overrides without taking suitable mitigating measures may result in
-   **SEVERE DATA CORRUPTION**! Please contact the AtlasDB team before attempting such a migration.
-
-*Namespaces* are a mechanism by which an AtlasDB application using Oracle may identify itself to TimeLock. This can
-be useful in situations where an Oracle instance is shared between services. This should be a unique value per
-user service, and must not be changed without a migration.
-
-By default, this is determined by the connection configuration (either from ``sid`` or ``serviceNameConfiguration``).
-However, in cases where a single application needs to be responsible for multiple AtlasDB instances connecting to
-the same Oracle instance under the same user, setting ``namespace`` accordingly allows for interactions with TimeLock
-to be handled properly.
-
 Migrating Connection Methods
 ----------------------------
 

--- a/docs/source/configuration/key_value_service_configs/postgres_key_value_service_config.rst
+++ b/docs/source/configuration/key_value_service_configs/postgres_key_value_service_config.rst
@@ -33,6 +33,7 @@ A minimal AtlasDB configuration for running against postgres will look like :
   atlasdb:
     keyValueService:
       type: relational
+      namespace: myAppAtlas # must be unique per product
       ddl:
         type: postgres
       connection:


### PR DESCRIPTION
**Goals (and why)**:
Pay down some legacy technical debt, and make configuration in atlasdb-proxy look smoother.
==COMMIT_MSG==
Users may now explicitly override the `namespace` of an Oracle connection configuration, which is usually the mechanism by which an individual AtlasDB user identifies itself (e.g. to timelock and possibly to the underlying key-value-service). This was previously automatically assumed to be the `sid` of the Oracle database; however, that is not actually the way an individual AtlasDB user identifies itself.
==COMMIT_MSG==

**Implementation Description (bullets)**:
- Allow explicit overriding of `namespace` while defaulting to the old behaviour; see above for discussion.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Added tests for the new behaviour.

**Concerns (what feedback would you like?)**:
- This might be bad if someone has explicitly a useless override `namespace: X` in their config, though in the worst case it'll just mean that they throw as opposed to doing anything explicitly wrong.

**Where should we start reviewing?**: small

**Priority (whenever / two weeks / yesterday)**: this week please