### PR TITLE
[PDS-253270] Treat matching tokens and number of hosts across token ranges as sufficient for consistency

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -531,6 +531,13 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
             return;
         }
 
+        if (TokenRangeResolution.rangesAreConsistent(tokenRangesToHost.keySet())) {
+            log.info("Although multiple ring descriptions were detected, we believe these to be consistent:"
+                    + " ranges detected were identical, and suggest a cluster of similar size. This may occur when"
+                    + " there are legitimate network routing changes, for instance.");
+            return;
+        }
+
         RuntimeException ex = new SafeIllegalStateException(
                 "Hosts have differing ring descriptions." + " This can lead to inconsistent reads and lost data. ");
         log.error(

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -531,10 +531,10 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
             return;
         }
 
-        if (TokenRangeResolution.rangesAreConsistent(tokenRangesToHost.keySet())) {
+        if (TokenRangeResolution.viewsHaveConsistentTokens(tokenRangesToHost.keySet())) {
             log.info("Although multiple ring descriptions were detected, we believe these to be consistent:"
-                    + " ranges detected were identical, and suggest a cluster of similar size. This may occur when"
-                    + " there are legitimate network routing changes, for instance.");
+                    + " ranges detected were identical. This may occur when there are legitimate network routing"
+                    + " changes, for instance.");
             return;
         }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -531,7 +531,7 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
             return;
         }
 
-        if (TokenRangeResolution.viewsHaveConsistentTokens(tokenRangesToHost.keySet())) {
+        if (TokenRangeResolution.viewsAreConsistent(tokenRangesToHost.keySet())) {
             log.info("Although multiple ring descriptions were detected, we believe these to be consistent:"
                     + " ranges detected were identical. This may occur when there are legitimate network routing"
                     + " changes, for instance.");

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TokenRangeResolution.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TokenRangeResolution.java
@@ -21,7 +21,6 @@ import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.cassandra.thrift.EndpointDetails;
 import org.apache.cassandra.thrift.TokenRange;
 import org.immutables.value.Value;
 
@@ -32,12 +31,7 @@ public final class TokenRangeResolution {
         // constructor
     }
 
-    public static boolean rangesAreConsistent(Set<Set<TokenRange>> tokenRangeViews) {
-        return rangesHaveConsistentEndpoints(tokenRangeViews)
-                && rangesHaveConsistentlySizedCluster(tokenRangeViews);
-    }
-
-    public static boolean rangesHaveConsistentEndpoints(Set<Set<TokenRange>> tokenRangeViews) {
+    public static boolean viewsHaveConsistentTokens(Set<Set<TokenRange>> tokenRangeViews) {
         if (tokenRangeViews.size() <= 1) {
             log.trace("<= 1 distinct views of token ranges were provided, so these must have consistent endpoints.");
             return true;
@@ -54,23 +48,6 @@ public final class TokenRangeResolution {
         log.info("Although more than 1 distinct view of the token ranges were obtained, these were consistent in their"
                 + " start and end tokens, which we view as acceptable.");
         return true;
-    }
-
-    public static boolean rangesHaveConsistentlySizedCluster(Set<Set<TokenRange>> tokenRangeViews) {
-        if (tokenRangeViews.size() <= 1) {
-            log.trace("<= 1 distinct views of token ranges were provided, so these must have a consistently sized"
-                    + " cluster.");
-            return true;
-        }
-
-        Set<Set<EndpointDetails>> distinctEndpointDetailsViews = tokenRangeViews.stream()
-                .map(ranges -> ranges.stream().flatMap(r -> r.getEndpoint_details().stream()).collect(Collectors.toSet()))
-                .collect(Collectors.toSet());
-        Set<Integer> endpointDetailsSizes = distinctEndpointDetailsViews.stream()
-                .map(Set::size)
-                .collect(Collectors.toSet());
-
-        return endpointDetailsSizes.size() != 1;
     }
 
     @Value.Immutable

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TokenRangeResolution.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TokenRangeResolution.java
@@ -28,17 +28,19 @@ public final class TokenRangeResolution {
     private static final SafeLogger log = SafeLoggerFactory.get(TokenRangeResolution.class);
 
     private TokenRangeResolution() {
-        // constructor
+        // utility
     }
 
-    public static boolean viewsHaveConsistentTokens(Set<Set<TokenRange>> tokenRangeViews) {
+    public static boolean viewsAreConsistent(Set<Set<TokenRange>> tokenRangeViews) {
         if (tokenRangeViews.size() <= 1) {
             log.trace("<= 1 distinct views of token ranges were provided, so these must have consistent endpoints.");
             return true;
         }
 
         Set<IdentityAgnosticRanges> distinctIdentityAgnosticRanges = tokenRangeViews.stream()
-                .map(ranges -> ranges.stream().map(IdentityAgnosticRange::fromTokenRange).collect(Collectors.toList()))
+                .map(ranges -> ranges.stream()
+                        .map(IdentityAgnosticRange::fromTokenRange)
+                        .collect(Collectors.toList()))
                 .map(ImmutableIdentityAgnosticRanges::of)
                 .collect(Collectors.toSet());
 
@@ -46,7 +48,7 @@ public final class TokenRangeResolution {
             return false;
         }
         log.info("Although more than 1 distinct view of the token ranges were obtained, these were consistent in their"
-                + " start and end tokens, which we view as acceptable.");
+                + " start and end tokens and in the number of nodes seen as endpoints, which we view as acceptable.");
         return true;
     }
 
@@ -59,12 +61,16 @@ public final class TokenRangeResolution {
     @Value.Immutable
     interface IdentityAgnosticRange {
         String startToken();
+
         String endToken();
+
+        int numEndpoints();
 
         static IdentityAgnosticRange fromTokenRange(TokenRange tokenRange) {
             return ImmutableIdentityAgnosticRange.builder()
                     .startToken(tokenRange.getStart_token())
                     .endToken(tokenRange.getEnd_token())
+                    .numEndpoints(tokenRange.getEndpoints().size())
                     .build();
         }
     }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TokenRangeResolution.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TokenRangeResolution.java
@@ -1,0 +1,94 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.cassandra.thrift.EndpointDetails;
+import org.apache.cassandra.thrift.TokenRange;
+import org.immutables.value.Value;
+
+public final class TokenRangeResolution {
+    private static final SafeLogger log = SafeLoggerFactory.get(TokenRangeResolution.class);
+
+    private TokenRangeResolution() {
+        // constructor
+    }
+
+    public static boolean rangesAreConsistent(Set<Set<TokenRange>> tokenRangeViews) {
+        return rangesHaveConsistentEndpoints(tokenRangeViews)
+                && rangesHaveConsistentlySizedCluster(tokenRangeViews);
+    }
+
+    public static boolean rangesHaveConsistentEndpoints(Set<Set<TokenRange>> tokenRangeViews) {
+        if (tokenRangeViews.size() <= 1) {
+            log.trace("<= 1 distinct views of token ranges were provided, so these must have consistent endpoints.");
+            return true;
+        }
+
+        Set<IdentityAgnosticRanges> distinctIdentityAgnosticRanges = tokenRangeViews.stream()
+                .map(ranges -> ranges.stream().map(IdentityAgnosticRange::fromTokenRange).collect(Collectors.toList()))
+                .map(ImmutableIdentityAgnosticRanges::of)
+                .collect(Collectors.toSet());
+
+        if (distinctIdentityAgnosticRanges.size() != 1) {
+            return false;
+        }
+        log.info("Although more than 1 distinct view of the token ranges were obtained, these were consistent in their"
+                + " start and end tokens, which we view as acceptable.");
+        return true;
+    }
+
+    public static boolean rangesHaveConsistentlySizedCluster(Set<Set<TokenRange>> tokenRangeViews) {
+        if (tokenRangeViews.size() <= 1) {
+            log.trace("<= 1 distinct views of token ranges were provided, so these must have a consistently sized"
+                    + " cluster.");
+            return true;
+        }
+
+        Set<Set<EndpointDetails>> distinctEndpointDetailsViews = tokenRangeViews.stream()
+                .map(ranges -> ranges.stream().flatMap(r -> r.getEndpoint_details().stream()).collect(Collectors.toSet()))
+                .collect(Collectors.toSet());
+        Set<Integer> endpointDetailsSizes = distinctEndpointDetailsViews.stream()
+                .map(Set::size)
+                .collect(Collectors.toSet());
+
+        return endpointDetailsSizes.size() != 1;
+    }
+
+    @Value.Immutable
+    interface IdentityAgnosticRanges {
+        @Value.Parameter
+        List<IdentityAgnosticRange> identityAgnosticRanges();
+    }
+
+    @Value.Immutable
+    interface IdentityAgnosticRange {
+        String startToken();
+        String endToken();
+
+        static IdentityAgnosticRange fromTokenRange(TokenRange tokenRange) {
+            return ImmutableIdentityAgnosticRange.builder()
+                    .startToken(tokenRange.getStart_token())
+                    .endToken(tokenRange.getEnd_token())
+                    .build();
+        }
+    }
+}

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/TokenRangeResolutionTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/TokenRangeResolutionTest.java
@@ -39,80 +39,96 @@ public class TokenRangeResolutionTest {
 
     @Test
     public void zeroViewsAreConsistent() {
-        assertThat(TokenRangeResolution.viewsHaveConsistentTokens(ImmutableSet.of())).isTrue();
+        assertThat(TokenRangeResolution.viewsAreConsistent(ImmutableSet.of())).isTrue();
     }
 
     @Test
     public void completelyAgreeingViewsAreConsistent() {
-        Set<Set<TokenRange>> singleNodeRingView = ImmutableSet.of(ImmutableSet.of(createRange(TOKEN_1, TOKEN_2)));
-        assertThat(TokenRangeResolution.viewsHaveConsistentTokens(singleNodeRingView)).isTrue();
+        assertThat(TokenRangeResolution.viewsAreConsistent(
+                        ImmutableSet.of(ImmutableSet.of(createRange(TOKEN_1, TOKEN_2)))))
+                .isTrue();
     }
 
     @Test
     public void viewsWithDifferentRangesDoNotHaveConsistentTokens() {
-        Set<TokenRange> firstNodeRingView = ImmutableSet.of(createRange(TOKEN_1, TOKEN_2), createRange(TOKEN_3,
-                TOKEN_4));
-        Set<TokenRange> secondNodeRingView = ImmutableSet.of(createRange(TOKEN_1, TOKEN_2), createRange(TOKEN_4,
-                TOKEN_5));
-        assertThat(TokenRangeResolution.viewsHaveConsistentTokens(
-                ImmutableSet.of(firstNodeRingView, secondNodeRingView))).isFalse();
+        Set<TokenRange> firstNodeRingView =
+                ImmutableSet.of(createRange(TOKEN_1, TOKEN_2), createRange(TOKEN_3, TOKEN_4));
+        Set<TokenRange> secondNodeRingView =
+                ImmutableSet.of(createRange(TOKEN_1, TOKEN_2), createRange(TOKEN_4, TOKEN_5));
+        assertThat(TokenRangeResolution.viewsAreConsistent(ImmutableSet.of(firstNodeRingView, secondNodeRingView)))
+                .isFalse();
     }
 
     @Test
-    public void viewsWithSameSingleRangeButDifferentEndpointsAreConsistent() {
+    public void viewsAssociatedWithDifferentNumberOfEndpointsAreNotConsistent() {
+        Set<TokenRange> firstNodeRingView = ImmutableSet.of(createRangeWithEndpoint(TOKEN_1, TOKEN_2, ENDPOINT_1));
+        Set<TokenRange> secondNodeRingView =
+                ImmutableSet.of(new TokenRange(TOKEN_1, TOKEN_2, ImmutableList.of(ENDPOINT_1, ENDPOINT_2)));
+        assertThat(TokenRangeResolution.viewsAreConsistent(ImmutableSet.of(firstNodeRingView, secondNodeRingView)))
+                .isFalse();
+    }
+
+    @Test
+    public void viewsWithSameSingleRangeAndSameNumberOfButDifferentEndpointsAreConsistent() {
         Set<TokenRange> firstNodeRingView = ImmutableSet.of(createRangeWithEndpoint(TOKEN_1, TOKEN_2, ENDPOINT_1));
         Set<TokenRange> secondNodeRingView = ImmutableSet.of(createRangeWithEndpoint(TOKEN_1, TOKEN_2, ENDPOINT_2));
-        assertThat(TokenRangeResolution.viewsHaveConsistentTokens(
-                ImmutableSet.of(firstNodeRingView, secondNodeRingView))).isTrue();
+        assertThat(TokenRangeResolution.viewsAreConsistent(ImmutableSet.of(firstNodeRingView, secondNodeRingView)))
+                .isTrue();
     }
 
     @Test
     public void viewsWithMissingRangesDoNotHaveConsistentTokens() {
         Set<TokenRange> firstNodeRingView = ImmutableSet.of(createRange(TOKEN_1, TOKEN_2));
-        Set<TokenRange> secondNodeRingView = ImmutableSet.of(createRange(TOKEN_1, TOKEN_2), createRange(TOKEN_2,
-                TOKEN_3));
-        assertThat(TokenRangeResolution.viewsHaveConsistentTokens(
-                ImmutableSet.of(firstNodeRingView, secondNodeRingView))).isFalse();
+        Set<TokenRange> secondNodeRingView =
+                ImmutableSet.of(createRange(TOKEN_1, TOKEN_2), createRange(TOKEN_2, TOKEN_3));
+        assertThat(TokenRangeResolution.viewsAreConsistent(ImmutableSet.of(firstNodeRingView, secondNodeRingView)))
+                .isFalse();
     }
 
     @Test
     public void consistencyAcrossMultipleRanges() {
-        Set<TokenRange> firstNodeRingView = ImmutableSet.of(createRangeWithEndpoint(TOKEN_1, TOKEN_2, ENDPOINT_1),
+        Set<TokenRange> firstNodeRingView = ImmutableSet.of(
+                createRangeWithEndpoint(TOKEN_1, TOKEN_2, ENDPOINT_1),
                 createRangeWithEndpoint(TOKEN_3, TOKEN_4, ENDPOINT_2));
-        Set<TokenRange> secondNodeRingView = ImmutableSet.of(createRangeWithEndpoint(TOKEN_1, TOKEN_2, ENDPOINT_3),
+        Set<TokenRange> secondNodeRingView = ImmutableSet.of(
+                createRangeWithEndpoint(TOKEN_1, TOKEN_2, ENDPOINT_3),
                 createRangeWithEndpoint(TOKEN_3, TOKEN_4, ENDPOINT_4));
-        assertThat(TokenRangeResolution.viewsHaveConsistentTokens(
-                ImmutableSet.of(firstNodeRingView, secondNodeRingView))).isTrue();
+        assertThat(TokenRangeResolution.viewsAreConsistent(ImmutableSet.of(firstNodeRingView, secondNodeRingView)))
+                .isTrue();
     }
 
     @Test
     public void oneInconsistentViewSufficesForViewsToBeInconsistent() {
-        Set<TokenRange> firstNodeRingView = ImmutableSet.of(createRangeWithEndpoint(TOKEN_1, TOKEN_2, ENDPOINT_1),
+        Set<TokenRange> firstNodeRingView = ImmutableSet.of(
+                createRangeWithEndpoint(TOKEN_1, TOKEN_2, ENDPOINT_1),
                 createRangeWithEndpoint(TOKEN_3, TOKEN_4, ENDPOINT_2));
-        Set<TokenRange> secondNodeRingView = ImmutableSet.of(createRangeWithEndpoint(TOKEN_1, TOKEN_2, ENDPOINT_3),
+        Set<TokenRange> secondNodeRingView = ImmutableSet.of(
+                createRangeWithEndpoint(TOKEN_1, TOKEN_2, ENDPOINT_3),
                 createRangeWithEndpoint(TOKEN_3, TOKEN_4, ENDPOINT_4));
-        Set<TokenRange> thirdNodeRingView = ImmutableSet.of(createRangeWithEndpoint(TOKEN_1, TOKEN_2, ENDPOINT_3),
-                createRangeWithEndpoint(TOKEN_4, TOKEN_5, ENDPOINT_1));
+        Set<TokenRange> thirdNodeRingView = ImmutableSet.of(
+                createRangeWithEndpoint(TOKEN_1, TOKEN_2, ENDPOINT_3),
+                new TokenRange(TOKEN_3, TOKEN_4, ImmutableList.of(ENDPOINT_2, ENDPOINT_4)));
 
-        assertThat(TokenRangeResolution.viewsHaveConsistentTokens(
-                ImmutableSet.of(firstNodeRingView, secondNodeRingView, thirdNodeRingView))).isFalse();
+        assertThat(TokenRangeResolution.viewsAreConsistent(
+                        ImmutableSet.of(firstNodeRingView, secondNodeRingView, thirdNodeRingView)))
+                .isFalse();
     }
 
     @Test
     public void multipleViewsCanAllBeConsistent() {
-        Set<Set<TokenRange>> tokenRanges = ImmutableList.of(ENDPOINT_1, ENDPOINT_2, ENDPOINT_3, ENDPOINT_4)
-                .stream().map(endpoint -> createRangeWithEndpoint(TOKEN_1, TOKEN_2, endpoint))
+        Set<Set<TokenRange>> tokenRanges = ImmutableList.of(ENDPOINT_1, ENDPOINT_2, ENDPOINT_3, ENDPOINT_4).stream()
+                .map(endpoint -> createRangeWithEndpoint(TOKEN_1, TOKEN_2, endpoint))
                 .map(ImmutableSet::of)
                 .collect(Collectors.toSet());
-        assertThat(TokenRangeResolution.viewsHaveConsistentTokens(tokenRanges)).isTrue();
+        assertThat(TokenRangeResolution.viewsAreConsistent(tokenRanges)).isTrue();
     }
 
     @Test
     public void startEndTokenOrderingIsSignificant() {
         Set<TokenRange> firstNodeRingView = ImmutableSet.of(createRange(TOKEN_1, TOKEN_2));
         Set<TokenRange> secondNodeRingView = ImmutableSet.of(createRange(TOKEN_2, TOKEN_1));
-        assertThat(TokenRangeResolution.viewsHaveConsistentTokens(
-                ImmutableSet.of(firstNodeRingView, secondNodeRingView))).isFalse();
+        assertThat(TokenRangeResolution.viewsAreConsistent(ImmutableSet.of(firstNodeRingView, secondNodeRingView)))
+                .isFalse();
     }
 
     private static TokenRange createRange(String startToken, String endToken) {

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/TokenRangeResolutionTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/TokenRangeResolutionTest.java
@@ -1,0 +1,125 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.cassandra.thrift.TokenRange;
+import org.junit.Test;
+
+public class TokenRangeResolutionTest {
+    private static final String TOKEN_1 = "one";
+    private static final String TOKEN_2 = "deux";
+    private static final String TOKEN_3 = "san";
+    private static final String TOKEN_4 = "quattro";
+    private static final String TOKEN_5 = "fünf";
+
+    private static final String ENDPOINT_1 = "tim burr";
+    private static final String ENDPOINT_2 = "anne teak";
+    private static final String ENDPOINT_3 = "matt tress";
+    private static final String ENDPOINT_4 = "tom a. toh";
+
+    @Test
+    public void zeroViewsAreConsistent() {
+        assertThat(TokenRangeResolution.viewsHaveConsistentTokens(ImmutableSet.of())).isTrue();
+    }
+
+    @Test
+    public void completelyAgreeingViewsAreConsistent() {
+        Set<Set<TokenRange>> singleNodeRingView = ImmutableSet.of(ImmutableSet.of(createRange(TOKEN_1, TOKEN_2)));
+        assertThat(TokenRangeResolution.viewsHaveConsistentTokens(singleNodeRingView)).isTrue();
+    }
+
+    @Test
+    public void viewsWithDifferentRangesDoNotHaveConsistentTokens() {
+        Set<TokenRange> firstNodeRingView = ImmutableSet.of(createRange(TOKEN_1, TOKEN_2), createRange(TOKEN_3,
+                TOKEN_4));
+        Set<TokenRange> secondNodeRingView = ImmutableSet.of(createRange(TOKEN_1, TOKEN_2), createRange(TOKEN_4,
+                TOKEN_5));
+        assertThat(TokenRangeResolution.viewsHaveConsistentTokens(
+                ImmutableSet.of(firstNodeRingView, secondNodeRingView))).isFalse();
+    }
+
+    @Test
+    public void viewsWithSameSingleRangeButDifferentEndpointsAreConsistent() {
+        Set<TokenRange> firstNodeRingView = ImmutableSet.of(createRangeWithEndpoint(TOKEN_1, TOKEN_2, ENDPOINT_1));
+        Set<TokenRange> secondNodeRingView = ImmutableSet.of(createRangeWithEndpoint(TOKEN_1, TOKEN_2, ENDPOINT_2));
+        assertThat(TokenRangeResolution.viewsHaveConsistentTokens(
+                ImmutableSet.of(firstNodeRingView, secondNodeRingView))).isTrue();
+    }
+
+    @Test
+    public void viewsWithMissingRangesDoNotHaveConsistentTokens() {
+        Set<TokenRange> firstNodeRingView = ImmutableSet.of(createRange(TOKEN_1, TOKEN_2));
+        Set<TokenRange> secondNodeRingView = ImmutableSet.of(createRange(TOKEN_1, TOKEN_2), createRange(TOKEN_2,
+                TOKEN_3));
+        assertThat(TokenRangeResolution.viewsHaveConsistentTokens(
+                ImmutableSet.of(firstNodeRingView, secondNodeRingView))).isFalse();
+    }
+
+    @Test
+    public void consistencyAcrossMultipleRanges() {
+        Set<TokenRange> firstNodeRingView = ImmutableSet.of(createRangeWithEndpoint(TOKEN_1, TOKEN_2, ENDPOINT_1),
+                createRangeWithEndpoint(TOKEN_3, TOKEN_4, ENDPOINT_2));
+        Set<TokenRange> secondNodeRingView = ImmutableSet.of(createRangeWithEndpoint(TOKEN_1, TOKEN_2, ENDPOINT_3),
+                createRangeWithEndpoint(TOKEN_3, TOKEN_4, ENDPOINT_4));
+        assertThat(TokenRangeResolution.viewsHaveConsistentTokens(
+                ImmutableSet.of(firstNodeRingView, secondNodeRingView))).isTrue();
+    }
+
+    @Test
+    public void oneInconsistentViewSufficesForViewsToBeInconsistent() {
+        Set<TokenRange> firstNodeRingView = ImmutableSet.of(createRangeWithEndpoint(TOKEN_1, TOKEN_2, ENDPOINT_1),
+                createRangeWithEndpoint(TOKEN_3, TOKEN_4, ENDPOINT_2));
+        Set<TokenRange> secondNodeRingView = ImmutableSet.of(createRangeWithEndpoint(TOKEN_1, TOKEN_2, ENDPOINT_3),
+                createRangeWithEndpoint(TOKEN_3, TOKEN_4, ENDPOINT_4));
+        Set<TokenRange> thirdNodeRingView = ImmutableSet.of(createRangeWithEndpoint(TOKEN_1, TOKEN_2, ENDPOINT_3),
+                createRangeWithEndpoint(TOKEN_4, TOKEN_5, ENDPOINT_1));
+
+        assertThat(TokenRangeResolution.viewsHaveConsistentTokens(
+                ImmutableSet.of(firstNodeRingView, secondNodeRingView, thirdNodeRingView))).isFalse();
+    }
+
+    @Test
+    public void multipleViewsCanAllBeConsistent() {
+        Set<Set<TokenRange>> tokenRanges = ImmutableList.of(ENDPOINT_1, ENDPOINT_2, ENDPOINT_3, ENDPOINT_4)
+                .stream().map(endpoint -> createRangeWithEndpoint(TOKEN_1, TOKEN_2, endpoint))
+                .map(ImmutableSet::of)
+                .collect(Collectors.toSet());
+        assertThat(TokenRangeResolution.viewsHaveConsistentTokens(tokenRanges)).isTrue();
+    }
+
+    @Test
+    public void startEndTokenOrderingIsSignificant() {
+        Set<TokenRange> firstNodeRingView = ImmutableSet.of(createRange(TOKEN_1, TOKEN_2));
+        Set<TokenRange> secondNodeRingView = ImmutableSet.of(createRange(TOKEN_2, TOKEN_1));
+        assertThat(TokenRangeResolution.viewsHaveConsistentTokens(
+                ImmutableSet.of(firstNodeRingView, secondNodeRingView))).isFalse();
+    }
+
+    private static TokenRange createRange(String startToken, String endToken) {
+        return new TokenRange(startToken, endToken, ImmutableList.of());
+    }
+
+    private static TokenRange createRangeWithEndpoint(String startToken, String endToken, String endpoint) {
+        return new TokenRange(startToken, endToken, ImmutableList.of(endpoint));
+    }
+}

--- a/changelog/@unreleased/pr-5969.v2.yml
+++ b/changelog/@unreleased/pr-5969.v2.yml
@@ -1,0 +1,8 @@
+type: fix
+fix:
+  description: Accept matching token ranges and number of hosts associated with each
+    range as sufficient for having a consistent view of the token ring. Previously,
+    there was a race condition at k8s deployments that meant that we would declare
+    an inconsistent ring when this was not the case.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5969


### PR DESCRIPTION
**Goals (and why)**:
At k8s deployments we find that the IPs of nodes change over time. This leads to a race condition where if this change happens while the cluster is live reloading, we incorrectly declare an inconsistent ring when the situation is completely benign.
==COMMIT_MSG==
Accept matching token ranges and number of hosts associated with each range as sufficient for having a consistent view of the token ring. Previously, there was a race condition at k8s deployments that meant that we would declare an inconsistent ring when this was not the case.
==COMMIT_MSG==

**Implementation Description (bullets)**:
- Extract only the start token, end token and number of endpoints from each token range, and use these for comparison.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added new tests

**Concerns (what feedback would you like?)**:
Is this too generous?

**Where should we start reviewing?**:
TokenRangeResolution.java

**Priority (whenever / two weeks / yesterday)**: Next week Tuesday please.

@tpetracca / @Sam-Kramer for SA