### PR TITLE
Fix tokenRangesToHost emitted log line by swapping host and range in formatted string

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
@@ -43,9 +43,8 @@ public final class CassandraLogHelper {
 
     static List<String> tokenRangesToHost(Multimap<Set<TokenRange>, InetSocketAddress> tokenRangesToHost) {
         return tokenRangesToHost.entries().stream()
-                .map(entry -> String.format(
-                        "host %s has range %s",
-                        host(entry.getValue()), entry.getKey().toString()))
+                .map(entry -> "host " + host(entry.getValue()) + " has range "
+                        + entry.getKey().toString())
                 .collect(Collectors.toList());
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
@@ -43,8 +43,9 @@ public final class CassandraLogHelper {
 
     static List<String> tokenRangesToHost(Multimap<Set<TokenRange>, InetSocketAddress> tokenRangesToHost) {
         return tokenRangesToHost.entries().stream()
-                .map(entry ->
-                        String.format("host %s has range %s", entry.getKey().toString(), host(entry.getValue())))
+                .map(entry -> String.format(
+                        "host %s has range %s",
+                        host(entry.getValue()), entry.getKey().toString()))
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
**Goals (and why)**:
Noticed that the tokenRangesToHost log line was incorrect - the previous string was "host ${range} has range ${host}". Fixed to be "host ${host} has range ${range}". I've also moved to using string concatenation as per https://github.com/palantir/atlasdb/pull/5967/files/cdd78560923f8eb9d64c951403cdf7dd96caf0f0#r830028543

==COMMIT_MSG==
Fixed an incorrectly formatted log line emitted when Cassandra doesn't have a consistent ring across all its nodes. Previously, the emitted log line had the form "host ${range} has range ${host}", and has been updated to the correct "host ${host} has range ${range}"
==COMMIT_MSG==

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**: whenever

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
