### PR TITLE
Cache persisted schema version locally

### DIFF
--- a/changelog/@unreleased/pr-5994.v2.yml
+++ b/changelog/@unreleased/pr-5994.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: The TimeLock Agent will now cache its locally-persisted schema version.
+    This will prevent health check flakes due to transient failures in fetching from
+    SQLite.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5994

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/PersistedSchemaVersion.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/PersistedSchemaVersion.java
@@ -61,7 +61,7 @@ public class PersistedSchemaVersion {
             return false;
         });
         if (updated) {
-            updatePersistedVersionTo(targetVersion);
+            updatePersistedVersionToAtLeast(targetVersion);
         }
     }
 
@@ -77,10 +77,10 @@ public class PersistedSchemaVersion {
     private long getVersionFromDb() {
         long versionInDb = execute(dao -> dao.getVersion(ONLY_ROW))
                 .orElseThrow(() -> new SafeIllegalStateException("No persisted schema version found."));
-        return updatePersistedVersionTo(versionInDb);
+        return updatePersistedVersionToAtLeast(versionInDb);
     }
 
-    private long updatePersistedVersionTo(long versionInDb) {
+    private long updatePersistedVersionToAtLeast(long versionInDb) {
         return persistedVersion.updateAndGet(storedValue -> Math.max(storedValue, versionInDb));
     }
 


### PR DESCRIPTION
**Goals (and why)**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
The TimeLock Agent will now cache its locally-persisted schema version. This will prevent health check flakes due to transient failures in fetching from SQLite. 
==COMMIT_MSG==

**Implementation Description (bullets)**:
- Store schema version in a field, analogous to the existing logic in DisabledNamespaces (#5922).

**Testing (What was existing testing like?  What have you done to improve it?)**:
PersistedSchemaVersionTest still passes. I considered adding a test on JDBI but mocking it is tricky and refactoring for such a test doesn't seem worthwhile at this point

**Concerns (what feedback would you like?)**: n/a

**Where should we start reviewing?**: PersistedSchemaVersion

**Priority (whenever / two weeks / yesterday)**: today

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
