### PR TITLE
shutdown executors

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/AsyncPuncher.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/AsyncPuncher.java
@@ -47,7 +47,7 @@ public final class AsyncPuncher implements Puncher {
         return asyncPuncher;
     }
 
-    private static final ScheduledExecutorService executor =
+    private final ScheduledExecutorService executor =
             PTExecutors.newSingleThreadScheduledExecutor(new NamedThreadFactory("puncher", true /* daemon */));
 
     private final Puncher delegate;
@@ -115,5 +115,6 @@ public final class AsyncPuncher implements Puncher {
         if (task != null) {
             task.cancel(false);
         }
+        executor.shutdown();
     }
 }

--- a/lock-api/src/main/java/com/palantir/lock/client/LockRefreshingLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockRefreshingLockService.java
@@ -43,9 +43,9 @@ import java.util.concurrent.TimeUnit;
 public final class LockRefreshingLockService extends SimplifyingLockService {
     public static final int REFRESH_BATCH_SIZE = 500_000;
     private static final SafeLogger log = SafeLoggerFactory.get(LockRefreshingLockService.class);
-    private static final ScheduledExecutorService executor =
-            PTExecutors.newScheduledThreadPool(1, PTExecutors.newNamedThreadFactory(true));
 
+    private final ScheduledExecutorService executor =
+            PTExecutors.newScheduledThreadPool(1, PTExecutors.newNamedThreadFactory(true));
     final LockService delegate;
     final Set<LockRefreshToken> toRefresh;
     final long refreshFrequencyMillis = 5000;
@@ -54,7 +54,7 @@ public final class LockRefreshingLockService extends SimplifyingLockService {
 
     public static LockRefreshingLockService create(LockService delegate) {
         final LockRefreshingLockService ret = new LockRefreshingLockService(delegate);
-        ret.task = executor.scheduleWithFixedDelay(
+        ret.task = ret.executor.scheduleWithFixedDelay(
                 () -> {
                     long startTime = System.currentTimeMillis();
                     try {
@@ -175,6 +175,7 @@ public final class LockRefreshingLockService extends SimplifyingLockService {
 
     public void dispose() {
         task.cancel(false);
+        executor.shutdown();
         isClosed = true;
     }
 


### PR DESCRIPTION
**Goals (and why)**:
Avoid thread leaks. It seems like bad practice to have static executors lying around.
==COMMIT_MSG==
shutdown executors
==COMMIT_MSG==

**Implementation Description (bullets)**:
Delete "static" from the executors and then shutdown in close()

**Testing (What was existing testing like?  What have you done to improve it?)**:
None.

**Concerns (what feedback would you like?)**:
None.

**Where should we start reviewing?**:
It's a very short PR.

**Priority (whenever / two weeks / yesterday)**:
Whenever.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
