### PR TITLE
[For RC] Disable metric filtration

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraClientPoolHostLevelMetric.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraClientPoolHostLevelMetric.java
@@ -17,12 +17,12 @@
 package com.palantir.atlasdb.keyvalue.cassandra.pool;
 
 public enum CassandraClientPoolHostLevelMetric {
-    MEAN_ACTIVE_TIME_MILLIS("meanActiveTimeMillis", 0.0, 2.0),
-    NUM_IDLE("numIdle", 0.1, 2.0),
-    NUM_ACTIVE("numActive", 0.1, 2.0),
-    CREATED("created", 0.01, 2.0),
-    DESTROYED_BY_EVICTOR("destroyedByEvictor", 0.01, 2.0),
-    DESTROYED("destroyed", 0.01, 2.0);
+    MEAN_ACTIVE_TIME_MILLIS("meanActiveTimeMillis", 0.0, -2.0),
+    NUM_IDLE("numIdle", 0.1, -2.0),
+    NUM_ACTIVE("numActive", 0.1, -2.0),
+    CREATED("created", 0.01, -2.0),
+    DESTROYED_BY_EVICTOR("destroyedByEvictor", 0.01, -2.0),
+    DESTROYED("destroyed", 0.01, -2.0);
 
     public final String metricName;
     public final double minimumMeanThreshold;


### PR DESCRIPTION
**Goals (and why)**:
==COMMIT_MSG==
(For RC Only): Disable metric filtration for Cassandra client pool metrics
==COMMIT_MSG==

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:
If we accumulate the metrics when we don't report them, we could then report them when they are within the mean, and we would actually retain signal (at least in the total case - things like service restarts would impact this, as would if we never left the mean).

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
