### PR TITLE
Delete entire row when performing named deletes

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/CompactMetadataTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/CompactMetadataTable.java
@@ -66,6 +66,7 @@ import com.palantir.atlasdb.table.api.TypedRowResult;
 import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Columns;
 import com.palantir.atlasdb.table.generation.Descending;
 import com.palantir.atlasdb.table.generation.NamedColumnValue;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
@@ -98,7 +99,7 @@ public final class CompactMetadataTable implements
     private final List<CompactMetadataTrigger> triggers;
     private final static String rawTableName = "metadata";
     private final TableReference tableRef;
-    private final static ColumnSelection allColumns = getColumnSelection(CompactMetadataNamedColumn.values());
+    private final static ColumnSelection allKnownColumns = getColumnSelection(CompactMetadataNamedColumn.values());
 
     static CompactMetadataTable of(Transaction t, Namespace namespace) {
         return new CompactMetadataTable(t, namespace, ImmutableList.<CompactMetadataTrigger>of());
@@ -442,14 +443,12 @@ public final class CompactMetadataTable implements
 
     @Override
     public void delete(Iterable<CompactMetadataRow> rows) {
-        List<byte[]> rowBytes = Persistables.persistAll(rows);
-        Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
-        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("t")));
-        t.delete(tableRef, cells);
+        Multimap<CompactMetadataRow, CompactMetadataNamedColumnValue<?>> result = getRowsMultimap(rows);
+        t.delete(tableRef, ColumnValues.toCells(result));
     }
 
     public Optional<CompactMetadataRowResult> getRow(CompactMetadataRow row) {
-        return getRow(row, allColumns);
+        return getRow(row, allKnownColumns);
     }
 
     public Optional<CompactMetadataRowResult> getRow(CompactMetadataRow row, ColumnSelection columns) {
@@ -464,7 +463,7 @@ public final class CompactMetadataTable implements
 
     @Override
     public List<CompactMetadataRowResult> getRows(Iterable<CompactMetadataRow> rows) {
-        return getRows(rows, allColumns);
+        return getRows(rows, allKnownColumns);
     }
 
     @Override
@@ -479,7 +478,7 @@ public final class CompactMetadataTable implements
 
     @Override
     public List<CompactMetadataNamedColumnValue<?>> getRowColumns(CompactMetadataRow row) {
-        return getRowColumns(row, allColumns);
+        return getRowColumns(row, ColumnSelection.all());
     }
 
     @Override
@@ -499,7 +498,7 @@ public final class CompactMetadataTable implements
 
     @Override
     public Multimap<CompactMetadataRow, CompactMetadataNamedColumnValue<?>> getRowsMultimap(Iterable<CompactMetadataRow> rows) {
-        return getRowsMultimapInternal(rows, allColumns);
+        return getRowsMultimapInternal(rows, ColumnSelection.all());
     }
 
     @Override
@@ -563,13 +562,13 @@ public final class CompactMetadataTable implements
 
     private ColumnSelection optimizeColumnSelection(ColumnSelection columns) {
         if (columns.allColumnsSelected()) {
-            return allColumns;
+            return allKnownColumns;
         }
         return columns;
     }
 
     public BatchingVisitableView<CompactMetadataRowResult> getAllRowsUnordered() {
-        return getAllRowsUnordered(allColumns);
+        return getAllRowsUnordered(allKnownColumns);
     }
 
     public BatchingVisitableView<CompactMetadataRowResult> getAllRowsUnordered(ColumnSelection columns) {
@@ -624,6 +623,7 @@ public final class CompactMetadataTable implements
      * {@link ColumnSelection}
      * {@link ColumnValue}
      * {@link ColumnValues}
+     * {@link Columns}
      * {@link ComparisonChain}
      * {@link Compression}
      * {@link CompressionUtils}
@@ -681,5 +681,5 @@ public final class CompactMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "3E7A2G8e28hDNktKg3axyw==";
+    static String __CLASS_HASH = "hHYqkhHs/SaNAX3xxOdxyA==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/generation/Columns.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/generation/Columns.java
@@ -1,0 +1,42 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.table.generation;
+
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.common.persist.Persistable;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+public final class Columns {
+
+    private Columns() {
+        // should not be instantiated
+    }
+
+    public static <T extends Persistable, V extends Persistable> Set<Cell> toCells(Multimap<T, V> map) {
+        Set<Cell> ret = Sets.newHashSetWithExpectedSize(map.size());
+        for (Map.Entry<T, Collection<V>> e : map.asMap().entrySet()) {
+            byte[] rowName = e.getKey().persistToBytes();
+            for (Persistable val : e.getValue()) {
+                ret.add(Cell.create(rowName, val.persistToBytes()));
+            }
+        }
+        return ret;
+    }
+}

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamValueTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamValueTable.java
@@ -66,6 +66,7 @@ import com.palantir.atlasdb.table.api.TypedRowResult;
 import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Columns;
 import com.palantir.atlasdb.table.generation.Descending;
 import com.palantir.atlasdb.table.generation.NamedColumnValue;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
@@ -98,7 +99,7 @@ public final class DataStreamValueTable implements
     private final List<DataStreamValueTrigger> triggers;
     private final static String rawTableName = "data_stream_value";
     private final TableReference tableRef;
-    private final static ColumnSelection allColumns = getColumnSelection(DataStreamValueNamedColumn.values());
+    private final static ColumnSelection allKnownColumns = getColumnSelection(DataStreamValueNamedColumn.values());
 
     static DataStreamValueTable of(Transaction t, Namespace namespace) {
         return new DataStreamValueTable(t, namespace, ImmutableList.<DataStreamValueTrigger>of());
@@ -469,14 +470,12 @@ public final class DataStreamValueTable implements
 
     @Override
     public void delete(Iterable<DataStreamValueRow> rows) {
-        List<byte[]> rowBytes = Persistables.persistAll(rows);
-        Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
-        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("v")));
-        t.delete(tableRef, cells);
+        Multimap<DataStreamValueRow, DataStreamValueNamedColumnValue<?>> result = getRowsMultimap(rows);
+        t.delete(tableRef, ColumnValues.toCells(result));
     }
 
     public Optional<DataStreamValueRowResult> getRow(DataStreamValueRow row) {
-        return getRow(row, allColumns);
+        return getRow(row, allKnownColumns);
     }
 
     public Optional<DataStreamValueRowResult> getRow(DataStreamValueRow row, ColumnSelection columns) {
@@ -491,7 +490,7 @@ public final class DataStreamValueTable implements
 
     @Override
     public List<DataStreamValueRowResult> getRows(Iterable<DataStreamValueRow> rows) {
-        return getRows(rows, allColumns);
+        return getRows(rows, allKnownColumns);
     }
 
     @Override
@@ -506,7 +505,7 @@ public final class DataStreamValueTable implements
 
     @Override
     public List<DataStreamValueNamedColumnValue<?>> getRowColumns(DataStreamValueRow row) {
-        return getRowColumns(row, allColumns);
+        return getRowColumns(row, ColumnSelection.all());
     }
 
     @Override
@@ -526,7 +525,7 @@ public final class DataStreamValueTable implements
 
     @Override
     public Multimap<DataStreamValueRow, DataStreamValueNamedColumnValue<?>> getRowsMultimap(Iterable<DataStreamValueRow> rows) {
-        return getRowsMultimapInternal(rows, allColumns);
+        return getRowsMultimapInternal(rows, ColumnSelection.all());
     }
 
     @Override
@@ -590,13 +589,13 @@ public final class DataStreamValueTable implements
 
     private ColumnSelection optimizeColumnSelection(ColumnSelection columns) {
         if (columns.allColumnsSelected()) {
-            return allColumns;
+            return allKnownColumns;
         }
         return columns;
     }
 
     public BatchingVisitableView<DataStreamValueRowResult> getAllRowsUnordered() {
-        return getAllRowsUnordered(allColumns);
+        return getAllRowsUnordered(allKnownColumns);
     }
 
     public BatchingVisitableView<DataStreamValueRowResult> getAllRowsUnordered(ColumnSelection columns) {
@@ -651,6 +650,7 @@ public final class DataStreamValueTable implements
      * {@link ColumnSelection}
      * {@link ColumnValue}
      * {@link ColumnValues}
+     * {@link Columns}
      * {@link ComparisonChain}
      * {@link Compression}
      * {@link CompressionUtils}
@@ -708,5 +708,5 @@ public final class DataStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "3HkS/oQvfojirEAfdSYjnw==";
+    static String __CLASS_HASH = "gtnIPre21qgpHcBZnBFpEQ==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamMetadataTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamMetadataTable.java
@@ -66,6 +66,7 @@ import com.palantir.atlasdb.table.api.TypedRowResult;
 import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Columns;
 import com.palantir.atlasdb.table.generation.Descending;
 import com.palantir.atlasdb.table.generation.NamedColumnValue;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
@@ -98,7 +99,7 @@ public final class HotspottyDataStreamMetadataTable implements
     private final List<HotspottyDataStreamMetadataTrigger> triggers;
     private final static String rawTableName = "hotspottyData_stream_metadata";
     private final TableReference tableRef;
-    private final static ColumnSelection allColumns = getColumnSelection(HotspottyDataStreamMetadataNamedColumn.values());
+    private final static ColumnSelection allKnownColumns = getColumnSelection(HotspottyDataStreamMetadataNamedColumn.values());
 
     static HotspottyDataStreamMetadataTable of(Transaction t, Namespace namespace) {
         return new HotspottyDataStreamMetadataTable(t, namespace, ImmutableList.<HotspottyDataStreamMetadataTrigger>of());
@@ -467,14 +468,12 @@ public final class HotspottyDataStreamMetadataTable implements
 
     @Override
     public void delete(Iterable<HotspottyDataStreamMetadataRow> rows) {
-        List<byte[]> rowBytes = Persistables.persistAll(rows);
-        Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
-        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("md")));
-        t.delete(tableRef, cells);
+        Multimap<HotspottyDataStreamMetadataRow, HotspottyDataStreamMetadataNamedColumnValue<?>> result = getRowsMultimap(rows);
+        t.delete(tableRef, ColumnValues.toCells(result));
     }
 
     public Optional<HotspottyDataStreamMetadataRowResult> getRow(HotspottyDataStreamMetadataRow row) {
-        return getRow(row, allColumns);
+        return getRow(row, allKnownColumns);
     }
 
     public Optional<HotspottyDataStreamMetadataRowResult> getRow(HotspottyDataStreamMetadataRow row, ColumnSelection columns) {
@@ -489,7 +488,7 @@ public final class HotspottyDataStreamMetadataTable implements
 
     @Override
     public List<HotspottyDataStreamMetadataRowResult> getRows(Iterable<HotspottyDataStreamMetadataRow> rows) {
-        return getRows(rows, allColumns);
+        return getRows(rows, allKnownColumns);
     }
 
     @Override
@@ -504,7 +503,7 @@ public final class HotspottyDataStreamMetadataTable implements
 
     @Override
     public List<HotspottyDataStreamMetadataNamedColumnValue<?>> getRowColumns(HotspottyDataStreamMetadataRow row) {
-        return getRowColumns(row, allColumns);
+        return getRowColumns(row, ColumnSelection.all());
     }
 
     @Override
@@ -524,7 +523,7 @@ public final class HotspottyDataStreamMetadataTable implements
 
     @Override
     public Multimap<HotspottyDataStreamMetadataRow, HotspottyDataStreamMetadataNamedColumnValue<?>> getRowsMultimap(Iterable<HotspottyDataStreamMetadataRow> rows) {
-        return getRowsMultimapInternal(rows, allColumns);
+        return getRowsMultimapInternal(rows, ColumnSelection.all());
     }
 
     @Override
@@ -588,13 +587,13 @@ public final class HotspottyDataStreamMetadataTable implements
 
     private ColumnSelection optimizeColumnSelection(ColumnSelection columns) {
         if (columns.allColumnsSelected()) {
-            return allColumns;
+            return allKnownColumns;
         }
         return columns;
     }
 
     public BatchingVisitableView<HotspottyDataStreamMetadataRowResult> getAllRowsUnordered() {
-        return getAllRowsUnordered(allColumns);
+        return getAllRowsUnordered(allKnownColumns);
     }
 
     public BatchingVisitableView<HotspottyDataStreamMetadataRowResult> getAllRowsUnordered(ColumnSelection columns) {
@@ -649,6 +648,7 @@ public final class HotspottyDataStreamMetadataTable implements
      * {@link ColumnSelection}
      * {@link ColumnValue}
      * {@link ColumnValues}
+     * {@link Columns}
      * {@link ComparisonChain}
      * {@link Compression}
      * {@link CompressionUtils}
@@ -706,5 +706,5 @@ public final class HotspottyDataStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "/o0oiRKrpv9bcIlY6oe0Jw==";
+    static String __CLASS_HASH = "+XJebZp5kr0OMj2g/0PmCA==";
 }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/KeyValueTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/KeyValueTable.java
@@ -66,6 +66,7 @@ import com.palantir.atlasdb.table.api.TypedRowResult;
 import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Columns;
 import com.palantir.atlasdb.table.generation.Descending;
 import com.palantir.atlasdb.table.generation.NamedColumnValue;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
@@ -98,7 +99,7 @@ public final class KeyValueTable implements
     private final List<KeyValueTrigger> triggers;
     private final static String rawTableName = "blobs";
     private final TableReference tableRef;
-    private final static ColumnSelection allColumns = getColumnSelection(KeyValueNamedColumn.values());
+    private final static ColumnSelection allKnownColumns = getColumnSelection(KeyValueNamedColumn.values());
 
     static KeyValueTable of(Transaction t, Namespace namespace) {
         return new KeyValueTable(t, namespace, ImmutableList.<KeyValueTrigger>of());
@@ -442,14 +443,12 @@ public final class KeyValueTable implements
 
     @Override
     public void delete(Iterable<KeyValueRow> rows) {
-        List<byte[]> rowBytes = Persistables.persistAll(rows);
-        Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
-        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("s")));
-        t.delete(tableRef, cells);
+        Multimap<KeyValueRow, KeyValueNamedColumnValue<?>> result = getRowsMultimap(rows);
+        t.delete(tableRef, ColumnValues.toCells(result));
     }
 
     public Optional<KeyValueRowResult> getRow(KeyValueRow row) {
-        return getRow(row, allColumns);
+        return getRow(row, allKnownColumns);
     }
 
     public Optional<KeyValueRowResult> getRow(KeyValueRow row, ColumnSelection columns) {
@@ -464,7 +463,7 @@ public final class KeyValueTable implements
 
     @Override
     public List<KeyValueRowResult> getRows(Iterable<KeyValueRow> rows) {
-        return getRows(rows, allColumns);
+        return getRows(rows, allKnownColumns);
     }
 
     @Override
@@ -479,7 +478,7 @@ public final class KeyValueTable implements
 
     @Override
     public List<KeyValueNamedColumnValue<?>> getRowColumns(KeyValueRow row) {
-        return getRowColumns(row, allColumns);
+        return getRowColumns(row, ColumnSelection.all());
     }
 
     @Override
@@ -499,7 +498,7 @@ public final class KeyValueTable implements
 
     @Override
     public Multimap<KeyValueRow, KeyValueNamedColumnValue<?>> getRowsMultimap(Iterable<KeyValueRow> rows) {
-        return getRowsMultimapInternal(rows, allColumns);
+        return getRowsMultimapInternal(rows, ColumnSelection.all());
     }
 
     @Override
@@ -563,7 +562,7 @@ public final class KeyValueTable implements
 
     private RangeRequest optimizeRangeRequest(RangeRequest range) {
         if (range.getColumnNames().isEmpty()) {
-            return range.getBuilder().retainColumns(allColumns).build();
+            return range.getBuilder().retainColumns(allKnownColumns).build();
         }
         return range;
     }
@@ -686,6 +685,7 @@ public final class KeyValueTable implements
      * {@link ColumnSelection}
      * {@link ColumnValue}
      * {@link ColumnValues}
+     * {@link Columns}
      * {@link ComparisonChain}
      * {@link Compression}
      * {@link CompressionUtils}
@@ -743,5 +743,5 @@ public final class KeyValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "OzVTBeZRDN3eNncbksH1sw==";
+    static String __CLASS_HASH = "Ttq5lOcFnhTudIxXPm+VHg==";
 }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamHashAidxTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamHashAidxTable.java
@@ -66,6 +66,7 @@ import com.palantir.atlasdb.table.api.TypedRowResult;
 import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Columns;
 import com.palantir.atlasdb.table.generation.Descending;
 import com.palantir.atlasdb.table.generation.NamedColumnValue;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
@@ -96,7 +97,7 @@ public final class ValueStreamHashAidxTable implements
     private final List<ValueStreamHashAidxTrigger> triggers;
     private final static String rawTableName = "blob_stream_hash_aidx";
     private final TableReference tableRef;
-    private final static ColumnSelection allColumns = ColumnSelection.all();
+    private final static ColumnSelection allKnownColumns = ColumnSelection.all();
 
     static ValueStreamHashAidxTable of(Transaction t, Namespace namespace) {
         return new ValueStreamHashAidxTable(t, namespace, ImmutableList.<ValueStreamHashAidxTrigger>of());
@@ -458,17 +459,13 @@ public final class ValueStreamHashAidxTable implements
 
     @Override
     public void delete(Iterable<ValueStreamHashAidxRow> rows) {
-        Multimap<ValueStreamHashAidxRow, ValueStreamHashAidxColumn> toRemove = HashMultimap.create();
         Multimap<ValueStreamHashAidxRow, ValueStreamHashAidxColumnValue> result = getRowsMultimap(rows);
-        for (Entry<ValueStreamHashAidxRow, ValueStreamHashAidxColumnValue> e : result.entries()) {
-            toRemove.put(e.getKey(), e.getValue().getColumnName());
-        }
-        delete(toRemove);
+        t.delete(tableRef, ColumnValues.toCells(result));
     }
 
     @Override
     public void delete(Multimap<ValueStreamHashAidxRow, ValueStreamHashAidxColumn> values) {
-        t.delete(tableRef, ColumnValues.toCells(values));
+        t.delete(tableRef, Columns.toCells(values));
     }
 
     @Override
@@ -511,7 +508,7 @@ public final class ValueStreamHashAidxTable implements
 
     @Override
     public Multimap<ValueStreamHashAidxRow, ValueStreamHashAidxColumnValue> get(Multimap<ValueStreamHashAidxRow, ValueStreamHashAidxColumn> cells) {
-        Set<Cell> rawCells = ColumnValues.toCells(cells);
+        Set<Cell> rawCells = Columns.toCells(cells);
         Map<Cell, byte[]> rawResults = t.get(tableRef, rawCells);
         Multimap<ValueStreamHashAidxRow, ValueStreamHashAidxColumnValue> rowMap = ArrayListMultimap.create();
         for (Entry<Cell, byte[]> e : rawResults.entrySet()) {
@@ -527,7 +524,7 @@ public final class ValueStreamHashAidxTable implements
 
     @Override
     public List<ValueStreamHashAidxColumnValue> getRowColumns(ValueStreamHashAidxRow row) {
-        return getRowColumns(row, allColumns);
+        return getRowColumns(row, ColumnSelection.all());
     }
 
     @Override
@@ -549,7 +546,7 @@ public final class ValueStreamHashAidxTable implements
 
     @Override
     public Multimap<ValueStreamHashAidxRow, ValueStreamHashAidxColumnValue> getRowsMultimap(Iterable<ValueStreamHashAidxRow> rows) {
-        return getRowsMultimapInternal(rows, allColumns);
+        return getRowsMultimapInternal(rows, ColumnSelection.all());
     }
 
     @Override
@@ -621,13 +618,13 @@ public final class ValueStreamHashAidxTable implements
 
     private ColumnSelection optimizeColumnSelection(ColumnSelection columns) {
         if (columns.allColumnsSelected()) {
-            return allColumns;
+            return allKnownColumns;
         }
         return columns;
     }
 
     public BatchingVisitableView<ValueStreamHashAidxRowResult> getAllRowsUnordered() {
-        return getAllRowsUnordered(allColumns);
+        return getAllRowsUnordered(allKnownColumns);
     }
 
     public BatchingVisitableView<ValueStreamHashAidxRowResult> getAllRowsUnordered(ColumnSelection columns) {
@@ -682,6 +679,7 @@ public final class ValueStreamHashAidxTable implements
      * {@link ColumnSelection}
      * {@link ColumnValue}
      * {@link ColumnValues}
+     * {@link Columns}
      * {@link ComparisonChain}
      * {@link Compression}
      * {@link CompressionUtils}
@@ -739,5 +737,5 @@ public final class ValueStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "iYsHQ2Mt1VCa6LRzMCAPrA==";
+    static String __CLASS_HASH = "9CpDoaw2WaS0kaw9GV4ZIg==";
 }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamIdxTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamIdxTable.java
@@ -66,6 +66,7 @@ import com.palantir.atlasdb.table.api.TypedRowResult;
 import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Columns;
 import com.palantir.atlasdb.table.generation.Descending;
 import com.palantir.atlasdb.table.generation.NamedColumnValue;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
@@ -96,7 +97,7 @@ public final class ValueStreamIdxTable implements
     private final List<ValueStreamIdxTrigger> triggers;
     private final static String rawTableName = "blob_stream_idx";
     private final TableReference tableRef;
-    private final static ColumnSelection allColumns = ColumnSelection.all();
+    private final static ColumnSelection allKnownColumns = ColumnSelection.all();
 
     static ValueStreamIdxTable of(Transaction t, Namespace namespace) {
         return new ValueStreamIdxTable(t, namespace, ImmutableList.<ValueStreamIdxTrigger>of());
@@ -458,17 +459,13 @@ public final class ValueStreamIdxTable implements
 
     @Override
     public void delete(Iterable<ValueStreamIdxRow> rows) {
-        Multimap<ValueStreamIdxRow, ValueStreamIdxColumn> toRemove = HashMultimap.create();
         Multimap<ValueStreamIdxRow, ValueStreamIdxColumnValue> result = getRowsMultimap(rows);
-        for (Entry<ValueStreamIdxRow, ValueStreamIdxColumnValue> e : result.entries()) {
-            toRemove.put(e.getKey(), e.getValue().getColumnName());
-        }
-        delete(toRemove);
+        t.delete(tableRef, ColumnValues.toCells(result));
     }
 
     @Override
     public void delete(Multimap<ValueStreamIdxRow, ValueStreamIdxColumn> values) {
-        t.delete(tableRef, ColumnValues.toCells(values));
+        t.delete(tableRef, Columns.toCells(values));
     }
 
     @Override
@@ -511,7 +508,7 @@ public final class ValueStreamIdxTable implements
 
     @Override
     public Multimap<ValueStreamIdxRow, ValueStreamIdxColumnValue> get(Multimap<ValueStreamIdxRow, ValueStreamIdxColumn> cells) {
-        Set<Cell> rawCells = ColumnValues.toCells(cells);
+        Set<Cell> rawCells = Columns.toCells(cells);
         Map<Cell, byte[]> rawResults = t.get(tableRef, rawCells);
         Multimap<ValueStreamIdxRow, ValueStreamIdxColumnValue> rowMap = ArrayListMultimap.create();
         for (Entry<Cell, byte[]> e : rawResults.entrySet()) {
@@ -527,7 +524,7 @@ public final class ValueStreamIdxTable implements
 
     @Override
     public List<ValueStreamIdxColumnValue> getRowColumns(ValueStreamIdxRow row) {
-        return getRowColumns(row, allColumns);
+        return getRowColumns(row, ColumnSelection.all());
     }
 
     @Override
@@ -549,7 +546,7 @@ public final class ValueStreamIdxTable implements
 
     @Override
     public Multimap<ValueStreamIdxRow, ValueStreamIdxColumnValue> getRowsMultimap(Iterable<ValueStreamIdxRow> rows) {
-        return getRowsMultimapInternal(rows, allColumns);
+        return getRowsMultimapInternal(rows, ColumnSelection.all());
     }
 
     @Override
@@ -621,13 +618,13 @@ public final class ValueStreamIdxTable implements
 
     private ColumnSelection optimizeColumnSelection(ColumnSelection columns) {
         if (columns.allColumnsSelected()) {
-            return allColumns;
+            return allKnownColumns;
         }
         return columns;
     }
 
     public BatchingVisitableView<ValueStreamIdxRowResult> getAllRowsUnordered() {
-        return getAllRowsUnordered(allColumns);
+        return getAllRowsUnordered(allKnownColumns);
     }
 
     public BatchingVisitableView<ValueStreamIdxRowResult> getAllRowsUnordered(ColumnSelection columns) {
@@ -682,6 +679,7 @@ public final class ValueStreamIdxTable implements
      * {@link ColumnSelection}
      * {@link ColumnValue}
      * {@link ColumnValues}
+     * {@link Columns}
      * {@link ComparisonChain}
      * {@link Compression}
      * {@link CompressionUtils}
@@ -739,5 +737,5 @@ public final class ValueStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "dNyGhtgZuzBzy4MfMVZHUw==";
+    static String __CLASS_HASH = "lmjGm03yTdvZPjLD06rbew==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamHashAidxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamHashAidxTable.java
@@ -66,6 +66,7 @@ import com.palantir.atlasdb.table.api.TypedRowResult;
 import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Columns;
 import com.palantir.atlasdb.table.generation.Descending;
 import com.palantir.atlasdb.table.generation.NamedColumnValue;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
@@ -96,7 +97,7 @@ public final class StreamTestMaxMemStreamHashAidxTable implements
     private final List<StreamTestMaxMemStreamHashAidxTrigger> triggers;
     private final static String rawTableName = "stream_test_max_mem_stream_hash_aidx";
     private final TableReference tableRef;
-    private final static ColumnSelection allColumns = ColumnSelection.all();
+    private final static ColumnSelection allKnownColumns = ColumnSelection.all();
 
     static StreamTestMaxMemStreamHashAidxTable of(Transaction t, Namespace namespace) {
         return new StreamTestMaxMemStreamHashAidxTable(t, namespace, ImmutableList.<StreamTestMaxMemStreamHashAidxTrigger>of());
@@ -458,17 +459,13 @@ public final class StreamTestMaxMemStreamHashAidxTable implements
 
     @Override
     public void delete(Iterable<StreamTestMaxMemStreamHashAidxRow> rows) {
-        Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumn> toRemove = HashMultimap.create();
         Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue> result = getRowsMultimap(rows);
-        for (Entry<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue> e : result.entries()) {
-            toRemove.put(e.getKey(), e.getValue().getColumnName());
-        }
-        delete(toRemove);
+        t.delete(tableRef, ColumnValues.toCells(result));
     }
 
     @Override
     public void delete(Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumn> values) {
-        t.delete(tableRef, ColumnValues.toCells(values));
+        t.delete(tableRef, Columns.toCells(values));
     }
 
     @Override
@@ -511,7 +508,7 @@ public final class StreamTestMaxMemStreamHashAidxTable implements
 
     @Override
     public Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue> get(Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumn> cells) {
-        Set<Cell> rawCells = ColumnValues.toCells(cells);
+        Set<Cell> rawCells = Columns.toCells(cells);
         Map<Cell, byte[]> rawResults = t.get(tableRef, rawCells);
         Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue> rowMap = ArrayListMultimap.create();
         for (Entry<Cell, byte[]> e : rawResults.entrySet()) {
@@ -527,7 +524,7 @@ public final class StreamTestMaxMemStreamHashAidxTable implements
 
     @Override
     public List<StreamTestMaxMemStreamHashAidxColumnValue> getRowColumns(StreamTestMaxMemStreamHashAidxRow row) {
-        return getRowColumns(row, allColumns);
+        return getRowColumns(row, ColumnSelection.all());
     }
 
     @Override
@@ -549,7 +546,7 @@ public final class StreamTestMaxMemStreamHashAidxTable implements
 
     @Override
     public Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue> getRowsMultimap(Iterable<StreamTestMaxMemStreamHashAidxRow> rows) {
-        return getRowsMultimapInternal(rows, allColumns);
+        return getRowsMultimapInternal(rows, ColumnSelection.all());
     }
 
     @Override
@@ -621,13 +618,13 @@ public final class StreamTestMaxMemStreamHashAidxTable implements
 
     private ColumnSelection optimizeColumnSelection(ColumnSelection columns) {
         if (columns.allColumnsSelected()) {
-            return allColumns;
+            return allKnownColumns;
         }
         return columns;
     }
 
     public BatchingVisitableView<StreamTestMaxMemStreamHashAidxRowResult> getAllRowsUnordered() {
-        return getAllRowsUnordered(allColumns);
+        return getAllRowsUnordered(allKnownColumns);
     }
 
     public BatchingVisitableView<StreamTestMaxMemStreamHashAidxRowResult> getAllRowsUnordered(ColumnSelection columns) {
@@ -682,6 +679,7 @@ public final class StreamTestMaxMemStreamHashAidxTable implements
      * {@link ColumnSelection}
      * {@link ColumnValue}
      * {@link ColumnValues}
+     * {@link Columns}
      * {@link ComparisonChain}
      * {@link Compression}
      * {@link CompressionUtils}
@@ -739,5 +737,5 @@ public final class StreamTestMaxMemStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "XSBb06gykyKROmqQ0U5okA==";
+    static String __CLASS_HASH = "cWsxk6ftTydIAZEzxjU92g==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamIdxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamIdxTable.java
@@ -66,6 +66,7 @@ import com.palantir.atlasdb.table.api.TypedRowResult;
 import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Columns;
 import com.palantir.atlasdb.table.generation.Descending;
 import com.palantir.atlasdb.table.generation.NamedColumnValue;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
@@ -96,7 +97,7 @@ public final class StreamTestMaxMemStreamIdxTable implements
     private final List<StreamTestMaxMemStreamIdxTrigger> triggers;
     private final static String rawTableName = "stream_test_max_mem_stream_idx";
     private final TableReference tableRef;
-    private final static ColumnSelection allColumns = ColumnSelection.all();
+    private final static ColumnSelection allKnownColumns = ColumnSelection.all();
 
     static StreamTestMaxMemStreamIdxTable of(Transaction t, Namespace namespace) {
         return new StreamTestMaxMemStreamIdxTable(t, namespace, ImmutableList.<StreamTestMaxMemStreamIdxTrigger>of());
@@ -458,17 +459,13 @@ public final class StreamTestMaxMemStreamIdxTable implements
 
     @Override
     public void delete(Iterable<StreamTestMaxMemStreamIdxRow> rows) {
-        Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumn> toRemove = HashMultimap.create();
         Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue> result = getRowsMultimap(rows);
-        for (Entry<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue> e : result.entries()) {
-            toRemove.put(e.getKey(), e.getValue().getColumnName());
-        }
-        delete(toRemove);
+        t.delete(tableRef, ColumnValues.toCells(result));
     }
 
     @Override
     public void delete(Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumn> values) {
-        t.delete(tableRef, ColumnValues.toCells(values));
+        t.delete(tableRef, Columns.toCells(values));
     }
 
     @Override
@@ -511,7 +508,7 @@ public final class StreamTestMaxMemStreamIdxTable implements
 
     @Override
     public Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue> get(Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumn> cells) {
-        Set<Cell> rawCells = ColumnValues.toCells(cells);
+        Set<Cell> rawCells = Columns.toCells(cells);
         Map<Cell, byte[]> rawResults = t.get(tableRef, rawCells);
         Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue> rowMap = ArrayListMultimap.create();
         for (Entry<Cell, byte[]> e : rawResults.entrySet()) {
@@ -527,7 +524,7 @@ public final class StreamTestMaxMemStreamIdxTable implements
 
     @Override
     public List<StreamTestMaxMemStreamIdxColumnValue> getRowColumns(StreamTestMaxMemStreamIdxRow row) {
-        return getRowColumns(row, allColumns);
+        return getRowColumns(row, ColumnSelection.all());
     }
 
     @Override
@@ -549,7 +546,7 @@ public final class StreamTestMaxMemStreamIdxTable implements
 
     @Override
     public Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue> getRowsMultimap(Iterable<StreamTestMaxMemStreamIdxRow> rows) {
-        return getRowsMultimapInternal(rows, allColumns);
+        return getRowsMultimapInternal(rows, ColumnSelection.all());
     }
 
     @Override
@@ -621,13 +618,13 @@ public final class StreamTestMaxMemStreamIdxTable implements
 
     private ColumnSelection optimizeColumnSelection(ColumnSelection columns) {
         if (columns.allColumnsSelected()) {
-            return allColumns;
+            return allKnownColumns;
         }
         return columns;
     }
 
     public BatchingVisitableView<StreamTestMaxMemStreamIdxRowResult> getAllRowsUnordered() {
-        return getAllRowsUnordered(allColumns);
+        return getAllRowsUnordered(allKnownColumns);
     }
 
     public BatchingVisitableView<StreamTestMaxMemStreamIdxRowResult> getAllRowsUnordered(ColumnSelection columns) {
@@ -682,6 +679,7 @@ public final class StreamTestMaxMemStreamIdxTable implements
      * {@link ColumnSelection}
      * {@link ColumnValue}
      * {@link ColumnValues}
+     * {@link Columns}
      * {@link ComparisonChain}
      * {@link Compression}
      * {@link CompressionUtils}
@@ -739,5 +737,5 @@ public final class StreamTestMaxMemStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "f3+mNJV5GuwYXKdlZSRKag==";
+    static String __CLASS_HASH = "l5jlN6GsS9hBeBRAjnv5eQ==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamMetadataTable.java
@@ -66,6 +66,7 @@ import com.palantir.atlasdb.table.api.TypedRowResult;
 import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Columns;
 import com.palantir.atlasdb.table.generation.Descending;
 import com.palantir.atlasdb.table.generation.NamedColumnValue;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
@@ -98,7 +99,7 @@ public final class StreamTestMaxMemStreamMetadataTable implements
     private final List<StreamTestMaxMemStreamMetadataTrigger> triggers;
     private final static String rawTableName = "stream_test_max_mem_stream_metadata";
     private final TableReference tableRef;
-    private final static ColumnSelection allColumns = getColumnSelection(StreamTestMaxMemStreamMetadataNamedColumn.values());
+    private final static ColumnSelection allKnownColumns = getColumnSelection(StreamTestMaxMemStreamMetadataNamedColumn.values());
 
     static StreamTestMaxMemStreamMetadataTable of(Transaction t, Namespace namespace) {
         return new StreamTestMaxMemStreamMetadataTable(t, namespace, ImmutableList.<StreamTestMaxMemStreamMetadataTrigger>of());
@@ -467,14 +468,12 @@ public final class StreamTestMaxMemStreamMetadataTable implements
 
     @Override
     public void delete(Iterable<StreamTestMaxMemStreamMetadataRow> rows) {
-        List<byte[]> rowBytes = Persistables.persistAll(rows);
-        Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
-        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("md")));
-        t.delete(tableRef, cells);
+        Multimap<StreamTestMaxMemStreamMetadataRow, StreamTestMaxMemStreamMetadataNamedColumnValue<?>> result = getRowsMultimap(rows);
+        t.delete(tableRef, ColumnValues.toCells(result));
     }
 
     public Optional<StreamTestMaxMemStreamMetadataRowResult> getRow(StreamTestMaxMemStreamMetadataRow row) {
-        return getRow(row, allColumns);
+        return getRow(row, allKnownColumns);
     }
 
     public Optional<StreamTestMaxMemStreamMetadataRowResult> getRow(StreamTestMaxMemStreamMetadataRow row, ColumnSelection columns) {
@@ -489,7 +488,7 @@ public final class StreamTestMaxMemStreamMetadataTable implements
 
     @Override
     public List<StreamTestMaxMemStreamMetadataRowResult> getRows(Iterable<StreamTestMaxMemStreamMetadataRow> rows) {
-        return getRows(rows, allColumns);
+        return getRows(rows, allKnownColumns);
     }
 
     @Override
@@ -504,7 +503,7 @@ public final class StreamTestMaxMemStreamMetadataTable implements
 
     @Override
     public List<StreamTestMaxMemStreamMetadataNamedColumnValue<?>> getRowColumns(StreamTestMaxMemStreamMetadataRow row) {
-        return getRowColumns(row, allColumns);
+        return getRowColumns(row, ColumnSelection.all());
     }
 
     @Override
@@ -524,7 +523,7 @@ public final class StreamTestMaxMemStreamMetadataTable implements
 
     @Override
     public Multimap<StreamTestMaxMemStreamMetadataRow, StreamTestMaxMemStreamMetadataNamedColumnValue<?>> getRowsMultimap(Iterable<StreamTestMaxMemStreamMetadataRow> rows) {
-        return getRowsMultimapInternal(rows, allColumns);
+        return getRowsMultimapInternal(rows, ColumnSelection.all());
     }
 
     @Override
@@ -588,13 +587,13 @@ public final class StreamTestMaxMemStreamMetadataTable implements
 
     private ColumnSelection optimizeColumnSelection(ColumnSelection columns) {
         if (columns.allColumnsSelected()) {
-            return allColumns;
+            return allKnownColumns;
         }
         return columns;
     }
 
     public BatchingVisitableView<StreamTestMaxMemStreamMetadataRowResult> getAllRowsUnordered() {
-        return getAllRowsUnordered(allColumns);
+        return getAllRowsUnordered(allKnownColumns);
     }
 
     public BatchingVisitableView<StreamTestMaxMemStreamMetadataRowResult> getAllRowsUnordered(ColumnSelection columns) {
@@ -649,6 +648,7 @@ public final class StreamTestMaxMemStreamMetadataTable implements
      * {@link ColumnSelection}
      * {@link ColumnValue}
      * {@link ColumnValues}
+     * {@link Columns}
      * {@link ComparisonChain}
      * {@link Compression}
      * {@link CompressionUtils}
@@ -706,5 +706,5 @@ public final class StreamTestMaxMemStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "lxkBgMs/0YB/yfs9lh69Kw==";
+    static String __CLASS_HASH = "MN7RPU0nf2X8EWMNj7akgw==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamValueTable.java
@@ -66,6 +66,7 @@ import com.palantir.atlasdb.table.api.TypedRowResult;
 import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Columns;
 import com.palantir.atlasdb.table.generation.Descending;
 import com.palantir.atlasdb.table.generation.NamedColumnValue;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
@@ -98,7 +99,7 @@ public final class StreamTestMaxMemStreamValueTable implements
     private final List<StreamTestMaxMemStreamValueTrigger> triggers;
     private final static String rawTableName = "stream_test_max_mem_stream_value";
     private final TableReference tableRef;
-    private final static ColumnSelection allColumns = getColumnSelection(StreamTestMaxMemStreamValueNamedColumn.values());
+    private final static ColumnSelection allKnownColumns = getColumnSelection(StreamTestMaxMemStreamValueNamedColumn.values());
 
     static StreamTestMaxMemStreamValueTable of(Transaction t, Namespace namespace) {
         return new StreamTestMaxMemStreamValueTable(t, namespace, ImmutableList.<StreamTestMaxMemStreamValueTrigger>of());
@@ -454,14 +455,12 @@ public final class StreamTestMaxMemStreamValueTable implements
 
     @Override
     public void delete(Iterable<StreamTestMaxMemStreamValueRow> rows) {
-        List<byte[]> rowBytes = Persistables.persistAll(rows);
-        Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
-        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("v")));
-        t.delete(tableRef, cells);
+        Multimap<StreamTestMaxMemStreamValueRow, StreamTestMaxMemStreamValueNamedColumnValue<?>> result = getRowsMultimap(rows);
+        t.delete(tableRef, ColumnValues.toCells(result));
     }
 
     public Optional<StreamTestMaxMemStreamValueRowResult> getRow(StreamTestMaxMemStreamValueRow row) {
-        return getRow(row, allColumns);
+        return getRow(row, allKnownColumns);
     }
 
     public Optional<StreamTestMaxMemStreamValueRowResult> getRow(StreamTestMaxMemStreamValueRow row, ColumnSelection columns) {
@@ -476,7 +475,7 @@ public final class StreamTestMaxMemStreamValueTable implements
 
     @Override
     public List<StreamTestMaxMemStreamValueRowResult> getRows(Iterable<StreamTestMaxMemStreamValueRow> rows) {
-        return getRows(rows, allColumns);
+        return getRows(rows, allKnownColumns);
     }
 
     @Override
@@ -491,7 +490,7 @@ public final class StreamTestMaxMemStreamValueTable implements
 
     @Override
     public List<StreamTestMaxMemStreamValueNamedColumnValue<?>> getRowColumns(StreamTestMaxMemStreamValueRow row) {
-        return getRowColumns(row, allColumns);
+        return getRowColumns(row, ColumnSelection.all());
     }
 
     @Override
@@ -511,7 +510,7 @@ public final class StreamTestMaxMemStreamValueTable implements
 
     @Override
     public Multimap<StreamTestMaxMemStreamValueRow, StreamTestMaxMemStreamValueNamedColumnValue<?>> getRowsMultimap(Iterable<StreamTestMaxMemStreamValueRow> rows) {
-        return getRowsMultimapInternal(rows, allColumns);
+        return getRowsMultimapInternal(rows, ColumnSelection.all());
     }
 
     @Override
@@ -575,13 +574,13 @@ public final class StreamTestMaxMemStreamValueTable implements
 
     private ColumnSelection optimizeColumnSelection(ColumnSelection columns) {
         if (columns.allColumnsSelected()) {
-            return allColumns;
+            return allKnownColumns;
         }
         return columns;
     }
 
     public BatchingVisitableView<StreamTestMaxMemStreamValueRowResult> getAllRowsUnordered() {
-        return getAllRowsUnordered(allColumns);
+        return getAllRowsUnordered(allKnownColumns);
     }
 
     public BatchingVisitableView<StreamTestMaxMemStreamValueRowResult> getAllRowsUnordered(ColumnSelection columns) {
@@ -636,6 +635,7 @@ public final class StreamTestMaxMemStreamValueTable implements
      * {@link ColumnSelection}
      * {@link ColumnValue}
      * {@link ColumnValues}
+     * {@link Columns}
      * {@link ComparisonChain}
      * {@link Compression}
      * {@link CompressionUtils}
@@ -693,5 +693,5 @@ public final class StreamTestMaxMemStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "HTNTUWJPFzBpXGmV9VxHdQ==";
+    static String __CLASS_HASH = "A1SoecxCtaWMfiNcPLezlw==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamHashAidxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamHashAidxTable.java
@@ -66,6 +66,7 @@ import com.palantir.atlasdb.table.api.TypedRowResult;
 import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Columns;
 import com.palantir.atlasdb.table.generation.Descending;
 import com.palantir.atlasdb.table.generation.NamedColumnValue;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
@@ -96,7 +97,7 @@ public final class StreamTestStreamHashAidxTable implements
     private final List<StreamTestStreamHashAidxTrigger> triggers;
     private final static String rawTableName = "stream_test_stream_hash_aidx";
     private final TableReference tableRef;
-    private final static ColumnSelection allColumns = ColumnSelection.all();
+    private final static ColumnSelection allKnownColumns = ColumnSelection.all();
 
     static StreamTestStreamHashAidxTable of(Transaction t, Namespace namespace) {
         return new StreamTestStreamHashAidxTable(t, namespace, ImmutableList.<StreamTestStreamHashAidxTrigger>of());
@@ -458,17 +459,13 @@ public final class StreamTestStreamHashAidxTable implements
 
     @Override
     public void delete(Iterable<StreamTestStreamHashAidxRow> rows) {
-        Multimap<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumn> toRemove = HashMultimap.create();
         Multimap<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumnValue> result = getRowsMultimap(rows);
-        for (Entry<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumnValue> e : result.entries()) {
-            toRemove.put(e.getKey(), e.getValue().getColumnName());
-        }
-        delete(toRemove);
+        t.delete(tableRef, ColumnValues.toCells(result));
     }
 
     @Override
     public void delete(Multimap<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumn> values) {
-        t.delete(tableRef, ColumnValues.toCells(values));
+        t.delete(tableRef, Columns.toCells(values));
     }
 
     @Override
@@ -511,7 +508,7 @@ public final class StreamTestStreamHashAidxTable implements
 
     @Override
     public Multimap<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumnValue> get(Multimap<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumn> cells) {
-        Set<Cell> rawCells = ColumnValues.toCells(cells);
+        Set<Cell> rawCells = Columns.toCells(cells);
         Map<Cell, byte[]> rawResults = t.get(tableRef, rawCells);
         Multimap<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumnValue> rowMap = ArrayListMultimap.create();
         for (Entry<Cell, byte[]> e : rawResults.entrySet()) {
@@ -527,7 +524,7 @@ public final class StreamTestStreamHashAidxTable implements
 
     @Override
     public List<StreamTestStreamHashAidxColumnValue> getRowColumns(StreamTestStreamHashAidxRow row) {
-        return getRowColumns(row, allColumns);
+        return getRowColumns(row, ColumnSelection.all());
     }
 
     @Override
@@ -549,7 +546,7 @@ public final class StreamTestStreamHashAidxTable implements
 
     @Override
     public Multimap<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumnValue> getRowsMultimap(Iterable<StreamTestStreamHashAidxRow> rows) {
-        return getRowsMultimapInternal(rows, allColumns);
+        return getRowsMultimapInternal(rows, ColumnSelection.all());
     }
 
     @Override
@@ -621,13 +618,13 @@ public final class StreamTestStreamHashAidxTable implements
 
     private ColumnSelection optimizeColumnSelection(ColumnSelection columns) {
         if (columns.allColumnsSelected()) {
-            return allColumns;
+            return allKnownColumns;
         }
         return columns;
     }
 
     public BatchingVisitableView<StreamTestStreamHashAidxRowResult> getAllRowsUnordered() {
-        return getAllRowsUnordered(allColumns);
+        return getAllRowsUnordered(allKnownColumns);
     }
 
     public BatchingVisitableView<StreamTestStreamHashAidxRowResult> getAllRowsUnordered(ColumnSelection columns) {
@@ -682,6 +679,7 @@ public final class StreamTestStreamHashAidxTable implements
      * {@link ColumnSelection}
      * {@link ColumnValue}
      * {@link ColumnValues}
+     * {@link Columns}
      * {@link ComparisonChain}
      * {@link Compression}
      * {@link CompressionUtils}
@@ -739,5 +737,5 @@ public final class StreamTestStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "sXc/2Nb1dUokOGRg3XB1tw==";
+    static String __CLASS_HASH = "dENSKY+G7RIB6Nd3IQOOQQ==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamMetadataTable.java
@@ -66,6 +66,7 @@ import com.palantir.atlasdb.table.api.TypedRowResult;
 import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Columns;
 import com.palantir.atlasdb.table.generation.Descending;
 import com.palantir.atlasdb.table.generation.NamedColumnValue;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
@@ -98,7 +99,7 @@ public final class StreamTestStreamMetadataTable implements
     private final List<StreamTestStreamMetadataTrigger> triggers;
     private final static String rawTableName = "stream_test_stream_metadata";
     private final TableReference tableRef;
-    private final static ColumnSelection allColumns = getColumnSelection(StreamTestStreamMetadataNamedColumn.values());
+    private final static ColumnSelection allKnownColumns = getColumnSelection(StreamTestStreamMetadataNamedColumn.values());
 
     static StreamTestStreamMetadataTable of(Transaction t, Namespace namespace) {
         return new StreamTestStreamMetadataTable(t, namespace, ImmutableList.<StreamTestStreamMetadataTrigger>of());
@@ -467,14 +468,12 @@ public final class StreamTestStreamMetadataTable implements
 
     @Override
     public void delete(Iterable<StreamTestStreamMetadataRow> rows) {
-        List<byte[]> rowBytes = Persistables.persistAll(rows);
-        Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
-        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("md")));
-        t.delete(tableRef, cells);
+        Multimap<StreamTestStreamMetadataRow, StreamTestStreamMetadataNamedColumnValue<?>> result = getRowsMultimap(rows);
+        t.delete(tableRef, ColumnValues.toCells(result));
     }
 
     public Optional<StreamTestStreamMetadataRowResult> getRow(StreamTestStreamMetadataRow row) {
-        return getRow(row, allColumns);
+        return getRow(row, allKnownColumns);
     }
 
     public Optional<StreamTestStreamMetadataRowResult> getRow(StreamTestStreamMetadataRow row, ColumnSelection columns) {
@@ -489,7 +488,7 @@ public final class StreamTestStreamMetadataTable implements
 
     @Override
     public List<StreamTestStreamMetadataRowResult> getRows(Iterable<StreamTestStreamMetadataRow> rows) {
-        return getRows(rows, allColumns);
+        return getRows(rows, allKnownColumns);
     }
 
     @Override
@@ -504,7 +503,7 @@ public final class StreamTestStreamMetadataTable implements
 
     @Override
     public List<StreamTestStreamMetadataNamedColumnValue<?>> getRowColumns(StreamTestStreamMetadataRow row) {
-        return getRowColumns(row, allColumns);
+        return getRowColumns(row, ColumnSelection.all());
     }
 
     @Override
@@ -524,7 +523,7 @@ public final class StreamTestStreamMetadataTable implements
 
     @Override
     public Multimap<StreamTestStreamMetadataRow, StreamTestStreamMetadataNamedColumnValue<?>> getRowsMultimap(Iterable<StreamTestStreamMetadataRow> rows) {
-        return getRowsMultimapInternal(rows, allColumns);
+        return getRowsMultimapInternal(rows, ColumnSelection.all());
     }
 
     @Override
@@ -588,13 +587,13 @@ public final class StreamTestStreamMetadataTable implements
 
     private ColumnSelection optimizeColumnSelection(ColumnSelection columns) {
         if (columns.allColumnsSelected()) {
-            return allColumns;
+            return allKnownColumns;
         }
         return columns;
     }
 
     public BatchingVisitableView<StreamTestStreamMetadataRowResult> getAllRowsUnordered() {
-        return getAllRowsUnordered(allColumns);
+        return getAllRowsUnordered(allKnownColumns);
     }
 
     public BatchingVisitableView<StreamTestStreamMetadataRowResult> getAllRowsUnordered(ColumnSelection columns) {
@@ -649,6 +648,7 @@ public final class StreamTestStreamMetadataTable implements
      * {@link ColumnSelection}
      * {@link ColumnValue}
      * {@link ColumnValues}
+     * {@link Columns}
      * {@link ComparisonChain}
      * {@link Compression}
      * {@link CompressionUtils}
@@ -706,5 +706,5 @@ public final class StreamTestStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "qHEdCKPB6VgXJi/ddskRaw==";
+    static String __CLASS_HASH = "uPiinHw2OZI+IR7jF8vjPw==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamValueTable.java
@@ -66,6 +66,7 @@ import com.palantir.atlasdb.table.api.TypedRowResult;
 import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Columns;
 import com.palantir.atlasdb.table.generation.Descending;
 import com.palantir.atlasdb.table.generation.NamedColumnValue;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
@@ -98,7 +99,7 @@ public final class StreamTestStreamValueTable implements
     private final List<StreamTestStreamValueTrigger> triggers;
     private final static String rawTableName = "stream_test_stream_value";
     private final TableReference tableRef;
-    private final static ColumnSelection allColumns = getColumnSelection(StreamTestStreamValueNamedColumn.values());
+    private final static ColumnSelection allKnownColumns = getColumnSelection(StreamTestStreamValueNamedColumn.values());
 
     static StreamTestStreamValueTable of(Transaction t, Namespace namespace) {
         return new StreamTestStreamValueTable(t, namespace, ImmutableList.<StreamTestStreamValueTrigger>of());
@@ -454,14 +455,12 @@ public final class StreamTestStreamValueTable implements
 
     @Override
     public void delete(Iterable<StreamTestStreamValueRow> rows) {
-        List<byte[]> rowBytes = Persistables.persistAll(rows);
-        Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
-        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("v")));
-        t.delete(tableRef, cells);
+        Multimap<StreamTestStreamValueRow, StreamTestStreamValueNamedColumnValue<?>> result = getRowsMultimap(rows);
+        t.delete(tableRef, ColumnValues.toCells(result));
     }
 
     public Optional<StreamTestStreamValueRowResult> getRow(StreamTestStreamValueRow row) {
-        return getRow(row, allColumns);
+        return getRow(row, allKnownColumns);
     }
 
     public Optional<StreamTestStreamValueRowResult> getRow(StreamTestStreamValueRow row, ColumnSelection columns) {
@@ -476,7 +475,7 @@ public final class StreamTestStreamValueTable implements
 
     @Override
     public List<StreamTestStreamValueRowResult> getRows(Iterable<StreamTestStreamValueRow> rows) {
-        return getRows(rows, allColumns);
+        return getRows(rows, allKnownColumns);
     }
 
     @Override
@@ -491,7 +490,7 @@ public final class StreamTestStreamValueTable implements
 
     @Override
     public List<StreamTestStreamValueNamedColumnValue<?>> getRowColumns(StreamTestStreamValueRow row) {
-        return getRowColumns(row, allColumns);
+        return getRowColumns(row, ColumnSelection.all());
     }
 
     @Override
@@ -511,7 +510,7 @@ public final class StreamTestStreamValueTable implements
 
     @Override
     public Multimap<StreamTestStreamValueRow, StreamTestStreamValueNamedColumnValue<?>> getRowsMultimap(Iterable<StreamTestStreamValueRow> rows) {
-        return getRowsMultimapInternal(rows, allColumns);
+        return getRowsMultimapInternal(rows, ColumnSelection.all());
     }
 
     @Override
@@ -575,13 +574,13 @@ public final class StreamTestStreamValueTable implements
 
     private ColumnSelection optimizeColumnSelection(ColumnSelection columns) {
         if (columns.allColumnsSelected()) {
-            return allColumns;
+            return allKnownColumns;
         }
         return columns;
     }
 
     public BatchingVisitableView<StreamTestStreamValueRowResult> getAllRowsUnordered() {
-        return getAllRowsUnordered(allColumns);
+        return getAllRowsUnordered(allKnownColumns);
     }
 
     public BatchingVisitableView<StreamTestStreamValueRowResult> getAllRowsUnordered(ColumnSelection columns) {
@@ -636,6 +635,7 @@ public final class StreamTestStreamValueTable implements
      * {@link ColumnSelection}
      * {@link ColumnValue}
      * {@link ColumnValues}
+     * {@link Columns}
      * {@link ComparisonChain}
      * {@link Compression}
      * {@link CompressionUtils}
@@ -693,5 +693,5 @@ public final class StreamTestStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "KSHVtzVJMr79hZ5W7cejyQ==";
+    static String __CLASS_HASH = "L/JXQQnCl3onwwTlu5GbVQ==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamHashAidxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamHashAidxTable.java
@@ -66,6 +66,7 @@ import com.palantir.atlasdb.table.api.TypedRowResult;
 import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Columns;
 import com.palantir.atlasdb.table.generation.Descending;
 import com.palantir.atlasdb.table.generation.NamedColumnValue;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
@@ -96,7 +97,7 @@ public final class StreamTestWithHashStreamHashAidxTable implements
     private final List<StreamTestWithHashStreamHashAidxTrigger> triggers;
     private final static String rawTableName = "stream_test_with_hash_stream_hash_aidx";
     private final TableReference tableRef;
-    private final static ColumnSelection allColumns = ColumnSelection.all();
+    private final static ColumnSelection allKnownColumns = ColumnSelection.all();
 
     static StreamTestWithHashStreamHashAidxTable of(Transaction t, Namespace namespace) {
         return new StreamTestWithHashStreamHashAidxTable(t, namespace, ImmutableList.<StreamTestWithHashStreamHashAidxTrigger>of());
@@ -458,17 +459,13 @@ public final class StreamTestWithHashStreamHashAidxTable implements
 
     @Override
     public void delete(Iterable<StreamTestWithHashStreamHashAidxRow> rows) {
-        Multimap<StreamTestWithHashStreamHashAidxRow, StreamTestWithHashStreamHashAidxColumn> toRemove = HashMultimap.create();
         Multimap<StreamTestWithHashStreamHashAidxRow, StreamTestWithHashStreamHashAidxColumnValue> result = getRowsMultimap(rows);
-        for (Entry<StreamTestWithHashStreamHashAidxRow, StreamTestWithHashStreamHashAidxColumnValue> e : result.entries()) {
-            toRemove.put(e.getKey(), e.getValue().getColumnName());
-        }
-        delete(toRemove);
+        t.delete(tableRef, ColumnValues.toCells(result));
     }
 
     @Override
     public void delete(Multimap<StreamTestWithHashStreamHashAidxRow, StreamTestWithHashStreamHashAidxColumn> values) {
-        t.delete(tableRef, ColumnValues.toCells(values));
+        t.delete(tableRef, Columns.toCells(values));
     }
 
     @Override
@@ -511,7 +508,7 @@ public final class StreamTestWithHashStreamHashAidxTable implements
 
     @Override
     public Multimap<StreamTestWithHashStreamHashAidxRow, StreamTestWithHashStreamHashAidxColumnValue> get(Multimap<StreamTestWithHashStreamHashAidxRow, StreamTestWithHashStreamHashAidxColumn> cells) {
-        Set<Cell> rawCells = ColumnValues.toCells(cells);
+        Set<Cell> rawCells = Columns.toCells(cells);
         Map<Cell, byte[]> rawResults = t.get(tableRef, rawCells);
         Multimap<StreamTestWithHashStreamHashAidxRow, StreamTestWithHashStreamHashAidxColumnValue> rowMap = ArrayListMultimap.create();
         for (Entry<Cell, byte[]> e : rawResults.entrySet()) {
@@ -527,7 +524,7 @@ public final class StreamTestWithHashStreamHashAidxTable implements
 
     @Override
     public List<StreamTestWithHashStreamHashAidxColumnValue> getRowColumns(StreamTestWithHashStreamHashAidxRow row) {
-        return getRowColumns(row, allColumns);
+        return getRowColumns(row, ColumnSelection.all());
     }
 
     @Override
@@ -549,7 +546,7 @@ public final class StreamTestWithHashStreamHashAidxTable implements
 
     @Override
     public Multimap<StreamTestWithHashStreamHashAidxRow, StreamTestWithHashStreamHashAidxColumnValue> getRowsMultimap(Iterable<StreamTestWithHashStreamHashAidxRow> rows) {
-        return getRowsMultimapInternal(rows, allColumns);
+        return getRowsMultimapInternal(rows, ColumnSelection.all());
     }
 
     @Override
@@ -621,13 +618,13 @@ public final class StreamTestWithHashStreamHashAidxTable implements
 
     private ColumnSelection optimizeColumnSelection(ColumnSelection columns) {
         if (columns.allColumnsSelected()) {
-            return allColumns;
+            return allKnownColumns;
         }
         return columns;
     }
 
     public BatchingVisitableView<StreamTestWithHashStreamHashAidxRowResult> getAllRowsUnordered() {
-        return getAllRowsUnordered(allColumns);
+        return getAllRowsUnordered(allKnownColumns);
     }
 
     public BatchingVisitableView<StreamTestWithHashStreamHashAidxRowResult> getAllRowsUnordered(ColumnSelection columns) {
@@ -682,6 +679,7 @@ public final class StreamTestWithHashStreamHashAidxTable implements
      * {@link ColumnSelection}
      * {@link ColumnValue}
      * {@link ColumnValues}
+     * {@link Columns}
      * {@link ComparisonChain}
      * {@link Compression}
      * {@link CompressionUtils}
@@ -739,5 +737,5 @@ public final class StreamTestWithHashStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "n5LSn5a3OH6VQMw1J/OB0g==";
+    static String __CLASS_HASH = "0p+aAo/xwm4J9h6aXJbIoA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamMetadataTable.java
@@ -66,6 +66,7 @@ import com.palantir.atlasdb.table.api.TypedRowResult;
 import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Columns;
 import com.palantir.atlasdb.table.generation.Descending;
 import com.palantir.atlasdb.table.generation.NamedColumnValue;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
@@ -98,7 +99,7 @@ public final class StreamTestWithHashStreamMetadataTable implements
     private final List<StreamTestWithHashStreamMetadataTrigger> triggers;
     private final static String rawTableName = "stream_test_with_hash_stream_metadata";
     private final TableReference tableRef;
-    private final static ColumnSelection allColumns = getColumnSelection(StreamTestWithHashStreamMetadataNamedColumn.values());
+    private final static ColumnSelection allKnownColumns = getColumnSelection(StreamTestWithHashStreamMetadataNamedColumn.values());
 
     static StreamTestWithHashStreamMetadataTable of(Transaction t, Namespace namespace) {
         return new StreamTestWithHashStreamMetadataTable(t, namespace, ImmutableList.<StreamTestWithHashStreamMetadataTrigger>of());
@@ -481,14 +482,12 @@ public final class StreamTestWithHashStreamMetadataTable implements
 
     @Override
     public void delete(Iterable<StreamTestWithHashStreamMetadataRow> rows) {
-        List<byte[]> rowBytes = Persistables.persistAll(rows);
-        Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
-        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("md")));
-        t.delete(tableRef, cells);
+        Multimap<StreamTestWithHashStreamMetadataRow, StreamTestWithHashStreamMetadataNamedColumnValue<?>> result = getRowsMultimap(rows);
+        t.delete(tableRef, ColumnValues.toCells(result));
     }
 
     public Optional<StreamTestWithHashStreamMetadataRowResult> getRow(StreamTestWithHashStreamMetadataRow row) {
-        return getRow(row, allColumns);
+        return getRow(row, allKnownColumns);
     }
 
     public Optional<StreamTestWithHashStreamMetadataRowResult> getRow(StreamTestWithHashStreamMetadataRow row, ColumnSelection columns) {
@@ -503,7 +502,7 @@ public final class StreamTestWithHashStreamMetadataTable implements
 
     @Override
     public List<StreamTestWithHashStreamMetadataRowResult> getRows(Iterable<StreamTestWithHashStreamMetadataRow> rows) {
-        return getRows(rows, allColumns);
+        return getRows(rows, allKnownColumns);
     }
 
     @Override
@@ -518,7 +517,7 @@ public final class StreamTestWithHashStreamMetadataTable implements
 
     @Override
     public List<StreamTestWithHashStreamMetadataNamedColumnValue<?>> getRowColumns(StreamTestWithHashStreamMetadataRow row) {
-        return getRowColumns(row, allColumns);
+        return getRowColumns(row, ColumnSelection.all());
     }
 
     @Override
@@ -538,7 +537,7 @@ public final class StreamTestWithHashStreamMetadataTable implements
 
     @Override
     public Multimap<StreamTestWithHashStreamMetadataRow, StreamTestWithHashStreamMetadataNamedColumnValue<?>> getRowsMultimap(Iterable<StreamTestWithHashStreamMetadataRow> rows) {
-        return getRowsMultimapInternal(rows, allColumns);
+        return getRowsMultimapInternal(rows, ColumnSelection.all());
     }
 
     @Override
@@ -602,13 +601,13 @@ public final class StreamTestWithHashStreamMetadataTable implements
 
     private ColumnSelection optimizeColumnSelection(ColumnSelection columns) {
         if (columns.allColumnsSelected()) {
-            return allColumns;
+            return allKnownColumns;
         }
         return columns;
     }
 
     public BatchingVisitableView<StreamTestWithHashStreamMetadataRowResult> getAllRowsUnordered() {
-        return getAllRowsUnordered(allColumns);
+        return getAllRowsUnordered(allKnownColumns);
     }
 
     public BatchingVisitableView<StreamTestWithHashStreamMetadataRowResult> getAllRowsUnordered(ColumnSelection columns) {
@@ -663,6 +662,7 @@ public final class StreamTestWithHashStreamMetadataTable implements
      * {@link ColumnSelection}
      * {@link ColumnValue}
      * {@link ColumnValues}
+     * {@link Columns}
      * {@link ComparisonChain}
      * {@link Compression}
      * {@link CompressionUtils}
@@ -720,5 +720,5 @@ public final class StreamTestWithHashStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "+CTiiWu+YOVuhh3VLe1XKg==";
+    static String __CLASS_HASH = "bWZ3Mts0/zOUA6LOGJr1ug==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamMetadataTable.java
@@ -66,6 +66,7 @@ import com.palantir.atlasdb.table.api.TypedRowResult;
 import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Columns;
 import com.palantir.atlasdb.table.generation.Descending;
 import com.palantir.atlasdb.table.generation.NamedColumnValue;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
@@ -98,7 +99,7 @@ public final class TestHashComponentsStreamMetadataTable implements
     private final List<TestHashComponentsStreamMetadataTrigger> triggers;
     private final static String rawTableName = "test_hash_components_stream_metadata";
     private final TableReference tableRef;
-    private final static ColumnSelection allColumns = getColumnSelection(TestHashComponentsStreamMetadataNamedColumn.values());
+    private final static ColumnSelection allKnownColumns = getColumnSelection(TestHashComponentsStreamMetadataNamedColumn.values());
 
     static TestHashComponentsStreamMetadataTable of(Transaction t, Namespace namespace) {
         return new TestHashComponentsStreamMetadataTable(t, namespace, ImmutableList.<TestHashComponentsStreamMetadataTrigger>of());
@@ -481,14 +482,12 @@ public final class TestHashComponentsStreamMetadataTable implements
 
     @Override
     public void delete(Iterable<TestHashComponentsStreamMetadataRow> rows) {
-        List<byte[]> rowBytes = Persistables.persistAll(rows);
-        Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
-        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("md")));
-        t.delete(tableRef, cells);
+        Multimap<TestHashComponentsStreamMetadataRow, TestHashComponentsStreamMetadataNamedColumnValue<?>> result = getRowsMultimap(rows);
+        t.delete(tableRef, ColumnValues.toCells(result));
     }
 
     public Optional<TestHashComponentsStreamMetadataRowResult> getRow(TestHashComponentsStreamMetadataRow row) {
-        return getRow(row, allColumns);
+        return getRow(row, allKnownColumns);
     }
 
     public Optional<TestHashComponentsStreamMetadataRowResult> getRow(TestHashComponentsStreamMetadataRow row, ColumnSelection columns) {
@@ -503,7 +502,7 @@ public final class TestHashComponentsStreamMetadataTable implements
 
     @Override
     public List<TestHashComponentsStreamMetadataRowResult> getRows(Iterable<TestHashComponentsStreamMetadataRow> rows) {
-        return getRows(rows, allColumns);
+        return getRows(rows, allKnownColumns);
     }
 
     @Override
@@ -518,7 +517,7 @@ public final class TestHashComponentsStreamMetadataTable implements
 
     @Override
     public List<TestHashComponentsStreamMetadataNamedColumnValue<?>> getRowColumns(TestHashComponentsStreamMetadataRow row) {
-        return getRowColumns(row, allColumns);
+        return getRowColumns(row, ColumnSelection.all());
     }
 
     @Override
@@ -538,7 +537,7 @@ public final class TestHashComponentsStreamMetadataTable implements
 
     @Override
     public Multimap<TestHashComponentsStreamMetadataRow, TestHashComponentsStreamMetadataNamedColumnValue<?>> getRowsMultimap(Iterable<TestHashComponentsStreamMetadataRow> rows) {
-        return getRowsMultimapInternal(rows, allColumns);
+        return getRowsMultimapInternal(rows, ColumnSelection.all());
     }
 
     @Override
@@ -602,13 +601,13 @@ public final class TestHashComponentsStreamMetadataTable implements
 
     private ColumnSelection optimizeColumnSelection(ColumnSelection columns) {
         if (columns.allColumnsSelected()) {
-            return allColumns;
+            return allKnownColumns;
         }
         return columns;
     }
 
     public BatchingVisitableView<TestHashComponentsStreamMetadataRowResult> getAllRowsUnordered() {
-        return getAllRowsUnordered(allColumns);
+        return getAllRowsUnordered(allKnownColumns);
     }
 
     public BatchingVisitableView<TestHashComponentsStreamMetadataRowResult> getAllRowsUnordered(ColumnSelection columns) {
@@ -663,6 +662,7 @@ public final class TestHashComponentsStreamMetadataTable implements
      * {@link ColumnSelection}
      * {@link ColumnValue}
      * {@link ColumnValues}
+     * {@link Columns}
      * {@link ComparisonChain}
      * {@link Compression}
      * {@link CompressionUtils}
@@ -720,5 +720,5 @@ public final class TestHashComponentsStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "nWGhnxJHTDG9KPTQr9Lp+Q==";
+    static String __CLASS_HASH = "tdfhh+g7RrNFenuQuoyopw==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamValueTable.java
@@ -66,6 +66,7 @@ import com.palantir.atlasdb.table.api.TypedRowResult;
 import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Columns;
 import com.palantir.atlasdb.table.generation.Descending;
 import com.palantir.atlasdb.table.generation.NamedColumnValue;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
@@ -98,7 +99,7 @@ public final class TestHashComponentsStreamValueTable implements
     private final List<TestHashComponentsStreamValueTrigger> triggers;
     private final static String rawTableName = "test_hash_components_stream_value";
     private final TableReference tableRef;
-    private final static ColumnSelection allColumns = getColumnSelection(TestHashComponentsStreamValueNamedColumn.values());
+    private final static ColumnSelection allKnownColumns = getColumnSelection(TestHashComponentsStreamValueNamedColumn.values());
 
     static TestHashComponentsStreamValueTable of(Transaction t, Namespace namespace) {
         return new TestHashComponentsStreamValueTable(t, namespace, ImmutableList.<TestHashComponentsStreamValueTrigger>of());
@@ -469,14 +470,12 @@ public final class TestHashComponentsStreamValueTable implements
 
     @Override
     public void delete(Iterable<TestHashComponentsStreamValueRow> rows) {
-        List<byte[]> rowBytes = Persistables.persistAll(rows);
-        Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
-        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("v")));
-        t.delete(tableRef, cells);
+        Multimap<TestHashComponentsStreamValueRow, TestHashComponentsStreamValueNamedColumnValue<?>> result = getRowsMultimap(rows);
+        t.delete(tableRef, ColumnValues.toCells(result));
     }
 
     public Optional<TestHashComponentsStreamValueRowResult> getRow(TestHashComponentsStreamValueRow row) {
-        return getRow(row, allColumns);
+        return getRow(row, allKnownColumns);
     }
 
     public Optional<TestHashComponentsStreamValueRowResult> getRow(TestHashComponentsStreamValueRow row, ColumnSelection columns) {
@@ -491,7 +490,7 @@ public final class TestHashComponentsStreamValueTable implements
 
     @Override
     public List<TestHashComponentsStreamValueRowResult> getRows(Iterable<TestHashComponentsStreamValueRow> rows) {
-        return getRows(rows, allColumns);
+        return getRows(rows, allKnownColumns);
     }
 
     @Override
@@ -506,7 +505,7 @@ public final class TestHashComponentsStreamValueTable implements
 
     @Override
     public List<TestHashComponentsStreamValueNamedColumnValue<?>> getRowColumns(TestHashComponentsStreamValueRow row) {
-        return getRowColumns(row, allColumns);
+        return getRowColumns(row, ColumnSelection.all());
     }
 
     @Override
@@ -526,7 +525,7 @@ public final class TestHashComponentsStreamValueTable implements
 
     @Override
     public Multimap<TestHashComponentsStreamValueRow, TestHashComponentsStreamValueNamedColumnValue<?>> getRowsMultimap(Iterable<TestHashComponentsStreamValueRow> rows) {
-        return getRowsMultimapInternal(rows, allColumns);
+        return getRowsMultimapInternal(rows, ColumnSelection.all());
     }
 
     @Override
@@ -590,13 +589,13 @@ public final class TestHashComponentsStreamValueTable implements
 
     private ColumnSelection optimizeColumnSelection(ColumnSelection columns) {
         if (columns.allColumnsSelected()) {
-            return allColumns;
+            return allKnownColumns;
         }
         return columns;
     }
 
     public BatchingVisitableView<TestHashComponentsStreamValueRowResult> getAllRowsUnordered() {
-        return getAllRowsUnordered(allColumns);
+        return getAllRowsUnordered(allKnownColumns);
     }
 
     public BatchingVisitableView<TestHashComponentsStreamValueRowResult> getAllRowsUnordered(ColumnSelection columns) {
@@ -651,6 +650,7 @@ public final class TestHashComponentsStreamValueTable implements
      * {@link ColumnSelection}
      * {@link ColumnValue}
      * {@link ColumnValues}
+     * {@link Columns}
      * {@link ComparisonChain}
      * {@link Compression}
      * {@link CompressionUtils}
@@ -708,5 +708,5 @@ public final class TestHashComponentsStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "OpgayffWbsYSqzi4fI/Qag==";
+    static String __CLASS_HASH = "+417oP7d4QNB6Dwu6wgpsA==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamHashAidxTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamHashAidxTable.java
@@ -1,26 +1,5 @@
 package com.palantir.example.profile.schema.generated;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.EnumSet;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.UUID;
-import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
-import java.util.function.BiFunction;
-import java.util.function.Supplier;
-import java.util.stream.Stream;
-
-import javax.annotation.Generated;
-
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
@@ -66,6 +45,7 @@ import com.palantir.atlasdb.table.api.TypedRowResult;
 import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Columns;
 import com.palantir.atlasdb.table.generation.Descending;
 import com.palantir.atlasdb.table.generation.NamedColumnValue;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
@@ -84,33 +64,65 @@ import com.palantir.common.persist.Persistable.Hydrator;
 import com.palantir.common.persist.Persistables;
 import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import javax.annotation.Generated;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
 @SuppressWarnings({"all", "deprecation"})
-public final class UserPhotosStreamHashAidxTable implements
-        AtlasDbDynamicMutablePersistentTable<UserPhotosStreamHashAidxTable.UserPhotosStreamHashAidxRow,
-                                                UserPhotosStreamHashAidxTable.UserPhotosStreamHashAidxColumn,
-                                                UserPhotosStreamHashAidxTable.UserPhotosStreamHashAidxColumnValue,
-                                                UserPhotosStreamHashAidxTable.UserPhotosStreamHashAidxRowResult> {
+public final class UserPhotosStreamHashAidxTable
+        implements AtlasDbDynamicMutablePersistentTable<
+                UserPhotosStreamHashAidxTable.UserPhotosStreamHashAidxRow,
+                UserPhotosStreamHashAidxTable.UserPhotosStreamHashAidxColumn,
+                UserPhotosStreamHashAidxTable.UserPhotosStreamHashAidxColumnValue,
+                UserPhotosStreamHashAidxTable.UserPhotosStreamHashAidxRowResult> {
     private final Transaction t;
     private final List<UserPhotosStreamHashAidxTrigger> triggers;
-    private final static String rawTableName = "user_photos_stream_hash_aidx";
+    private static final String rawTableName = "user_photos_stream_hash_aidx";
     private final TableReference tableRef;
-    private final static ColumnSelection allColumns = ColumnSelection.all();
+    private static final ColumnSelection allKnownColumns = ColumnSelection.all();
 
     static UserPhotosStreamHashAidxTable of(Transaction t, Namespace namespace) {
         return new UserPhotosStreamHashAidxTable(t, namespace, ImmutableList.<UserPhotosStreamHashAidxTrigger>of());
     }
 
-    static UserPhotosStreamHashAidxTable of(Transaction t, Namespace namespace, UserPhotosStreamHashAidxTrigger trigger, UserPhotosStreamHashAidxTrigger... triggers) {
-        return new UserPhotosStreamHashAidxTable(t, namespace, ImmutableList.<UserPhotosStreamHashAidxTrigger>builder().add(trigger).add(triggers).build());
+    static UserPhotosStreamHashAidxTable of(
+            Transaction t,
+            Namespace namespace,
+            UserPhotosStreamHashAidxTrigger trigger,
+            UserPhotosStreamHashAidxTrigger... triggers) {
+        return new UserPhotosStreamHashAidxTable(
+                t,
+                namespace,
+                ImmutableList.<UserPhotosStreamHashAidxTrigger>builder()
+                        .add(trigger)
+                        .add(triggers)
+                        .build());
     }
 
-    static UserPhotosStreamHashAidxTable of(Transaction t, Namespace namespace, List<UserPhotosStreamHashAidxTrigger> triggers) {
+    static UserPhotosStreamHashAidxTable of(
+            Transaction t, Namespace namespace, List<UserPhotosStreamHashAidxTrigger> triggers) {
         return new UserPhotosStreamHashAidxTable(t, namespace, triggers);
     }
 
-    private UserPhotosStreamHashAidxTable(Transaction t, Namespace namespace, List<UserPhotosStreamHashAidxTrigger> triggers) {
+    private UserPhotosStreamHashAidxTable(
+            Transaction t, Namespace namespace, List<UserPhotosStreamHashAidxTrigger> triggers) {
         this.t = t;
         this.tableRef = TableReference.create(namespace, rawTableName);
         this.triggers = triggers;
@@ -139,7 +151,8 @@ public final class UserPhotosStreamHashAidxTable implements
      * }
      * </pre>
      */
-    public static final class UserPhotosStreamHashAidxRow implements Persistable, Comparable<UserPhotosStreamHashAidxRow> {
+    public static final class UserPhotosStreamHashAidxRow
+            implements Persistable, Comparable<UserPhotosStreamHashAidxRow> {
         private final Sha256Hash hash;
 
         public static UserPhotosStreamHashAidxRow of(Sha256Hash hash) {
@@ -178,21 +191,22 @@ public final class UserPhotosStreamHashAidxTable implements
             return EncodingUtils.add(hashBytes);
         }
 
-        public static final Hydrator<UserPhotosStreamHashAidxRow> BYTES_HYDRATOR = new Hydrator<UserPhotosStreamHashAidxRow>() {
-            @Override
-            public UserPhotosStreamHashAidxRow hydrateFromBytes(byte[] __input) {
-                int __index = 0;
-                Sha256Hash hash = new Sha256Hash(EncodingUtils.get32Bytes(__input, __index));
-                __index += 32;
-                return new UserPhotosStreamHashAidxRow(hash);
-            }
-        };
+        public static final Hydrator<UserPhotosStreamHashAidxRow> BYTES_HYDRATOR =
+                new Hydrator<UserPhotosStreamHashAidxRow>() {
+                    @Override
+                    public UserPhotosStreamHashAidxRow hydrateFromBytes(byte[] __input) {
+                        int __index = 0;
+                        Sha256Hash hash = new Sha256Hash(EncodingUtils.get32Bytes(__input, __index));
+                        __index += 32;
+                        return new UserPhotosStreamHashAidxRow(hash);
+                    }
+                };
 
         @Override
         public String toString() {
             return MoreObjects.toStringHelper(getClass().getSimpleName())
-                .add("hash", hash)
-                .toString();
+                    .add("hash", hash)
+                    .toString();
         }
 
         @Override
@@ -218,9 +232,7 @@ public final class UserPhotosStreamHashAidxTable implements
 
         @Override
         public int compareTo(UserPhotosStreamHashAidxRow o) {
-            return ComparisonChain.start()
-                .compare(this.hash, o.hash)
-                .result();
+            return ComparisonChain.start().compare(this.hash, o.hash).result();
         }
     }
 
@@ -231,7 +243,8 @@ public final class UserPhotosStreamHashAidxTable implements
      * }
      * </pre>
      */
-    public static final class UserPhotosStreamHashAidxColumn implements Persistable, Comparable<UserPhotosStreamHashAidxColumn> {
+    public static final class UserPhotosStreamHashAidxColumn
+            implements Persistable, Comparable<UserPhotosStreamHashAidxColumn> {
         private final long streamId;
 
         public static UserPhotosStreamHashAidxColumn of(long streamId) {
@@ -270,21 +283,22 @@ public final class UserPhotosStreamHashAidxTable implements
             return EncodingUtils.add(streamIdBytes);
         }
 
-        public static final Hydrator<UserPhotosStreamHashAidxColumn> BYTES_HYDRATOR = new Hydrator<UserPhotosStreamHashAidxColumn>() {
-            @Override
-            public UserPhotosStreamHashAidxColumn hydrateFromBytes(byte[] __input) {
-                int __index = 0;
-                Long streamId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(streamId);
-                return new UserPhotosStreamHashAidxColumn(streamId);
-            }
-        };
+        public static final Hydrator<UserPhotosStreamHashAidxColumn> BYTES_HYDRATOR =
+                new Hydrator<UserPhotosStreamHashAidxColumn>() {
+                    @Override
+                    public UserPhotosStreamHashAidxColumn hydrateFromBytes(byte[] __input) {
+                        int __index = 0;
+                        Long streamId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
+                        __index += EncodingUtils.sizeOfUnsignedVarLong(streamId);
+                        return new UserPhotosStreamHashAidxColumn(streamId);
+                    }
+                };
 
         @Override
         public String toString() {
             return MoreObjects.toStringHelper(getClass().getSimpleName())
-                .add("streamId", streamId)
-                .toString();
+                    .add("streamId", streamId)
+                    .toString();
         }
 
         @Override
@@ -310,14 +324,13 @@ public final class UserPhotosStreamHashAidxTable implements
 
         @Override
         public int compareTo(UserPhotosStreamHashAidxColumn o) {
-            return ComparisonChain.start()
-                .compare(this.streamId, o.streamId)
-                .result();
+            return ComparisonChain.start().compare(this.streamId, o.streamId).result();
         }
     }
 
     public interface UserPhotosStreamHashAidxTrigger {
-        public void putUserPhotosStreamHashAidx(Multimap<UserPhotosStreamHashAidxRow, ? extends UserPhotosStreamHashAidxColumnValue> newRows);
+        public void putUserPhotosStreamHashAidx(
+                Multimap<UserPhotosStreamHashAidxRow, ? extends UserPhotosStreamHashAidxColumnValue> newRows);
     }
 
     /**
@@ -389,9 +402,9 @@ public final class UserPhotosStreamHashAidxTable implements
         @Override
         public String toString() {
             return MoreObjects.toStringHelper(getClass().getSimpleName())
-                .add("ColumnName", this.columnName)
-                .add("Value", this.value)
-                .toString();
+                    .add("ColumnName", this.columnName)
+                    .add("Value", this.value)
+                    .toString();
         }
     }
 
@@ -400,17 +413,21 @@ public final class UserPhotosStreamHashAidxTable implements
         private final ImmutableSet<UserPhotosStreamHashAidxColumnValue> columnValues;
 
         public static UserPhotosStreamHashAidxRowResult of(RowResult<byte[]> rowResult) {
-            UserPhotosStreamHashAidxRow rowName = UserPhotosStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(rowResult.getRowName());
-            Set<UserPhotosStreamHashAidxColumnValue> columnValues = Sets.newHashSetWithExpectedSize(rowResult.getColumns().size());
+            UserPhotosStreamHashAidxRow rowName =
+                    UserPhotosStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(rowResult.getRowName());
+            Set<UserPhotosStreamHashAidxColumnValue> columnValues =
+                    Sets.newHashSetWithExpectedSize(rowResult.getColumns().size());
             for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
-                UserPhotosStreamHashAidxColumn col = UserPhotosStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                UserPhotosStreamHashAidxColumn col =
+                        UserPhotosStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
                 Long value = UserPhotosStreamHashAidxColumnValue.hydrateValue(e.getValue());
                 columnValues.add(UserPhotosStreamHashAidxColumnValue.of(col, value));
             }
             return new UserPhotosStreamHashAidxRowResult(rowName, ImmutableSet.copyOf(columnValues));
         }
 
-        private UserPhotosStreamHashAidxRowResult(UserPhotosStreamHashAidxRow rowName, ImmutableSet<UserPhotosStreamHashAidxColumnValue> columnValues) {
+        private UserPhotosStreamHashAidxRowResult(
+                UserPhotosStreamHashAidxRow rowName, ImmutableSet<UserPhotosStreamHashAidxColumnValue> columnValues) {
             this.rowName = rowName;
             this.columnValues = columnValues;
         }
@@ -433,10 +450,13 @@ public final class UserPhotosStreamHashAidxTable implements
             };
         }
 
-        public static Function<UserPhotosStreamHashAidxRowResult, ImmutableSet<UserPhotosStreamHashAidxColumnValue>> getColumnValuesFun() {
-            return new Function<UserPhotosStreamHashAidxRowResult, ImmutableSet<UserPhotosStreamHashAidxColumnValue>>() {
+        public static Function<UserPhotosStreamHashAidxRowResult, ImmutableSet<UserPhotosStreamHashAidxColumnValue>>
+                getColumnValuesFun() {
+            return new Function<
+                    UserPhotosStreamHashAidxRowResult, ImmutableSet<UserPhotosStreamHashAidxColumnValue>>() {
                 @Override
-                public ImmutableSet<UserPhotosStreamHashAidxColumnValue> apply(UserPhotosStreamHashAidxRowResult rowResult) {
+                public ImmutableSet<UserPhotosStreamHashAidxColumnValue> apply(
+                        UserPhotosStreamHashAidxRowResult rowResult) {
                     return rowResult.columnValues;
                 }
             };
@@ -445,9 +465,9 @@ public final class UserPhotosStreamHashAidxTable implements
         @Override
         public String toString() {
             return MoreObjects.toStringHelper(getClass().getSimpleName())
-                .add("RowName", getRowName())
-                .add("ColumnValues", getColumnValues())
-                .toString();
+                    .add("RowName", getRowName())
+                    .add("ColumnValues", getColumnValues())
+                    .toString();
         }
     }
 
@@ -458,27 +478,27 @@ public final class UserPhotosStreamHashAidxTable implements
 
     @Override
     public void delete(Iterable<UserPhotosStreamHashAidxRow> rows) {
-        Multimap<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumn> toRemove = HashMultimap.create();
         Multimap<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumnValue> result = getRowsMultimap(rows);
-        for (Entry<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumnValue> e : result.entries()) {
-            toRemove.put(e.getKey(), e.getValue().getColumnName());
-        }
-        delete(toRemove);
+        t.delete(tableRef, ColumnValues.toCells(result));
     }
 
     @Override
     public void delete(Multimap<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumn> values) {
-        t.delete(tableRef, ColumnValues.toCells(values));
+        t.delete(tableRef, Columns.toCells(values));
     }
 
     @Override
     public void put(UserPhotosStreamHashAidxRow rowName, Iterable<UserPhotosStreamHashAidxColumnValue> values) {
-        put(ImmutableMultimap.<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumnValue>builder().putAll(rowName, values).build());
+        put(ImmutableMultimap.<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumnValue>builder()
+                .putAll(rowName, values)
+                .build());
     }
 
     @Override
     public void put(UserPhotosStreamHashAidxRow rowName, UserPhotosStreamHashAidxColumnValue... values) {
-        put(ImmutableMultimap.<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumnValue>builder().putAll(rowName, values).build());
+        put(ImmutableMultimap.<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumnValue>builder()
+                .putAll(rowName, values)
+                .build());
     }
 
     @Override
@@ -510,14 +530,17 @@ public final class UserPhotosStreamHashAidxTable implements
     }
 
     @Override
-    public Multimap<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumnValue> get(Multimap<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumn> cells) {
-        Set<Cell> rawCells = ColumnValues.toCells(cells);
+    public Multimap<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumnValue> get(
+            Multimap<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumn> cells) {
+        Set<Cell> rawCells = Columns.toCells(cells);
         Map<Cell, byte[]> rawResults = t.get(tableRef, rawCells);
         Multimap<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumnValue> rowMap = ArrayListMultimap.create();
         for (Entry<Cell, byte[]> e : rawResults.entrySet()) {
             if (e.getValue().length > 0) {
-                UserPhotosStreamHashAidxRow row = UserPhotosStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
-                UserPhotosStreamHashAidxColumn col = UserPhotosStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getColumnName());
+                UserPhotosStreamHashAidxRow row = UserPhotosStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(
+                        e.getKey().getRowName());
+                UserPhotosStreamHashAidxColumn col = UserPhotosStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(
+                        e.getKey().getColumnName());
                 Long val = UserPhotosStreamHashAidxColumnValue.hydrateValue(e.getValue());
                 rowMap.put(row, UserPhotosStreamHashAidxColumnValue.of(col, val));
             }
@@ -527,19 +550,23 @@ public final class UserPhotosStreamHashAidxTable implements
 
     @Override
     public List<UserPhotosStreamHashAidxColumnValue> getRowColumns(UserPhotosStreamHashAidxRow row) {
-        return getRowColumns(row, allColumns);
+        return getRowColumns(row, ColumnSelection.all());
     }
 
     @Override
-    public List<UserPhotosStreamHashAidxColumnValue> getRowColumns(UserPhotosStreamHashAidxRow row, ColumnSelection columns) {
+    public List<UserPhotosStreamHashAidxColumnValue> getRowColumns(
+            UserPhotosStreamHashAidxRow row, ColumnSelection columns) {
         byte[] bytes = row.persistToBytes();
-        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        RowResult<byte[]> rowResult =
+                t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
         if (rowResult == null) {
             return ImmutableList.of();
         } else {
-            List<UserPhotosStreamHashAidxColumnValue> ret = Lists.newArrayListWithCapacity(rowResult.getColumns().size());
+            List<UserPhotosStreamHashAidxColumnValue> ret =
+                    Lists.newArrayListWithCapacity(rowResult.getColumns().size());
             for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
-                UserPhotosStreamHashAidxColumn col = UserPhotosStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                UserPhotosStreamHashAidxColumn col =
+                        UserPhotosStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
                 Long val = UserPhotosStreamHashAidxColumnValue.hydrateValue(e.getValue());
                 ret.add(UserPhotosStreamHashAidxColumnValue.of(col, val));
             }
@@ -548,26 +575,32 @@ public final class UserPhotosStreamHashAidxTable implements
     }
 
     @Override
-    public Multimap<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumnValue> getRowsMultimap(Iterable<UserPhotosStreamHashAidxRow> rows) {
-        return getRowsMultimapInternal(rows, allColumns);
+    public Multimap<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumnValue> getRowsMultimap(
+            Iterable<UserPhotosStreamHashAidxRow> rows) {
+        return getRowsMultimapInternal(rows, ColumnSelection.all());
     }
 
     @Override
-    public Multimap<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumnValue> getRowsMultimap(Iterable<UserPhotosStreamHashAidxRow> rows, ColumnSelection columns) {
+    public Multimap<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumnValue> getRowsMultimap(
+            Iterable<UserPhotosStreamHashAidxRow> rows, ColumnSelection columns) {
         return getRowsMultimapInternal(rows, columns);
     }
 
-    private Multimap<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumnValue> getRowsMultimapInternal(Iterable<UserPhotosStreamHashAidxRow> rows, ColumnSelection columns) {
+    private Multimap<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumnValue> getRowsMultimapInternal(
+            Iterable<UserPhotosStreamHashAidxRow> rows, ColumnSelection columns) {
         SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
         return getRowMapFromRowResults(results.values());
     }
 
-    private static Multimap<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumnValue> getRowMapFromRowResults(Collection<RowResult<byte[]>> rowResults) {
+    private static Multimap<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumnValue> getRowMapFromRowResults(
+            Collection<RowResult<byte[]>> rowResults) {
         Multimap<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumnValue> rowMap = ArrayListMultimap.create();
         for (RowResult<byte[]> result : rowResults) {
-            UserPhotosStreamHashAidxRow row = UserPhotosStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
+            UserPhotosStreamHashAidxRow row =
+                    UserPhotosStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
             for (Entry<byte[], byte[]> e : result.getColumns().entrySet()) {
-                UserPhotosStreamHashAidxColumn col = UserPhotosStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                UserPhotosStreamHashAidxColumn col =
+                        UserPhotosStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
                 Long val = UserPhotosStreamHashAidxColumnValue.hydrateValue(e.getValue());
                 rowMap.put(row, UserPhotosStreamHashAidxColumnValue.of(col, val));
             }
@@ -576,27 +609,37 @@ public final class UserPhotosStreamHashAidxTable implements
     }
 
     @Override
-    public Map<UserPhotosStreamHashAidxRow, BatchingVisitable<UserPhotosStreamHashAidxColumnValue>> getRowsColumnRange(Iterable<UserPhotosStreamHashAidxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
-        Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
-        Map<UserPhotosStreamHashAidxRow, BatchingVisitable<UserPhotosStreamHashAidxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+    public Map<UserPhotosStreamHashAidxRow, BatchingVisitable<UserPhotosStreamHashAidxColumnValue>> getRowsColumnRange(
+            Iterable<UserPhotosStreamHashAidxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results =
+                t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<UserPhotosStreamHashAidxRow, BatchingVisitable<UserPhotosStreamHashAidxColumnValue>> transformed =
+                Maps.newHashMapWithExpectedSize(results.size());
         for (Entry<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
             UserPhotosStreamHashAidxRow row = UserPhotosStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
-            BatchingVisitable<UserPhotosStreamHashAidxColumnValue> bv = BatchingVisitables.transform(e.getValue(), result -> {
-                UserPhotosStreamHashAidxColumn col = UserPhotosStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
-                Long val = UserPhotosStreamHashAidxColumnValue.hydrateValue(result.getValue());
-                return UserPhotosStreamHashAidxColumnValue.of(col, val);
-            });
+            BatchingVisitable<UserPhotosStreamHashAidxColumnValue> bv =
+                    BatchingVisitables.transform(e.getValue(), result -> {
+                        UserPhotosStreamHashAidxColumn col =
+                                UserPhotosStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(
+                                        result.getKey().getColumnName());
+                        Long val = UserPhotosStreamHashAidxColumnValue.hydrateValue(result.getValue());
+                        return UserPhotosStreamHashAidxColumnValue.of(col, val);
+                    });
             transformed.put(row, bv);
         }
         return transformed;
     }
 
     @Override
-    public Iterator<Map.Entry<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumnValue>> getRowsColumnRange(Iterable<UserPhotosStreamHashAidxRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
-        Iterator<Map.Entry<Cell, byte[]>> results = t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
+    public Iterator<Map.Entry<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumnValue>> getRowsColumnRange(
+            Iterable<UserPhotosStreamHashAidxRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
+        Iterator<Map.Entry<Cell, byte[]>> results =
+                t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
         return Iterators.transform(results, e -> {
-            UserPhotosStreamHashAidxRow row = UserPhotosStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
-            UserPhotosStreamHashAidxColumn col = UserPhotosStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getColumnName());
+            UserPhotosStreamHashAidxRow row = UserPhotosStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(
+                    e.getKey().getRowName());
+            UserPhotosStreamHashAidxColumn col = UserPhotosStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(
+                    e.getKey().getColumnName());
             Long val = UserPhotosStreamHashAidxColumnValue.hydrateValue(e.getValue());
             UserPhotosStreamHashAidxColumnValue colValue = UserPhotosStreamHashAidxColumnValue.of(col, val);
             return Maps.immutableEntry(row, colValue);
@@ -604,13 +647,17 @@ public final class UserPhotosStreamHashAidxTable implements
     }
 
     @Override
-    public Map<UserPhotosStreamHashAidxRow, Iterator<UserPhotosStreamHashAidxColumnValue>> getRowsColumnRangeIterator(Iterable<UserPhotosStreamHashAidxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
-        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
-        Map<UserPhotosStreamHashAidxRow, Iterator<UserPhotosStreamHashAidxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+    public Map<UserPhotosStreamHashAidxRow, Iterator<UserPhotosStreamHashAidxColumnValue>> getRowsColumnRangeIterator(
+            Iterable<UserPhotosStreamHashAidxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results =
+                t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<UserPhotosStreamHashAidxRow, Iterator<UserPhotosStreamHashAidxColumnValue>> transformed =
+                Maps.newHashMapWithExpectedSize(results.size());
         for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
             UserPhotosStreamHashAidxRow row = UserPhotosStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
             Iterator<UserPhotosStreamHashAidxColumnValue> bv = Iterators.transform(e.getValue(), result -> {
-                UserPhotosStreamHashAidxColumn col = UserPhotosStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                UserPhotosStreamHashAidxColumn col = UserPhotosStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(
+                        result.getKey().getColumnName());
                 Long val = UserPhotosStreamHashAidxColumnValue.hydrateValue(result.getValue());
                 return UserPhotosStreamHashAidxColumnValue.of(col, val);
             });
@@ -621,36 +668,41 @@ public final class UserPhotosStreamHashAidxTable implements
 
     private ColumnSelection optimizeColumnSelection(ColumnSelection columns) {
         if (columns.allColumnsSelected()) {
-            return allColumns;
+            return allKnownColumns;
         }
         return columns;
     }
 
     public BatchingVisitableView<UserPhotosStreamHashAidxRowResult> getAllRowsUnordered() {
-        return getAllRowsUnordered(allColumns);
+        return getAllRowsUnordered(allKnownColumns);
     }
 
     public BatchingVisitableView<UserPhotosStreamHashAidxRowResult> getAllRowsUnordered(ColumnSelection columns) {
-        return BatchingVisitables.transform(t.getRange(tableRef, RangeRequest.builder()
-                .retainColumns(optimizeColumnSelection(columns)).build()),
+        return BatchingVisitables.transform(
+                t.getRange(
+                        tableRef,
+                        RangeRequest.builder()
+                                .retainColumns(optimizeColumnSelection(columns))
+                                .build()),
                 new Function<RowResult<byte[]>, UserPhotosStreamHashAidxRowResult>() {
-            @Override
-            public UserPhotosStreamHashAidxRowResult apply(RowResult<byte[]> input) {
-                return UserPhotosStreamHashAidxRowResult.of(input);
-            }
-        });
+                    @Override
+                    public UserPhotosStreamHashAidxRowResult apply(RowResult<byte[]> input) {
+                        return UserPhotosStreamHashAidxRowResult.of(input);
+                    }
+                });
     }
 
     @Override
-    public List<String> findConstraintFailures(Map<Cell, byte[]> writes,
-                                               ConstraintCheckingTransaction transaction,
-                                               AtlasDbConstraintCheckingMode constraintCheckingMode) {
+    public List<String> findConstraintFailures(
+            Map<Cell, byte[]> writes,
+            ConstraintCheckingTransaction transaction,
+            AtlasDbConstraintCheckingMode constraintCheckingMode) {
         return ImmutableList.of();
     }
 
     @Override
-    public List<String> findConstraintFailuresNoRead(Map<Cell, byte[]> writes,
-                                                     AtlasDbConstraintCheckingMode constraintCheckingMode) {
+    public List<String> findConstraintFailuresNoRead(
+            Map<Cell, byte[]> writes, AtlasDbConstraintCheckingMode constraintCheckingMode) {
         return ImmutableList.of();
     }
 
@@ -682,6 +734,7 @@ public final class UserPhotosStreamHashAidxTable implements
      * {@link ColumnSelection}
      * {@link ColumnValue}
      * {@link ColumnValues}
+     * {@link Columns}
      * {@link ComparisonChain}
      * {@link Compression}
      * {@link CompressionUtils}
@@ -739,5 +792,5 @@ public final class UserPhotosStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "Lz3ywZCktSQ3ANOoklDOfg==";
+    static String __CLASS_HASH = "cjb1brTkavXGN60qGNNuPA==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamIdxTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamIdxTable.java
@@ -1,26 +1,5 @@
 package com.palantir.example.profile.schema.generated;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.EnumSet;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.UUID;
-import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
-import java.util.function.BiFunction;
-import java.util.function.Supplier;
-import java.util.stream.Stream;
-
-import javax.annotation.Generated;
-
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
@@ -66,6 +45,7 @@ import com.palantir.atlasdb.table.api.TypedRowResult;
 import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Columns;
 import com.palantir.atlasdb.table.generation.Descending;
 import com.palantir.atlasdb.table.generation.NamedColumnValue;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
@@ -84,26 +64,56 @@ import com.palantir.common.persist.Persistable.Hydrator;
 import com.palantir.common.persist.Persistables;
 import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import javax.annotation.Generated;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
 @SuppressWarnings({"all", "deprecation"})
-public final class UserPhotosStreamIdxTable implements
-        AtlasDbDynamicMutablePersistentTable<UserPhotosStreamIdxTable.UserPhotosStreamIdxRow,
-                                                UserPhotosStreamIdxTable.UserPhotosStreamIdxColumn,
-                                                UserPhotosStreamIdxTable.UserPhotosStreamIdxColumnValue,
-                                                UserPhotosStreamIdxTable.UserPhotosStreamIdxRowResult> {
+public final class UserPhotosStreamIdxTable
+        implements AtlasDbDynamicMutablePersistentTable<
+                UserPhotosStreamIdxTable.UserPhotosStreamIdxRow,
+                UserPhotosStreamIdxTable.UserPhotosStreamIdxColumn,
+                UserPhotosStreamIdxTable.UserPhotosStreamIdxColumnValue,
+                UserPhotosStreamIdxTable.UserPhotosStreamIdxRowResult> {
     private final Transaction t;
     private final List<UserPhotosStreamIdxTrigger> triggers;
-    private final static String rawTableName = "user_photos_stream_idx";
+    private static final String rawTableName = "user_photos_stream_idx";
     private final TableReference tableRef;
-    private final static ColumnSelection allColumns = ColumnSelection.all();
+    private static final ColumnSelection allKnownColumns = ColumnSelection.all();
 
     static UserPhotosStreamIdxTable of(Transaction t, Namespace namespace) {
         return new UserPhotosStreamIdxTable(t, namespace, ImmutableList.<UserPhotosStreamIdxTrigger>of());
     }
 
-    static UserPhotosStreamIdxTable of(Transaction t, Namespace namespace, UserPhotosStreamIdxTrigger trigger, UserPhotosStreamIdxTrigger... triggers) {
-        return new UserPhotosStreamIdxTable(t, namespace, ImmutableList.<UserPhotosStreamIdxTrigger>builder().add(trigger).add(triggers).build());
+    static UserPhotosStreamIdxTable of(
+            Transaction t,
+            Namespace namespace,
+            UserPhotosStreamIdxTrigger trigger,
+            UserPhotosStreamIdxTrigger... triggers) {
+        return new UserPhotosStreamIdxTable(
+                t,
+                namespace,
+                ImmutableList.<UserPhotosStreamIdxTrigger>builder()
+                        .add(trigger)
+                        .add(triggers)
+                        .build());
     }
 
     static UserPhotosStreamIdxTable of(Transaction t, Namespace namespace, List<UserPhotosStreamIdxTrigger> triggers) {
@@ -191,8 +201,8 @@ public final class UserPhotosStreamIdxTable implements
         @Override
         public String toString() {
             return MoreObjects.toStringHelper(getClass().getSimpleName())
-                .add("id", id)
-                .toString();
+                    .add("id", id)
+                    .toString();
         }
 
         @Override
@@ -218,9 +228,7 @@ public final class UserPhotosStreamIdxTable implements
 
         @Override
         public int compareTo(UserPhotosStreamIdxRow o) {
-            return ComparisonChain.start()
-                .compare(this.id, o.id)
-                .result();
+            return ComparisonChain.start().compare(this.id, o.id).result();
         }
     }
 
@@ -270,21 +278,22 @@ public final class UserPhotosStreamIdxTable implements
             return EncodingUtils.add(referenceBytes);
         }
 
-        public static final Hydrator<UserPhotosStreamIdxColumn> BYTES_HYDRATOR = new Hydrator<UserPhotosStreamIdxColumn>() {
-            @Override
-            public UserPhotosStreamIdxColumn hydrateFromBytes(byte[] __input) {
-                int __index = 0;
-                byte[] reference = EncodingUtils.decodeSizedBytes(__input, __index);
-                __index += EncodingUtils.sizeOfSizedBytes(reference);
-                return new UserPhotosStreamIdxColumn(reference);
-            }
-        };
+        public static final Hydrator<UserPhotosStreamIdxColumn> BYTES_HYDRATOR =
+                new Hydrator<UserPhotosStreamIdxColumn>() {
+                    @Override
+                    public UserPhotosStreamIdxColumn hydrateFromBytes(byte[] __input) {
+                        int __index = 0;
+                        byte[] reference = EncodingUtils.decodeSizedBytes(__input, __index);
+                        __index += EncodingUtils.sizeOfSizedBytes(reference);
+                        return new UserPhotosStreamIdxColumn(reference);
+                    }
+                };
 
         @Override
         public String toString() {
             return MoreObjects.toStringHelper(getClass().getSimpleName())
-                .add("reference", reference)
-                .toString();
+                    .add("reference", reference)
+                    .toString();
         }
 
         @Override
@@ -311,13 +320,14 @@ public final class UserPhotosStreamIdxTable implements
         @Override
         public int compareTo(UserPhotosStreamIdxColumn o) {
             return ComparisonChain.start()
-                .compare(this.reference, o.reference, UnsignedBytes.lexicographicalComparator())
-                .result();
+                    .compare(this.reference, o.reference, UnsignedBytes.lexicographicalComparator())
+                    .result();
         }
     }
 
     public interface UserPhotosStreamIdxTrigger {
-        public void putUserPhotosStreamIdx(Multimap<UserPhotosStreamIdxRow, ? extends UserPhotosStreamIdxColumnValue> newRows);
+        public void putUserPhotosStreamIdx(
+                Multimap<UserPhotosStreamIdxRow, ? extends UserPhotosStreamIdxColumnValue> newRows);
     }
 
     /**
@@ -389,9 +399,9 @@ public final class UserPhotosStreamIdxTable implements
         @Override
         public String toString() {
             return MoreObjects.toStringHelper(getClass().getSimpleName())
-                .add("ColumnName", this.columnName)
-                .add("Value", this.value)
-                .toString();
+                    .add("ColumnName", this.columnName)
+                    .add("Value", this.value)
+                    .toString();
         }
     }
 
@@ -400,8 +410,10 @@ public final class UserPhotosStreamIdxTable implements
         private final ImmutableSet<UserPhotosStreamIdxColumnValue> columnValues;
 
         public static UserPhotosStreamIdxRowResult of(RowResult<byte[]> rowResult) {
-            UserPhotosStreamIdxRow rowName = UserPhotosStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(rowResult.getRowName());
-            Set<UserPhotosStreamIdxColumnValue> columnValues = Sets.newHashSetWithExpectedSize(rowResult.getColumns().size());
+            UserPhotosStreamIdxRow rowName =
+                    UserPhotosStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(rowResult.getRowName());
+            Set<UserPhotosStreamIdxColumnValue> columnValues =
+                    Sets.newHashSetWithExpectedSize(rowResult.getColumns().size());
             for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
                 UserPhotosStreamIdxColumn col = UserPhotosStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
                 Long value = UserPhotosStreamIdxColumnValue.hydrateValue(e.getValue());
@@ -410,7 +422,8 @@ public final class UserPhotosStreamIdxTable implements
             return new UserPhotosStreamIdxRowResult(rowName, ImmutableSet.copyOf(columnValues));
         }
 
-        private UserPhotosStreamIdxRowResult(UserPhotosStreamIdxRow rowName, ImmutableSet<UserPhotosStreamIdxColumnValue> columnValues) {
+        private UserPhotosStreamIdxRowResult(
+                UserPhotosStreamIdxRow rowName, ImmutableSet<UserPhotosStreamIdxColumnValue> columnValues) {
             this.rowName = rowName;
             this.columnValues = columnValues;
         }
@@ -433,7 +446,8 @@ public final class UserPhotosStreamIdxTable implements
             };
         }
 
-        public static Function<UserPhotosStreamIdxRowResult, ImmutableSet<UserPhotosStreamIdxColumnValue>> getColumnValuesFun() {
+        public static Function<UserPhotosStreamIdxRowResult, ImmutableSet<UserPhotosStreamIdxColumnValue>>
+                getColumnValuesFun() {
             return new Function<UserPhotosStreamIdxRowResult, ImmutableSet<UserPhotosStreamIdxColumnValue>>() {
                 @Override
                 public ImmutableSet<UserPhotosStreamIdxColumnValue> apply(UserPhotosStreamIdxRowResult rowResult) {
@@ -445,9 +459,9 @@ public final class UserPhotosStreamIdxTable implements
         @Override
         public String toString() {
             return MoreObjects.toStringHelper(getClass().getSimpleName())
-                .add("RowName", getRowName())
-                .add("ColumnValues", getColumnValues())
-                .toString();
+                    .add("RowName", getRowName())
+                    .add("ColumnValues", getColumnValues())
+                    .toString();
         }
     }
 
@@ -458,27 +472,27 @@ public final class UserPhotosStreamIdxTable implements
 
     @Override
     public void delete(Iterable<UserPhotosStreamIdxRow> rows) {
-        Multimap<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumn> toRemove = HashMultimap.create();
         Multimap<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumnValue> result = getRowsMultimap(rows);
-        for (Entry<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumnValue> e : result.entries()) {
-            toRemove.put(e.getKey(), e.getValue().getColumnName());
-        }
-        delete(toRemove);
+        t.delete(tableRef, ColumnValues.toCells(result));
     }
 
     @Override
     public void delete(Multimap<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumn> values) {
-        t.delete(tableRef, ColumnValues.toCells(values));
+        t.delete(tableRef, Columns.toCells(values));
     }
 
     @Override
     public void put(UserPhotosStreamIdxRow rowName, Iterable<UserPhotosStreamIdxColumnValue> values) {
-        put(ImmutableMultimap.<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumnValue>builder().putAll(rowName, values).build());
+        put(ImmutableMultimap.<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumnValue>builder()
+                .putAll(rowName, values)
+                .build());
     }
 
     @Override
     public void put(UserPhotosStreamIdxRow rowName, UserPhotosStreamIdxColumnValue... values) {
-        put(ImmutableMultimap.<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumnValue>builder().putAll(rowName, values).build());
+        put(ImmutableMultimap.<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumnValue>builder()
+                .putAll(rowName, values)
+                .build());
     }
 
     @Override
@@ -510,14 +524,17 @@ public final class UserPhotosStreamIdxTable implements
     }
 
     @Override
-    public Multimap<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumnValue> get(Multimap<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumn> cells) {
-        Set<Cell> rawCells = ColumnValues.toCells(cells);
+    public Multimap<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumnValue> get(
+            Multimap<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumn> cells) {
+        Set<Cell> rawCells = Columns.toCells(cells);
         Map<Cell, byte[]> rawResults = t.get(tableRef, rawCells);
         Multimap<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumnValue> rowMap = ArrayListMultimap.create();
         for (Entry<Cell, byte[]> e : rawResults.entrySet()) {
             if (e.getValue().length > 0) {
-                UserPhotosStreamIdxRow row = UserPhotosStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
-                UserPhotosStreamIdxColumn col = UserPhotosStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getColumnName());
+                UserPhotosStreamIdxRow row = UserPhotosStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(
+                        e.getKey().getRowName());
+                UserPhotosStreamIdxColumn col = UserPhotosStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(
+                        e.getKey().getColumnName());
                 Long val = UserPhotosStreamIdxColumnValue.hydrateValue(e.getValue());
                 rowMap.put(row, UserPhotosStreamIdxColumnValue.of(col, val));
             }
@@ -527,17 +544,19 @@ public final class UserPhotosStreamIdxTable implements
 
     @Override
     public List<UserPhotosStreamIdxColumnValue> getRowColumns(UserPhotosStreamIdxRow row) {
-        return getRowColumns(row, allColumns);
+        return getRowColumns(row, ColumnSelection.all());
     }
 
     @Override
     public List<UserPhotosStreamIdxColumnValue> getRowColumns(UserPhotosStreamIdxRow row, ColumnSelection columns) {
         byte[] bytes = row.persistToBytes();
-        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        RowResult<byte[]> rowResult =
+                t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
         if (rowResult == null) {
             return ImmutableList.of();
         } else {
-            List<UserPhotosStreamIdxColumnValue> ret = Lists.newArrayListWithCapacity(rowResult.getColumns().size());
+            List<UserPhotosStreamIdxColumnValue> ret =
+                    Lists.newArrayListWithCapacity(rowResult.getColumns().size());
             for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
                 UserPhotosStreamIdxColumn col = UserPhotosStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
                 Long val = UserPhotosStreamIdxColumnValue.hydrateValue(e.getValue());
@@ -548,21 +567,25 @@ public final class UserPhotosStreamIdxTable implements
     }
 
     @Override
-    public Multimap<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumnValue> getRowsMultimap(Iterable<UserPhotosStreamIdxRow> rows) {
-        return getRowsMultimapInternal(rows, allColumns);
+    public Multimap<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumnValue> getRowsMultimap(
+            Iterable<UserPhotosStreamIdxRow> rows) {
+        return getRowsMultimapInternal(rows, ColumnSelection.all());
     }
 
     @Override
-    public Multimap<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumnValue> getRowsMultimap(Iterable<UserPhotosStreamIdxRow> rows, ColumnSelection columns) {
+    public Multimap<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumnValue> getRowsMultimap(
+            Iterable<UserPhotosStreamIdxRow> rows, ColumnSelection columns) {
         return getRowsMultimapInternal(rows, columns);
     }
 
-    private Multimap<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumnValue> getRowsMultimapInternal(Iterable<UserPhotosStreamIdxRow> rows, ColumnSelection columns) {
+    private Multimap<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumnValue> getRowsMultimapInternal(
+            Iterable<UserPhotosStreamIdxRow> rows, ColumnSelection columns) {
         SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
         return getRowMapFromRowResults(results.values());
     }
 
-    private static Multimap<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumnValue> getRowMapFromRowResults(Collection<RowResult<byte[]>> rowResults) {
+    private static Multimap<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumnValue> getRowMapFromRowResults(
+            Collection<RowResult<byte[]>> rowResults) {
         Multimap<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumnValue> rowMap = ArrayListMultimap.create();
         for (RowResult<byte[]> result : rowResults) {
             UserPhotosStreamIdxRow row = UserPhotosStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
@@ -576,27 +599,36 @@ public final class UserPhotosStreamIdxTable implements
     }
 
     @Override
-    public Map<UserPhotosStreamIdxRow, BatchingVisitable<UserPhotosStreamIdxColumnValue>> getRowsColumnRange(Iterable<UserPhotosStreamIdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
-        Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
-        Map<UserPhotosStreamIdxRow, BatchingVisitable<UserPhotosStreamIdxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+    public Map<UserPhotosStreamIdxRow, BatchingVisitable<UserPhotosStreamIdxColumnValue>> getRowsColumnRange(
+            Iterable<UserPhotosStreamIdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results =
+                t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<UserPhotosStreamIdxRow, BatchingVisitable<UserPhotosStreamIdxColumnValue>> transformed =
+                Maps.newHashMapWithExpectedSize(results.size());
         for (Entry<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
             UserPhotosStreamIdxRow row = UserPhotosStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
-            BatchingVisitable<UserPhotosStreamIdxColumnValue> bv = BatchingVisitables.transform(e.getValue(), result -> {
-                UserPhotosStreamIdxColumn col = UserPhotosStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
-                Long val = UserPhotosStreamIdxColumnValue.hydrateValue(result.getValue());
-                return UserPhotosStreamIdxColumnValue.of(col, val);
-            });
+            BatchingVisitable<UserPhotosStreamIdxColumnValue> bv =
+                    BatchingVisitables.transform(e.getValue(), result -> {
+                        UserPhotosStreamIdxColumn col = UserPhotosStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(
+                                result.getKey().getColumnName());
+                        Long val = UserPhotosStreamIdxColumnValue.hydrateValue(result.getValue());
+                        return UserPhotosStreamIdxColumnValue.of(col, val);
+                    });
             transformed.put(row, bv);
         }
         return transformed;
     }
 
     @Override
-    public Iterator<Map.Entry<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumnValue>> getRowsColumnRange(Iterable<UserPhotosStreamIdxRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
-        Iterator<Map.Entry<Cell, byte[]>> results = t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
+    public Iterator<Map.Entry<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumnValue>> getRowsColumnRange(
+            Iterable<UserPhotosStreamIdxRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
+        Iterator<Map.Entry<Cell, byte[]>> results =
+                t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
         return Iterators.transform(results, e -> {
-            UserPhotosStreamIdxRow row = UserPhotosStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
-            UserPhotosStreamIdxColumn col = UserPhotosStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getColumnName());
+            UserPhotosStreamIdxRow row = UserPhotosStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(
+                    e.getKey().getRowName());
+            UserPhotosStreamIdxColumn col = UserPhotosStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(
+                    e.getKey().getColumnName());
             Long val = UserPhotosStreamIdxColumnValue.hydrateValue(e.getValue());
             UserPhotosStreamIdxColumnValue colValue = UserPhotosStreamIdxColumnValue.of(col, val);
             return Maps.immutableEntry(row, colValue);
@@ -604,13 +636,17 @@ public final class UserPhotosStreamIdxTable implements
     }
 
     @Override
-    public Map<UserPhotosStreamIdxRow, Iterator<UserPhotosStreamIdxColumnValue>> getRowsColumnRangeIterator(Iterable<UserPhotosStreamIdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
-        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
-        Map<UserPhotosStreamIdxRow, Iterator<UserPhotosStreamIdxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+    public Map<UserPhotosStreamIdxRow, Iterator<UserPhotosStreamIdxColumnValue>> getRowsColumnRangeIterator(
+            Iterable<UserPhotosStreamIdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results =
+                t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<UserPhotosStreamIdxRow, Iterator<UserPhotosStreamIdxColumnValue>> transformed =
+                Maps.newHashMapWithExpectedSize(results.size());
         for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
             UserPhotosStreamIdxRow row = UserPhotosStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
             Iterator<UserPhotosStreamIdxColumnValue> bv = Iterators.transform(e.getValue(), result -> {
-                UserPhotosStreamIdxColumn col = UserPhotosStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                UserPhotosStreamIdxColumn col = UserPhotosStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(
+                        result.getKey().getColumnName());
                 Long val = UserPhotosStreamIdxColumnValue.hydrateValue(result.getValue());
                 return UserPhotosStreamIdxColumnValue.of(col, val);
             });
@@ -621,36 +657,41 @@ public final class UserPhotosStreamIdxTable implements
 
     private ColumnSelection optimizeColumnSelection(ColumnSelection columns) {
         if (columns.allColumnsSelected()) {
-            return allColumns;
+            return allKnownColumns;
         }
         return columns;
     }
 
     public BatchingVisitableView<UserPhotosStreamIdxRowResult> getAllRowsUnordered() {
-        return getAllRowsUnordered(allColumns);
+        return getAllRowsUnordered(allKnownColumns);
     }
 
     public BatchingVisitableView<UserPhotosStreamIdxRowResult> getAllRowsUnordered(ColumnSelection columns) {
-        return BatchingVisitables.transform(t.getRange(tableRef, RangeRequest.builder()
-                .retainColumns(optimizeColumnSelection(columns)).build()),
+        return BatchingVisitables.transform(
+                t.getRange(
+                        tableRef,
+                        RangeRequest.builder()
+                                .retainColumns(optimizeColumnSelection(columns))
+                                .build()),
                 new Function<RowResult<byte[]>, UserPhotosStreamIdxRowResult>() {
-            @Override
-            public UserPhotosStreamIdxRowResult apply(RowResult<byte[]> input) {
-                return UserPhotosStreamIdxRowResult.of(input);
-            }
-        });
+                    @Override
+                    public UserPhotosStreamIdxRowResult apply(RowResult<byte[]> input) {
+                        return UserPhotosStreamIdxRowResult.of(input);
+                    }
+                });
     }
 
     @Override
-    public List<String> findConstraintFailures(Map<Cell, byte[]> writes,
-                                               ConstraintCheckingTransaction transaction,
-                                               AtlasDbConstraintCheckingMode constraintCheckingMode) {
+    public List<String> findConstraintFailures(
+            Map<Cell, byte[]> writes,
+            ConstraintCheckingTransaction transaction,
+            AtlasDbConstraintCheckingMode constraintCheckingMode) {
         return ImmutableList.of();
     }
 
     @Override
-    public List<String> findConstraintFailuresNoRead(Map<Cell, byte[]> writes,
-                                                     AtlasDbConstraintCheckingMode constraintCheckingMode) {
+    public List<String> findConstraintFailuresNoRead(
+            Map<Cell, byte[]> writes, AtlasDbConstraintCheckingMode constraintCheckingMode) {
         return ImmutableList.of();
     }
 
@@ -682,6 +723,7 @@ public final class UserPhotosStreamIdxTable implements
      * {@link ColumnSelection}
      * {@link ColumnValue}
      * {@link ColumnValues}
+     * {@link Columns}
      * {@link ComparisonChain}
      * {@link Compression}
      * {@link CompressionUtils}
@@ -739,5 +781,5 @@ public final class UserPhotosStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "FpEa3fs0ZvMZVC8txa0u7w==";
+    static String __CLASS_HASH = "Lrg+5R6SB2zRxGSBr0igxA==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamMetadataTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamMetadataTable.java
@@ -1,26 +1,5 @@
 package com.palantir.example.profile.schema.generated;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.EnumSet;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.UUID;
-import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
-import java.util.function.BiFunction;
-import java.util.function.Supplier;
-import java.util.stream.Stream;
-
-import javax.annotation.Generated;
-
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
@@ -66,6 +45,7 @@ import com.palantir.atlasdb.table.api.TypedRowResult;
 import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Columns;
 import com.palantir.atlasdb.table.generation.Descending;
 import com.palantir.atlasdb.table.generation.NamedColumnValue;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
@@ -84,35 +64,69 @@ import com.palantir.common.persist.Persistable.Hydrator;
 import com.palantir.common.persist.Persistables;
 import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import javax.annotation.Generated;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
 @SuppressWarnings({"all", "deprecation"})
-public final class UserPhotosStreamMetadataTable implements
-        AtlasDbMutablePersistentTable<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow,
-                                         UserPhotosStreamMetadataTable.UserPhotosStreamMetadataNamedColumnValue<?>,
-                                         UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRowResult>,
-        AtlasDbNamedMutableTable<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow,
-                                    UserPhotosStreamMetadataTable.UserPhotosStreamMetadataNamedColumnValue<?>,
-                                    UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRowResult> {
+public final class UserPhotosStreamMetadataTable
+        implements AtlasDbMutablePersistentTable<
+                        UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow,
+                        UserPhotosStreamMetadataTable.UserPhotosStreamMetadataNamedColumnValue<?>,
+                        UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRowResult>,
+                AtlasDbNamedMutableTable<
+                        UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow,
+                        UserPhotosStreamMetadataTable.UserPhotosStreamMetadataNamedColumnValue<?>,
+                        UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRowResult> {
     private final Transaction t;
     private final List<UserPhotosStreamMetadataTrigger> triggers;
-    private final static String rawTableName = "user_photos_stream_metadata";
+    private static final String rawTableName = "user_photos_stream_metadata";
     private final TableReference tableRef;
-    private final static ColumnSelection allColumns = getColumnSelection(UserPhotosStreamMetadataNamedColumn.values());
+    private static final ColumnSelection allKnownColumns =
+            getColumnSelection(UserPhotosStreamMetadataNamedColumn.values());
 
     static UserPhotosStreamMetadataTable of(Transaction t, Namespace namespace) {
         return new UserPhotosStreamMetadataTable(t, namespace, ImmutableList.<UserPhotosStreamMetadataTrigger>of());
     }
 
-    static UserPhotosStreamMetadataTable of(Transaction t, Namespace namespace, UserPhotosStreamMetadataTrigger trigger, UserPhotosStreamMetadataTrigger... triggers) {
-        return new UserPhotosStreamMetadataTable(t, namespace, ImmutableList.<UserPhotosStreamMetadataTrigger>builder().add(trigger).add(triggers).build());
+    static UserPhotosStreamMetadataTable of(
+            Transaction t,
+            Namespace namespace,
+            UserPhotosStreamMetadataTrigger trigger,
+            UserPhotosStreamMetadataTrigger... triggers) {
+        return new UserPhotosStreamMetadataTable(
+                t,
+                namespace,
+                ImmutableList.<UserPhotosStreamMetadataTrigger>builder()
+                        .add(trigger)
+                        .add(triggers)
+                        .build());
     }
 
-    static UserPhotosStreamMetadataTable of(Transaction t, Namespace namespace, List<UserPhotosStreamMetadataTrigger> triggers) {
+    static UserPhotosStreamMetadataTable of(
+            Transaction t, Namespace namespace, List<UserPhotosStreamMetadataTrigger> triggers) {
         return new UserPhotosStreamMetadataTable(t, namespace, triggers);
     }
 
-    private UserPhotosStreamMetadataTable(Transaction t, Namespace namespace, List<UserPhotosStreamMetadataTrigger> triggers) {
+    private UserPhotosStreamMetadataTable(
+            Transaction t, Namespace namespace, List<UserPhotosStreamMetadataTrigger> triggers) {
         this.t = t;
         this.tableRef = TableReference.create(namespace, rawTableName);
         this.triggers = triggers;
@@ -141,7 +155,8 @@ public final class UserPhotosStreamMetadataTable implements
      * }
      * </pre>
      */
-    public static final class UserPhotosStreamMetadataRow implements Persistable, Comparable<UserPhotosStreamMetadataRow> {
+    public static final class UserPhotosStreamMetadataRow
+            implements Persistable, Comparable<UserPhotosStreamMetadataRow> {
         private final long id;
 
         public static UserPhotosStreamMetadataRow of(long id) {
@@ -180,21 +195,22 @@ public final class UserPhotosStreamMetadataTable implements
             return EncodingUtils.add(idBytes);
         }
 
-        public static final Hydrator<UserPhotosStreamMetadataRow> BYTES_HYDRATOR = new Hydrator<UserPhotosStreamMetadataRow>() {
-            @Override
-            public UserPhotosStreamMetadataRow hydrateFromBytes(byte[] __input) {
-                int __index = 0;
-                Long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(id);
-                return new UserPhotosStreamMetadataRow(id);
-            }
-        };
+        public static final Hydrator<UserPhotosStreamMetadataRow> BYTES_HYDRATOR =
+                new Hydrator<UserPhotosStreamMetadataRow>() {
+                    @Override
+                    public UserPhotosStreamMetadataRow hydrateFromBytes(byte[] __input) {
+                        int __index = 0;
+                        Long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
+                        __index += EncodingUtils.sizeOfUnsignedVarLong(id);
+                        return new UserPhotosStreamMetadataRow(id);
+                    }
+                };
 
         @Override
         public String toString() {
             return MoreObjects.toStringHelper(getClass().getSimpleName())
-                .add("id", id)
-                .toString();
+                    .add("id", id)
+                    .toString();
         }
 
         @Override
@@ -220,13 +236,13 @@ public final class UserPhotosStreamMetadataTable implements
 
         @Override
         public int compareTo(UserPhotosStreamMetadataRow o) {
-            return ComparisonChain.start()
-                .compare(this.id, o.id)
-                .result();
+            return ComparisonChain.start().compare(this.id, o.id).result();
         }
     }
 
-    public interface UserPhotosStreamMetadataNamedColumnValue<T> extends NamedColumnValue<T> { /* */ }
+    public interface UserPhotosStreamMetadataNamedColumnValue<T> extends NamedColumnValue<T> {
+        /* */
+    }
 
     /**
      * <pre>
@@ -252,11 +268,13 @@ public final class UserPhotosStreamMetadataTable implements
      *     label: LABEL_REQUIRED
      *     type: TYPE_BYTES
      *   }
-     *   
+     *
      * }
      * </pre>
      */
-    public static final class Metadata implements UserPhotosStreamMetadataNamedColumnValue<com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> {
+    public static final class Metadata
+            implements UserPhotosStreamMetadataNamedColumnValue<
+                    com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> {
         private final com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata value;
 
         public static Metadata of(com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata value) {
@@ -308,13 +326,14 @@ public final class UserPhotosStreamMetadataTable implements
         @Override
         public String toString() {
             return MoreObjects.toStringHelper(getClass().getSimpleName())
-                .add("Value", this.value)
-                .toString();
+                    .add("Value", this.value)
+                    .toString();
         }
     }
 
     public interface UserPhotosStreamMetadataTrigger {
-        public void putUserPhotosStreamMetadata(Multimap<UserPhotosStreamMetadataRow, ? extends UserPhotosStreamMetadataNamedColumnValue<?>> newRows);
+        public void putUserPhotosStreamMetadata(
+                Multimap<UserPhotosStreamMetadataRow, ? extends UserPhotosStreamMetadataNamedColumnValue<?>> newRows);
     }
 
     public static final class UserPhotosStreamMetadataRowResult implements TypedRowResult {
@@ -364,10 +383,16 @@ public final class UserPhotosStreamMetadataTable implements
             return value.getValue();
         }
 
-        public static Function<UserPhotosStreamMetadataRowResult, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> getMetadataFun() {
-            return new Function<UserPhotosStreamMetadataRowResult, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata>() {
+        public static Function<
+                        UserPhotosStreamMetadataRowResult,
+                        com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata>
+                getMetadataFun() {
+            return new Function<
+                    UserPhotosStreamMetadataRowResult,
+                    com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata>() {
                 @Override
-                public com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata apply(UserPhotosStreamMetadataRowResult rowResult) {
+                public com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata apply(
+                        UserPhotosStreamMetadataRowResult rowResult) {
                     return rowResult.getMetadata();
                 }
             };
@@ -376,9 +401,9 @@ public final class UserPhotosStreamMetadataTable implements
         @Override
         public String toString() {
             return MoreObjects.toStringHelper(getClass().getSimpleName())
-                .add("RowName", getRowName())
-                .add("Metadata", getMetadata())
-                .toString();
+                    .add("RowName", getRowName())
+                    .add("Metadata", getMetadata())
+                    .toString();
         }
     }
 
@@ -410,32 +435,42 @@ public final class UserPhotosStreamMetadataTable implements
         return getColumnSelection(Arrays.asList(cols));
     }
 
-    private static final Map<String, Hydrator<? extends UserPhotosStreamMetadataNamedColumnValue<?>>> shortNameToHydrator =
-            ImmutableMap.<String, Hydrator<? extends UserPhotosStreamMetadataNamedColumnValue<?>>>builder()
-                .put("md", Metadata.BYTES_HYDRATOR)
-                .build();
+    private static final Map<String, Hydrator<? extends UserPhotosStreamMetadataNamedColumnValue<?>>>
+            shortNameToHydrator =
+                    ImmutableMap.<String, Hydrator<? extends UserPhotosStreamMetadataNamedColumnValue<?>>>builder()
+                            .put("md", Metadata.BYTES_HYDRATOR)
+                            .build();
 
-    public Map<UserPhotosStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> getMetadatas(Collection<UserPhotosStreamMetadataRow> rows) {
+    public Map<UserPhotosStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata>
+            getMetadatas(Collection<UserPhotosStreamMetadataRow> rows) {
         Map<Cell, UserPhotosStreamMetadataRow> cells = Maps.newHashMapWithExpectedSize(rows.size());
         for (UserPhotosStreamMetadataRow row : rows) {
             cells.put(Cell.create(row.persistToBytes(), PtBytes.toCachedBytes("md")), row);
         }
         Map<Cell, byte[]> results = t.get(tableRef, cells.keySet());
-        Map<UserPhotosStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> ret = Maps.newHashMapWithExpectedSize(results.size());
+        Map<UserPhotosStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> ret =
+                Maps.newHashMapWithExpectedSize(results.size());
         for (Entry<Cell, byte[]> e : results.entrySet()) {
-            com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata val = Metadata.BYTES_HYDRATOR.hydrateFromBytes(e.getValue()).getValue();
+            com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata val =
+                    Metadata.BYTES_HYDRATOR.hydrateFromBytes(e.getValue()).getValue();
             ret.put(cells.get(e.getKey()), val);
         }
         return ret;
     }
 
-    public void putMetadata(UserPhotosStreamMetadataRow row, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata value) {
+    public void putMetadata(
+            UserPhotosStreamMetadataRow row,
+            com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata value) {
         put(ImmutableMultimap.of(row, Metadata.of(value)));
     }
 
-    public void putMetadata(Map<UserPhotosStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> map) {
-        Map<UserPhotosStreamMetadataRow, UserPhotosStreamMetadataNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<UserPhotosStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> e : map.entrySet()) {
+    public void putMetadata(
+            Map<UserPhotosStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata>
+                    map) {
+        Map<UserPhotosStreamMetadataRow, UserPhotosStreamMetadataNamedColumnValue<?>> toPut =
+                Maps.newHashMapWithExpectedSize(map.size());
+        for (Entry<UserPhotosStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata>
+                e : map.entrySet()) {
             toPut.put(e.getKey(), Metadata.of(e.getValue()));
         }
         put(Multimaps.forMap(toPut));
@@ -467,19 +502,20 @@ public final class UserPhotosStreamMetadataTable implements
 
     @Override
     public void delete(Iterable<UserPhotosStreamMetadataRow> rows) {
-        List<byte[]> rowBytes = Persistables.persistAll(rows);
-        Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
-        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("md")));
-        t.delete(tableRef, cells);
+        Multimap<UserPhotosStreamMetadataRow, UserPhotosStreamMetadataNamedColumnValue<?>> result =
+                getRowsMultimap(rows);
+        t.delete(tableRef, ColumnValues.toCells(result));
     }
 
     public Optional<UserPhotosStreamMetadataRowResult> getRow(UserPhotosStreamMetadataRow row) {
-        return getRow(row, allColumns);
+        return getRow(row, allKnownColumns);
     }
 
-    public Optional<UserPhotosStreamMetadataRowResult> getRow(UserPhotosStreamMetadataRow row, ColumnSelection columns) {
+    public Optional<UserPhotosStreamMetadataRowResult> getRow(
+            UserPhotosStreamMetadataRow row, ColumnSelection columns) {
         byte[] bytes = row.persistToBytes();
-        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        RowResult<byte[]> rowResult =
+                t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
         if (rowResult == null) {
             return Optional.empty();
         } else {
@@ -489,11 +525,12 @@ public final class UserPhotosStreamMetadataTable implements
 
     @Override
     public List<UserPhotosStreamMetadataRowResult> getRows(Iterable<UserPhotosStreamMetadataRow> rows) {
-        return getRows(rows, allColumns);
+        return getRows(rows, allKnownColumns);
     }
 
     @Override
-    public List<UserPhotosStreamMetadataRowResult> getRows(Iterable<UserPhotosStreamMetadataRow> rows, ColumnSelection columns) {
+    public List<UserPhotosStreamMetadataRowResult> getRows(
+            Iterable<UserPhotosStreamMetadataRow> rows, ColumnSelection columns) {
         SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
         List<UserPhotosStreamMetadataRowResult> rowResults = Lists.newArrayListWithCapacity(results.size());
         for (RowResult<byte[]> row : results.values()) {
@@ -504,17 +541,20 @@ public final class UserPhotosStreamMetadataTable implements
 
     @Override
     public List<UserPhotosStreamMetadataNamedColumnValue<?>> getRowColumns(UserPhotosStreamMetadataRow row) {
-        return getRowColumns(row, allColumns);
+        return getRowColumns(row, ColumnSelection.all());
     }
 
     @Override
-    public List<UserPhotosStreamMetadataNamedColumnValue<?>> getRowColumns(UserPhotosStreamMetadataRow row, ColumnSelection columns) {
+    public List<UserPhotosStreamMetadataNamedColumnValue<?>> getRowColumns(
+            UserPhotosStreamMetadataRow row, ColumnSelection columns) {
         byte[] bytes = row.persistToBytes();
-        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        RowResult<byte[]> rowResult =
+                t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
         if (rowResult == null) {
             return ImmutableList.of();
         } else {
-            List<UserPhotosStreamMetadataNamedColumnValue<?>> ret = Lists.newArrayListWithCapacity(rowResult.getColumns().size());
+            List<UserPhotosStreamMetadataNamedColumnValue<?>> ret =
+                    Lists.newArrayListWithCapacity(rowResult.getColumns().size());
             for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
                 ret.add(shortNameToHydrator.get(PtBytes.toString(e.getKey())).hydrateFromBytes(e.getValue()));
             }
@@ -523,63 +563,92 @@ public final class UserPhotosStreamMetadataTable implements
     }
 
     @Override
-    public Multimap<UserPhotosStreamMetadataRow, UserPhotosStreamMetadataNamedColumnValue<?>> getRowsMultimap(Iterable<UserPhotosStreamMetadataRow> rows) {
-        return getRowsMultimapInternal(rows, allColumns);
+    public Multimap<UserPhotosStreamMetadataRow, UserPhotosStreamMetadataNamedColumnValue<?>> getRowsMultimap(
+            Iterable<UserPhotosStreamMetadataRow> rows) {
+        return getRowsMultimapInternal(rows, ColumnSelection.all());
     }
 
     @Override
-    public Multimap<UserPhotosStreamMetadataRow, UserPhotosStreamMetadataNamedColumnValue<?>> getRowsMultimap(Iterable<UserPhotosStreamMetadataRow> rows, ColumnSelection columns) {
+    public Multimap<UserPhotosStreamMetadataRow, UserPhotosStreamMetadataNamedColumnValue<?>> getRowsMultimap(
+            Iterable<UserPhotosStreamMetadataRow> rows, ColumnSelection columns) {
         return getRowsMultimapInternal(rows, columns);
     }
 
-    private Multimap<UserPhotosStreamMetadataRow, UserPhotosStreamMetadataNamedColumnValue<?>> getRowsMultimapInternal(Iterable<UserPhotosStreamMetadataRow> rows, ColumnSelection columns) {
+    private Multimap<UserPhotosStreamMetadataRow, UserPhotosStreamMetadataNamedColumnValue<?>> getRowsMultimapInternal(
+            Iterable<UserPhotosStreamMetadataRow> rows, ColumnSelection columns) {
         SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
         return getRowMapFromRowResults(results.values());
     }
 
-    private static Multimap<UserPhotosStreamMetadataRow, UserPhotosStreamMetadataNamedColumnValue<?>> getRowMapFromRowResults(Collection<RowResult<byte[]>> rowResults) {
-        Multimap<UserPhotosStreamMetadataRow, UserPhotosStreamMetadataNamedColumnValue<?>> rowMap = ArrayListMultimap.create();
+    private static Multimap<UserPhotosStreamMetadataRow, UserPhotosStreamMetadataNamedColumnValue<?>>
+            getRowMapFromRowResults(Collection<RowResult<byte[]>> rowResults) {
+        Multimap<UserPhotosStreamMetadataRow, UserPhotosStreamMetadataNamedColumnValue<?>> rowMap =
+                ArrayListMultimap.create();
         for (RowResult<byte[]> result : rowResults) {
-            UserPhotosStreamMetadataRow row = UserPhotosStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
+            UserPhotosStreamMetadataRow row =
+                    UserPhotosStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
             for (Entry<byte[], byte[]> e : result.getColumns().entrySet()) {
-                rowMap.put(row, shortNameToHydrator.get(PtBytes.toString(e.getKey())).hydrateFromBytes(e.getValue()));
+                rowMap.put(
+                        row,
+                        shortNameToHydrator.get(PtBytes.toString(e.getKey())).hydrateFromBytes(e.getValue()));
             }
         }
         return rowMap;
     }
 
     @Override
-    public Map<UserPhotosStreamMetadataRow, BatchingVisitable<UserPhotosStreamMetadataNamedColumnValue<?>>> getRowsColumnRange(Iterable<UserPhotosStreamMetadataRow> rows, BatchColumnRangeSelection columnRangeSelection) {
-        Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
-        Map<UserPhotosStreamMetadataRow, BatchingVisitable<UserPhotosStreamMetadataNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+    public Map<UserPhotosStreamMetadataRow, BatchingVisitable<UserPhotosStreamMetadataNamedColumnValue<?>>>
+            getRowsColumnRange(
+                    Iterable<UserPhotosStreamMetadataRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results =
+                t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<UserPhotosStreamMetadataRow, BatchingVisitable<UserPhotosStreamMetadataNamedColumnValue<?>>> transformed =
+                Maps.newHashMapWithExpectedSize(results.size());
         for (Entry<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
             UserPhotosStreamMetadataRow row = UserPhotosStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
-            BatchingVisitable<UserPhotosStreamMetadataNamedColumnValue<?>> bv = BatchingVisitables.transform(e.getValue(), result -> {
-                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
-            });
+            BatchingVisitable<UserPhotosStreamMetadataNamedColumnValue<?>> bv =
+                    BatchingVisitables.transform(e.getValue(), result -> {
+                        return shortNameToHydrator
+                                .get(PtBytes.toString(result.getKey().getColumnName()))
+                                .hydrateFromBytes(result.getValue());
+                    });
             transformed.put(row, bv);
         }
         return transformed;
     }
 
     @Override
-    public Iterator<Map.Entry<UserPhotosStreamMetadataRow, UserPhotosStreamMetadataNamedColumnValue<?>>> getRowsColumnRange(Iterable<UserPhotosStreamMetadataRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
-        Iterator<Map.Entry<Cell, byte[]>> results = t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
+    public Iterator<Map.Entry<UserPhotosStreamMetadataRow, UserPhotosStreamMetadataNamedColumnValue<?>>>
+            getRowsColumnRange(
+                    Iterable<UserPhotosStreamMetadataRow> rows,
+                    ColumnRangeSelection columnRangeSelection,
+                    int batchHint) {
+        Iterator<Map.Entry<Cell, byte[]>> results =
+                t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
         return Iterators.transform(results, e -> {
-            UserPhotosStreamMetadataRow row = UserPhotosStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
-            UserPhotosStreamMetadataNamedColumnValue<?> colValue = shortNameToHydrator.get(PtBytes.toString(e.getKey().getColumnName())).hydrateFromBytes(e.getValue());
+            UserPhotosStreamMetadataRow row = UserPhotosStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(
+                    e.getKey().getRowName());
+            UserPhotosStreamMetadataNamedColumnValue<?> colValue = shortNameToHydrator
+                    .get(PtBytes.toString(e.getKey().getColumnName()))
+                    .hydrateFromBytes(e.getValue());
             return Maps.immutableEntry(row, colValue);
         });
     }
 
     @Override
-    public Map<UserPhotosStreamMetadataRow, Iterator<UserPhotosStreamMetadataNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<UserPhotosStreamMetadataRow> rows, BatchColumnRangeSelection columnRangeSelection) {
-        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
-        Map<UserPhotosStreamMetadataRow, Iterator<UserPhotosStreamMetadataNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+    public Map<UserPhotosStreamMetadataRow, Iterator<UserPhotosStreamMetadataNamedColumnValue<?>>>
+            getRowsColumnRangeIterator(
+                    Iterable<UserPhotosStreamMetadataRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results =
+                t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<UserPhotosStreamMetadataRow, Iterator<UserPhotosStreamMetadataNamedColumnValue<?>>> transformed =
+                Maps.newHashMapWithExpectedSize(results.size());
         for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
             UserPhotosStreamMetadataRow row = UserPhotosStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
             Iterator<UserPhotosStreamMetadataNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
-                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+                return shortNameToHydrator
+                        .get(PtBytes.toString(result.getKey().getColumnName()))
+                        .hydrateFromBytes(result.getValue());
             });
             transformed.put(row, bv);
         }
@@ -588,36 +657,41 @@ public final class UserPhotosStreamMetadataTable implements
 
     private ColumnSelection optimizeColumnSelection(ColumnSelection columns) {
         if (columns.allColumnsSelected()) {
-            return allColumns;
+            return allKnownColumns;
         }
         return columns;
     }
 
     public BatchingVisitableView<UserPhotosStreamMetadataRowResult> getAllRowsUnordered() {
-        return getAllRowsUnordered(allColumns);
+        return getAllRowsUnordered(allKnownColumns);
     }
 
     public BatchingVisitableView<UserPhotosStreamMetadataRowResult> getAllRowsUnordered(ColumnSelection columns) {
-        return BatchingVisitables.transform(t.getRange(tableRef, RangeRequest.builder()
-                .retainColumns(optimizeColumnSelection(columns)).build()),
+        return BatchingVisitables.transform(
+                t.getRange(
+                        tableRef,
+                        RangeRequest.builder()
+                                .retainColumns(optimizeColumnSelection(columns))
+                                .build()),
                 new Function<RowResult<byte[]>, UserPhotosStreamMetadataRowResult>() {
-            @Override
-            public UserPhotosStreamMetadataRowResult apply(RowResult<byte[]> input) {
-                return UserPhotosStreamMetadataRowResult.of(input);
-            }
-        });
+                    @Override
+                    public UserPhotosStreamMetadataRowResult apply(RowResult<byte[]> input) {
+                        return UserPhotosStreamMetadataRowResult.of(input);
+                    }
+                });
     }
 
     @Override
-    public List<String> findConstraintFailures(Map<Cell, byte[]> writes,
-                                               ConstraintCheckingTransaction transaction,
-                                               AtlasDbConstraintCheckingMode constraintCheckingMode) {
+    public List<String> findConstraintFailures(
+            Map<Cell, byte[]> writes,
+            ConstraintCheckingTransaction transaction,
+            AtlasDbConstraintCheckingMode constraintCheckingMode) {
         return ImmutableList.of();
     }
 
     @Override
-    public List<String> findConstraintFailuresNoRead(Map<Cell, byte[]> writes,
-                                                     AtlasDbConstraintCheckingMode constraintCheckingMode) {
+    public List<String> findConstraintFailuresNoRead(
+            Map<Cell, byte[]> writes, AtlasDbConstraintCheckingMode constraintCheckingMode) {
         return ImmutableList.of();
     }
 
@@ -649,6 +723,7 @@ public final class UserPhotosStreamMetadataTable implements
      * {@link ColumnSelection}
      * {@link ColumnValue}
      * {@link ColumnValues}
+     * {@link Columns}
      * {@link ComparisonChain}
      * {@link Compression}
      * {@link CompressionUtils}
@@ -706,5 +781,5 @@ public final class UserPhotosStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "XV63us7jbRmQA7+aqtfI9g==";
+    static String __CLASS_HASH = "tknvQqY6VqHA/pTirr+Kew==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamValueTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamValueTable.java
@@ -1,26 +1,5 @@
 package com.palantir.example.profile.schema.generated;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.EnumSet;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.UUID;
-import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
-import java.util.function.BiFunction;
-import java.util.function.Supplier;
-import java.util.stream.Stream;
-
-import javax.annotation.Generated;
-
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
@@ -66,6 +45,7 @@ import com.palantir.atlasdb.table.api.TypedRowResult;
 import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Columns;
 import com.palantir.atlasdb.table.generation.Descending;
 import com.palantir.atlasdb.table.generation.NamedColumnValue;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
@@ -84,35 +64,69 @@ import com.palantir.common.persist.Persistable.Hydrator;
 import com.palantir.common.persist.Persistables;
 import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import javax.annotation.Generated;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
 @SuppressWarnings({"all", "deprecation"})
-public final class UserPhotosStreamValueTable implements
-        AtlasDbMutablePersistentTable<UserPhotosStreamValueTable.UserPhotosStreamValueRow,
-                                         UserPhotosStreamValueTable.UserPhotosStreamValueNamedColumnValue<?>,
-                                         UserPhotosStreamValueTable.UserPhotosStreamValueRowResult>,
-        AtlasDbNamedMutableTable<UserPhotosStreamValueTable.UserPhotosStreamValueRow,
-                                    UserPhotosStreamValueTable.UserPhotosStreamValueNamedColumnValue<?>,
-                                    UserPhotosStreamValueTable.UserPhotosStreamValueRowResult> {
+public final class UserPhotosStreamValueTable
+        implements AtlasDbMutablePersistentTable<
+                        UserPhotosStreamValueTable.UserPhotosStreamValueRow,
+                        UserPhotosStreamValueTable.UserPhotosStreamValueNamedColumnValue<?>,
+                        UserPhotosStreamValueTable.UserPhotosStreamValueRowResult>,
+                AtlasDbNamedMutableTable<
+                        UserPhotosStreamValueTable.UserPhotosStreamValueRow,
+                        UserPhotosStreamValueTable.UserPhotosStreamValueNamedColumnValue<?>,
+                        UserPhotosStreamValueTable.UserPhotosStreamValueRowResult> {
     private final Transaction t;
     private final List<UserPhotosStreamValueTrigger> triggers;
-    private final static String rawTableName = "user_photos_stream_value";
+    private static final String rawTableName = "user_photos_stream_value";
     private final TableReference tableRef;
-    private final static ColumnSelection allColumns = getColumnSelection(UserPhotosStreamValueNamedColumn.values());
+    private static final ColumnSelection allKnownColumns =
+            getColumnSelection(UserPhotosStreamValueNamedColumn.values());
 
     static UserPhotosStreamValueTable of(Transaction t, Namespace namespace) {
         return new UserPhotosStreamValueTable(t, namespace, ImmutableList.<UserPhotosStreamValueTrigger>of());
     }
 
-    static UserPhotosStreamValueTable of(Transaction t, Namespace namespace, UserPhotosStreamValueTrigger trigger, UserPhotosStreamValueTrigger... triggers) {
-        return new UserPhotosStreamValueTable(t, namespace, ImmutableList.<UserPhotosStreamValueTrigger>builder().add(trigger).add(triggers).build());
+    static UserPhotosStreamValueTable of(
+            Transaction t,
+            Namespace namespace,
+            UserPhotosStreamValueTrigger trigger,
+            UserPhotosStreamValueTrigger... triggers) {
+        return new UserPhotosStreamValueTable(
+                t,
+                namespace,
+                ImmutableList.<UserPhotosStreamValueTrigger>builder()
+                        .add(trigger)
+                        .add(triggers)
+                        .build());
     }
 
-    static UserPhotosStreamValueTable of(Transaction t, Namespace namespace, List<UserPhotosStreamValueTrigger> triggers) {
+    static UserPhotosStreamValueTable of(
+            Transaction t, Namespace namespace, List<UserPhotosStreamValueTrigger> triggers) {
         return new UserPhotosStreamValueTable(t, namespace, triggers);
     }
 
-    private UserPhotosStreamValueTable(Transaction t, Namespace namespace, List<UserPhotosStreamValueTrigger> triggers) {
+    private UserPhotosStreamValueTable(
+            Transaction t, Namespace namespace, List<UserPhotosStreamValueTrigger> triggers) {
         this.t = t;
         this.tableRef = TableReference.create(namespace, rawTableName);
         this.triggers = triggers;
@@ -188,24 +202,25 @@ public final class UserPhotosStreamValueTable implements
             return EncodingUtils.add(idBytes, blockIdBytes);
         }
 
-        public static final Hydrator<UserPhotosStreamValueRow> BYTES_HYDRATOR = new Hydrator<UserPhotosStreamValueRow>() {
-            @Override
-            public UserPhotosStreamValueRow hydrateFromBytes(byte[] __input) {
-                int __index = 0;
-                Long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(id);
-                Long blockId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(blockId);
-                return new UserPhotosStreamValueRow(id, blockId);
-            }
-        };
+        public static final Hydrator<UserPhotosStreamValueRow> BYTES_HYDRATOR =
+                new Hydrator<UserPhotosStreamValueRow>() {
+                    @Override
+                    public UserPhotosStreamValueRow hydrateFromBytes(byte[] __input) {
+                        int __index = 0;
+                        Long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
+                        __index += EncodingUtils.sizeOfUnsignedVarLong(id);
+                        Long blockId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
+                        __index += EncodingUtils.sizeOfUnsignedVarLong(blockId);
+                        return new UserPhotosStreamValueRow(id, blockId);
+                    }
+                };
 
         @Override
         public String toString() {
             return MoreObjects.toStringHelper(getClass().getSimpleName())
-                .add("id", id)
-                .add("blockId", blockId)
-                .toString();
+                    .add("id", id)
+                    .add("blockId", blockId)
+                    .toString();
         }
 
         @Override
@@ -226,19 +241,21 @@ public final class UserPhotosStreamValueTable implements
         @SuppressWarnings("ArrayHashCode")
         @Override
         public int hashCode() {
-            return Arrays.deepHashCode(new Object[]{ id, blockId });
+            return Arrays.deepHashCode(new Object[] {id, blockId});
         }
 
         @Override
         public int compareTo(UserPhotosStreamValueRow o) {
             return ComparisonChain.start()
-                .compare(this.id, o.id)
-                .compare(this.blockId, o.blockId)
-                .result();
+                    .compare(this.id, o.id)
+                    .compare(this.blockId, o.blockId)
+                    .result();
         }
     }
 
-    public interface UserPhotosStreamValueNamedColumnValue<T> extends NamedColumnValue<T> { /* */ }
+    public interface UserPhotosStreamValueNamedColumnValue<T> extends NamedColumnValue<T> {
+        /* */
+    }
 
     /**
      * <pre>
@@ -295,13 +312,14 @@ public final class UserPhotosStreamValueTable implements
         @Override
         public String toString() {
             return MoreObjects.toStringHelper(getClass().getSimpleName())
-                .add("Value", this.value)
-                .toString();
+                    .add("Value", this.value)
+                    .toString();
         }
     }
 
     public interface UserPhotosStreamValueTrigger {
-        public void putUserPhotosStreamValue(Multimap<UserPhotosStreamValueRow, ? extends UserPhotosStreamValueNamedColumnValue<?>> newRows);
+        public void putUserPhotosStreamValue(
+                Multimap<UserPhotosStreamValueRow, ? extends UserPhotosStreamValueNamedColumnValue<?>> newRows);
     }
 
     public static final class UserPhotosStreamValueRowResult implements TypedRowResult {
@@ -363,9 +381,9 @@ public final class UserPhotosStreamValueTable implements
         @Override
         public String toString() {
             return MoreObjects.toStringHelper(getClass().getSimpleName())
-                .add("RowName", getRowName())
-                .add("Value", getValue())
-                .toString();
+                    .add("RowName", getRowName())
+                    .add("Value", getValue())
+                    .toString();
         }
     }
 
@@ -399,8 +417,8 @@ public final class UserPhotosStreamValueTable implements
 
     private static final Map<String, Hydrator<? extends UserPhotosStreamValueNamedColumnValue<?>>> shortNameToHydrator =
             ImmutableMap.<String, Hydrator<? extends UserPhotosStreamValueNamedColumnValue<?>>>builder()
-                .put("v", Value.BYTES_HYDRATOR)
-                .build();
+                    .put("v", Value.BYTES_HYDRATOR)
+                    .build();
 
     public Map<UserPhotosStreamValueRow, byte[]> getValues(Collection<UserPhotosStreamValueRow> rows) {
         Map<Cell, UserPhotosStreamValueRow> cells = Maps.newHashMapWithExpectedSize(rows.size());
@@ -421,7 +439,8 @@ public final class UserPhotosStreamValueTable implements
     }
 
     public void putValue(Map<UserPhotosStreamValueRow, byte[]> map) {
-        Map<UserPhotosStreamValueRow, UserPhotosStreamValueNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
+        Map<UserPhotosStreamValueRow, UserPhotosStreamValueNamedColumnValue<?>> toPut =
+                Maps.newHashMapWithExpectedSize(map.size());
         for (Entry<UserPhotosStreamValueRow, byte[]> e : map.entrySet()) {
             toPut.put(e.getKey(), Value.of(e.getValue()));
         }
@@ -454,19 +473,18 @@ public final class UserPhotosStreamValueTable implements
 
     @Override
     public void delete(Iterable<UserPhotosStreamValueRow> rows) {
-        List<byte[]> rowBytes = Persistables.persistAll(rows);
-        Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
-        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("v")));
-        t.delete(tableRef, cells);
+        Multimap<UserPhotosStreamValueRow, UserPhotosStreamValueNamedColumnValue<?>> result = getRowsMultimap(rows);
+        t.delete(tableRef, ColumnValues.toCells(result));
     }
 
     public Optional<UserPhotosStreamValueRowResult> getRow(UserPhotosStreamValueRow row) {
-        return getRow(row, allColumns);
+        return getRow(row, allKnownColumns);
     }
 
     public Optional<UserPhotosStreamValueRowResult> getRow(UserPhotosStreamValueRow row, ColumnSelection columns) {
         byte[] bytes = row.persistToBytes();
-        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        RowResult<byte[]> rowResult =
+                t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
         if (rowResult == null) {
             return Optional.empty();
         } else {
@@ -476,11 +494,12 @@ public final class UserPhotosStreamValueTable implements
 
     @Override
     public List<UserPhotosStreamValueRowResult> getRows(Iterable<UserPhotosStreamValueRow> rows) {
-        return getRows(rows, allColumns);
+        return getRows(rows, allKnownColumns);
     }
 
     @Override
-    public List<UserPhotosStreamValueRowResult> getRows(Iterable<UserPhotosStreamValueRow> rows, ColumnSelection columns) {
+    public List<UserPhotosStreamValueRowResult> getRows(
+            Iterable<UserPhotosStreamValueRow> rows, ColumnSelection columns) {
         SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
         List<UserPhotosStreamValueRowResult> rowResults = Lists.newArrayListWithCapacity(results.size());
         for (RowResult<byte[]> row : results.values()) {
@@ -491,17 +510,20 @@ public final class UserPhotosStreamValueTable implements
 
     @Override
     public List<UserPhotosStreamValueNamedColumnValue<?>> getRowColumns(UserPhotosStreamValueRow row) {
-        return getRowColumns(row, allColumns);
+        return getRowColumns(row, ColumnSelection.all());
     }
 
     @Override
-    public List<UserPhotosStreamValueNamedColumnValue<?>> getRowColumns(UserPhotosStreamValueRow row, ColumnSelection columns) {
+    public List<UserPhotosStreamValueNamedColumnValue<?>> getRowColumns(
+            UserPhotosStreamValueRow row, ColumnSelection columns) {
         byte[] bytes = row.persistToBytes();
-        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        RowResult<byte[]> rowResult =
+                t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
         if (rowResult == null) {
             return ImmutableList.of();
         } else {
-            List<UserPhotosStreamValueNamedColumnValue<?>> ret = Lists.newArrayListWithCapacity(rowResult.getColumns().size());
+            List<UserPhotosStreamValueNamedColumnValue<?>> ret =
+                    Lists.newArrayListWithCapacity(rowResult.getColumns().size());
             for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
                 ret.add(shortNameToHydrator.get(PtBytes.toString(e.getKey())).hydrateFromBytes(e.getValue()));
             }
@@ -510,63 +532,88 @@ public final class UserPhotosStreamValueTable implements
     }
 
     @Override
-    public Multimap<UserPhotosStreamValueRow, UserPhotosStreamValueNamedColumnValue<?>> getRowsMultimap(Iterable<UserPhotosStreamValueRow> rows) {
-        return getRowsMultimapInternal(rows, allColumns);
+    public Multimap<UserPhotosStreamValueRow, UserPhotosStreamValueNamedColumnValue<?>> getRowsMultimap(
+            Iterable<UserPhotosStreamValueRow> rows) {
+        return getRowsMultimapInternal(rows, ColumnSelection.all());
     }
 
     @Override
-    public Multimap<UserPhotosStreamValueRow, UserPhotosStreamValueNamedColumnValue<?>> getRowsMultimap(Iterable<UserPhotosStreamValueRow> rows, ColumnSelection columns) {
+    public Multimap<UserPhotosStreamValueRow, UserPhotosStreamValueNamedColumnValue<?>> getRowsMultimap(
+            Iterable<UserPhotosStreamValueRow> rows, ColumnSelection columns) {
         return getRowsMultimapInternal(rows, columns);
     }
 
-    private Multimap<UserPhotosStreamValueRow, UserPhotosStreamValueNamedColumnValue<?>> getRowsMultimapInternal(Iterable<UserPhotosStreamValueRow> rows, ColumnSelection columns) {
+    private Multimap<UserPhotosStreamValueRow, UserPhotosStreamValueNamedColumnValue<?>> getRowsMultimapInternal(
+            Iterable<UserPhotosStreamValueRow> rows, ColumnSelection columns) {
         SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
         return getRowMapFromRowResults(results.values());
     }
 
-    private static Multimap<UserPhotosStreamValueRow, UserPhotosStreamValueNamedColumnValue<?>> getRowMapFromRowResults(Collection<RowResult<byte[]>> rowResults) {
-        Multimap<UserPhotosStreamValueRow, UserPhotosStreamValueNamedColumnValue<?>> rowMap = ArrayListMultimap.create();
+    private static Multimap<UserPhotosStreamValueRow, UserPhotosStreamValueNamedColumnValue<?>> getRowMapFromRowResults(
+            Collection<RowResult<byte[]>> rowResults) {
+        Multimap<UserPhotosStreamValueRow, UserPhotosStreamValueNamedColumnValue<?>> rowMap =
+                ArrayListMultimap.create();
         for (RowResult<byte[]> result : rowResults) {
-            UserPhotosStreamValueRow row = UserPhotosStreamValueRow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
+            UserPhotosStreamValueRow row =
+                    UserPhotosStreamValueRow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
             for (Entry<byte[], byte[]> e : result.getColumns().entrySet()) {
-                rowMap.put(row, shortNameToHydrator.get(PtBytes.toString(e.getKey())).hydrateFromBytes(e.getValue()));
+                rowMap.put(
+                        row,
+                        shortNameToHydrator.get(PtBytes.toString(e.getKey())).hydrateFromBytes(e.getValue()));
             }
         }
         return rowMap;
     }
 
     @Override
-    public Map<UserPhotosStreamValueRow, BatchingVisitable<UserPhotosStreamValueNamedColumnValue<?>>> getRowsColumnRange(Iterable<UserPhotosStreamValueRow> rows, BatchColumnRangeSelection columnRangeSelection) {
-        Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
-        Map<UserPhotosStreamValueRow, BatchingVisitable<UserPhotosStreamValueNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+    public Map<UserPhotosStreamValueRow, BatchingVisitable<UserPhotosStreamValueNamedColumnValue<?>>>
+            getRowsColumnRange(
+                    Iterable<UserPhotosStreamValueRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results =
+                t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<UserPhotosStreamValueRow, BatchingVisitable<UserPhotosStreamValueNamedColumnValue<?>>> transformed =
+                Maps.newHashMapWithExpectedSize(results.size());
         for (Entry<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
             UserPhotosStreamValueRow row = UserPhotosStreamValueRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
-            BatchingVisitable<UserPhotosStreamValueNamedColumnValue<?>> bv = BatchingVisitables.transform(e.getValue(), result -> {
-                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
-            });
+            BatchingVisitable<UserPhotosStreamValueNamedColumnValue<?>> bv =
+                    BatchingVisitables.transform(e.getValue(), result -> {
+                        return shortNameToHydrator
+                                .get(PtBytes.toString(result.getKey().getColumnName()))
+                                .hydrateFromBytes(result.getValue());
+                    });
             transformed.put(row, bv);
         }
         return transformed;
     }
 
     @Override
-    public Iterator<Map.Entry<UserPhotosStreamValueRow, UserPhotosStreamValueNamedColumnValue<?>>> getRowsColumnRange(Iterable<UserPhotosStreamValueRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
-        Iterator<Map.Entry<Cell, byte[]>> results = t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
+    public Iterator<Map.Entry<UserPhotosStreamValueRow, UserPhotosStreamValueNamedColumnValue<?>>> getRowsColumnRange(
+            Iterable<UserPhotosStreamValueRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
+        Iterator<Map.Entry<Cell, byte[]>> results =
+                t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
         return Iterators.transform(results, e -> {
-            UserPhotosStreamValueRow row = UserPhotosStreamValueRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
-            UserPhotosStreamValueNamedColumnValue<?> colValue = shortNameToHydrator.get(PtBytes.toString(e.getKey().getColumnName())).hydrateFromBytes(e.getValue());
+            UserPhotosStreamValueRow row = UserPhotosStreamValueRow.BYTES_HYDRATOR.hydrateFromBytes(
+                    e.getKey().getRowName());
+            UserPhotosStreamValueNamedColumnValue<?> colValue = shortNameToHydrator
+                    .get(PtBytes.toString(e.getKey().getColumnName()))
+                    .hydrateFromBytes(e.getValue());
             return Maps.immutableEntry(row, colValue);
         });
     }
 
     @Override
-    public Map<UserPhotosStreamValueRow, Iterator<UserPhotosStreamValueNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<UserPhotosStreamValueRow> rows, BatchColumnRangeSelection columnRangeSelection) {
-        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
-        Map<UserPhotosStreamValueRow, Iterator<UserPhotosStreamValueNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+    public Map<UserPhotosStreamValueRow, Iterator<UserPhotosStreamValueNamedColumnValue<?>>> getRowsColumnRangeIterator(
+            Iterable<UserPhotosStreamValueRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results =
+                t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<UserPhotosStreamValueRow, Iterator<UserPhotosStreamValueNamedColumnValue<?>>> transformed =
+                Maps.newHashMapWithExpectedSize(results.size());
         for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
             UserPhotosStreamValueRow row = UserPhotosStreamValueRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
             Iterator<UserPhotosStreamValueNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
-                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+                return shortNameToHydrator
+                        .get(PtBytes.toString(result.getKey().getColumnName()))
+                        .hydrateFromBytes(result.getValue());
             });
             transformed.put(row, bv);
         }
@@ -575,36 +622,41 @@ public final class UserPhotosStreamValueTable implements
 
     private ColumnSelection optimizeColumnSelection(ColumnSelection columns) {
         if (columns.allColumnsSelected()) {
-            return allColumns;
+            return allKnownColumns;
         }
         return columns;
     }
 
     public BatchingVisitableView<UserPhotosStreamValueRowResult> getAllRowsUnordered() {
-        return getAllRowsUnordered(allColumns);
+        return getAllRowsUnordered(allKnownColumns);
     }
 
     public BatchingVisitableView<UserPhotosStreamValueRowResult> getAllRowsUnordered(ColumnSelection columns) {
-        return BatchingVisitables.transform(t.getRange(tableRef, RangeRequest.builder()
-                .retainColumns(optimizeColumnSelection(columns)).build()),
+        return BatchingVisitables.transform(
+                t.getRange(
+                        tableRef,
+                        RangeRequest.builder()
+                                .retainColumns(optimizeColumnSelection(columns))
+                                .build()),
                 new Function<RowResult<byte[]>, UserPhotosStreamValueRowResult>() {
-            @Override
-            public UserPhotosStreamValueRowResult apply(RowResult<byte[]> input) {
-                return UserPhotosStreamValueRowResult.of(input);
-            }
-        });
+                    @Override
+                    public UserPhotosStreamValueRowResult apply(RowResult<byte[]> input) {
+                        return UserPhotosStreamValueRowResult.of(input);
+                    }
+                });
     }
 
     @Override
-    public List<String> findConstraintFailures(Map<Cell, byte[]> writes,
-                                               ConstraintCheckingTransaction transaction,
-                                               AtlasDbConstraintCheckingMode constraintCheckingMode) {
+    public List<String> findConstraintFailures(
+            Map<Cell, byte[]> writes,
+            ConstraintCheckingTransaction transaction,
+            AtlasDbConstraintCheckingMode constraintCheckingMode) {
         return ImmutableList.of();
     }
 
     @Override
-    public List<String> findConstraintFailuresNoRead(Map<Cell, byte[]> writes,
-                                                     AtlasDbConstraintCheckingMode constraintCheckingMode) {
+    public List<String> findConstraintFailuresNoRead(
+            Map<Cell, byte[]> writes, AtlasDbConstraintCheckingMode constraintCheckingMode) {
         return ImmutableList.of();
     }
 
@@ -636,6 +688,7 @@ public final class UserPhotosStreamValueTable implements
      * {@link ColumnSelection}
      * {@link ColumnValue}
      * {@link ColumnValues}
+     * {@link Columns}
      * {@link ComparisonChain}
      * {@link Compression}
      * {@link CompressionUtils}
@@ -693,5 +746,5 @@ public final class UserPhotosStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "UoztUHiQjLh+pDv9vS1v+Q==";
+    static String __CLASS_HASH = "D4vZ7xzP3/t6nWHrlIaeHw==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserProfileTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserProfileTable.java
@@ -1,26 +1,5 @@
 package com.palantir.example.profile.schema.generated;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.EnumSet;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.UUID;
-import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
-import java.util.function.BiFunction;
-import java.util.function.Supplier;
-import java.util.stream.Stream;
-
-import javax.annotation.Generated;
-
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
@@ -66,6 +45,7 @@ import com.palantir.atlasdb.table.api.TypedRowResult;
 import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Columns;
 import com.palantir.atlasdb.table.generation.Descending;
 import com.palantir.atlasdb.table.generation.NamedColumnValue;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
@@ -84,28 +64,56 @@ import com.palantir.common.persist.Persistable.Hydrator;
 import com.palantir.common.persist.Persistables;
 import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import javax.annotation.Generated;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
 @SuppressWarnings({"all", "deprecation"})
-public final class UserProfileTable implements
-        AtlasDbMutablePersistentTable<UserProfileTable.UserProfileRow,
-                                         UserProfileTable.UserProfileNamedColumnValue<?>,
-                                         UserProfileTable.UserProfileRowResult>,
-        AtlasDbNamedMutableTable<UserProfileTable.UserProfileRow,
-                                    UserProfileTable.UserProfileNamedColumnValue<?>,
-                                    UserProfileTable.UserProfileRowResult> {
+public final class UserProfileTable
+        implements AtlasDbMutablePersistentTable<
+                        UserProfileTable.UserProfileRow,
+                        UserProfileTable.UserProfileNamedColumnValue<?>,
+                        UserProfileTable.UserProfileRowResult>,
+                AtlasDbNamedMutableTable<
+                        UserProfileTable.UserProfileRow,
+                        UserProfileTable.UserProfileNamedColumnValue<?>,
+                        UserProfileTable.UserProfileRowResult> {
     private final Transaction t;
     private final List<UserProfileTrigger> triggers;
-    private final static String rawTableName = "user_profile";
+    private static final String rawTableName = "user_profile";
     private final TableReference tableRef;
-    private final static ColumnSelection allColumns = getColumnSelection(UserProfileNamedColumn.values());
+    private static final ColumnSelection allKnownColumns = getColumnSelection(UserProfileNamedColumn.values());
 
     static UserProfileTable of(Transaction t, Namespace namespace) {
         return new UserProfileTable(t, namespace, ImmutableList.<UserProfileTrigger>of());
     }
 
-    static UserProfileTable of(Transaction t, Namespace namespace, UserProfileTrigger trigger, UserProfileTrigger... triggers) {
-        return new UserProfileTable(t, namespace, ImmutableList.<UserProfileTrigger>builder().add(trigger).add(triggers).build());
+    static UserProfileTable of(
+            Transaction t, Namespace namespace, UserProfileTrigger trigger, UserProfileTrigger... triggers) {
+        return new UserProfileTable(
+                t,
+                namespace,
+                ImmutableList.<UserProfileTrigger>builder()
+                        .add(trigger)
+                        .add(triggers)
+                        .build());
     }
 
     static UserProfileTable of(Transaction t, Namespace namespace, List<UserProfileTrigger> triggers) {
@@ -193,8 +201,8 @@ public final class UserProfileTable implements
         @Override
         public String toString() {
             return MoreObjects.toStringHelper(getClass().getSimpleName())
-                .add("id", id)
-                .toString();
+                    .add("id", id)
+                    .toString();
         }
 
         @Override
@@ -220,13 +228,13 @@ public final class UserProfileTable implements
 
         @Override
         public int compareTo(UserProfileRow o) {
-            return ComparisonChain.start()
-                .compare(this.id, o.id)
-                .result();
+            return ComparisonChain.start().compare(this.id, o.id).result();
         }
     }
 
-    public interface UserProfileNamedColumnValue<T> extends NamedColumnValue<T> { /* */ }
+    public interface UserProfileNamedColumnValue<T> extends NamedColumnValue<T> {
+        /* */
+    }
 
     /**
      * <pre>
@@ -235,7 +243,8 @@ public final class UserProfileTable implements
      * }
      * </pre>
      */
-    public static final class Create implements UserProfileNamedColumnValue<com.palantir.example.profile.schema.CreationData> {
+    public static final class Create
+            implements UserProfileNamedColumnValue<com.palantir.example.profile.schema.CreationData> {
         private final com.palantir.example.profile.schema.CreationData value;
 
         public static Create of(com.palantir.example.profile.schema.CreationData value) {
@@ -263,7 +272,9 @@ public final class UserProfileTable implements
 
         @Override
         public byte[] persistValue() {
-            byte[] bytes = com.palantir.atlasdb.compress.CompressionUtils.compress(new com.palantir.example.profile.schema.CreationData.Persister().persistToBytes(value), com.palantir.atlasdb.table.description.ColumnValueDescription.Compression.NONE);
+            byte[] bytes = com.palantir.atlasdb.compress.CompressionUtils.compress(
+                    new com.palantir.example.profile.schema.CreationData.Persister().persistToBytes(value),
+                    com.palantir.atlasdb.table.description.ColumnValueDescription.Compression.NONE);
             return CompressionUtils.compress(bytes, Compression.NONE);
         }
 
@@ -276,15 +287,18 @@ public final class UserProfileTable implements
             @Override
             public Create hydrateFromBytes(byte[] bytes) {
                 bytes = CompressionUtils.decompress(bytes, Compression.NONE);
-                return of(new com.palantir.example.profile.schema.CreationData.Persister().hydrateFromBytes(com.palantir.atlasdb.compress.CompressionUtils.decompress(bytes, com.palantir.atlasdb.table.description.ColumnValueDescription.Compression.NONE)));
+                return of(new com.palantir.example.profile.schema.CreationData.Persister()
+                        .hydrateFromBytes(com.palantir.atlasdb.compress.CompressionUtils.decompress(
+                                bytes,
+                                com.palantir.atlasdb.table.description.ColumnValueDescription.Compression.NONE)));
             }
         };
 
         @Override
         public String toString() {
             return MoreObjects.toStringHelper(getClass().getSimpleName())
-                .add("Value", this.value)
-                .toString();
+                    .add("Value", this.value)
+                    .toString();
         }
     }
 
@@ -323,7 +337,9 @@ public final class UserProfileTable implements
 
         @Override
         public byte[] persistValue() {
-            byte[] bytes = com.palantir.atlasdb.compress.CompressionUtils.compress(new com.palantir.atlasdb.persister.JsonNodePersister().persistToBytes(value), com.palantir.atlasdb.table.description.ColumnValueDescription.Compression.NONE);
+            byte[] bytes = com.palantir.atlasdb.compress.CompressionUtils.compress(
+                    new com.palantir.atlasdb.persister.JsonNodePersister().persistToBytes(value),
+                    com.palantir.atlasdb.table.description.ColumnValueDescription.Compression.NONE);
             return CompressionUtils.compress(bytes, Compression.NONE);
         }
 
@@ -336,16 +352,19 @@ public final class UserProfileTable implements
             @Override
             public Json hydrateFromBytes(byte[] bytes) {
                 bytes = CompressionUtils.decompress(bytes, Compression.NONE);
-                return of(REUSABLE_PERSISTER.hydrateFromBytes(com.palantir.atlasdb.compress.CompressionUtils.decompress(bytes, com.palantir.atlasdb.table.description.ColumnValueDescription.Compression.NONE)));
+                return of(REUSABLE_PERSISTER.hydrateFromBytes(com.palantir.atlasdb.compress.CompressionUtils.decompress(
+                        bytes, com.palantir.atlasdb.table.description.ColumnValueDescription.Compression.NONE)));
             }
-            private final com.palantir.atlasdb.persister.JsonNodePersister REUSABLE_PERSISTER = new com.palantir.atlasdb.persister.JsonNodePersister();
+
+            private final com.palantir.atlasdb.persister.JsonNodePersister REUSABLE_PERSISTER =
+                    new com.palantir.atlasdb.persister.JsonNodePersister();
         };
 
         @Override
         public String toString() {
             return MoreObjects.toStringHelper(getClass().getSimpleName())
-                .add("Value", this.value)
-                .toString();
+                    .add("Value", this.value)
+                    .toString();
         }
     }
 
@@ -366,11 +385,13 @@ public final class UserProfileTable implements
      *     label: LABEL_REQUIRED
      *     type: TYPE_SINT64
      *   }
-     *   
+     *
      * }
      * </pre>
      */
-    public static final class Metadata implements UserProfileNamedColumnValue<com.palantir.example.profile.protos.generated.ProfilePersistence.UserProfile> {
+    public static final class Metadata
+            implements UserProfileNamedColumnValue<
+                    com.palantir.example.profile.protos.generated.ProfilePersistence.UserProfile> {
         private final com.palantir.example.profile.protos.generated.ProfilePersistence.UserProfile value;
 
         public static Metadata of(com.palantir.example.profile.protos.generated.ProfilePersistence.UserProfile value) {
@@ -412,7 +433,8 @@ public final class UserProfileTable implements
             public Metadata hydrateFromBytes(byte[] bytes) {
                 bytes = CompressionUtils.decompress(bytes, Compression.NONE);
                 try {
-                    return of(com.palantir.example.profile.protos.generated.ProfilePersistence.UserProfile.parseFrom(bytes));
+                    return of(com.palantir.example.profile.protos.generated.ProfilePersistence.UserProfile.parseFrom(
+                            bytes));
                 } catch (InvalidProtocolBufferException e) {
                     throw Throwables.throwUncheckedException(e);
                 }
@@ -422,8 +444,8 @@ public final class UserProfileTable implements
         @Override
         public String toString() {
             return MoreObjects.toStringHelper(getClass().getSimpleName())
-                .add("Value", this.value)
-                .toString();
+                    .add("Value", this.value)
+                    .toString();
         }
     }
 
@@ -482,8 +504,8 @@ public final class UserProfileTable implements
         @Override
         public String toString() {
             return MoreObjects.toStringHelper(getClass().getSimpleName())
-                .add("Value", this.value)
-                .toString();
+                    .add("Value", this.value)
+                    .toString();
         }
     }
 
@@ -595,10 +617,16 @@ public final class UserProfileTable implements
             };
         }
 
-        public static Function<UserProfileRowResult, com.palantir.example.profile.protos.generated.ProfilePersistence.UserProfile> getMetadataFun() {
-            return new Function<UserProfileRowResult, com.palantir.example.profile.protos.generated.ProfilePersistence.UserProfile>() {
+        public static Function<
+                        UserProfileRowResult,
+                        com.palantir.example.profile.protos.generated.ProfilePersistence.UserProfile>
+                getMetadataFun() {
+            return new Function<
+                    UserProfileRowResult,
+                    com.palantir.example.profile.protos.generated.ProfilePersistence.UserProfile>() {
                 @Override
-                public com.palantir.example.profile.protos.generated.ProfilePersistence.UserProfile apply(UserProfileRowResult rowResult) {
+                public com.palantir.example.profile.protos.generated.ProfilePersistence.UserProfile apply(
+                        UserProfileRowResult rowResult) {
                     return rowResult.getMetadata();
                 }
             };
@@ -616,12 +644,12 @@ public final class UserProfileTable implements
         @Override
         public String toString() {
             return MoreObjects.toStringHelper(getClass().getSimpleName())
-                .add("RowName", getRowName())
-                .add("Create", getCreate())
-                .add("Json", getJson())
-                .add("Metadata", getMetadata())
-                .add("PhotoStreamId", getPhotoStreamId())
-                .toString();
+                    .add("RowName", getRowName())
+                    .add("Create", getCreate())
+                    .add("Json", getJson())
+                    .add("Metadata", getMetadata())
+                    .add("PhotoStreamId", getPhotoStreamId())
+                    .toString();
         }
     }
 
@@ -673,35 +701,41 @@ public final class UserProfileTable implements
 
     private static final Map<String, Hydrator<? extends UserProfileNamedColumnValue<?>>> shortNameToHydrator =
             ImmutableMap.<String, Hydrator<? extends UserProfileNamedColumnValue<?>>>builder()
-                .put("m", Metadata.BYTES_HYDRATOR)
-                .put("c", Create.BYTES_HYDRATOR)
-                .put("j", Json.BYTES_HYDRATOR)
-                .put("p", PhotoStreamId.BYTES_HYDRATOR)
-                .build();
+                    .put("m", Metadata.BYTES_HYDRATOR)
+                    .put("c", Create.BYTES_HYDRATOR)
+                    .put("j", Json.BYTES_HYDRATOR)
+                    .put("p", PhotoStreamId.BYTES_HYDRATOR)
+                    .build();
 
-    public Map<UserProfileRow, com.palantir.example.profile.protos.generated.ProfilePersistence.UserProfile> getMetadatas(Collection<UserProfileRow> rows) {
+    public Map<UserProfileRow, com.palantir.example.profile.protos.generated.ProfilePersistence.UserProfile>
+            getMetadatas(Collection<UserProfileRow> rows) {
         Map<Cell, UserProfileRow> cells = Maps.newHashMapWithExpectedSize(rows.size());
         for (UserProfileRow row : rows) {
             cells.put(Cell.create(row.persistToBytes(), PtBytes.toCachedBytes("m")), row);
         }
         Map<Cell, byte[]> results = t.get(tableRef, cells.keySet());
-        Map<UserProfileRow, com.palantir.example.profile.protos.generated.ProfilePersistence.UserProfile> ret = Maps.newHashMapWithExpectedSize(results.size());
+        Map<UserProfileRow, com.palantir.example.profile.protos.generated.ProfilePersistence.UserProfile> ret =
+                Maps.newHashMapWithExpectedSize(results.size());
         for (Entry<Cell, byte[]> e : results.entrySet()) {
-            com.palantir.example.profile.protos.generated.ProfilePersistence.UserProfile val = Metadata.BYTES_HYDRATOR.hydrateFromBytes(e.getValue()).getValue();
+            com.palantir.example.profile.protos.generated.ProfilePersistence.UserProfile val =
+                    Metadata.BYTES_HYDRATOR.hydrateFromBytes(e.getValue()).getValue();
             ret.put(cells.get(e.getKey()), val);
         }
         return ret;
     }
 
-    public Map<UserProfileRow, com.palantir.example.profile.schema.CreationData> getCreates(Collection<UserProfileRow> rows) {
+    public Map<UserProfileRow, com.palantir.example.profile.schema.CreationData> getCreates(
+            Collection<UserProfileRow> rows) {
         Map<Cell, UserProfileRow> cells = Maps.newHashMapWithExpectedSize(rows.size());
         for (UserProfileRow row : rows) {
             cells.put(Cell.create(row.persistToBytes(), PtBytes.toCachedBytes("c")), row);
         }
         Map<Cell, byte[]> results = t.get(tableRef, cells.keySet());
-        Map<UserProfileRow, com.palantir.example.profile.schema.CreationData> ret = Maps.newHashMapWithExpectedSize(results.size());
+        Map<UserProfileRow, com.palantir.example.profile.schema.CreationData> ret =
+                Maps.newHashMapWithExpectedSize(results.size());
         for (Entry<Cell, byte[]> e : results.entrySet()) {
-            com.palantir.example.profile.schema.CreationData val = Create.BYTES_HYDRATOR.hydrateFromBytes(e.getValue()).getValue();
+            com.palantir.example.profile.schema.CreationData val =
+                    Create.BYTES_HYDRATOR.hydrateFromBytes(e.getValue()).getValue();
             ret.put(cells.get(e.getKey()), val);
         }
         return ret;
@@ -713,9 +747,11 @@ public final class UserProfileTable implements
             cells.put(Cell.create(row.persistToBytes(), PtBytes.toCachedBytes("j")), row);
         }
         Map<Cell, byte[]> results = t.get(tableRef, cells.keySet());
-        Map<UserProfileRow, com.fasterxml.jackson.databind.JsonNode> ret = Maps.newHashMapWithExpectedSize(results.size());
+        Map<UserProfileRow, com.fasterxml.jackson.databind.JsonNode> ret =
+                Maps.newHashMapWithExpectedSize(results.size());
         for (Entry<Cell, byte[]> e : results.entrySet()) {
-            com.fasterxml.jackson.databind.JsonNode val = Json.BYTES_HYDRATOR.hydrateFromBytes(e.getValue()).getValue();
+            com.fasterxml.jackson.databind.JsonNode val =
+                    Json.BYTES_HYDRATOR.hydrateFromBytes(e.getValue()).getValue();
             ret.put(cells.get(e.getKey()), val);
         }
         return ret;
@@ -729,19 +765,23 @@ public final class UserProfileTable implements
         Map<Cell, byte[]> results = t.get(tableRef, cells.keySet());
         Map<UserProfileRow, Long> ret = Maps.newHashMapWithExpectedSize(results.size());
         for (Entry<Cell, byte[]> e : results.entrySet()) {
-            Long val = PhotoStreamId.BYTES_HYDRATOR.hydrateFromBytes(e.getValue()).getValue();
+            Long val =
+                    PhotoStreamId.BYTES_HYDRATOR.hydrateFromBytes(e.getValue()).getValue();
             ret.put(cells.get(e.getKey()), val);
         }
         return ret;
     }
 
-    public void putMetadata(UserProfileRow row, com.palantir.example.profile.protos.generated.ProfilePersistence.UserProfile value) {
+    public void putMetadata(
+            UserProfileRow row, com.palantir.example.profile.protos.generated.ProfilePersistence.UserProfile value) {
         put(ImmutableMultimap.of(row, Metadata.of(value)));
     }
 
-    public void putMetadata(Map<UserProfileRow, com.palantir.example.profile.protos.generated.ProfilePersistence.UserProfile> map) {
+    public void putMetadata(
+            Map<UserProfileRow, com.palantir.example.profile.protos.generated.ProfilePersistence.UserProfile> map) {
         Map<UserProfileRow, UserProfileNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<UserProfileRow, com.palantir.example.profile.protos.generated.ProfilePersistence.UserProfile> e : map.entrySet()) {
+        for (Entry<UserProfileRow, com.palantir.example.profile.protos.generated.ProfilePersistence.UserProfile> e :
+                map.entrySet()) {
             toPut.put(e.getKey(), Metadata.of(e.getValue()));
         }
         put(Multimaps.forMap(toPut));
@@ -791,24 +831,25 @@ public final class UserProfileTable implements
         deleteCreatedIdx(affectedCells);
         deleteUserBirthdaysIdx(affectedCells);
         for (Entry<UserProfileRow, ? extends UserProfileNamedColumnValue<?>> e : rows.entries()) {
-            if (e.getValue() instanceof Json)
-            {
+            if (e.getValue() instanceof Json) {
                 Json col = (Json) e.getValue();
                 {
                     UserProfileRow row = e.getKey();
                     CookiesIdxTable table = CookiesIdxTable.of(this);
-                    Iterable<String> cookieIterable = com.palantir.example.profile.schema.ProfileSchema.getCookies(col.getValue());
+                    Iterable<String> cookieIterable =
+                            com.palantir.example.profile.schema.ProfileSchema.getCookies(col.getValue());
                     UUID id = row.getId();
                     for (String cookie : cookieIterable) {
                         CookiesIdxTable.CookiesIdxRow indexRow = CookiesIdxTable.CookiesIdxRow.of(cookie);
-                        CookiesIdxTable.CookiesIdxColumn indexCol = CookiesIdxTable.CookiesIdxColumn.of(row.persistToBytes(), e.getValue().persistColumnName(), id);
-                        CookiesIdxTable.CookiesIdxColumnValue indexColVal = CookiesIdxTable.CookiesIdxColumnValue.of(indexCol, 0L);
+                        CookiesIdxTable.CookiesIdxColumn indexCol = CookiesIdxTable.CookiesIdxColumn.of(
+                                row.persistToBytes(), e.getValue().persistColumnName(), id);
+                        CookiesIdxTable.CookiesIdxColumnValue indexColVal =
+                                CookiesIdxTable.CookiesIdxColumnValue.of(indexCol, 0L);
                         table.put(indexRow, indexColVal);
                     }
                 }
             }
-            if (e.getValue() instanceof Create)
-            {
+            if (e.getValue() instanceof Create) {
                 Create col = (Create) e.getValue();
                 {
                     UserProfileRow row = e.getKey();
@@ -816,22 +857,27 @@ public final class UserProfileTable implements
                     long time = col.getValue().getTimeCreated();
                     UUID id = row.getId();
                     CreatedIdxTable.CreatedIdxRow indexRow = CreatedIdxTable.CreatedIdxRow.of(time);
-                    CreatedIdxTable.CreatedIdxColumn indexCol = CreatedIdxTable.CreatedIdxColumn.of(row.persistToBytes(), e.getValue().persistColumnName(), id);
-                    CreatedIdxTable.CreatedIdxColumnValue indexColVal = CreatedIdxTable.CreatedIdxColumnValue.of(indexCol, 0L);
+                    CreatedIdxTable.CreatedIdxColumn indexCol = CreatedIdxTable.CreatedIdxColumn.of(
+                            row.persistToBytes(), e.getValue().persistColumnName(), id);
+                    CreatedIdxTable.CreatedIdxColumnValue indexColVal =
+                            CreatedIdxTable.CreatedIdxColumnValue.of(indexCol, 0L);
                     table.put(indexRow, indexColVal);
                 }
             }
-            if (e.getValue() instanceof Metadata)
-            {
+            if (e.getValue() instanceof Metadata) {
                 Metadata col = (Metadata) e.getValue();
                 {
                     UserProfileRow row = e.getKey();
                     UserBirthdaysIdxTable table = UserBirthdaysIdxTable.of(this);
                     long birthday = col.getValue().getBirthEpochDay();
                     UUID id = row.getId();
-                    UserBirthdaysIdxTable.UserBirthdaysIdxRow indexRow = UserBirthdaysIdxTable.UserBirthdaysIdxRow.of(birthday);
-                    UserBirthdaysIdxTable.UserBirthdaysIdxColumn indexCol = UserBirthdaysIdxTable.UserBirthdaysIdxColumn.of(row.persistToBytes(), e.getValue().persistColumnName(), id);
-                    UserBirthdaysIdxTable.UserBirthdaysIdxColumnValue indexColVal = UserBirthdaysIdxTable.UserBirthdaysIdxColumnValue.of(indexCol, 0L);
+                    UserBirthdaysIdxTable.UserBirthdaysIdxRow indexRow =
+                            UserBirthdaysIdxTable.UserBirthdaysIdxRow.of(birthday);
+                    UserBirthdaysIdxTable.UserBirthdaysIdxColumn indexCol =
+                            UserBirthdaysIdxTable.UserBirthdaysIdxColumn.of(
+                                    row.persistToBytes(), e.getValue().persistColumnName(), id);
+                    UserBirthdaysIdxTable.UserBirthdaysIdxColumnValue indexColVal =
+                            UserBirthdaysIdxTable.UserBirthdaysIdxColumnValue.of(indexCol, 0L);
                     table.put(indexRow, indexColVal);
                 }
             }
@@ -858,11 +904,13 @@ public final class UserProfileTable implements
         Set<Cell> indexCells = Sets.newHashSetWithExpectedSize(results.size());
         for (Entry<Cell, byte[]> result : results.entrySet()) {
             Metadata col = (Metadata) shortNameToHydrator.get("m").hydrateFromBytes(result.getValue());
-            UserProfileRow row = UserProfileRow.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getRowName());
+            UserProfileRow row = UserProfileRow.BYTES_HYDRATOR.hydrateFromBytes(
+                    result.getKey().getRowName());
             long birthday = col.getValue().getBirthEpochDay();
             UUID id = row.getId();
             UserBirthdaysIdxTable.UserBirthdaysIdxRow indexRow = UserBirthdaysIdxTable.UserBirthdaysIdxRow.of(birthday);
-            UserBirthdaysIdxTable.UserBirthdaysIdxColumn indexCol = UserBirthdaysIdxTable.UserBirthdaysIdxColumn.of(row.persistToBytes(), col.persistColumnName(), id);
+            UserBirthdaysIdxTable.UserBirthdaysIdxColumn indexCol =
+                    UserBirthdaysIdxTable.UserBirthdaysIdxColumn.of(row.persistToBytes(), col.persistColumnName(), id);
             indexCells.add(Cell.create(indexRow.persistToBytes(), indexCol.persistToBytes()));
         }
         t.delete(TableReference.createFromFullyQualifiedName("default.user_birthdays_idx"), indexCells);
@@ -884,11 +932,13 @@ public final class UserProfileTable implements
         Set<Cell> indexCells = Sets.newHashSetWithExpectedSize(results.size());
         for (Entry<Cell, byte[]> result : results.entrySet()) {
             Create col = (Create) shortNameToHydrator.get("c").hydrateFromBytes(result.getValue());
-            UserProfileRow row = UserProfileRow.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getRowName());
+            UserProfileRow row = UserProfileRow.BYTES_HYDRATOR.hydrateFromBytes(
+                    result.getKey().getRowName());
             long time = col.getValue().getTimeCreated();
             UUID id = row.getId();
             CreatedIdxTable.CreatedIdxRow indexRow = CreatedIdxTable.CreatedIdxRow.of(time);
-            CreatedIdxTable.CreatedIdxColumn indexCol = CreatedIdxTable.CreatedIdxColumn.of(row.persistToBytes(), col.persistColumnName(), id);
+            CreatedIdxTable.CreatedIdxColumn indexCol =
+                    CreatedIdxTable.CreatedIdxColumn.of(row.persistToBytes(), col.persistColumnName(), id);
             indexCells.add(Cell.create(indexRow.persistToBytes(), indexCol.persistToBytes()));
         }
         t.delete(TableReference.createFromFullyQualifiedName("default.created_idx"), indexCells);
@@ -910,12 +960,15 @@ public final class UserProfileTable implements
         Set<Cell> indexCells = Sets.newHashSetWithExpectedSize(results.size());
         for (Entry<Cell, byte[]> result : results.entrySet()) {
             Json col = (Json) shortNameToHydrator.get("j").hydrateFromBytes(result.getValue());
-            UserProfileRow row = UserProfileRow.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getRowName());
-            Iterable<String> cookieIterable = com.palantir.example.profile.schema.ProfileSchema.getCookies(col.getValue());
+            UserProfileRow row = UserProfileRow.BYTES_HYDRATOR.hydrateFromBytes(
+                    result.getKey().getRowName());
+            Iterable<String> cookieIterable =
+                    com.palantir.example.profile.schema.ProfileSchema.getCookies(col.getValue());
             UUID id = row.getId();
             for (String cookie : cookieIterable) {
                 CookiesIdxTable.CookiesIdxRow indexRow = CookiesIdxTable.CookiesIdxRow.of(cookie);
-                CookiesIdxTable.CookiesIdxColumn indexCol = CookiesIdxTable.CookiesIdxColumn.of(row.persistToBytes(), col.persistColumnName(), id);
+                CookiesIdxTable.CookiesIdxColumn indexCol =
+                        CookiesIdxTable.CookiesIdxColumn.of(row.persistToBytes(), col.persistColumnName(), id);
                 indexCells.add(Cell.create(indexRow.persistToBytes(), indexCol.persistToBytes()));
             }
         }
@@ -943,22 +996,17 @@ public final class UserProfileTable implements
         deleteCookiesIdx(result);
         deleteCreatedIdx(result);
         deleteUserBirthdaysIdx(result);
-        List<byte[]> rowBytes = Persistables.persistAll(rows);
-        Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size() * 4);
-        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("c")));
-        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("j")));
-        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("m")));
-        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("p")));
-        t.delete(tableRef, cells);
+        t.delete(tableRef, ColumnValues.toCells(result));
     }
 
     public Optional<UserProfileRowResult> getRow(UserProfileRow row) {
-        return getRow(row, allColumns);
+        return getRow(row, allKnownColumns);
     }
 
     public Optional<UserProfileRowResult> getRow(UserProfileRow row, ColumnSelection columns) {
         byte[] bytes = row.persistToBytes();
-        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        RowResult<byte[]> rowResult =
+                t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
         if (rowResult == null) {
             return Optional.empty();
         } else {
@@ -968,7 +1016,7 @@ public final class UserProfileTable implements
 
     @Override
     public List<UserProfileRowResult> getRows(Iterable<UserProfileRow> rows) {
-        return getRows(rows, allColumns);
+        return getRows(rows, allKnownColumns);
     }
 
     @Override
@@ -983,17 +1031,19 @@ public final class UserProfileTable implements
 
     @Override
     public List<UserProfileNamedColumnValue<?>> getRowColumns(UserProfileRow row) {
-        return getRowColumns(row, allColumns);
+        return getRowColumns(row, ColumnSelection.all());
     }
 
     @Override
     public List<UserProfileNamedColumnValue<?>> getRowColumns(UserProfileRow row, ColumnSelection columns) {
         byte[] bytes = row.persistToBytes();
-        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        RowResult<byte[]> rowResult =
+                t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
         if (rowResult == null) {
             return ImmutableList.of();
         } else {
-            List<UserProfileNamedColumnValue<?>> ret = Lists.newArrayListWithCapacity(rowResult.getColumns().size());
+            List<UserProfileNamedColumnValue<?>> ret =
+                    Lists.newArrayListWithCapacity(rowResult.getColumns().size());
             for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
                 ret.add(shortNameToHydrator.get(PtBytes.toString(e.getKey())).hydrateFromBytes(e.getValue()));
             }
@@ -1003,69 +1053,91 @@ public final class UserProfileTable implements
 
     @Override
     public Multimap<UserProfileRow, UserProfileNamedColumnValue<?>> getRowsMultimap(Iterable<UserProfileRow> rows) {
-        return getRowsMultimapInternal(rows, allColumns);
+        return getRowsMultimapInternal(rows, ColumnSelection.all());
     }
 
     @Override
-    public Multimap<UserProfileRow, UserProfileNamedColumnValue<?>> getRowsMultimap(Iterable<UserProfileRow> rows, ColumnSelection columns) {
+    public Multimap<UserProfileRow, UserProfileNamedColumnValue<?>> getRowsMultimap(
+            Iterable<UserProfileRow> rows, ColumnSelection columns) {
         return getRowsMultimapInternal(rows, columns);
     }
 
-    private Multimap<UserProfileRow, UserProfileNamedColumnValue<?>> getRowsMultimapInternal(Iterable<UserProfileRow> rows, ColumnSelection columns) {
+    private Multimap<UserProfileRow, UserProfileNamedColumnValue<?>> getRowsMultimapInternal(
+            Iterable<UserProfileRow> rows, ColumnSelection columns) {
         SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
         return getRowMapFromRowResults(results.values());
     }
 
-    private static Multimap<UserProfileRow, UserProfileNamedColumnValue<?>> getRowMapFromRowResults(Collection<RowResult<byte[]>> rowResults) {
+    private static Multimap<UserProfileRow, UserProfileNamedColumnValue<?>> getRowMapFromRowResults(
+            Collection<RowResult<byte[]>> rowResults) {
         Multimap<UserProfileRow, UserProfileNamedColumnValue<?>> rowMap = ArrayListMultimap.create();
         for (RowResult<byte[]> result : rowResults) {
             UserProfileRow row = UserProfileRow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
             for (Entry<byte[], byte[]> e : result.getColumns().entrySet()) {
-                rowMap.put(row, shortNameToHydrator.get(PtBytes.toString(e.getKey())).hydrateFromBytes(e.getValue()));
+                rowMap.put(
+                        row,
+                        shortNameToHydrator.get(PtBytes.toString(e.getKey())).hydrateFromBytes(e.getValue()));
             }
         }
         return rowMap;
     }
 
     @Override
-    public Map<UserProfileRow, BatchingVisitable<UserProfileNamedColumnValue<?>>> getRowsColumnRange(Iterable<UserProfileRow> rows, BatchColumnRangeSelection columnRangeSelection) {
-        Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
-        Map<UserProfileRow, BatchingVisitable<UserProfileNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+    public Map<UserProfileRow, BatchingVisitable<UserProfileNamedColumnValue<?>>> getRowsColumnRange(
+            Iterable<UserProfileRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results =
+                t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<UserProfileRow, BatchingVisitable<UserProfileNamedColumnValue<?>>> transformed =
+                Maps.newHashMapWithExpectedSize(results.size());
         for (Entry<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
             UserProfileRow row = UserProfileRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
-            BatchingVisitable<UserProfileNamedColumnValue<?>> bv = BatchingVisitables.transform(e.getValue(), result -> {
-                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
-            });
+            BatchingVisitable<UserProfileNamedColumnValue<?>> bv =
+                    BatchingVisitables.transform(e.getValue(), result -> {
+                        return shortNameToHydrator
+                                .get(PtBytes.toString(result.getKey().getColumnName()))
+                                .hydrateFromBytes(result.getValue());
+                    });
             transformed.put(row, bv);
         }
         return transformed;
     }
 
     @Override
-    public Iterator<Map.Entry<UserProfileRow, UserProfileNamedColumnValue<?>>> getRowsColumnRange(Iterable<UserProfileRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
-        Iterator<Map.Entry<Cell, byte[]>> results = t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
+    public Iterator<Map.Entry<UserProfileRow, UserProfileNamedColumnValue<?>>> getRowsColumnRange(
+            Iterable<UserProfileRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
+        Iterator<Map.Entry<Cell, byte[]>> results =
+                t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
         return Iterators.transform(results, e -> {
-            UserProfileRow row = UserProfileRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
-            UserProfileNamedColumnValue<?> colValue = shortNameToHydrator.get(PtBytes.toString(e.getKey().getColumnName())).hydrateFromBytes(e.getValue());
+            UserProfileRow row =
+                    UserProfileRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
+            UserProfileNamedColumnValue<?> colValue = shortNameToHydrator
+                    .get(PtBytes.toString(e.getKey().getColumnName()))
+                    .hydrateFromBytes(e.getValue());
             return Maps.immutableEntry(row, colValue);
         });
     }
 
     @Override
-    public Map<UserProfileRow, Iterator<UserProfileNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<UserProfileRow> rows, BatchColumnRangeSelection columnRangeSelection) {
-        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
-        Map<UserProfileRow, Iterator<UserProfileNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+    public Map<UserProfileRow, Iterator<UserProfileNamedColumnValue<?>>> getRowsColumnRangeIterator(
+            Iterable<UserProfileRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results =
+                t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<UserProfileRow, Iterator<UserProfileNamedColumnValue<?>>> transformed =
+                Maps.newHashMapWithExpectedSize(results.size());
         for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
             UserProfileRow row = UserProfileRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
             Iterator<UserProfileNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
-                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+                return shortNameToHydrator
+                        .get(PtBytes.toString(result.getKey().getColumnName()))
+                        .hydrateFromBytes(result.getValue());
             });
             transformed.put(row, bv);
         }
         return transformed;
     }
 
-    private Multimap<UserProfileRow, UserProfileNamedColumnValue<?>> getAffectedCells(Multimap<UserProfileRow, ? extends UserProfileNamedColumnValue<?>> rows) {
+    private Multimap<UserProfileRow, UserProfileNamedColumnValue<?>> getAffectedCells(
+            Multimap<UserProfileRow, ? extends UserProfileNamedColumnValue<?>> rows) {
         Multimap<UserProfileRow, UserProfileNamedColumnValue<?>> oldData = getRowsMultimap(rows.keySet());
         Multimap<UserProfileRow, UserProfileNamedColumnValue<?>> cellsAffected = ArrayListMultimap.create();
         for (UserProfileRow row : oldData.keySet()) {
@@ -1086,13 +1158,16 @@ public final class UserProfileTable implements
         ImmutableSet.Builder<Cell> indexCells = ImmutableSet.builder();
         for (Entry<UserProfileRow, UserProfileNamedColumnValue<?>> e : result.entries()) {
             if (e.getValue() instanceof Json) {
-                Json col = (Json) e.getValue();{
+                Json col = (Json) e.getValue();
+                {
                     UserProfileRow row = e.getKey();
-                    Iterable<String> cookieIterable = com.palantir.example.profile.schema.ProfileSchema.getCookies(col.getValue());
+                    Iterable<String> cookieIterable =
+                            com.palantir.example.profile.schema.ProfileSchema.getCookies(col.getValue());
                     UUID id = row.getId();
                     for (String cookie : cookieIterable) {
                         CookiesIdxTable.CookiesIdxRow indexRow = CookiesIdxTable.CookiesIdxRow.of(cookie);
-                        CookiesIdxTable.CookiesIdxColumn indexCol = CookiesIdxTable.CookiesIdxColumn.of(row.persistToBytes(), e.getValue().persistColumnName(), id);
+                        CookiesIdxTable.CookiesIdxColumn indexCol = CookiesIdxTable.CookiesIdxColumn.of(
+                                row.persistToBytes(), e.getValue().persistColumnName(), id);
                         indexCells.add(Cell.create(indexRow.persistToBytes(), indexCol.persistToBytes()));
                     }
                 }
@@ -1105,12 +1180,14 @@ public final class UserProfileTable implements
         ImmutableSet.Builder<Cell> indexCells = ImmutableSet.builder();
         for (Entry<UserProfileRow, UserProfileNamedColumnValue<?>> e : result.entries()) {
             if (e.getValue() instanceof Create) {
-                Create col = (Create) e.getValue();{
+                Create col = (Create) e.getValue();
+                {
                     UserProfileRow row = e.getKey();
                     long time = col.getValue().getTimeCreated();
                     UUID id = row.getId();
                     CreatedIdxTable.CreatedIdxRow indexRow = CreatedIdxTable.CreatedIdxRow.of(time);
-                    CreatedIdxTable.CreatedIdxColumn indexCol = CreatedIdxTable.CreatedIdxColumn.of(row.persistToBytes(), e.getValue().persistColumnName(), id);
+                    CreatedIdxTable.CreatedIdxColumn indexCol = CreatedIdxTable.CreatedIdxColumn.of(
+                            row.persistToBytes(), e.getValue().persistColumnName(), id);
                     indexCells.add(Cell.create(indexRow.persistToBytes(), indexCol.persistToBytes()));
                 }
             }
@@ -1122,12 +1199,16 @@ public final class UserProfileTable implements
         ImmutableSet.Builder<Cell> indexCells = ImmutableSet.builder();
         for (Entry<UserProfileRow, UserProfileNamedColumnValue<?>> e : result.entries()) {
             if (e.getValue() instanceof Metadata) {
-                Metadata col = (Metadata) e.getValue();{
+                Metadata col = (Metadata) e.getValue();
+                {
                     UserProfileRow row = e.getKey();
                     long birthday = col.getValue().getBirthEpochDay();
                     UUID id = row.getId();
-                    UserBirthdaysIdxTable.UserBirthdaysIdxRow indexRow = UserBirthdaysIdxTable.UserBirthdaysIdxRow.of(birthday);
-                    UserBirthdaysIdxTable.UserBirthdaysIdxColumn indexCol = UserBirthdaysIdxTable.UserBirthdaysIdxColumn.of(row.persistToBytes(), e.getValue().persistColumnName(), id);
+                    UserBirthdaysIdxTable.UserBirthdaysIdxRow indexRow =
+                            UserBirthdaysIdxTable.UserBirthdaysIdxRow.of(birthday);
+                    UserBirthdaysIdxTable.UserBirthdaysIdxColumn indexCol =
+                            UserBirthdaysIdxTable.UserBirthdaysIdxColumn.of(
+                                    row.persistToBytes(), e.getValue().persistColumnName(), id);
                     indexCells.add(Cell.create(indexRow.persistToBytes(), indexCol.persistToBytes()));
                 }
             }
@@ -1137,58 +1218,71 @@ public final class UserProfileTable implements
 
     private ColumnSelection optimizeColumnSelection(ColumnSelection columns) {
         if (columns.allColumnsSelected()) {
-            return allColumns;
+            return allKnownColumns;
         }
         return columns;
     }
 
     public BatchingVisitableView<UserProfileRowResult> getAllRowsUnordered() {
-        return getAllRowsUnordered(allColumns);
+        return getAllRowsUnordered(allKnownColumns);
     }
 
     public BatchingVisitableView<UserProfileRowResult> getAllRowsUnordered(ColumnSelection columns) {
-        return BatchingVisitables.transform(t.getRange(tableRef, RangeRequest.builder()
-                .retainColumns(optimizeColumnSelection(columns)).build()),
+        return BatchingVisitables.transform(
+                t.getRange(
+                        tableRef,
+                        RangeRequest.builder()
+                                .retainColumns(optimizeColumnSelection(columns))
+                                .build()),
                 new Function<RowResult<byte[]>, UserProfileRowResult>() {
-            @Override
-            public UserProfileRowResult apply(RowResult<byte[]> input) {
-                return UserProfileRowResult.of(input);
-            }
-        });
+                    @Override
+                    public UserProfileRowResult apply(RowResult<byte[]> input) {
+                        return UserProfileRowResult.of(input);
+                    }
+                });
     }
 
     @Override
-    public List<String> findConstraintFailures(Map<Cell, byte[]> writes,
-                                               ConstraintCheckingTransaction transaction,
-                                               AtlasDbConstraintCheckingMode constraintCheckingMode) {
+    public List<String> findConstraintFailures(
+            Map<Cell, byte[]> writes,
+            ConstraintCheckingTransaction transaction,
+            AtlasDbConstraintCheckingMode constraintCheckingMode) {
         return ImmutableList.of();
     }
 
     @Override
-    public List<String> findConstraintFailuresNoRead(Map<Cell, byte[]> writes,
-                                                     AtlasDbConstraintCheckingMode constraintCheckingMode) {
+    public List<String> findConstraintFailuresNoRead(
+            Map<Cell, byte[]> writes, AtlasDbConstraintCheckingMode constraintCheckingMode) {
         return ImmutableList.of();
     }
 
     @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
     @SuppressWarnings({"all", "deprecation"})
-    public static final class CookiesIdxTable implements
-            AtlasDbDynamicMutablePersistentTable<CookiesIdxTable.CookiesIdxRow,
-                                                    CookiesIdxTable.CookiesIdxColumn,
-                                                    CookiesIdxTable.CookiesIdxColumnValue,
-                                                    CookiesIdxTable.CookiesIdxRowResult> {
+    public static final class CookiesIdxTable
+            implements AtlasDbDynamicMutablePersistentTable<
+                    CookiesIdxTable.CookiesIdxRow,
+                    CookiesIdxTable.CookiesIdxColumn,
+                    CookiesIdxTable.CookiesIdxColumnValue,
+                    CookiesIdxTable.CookiesIdxRowResult> {
         private final Transaction t;
         private final List<CookiesIdxTrigger> triggers;
-        private final static String rawTableName = "cookies_idx";
+        private static final String rawTableName = "cookies_idx";
         private final TableReference tableRef;
-        private final static ColumnSelection allColumns = ColumnSelection.all();
+        private static final ColumnSelection allKnownColumns = ColumnSelection.all();
 
         public static CookiesIdxTable of(UserProfileTable table) {
             return new CookiesIdxTable(table.t, table.tableRef.getNamespace(), ImmutableList.<CookiesIdxTrigger>of());
         }
 
-        public static CookiesIdxTable of(UserProfileTable table, CookiesIdxTrigger trigger, CookiesIdxTrigger... triggers) {
-            return new CookiesIdxTable(table.t, table.tableRef.getNamespace(), ImmutableList.<CookiesIdxTrigger>builder().add(trigger).add(triggers).build());
+        public static CookiesIdxTable of(
+                UserProfileTable table, CookiesIdxTrigger trigger, CookiesIdxTrigger... triggers) {
+            return new CookiesIdxTable(
+                    table.t,
+                    table.tableRef.getNamespace(),
+                    ImmutableList.<CookiesIdxTrigger>builder()
+                            .add(trigger)
+                            .add(triggers)
+                            .build());
         }
 
         public static CookiesIdxTable of(UserProfileTable table, List<CookiesIdxTrigger> triggers) {
@@ -1267,7 +1361,7 @@ public final class UserProfileTable implements
                 @Override
                 public CookiesIdxRow hydrateFromBytes(byte[] __input) {
                     int __index = 0;
-                    String cookie = PtBytes.toString(__input, __index, __input.length-__index);
+                    String cookie = PtBytes.toString(__input, __index, __input.length - __index);
                     __index += 0;
                     return new CookiesIdxRow(cookie);
                 }
@@ -1276,8 +1370,8 @@ public final class UserProfileTable implements
             @Override
             public String toString() {
                 return MoreObjects.toStringHelper(getClass().getSimpleName())
-                    .add("cookie", cookie)
-                    .toString();
+                        .add("cookie", cookie)
+                        .toString();
             }
 
             @Override
@@ -1303,9 +1397,7 @@ public final class UserProfileTable implements
 
             @Override
             public int compareTo(CookiesIdxRow o) {
-                return ComparisonChain.start()
-                    .compare(this.cookie, o.cookie)
-                    .result();
+                return ComparisonChain.start().compare(this.cookie, o.cookie).result();
             }
         }
 
@@ -1404,10 +1496,12 @@ public final class UserProfileTable implements
                 return new Prefix(EncodingUtils.add(rowNameBytes));
             }
 
-            public static BatchColumnRangeSelection createPrefixRange(byte[] rowName, byte[] columnName, int batchSize) {
+            public static BatchColumnRangeSelection createPrefixRange(
+                    byte[] rowName, byte[] columnName, int batchSize) {
                 byte[] rowNameBytes = EncodingUtils.encodeSizedBytes(rowName);
                 byte[] columnNameBytes = EncodingUtils.encodeSizedBytes(columnName);
-                return ColumnRangeSelections.createPrefixRange(EncodingUtils.add(rowNameBytes, columnNameBytes), batchSize);
+                return ColumnRangeSelections.createPrefixRange(
+                        EncodingUtils.add(rowNameBytes, columnNameBytes), batchSize);
             }
 
             public static Prefix prefix(byte[] rowName, byte[] columnName) {
@@ -1419,10 +1513,10 @@ public final class UserProfileTable implements
             @Override
             public String toString() {
                 return MoreObjects.toStringHelper(getClass().getSimpleName())
-                    .add("rowName", rowName)
-                    .add("columnName", columnName)
-                    .add("id", id)
-                    .toString();
+                        .add("rowName", rowName)
+                        .add("columnName", columnName)
+                        .add("id", id)
+                        .toString();
             }
 
             @Override
@@ -1437,22 +1531,24 @@ public final class UserProfileTable implements
                     return false;
                 }
                 CookiesIdxColumn other = (CookiesIdxColumn) obj;
-                return Arrays.equals(rowName, other.rowName) && Arrays.equals(columnName, other.columnName) && Objects.equals(id, other.id);
+                return Arrays.equals(rowName, other.rowName)
+                        && Arrays.equals(columnName, other.columnName)
+                        && Objects.equals(id, other.id);
             }
 
             @SuppressWarnings("ArrayHashCode")
             @Override
             public int hashCode() {
-                return Arrays.deepHashCode(new Object[]{ rowName, columnName, id });
+                return Arrays.deepHashCode(new Object[] {rowName, columnName, id});
             }
 
             @Override
             public int compareTo(CookiesIdxColumn o) {
                 return ComparisonChain.start()
-                    .compare(this.rowName, o.rowName, UnsignedBytes.lexicographicalComparator())
-                    .compare(this.columnName, o.columnName, UnsignedBytes.lexicographicalComparator())
-                    .compare(this.id, o.id)
-                    .result();
+                        .compare(this.rowName, o.rowName, UnsignedBytes.lexicographicalComparator())
+                        .compare(this.columnName, o.columnName, UnsignedBytes.lexicographicalComparator())
+                        .compare(this.id, o.id)
+                        .result();
             }
         }
 
@@ -1531,9 +1627,9 @@ public final class UserProfileTable implements
             @Override
             public String toString() {
                 return MoreObjects.toStringHelper(getClass().getSimpleName())
-                    .add("ColumnName", this.columnName)
-                    .add("Value", this.value)
-                    .toString();
+                        .add("ColumnName", this.columnName)
+                        .add("Value", this.value)
+                        .toString();
             }
         }
 
@@ -1543,7 +1639,8 @@ public final class UserProfileTable implements
 
             public static CookiesIdxRowResult of(RowResult<byte[]> rowResult) {
                 CookiesIdxRow rowName = CookiesIdxRow.BYTES_HYDRATOR.hydrateFromBytes(rowResult.getRowName());
-                Set<CookiesIdxColumnValue> columnValues = Sets.newHashSetWithExpectedSize(rowResult.getColumns().size());
+                Set<CookiesIdxColumnValue> columnValues =
+                        Sets.newHashSetWithExpectedSize(rowResult.getColumns().size());
                 for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
                     CookiesIdxColumn col = CookiesIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
                     Long value = CookiesIdxColumnValue.hydrateValue(e.getValue());
@@ -1587,9 +1684,9 @@ public final class UserProfileTable implements
             @Override
             public String toString() {
                 return MoreObjects.toStringHelper(getClass().getSimpleName())
-                    .add("RowName", getRowName())
-                    .add("ColumnValues", getColumnValues())
-                    .toString();
+                        .add("RowName", getRowName())
+                        .add("ColumnValues", getColumnValues())
+                        .toString();
             }
         }
 
@@ -1600,27 +1697,27 @@ public final class UserProfileTable implements
 
         @Override
         public void delete(Iterable<CookiesIdxRow> rows) {
-            Multimap<CookiesIdxRow, CookiesIdxColumn> toRemove = HashMultimap.create();
             Multimap<CookiesIdxRow, CookiesIdxColumnValue> result = getRowsMultimap(rows);
-            for (Entry<CookiesIdxRow, CookiesIdxColumnValue> e : result.entries()) {
-                toRemove.put(e.getKey(), e.getValue().getColumnName());
-            }
-            delete(toRemove);
+            t.delete(tableRef, ColumnValues.toCells(result));
         }
 
         @Override
         public void delete(Multimap<CookiesIdxRow, CookiesIdxColumn> values) {
-            t.delete(tableRef, ColumnValues.toCells(values));
+            t.delete(tableRef, Columns.toCells(values));
         }
 
         @Override
         public void put(CookiesIdxRow rowName, Iterable<CookiesIdxColumnValue> values) {
-            put(ImmutableMultimap.<CookiesIdxRow, CookiesIdxColumnValue>builder().putAll(rowName, values).build());
+            put(ImmutableMultimap.<CookiesIdxRow, CookiesIdxColumnValue>builder()
+                    .putAll(rowName, values)
+                    .build());
         }
 
         @Override
         public void put(CookiesIdxRow rowName, CookiesIdxColumnValue... values) {
-            put(ImmutableMultimap.<CookiesIdxRow, CookiesIdxColumnValue>builder().putAll(rowName, values).build());
+            put(ImmutableMultimap.<CookiesIdxRow, CookiesIdxColumnValue>builder()
+                    .putAll(rowName, values)
+                    .build());
         }
 
         @Override
@@ -1653,13 +1750,15 @@ public final class UserProfileTable implements
 
         @Override
         public Multimap<CookiesIdxRow, CookiesIdxColumnValue> get(Multimap<CookiesIdxRow, CookiesIdxColumn> cells) {
-            Set<Cell> rawCells = ColumnValues.toCells(cells);
+            Set<Cell> rawCells = Columns.toCells(cells);
             Map<Cell, byte[]> rawResults = t.get(tableRef, rawCells);
             Multimap<CookiesIdxRow, CookiesIdxColumnValue> rowMap = ArrayListMultimap.create();
             for (Entry<Cell, byte[]> e : rawResults.entrySet()) {
                 if (e.getValue().length > 0) {
-                    CookiesIdxRow row = CookiesIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
-                    CookiesIdxColumn col = CookiesIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getColumnName());
+                    CookiesIdxRow row = CookiesIdxRow.BYTES_HYDRATOR.hydrateFromBytes(
+                            e.getKey().getRowName());
+                    CookiesIdxColumn col = CookiesIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(
+                            e.getKey().getColumnName());
                     Long val = CookiesIdxColumnValue.hydrateValue(e.getValue());
                     rowMap.put(row, CookiesIdxColumnValue.of(col, val));
                 }
@@ -1669,17 +1768,19 @@ public final class UserProfileTable implements
 
         @Override
         public List<CookiesIdxColumnValue> getRowColumns(CookiesIdxRow row) {
-            return getRowColumns(row, allColumns);
+            return getRowColumns(row, ColumnSelection.all());
         }
 
         @Override
         public List<CookiesIdxColumnValue> getRowColumns(CookiesIdxRow row, ColumnSelection columns) {
             byte[] bytes = row.persistToBytes();
-            RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+            RowResult<byte[]> rowResult =
+                    t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
             if (rowResult == null) {
                 return ImmutableList.of();
             } else {
-                List<CookiesIdxColumnValue> ret = Lists.newArrayListWithCapacity(rowResult.getColumns().size());
+                List<CookiesIdxColumnValue> ret =
+                        Lists.newArrayListWithCapacity(rowResult.getColumns().size());
                 for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
                     CookiesIdxColumn col = CookiesIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
                     Long val = CookiesIdxColumnValue.hydrateValue(e.getValue());
@@ -1691,20 +1792,23 @@ public final class UserProfileTable implements
 
         @Override
         public Multimap<CookiesIdxRow, CookiesIdxColumnValue> getRowsMultimap(Iterable<CookiesIdxRow> rows) {
-            return getRowsMultimapInternal(rows, allColumns);
+            return getRowsMultimapInternal(rows, ColumnSelection.all());
         }
 
         @Override
-        public Multimap<CookiesIdxRow, CookiesIdxColumnValue> getRowsMultimap(Iterable<CookiesIdxRow> rows, ColumnSelection columns) {
+        public Multimap<CookiesIdxRow, CookiesIdxColumnValue> getRowsMultimap(
+                Iterable<CookiesIdxRow> rows, ColumnSelection columns) {
             return getRowsMultimapInternal(rows, columns);
         }
 
-        private Multimap<CookiesIdxRow, CookiesIdxColumnValue> getRowsMultimapInternal(Iterable<CookiesIdxRow> rows, ColumnSelection columns) {
+        private Multimap<CookiesIdxRow, CookiesIdxColumnValue> getRowsMultimapInternal(
+                Iterable<CookiesIdxRow> rows, ColumnSelection columns) {
             SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
             return getRowMapFromRowResults(results.values());
         }
 
-        private static Multimap<CookiesIdxRow, CookiesIdxColumnValue> getRowMapFromRowResults(Collection<RowResult<byte[]>> rowResults) {
+        private static Multimap<CookiesIdxRow, CookiesIdxColumnValue> getRowMapFromRowResults(
+                Collection<RowResult<byte[]>> rowResults) {
             Multimap<CookiesIdxRow, CookiesIdxColumnValue> rowMap = ArrayListMultimap.create();
             for (RowResult<byte[]> result : rowResults) {
                 CookiesIdxRow row = CookiesIdxRow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
@@ -1718,13 +1822,17 @@ public final class UserProfileTable implements
         }
 
         @Override
-        public Map<CookiesIdxRow, BatchingVisitable<CookiesIdxColumnValue>> getRowsColumnRange(Iterable<CookiesIdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
-            Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
-            Map<CookiesIdxRow, BatchingVisitable<CookiesIdxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        public Map<CookiesIdxRow, BatchingVisitable<CookiesIdxColumnValue>> getRowsColumnRange(
+                Iterable<CookiesIdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+            Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results =
+                    t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+            Map<CookiesIdxRow, BatchingVisitable<CookiesIdxColumnValue>> transformed =
+                    Maps.newHashMapWithExpectedSize(results.size());
             for (Entry<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
                 CookiesIdxRow row = CookiesIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
                 BatchingVisitable<CookiesIdxColumnValue> bv = BatchingVisitables.transform(e.getValue(), result -> {
-                    CookiesIdxColumn col = CookiesIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                    CookiesIdxColumn col = CookiesIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(
+                            result.getKey().getColumnName());
                     Long val = CookiesIdxColumnValue.hydrateValue(result.getValue());
                     return CookiesIdxColumnValue.of(col, val);
                 });
@@ -1734,11 +1842,15 @@ public final class UserProfileTable implements
         }
 
         @Override
-        public Iterator<Map.Entry<CookiesIdxRow, CookiesIdxColumnValue>> getRowsColumnRange(Iterable<CookiesIdxRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
-            Iterator<Map.Entry<Cell, byte[]>> results = t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
+        public Iterator<Map.Entry<CookiesIdxRow, CookiesIdxColumnValue>> getRowsColumnRange(
+                Iterable<CookiesIdxRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
+            Iterator<Map.Entry<Cell, byte[]>> results =
+                    t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
             return Iterators.transform(results, e -> {
-                CookiesIdxRow row = CookiesIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
-                CookiesIdxColumn col = CookiesIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getColumnName());
+                CookiesIdxRow row =
+                        CookiesIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
+                CookiesIdxColumn col = CookiesIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(
+                        e.getKey().getColumnName());
                 Long val = CookiesIdxColumnValue.hydrateValue(e.getValue());
                 CookiesIdxColumnValue colValue = CookiesIdxColumnValue.of(col, val);
                 return Maps.immutableEntry(row, colValue);
@@ -1746,13 +1858,17 @@ public final class UserProfileTable implements
         }
 
         @Override
-        public Map<CookiesIdxRow, Iterator<CookiesIdxColumnValue>> getRowsColumnRangeIterator(Iterable<CookiesIdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
-            Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
-            Map<CookiesIdxRow, Iterator<CookiesIdxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        public Map<CookiesIdxRow, Iterator<CookiesIdxColumnValue>> getRowsColumnRangeIterator(
+                Iterable<CookiesIdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+            Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results =
+                    t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+            Map<CookiesIdxRow, Iterator<CookiesIdxColumnValue>> transformed =
+                    Maps.newHashMapWithExpectedSize(results.size());
             for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
                 CookiesIdxRow row = CookiesIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
                 Iterator<CookiesIdxColumnValue> bv = Iterators.transform(e.getValue(), result -> {
-                    CookiesIdxColumn col = CookiesIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                    CookiesIdxColumn col = CookiesIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(
+                            result.getKey().getColumnName());
                     Long val = CookiesIdxColumnValue.hydrateValue(result.getValue());
                     return CookiesIdxColumnValue.of(col, val);
                 });
@@ -1763,7 +1879,7 @@ public final class UserProfileTable implements
 
         private RangeRequest optimizeRangeRequest(RangeRequest range) {
             if (range.getColumnNames().isEmpty()) {
-                return range.getBuilder().retainColumns(allColumns).build();
+                return range.getBuilder().retainColumns(allKnownColumns).build();
             }
             return range;
         }
@@ -1773,59 +1889,67 @@ public final class UserProfileTable implements
         }
 
         public BatchingVisitableView<CookiesIdxRowResult> getRange(RangeRequest range) {
-            return BatchingVisitables.transform(t.getRange(tableRef, optimizeRangeRequest(range)), new Function<RowResult<byte[]>, CookiesIdxRowResult>() {
-                @Override
-                public CookiesIdxRowResult apply(RowResult<byte[]> input) {
-                    return CookiesIdxRowResult.of(input);
-                }
-            });
+            return BatchingVisitables.transform(
+                    t.getRange(tableRef, optimizeRangeRequest(range)),
+                    new Function<RowResult<byte[]>, CookiesIdxRowResult>() {
+                        @Override
+                        public CookiesIdxRowResult apply(RowResult<byte[]> input) {
+                            return CookiesIdxRowResult.of(input);
+                        }
+                    });
         }
 
         @Deprecated
         public IterableView<BatchingVisitable<CookiesIdxRowResult>> getRanges(Iterable<RangeRequest> ranges) {
-            Iterable<BatchingVisitable<RowResult<byte[]>>> rangeResults = t.getRanges(tableRef, optimizeRangeRequests(ranges));
-            return IterableView.of(rangeResults).transform(
-                    new Function<BatchingVisitable<RowResult<byte[]>>, BatchingVisitable<CookiesIdxRowResult>>() {
-                @Override
-                public BatchingVisitable<CookiesIdxRowResult> apply(BatchingVisitable<RowResult<byte[]>> visitable) {
-                    return BatchingVisitables.transform(visitable, new Function<RowResult<byte[]>, CookiesIdxRowResult>() {
-                        @Override
-                        public CookiesIdxRowResult apply(RowResult<byte[]> row) {
-                            return CookiesIdxRowResult.of(row);
-                        }
-                    });
-                }
-            });
+            Iterable<BatchingVisitable<RowResult<byte[]>>> rangeResults =
+                    t.getRanges(tableRef, optimizeRangeRequests(ranges));
+            return IterableView.of(rangeResults)
+                    .transform(
+                            new Function<
+                                    BatchingVisitable<RowResult<byte[]>>, BatchingVisitable<CookiesIdxRowResult>>() {
+                                @Override
+                                public BatchingVisitable<CookiesIdxRowResult> apply(
+                                        BatchingVisitable<RowResult<byte[]>> visitable) {
+                                    return BatchingVisitables.transform(
+                                            visitable, new Function<RowResult<byte[]>, CookiesIdxRowResult>() {
+                                                @Override
+                                                public CookiesIdxRowResult apply(RowResult<byte[]> row) {
+                                                    return CookiesIdxRowResult.of(row);
+                                                }
+                                            });
+                                }
+                            });
         }
 
-        public <T> Stream<T> getRanges(Iterable<RangeRequest> ranges,
-                                       int concurrencyLevel,
-                                       BiFunction<RangeRequest, BatchingVisitable<CookiesIdxRowResult>, T> visitableProcessor) {
+        public <T> Stream<T> getRanges(
+                Iterable<RangeRequest> ranges,
+                int concurrencyLevel,
+                BiFunction<RangeRequest, BatchingVisitable<CookiesIdxRowResult>, T> visitableProcessor) {
             return t.getRanges(ImmutableGetRangesQuery.<T>builder()
-                                .tableRef(tableRef)
-                                .rangeRequests(ranges)
-                                .rangeRequestOptimizer(this::optimizeRangeRequest)
-                                .concurrencyLevel(concurrencyLevel)
-                                .visitableProcessor((rangeRequest, visitable) ->
-                                        visitableProcessor.apply(rangeRequest,
-                                                BatchingVisitables.transform(visitable, CookiesIdxRowResult::of)))
-                                .build());
+                    .tableRef(tableRef)
+                    .rangeRequests(ranges)
+                    .rangeRequestOptimizer(this::optimizeRangeRequest)
+                    .concurrencyLevel(concurrencyLevel)
+                    .visitableProcessor((rangeRequest, visitable) -> visitableProcessor.apply(
+                            rangeRequest, BatchingVisitables.transform(visitable, CookiesIdxRowResult::of)))
+                    .build());
         }
 
-        public <T> Stream<T> getRanges(Iterable<RangeRequest> ranges,
-                                       BiFunction<RangeRequest, BatchingVisitable<CookiesIdxRowResult>, T> visitableProcessor) {
+        public <T> Stream<T> getRanges(
+                Iterable<RangeRequest> ranges,
+                BiFunction<RangeRequest, BatchingVisitable<CookiesIdxRowResult>, T> visitableProcessor) {
             return t.getRanges(ImmutableGetRangesQuery.<T>builder()
-                                .tableRef(tableRef)
-                                .rangeRequests(ranges)
-                                .rangeRequestOptimizer(this::optimizeRangeRequest)
-                                .visitableProcessor((rangeRequest, visitable) ->
-                                        visitableProcessor.apply(rangeRequest,
-                                                BatchingVisitables.transform(visitable, CookiesIdxRowResult::of)))
-                                .build());
+                    .tableRef(tableRef)
+                    .rangeRequests(ranges)
+                    .rangeRequestOptimizer(this::optimizeRangeRequest)
+                    .visitableProcessor((rangeRequest, visitable) -> visitableProcessor.apply(
+                            rangeRequest, BatchingVisitables.transform(visitable, CookiesIdxRowResult::of)))
+                    .build());
         }
 
         public Stream<BatchingVisitable<CookiesIdxRowResult>> getRangesLazy(Iterable<RangeRequest> ranges) {
-            Stream<BatchingVisitable<RowResult<byte[]>>> rangeResults = t.getRangesLazy(tableRef, optimizeRangeRequests(ranges));
+            Stream<BatchingVisitable<RowResult<byte[]>>> rangeResults =
+                    t.getRangesLazy(tableRef, optimizeRangeRequests(ranges));
             return rangeResults.map(visitable -> BatchingVisitables.transform(visitable, CookiesIdxRowResult::of));
         }
 
@@ -1834,55 +1958,64 @@ public final class UserProfileTable implements
         }
 
         public void deleteRanges(Iterable<RangeRequest> ranges) {
-            BatchingVisitables.concat(getRanges(ranges)).batchAccept(1000, new AbortingVisitor<List<CookiesIdxRowResult>, RuntimeException>() {
-                @Override
-                public boolean visit(List<CookiesIdxRowResult> rowResults) {
-                    Multimap<CookiesIdxRow, CookiesIdxColumn> toRemove = HashMultimap.create();
-                    for (CookiesIdxRowResult rowResult : rowResults) {
-                        for (CookiesIdxColumnValue columnValue : rowResult.getColumnValues()) {
-                            toRemove.put(rowResult.getRowName(), columnValue.getColumnName());
+            BatchingVisitables.concat(getRanges(ranges))
+                    .batchAccept(1000, new AbortingVisitor<List<CookiesIdxRowResult>, RuntimeException>() {
+                        @Override
+                        public boolean visit(List<CookiesIdxRowResult> rowResults) {
+                            Multimap<CookiesIdxRow, CookiesIdxColumn> toRemove = HashMultimap.create();
+                            for (CookiesIdxRowResult rowResult : rowResults) {
+                                for (CookiesIdxColumnValue columnValue : rowResult.getColumnValues()) {
+                                    toRemove.put(rowResult.getRowName(), columnValue.getColumnName());
+                                }
+                            }
+                            delete(toRemove);
+                            return true;
                         }
-                    }
-                    delete(toRemove);
-                    return true;
-                }
-            });
+                    });
         }
 
         @Override
-        public List<String> findConstraintFailures(Map<Cell, byte[]> writes,
-                                                   ConstraintCheckingTransaction transaction,
-                                                   AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        public List<String> findConstraintFailures(
+                Map<Cell, byte[]> writes,
+                ConstraintCheckingTransaction transaction,
+                AtlasDbConstraintCheckingMode constraintCheckingMode) {
             return ImmutableList.of();
         }
 
         @Override
-        public List<String> findConstraintFailuresNoRead(Map<Cell, byte[]> writes,
-                                                         AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        public List<String> findConstraintFailuresNoRead(
+                Map<Cell, byte[]> writes, AtlasDbConstraintCheckingMode constraintCheckingMode) {
             return ImmutableList.of();
         }
     }
 
-
     @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
     @SuppressWarnings({"all", "deprecation"})
-    public static final class CreatedIdxTable implements
-            AtlasDbDynamicMutablePersistentTable<CreatedIdxTable.CreatedIdxRow,
-                                                    CreatedIdxTable.CreatedIdxColumn,
-                                                    CreatedIdxTable.CreatedIdxColumnValue,
-                                                    CreatedIdxTable.CreatedIdxRowResult> {
+    public static final class CreatedIdxTable
+            implements AtlasDbDynamicMutablePersistentTable<
+                    CreatedIdxTable.CreatedIdxRow,
+                    CreatedIdxTable.CreatedIdxColumn,
+                    CreatedIdxTable.CreatedIdxColumnValue,
+                    CreatedIdxTable.CreatedIdxRowResult> {
         private final Transaction t;
         private final List<CreatedIdxTrigger> triggers;
-        private final static String rawTableName = "created_idx";
+        private static final String rawTableName = "created_idx";
         private final TableReference tableRef;
-        private final static ColumnSelection allColumns = ColumnSelection.all();
+        private static final ColumnSelection allKnownColumns = ColumnSelection.all();
 
         public static CreatedIdxTable of(UserProfileTable table) {
             return new CreatedIdxTable(table.t, table.tableRef.getNamespace(), ImmutableList.<CreatedIdxTrigger>of());
         }
 
-        public static CreatedIdxTable of(UserProfileTable table, CreatedIdxTrigger trigger, CreatedIdxTrigger... triggers) {
-            return new CreatedIdxTable(table.t, table.tableRef.getNamespace(), ImmutableList.<CreatedIdxTrigger>builder().add(trigger).add(triggers).build());
+        public static CreatedIdxTable of(
+                UserProfileTable table, CreatedIdxTrigger trigger, CreatedIdxTrigger... triggers) {
+            return new CreatedIdxTable(
+                    table.t,
+                    table.tableRef.getNamespace(),
+                    ImmutableList.<CreatedIdxTrigger>builder()
+                            .add(trigger)
+                            .add(triggers)
+                            .build());
         }
 
         public static CreatedIdxTable of(UserProfileTable table, List<CreatedIdxTrigger> triggers) {
@@ -1970,8 +2103,8 @@ public final class UserProfileTable implements
             @Override
             public String toString() {
                 return MoreObjects.toStringHelper(getClass().getSimpleName())
-                    .add("time", time)
-                    .toString();
+                        .add("time", time)
+                        .toString();
             }
 
             @Override
@@ -1997,9 +2130,7 @@ public final class UserProfileTable implements
 
             @Override
             public int compareTo(CreatedIdxRow o) {
-                return ComparisonChain.start()
-                    .compare(this.time, o.time)
-                    .result();
+                return ComparisonChain.start().compare(this.time, o.time).result();
             }
         }
 
@@ -2098,10 +2229,12 @@ public final class UserProfileTable implements
                 return new Prefix(EncodingUtils.add(rowNameBytes));
             }
 
-            public static BatchColumnRangeSelection createPrefixRange(byte[] rowName, byte[] columnName, int batchSize) {
+            public static BatchColumnRangeSelection createPrefixRange(
+                    byte[] rowName, byte[] columnName, int batchSize) {
                 byte[] rowNameBytes = EncodingUtils.encodeSizedBytes(rowName);
                 byte[] columnNameBytes = EncodingUtils.encodeSizedBytes(columnName);
-                return ColumnRangeSelections.createPrefixRange(EncodingUtils.add(rowNameBytes, columnNameBytes), batchSize);
+                return ColumnRangeSelections.createPrefixRange(
+                        EncodingUtils.add(rowNameBytes, columnNameBytes), batchSize);
             }
 
             public static Prefix prefix(byte[] rowName, byte[] columnName) {
@@ -2113,10 +2246,10 @@ public final class UserProfileTable implements
             @Override
             public String toString() {
                 return MoreObjects.toStringHelper(getClass().getSimpleName())
-                    .add("rowName", rowName)
-                    .add("columnName", columnName)
-                    .add("id", id)
-                    .toString();
+                        .add("rowName", rowName)
+                        .add("columnName", columnName)
+                        .add("id", id)
+                        .toString();
             }
 
             @Override
@@ -2131,22 +2264,24 @@ public final class UserProfileTable implements
                     return false;
                 }
                 CreatedIdxColumn other = (CreatedIdxColumn) obj;
-                return Arrays.equals(rowName, other.rowName) && Arrays.equals(columnName, other.columnName) && Objects.equals(id, other.id);
+                return Arrays.equals(rowName, other.rowName)
+                        && Arrays.equals(columnName, other.columnName)
+                        && Objects.equals(id, other.id);
             }
 
             @SuppressWarnings("ArrayHashCode")
             @Override
             public int hashCode() {
-                return Arrays.deepHashCode(new Object[]{ rowName, columnName, id });
+                return Arrays.deepHashCode(new Object[] {rowName, columnName, id});
             }
 
             @Override
             public int compareTo(CreatedIdxColumn o) {
                 return ComparisonChain.start()
-                    .compare(this.rowName, o.rowName, UnsignedBytes.lexicographicalComparator())
-                    .compare(this.columnName, o.columnName, UnsignedBytes.lexicographicalComparator())
-                    .compare(this.id, o.id)
-                    .result();
+                        .compare(this.rowName, o.rowName, UnsignedBytes.lexicographicalComparator())
+                        .compare(this.columnName, o.columnName, UnsignedBytes.lexicographicalComparator())
+                        .compare(this.id, o.id)
+                        .result();
             }
         }
 
@@ -2225,9 +2360,9 @@ public final class UserProfileTable implements
             @Override
             public String toString() {
                 return MoreObjects.toStringHelper(getClass().getSimpleName())
-                    .add("ColumnName", this.columnName)
-                    .add("Value", this.value)
-                    .toString();
+                        .add("ColumnName", this.columnName)
+                        .add("Value", this.value)
+                        .toString();
             }
         }
 
@@ -2237,7 +2372,8 @@ public final class UserProfileTable implements
 
             public static CreatedIdxRowResult of(RowResult<byte[]> rowResult) {
                 CreatedIdxRow rowName = CreatedIdxRow.BYTES_HYDRATOR.hydrateFromBytes(rowResult.getRowName());
-                Set<CreatedIdxColumnValue> columnValues = Sets.newHashSetWithExpectedSize(rowResult.getColumns().size());
+                Set<CreatedIdxColumnValue> columnValues =
+                        Sets.newHashSetWithExpectedSize(rowResult.getColumns().size());
                 for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
                     CreatedIdxColumn col = CreatedIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
                     Long value = CreatedIdxColumnValue.hydrateValue(e.getValue());
@@ -2281,9 +2417,9 @@ public final class UserProfileTable implements
             @Override
             public String toString() {
                 return MoreObjects.toStringHelper(getClass().getSimpleName())
-                    .add("RowName", getRowName())
-                    .add("ColumnValues", getColumnValues())
-                    .toString();
+                        .add("RowName", getRowName())
+                        .add("ColumnValues", getColumnValues())
+                        .toString();
             }
         }
 
@@ -2294,27 +2430,27 @@ public final class UserProfileTable implements
 
         @Override
         public void delete(Iterable<CreatedIdxRow> rows) {
-            Multimap<CreatedIdxRow, CreatedIdxColumn> toRemove = HashMultimap.create();
             Multimap<CreatedIdxRow, CreatedIdxColumnValue> result = getRowsMultimap(rows);
-            for (Entry<CreatedIdxRow, CreatedIdxColumnValue> e : result.entries()) {
-                toRemove.put(e.getKey(), e.getValue().getColumnName());
-            }
-            delete(toRemove);
+            t.delete(tableRef, ColumnValues.toCells(result));
         }
 
         @Override
         public void delete(Multimap<CreatedIdxRow, CreatedIdxColumn> values) {
-            t.delete(tableRef, ColumnValues.toCells(values));
+            t.delete(tableRef, Columns.toCells(values));
         }
 
         @Override
         public void put(CreatedIdxRow rowName, Iterable<CreatedIdxColumnValue> values) {
-            put(ImmutableMultimap.<CreatedIdxRow, CreatedIdxColumnValue>builder().putAll(rowName, values).build());
+            put(ImmutableMultimap.<CreatedIdxRow, CreatedIdxColumnValue>builder()
+                    .putAll(rowName, values)
+                    .build());
         }
 
         @Override
         public void put(CreatedIdxRow rowName, CreatedIdxColumnValue... values) {
-            put(ImmutableMultimap.<CreatedIdxRow, CreatedIdxColumnValue>builder().putAll(rowName, values).build());
+            put(ImmutableMultimap.<CreatedIdxRow, CreatedIdxColumnValue>builder()
+                    .putAll(rowName, values)
+                    .build());
         }
 
         @Override
@@ -2347,13 +2483,15 @@ public final class UserProfileTable implements
 
         @Override
         public Multimap<CreatedIdxRow, CreatedIdxColumnValue> get(Multimap<CreatedIdxRow, CreatedIdxColumn> cells) {
-            Set<Cell> rawCells = ColumnValues.toCells(cells);
+            Set<Cell> rawCells = Columns.toCells(cells);
             Map<Cell, byte[]> rawResults = t.get(tableRef, rawCells);
             Multimap<CreatedIdxRow, CreatedIdxColumnValue> rowMap = ArrayListMultimap.create();
             for (Entry<Cell, byte[]> e : rawResults.entrySet()) {
                 if (e.getValue().length > 0) {
-                    CreatedIdxRow row = CreatedIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
-                    CreatedIdxColumn col = CreatedIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getColumnName());
+                    CreatedIdxRow row = CreatedIdxRow.BYTES_HYDRATOR.hydrateFromBytes(
+                            e.getKey().getRowName());
+                    CreatedIdxColumn col = CreatedIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(
+                            e.getKey().getColumnName());
                     Long val = CreatedIdxColumnValue.hydrateValue(e.getValue());
                     rowMap.put(row, CreatedIdxColumnValue.of(col, val));
                 }
@@ -2363,17 +2501,19 @@ public final class UserProfileTable implements
 
         @Override
         public List<CreatedIdxColumnValue> getRowColumns(CreatedIdxRow row) {
-            return getRowColumns(row, allColumns);
+            return getRowColumns(row, ColumnSelection.all());
         }
 
         @Override
         public List<CreatedIdxColumnValue> getRowColumns(CreatedIdxRow row, ColumnSelection columns) {
             byte[] bytes = row.persistToBytes();
-            RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+            RowResult<byte[]> rowResult =
+                    t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
             if (rowResult == null) {
                 return ImmutableList.of();
             } else {
-                List<CreatedIdxColumnValue> ret = Lists.newArrayListWithCapacity(rowResult.getColumns().size());
+                List<CreatedIdxColumnValue> ret =
+                        Lists.newArrayListWithCapacity(rowResult.getColumns().size());
                 for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
                     CreatedIdxColumn col = CreatedIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
                     Long val = CreatedIdxColumnValue.hydrateValue(e.getValue());
@@ -2385,20 +2525,23 @@ public final class UserProfileTable implements
 
         @Override
         public Multimap<CreatedIdxRow, CreatedIdxColumnValue> getRowsMultimap(Iterable<CreatedIdxRow> rows) {
-            return getRowsMultimapInternal(rows, allColumns);
+            return getRowsMultimapInternal(rows, ColumnSelection.all());
         }
 
         @Override
-        public Multimap<CreatedIdxRow, CreatedIdxColumnValue> getRowsMultimap(Iterable<CreatedIdxRow> rows, ColumnSelection columns) {
+        public Multimap<CreatedIdxRow, CreatedIdxColumnValue> getRowsMultimap(
+                Iterable<CreatedIdxRow> rows, ColumnSelection columns) {
             return getRowsMultimapInternal(rows, columns);
         }
 
-        private Multimap<CreatedIdxRow, CreatedIdxColumnValue> getRowsMultimapInternal(Iterable<CreatedIdxRow> rows, ColumnSelection columns) {
+        private Multimap<CreatedIdxRow, CreatedIdxColumnValue> getRowsMultimapInternal(
+                Iterable<CreatedIdxRow> rows, ColumnSelection columns) {
             SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
             return getRowMapFromRowResults(results.values());
         }
 
-        private static Multimap<CreatedIdxRow, CreatedIdxColumnValue> getRowMapFromRowResults(Collection<RowResult<byte[]>> rowResults) {
+        private static Multimap<CreatedIdxRow, CreatedIdxColumnValue> getRowMapFromRowResults(
+                Collection<RowResult<byte[]>> rowResults) {
             Multimap<CreatedIdxRow, CreatedIdxColumnValue> rowMap = ArrayListMultimap.create();
             for (RowResult<byte[]> result : rowResults) {
                 CreatedIdxRow row = CreatedIdxRow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
@@ -2412,13 +2555,17 @@ public final class UserProfileTable implements
         }
 
         @Override
-        public Map<CreatedIdxRow, BatchingVisitable<CreatedIdxColumnValue>> getRowsColumnRange(Iterable<CreatedIdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
-            Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
-            Map<CreatedIdxRow, BatchingVisitable<CreatedIdxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        public Map<CreatedIdxRow, BatchingVisitable<CreatedIdxColumnValue>> getRowsColumnRange(
+                Iterable<CreatedIdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+            Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results =
+                    t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+            Map<CreatedIdxRow, BatchingVisitable<CreatedIdxColumnValue>> transformed =
+                    Maps.newHashMapWithExpectedSize(results.size());
             for (Entry<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
                 CreatedIdxRow row = CreatedIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
                 BatchingVisitable<CreatedIdxColumnValue> bv = BatchingVisitables.transform(e.getValue(), result -> {
-                    CreatedIdxColumn col = CreatedIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                    CreatedIdxColumn col = CreatedIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(
+                            result.getKey().getColumnName());
                     Long val = CreatedIdxColumnValue.hydrateValue(result.getValue());
                     return CreatedIdxColumnValue.of(col, val);
                 });
@@ -2428,11 +2575,15 @@ public final class UserProfileTable implements
         }
 
         @Override
-        public Iterator<Map.Entry<CreatedIdxRow, CreatedIdxColumnValue>> getRowsColumnRange(Iterable<CreatedIdxRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
-            Iterator<Map.Entry<Cell, byte[]>> results = t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
+        public Iterator<Map.Entry<CreatedIdxRow, CreatedIdxColumnValue>> getRowsColumnRange(
+                Iterable<CreatedIdxRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
+            Iterator<Map.Entry<Cell, byte[]>> results =
+                    t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
             return Iterators.transform(results, e -> {
-                CreatedIdxRow row = CreatedIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
-                CreatedIdxColumn col = CreatedIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getColumnName());
+                CreatedIdxRow row =
+                        CreatedIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
+                CreatedIdxColumn col = CreatedIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(
+                        e.getKey().getColumnName());
                 Long val = CreatedIdxColumnValue.hydrateValue(e.getValue());
                 CreatedIdxColumnValue colValue = CreatedIdxColumnValue.of(col, val);
                 return Maps.immutableEntry(row, colValue);
@@ -2440,13 +2591,17 @@ public final class UserProfileTable implements
         }
 
         @Override
-        public Map<CreatedIdxRow, Iterator<CreatedIdxColumnValue>> getRowsColumnRangeIterator(Iterable<CreatedIdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
-            Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
-            Map<CreatedIdxRow, Iterator<CreatedIdxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        public Map<CreatedIdxRow, Iterator<CreatedIdxColumnValue>> getRowsColumnRangeIterator(
+                Iterable<CreatedIdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+            Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results =
+                    t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+            Map<CreatedIdxRow, Iterator<CreatedIdxColumnValue>> transformed =
+                    Maps.newHashMapWithExpectedSize(results.size());
             for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
                 CreatedIdxRow row = CreatedIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
                 Iterator<CreatedIdxColumnValue> bv = Iterators.transform(e.getValue(), result -> {
-                    CreatedIdxColumn col = CreatedIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                    CreatedIdxColumn col = CreatedIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(
+                            result.getKey().getColumnName());
                     Long val = CreatedIdxColumnValue.hydrateValue(result.getValue());
                     return CreatedIdxColumnValue.of(col, val);
                 });
@@ -2457,7 +2612,7 @@ public final class UserProfileTable implements
 
         private RangeRequest optimizeRangeRequest(RangeRequest range) {
             if (range.getColumnNames().isEmpty()) {
-                return range.getBuilder().retainColumns(allColumns).build();
+                return range.getBuilder().retainColumns(allKnownColumns).build();
             }
             return range;
         }
@@ -2467,59 +2622,67 @@ public final class UserProfileTable implements
         }
 
         public BatchingVisitableView<CreatedIdxRowResult> getRange(RangeRequest range) {
-            return BatchingVisitables.transform(t.getRange(tableRef, optimizeRangeRequest(range)), new Function<RowResult<byte[]>, CreatedIdxRowResult>() {
-                @Override
-                public CreatedIdxRowResult apply(RowResult<byte[]> input) {
-                    return CreatedIdxRowResult.of(input);
-                }
-            });
+            return BatchingVisitables.transform(
+                    t.getRange(tableRef, optimizeRangeRequest(range)),
+                    new Function<RowResult<byte[]>, CreatedIdxRowResult>() {
+                        @Override
+                        public CreatedIdxRowResult apply(RowResult<byte[]> input) {
+                            return CreatedIdxRowResult.of(input);
+                        }
+                    });
         }
 
         @Deprecated
         public IterableView<BatchingVisitable<CreatedIdxRowResult>> getRanges(Iterable<RangeRequest> ranges) {
-            Iterable<BatchingVisitable<RowResult<byte[]>>> rangeResults = t.getRanges(tableRef, optimizeRangeRequests(ranges));
-            return IterableView.of(rangeResults).transform(
-                    new Function<BatchingVisitable<RowResult<byte[]>>, BatchingVisitable<CreatedIdxRowResult>>() {
-                @Override
-                public BatchingVisitable<CreatedIdxRowResult> apply(BatchingVisitable<RowResult<byte[]>> visitable) {
-                    return BatchingVisitables.transform(visitable, new Function<RowResult<byte[]>, CreatedIdxRowResult>() {
-                        @Override
-                        public CreatedIdxRowResult apply(RowResult<byte[]> row) {
-                            return CreatedIdxRowResult.of(row);
-                        }
-                    });
-                }
-            });
+            Iterable<BatchingVisitable<RowResult<byte[]>>> rangeResults =
+                    t.getRanges(tableRef, optimizeRangeRequests(ranges));
+            return IterableView.of(rangeResults)
+                    .transform(
+                            new Function<
+                                    BatchingVisitable<RowResult<byte[]>>, BatchingVisitable<CreatedIdxRowResult>>() {
+                                @Override
+                                public BatchingVisitable<CreatedIdxRowResult> apply(
+                                        BatchingVisitable<RowResult<byte[]>> visitable) {
+                                    return BatchingVisitables.transform(
+                                            visitable, new Function<RowResult<byte[]>, CreatedIdxRowResult>() {
+                                                @Override
+                                                public CreatedIdxRowResult apply(RowResult<byte[]> row) {
+                                                    return CreatedIdxRowResult.of(row);
+                                                }
+                                            });
+                                }
+                            });
         }
 
-        public <T> Stream<T> getRanges(Iterable<RangeRequest> ranges,
-                                       int concurrencyLevel,
-                                       BiFunction<RangeRequest, BatchingVisitable<CreatedIdxRowResult>, T> visitableProcessor) {
+        public <T> Stream<T> getRanges(
+                Iterable<RangeRequest> ranges,
+                int concurrencyLevel,
+                BiFunction<RangeRequest, BatchingVisitable<CreatedIdxRowResult>, T> visitableProcessor) {
             return t.getRanges(ImmutableGetRangesQuery.<T>builder()
-                                .tableRef(tableRef)
-                                .rangeRequests(ranges)
-                                .rangeRequestOptimizer(this::optimizeRangeRequest)
-                                .concurrencyLevel(concurrencyLevel)
-                                .visitableProcessor((rangeRequest, visitable) ->
-                                        visitableProcessor.apply(rangeRequest,
-                                                BatchingVisitables.transform(visitable, CreatedIdxRowResult::of)))
-                                .build());
+                    .tableRef(tableRef)
+                    .rangeRequests(ranges)
+                    .rangeRequestOptimizer(this::optimizeRangeRequest)
+                    .concurrencyLevel(concurrencyLevel)
+                    .visitableProcessor((rangeRequest, visitable) -> visitableProcessor.apply(
+                            rangeRequest, BatchingVisitables.transform(visitable, CreatedIdxRowResult::of)))
+                    .build());
         }
 
-        public <T> Stream<T> getRanges(Iterable<RangeRequest> ranges,
-                                       BiFunction<RangeRequest, BatchingVisitable<CreatedIdxRowResult>, T> visitableProcessor) {
+        public <T> Stream<T> getRanges(
+                Iterable<RangeRequest> ranges,
+                BiFunction<RangeRequest, BatchingVisitable<CreatedIdxRowResult>, T> visitableProcessor) {
             return t.getRanges(ImmutableGetRangesQuery.<T>builder()
-                                .tableRef(tableRef)
-                                .rangeRequests(ranges)
-                                .rangeRequestOptimizer(this::optimizeRangeRequest)
-                                .visitableProcessor((rangeRequest, visitable) ->
-                                        visitableProcessor.apply(rangeRequest,
-                                                BatchingVisitables.transform(visitable, CreatedIdxRowResult::of)))
-                                .build());
+                    .tableRef(tableRef)
+                    .rangeRequests(ranges)
+                    .rangeRequestOptimizer(this::optimizeRangeRequest)
+                    .visitableProcessor((rangeRequest, visitable) -> visitableProcessor.apply(
+                            rangeRequest, BatchingVisitables.transform(visitable, CreatedIdxRowResult::of)))
+                    .build());
         }
 
         public Stream<BatchingVisitable<CreatedIdxRowResult>> getRangesLazy(Iterable<RangeRequest> ranges) {
-            Stream<BatchingVisitable<RowResult<byte[]>>> rangeResults = t.getRangesLazy(tableRef, optimizeRangeRequests(ranges));
+            Stream<BatchingVisitable<RowResult<byte[]>>> rangeResults =
+                    t.getRangesLazy(tableRef, optimizeRangeRequests(ranges));
             return rangeResults.map(visitable -> BatchingVisitables.transform(visitable, CreatedIdxRowResult::of));
         }
 
@@ -2528,55 +2691,65 @@ public final class UserProfileTable implements
         }
 
         public void deleteRanges(Iterable<RangeRequest> ranges) {
-            BatchingVisitables.concat(getRanges(ranges)).batchAccept(1000, new AbortingVisitor<List<CreatedIdxRowResult>, RuntimeException>() {
-                @Override
-                public boolean visit(List<CreatedIdxRowResult> rowResults) {
-                    Multimap<CreatedIdxRow, CreatedIdxColumn> toRemove = HashMultimap.create();
-                    for (CreatedIdxRowResult rowResult : rowResults) {
-                        for (CreatedIdxColumnValue columnValue : rowResult.getColumnValues()) {
-                            toRemove.put(rowResult.getRowName(), columnValue.getColumnName());
+            BatchingVisitables.concat(getRanges(ranges))
+                    .batchAccept(1000, new AbortingVisitor<List<CreatedIdxRowResult>, RuntimeException>() {
+                        @Override
+                        public boolean visit(List<CreatedIdxRowResult> rowResults) {
+                            Multimap<CreatedIdxRow, CreatedIdxColumn> toRemove = HashMultimap.create();
+                            for (CreatedIdxRowResult rowResult : rowResults) {
+                                for (CreatedIdxColumnValue columnValue : rowResult.getColumnValues()) {
+                                    toRemove.put(rowResult.getRowName(), columnValue.getColumnName());
+                                }
+                            }
+                            delete(toRemove);
+                            return true;
                         }
-                    }
-                    delete(toRemove);
-                    return true;
-                }
-            });
+                    });
         }
 
         @Override
-        public List<String> findConstraintFailures(Map<Cell, byte[]> writes,
-                                                   ConstraintCheckingTransaction transaction,
-                                                   AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        public List<String> findConstraintFailures(
+                Map<Cell, byte[]> writes,
+                ConstraintCheckingTransaction transaction,
+                AtlasDbConstraintCheckingMode constraintCheckingMode) {
             return ImmutableList.of();
         }
 
         @Override
-        public List<String> findConstraintFailuresNoRead(Map<Cell, byte[]> writes,
-                                                         AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        public List<String> findConstraintFailuresNoRead(
+                Map<Cell, byte[]> writes, AtlasDbConstraintCheckingMode constraintCheckingMode) {
             return ImmutableList.of();
         }
     }
 
-
     @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
     @SuppressWarnings({"all", "deprecation"})
-    public static final class UserBirthdaysIdxTable implements
-            AtlasDbDynamicMutablePersistentTable<UserBirthdaysIdxTable.UserBirthdaysIdxRow,
-                                                    UserBirthdaysIdxTable.UserBirthdaysIdxColumn,
-                                                    UserBirthdaysIdxTable.UserBirthdaysIdxColumnValue,
-                                                    UserBirthdaysIdxTable.UserBirthdaysIdxRowResult> {
+    public static final class UserBirthdaysIdxTable
+            implements AtlasDbDynamicMutablePersistentTable<
+                    UserBirthdaysIdxTable.UserBirthdaysIdxRow,
+                    UserBirthdaysIdxTable.UserBirthdaysIdxColumn,
+                    UserBirthdaysIdxTable.UserBirthdaysIdxColumnValue,
+                    UserBirthdaysIdxTable.UserBirthdaysIdxRowResult> {
         private final Transaction t;
         private final List<UserBirthdaysIdxTrigger> triggers;
-        private final static String rawTableName = "user_birthdays_idx";
+        private static final String rawTableName = "user_birthdays_idx";
         private final TableReference tableRef;
-        private final static ColumnSelection allColumns = ColumnSelection.all();
+        private static final ColumnSelection allKnownColumns = ColumnSelection.all();
 
         public static UserBirthdaysIdxTable of(UserProfileTable table) {
-            return new UserBirthdaysIdxTable(table.t, table.tableRef.getNamespace(), ImmutableList.<UserBirthdaysIdxTrigger>of());
+            return new UserBirthdaysIdxTable(
+                    table.t, table.tableRef.getNamespace(), ImmutableList.<UserBirthdaysIdxTrigger>of());
         }
 
-        public static UserBirthdaysIdxTable of(UserProfileTable table, UserBirthdaysIdxTrigger trigger, UserBirthdaysIdxTrigger... triggers) {
-            return new UserBirthdaysIdxTable(table.t, table.tableRef.getNamespace(), ImmutableList.<UserBirthdaysIdxTrigger>builder().add(trigger).add(triggers).build());
+        public static UserBirthdaysIdxTable of(
+                UserProfileTable table, UserBirthdaysIdxTrigger trigger, UserBirthdaysIdxTrigger... triggers) {
+            return new UserBirthdaysIdxTable(
+                    table.t,
+                    table.tableRef.getNamespace(),
+                    ImmutableList.<UserBirthdaysIdxTrigger>builder()
+                            .add(trigger)
+                            .add(triggers)
+                            .build());
         }
 
         public static UserBirthdaysIdxTable of(UserProfileTable table, List<UserBirthdaysIdxTrigger> triggers) {
@@ -2664,8 +2837,8 @@ public final class UserProfileTable implements
             @Override
             public String toString() {
                 return MoreObjects.toStringHelper(getClass().getSimpleName())
-                    .add("birthday", birthday)
-                    .toString();
+                        .add("birthday", birthday)
+                        .toString();
             }
 
             @Override
@@ -2692,8 +2865,8 @@ public final class UserProfileTable implements
             @Override
             public int compareTo(UserBirthdaysIdxRow o) {
                 return ComparisonChain.start()
-                    .compare(this.birthday, o.birthday)
-                    .result();
+                        .compare(this.birthday, o.birthday)
+                        .result();
             }
         }
 
@@ -2768,19 +2941,20 @@ public final class UserProfileTable implements
                 return EncodingUtils.add(rowNameBytes, columnNameBytes, idBytes);
             }
 
-            public static final Hydrator<UserBirthdaysIdxColumn> BYTES_HYDRATOR = new Hydrator<UserBirthdaysIdxColumn>() {
-                @Override
-                public UserBirthdaysIdxColumn hydrateFromBytes(byte[] __input) {
-                    int __index = 0;
-                    byte[] rowName = EncodingUtils.decodeSizedBytes(__input, __index);
-                    __index += EncodingUtils.sizeOfSizedBytes(rowName);
-                    byte[] columnName = EncodingUtils.decodeSizedBytes(__input, __index);
-                    __index += EncodingUtils.sizeOfSizedBytes(columnName);
-                    UUID id = EncodingUtils.decodeUUID(__input, __index);
-                    __index += 16;
-                    return new UserBirthdaysIdxColumn(rowName, columnName, id);
-                }
-            };
+            public static final Hydrator<UserBirthdaysIdxColumn> BYTES_HYDRATOR =
+                    new Hydrator<UserBirthdaysIdxColumn>() {
+                        @Override
+                        public UserBirthdaysIdxColumn hydrateFromBytes(byte[] __input) {
+                            int __index = 0;
+                            byte[] rowName = EncodingUtils.decodeSizedBytes(__input, __index);
+                            __index += EncodingUtils.sizeOfSizedBytes(rowName);
+                            byte[] columnName = EncodingUtils.decodeSizedBytes(__input, __index);
+                            __index += EncodingUtils.sizeOfSizedBytes(columnName);
+                            UUID id = EncodingUtils.decodeUUID(__input, __index);
+                            __index += 16;
+                            return new UserBirthdaysIdxColumn(rowName, columnName, id);
+                        }
+                    };
 
             public static BatchColumnRangeSelection createPrefixRangeUnsorted(byte[] rowName, int batchSize) {
                 byte[] rowNameBytes = EncodingUtils.encodeSizedBytes(rowName);
@@ -2792,10 +2966,12 @@ public final class UserProfileTable implements
                 return new Prefix(EncodingUtils.add(rowNameBytes));
             }
 
-            public static BatchColumnRangeSelection createPrefixRange(byte[] rowName, byte[] columnName, int batchSize) {
+            public static BatchColumnRangeSelection createPrefixRange(
+                    byte[] rowName, byte[] columnName, int batchSize) {
                 byte[] rowNameBytes = EncodingUtils.encodeSizedBytes(rowName);
                 byte[] columnNameBytes = EncodingUtils.encodeSizedBytes(columnName);
-                return ColumnRangeSelections.createPrefixRange(EncodingUtils.add(rowNameBytes, columnNameBytes), batchSize);
+                return ColumnRangeSelections.createPrefixRange(
+                        EncodingUtils.add(rowNameBytes, columnNameBytes), batchSize);
             }
 
             public static Prefix prefix(byte[] rowName, byte[] columnName) {
@@ -2807,10 +2983,10 @@ public final class UserProfileTable implements
             @Override
             public String toString() {
                 return MoreObjects.toStringHelper(getClass().getSimpleName())
-                    .add("rowName", rowName)
-                    .add("columnName", columnName)
-                    .add("id", id)
-                    .toString();
+                        .add("rowName", rowName)
+                        .add("columnName", columnName)
+                        .add("id", id)
+                        .toString();
             }
 
             @Override
@@ -2825,27 +3001,30 @@ public final class UserProfileTable implements
                     return false;
                 }
                 UserBirthdaysIdxColumn other = (UserBirthdaysIdxColumn) obj;
-                return Arrays.equals(rowName, other.rowName) && Arrays.equals(columnName, other.columnName) && Objects.equals(id, other.id);
+                return Arrays.equals(rowName, other.rowName)
+                        && Arrays.equals(columnName, other.columnName)
+                        && Objects.equals(id, other.id);
             }
 
             @SuppressWarnings("ArrayHashCode")
             @Override
             public int hashCode() {
-                return Arrays.deepHashCode(new Object[]{ rowName, columnName, id });
+                return Arrays.deepHashCode(new Object[] {rowName, columnName, id});
             }
 
             @Override
             public int compareTo(UserBirthdaysIdxColumn o) {
                 return ComparisonChain.start()
-                    .compare(this.rowName, o.rowName, UnsignedBytes.lexicographicalComparator())
-                    .compare(this.columnName, o.columnName, UnsignedBytes.lexicographicalComparator())
-                    .compare(this.id, o.id)
-                    .result();
+                        .compare(this.rowName, o.rowName, UnsignedBytes.lexicographicalComparator())
+                        .compare(this.columnName, o.columnName, UnsignedBytes.lexicographicalComparator())
+                        .compare(this.id, o.id)
+                        .result();
             }
         }
 
         public interface UserBirthdaysIdxTrigger {
-            public void putUserBirthdaysIdx(Multimap<UserBirthdaysIdxRow, ? extends UserBirthdaysIdxColumnValue> newRows);
+            public void putUserBirthdaysIdx(
+                    Multimap<UserBirthdaysIdxRow, ? extends UserBirthdaysIdxColumnValue> newRows);
         }
 
         /**
@@ -2919,9 +3098,9 @@ public final class UserProfileTable implements
             @Override
             public String toString() {
                 return MoreObjects.toStringHelper(getClass().getSimpleName())
-                    .add("ColumnName", this.columnName)
-                    .add("Value", this.value)
-                    .toString();
+                        .add("ColumnName", this.columnName)
+                        .add("Value", this.value)
+                        .toString();
             }
         }
 
@@ -2930,8 +3109,10 @@ public final class UserProfileTable implements
             private final ImmutableSet<UserBirthdaysIdxColumnValue> columnValues;
 
             public static UserBirthdaysIdxRowResult of(RowResult<byte[]> rowResult) {
-                UserBirthdaysIdxRow rowName = UserBirthdaysIdxRow.BYTES_HYDRATOR.hydrateFromBytes(rowResult.getRowName());
-                Set<UserBirthdaysIdxColumnValue> columnValues = Sets.newHashSetWithExpectedSize(rowResult.getColumns().size());
+                UserBirthdaysIdxRow rowName =
+                        UserBirthdaysIdxRow.BYTES_HYDRATOR.hydrateFromBytes(rowResult.getRowName());
+                Set<UserBirthdaysIdxColumnValue> columnValues =
+                        Sets.newHashSetWithExpectedSize(rowResult.getColumns().size());
                 for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
                     UserBirthdaysIdxColumn col = UserBirthdaysIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
                     Long value = UserBirthdaysIdxColumnValue.hydrateValue(e.getValue());
@@ -2940,7 +3121,8 @@ public final class UserProfileTable implements
                 return new UserBirthdaysIdxRowResult(rowName, ImmutableSet.copyOf(columnValues));
             }
 
-            private UserBirthdaysIdxRowResult(UserBirthdaysIdxRow rowName, ImmutableSet<UserBirthdaysIdxColumnValue> columnValues) {
+            private UserBirthdaysIdxRowResult(
+                    UserBirthdaysIdxRow rowName, ImmutableSet<UserBirthdaysIdxColumnValue> columnValues) {
                 this.rowName = rowName;
                 this.columnValues = columnValues;
             }
@@ -2963,7 +3145,8 @@ public final class UserProfileTable implements
                 };
             }
 
-            public static Function<UserBirthdaysIdxRowResult, ImmutableSet<UserBirthdaysIdxColumnValue>> getColumnValuesFun() {
+            public static Function<UserBirthdaysIdxRowResult, ImmutableSet<UserBirthdaysIdxColumnValue>>
+                    getColumnValuesFun() {
                 return new Function<UserBirthdaysIdxRowResult, ImmutableSet<UserBirthdaysIdxColumnValue>>() {
                     @Override
                     public ImmutableSet<UserBirthdaysIdxColumnValue> apply(UserBirthdaysIdxRowResult rowResult) {
@@ -2975,9 +3158,9 @@ public final class UserProfileTable implements
             @Override
             public String toString() {
                 return MoreObjects.toStringHelper(getClass().getSimpleName())
-                    .add("RowName", getRowName())
-                    .add("ColumnValues", getColumnValues())
-                    .toString();
+                        .add("RowName", getRowName())
+                        .add("ColumnValues", getColumnValues())
+                        .toString();
             }
         }
 
@@ -2988,27 +3171,27 @@ public final class UserProfileTable implements
 
         @Override
         public void delete(Iterable<UserBirthdaysIdxRow> rows) {
-            Multimap<UserBirthdaysIdxRow, UserBirthdaysIdxColumn> toRemove = HashMultimap.create();
             Multimap<UserBirthdaysIdxRow, UserBirthdaysIdxColumnValue> result = getRowsMultimap(rows);
-            for (Entry<UserBirthdaysIdxRow, UserBirthdaysIdxColumnValue> e : result.entries()) {
-                toRemove.put(e.getKey(), e.getValue().getColumnName());
-            }
-            delete(toRemove);
+            t.delete(tableRef, ColumnValues.toCells(result));
         }
 
         @Override
         public void delete(Multimap<UserBirthdaysIdxRow, UserBirthdaysIdxColumn> values) {
-            t.delete(tableRef, ColumnValues.toCells(values));
+            t.delete(tableRef, Columns.toCells(values));
         }
 
         @Override
         public void put(UserBirthdaysIdxRow rowName, Iterable<UserBirthdaysIdxColumnValue> values) {
-            put(ImmutableMultimap.<UserBirthdaysIdxRow, UserBirthdaysIdxColumnValue>builder().putAll(rowName, values).build());
+            put(ImmutableMultimap.<UserBirthdaysIdxRow, UserBirthdaysIdxColumnValue>builder()
+                    .putAll(rowName, values)
+                    .build());
         }
 
         @Override
         public void put(UserBirthdaysIdxRow rowName, UserBirthdaysIdxColumnValue... values) {
-            put(ImmutableMultimap.<UserBirthdaysIdxRow, UserBirthdaysIdxColumnValue>builder().putAll(rowName, values).build());
+            put(ImmutableMultimap.<UserBirthdaysIdxRow, UserBirthdaysIdxColumnValue>builder()
+                    .putAll(rowName, values)
+                    .build());
         }
 
         @Override
@@ -3040,14 +3223,17 @@ public final class UserProfileTable implements
         }
 
         @Override
-        public Multimap<UserBirthdaysIdxRow, UserBirthdaysIdxColumnValue> get(Multimap<UserBirthdaysIdxRow, UserBirthdaysIdxColumn> cells) {
-            Set<Cell> rawCells = ColumnValues.toCells(cells);
+        public Multimap<UserBirthdaysIdxRow, UserBirthdaysIdxColumnValue> get(
+                Multimap<UserBirthdaysIdxRow, UserBirthdaysIdxColumn> cells) {
+            Set<Cell> rawCells = Columns.toCells(cells);
             Map<Cell, byte[]> rawResults = t.get(tableRef, rawCells);
             Multimap<UserBirthdaysIdxRow, UserBirthdaysIdxColumnValue> rowMap = ArrayListMultimap.create();
             for (Entry<Cell, byte[]> e : rawResults.entrySet()) {
                 if (e.getValue().length > 0) {
-                    UserBirthdaysIdxRow row = UserBirthdaysIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
-                    UserBirthdaysIdxColumn col = UserBirthdaysIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getColumnName());
+                    UserBirthdaysIdxRow row = UserBirthdaysIdxRow.BYTES_HYDRATOR.hydrateFromBytes(
+                            e.getKey().getRowName());
+                    UserBirthdaysIdxColumn col = UserBirthdaysIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(
+                            e.getKey().getColumnName());
                     Long val = UserBirthdaysIdxColumnValue.hydrateValue(e.getValue());
                     rowMap.put(row, UserBirthdaysIdxColumnValue.of(col, val));
                 }
@@ -3057,17 +3243,19 @@ public final class UserProfileTable implements
 
         @Override
         public List<UserBirthdaysIdxColumnValue> getRowColumns(UserBirthdaysIdxRow row) {
-            return getRowColumns(row, allColumns);
+            return getRowColumns(row, ColumnSelection.all());
         }
 
         @Override
         public List<UserBirthdaysIdxColumnValue> getRowColumns(UserBirthdaysIdxRow row, ColumnSelection columns) {
             byte[] bytes = row.persistToBytes();
-            RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+            RowResult<byte[]> rowResult =
+                    t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
             if (rowResult == null) {
                 return ImmutableList.of();
             } else {
-                List<UserBirthdaysIdxColumnValue> ret = Lists.newArrayListWithCapacity(rowResult.getColumns().size());
+                List<UserBirthdaysIdxColumnValue> ret =
+                        Lists.newArrayListWithCapacity(rowResult.getColumns().size());
                 for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
                     UserBirthdaysIdxColumn col = UserBirthdaysIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
                     Long val = UserBirthdaysIdxColumnValue.hydrateValue(e.getValue());
@@ -3078,21 +3266,25 @@ public final class UserProfileTable implements
         }
 
         @Override
-        public Multimap<UserBirthdaysIdxRow, UserBirthdaysIdxColumnValue> getRowsMultimap(Iterable<UserBirthdaysIdxRow> rows) {
-            return getRowsMultimapInternal(rows, allColumns);
+        public Multimap<UserBirthdaysIdxRow, UserBirthdaysIdxColumnValue> getRowsMultimap(
+                Iterable<UserBirthdaysIdxRow> rows) {
+            return getRowsMultimapInternal(rows, ColumnSelection.all());
         }
 
         @Override
-        public Multimap<UserBirthdaysIdxRow, UserBirthdaysIdxColumnValue> getRowsMultimap(Iterable<UserBirthdaysIdxRow> rows, ColumnSelection columns) {
+        public Multimap<UserBirthdaysIdxRow, UserBirthdaysIdxColumnValue> getRowsMultimap(
+                Iterable<UserBirthdaysIdxRow> rows, ColumnSelection columns) {
             return getRowsMultimapInternal(rows, columns);
         }
 
-        private Multimap<UserBirthdaysIdxRow, UserBirthdaysIdxColumnValue> getRowsMultimapInternal(Iterable<UserBirthdaysIdxRow> rows, ColumnSelection columns) {
+        private Multimap<UserBirthdaysIdxRow, UserBirthdaysIdxColumnValue> getRowsMultimapInternal(
+                Iterable<UserBirthdaysIdxRow> rows, ColumnSelection columns) {
             SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
             return getRowMapFromRowResults(results.values());
         }
 
-        private static Multimap<UserBirthdaysIdxRow, UserBirthdaysIdxColumnValue> getRowMapFromRowResults(Collection<RowResult<byte[]>> rowResults) {
+        private static Multimap<UserBirthdaysIdxRow, UserBirthdaysIdxColumnValue> getRowMapFromRowResults(
+                Collection<RowResult<byte[]>> rowResults) {
             Multimap<UserBirthdaysIdxRow, UserBirthdaysIdxColumnValue> rowMap = ArrayListMultimap.create();
             for (RowResult<byte[]> result : rowResults) {
                 UserBirthdaysIdxRow row = UserBirthdaysIdxRow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
@@ -3106,27 +3298,36 @@ public final class UserProfileTable implements
         }
 
         @Override
-        public Map<UserBirthdaysIdxRow, BatchingVisitable<UserBirthdaysIdxColumnValue>> getRowsColumnRange(Iterable<UserBirthdaysIdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
-            Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
-            Map<UserBirthdaysIdxRow, BatchingVisitable<UserBirthdaysIdxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        public Map<UserBirthdaysIdxRow, BatchingVisitable<UserBirthdaysIdxColumnValue>> getRowsColumnRange(
+                Iterable<UserBirthdaysIdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+            Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results =
+                    t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+            Map<UserBirthdaysIdxRow, BatchingVisitable<UserBirthdaysIdxColumnValue>> transformed =
+                    Maps.newHashMapWithExpectedSize(results.size());
             for (Entry<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
                 UserBirthdaysIdxRow row = UserBirthdaysIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
-                BatchingVisitable<UserBirthdaysIdxColumnValue> bv = BatchingVisitables.transform(e.getValue(), result -> {
-                    UserBirthdaysIdxColumn col = UserBirthdaysIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
-                    Long val = UserBirthdaysIdxColumnValue.hydrateValue(result.getValue());
-                    return UserBirthdaysIdxColumnValue.of(col, val);
-                });
+                BatchingVisitable<UserBirthdaysIdxColumnValue> bv =
+                        BatchingVisitables.transform(e.getValue(), result -> {
+                            UserBirthdaysIdxColumn col = UserBirthdaysIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(
+                                    result.getKey().getColumnName());
+                            Long val = UserBirthdaysIdxColumnValue.hydrateValue(result.getValue());
+                            return UserBirthdaysIdxColumnValue.of(col, val);
+                        });
                 transformed.put(row, bv);
             }
             return transformed;
         }
 
         @Override
-        public Iterator<Map.Entry<UserBirthdaysIdxRow, UserBirthdaysIdxColumnValue>> getRowsColumnRange(Iterable<UserBirthdaysIdxRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
-            Iterator<Map.Entry<Cell, byte[]>> results = t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
+        public Iterator<Map.Entry<UserBirthdaysIdxRow, UserBirthdaysIdxColumnValue>> getRowsColumnRange(
+                Iterable<UserBirthdaysIdxRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
+            Iterator<Map.Entry<Cell, byte[]>> results =
+                    t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
             return Iterators.transform(results, e -> {
-                UserBirthdaysIdxRow row = UserBirthdaysIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
-                UserBirthdaysIdxColumn col = UserBirthdaysIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getColumnName());
+                UserBirthdaysIdxRow row = UserBirthdaysIdxRow.BYTES_HYDRATOR.hydrateFromBytes(
+                        e.getKey().getRowName());
+                UserBirthdaysIdxColumn col = UserBirthdaysIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(
+                        e.getKey().getColumnName());
                 Long val = UserBirthdaysIdxColumnValue.hydrateValue(e.getValue());
                 UserBirthdaysIdxColumnValue colValue = UserBirthdaysIdxColumnValue.of(col, val);
                 return Maps.immutableEntry(row, colValue);
@@ -3134,13 +3335,17 @@ public final class UserProfileTable implements
         }
 
         @Override
-        public Map<UserBirthdaysIdxRow, Iterator<UserBirthdaysIdxColumnValue>> getRowsColumnRangeIterator(Iterable<UserBirthdaysIdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
-            Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
-            Map<UserBirthdaysIdxRow, Iterator<UserBirthdaysIdxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        public Map<UserBirthdaysIdxRow, Iterator<UserBirthdaysIdxColumnValue>> getRowsColumnRangeIterator(
+                Iterable<UserBirthdaysIdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+            Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results =
+                    t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+            Map<UserBirthdaysIdxRow, Iterator<UserBirthdaysIdxColumnValue>> transformed =
+                    Maps.newHashMapWithExpectedSize(results.size());
             for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
                 UserBirthdaysIdxRow row = UserBirthdaysIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
                 Iterator<UserBirthdaysIdxColumnValue> bv = Iterators.transform(e.getValue(), result -> {
-                    UserBirthdaysIdxColumn col = UserBirthdaysIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                    UserBirthdaysIdxColumn col = UserBirthdaysIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(
+                            result.getKey().getColumnName());
                     Long val = UserBirthdaysIdxColumnValue.hydrateValue(result.getValue());
                     return UserBirthdaysIdxColumnValue.of(col, val);
                 });
@@ -3151,7 +3356,7 @@ public final class UserProfileTable implements
 
         private RangeRequest optimizeRangeRequest(RangeRequest range) {
             if (range.getColumnNames().isEmpty()) {
-                return range.getBuilder().retainColumns(allColumns).build();
+                return range.getBuilder().retainColumns(allKnownColumns).build();
             }
             return range;
         }
@@ -3161,60 +3366,70 @@ public final class UserProfileTable implements
         }
 
         public BatchingVisitableView<UserBirthdaysIdxRowResult> getRange(RangeRequest range) {
-            return BatchingVisitables.transform(t.getRange(tableRef, optimizeRangeRequest(range)), new Function<RowResult<byte[]>, UserBirthdaysIdxRowResult>() {
-                @Override
-                public UserBirthdaysIdxRowResult apply(RowResult<byte[]> input) {
-                    return UserBirthdaysIdxRowResult.of(input);
-                }
-            });
+            return BatchingVisitables.transform(
+                    t.getRange(tableRef, optimizeRangeRequest(range)),
+                    new Function<RowResult<byte[]>, UserBirthdaysIdxRowResult>() {
+                        @Override
+                        public UserBirthdaysIdxRowResult apply(RowResult<byte[]> input) {
+                            return UserBirthdaysIdxRowResult.of(input);
+                        }
+                    });
         }
 
         @Deprecated
         public IterableView<BatchingVisitable<UserBirthdaysIdxRowResult>> getRanges(Iterable<RangeRequest> ranges) {
-            Iterable<BatchingVisitable<RowResult<byte[]>>> rangeResults = t.getRanges(tableRef, optimizeRangeRequests(ranges));
-            return IterableView.of(rangeResults).transform(
-                    new Function<BatchingVisitable<RowResult<byte[]>>, BatchingVisitable<UserBirthdaysIdxRowResult>>() {
-                @Override
-                public BatchingVisitable<UserBirthdaysIdxRowResult> apply(BatchingVisitable<RowResult<byte[]>> visitable) {
-                    return BatchingVisitables.transform(visitable, new Function<RowResult<byte[]>, UserBirthdaysIdxRowResult>() {
-                        @Override
-                        public UserBirthdaysIdxRowResult apply(RowResult<byte[]> row) {
-                            return UserBirthdaysIdxRowResult.of(row);
-                        }
-                    });
-                }
-            });
+            Iterable<BatchingVisitable<RowResult<byte[]>>> rangeResults =
+                    t.getRanges(tableRef, optimizeRangeRequests(ranges));
+            return IterableView.of(rangeResults)
+                    .transform(
+                            new Function<
+                                    BatchingVisitable<RowResult<byte[]>>,
+                                    BatchingVisitable<UserBirthdaysIdxRowResult>>() {
+                                @Override
+                                public BatchingVisitable<UserBirthdaysIdxRowResult> apply(
+                                        BatchingVisitable<RowResult<byte[]>> visitable) {
+                                    return BatchingVisitables.transform(
+                                            visitable, new Function<RowResult<byte[]>, UserBirthdaysIdxRowResult>() {
+                                                @Override
+                                                public UserBirthdaysIdxRowResult apply(RowResult<byte[]> row) {
+                                                    return UserBirthdaysIdxRowResult.of(row);
+                                                }
+                                            });
+                                }
+                            });
         }
 
-        public <T> Stream<T> getRanges(Iterable<RangeRequest> ranges,
-                                       int concurrencyLevel,
-                                       BiFunction<RangeRequest, BatchingVisitable<UserBirthdaysIdxRowResult>, T> visitableProcessor) {
+        public <T> Stream<T> getRanges(
+                Iterable<RangeRequest> ranges,
+                int concurrencyLevel,
+                BiFunction<RangeRequest, BatchingVisitable<UserBirthdaysIdxRowResult>, T> visitableProcessor) {
             return t.getRanges(ImmutableGetRangesQuery.<T>builder()
-                                .tableRef(tableRef)
-                                .rangeRequests(ranges)
-                                .rangeRequestOptimizer(this::optimizeRangeRequest)
-                                .concurrencyLevel(concurrencyLevel)
-                                .visitableProcessor((rangeRequest, visitable) ->
-                                        visitableProcessor.apply(rangeRequest,
-                                                BatchingVisitables.transform(visitable, UserBirthdaysIdxRowResult::of)))
-                                .build());
+                    .tableRef(tableRef)
+                    .rangeRequests(ranges)
+                    .rangeRequestOptimizer(this::optimizeRangeRequest)
+                    .concurrencyLevel(concurrencyLevel)
+                    .visitableProcessor((rangeRequest, visitable) -> visitableProcessor.apply(
+                            rangeRequest, BatchingVisitables.transform(visitable, UserBirthdaysIdxRowResult::of)))
+                    .build());
         }
 
-        public <T> Stream<T> getRanges(Iterable<RangeRequest> ranges,
-                                       BiFunction<RangeRequest, BatchingVisitable<UserBirthdaysIdxRowResult>, T> visitableProcessor) {
+        public <T> Stream<T> getRanges(
+                Iterable<RangeRequest> ranges,
+                BiFunction<RangeRequest, BatchingVisitable<UserBirthdaysIdxRowResult>, T> visitableProcessor) {
             return t.getRanges(ImmutableGetRangesQuery.<T>builder()
-                                .tableRef(tableRef)
-                                .rangeRequests(ranges)
-                                .rangeRequestOptimizer(this::optimizeRangeRequest)
-                                .visitableProcessor((rangeRequest, visitable) ->
-                                        visitableProcessor.apply(rangeRequest,
-                                                BatchingVisitables.transform(visitable, UserBirthdaysIdxRowResult::of)))
-                                .build());
+                    .tableRef(tableRef)
+                    .rangeRequests(ranges)
+                    .rangeRequestOptimizer(this::optimizeRangeRequest)
+                    .visitableProcessor((rangeRequest, visitable) -> visitableProcessor.apply(
+                            rangeRequest, BatchingVisitables.transform(visitable, UserBirthdaysIdxRowResult::of)))
+                    .build());
         }
 
         public Stream<BatchingVisitable<UserBirthdaysIdxRowResult>> getRangesLazy(Iterable<RangeRequest> ranges) {
-            Stream<BatchingVisitable<RowResult<byte[]>>> rangeResults = t.getRangesLazy(tableRef, optimizeRangeRequests(ranges));
-            return rangeResults.map(visitable -> BatchingVisitables.transform(visitable, UserBirthdaysIdxRowResult::of));
+            Stream<BatchingVisitable<RowResult<byte[]>>> rangeResults =
+                    t.getRangesLazy(tableRef, optimizeRangeRequests(ranges));
+            return rangeResults.map(
+                    visitable -> BatchingVisitables.transform(visitable, UserBirthdaysIdxRowResult::of));
         }
 
         public void deleteRange(RangeRequest range) {
@@ -3222,35 +3437,36 @@ public final class UserProfileTable implements
         }
 
         public void deleteRanges(Iterable<RangeRequest> ranges) {
-            BatchingVisitables.concat(getRanges(ranges)).batchAccept(1000, new AbortingVisitor<List<UserBirthdaysIdxRowResult>, RuntimeException>() {
-                @Override
-                public boolean visit(List<UserBirthdaysIdxRowResult> rowResults) {
-                    Multimap<UserBirthdaysIdxRow, UserBirthdaysIdxColumn> toRemove = HashMultimap.create();
-                    for (UserBirthdaysIdxRowResult rowResult : rowResults) {
-                        for (UserBirthdaysIdxColumnValue columnValue : rowResult.getColumnValues()) {
-                            toRemove.put(rowResult.getRowName(), columnValue.getColumnName());
+            BatchingVisitables.concat(getRanges(ranges))
+                    .batchAccept(1000, new AbortingVisitor<List<UserBirthdaysIdxRowResult>, RuntimeException>() {
+                        @Override
+                        public boolean visit(List<UserBirthdaysIdxRowResult> rowResults) {
+                            Multimap<UserBirthdaysIdxRow, UserBirthdaysIdxColumn> toRemove = HashMultimap.create();
+                            for (UserBirthdaysIdxRowResult rowResult : rowResults) {
+                                for (UserBirthdaysIdxColumnValue columnValue : rowResult.getColumnValues()) {
+                                    toRemove.put(rowResult.getRowName(), columnValue.getColumnName());
+                                }
+                            }
+                            delete(toRemove);
+                            return true;
                         }
-                    }
-                    delete(toRemove);
-                    return true;
-                }
-            });
+                    });
         }
 
         @Override
-        public List<String> findConstraintFailures(Map<Cell, byte[]> writes,
-                                                   ConstraintCheckingTransaction transaction,
-                                                   AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        public List<String> findConstraintFailures(
+                Map<Cell, byte[]> writes,
+                ConstraintCheckingTransaction transaction,
+                AtlasDbConstraintCheckingMode constraintCheckingMode) {
             return ImmutableList.of();
         }
 
         @Override
-        public List<String> findConstraintFailuresNoRead(Map<Cell, byte[]> writes,
-                                                         AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        public List<String> findConstraintFailuresNoRead(
+                Map<Cell, byte[]> writes, AtlasDbConstraintCheckingMode constraintCheckingMode) {
             return ImmutableList.of();
         }
     }
-
 
     /**
      * This exists to avoid unused import warnings
@@ -3280,6 +3496,7 @@ public final class UserProfileTable implements
      * {@link ColumnSelection}
      * {@link ColumnValue}
      * {@link ColumnValues}
+     * {@link Columns}
      * {@link ComparisonChain}
      * {@link Compression}
      * {@link CompressionUtils}
@@ -3337,5 +3554,5 @@ public final class UserProfileTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "XQx5IMlaY1C+fEZFXzLO7Q==";
+    static String __CLASS_HASH = "AQwle3iR0wX3c8rMc9yz3g==";
 }

--- a/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/BlobsSerializableTable.java
+++ b/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/BlobsSerializableTable.java
@@ -66,6 +66,7 @@ import com.palantir.atlasdb.table.api.TypedRowResult;
 import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Columns;
 import com.palantir.atlasdb.table.generation.Descending;
 import com.palantir.atlasdb.table.generation.NamedColumnValue;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
@@ -98,7 +99,7 @@ public final class BlobsSerializableTable implements
     private final List<BlobsSerializableTrigger> triggers;
     private final static String rawTableName = "BlobsSerializable";
     private final TableReference tableRef;
-    private final static ColumnSelection allColumns = getColumnSelection(BlobsSerializableNamedColumn.values());
+    private final static ColumnSelection allKnownColumns = getColumnSelection(BlobsSerializableNamedColumn.values());
 
     static BlobsSerializableTable of(Transaction t, Namespace namespace) {
         return new BlobsSerializableTable(t, namespace, ImmutableList.<BlobsSerializableTrigger>of());
@@ -442,14 +443,12 @@ public final class BlobsSerializableTable implements
 
     @Override
     public void delete(Iterable<BlobsSerializableRow> rows) {
-        List<byte[]> rowBytes = Persistables.persistAll(rows);
-        Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
-        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("d")));
-        t.delete(tableRef, cells);
+        Multimap<BlobsSerializableRow, BlobsSerializableNamedColumnValue<?>> result = getRowsMultimap(rows);
+        t.delete(tableRef, ColumnValues.toCells(result));
     }
 
     public Optional<BlobsSerializableRowResult> getRow(BlobsSerializableRow row) {
-        return getRow(row, allColumns);
+        return getRow(row, allKnownColumns);
     }
 
     public Optional<BlobsSerializableRowResult> getRow(BlobsSerializableRow row, ColumnSelection columns) {
@@ -464,7 +463,7 @@ public final class BlobsSerializableTable implements
 
     @Override
     public List<BlobsSerializableRowResult> getRows(Iterable<BlobsSerializableRow> rows) {
-        return getRows(rows, allColumns);
+        return getRows(rows, allKnownColumns);
     }
 
     @Override
@@ -479,7 +478,7 @@ public final class BlobsSerializableTable implements
 
     @Override
     public List<BlobsSerializableNamedColumnValue<?>> getRowColumns(BlobsSerializableRow row) {
-        return getRowColumns(row, allColumns);
+        return getRowColumns(row, ColumnSelection.all());
     }
 
     @Override
@@ -499,7 +498,7 @@ public final class BlobsSerializableTable implements
 
     @Override
     public Multimap<BlobsSerializableRow, BlobsSerializableNamedColumnValue<?>> getRowsMultimap(Iterable<BlobsSerializableRow> rows) {
-        return getRowsMultimapInternal(rows, allColumns);
+        return getRowsMultimapInternal(rows, ColumnSelection.all());
     }
 
     @Override
@@ -563,13 +562,13 @@ public final class BlobsSerializableTable implements
 
     private ColumnSelection optimizeColumnSelection(ColumnSelection columns) {
         if (columns.allColumnsSelected()) {
-            return allColumns;
+            return allKnownColumns;
         }
         return columns;
     }
 
     public BatchingVisitableView<BlobsSerializableRowResult> getAllRowsUnordered() {
-        return getAllRowsUnordered(allColumns);
+        return getAllRowsUnordered(allKnownColumns);
     }
 
     public BatchingVisitableView<BlobsSerializableRowResult> getAllRowsUnordered(ColumnSelection columns) {
@@ -624,6 +623,7 @@ public final class BlobsSerializableTable implements
      * {@link ColumnSelection}
      * {@link ColumnValue}
      * {@link ColumnValues}
+     * {@link Columns}
      * {@link ComparisonChain}
      * {@link Compression}
      * {@link CompressionUtils}
@@ -681,5 +681,5 @@ public final class BlobsSerializableTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "/tUuzuVxP4izSsze9aTJKg==";
+    static String __CLASS_HASH = "CXC8lUHkVL6AMSY9Vq59xA==";
 }

--- a/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/BlobsTable.java
+++ b/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/BlobsTable.java
@@ -66,6 +66,7 @@ import com.palantir.atlasdb.table.api.TypedRowResult;
 import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Columns;
 import com.palantir.atlasdb.table.generation.Descending;
 import com.palantir.atlasdb.table.generation.NamedColumnValue;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
@@ -98,7 +99,7 @@ public final class BlobsTable implements
     private final List<BlobsTrigger> triggers;
     private final static String rawTableName = "Blobs";
     private final TableReference tableRef;
-    private final static ColumnSelection allColumns = getColumnSelection(BlobsNamedColumn.values());
+    private final static ColumnSelection allKnownColumns = getColumnSelection(BlobsNamedColumn.values());
 
     static BlobsTable of(Transaction t, Namespace namespace) {
         return new BlobsTable(t, namespace, ImmutableList.<BlobsTrigger>of());
@@ -442,14 +443,12 @@ public final class BlobsTable implements
 
     @Override
     public void delete(Iterable<BlobsRow> rows) {
-        List<byte[]> rowBytes = Persistables.persistAll(rows);
-        Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
-        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("d")));
-        t.delete(tableRef, cells);
+        Multimap<BlobsRow, BlobsNamedColumnValue<?>> result = getRowsMultimap(rows);
+        t.delete(tableRef, ColumnValues.toCells(result));
     }
 
     public Optional<BlobsRowResult> getRow(BlobsRow row) {
-        return getRow(row, allColumns);
+        return getRow(row, allKnownColumns);
     }
 
     public Optional<BlobsRowResult> getRow(BlobsRow row, ColumnSelection columns) {
@@ -464,7 +463,7 @@ public final class BlobsTable implements
 
     @Override
     public List<BlobsRowResult> getRows(Iterable<BlobsRow> rows) {
-        return getRows(rows, allColumns);
+        return getRows(rows, allKnownColumns);
     }
 
     @Override
@@ -479,7 +478,7 @@ public final class BlobsTable implements
 
     @Override
     public List<BlobsNamedColumnValue<?>> getRowColumns(BlobsRow row) {
-        return getRowColumns(row, allColumns);
+        return getRowColumns(row, ColumnSelection.all());
     }
 
     @Override
@@ -499,7 +498,7 @@ public final class BlobsTable implements
 
     @Override
     public Multimap<BlobsRow, BlobsNamedColumnValue<?>> getRowsMultimap(Iterable<BlobsRow> rows) {
-        return getRowsMultimapInternal(rows, allColumns);
+        return getRowsMultimapInternal(rows, ColumnSelection.all());
     }
 
     @Override
@@ -563,13 +562,13 @@ public final class BlobsTable implements
 
     private ColumnSelection optimizeColumnSelection(ColumnSelection columns) {
         if (columns.allColumnsSelected()) {
-            return allColumns;
+            return allKnownColumns;
         }
         return columns;
     }
 
     public BatchingVisitableView<BlobsRowResult> getAllRowsUnordered() {
-        return getAllRowsUnordered(allColumns);
+        return getAllRowsUnordered(allKnownColumns);
     }
 
     public BatchingVisitableView<BlobsRowResult> getAllRowsUnordered(ColumnSelection columns) {
@@ -624,6 +623,7 @@ public final class BlobsTable implements
      * {@link ColumnSelection}
      * {@link ColumnValue}
      * {@link ColumnValues}
+     * {@link Columns}
      * {@link ComparisonChain}
      * {@link Compression}
      * {@link CompressionUtils}
@@ -681,5 +681,5 @@ public final class BlobsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "f1OGdw5MY7EKfykqIgqEKQ==";
+    static String __CLASS_HASH = "UW03gjA5I7yUnMiJ9Zq5MQ==";
 }


### PR DESCRIPTION
## Goals

We recently had a P0 caused by the following scenario:
- Have version V1 with a named columns table
- Create version V2 that adds a column to that table
- During an upgrade, a V2 node writes a row to that table. That row contains the new column.
- Also during the upgrade, a V1 node deletes that row from the table. **_This does not delete the new column._**
- All future reads of that row by V2 nodes will return a present row result with all null values except the new column. The correct behavior would be to return no row result.

As an AtlasDB user, I expect that this API will delete all cells from the row. More precisely, I expect that after `delete(Row)`, any future `get(Row)` will not return a row result - regardless of what columns are declared in my schema. Both of these methods operate on `Row` values and should not be dependent on the declare columns.

Furthermore, there seems to be some inconsistency with respect to the semantics of the `delete(Row)` method. Tables with dynamic columns do have these semantics (`delete(Row)` will delete all cells) but tables with named columns do not (`delete(Row)` only deletes known cells).

## Implementation Description

The named delete methods for named column tables has been changed to delete all cells rather than just known cells.

In order to support this, any table methods that return `ColumnValue`, now use `ColumnSelection.all()` instead of just `allKnownColumns`. Table methods that return `RowResult` preserve the existing optimization and still use `allKnownColumns` because unknown columns are not exposed in the `RowResult`.

## Concerns

There are two primary concerns with this PR:
1. Users may have been depending on the existing behavior

    This seems fairly unlikely to me. I can't think of any scenario where the existing behavior would be preferred or expected over the proposed new behavior. If you are calling `delete(Row)`, your intention is almost certainly to delete the entire row.

1. This requires a read when deleting

    Note that we already perform this read for tables with at least one cell-referencing index. So this only affects named column tables without cell-referencing indexes.

    Given that these are named columns, the number of columns is almost certainly bounded and fairly small. Write code paths are generally less performance sensitive than read codepaths, so this feels acceptable to me.