### PR TITLE
[Alta DbKVS] Part 8: Serialization of Oracle Config Change

### DIFF
--- a/atlasdb-dbkvs/build.gradle
+++ b/atlasdb-dbkvs/build.gradle
@@ -32,6 +32,7 @@ dependencies {
   implementation project(':timestamp-api')
 
   testImplementation 'com.google.guava:guava'
+  testImplementation 'com.palantir.conjure.java.runtime:conjure-java-jackson-serialization'
   testImplementation 'com.palantir.safe-logging:safe-logging'
   testImplementation 'com.zaxxer:HikariCP'
   testImplementation 'org.slf4j:slf4j-api'

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfig.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfig.java
@@ -88,6 +88,7 @@ public abstract class OracleDdlConfig extends DdlConfig {
     }
 
     @Value.Derived
+    @JsonIgnore
     public OracleIdentifierLengthLimits identifierLengthLimits() {
         return longIdentifierNamesSupported()
                 ? OracleIdentifierLengthLimitOptions.ORACLE_12_2

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleIdentifierLengthLimits.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleIdentifierLengthLimits.java
@@ -16,8 +16,6 @@
 
 package com.palantir.atlasdb.keyvalue.dbkvs;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
@@ -27,8 +25,6 @@ import org.immutables.value.Value;
  * Tracks length limits on tables and identifier names within Oracle.
  */
 @Value.Immutable
-@JsonDeserialize(as = ImmutableOracleIdentifierLengthLimits.class)
-@JsonSerialize(as = ImmutableOracleIdentifierLengthLimits.class)
 public interface OracleIdentifierLengthLimits {
     int identifierLengthLimit();
 

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfigTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfigTest.java
@@ -160,19 +160,19 @@ public class OracleDdlConfigTest {
     public void serializedFormDoesNotIncludeLengthLimits() throws JsonProcessingException {
         JsonMapper jsonMapper = ObjectMappers.newServerJsonMapper();
 
-        OracleDdlConfig config = createLongNameSupportingOracleConfigWithPrefixes(
-                getPrefixWithLength(8), getPrefixWithLength(15));
-        String json = jsonMapper.writeValueAsString(config);
-        assertThat(json).doesNotContain("identifierLengthLimits");
+        OracleDdlConfig config =
+                createLongNameSupportingOracleConfigWithPrefixes(getPrefixWithLength(8), getPrefixWithLength(15));
+        assertThat(jsonMapper.writeValueAsString(config)).doesNotContain("identifierLengthLimits");
     }
 
     @Test
     public void serializeAndDeserializeIsNoOp() throws JsonProcessingException {
         JsonMapper jsonMapper = ObjectMappers.newServerJsonMapper();
 
-        OracleDdlConfig config = createLongNameSupportingOracleConfigWithPrefixes(
-                getPrefixWithLength(44), getPrefixWithLength(33));
-        assertThat(jsonMapper.readValue(jsonMapper.writeValueAsString(config), OracleDdlConfig.class)).isEqualTo(config);
+        OracleDdlConfig config =
+                createLongNameSupportingOracleConfigWithPrefixes(getPrefixWithLength(44), getPrefixWithLength(33));
+        assertThat(jsonMapper.readValue(jsonMapper.writeValueAsString(config), OracleDdlConfig.class))
+                .isEqualTo(config);
     }
 
     private static OracleDdlConfig createLegacyCompatibleOracleConfigWithPrefixes(

--- a/changelog/@unreleased/pr-5964.v2.yml
+++ b/changelog/@unreleased/pr-5964.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: |-
+    Serialization of `identifierLengthLimits` as part of serializing an `OracleDdlConfig` no longer happens.
+    Note that this doesn't affect config _deserialization_, which covers most (non-timelock) AtlasDB users.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5964


### PR DESCRIPTION
**Goals (and why)**:
==COMMIT_MSG==
Although this is not a common operation, internal timelock implementation serializes KVS config, including that of Oracle. In #5942 we accidentally changed the _serialized_ form of the Oracle config. Note that this doesn't affect config _deserialization_, which covers most (non-timelock) AtlasDB users.
==COMMIT_MSG==

**Implementation Description (bullets)**:
- Explicitly `@JsonIgnore` identifier length limits.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Add some tests.

**Concerns (what feedback would you like?)**:
- Are there other people that re-serialize their AtlasDB config?

**Where should we start reviewing?**:
- small

**Priority (whenever / two weeks / yesterday)**: this week
