### PR TITLE
Add telemetry around client destruction in the Cassandra client poolls

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -168,7 +168,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Cassand
                 log.warn(
                         "Not reusing resource due to {} of host {}",
                         UnsafeArg.of("exception", e.toString()),
-                        SafeArg.of("cassandraHostname", cassandraServer.cassandraHostName()),
+                        SafeArg.of("cassandraHostName", cassandraServer.cassandraHostName()),
                         SafeArg.of("proxy", CassandraLogHelper.host(proxy)),
                         e);
                 shouldReuse = false;
@@ -176,6 +176,11 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Cassand
             if (e instanceof TTransportException
                     && ((TTransportException) e).getType() == TTransportException.END_OF_FILE) {
                 // If we have an end of file this is most likely due to this cassandra node being bounced.
+                log.warn(
+                        "Clearing client pool due to exception",
+                        SafeArg.of("cassandraHostName", cassandraServer.cassandraHostName()),
+                        SafeArg.of("proxy", CassandraLogHelper.host(proxy)),
+                        e);
                 clientPool.clear();
             }
             throw (K) e;
@@ -353,6 +358,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Cassand
         registerPoolMetric(CassandraClientPoolHostLevelMetric.NUM_ACTIVE, () -> (long) pool.getNumActive());
         registerPoolMetric(CassandraClientPoolHostLevelMetric.CREATED, pool::getCreatedCount);
         registerPoolMetric(CassandraClientPoolHostLevelMetric.DESTROYED_BY_EVICTOR, pool::getDestroyedByEvictorCount);
+        registerPoolMetric(CassandraClientPoolHostLevelMetric.DESTROYED, pool::getDestroyedCount);
     }
 
     private void registerPoolMetric(CassandraClientPoolHostLevelMetric metric, Gauge<Long> gauge) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraClientPoolHostLevelMetric.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraClientPoolHostLevelMetric.java
@@ -21,7 +21,8 @@ public enum CassandraClientPoolHostLevelMetric {
     NUM_IDLE("numIdle", 0.1, 2.0),
     NUM_ACTIVE("numActive", 0.1, 2.0),
     CREATED("created", 0.01, 2.0),
-    DESTROYED_BY_EVICTOR("destroyedByEvictor", 0.01, 2.0);
+    DESTROYED_BY_EVICTOR("destroyedByEvictor", 0.01, 2.0),
+    DESTROYED("destroyed", 0.01, 2.0);
 
     public final String metricName;
     public final double minimumMeanThreshold;

--- a/changelog/@unreleased/pr-5985.v2.yml
+++ b/changelog/@unreleased/pr-5985.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Add logging for when a Cassandra client pool is cleared of idle connections,
+    and add a metric for number of connections destroyed in total (not just by the
+    evictor).
+  links:
+  - https://github.com/palantir/atlasdb/pull/5985


### PR DESCRIPTION
**Goals (and why)**:
==COMMIT_MSG==
Add logging for when a Cassandra client pool is cleared of idle connections, and add a metric for number of connections destroyed in total (not just by the evictor).
==COMMIT_MSG==

**Implementation Description (bullets)**:
We seem to have a mismatch in the number of clients created as reported by the client factory, and the number reported by the pool. This may just be a factor of our outlier metric filters (which are not reporting all metrics, and thus any aggregation over them will not be fully representative), or may also be due to clients being removed elsewhere (although they should still be reported as created by the pool, if not evicted...).

**Testing (What was existing testing like?  What have you done to improve it?)**:
Telemetry.

**Concerns (what feedback would you like?)**:
This should give us more insight into how often we're killing connections due to exceptions, but may not inform us of the how and why there are these possibly rouge connections being created.

**Where should we start reviewing?**:
Diff

**Priority (whenever / two weeks / yesterday)**:
ASAP to get signal