### PR TITLE
[WIP] | Modify CassServer semantics to accommodate changing proxies

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/Blacklist.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/Blacklist.java
@@ -144,7 +144,9 @@ public class Blacklist {
     public List<String> blacklistDetails() {
         return blacklist.entrySet().stream()
                 .map(blacklistedHostToBlacklistTime -> String.format(
-                        "host: %s was blacklisted at %s",
+                        "proxy: %s for host: %s was blacklisted at %s",
+                        CassandraLogHelper.host(
+                                blacklistedHostToBlacklistTime.getKey().proxy()),
                         CassandraLogHelper.cassandraServer(blacklistedHostToBlacklistTime.getKey()),
                         blacklistedHostToBlacklistTime.getValue().longValue()))
                 .collect(Collectors.toList());

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraAbsentHostTracker.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraAbsentHostTracker.java
@@ -40,7 +40,8 @@ public final class CassandraAbsentHostTracker {
         this.absentCassandraServers = new HashMap<>();
     }
 
-    public synchronized Optional<CassandraClientPoolingContainer> returnPool(CassandraServer cassandraServer) {
+    public synchronized Optional<CassandraClientPoolingContainer> returnPoolsForCassandraHost(
+            CassandraServer cassandraServer) {
         return Optional.ofNullable(absentCassandraServers.remove(cassandraServer))
                 .map(PoolAndCount::container);
     }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServer.java
@@ -17,7 +17,6 @@
 package com.palantir.atlasdb.keyvalue.cassandra.pool;
 
 import java.net.InetSocketAddress;
-import java.util.List;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -26,34 +25,13 @@ public interface CassandraServer {
     InetSocketAddress cassandraHostAddress();
 
     /**
-     * We do maintain a list of all IPs but do not create a client pool for each one of these. As of now this list is
-     * unused.
+     * The proxy that will be used to reach the Cassandra host.
      * */
-    @Value.Auxiliary
-    List<InetSocketAddress> reachableProxyIps();
-
-    /**
-     * The only proxy that will be used to reach the Cassandra host.
-     *
-     * We are making the assumption here that the list of IPs for a host will be consistent.
-     * In case this does not happen, we will black list this host as it will not be reachable using the proxy.
-     * */
-    @Value.Lazy
-    default InetSocketAddress proxy() {
-        return reachableProxyIps().get(0);
-    }
-
-    @Value.Check
-    default void check() {
-        com.palantir.logsafe.Preconditions.checkState(
-                reachableProxyIps().size() > 0, "Must have at least one reachable IP.");
-    }
+    @Value.Parameter
+    InetSocketAddress proxy();
 
     static CassandraServer from(InetSocketAddress addr) {
-        return CassandraServer.builder()
-                .cassandraHostAddress(addr)
-                .addReachableProxyIps(addr)
-                .build();
+        return CassandraServer.builder().cassandraHostAddress(addr).proxy(addr).build();
     }
 
     static ImmutableCassandraServer.Builder builder() {

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraAbsentHostTrackerTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraAbsentHostTrackerTest.java
@@ -48,14 +48,14 @@ public class CassandraAbsentHostTrackerTest {
 
     @Test
     public void returnEmptyIfNothingThePool() {
-        assertThat(hostTracker.returnPool(SERVER_1)).isEmpty();
+        assertThat(hostTracker.returnPoolsForCassandraHost(SERVER_1)).isEmpty();
     }
 
     @Test
     public void returnPoolIfPresent() {
         hostTracker.trackAbsentCassandraServer(SERVER_1, container1);
-        assertThat(hostTracker.returnPool(SERVER_1)).hasValue(container1);
-        assertThat(hostTracker.returnPool(SERVER_1)).isEmpty();
+        assertThat(hostTracker.returnPoolsForCassandraHost(SERVER_1)).hasValue(container1);
+        assertThat(hostTracker.returnPoolsForCassandraHost(SERVER_1)).isEmpty();
     }
 
     @Test

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
@@ -97,7 +97,7 @@ public class CassandraServiceTest {
     public void shouldReturnAddressForSingleHostInPool() throws UnknownHostException {
         CassandraService cassandra = clientPoolWithServers(ImmutableSet.of(SERVER_1));
 
-        CassandraServer resolvedHost = cassandra.getAddressForHost(HOSTNAME_1);
+        CassandraServer resolvedHost = cassandra.getReachableServersForHost(HOSTNAME_1);
 
         assertThat(resolvedHost.proxy().getHostString()).isEqualTo(HOSTNAME_1);
         assertThat(resolvedHost.proxy().getPort()).isEqualTo(DEFAULT_PORT);
@@ -107,7 +107,7 @@ public class CassandraServiceTest {
     public void shouldReturnAddressForSingleServer() throws UnknownHostException {
         CassandraService cassandra = clientPoolWithServers(ImmutableSet.of(SERVER_1));
 
-        CassandraServer resolvedHost = cassandra.getAddressForHost(HOSTNAME_1);
+        CassandraServer resolvedHost = cassandra.getReachableServersForHost(HOSTNAME_1);
 
         assertThat(resolvedHost.proxy().getHostString()).isEqualTo(HOSTNAME_1);
         assertThat(resolvedHost.proxy().getPort()).isEqualTo(DEFAULT_PORT);
@@ -117,7 +117,7 @@ public class CassandraServiceTest {
     public void shouldUseCommonPortIfThereIsOnlyOneAndNoAddressMatches() throws UnknownHostException {
         CassandraService cassandra = clientPoolWithServers(ImmutableSet.of(SERVER_1, SERVER_2));
 
-        CassandraServer resolvedHost = cassandra.getAddressForHost(HOSTNAME_3);
+        CassandraServer resolvedHost = cassandra.getReachableServersForHost(HOSTNAME_3);
 
         assertThat(resolvedHost.proxy().getHostString()).isEqualTo(HOSTNAME_3);
         assertThat(resolvedHost.proxy().getPort()).isEqualTo(DEFAULT_PORT);
@@ -129,7 +129,8 @@ public class CassandraServiceTest {
 
         CassandraService cassandra = clientPoolWithServers(ImmutableSet.of(SERVER_1, server2));
 
-        assertThatThrownBy(() -> cassandra.getAddressForHost(HOSTNAME_3)).isInstanceOf(UnknownHostException.class);
+        assertThatThrownBy(() -> cassandra.getReachableServersForHost(HOSTNAME_3))
+                .isInstanceOf(UnknownHostException.class);
     }
 
     @Test


### PR DESCRIPTION
**Goals (and why)**:
Changes the semantics of `CassandraServer` 

**Implementation Description (bullets)**:
1. CassandraServer is now a `Pair<CassandraHost,ReachableProxy>`.
2. We maintain one clientPool container per `Pair<CassandraHost,ReachableProxy>`
3. The blacklisting logic with now be per `Pair<CassandraHost,ReachableProxy>`
4. The absence logic is also per `Pair<CassandraHost,ReachableProxy>`
5. The logic to mark absent host has changed as well - we now only mark respective proxies absent if the Cassandra host was not discovered in the `describe_ring`
6. If there is a proxy change, the new proxy will be added to the `cachedPool` but for removing the old proxy we will be relying on the blacklisting logic.

**Testing (What was existing testing like?  What have you done to improve it?)**:
TBD

**Concerns (what feedback would you like?)**:
This is a memory leak right now.

**Where should we start reviewing?**:
CassanadraService

**Priority (whenever / two weeks / yesterday)**:
Yesterday

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
