### PR TITLE
Add metrics to Cassandra reads and writes

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
@@ -72,9 +72,7 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
         this.config = config;
         this.sslSocketFactory = createSslSocketFactory(config);
         this.timedRunner = TimedRunner.create(config.timeoutOnConnectionClose());
-        this.tSocketFactory = new InstrumentedTSocket.Factory(
-                metricsManager.registerOrGetCounter(CassandraClientFactory.class, "bytesRead"),
-                metricsManager.registerOrGetCounter(CassandraClientFactory.class, "bytesWritten"));
+        this.tSocketFactory = new InstrumentedTSocket.Factory(metricsManager);
     }
 
     @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
@@ -72,7 +72,7 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
         this.config = config;
         this.sslSocketFactory = createSslSocketFactory(config);
         this.timedRunner = TimedRunner.create(config.timeoutOnConnectionClose());
-        this.tSocketFactory = new InstrumentedSocket.Factory(
+        this.tSocketFactory = new InstrumentedTSocket.Factory(
                 metricsManager.registerOrGetCounter(CassandraClientFactory.class, "bytesRead"),
                 metricsManager.registerOrGetCounter(CassandraClientFactory.class, "bytesWritten"));
     }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
@@ -63,6 +63,7 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
     private final CassandraKeyValueServiceConfig config;
     private final SSLSocketFactory sslSocketFactory;
     private final TimedRunner timedRunner;
+    private final TSocketFactory tSocketFactory;
 
     public CassandraClientFactory(
             MetricsManager metricsManager, InetSocketAddress addr, CassandraKeyValueServiceConfig config) {
@@ -71,6 +72,9 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
         this.config = config;
         this.sslSocketFactory = createSslSocketFactory(config);
         this.timedRunner = TimedRunner.create(config.timeoutOnConnectionClose());
+        this.tSocketFactory = new InstrumentedSocket.Factory(
+                metricsManager.registerOrGetCounter(CassandraClientFactory.class, "bytesRead"),
+                metricsManager.registerOrGetCounter(CassandraClientFactory.class, "bytesWritten"));
     }
 
     @Override
@@ -117,7 +121,8 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
 
     static CassandraClient getClientInternal(InetSocketAddress addr, CassandraKeyValueServiceConfig config)
             throws TException {
-        return new CassandraClientImpl(getRawClient(addr, config, createSslSocketFactory(config)));
+        return new CassandraClientImpl(
+                getRawClient(addr, config, createSslSocketFactory(config), TSocketFactory.Default.INSTANCE));
     }
 
     private static SSLSocketFactory createSslSocketFactory(CassandraKeyValueServiceConfig config) {
@@ -130,14 +135,18 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
     private Cassandra.Client getRawClientWithTimedCreation() throws TException {
         Timer clientCreation = metricsManager.registerOrGetTimer(CassandraClientFactory.class, "clientCreation");
         try (Timer.Context timer = clientCreation.time()) {
-            return getRawClient(addr, config, sslSocketFactory);
+            return getRawClient(addr, config, sslSocketFactory, tSocketFactory);
         }
     }
 
     private static Cassandra.Client getRawClient(
-            InetSocketAddress addr, CassandraKeyValueServiceConfig config, SSLSocketFactory sslSocketFactory)
+            InetSocketAddress addr,
+            CassandraKeyValueServiceConfig config,
+            SSLSocketFactory sslSocketFactory,
+            TSocketFactory tSocketFactory)
             throws TException {
-        TSocket thriftSocket = new TSocket(addr.getHostString(), addr.getPort(), config.socketTimeoutMillis());
+        TSocket thriftSocket =
+                tSocketFactory.create(addr.getHostString(), addr.getPort(), config.socketTimeoutMillis());
         thriftSocket.open();
         setSocketOptions(
                 thriftSocket,
@@ -152,7 +161,7 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
             try {
                 SSLSocket socket = (SSLSocket) sslSocketFactory.createSocket(
                         thriftSocket.getSocket(), addr.getHostString(), addr.getPort(), true);
-                thriftSocket = new TSocket(socket);
+                thriftSocket = tSocketFactory.create(socket);
                 success = true;
             } catch (IOException e) {
                 throw new TTransportException(e);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/InstrumentedSocket.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/InstrumentedSocket.java
@@ -1,0 +1,90 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import com.codahale.metrics.Counter;
+import java.net.Socket;
+import org.apache.thrift.transport.TSocket;
+import org.apache.thrift.transport.TTransportException;
+
+/**
+ * A simple wrapping implementation of TSocket which on all reads, marks the number of bytes read in counters.
+ * This extends TSocket because TSocket has simple read methods rather than needing to override methods in e.g.
+ * InputStream or . It uses Counter as opposed to Meter because Counter is designed to be extremely low overhead.
+ */
+public final class InstrumentedSocket extends TSocket {
+    private final Counter bytesRead;
+    private final Counter bytesWritten;
+
+    private InstrumentedSocket(Socket socket, Counter bytesRead, Counter bytesWritten) throws TTransportException {
+        super(socket);
+        this.bytesRead = bytesRead;
+        this.bytesWritten = bytesWritten;
+    }
+
+    private InstrumentedSocket(String host, int port, int timeout, Counter bytesRead, Counter bytesWritten) {
+        super(host, port, timeout);
+        this.bytesRead = bytesRead;
+        this.bytesWritten = bytesWritten;
+    }
+
+    @Override
+    public int read(byte[] buf, int off, int len) throws TTransportException {
+        int read = super.read(buf, off, len);
+        bytesRead.inc(read);
+        return read;
+    }
+
+    @Override
+    public int readAll(byte[] buf, int off, int len) throws TTransportException {
+        int read = super.readAll(buf, off, len);
+        bytesRead.inc(read);
+        return read;
+    }
+
+    @Override
+    public void write(byte[] buf, int off, int len) throws TTransportException {
+        super.write(buf, off, len);
+        bytesWritten.inc(len);
+    }
+
+    @Override
+    public void write(byte[] buf) throws TTransportException {
+        super.write(buf);
+        bytesWritten.inc(buf.length);
+    }
+
+    public static final class Factory implements TSocketFactory {
+        private final Counter bytesRead;
+        private final Counter bytesWritten;
+
+        public Factory(Counter bytesRead, Counter bytesWritten) {
+            this.bytesRead = bytesRead;
+            this.bytesWritten = bytesWritten;
+        }
+
+        @Override
+        public TSocket create(Socket socket) throws TTransportException {
+            return new InstrumentedSocket(socket, bytesRead, bytesWritten);
+        }
+
+        @Override
+        public TSocket create(String host, int port, int timeout) {
+            return new InstrumentedSocket(host, port, timeout, bytesRead, bytesWritten);
+        }
+    }
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/InstrumentedTSocket.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/InstrumentedTSocket.java
@@ -17,6 +17,7 @@
 package com.palantir.atlasdb.keyvalue.cassandra;
 
 import com.codahale.metrics.Counter;
+import com.palantir.atlasdb.util.MetricsManager;
 import java.net.Socket;
 import org.apache.thrift.transport.TSocket;
 import org.apache.thrift.transport.TTransportException;
@@ -73,9 +74,9 @@ public final class InstrumentedTSocket extends TSocket {
         private final Counter bytesRead;
         private final Counter bytesWritten;
 
-        public Factory(Counter bytesRead, Counter bytesWritten) {
-            this.bytesRead = bytesRead;
-            this.bytesWritten = bytesWritten;
+        public Factory(MetricsManager metrics) {
+            this.bytesRead = metrics.registerOrGetCounter(InstrumentedTSocket.class, "bytesRead");
+            this.bytesWritten = metrics.registerOrGetCounter(InstrumentedTSocket.class, "bytesWritten");
         }
 
         @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/InstrumentedTSocket.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/InstrumentedTSocket.java
@@ -24,19 +24,20 @@ import org.apache.thrift.transport.TTransportException;
 /**
  * A simple wrapping implementation of TSocket which on all reads, marks the number of bytes read in counters.
  * This extends TSocket because TSocket has simple read methods rather than needing to override methods in e.g.
- * InputStream or . It uses Counter as opposed to Meter because Counter is designed to be extremely low overhead.
+ * InputStream or OutputStream. It ignores the 'buffer' related methods because the superclasses do not set it and it's
+ * optional functionality.
  */
-public final class InstrumentedSocket extends TSocket {
+public final class InstrumentedTSocket extends TSocket {
     private final Counter bytesRead;
     private final Counter bytesWritten;
 
-    private InstrumentedSocket(Socket socket, Counter bytesRead, Counter bytesWritten) throws TTransportException {
+    private InstrumentedTSocket(Socket socket, Counter bytesRead, Counter bytesWritten) throws TTransportException {
         super(socket);
         this.bytesRead = bytesRead;
         this.bytesWritten = bytesWritten;
     }
 
-    private InstrumentedSocket(String host, int port, int timeout, Counter bytesRead, Counter bytesWritten) {
+    private InstrumentedTSocket(String host, int port, int timeout, Counter bytesRead, Counter bytesWritten) {
         super(host, port, timeout);
         this.bytesRead = bytesRead;
         this.bytesWritten = bytesWritten;
@@ -79,12 +80,12 @@ public final class InstrumentedSocket extends TSocket {
 
         @Override
         public TSocket create(Socket socket) throws TTransportException {
-            return new InstrumentedSocket(socket, bytesRead, bytesWritten);
+            return new InstrumentedTSocket(socket, bytesRead, bytesWritten);
         }
 
         @Override
         public TSocket create(String host, int port, int timeout) {
-            return new InstrumentedSocket(host, port, timeout, bytesRead, bytesWritten);
+            return new InstrumentedTSocket(host, port, timeout, bytesRead, bytesWritten);
         }
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/InstrumentedTSocket.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/InstrumentedTSocket.java
@@ -23,10 +23,10 @@ import org.apache.thrift.transport.TSocket;
 import org.apache.thrift.transport.TTransportException;
 
 /**
- * A simple wrapping implementation of TSocket which on all reads, marks the number of bytes read in counters.
- * This extends TSocket because TSocket has simple read methods rather than needing to override methods in e.g.
- * InputStream or OutputStream. It ignores the 'buffer' related methods because the superclasses do not set it and it's
- * optional functionality.
+ * A simple wrapping implementation of TSocket which on all reads/writes, marks the number of bytes read/written in
+ * counters. This extends TSocket because TSocket has simple read methods rather than needing to override methods in
+ * e.g. InputStream or OutputStream. It ignores the 'buffer' related methods because the superclasses do not set it
+ * and it's optional functionality.
  */
 public final class InstrumentedTSocket extends TSocket {
     private final Counter bytesRead;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TSocketFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TSocketFactory.java
@@ -1,0 +1,41 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import java.net.Socket;
+import org.apache.thrift.transport.TSocket;
+import org.apache.thrift.transport.TTransportException;
+
+interface TSocketFactory {
+    TSocket create(Socket socket) throws TTransportException;
+
+    TSocket create(String host, int port, int timeout);
+
+    enum Default implements TSocketFactory {
+        INSTANCE;
+
+        @Override
+        public TSocket create(Socket socket) throws TTransportException {
+            return new TSocket(socket);
+        }
+
+        @Override
+        public TSocket create(String host, int port, int timeout) {
+            return new TSocket(host, port, timeout);
+        }
+    }
+}

--- a/changelog/@unreleased/pr-5943.v2.yml
+++ b/changelog/@unreleased/pr-5943.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add metrics to Cassandra reads and writes
+  links:
+  - https://github.com/palantir/atlasdb/pull/5943


### PR DESCRIPTION
Instrument the underlying socket to guarantee that we're catching all
the calls. Will help estimate how much networking traffic we're causing
for Cassandra hosts.