### PR TITLE
Don't load metadata on conflicts

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/Cells.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/Cells.java
@@ -187,7 +187,7 @@ public final class Cells {
         return BaseEncoding.base16().lowerCase().encode(name);
     }
 
-    public static CellConflict createConflictWithMetadata(Cell cell, long theirStartTs, long theirCommitTs) {
+    public static CellConflict createConflict(Cell cell, long theirStartTs, long theirCommitTs) {
         return new CellConflict(cell, getHumanReadableCellName(cell), theirStartTs, theirCommitTs);
     }
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/Cells.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/Cells.java
@@ -28,12 +28,8 @@ import com.google.common.collect.PeekingIterator;
 import com.google.common.collect.Sets;
 import com.google.common.io.BaseEncoding;
 import com.google.common.primitives.UnsignedBytes;
-import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.Cell;
-import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
-import com.palantir.atlasdb.keyvalue.api.TableReference;
-import com.palantir.atlasdb.table.description.TableMetadata;
 import com.palantir.atlasdb.transaction.api.TransactionConflictException.CellConflict;
 import com.palantir.atlasdb.transaction.impl.TransactionConstants;
 import com.palantir.common.annotation.Output;
@@ -48,7 +44,6 @@ import java.util.NavigableMap;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeMap;
-import javax.annotation.Nullable;
 
 public final class Cells {
     private static final SafeLogger log = SafeLoggerFactory.get(Cells.class);
@@ -192,34 +187,14 @@ public final class Cells {
         return BaseEncoding.base16().lowerCase().encode(name);
     }
 
-    public static CellConflict createConflictWithMetadata(
-            KeyValueService kv, TableReference tableRef, Cell cell, long theirStartTs, long theirCommitTs) {
-        TableMetadata metadata = KeyValueServices.getTableMetadataSafe(kv, tableRef);
-        return new CellConflict(cell, getHumanReadableCellName(metadata, cell), theirStartTs, theirCommitTs);
+    public static CellConflict createConflictWithMetadata(Cell cell, long theirStartTs, long theirCommitTs) {
+        return new CellConflict(cell, getHumanReadableCellName(cell), theirStartTs, theirCommitTs);
     }
 
-    public static String getHumanReadableCellName(@Nullable TableMetadata metadata, Cell cell) {
+    public static String getHumanReadableCellName(Cell cell) {
         if (cell == null) {
             return "null";
         }
-        if (metadata == null) {
-            return cell.toString();
-        }
-        try {
-            String rowName = metadata.getRowMetadata().renderToJson(cell.getRowName());
-            String colName;
-            if (metadata.getColumns().hasDynamicColumns()) {
-                colName = metadata.getColumns()
-                        .getDynamicColumn()
-                        .getColumnNameDesc()
-                        .renderToJson(cell.getColumnName());
-            } else {
-                colName = PtBytes.toString(cell.getColumnName());
-            }
-            return "Cell [rowName=" + rowName + ", columnName=" + colName + "]";
-        } catch (Exception e) {
-            log.warn("Failed to render as json", e);
-            return cell.toString();
-        }
+        return cell.toString();
     }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/KeyValueServices.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/KeyValueServices.java
@@ -36,7 +36,6 @@ import com.palantir.atlasdb.keyvalue.api.RowColumnRangeIterator;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
-import com.palantir.atlasdb.table.description.TableMetadata;
 import com.palantir.common.annotation.Output;
 import com.palantir.common.base.ClosableIterator;
 import com.palantir.common.base.Throwables;
@@ -64,19 +63,6 @@ public final class KeyValueServices {
 
     private KeyValueServices() {
         /**/
-    }
-
-    public static TableMetadata getTableMetadataSafe(KeyValueService service, TableReference tableRef) {
-        try {
-            byte[] metadataForTable = service.getMetadataForTable(tableRef);
-            if (metadataForTable == null || metadataForTable.length == 0) {
-                return null;
-            }
-            return TableMetadata.BYTES_HYDRATOR.hydrateFromBytes(metadataForTable);
-        } catch (Exception e) {
-            log.warn("failed to get metadata for table", e);
-            return null;
-        }
     }
 
     public static void getFirstBatchForRangeUsingGetRange(

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -2140,9 +2140,9 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             AssertUtils.assertAndLog(
                     log, theirCommitTimestamp != getStartTimestamp(), "Timestamp reuse is bad:" + getStartTimestamp());
             if (theirStartTimestamp > getStartTimestamp()) {
-                dominatingWrites.add(Cells.createConflictWithMetadata(key, theirStartTimestamp, theirCommitTimestamp));
+                dominatingWrites.add(Cells.createConflict(key, theirStartTimestamp, theirCommitTimestamp));
             } else if (theirCommitTimestamp > getStartTimestamp()) {
-                spanningWrites.add(Cells.createConflictWithMetadata(key, theirStartTimestamp, theirCommitTimestamp));
+                spanningWrites.add(Cells.createConflict(key, theirStartTimestamp, theirCommitTimestamp));
             }
         }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -2140,11 +2140,9 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             AssertUtils.assertAndLog(
                     log, theirCommitTimestamp != getStartTimestamp(), "Timestamp reuse is bad:" + getStartTimestamp());
             if (theirStartTimestamp > getStartTimestamp()) {
-                dominatingWrites.add(Cells.createConflictWithMetadata(
-                        keyValueService, tableRef, key, theirStartTimestamp, theirCommitTimestamp));
+                dominatingWrites.add(Cells.createConflictWithMetadata(key, theirStartTimestamp, theirCommitTimestamp));
             } else if (theirCommitTimestamp > getStartTimestamp()) {
-                spanningWrites.add(Cells.createConflictWithMetadata(
-                        keyValueService, tableRef, key, theirStartTimestamp, theirCommitTimestamp));
+                spanningWrites.add(Cells.createConflictWithMetadata(key, theirStartTimestamp, theirCommitTimestamp));
             }
         }
 

--- a/changelog/@unreleased/pr-5983.v2.yml
+++ b/changelog/@unreleased/pr-5983.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: When a txn did a lot of writes, and it conflicted, we'd read the kvs
+    for each cell which conflicted.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5983


### PR DESCRIPTION
**Goals (and why)**:
<!-- User-facing outcomes this PR delivers go below -->
Alternative to https://github.com/palantir/atlasdb/pull/5981/files -- turns out we cannot cache table metadata as large internal product can sometimes update it's metadata and we don't want nodes to have inconsistent views of which table metadata exists.