### PR TITLE
Serialize/ deserialize `OracleIdentifierLengthLimits`

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleIdentifierLengthLimits.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleIdentifierLengthLimits.java
@@ -16,6 +16,8 @@
 
 package com.palantir.atlasdb.keyvalue.dbkvs;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
@@ -25,6 +27,8 @@ import org.immutables.value.Value;
  * Tracks length limits on tables and identifier names within Oracle.
  */
 @Value.Immutable
+@JsonDeserialize(as = ImmutableOracleIdentifierLengthLimits.class)
+@JsonSerialize(as = ImmutableOracleIdentifierLengthLimits.class)
 public interface OracleIdentifierLengthLimits {
     int identifierLengthLimit();
 


### PR DESCRIPTION
**Goals (and why)**:
Allow ser/deser of `OracleIdentifierLengthLimits`

**Priority (whenever / two weeks / yesterday)**:
🏃🏼‍♀️ 

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
