### PR TITLE
Trim log line

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -2185,9 +2185,8 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             runTaskOnDeleteExecutor(kvs -> deleteCells(kvs, tableRef, keysToDelete));
         } catch (RejectedExecutionException rejected) {
             log.info(
-                    "Could not delete keys {} for table {}, because the delete executor's queue was full."
+                    "Could not delete keys for table {}, because the delete executor's queue was full."
                             + " Sweep should eventually clean these values.",
-                    UnsafeArg.of("keysToDelete", keysToDelete),
                     LoggingArgs.tableRef(tableRef),
                     rejected);
         }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -2185,8 +2185,9 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             runTaskOnDeleteExecutor(kvs -> deleteCells(kvs, tableRef, keysToDelete));
         } catch (RejectedExecutionException rejected) {
             log.info(
-                    "Could not delete keys for table {}, because the delete executor's queue was full."
+                    "Could not delete keys {} for table {}, because the delete executor's queue was full."
                             + " Sweep should eventually clean these values.",
+                    SafeArg.of("numKeysToDelete", keysToDelete.size()),
                     LoggingArgs.tableRef(tableRef),
                     rejected);
         }


### PR DESCRIPTION
**Goals (and why)**:
PDS-247037 | The log line is quite heavy. Killing the keysToDelete arg for now. 

**Concerns (what feedback would you like?)**:
Should we just kill the deleteExecutor?

**Priority (whenever / two weeks / yesterday)**:
yesterday 🏃🏼‍♀️ 

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
