### PR TITLE
fix workaround for hikari executor leak

### DIFF
--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/HikariCPConnectionManager.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/HikariCPConnectionManager.java
@@ -334,10 +334,11 @@ public class HikariCPConnectionManager extends BaseConnectionManager {
                     String newPoolName =
                             poolName + "-" + ThreadLocalRandom.current().nextInt();
                     hikariConfig.setPoolName(newPoolName);
+                    dataSourcePool = new HikariDataSource(hikariConfig);
                     log.error(
                             "Created second data source pool. Metrics will be logged under an unexpected pool name.",
-                            SafeArg.of("newPoolName", newPoolName));
-                    dataSourcePool = new HikariDataSource(hikariConfig);
+                            SafeArg.of("newPoolName", newPoolName),
+                            e);
                 } else {
                     throw e;
                 }

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/HikariCPConnectionManager.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/HikariCPConnectionManager.java
@@ -332,10 +332,10 @@ public class HikariCPConnectionManager extends BaseConnectionManager {
                 if (e.getMessage().contains("A metric named")) {
                     String poolName = connConfig.getConnectionPoolName();
                     String newPoolName =
-                            poolName + "-" + ThreadLocalRandom.current().nextInt();
+                            poolName + "-" + ThreadLocalRandom.current().nextInt(Integer.MAX_VALUE);
                     hikariConfig.setPoolName(newPoolName);
                     dataSourcePool = new HikariDataSource(hikariConfig);
-                    log.error(
+                    log.warn(
                             "Created second data source pool. Metrics will be logged under an unexpected pool name.",
                             SafeArg.of("newPoolName", newPoolName),
                             e);

--- a/changelog/@unreleased/pr-5999.v2.yml
+++ b/changelog/@unreleased/pr-5999.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Modify the workaround for hikari executor leak so that metric names
+    are unchanged.
+  links:
+  - https://github.com/palantir/atlasdb/pull/5999


### PR DESCRIPTION
It is important for the metric names to be stable. Log at error
when we change the pool name so consumers are not broken.

**Goals (and why)**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
fix workaround for hikari executor leak

It is important for the metric names to be stable. Log at error
when we change the pool name so consumers are not broken.
==COMMIT_MSG==

**Implementation Description (bullets)**:
Keep the given pool name
Manage our own executor
Restore the retry of creating HikariDataSource
Log at error when it happens instead of just swallowing the error

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:
P1

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
