### PR TITLE
Reduce CassandraLogHelper.host(InetSocketAddress) memory allocations

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
@@ -103,13 +103,16 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
         Client ret = getRawClientWithTimedCreation();
         try {
             ret.set_keyspace(config.getKeyspaceOrThrow());
-            log.debug(
-                    "Created new client for {}/{}{}{}",
-                    SafeArg.of("address", CassandraLogHelper.host(addr)),
-                    UnsafeArg.of("keyspace", config.getKeyspaceOrThrow()),
-                    SafeArg.of("usingSsl", config.usingSsl() ? " over SSL" : ""),
-                    UnsafeArg.of(
-                            "usernameConfig", " as user " + config.credentials().username()));
+            if (log.isDebugEnabled()) {
+                log.debug(
+                        "Created new client for {}/{}{}{}",
+                        SafeArg.of("address", CassandraLogHelper.host(addr)),
+                        UnsafeArg.of("keyspace", config.getKeyspaceOrThrow()),
+                        SafeArg.of("usingSsl", config.usingSsl() ? " over SSL" : ""),
+                        UnsafeArg.of(
+                                "usernameConfig",
+                                " as user " + config.credentials().username()));
+            }
             return ret;
         } catch (TException e) {
             ret.getOutputProtocol().getTransport().close();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -173,8 +173,11 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Cassand
         } finally {
             if (resource != null) {
                 if (shouldReuse) {
-                    log.debug(
-                            "Returning resource to pool of host {}", SafeArg.of("host", CassandraLogHelper.host(host)));
+                    if (log.isDebugEnabled()) {
+                        log.debug(
+                                "Returning resource to pool of host {}",
+                                SafeArg.of("host", CassandraLogHelper.host(host)));
+                    }
                     eagerlyCleanupReadBuffersFromIdleConnection(resource, host);
                     clientPool.returnObject(resource);
                 } else {
@@ -197,11 +200,13 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Cassand
                 TMemoryInputTransport memoryInputTransport = (TMemoryInputTransport) readBuffer.get(transport);
                 byte[] underlyingBuffer = memoryInputTransport.getBuffer();
                 if (underlyingBuffer != null && memoryInputTransport.getBytesRemainingInBuffer() == 0) {
-                    log.debug(
-                            "During {} check-in, cleaned up a read buffer of {} bytes of host {}",
-                            UnsafeArg.of("pool", idleClient),
-                            SafeArg.of("bufferLength", underlyingBuffer.length),
-                            SafeArg.of("host", CassandraLogHelper.host(host)));
+                    if (log.isDebugEnabled()) {
+                        log.debug(
+                                "During {} check-in, cleaned up a read buffer of {} bytes of host {}",
+                                UnsafeArg.of("pool", idleClient),
+                                SafeArg.of("bufferLength", underlyingBuffer.length),
+                                SafeArg.of("host", CassandraLogHelper.host(host)));
+                    }
                     memoryInputTransport.reset(PtBytes.EMPTY_BYTE_ARRAY);
                 }
             }
@@ -216,7 +221,9 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Cassand
 
     private void invalidateQuietly(CassandraClient resource) {
         try {
-            log.debug("Discarding resource of host {}", SafeArg.of("host", CassandraLogHelper.host(host)));
+            if (log.isDebugEnabled()) {
+                log.debug("Discarding resource of host {}", SafeArg.of("host", CassandraLogHelper.host(host)));
+            }
             clientPool.invalidateObject(resource);
         } catch (Exception e) {
             log.warn("Attempted to invalidate a non-reusable Cassandra resource, but failed to due an exception", e);

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelperTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelperTest.java
@@ -1,0 +1,48 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.InetSocketAddress;
+import org.junit.Test;
+
+public class CassandraLogHelperTest {
+
+    @Test
+    public void unresolvedHost() {
+        assertThat(CassandraLogHelper.host(InetSocketAddress.createUnresolved("localhost", 1234)))
+                .satisfies(hostAndIpAddress -> {
+                    assertThat(hostAndIpAddress.host()).isEqualTo("localhost");
+                    assertThat(hostAndIpAddress.ipAddress()).isNull();
+                })
+                .asString()
+                .isEqualTo("HostAndIpAddress{host=localhost}");
+    }
+
+    @Test
+    @SuppressWarnings("DnsLookup") // we want the DNS lookup to resolve localhost
+    public void resolvedHost() {
+        assertThat(CassandraLogHelper.host(new InetSocketAddress("localhost", 1234)))
+                .satisfies(hostAndIpAddress -> {
+                    assertThat(hostAndIpAddress.host()).isEqualTo("localhost");
+                    assertThat(hostAndIpAddress.ipAddress()).isEqualTo("127.0.0.1");
+                })
+                .asString()
+                .isEqualTo("HostAndIpAddress{host=localhost, ipAddress=127.0.0.1}");
+    }
+}

--- a/changelog/@unreleased/pr-5975.v2.yml
+++ b/changelog/@unreleased/pr-5975.v2.yml
@@ -1,0 +1,9 @@
+type: improvement
+improvement:
+  description: |-
+    Reduce CassandraLogHelper.host(InetSocketAddress) memory allocations
+
+    CassandraLogHelper.host allocates less memory wrapping InetSocketAddress
+    Avoid safe-logging args and CassandraLogHelper.host for debug logging
+  links:
+  - https://github.com/palantir/atlasdb/pull/5975


### PR DESCRIPTION
**Goals (and why)**:
https://github.com/palantir/atlasdb/pull/5916 introduced some significant allocation pressure on hot code paths that we should avoid, especially around the use of CassandraLogHelper.host(InetSocketAddress) for logging debug as a debug argument even if debug logging is disabled.

==COMMIT_MSG==
Reduce CassandraLogHelper.host(InetSocketAddress) memory allocations

CassandraLogHelper.host allocates less memory wrapping InetSocketAddress
Avoid safe-logging args and CassandraLogHelper.host for debug logging
==COMMIT_MSG==

**Implementation Description (bullets)**: Don't use `Optional`s on hot code paths

**Testing (What was existing testing like?  What have you done to improve it?)**: Added unit test covering previously expected behavior and ensure correctness  

**Concerns (what feedback would you like?)**: code is not as pretty as with `Optional`, but given performance sensitive code paths, I think we opt for functionality and efficiency

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**: ASAP as we've seen unnecessary memory pressure around Cassandra cluster state, especially when clusters are shapeshifting

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->