### PR TITLE
TransactionFailedException is SafeLoggable

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionCommitFailedException.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionCommitFailedException.java
@@ -36,4 +36,9 @@ public class TransactionCommitFailedException extends TransactionFailedNonRetria
     public TransactionCommitFailedException(String message) {
         super(message);
     }
+
+    @Override
+    public String getLogMessage() {
+        return "Transaction commit failed";
+    }
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionConflictException.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionConflictException.java
@@ -19,8 +19,11 @@ import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.SafeArg;
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -149,5 +152,15 @@ public final class TransactionConflictException extends TransactionFailedRetriab
         this.spanningWrites = ImmutableList.copyOf(spanningWrites);
         this.dominatingWrites = ImmutableList.copyOf(dominatingWrites);
         this.conflictingTable = conflictingTable;
+    }
+
+    @Override
+    public String getLogMessage() {
+        return "Transaction conflict";
+    }
+
+    @Override
+    public List<Arg<?>> getArgs() {
+        return List.of(SafeArg.of("conflictingTableName", conflictingTable.getTableName()));
     }
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionFailedException.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionFailedException.java
@@ -15,6 +15,10 @@
  */
 package com.palantir.atlasdb.transaction.api;
 
+import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.SafeLoggable;
+import java.util.List;
+
 /**
  * This is a generic exception for all failures thrown from a Transaction
  * <p>
@@ -24,7 +28,7 @@ package com.palantir.atlasdb.transaction.api;
  * @author carrino
  *
  */
-public abstract class TransactionFailedException extends RuntimeException {
+public abstract class TransactionFailedException extends RuntimeException implements SafeLoggable {
     private static final long serialVersionUID = 1L;
 
     TransactionFailedException(String message, Throwable cause) {
@@ -36,4 +40,14 @@ public abstract class TransactionFailedException extends RuntimeException {
     }
 
     public abstract boolean canTransactionBeRetried();
+
+    @Override
+    public String getLogMessage() {
+        return "Transaction failed";
+    }
+
+    @Override
+    public List<Arg<?>> getArgs() {
+        return List.of();
+    }
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionFailedNonRetriableException.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionFailedNonRetriableException.java
@@ -15,6 +15,9 @@
  */
 package com.palantir.atlasdb.transaction.api;
 
+import com.palantir.logsafe.Arg;
+import java.util.List;
+
 public class TransactionFailedNonRetriableException extends TransactionFailedException {
     private static final long serialVersionUID = 1L;
 

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionLockAcquisitionTimeoutException.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionLockAcquisitionTimeoutException.java
@@ -23,4 +23,9 @@ public class TransactionLockAcquisitionTimeoutException extends TransactionFaile
     public TransactionLockAcquisitionTimeoutException(String message) {
         super(message);
     }
+
+    @Override
+    public String getLogMessage() {
+        return "Transaction lock acquisition timeout";
+    }
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionLockTimeoutException.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionLockTimeoutException.java
@@ -30,4 +30,9 @@ public class TransactionLockTimeoutException extends TransactionFailedRetriableE
     public TransactionLockTimeoutException(String message) {
         super(message);
     }
+
+    @Override
+    public String getLogMessage() {
+        return "Transaction lock timeout";
+    }
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionLockTimeoutNonRetriableException.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionLockTimeoutNonRetriableException.java
@@ -25,4 +25,9 @@ public class TransactionLockTimeoutNonRetriableException extends TransactionFail
     public TransactionLockTimeoutNonRetriableException(String message) {
         super(message);
     }
+
+    @Override
+    public String getLogMessage() {
+        return "Transaction lock timeout";
+    }
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionLockWatchFailedException.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionLockWatchFailedException.java
@@ -24,4 +24,9 @@ public final class TransactionLockWatchFailedException extends TransactionFailed
     public TransactionLockWatchFailedException(String message) {
         super(message);
     }
+
+    @Override
+    public String getLogMessage() {
+        return "Transaction lock watch failed";
+    }
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionSerializableConflictException.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionSerializableConflictException.java
@@ -16,6 +16,9 @@
 package com.palantir.atlasdb.transaction.api;
 
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.SafeArg;
+import java.util.List;
 
 public class TransactionSerializableConflictException extends TransactionFailedRetriableException {
     private static final long serialVersionUID = 1L;
@@ -39,5 +42,15 @@ public class TransactionSerializableConflictException extends TransactionFailedR
 
     public TableReference getConflictingTable() {
         return conflictingTable;
+    }
+
+    @Override
+    public String getLogMessage() {
+        return "Transaction serializable conflict";
+    }
+
+    @Override
+    public List<Arg<?>> getArgs() {
+        return List.of(SafeArg.of("conflictingTableName", conflictingTable.getTableName()));
     }
 }


### PR DESCRIPTION
**Goals (and why)**:
Make `TransactionFailedException` implement `SafeLoggable` so we can view the conflicting table names of transaction conflicts.

**Concerns (what feedback would you like?)**:
Should we push this further and annotate the message constructor parameters with `@CompileTimeConstant` so we can get more specific error messages?