### PR TITLE
use unique pool names

### DIFF
--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/HikariCPConnectionManager.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/HikariCPConnectionManager.java
@@ -88,8 +88,7 @@ public class HikariCPConnectionManager extends BaseConnectionManager {
     public HikariCPConnectionManager(ConnectionConfig connConfig) {
         this.connConfig = Preconditions.checkNotNull(connConfig, "ConnectionConfig must not be null");
         this.hikariConfig = connConfig.getHikariConfig();
-        hikariConfig.setPoolName(
-                hikariConfig.getPoolName() + "-" + uniquePoolId.incrementAndGet());
+        hikariConfig.setPoolName(hikariConfig.getPoolName() + "-" + uniquePoolId.incrementAndGet());
     }
 
     @Override

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/HikariCPConnectionManager.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/HikariCPConnectionManager.java
@@ -35,8 +35,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.TimeZone;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import javax.management.JMX;
 import javax.management.MBeanServer;
 import javax.management.MalformedObjectNameException;
@@ -52,6 +52,8 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public class HikariCPConnectionManager extends BaseConnectionManager {
     private static final SafeLogger log = SafeLoggerFactory.get(HikariCPConnectionManager.class);
+
+    private static final AtomicLong uniquePoolId = new AtomicLong(0L);
 
     private final ConnectionConfig connConfig;
     private final HikariConfig hikariConfig;
@@ -86,6 +88,8 @@ public class HikariCPConnectionManager extends BaseConnectionManager {
     public HikariCPConnectionManager(ConnectionConfig connConfig) {
         this.connConfig = Preconditions.checkNotNull(connConfig, "ConnectionConfig must not be null");
         this.hikariConfig = connConfig.getHikariConfig();
+        hikariConfig.setPoolName(
+                hikariConfig.getPoolName() + "-" + uniquePoolId.incrementAndGet());
     }
 
     @Override
@@ -300,20 +304,7 @@ public class HikariCPConnectionManager extends BaseConnectionManager {
         HikariDataSource dataSourcePool;
 
         try {
-            try {
-                dataSourcePool = new HikariDataSource(hikariConfig);
-            } catch (IllegalArgumentException e) {
-                // allow multiple pools on same JVM (they need unique names / endpoints)
-                if (e.getMessage().contains("A metric named")) {
-                    String poolName = connConfig.getConnectionPoolName();
-
-                    hikariConfig.setPoolName(
-                            poolName + "-" + ThreadLocalRandom.current().nextInt());
-                    dataSourcePool = new HikariDataSource(hikariConfig);
-                } else {
-                    throw e;
-                }
-            }
+            dataSourcePool = new HikariDataSource(hikariConfig);
         } catch (PoolInitializationException e) {
             log.error(
                     "Failed to initialize hikari data source",

--- a/changelog/@unreleased/pr-5963.v2.yml
+++ b/changelog/@unreleased/pr-5963.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Use a global counter to avoid conflicts in hikari pool name. If the
+    old exception handling code was hit, an executor would be leaked due to a bug
+    in hikari.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5963


### PR DESCRIPTION
**Goals (and why)**:
==COMMIT_MSG==
Use a global counter to avoid conflicts in hikari pool name. If the old exception handling code was hit, an executor would be leaked due to a bug in hikari.
==COMMIT_MSG==

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:
Tried it on an internal repo.

**Concerns (what feedback would you like?)**:
None.

**Where should we start reviewing?**:
It's a short PR.

**Priority (whenever / two weeks / yesterday)**:
Whenever.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
