### PR TITLE
Optimize a few hot code paths

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -700,7 +700,9 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                                         query,
                                         readConsistencyProvider.getConsistency(tableRef));
 
-                        return Maps.transformValues(results, lists -> Lists.newArrayList(Iterables.concat(lists)));
+                        return Maps.transformValues(results, lists -> lists.stream()
+                                .flatMap(Collection::stream)
+                                .collect(Collectors.toList()));
                     }
 
                     @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoader.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoader.java
@@ -16,8 +16,6 @@
 package com.palantir.atlasdb.keyvalue.cassandra;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.primitives.UnsignedBytes;
@@ -43,6 +41,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;
 import org.apache.cassandra.thrift.ColumnParent;
 import org.apache.cassandra.thrift.ConsistencyLevel;
@@ -180,7 +179,9 @@ final class CellLoader {
                             Map<ByteBuffer, List<List<ColumnOrSuperColumn>>> results = queryRunner.multiget_multislice(
                                     kvsMethodName, client, tableRef, query, consistency);
                             Map<ByteBuffer, List<ColumnOrSuperColumn>> aggregatedResults =
-                                    Maps.transformValues(results, lists -> Lists.newArrayList(Iterables.concat(lists)));
+                                    Maps.transformValues(results, lists -> lists.stream()
+                                            .flatMap(Collection::stream)
+                                            .collect(Collectors.toList()));
                             visitor.visit(aggregatedResults);
                             return null;
                         }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueService.java
@@ -45,9 +45,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.regex.Pattern;
 
 @SuppressFBWarnings("SLF4J_ILLEGAL_PASSED_CLASS")
 public abstract class AbstractKeyValueService implements KeyValueService {
+    private static final Pattern PERIOD_REGEX = Pattern.compile("\\.");
+
     protected ExecutorService executor;
 
     /**
@@ -148,7 +151,6 @@ public abstract class AbstractKeyValueService implements KeyValueService {
             while (iterator.hasNext()) {
                 RowResult<Set<Long>> rowResult = iterator.next();
                 Multimap<Cell, Long> cellsToDelete = HashMultimap.create();
-
                 rowResult.getCells().forEach(entry -> cellsToDelete.putAll(entry.getKey(), entry.getValue()));
                 delete(tableRef, cellsToDelete);
             }
@@ -185,7 +187,7 @@ public abstract class AbstractKeyValueService implements KeyValueService {
         if (tableName.startsWith("_")) {
             return tableName;
         }
-        return tableName.replaceFirst("\\.", "__");
+        return PERIOD_REGEX.matcher(tableName).replaceFirst("__");
     }
 
     @Override

--- a/changelog/@unreleased/pr-5954.v2.yml
+++ b/changelog/@unreleased/pr-5954.v2.yml
@@ -1,0 +1,9 @@
+type: improvement
+improvement:
+  description: |-
+    Optimize a few hot code paths
+
+    Precompile regex used in table reference to name normalization.
+    Avoid additional interim ArrayList.grow when streaming provides improved estimated sizes.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5954


### PR DESCRIPTION
**Goals (and why)**:
While looking through JFRs for some services using AtlasDB, noticed a couple hot spots that were allocating memory and consuming CPU that could be optimized.

==COMMIT_MSG==
Optimize a few hot code paths

Precompile regex used in table reference to name normalization.
Avoid additional interim ArrayList.grow when streaming provides improved estimated sizes.
==COMMIT_MSG==

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
