### PR TITLE
[PDS-253270] Log hash of token ring endpoints when disagreement is detected

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -50,6 +50,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import org.apache.cassandra.thrift.NotFoundException;
 import org.apache.cassandra.thrift.TokenRange;
 
@@ -532,11 +533,16 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
         }
 
         RuntimeException ex = new SafeIllegalStateException(
-                "Hosts have differing ring descriptions." + " This can lead to inconsistent reads and lost data. ");
+                "Hosts have differing ring descriptions. This can lead to inconsistent reads and lost data.");
         log.error(
                 "Cassandra does not appear to have a consistent ring across all of its nodes. This could cause us to"
                         + " lose writes. The mapping of token ranges to hosts is:\n{}",
                 UnsafeArg.of("tokenRangesToHost", CassandraLogHelper.tokenRangesToHost(tokenRangesToHost)),
+                SafeArg.of(
+                        "tokenRangeHashes",
+                        CassandraLogHelper.tokenRangeHashes(tokenRangesToHost.keySet().stream()
+                                .flatMap(Set::stream)
+                                .collect(Collectors.toSet()))),
                 ex);
 
         // provide some easier to grok logging for the two most common cases

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
@@ -72,6 +72,14 @@ public final class CassandraLogHelper {
         return range.upperEndpoint().toString();
     }
 
+    public static Set<String> tokenRangeHashes(Set<TokenRange> tokenRanges) {
+        return tokenRanges.stream()
+                .map(range -> String.format(
+                        "(%d, %d)",
+                        range.getStart_token().hashCode(), range.getEnd_token().hashCode()))
+                .collect(Collectors.toSet());
+    }
+
     @Value.Immutable
     interface HostAndIpAddress {
         String host();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
@@ -72,12 +72,12 @@ public final class CassandraLogHelper {
         return range.upperEndpoint().toString();
     }
 
-    public static Set<String> tokenRangeHashes(Set<TokenRange> tokenRanges) {
+    public static List<String> tokenRangeHashes(Set<TokenRange> tokenRanges) {
         return tokenRanges.stream()
                 .map(range -> String.format(
                         "(%d, %d)",
                         range.getStart_token().hashCode(), range.getEnd_token().hashCode()))
-                .collect(Collectors.toSet());
+                .collect(Collectors.toList());
     }
 
     @Value.Immutable

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelperTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelperTest.java
@@ -1,0 +1,52 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+import java.util.Set;
+import org.apache.cassandra.thrift.TokenRange;
+import org.junit.Test;
+
+public class CassandraLogHelperTest {
+    private static final String TOKEN_1 = "i-am-a-token";
+    private static final String TOKEN_2 = "this-is-another-token";
+    private static final String TOKEN_3 = "yet-another-token";
+
+    private static final TokenRange TOKEN_RANGE_1_TO_2 = new TokenRange(TOKEN_1, TOKEN_2, ImmutableList.of());
+    private static final TokenRange TOKEN_RANGE_2_TO_3 = new TokenRange(TOKEN_2, TOKEN_3, ImmutableList.of());
+
+    @Test
+    public void tokenRangeHashesHashesIndividualRanges() {
+        Set<String> expectedHashes = Sets.union(
+                CassandraLogHelper.tokenRangeHashes(ImmutableSet.of(TOKEN_RANGE_1_TO_2)),
+                CassandraLogHelper.tokenRangeHashes(ImmutableSet.of(TOKEN_RANGE_2_TO_3)));
+        assertThat(CassandraLogHelper.tokenRangeHashes(ImmutableSet.of(TOKEN_RANGE_1_TO_2, TOKEN_RANGE_2_TO_3)))
+                .containsExactlyInAnyOrderElementsOf(expectedHashes);
+    }
+
+    @Test
+    public void tokenRangeHashesDoesNotPublishActualValues() {
+        assertThat(Iterables.getOnlyElement(CassandraLogHelper.tokenRangeHashes(ImmutableSet.of(TOKEN_RANGE_1_TO_2))))
+                .doesNotContain(TOKEN_1)
+                .doesNotContain(TOKEN_2);
+    }
+}


### PR DESCRIPTION
**Goals (and why)**:
- Have a mechanism for understanding roughly how many token ranges there was disagreement on (if any) in a safe-visible way.

**Implementation Description (bullets)**:
When disagreement is detected (and only when disagreement is detected), we hash all of the token range endpoints, and log these as a SafeArg in `CassandraClientPoolImpl`.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Added new tests

**Concerns (what feedback would you like?)**: N/A

**Where should we start reviewing?**: CassandraLogHelper.java

**Priority (whenever / two weeks / yesterday)**: this week
