### PR TITLE
ABR 22: Namespace -> AtlasService

### DIFF
--- a/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/AtlasBackupService.java
+++ b/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/AtlasBackupService.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.backup.api.AtlasBackupClient;
 import com.palantir.atlasdb.backup.api.AtlasBackupClientBlocking;
+import com.palantir.atlasdb.backup.api.AtlasService;
 import com.palantir.atlasdb.backup.api.CompleteBackupRequest;
 import com.palantir.atlasdb.backup.api.CompleteBackupResponse;
 import com.palantir.atlasdb.backup.api.CompletedBackup;
@@ -30,7 +31,6 @@ import com.palantir.atlasdb.backup.api.PrepareBackupResponse;
 import com.palantir.atlasdb.backup.api.RefreshBackupRequest;
 import com.palantir.atlasdb.http.AtlasDbRemotingConstants;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
-import com.palantir.atlasdb.timelock.api.Namespace;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.common.concurrent.NamedThreadFactory;
 import com.palantir.common.concurrent.PTExecutors;
@@ -63,7 +63,7 @@ public final class AtlasBackupService {
     private final AtlasBackupClient atlasBackupClient;
     private final CoordinationServiceRecorder coordinationServiceRecorder;
     private final BackupPersister backupPersister;
-    private final Map<Namespace, InProgressBackupToken> inProgressBackups;
+    private final Map<AtlasService, InProgressBackupToken> inProgressBackups;
     private final LockRefresher<InProgressBackupToken> lockRefresher;
 
     @VisibleForTesting
@@ -85,8 +85,8 @@ public final class AtlasBackupService {
             AuthHeader authHeader,
             Refreshable<ServicesConfigBlock> servicesConfigBlock,
             String serviceName,
-            Function<Namespace, Path> backupFolderFactory,
-            Function<Namespace, KeyValueService> keyValueServiceFactory) {
+            Function<AtlasService, Path> backupFolderFactory,
+            Function<AtlasService, KeyValueService> keyValueServiceFactory) {
         ReloadingFactory reloadingFactory = DialogueClients.create(servicesConfigBlock)
                 .withUserAgent(UserAgent.of(AtlasDbRemotingConstants.ATLASDB_HTTP_CLIENT_AGENT));
 
@@ -107,7 +107,7 @@ public final class AtlasBackupService {
             AuthHeader authHeader,
             AtlasBackupClient atlasBackupClient,
             TransactionManager transactionManager,
-            Function<Namespace, Path> backupFolderFactory) {
+            Function<AtlasService, Path> backupFolderFactory) {
         BackupPersister backupPersister = new ExternalBackupPersister(backupFolderFactory);
         KvsRunner kvsRunner = KvsRunner.create(transactionManager);
         CoordinationServiceRecorder coordinationServiceRecorder =
@@ -128,72 +128,73 @@ public final class AtlasBackupService {
         return new LockRefresher<>(refreshExecutor, lockLeaseRefresher, REFRESH_INTERVAL_MILLIS);
     }
 
-    public Set<Namespace> prepareBackup(Set<Namespace> namespaces) {
-        PrepareBackupRequest request = PrepareBackupRequest.of(namespaces);
+    public Set<AtlasService> prepareBackup(Set<AtlasService> atlasServices) {
+        PrepareBackupRequest request = PrepareBackupRequest.of(atlasServices);
         PrepareBackupResponse response = atlasBackupClient.prepareBackup(authHeader, request);
 
         return response.getSuccessful().stream()
                 .peek(this::storeBackupToken)
-                .map(InProgressBackupToken::getNamespace)
+                .map(InProgressBackupToken::getAtlasService)
                 .collect(Collectors.toSet());
     }
 
     private void storeBackupToken(InProgressBackupToken backupToken) {
-        inProgressBackups.put(backupToken.getNamespace(), backupToken);
+        inProgressBackups.put(backupToken.getAtlasService(), backupToken);
         backupPersister.storeImmutableTimestamp(backupToken);
         lockRefresher.registerLocks(ImmutableSet.of(backupToken));
     }
 
     /**
-     * Completes backup for the given set of namespaces.
+     * Completes backup for the given set of atlas services.
      * This will store metadata about the completed backup via the BackupPersister.
      *
-     * In order to do this, we must unlock the immutable timestamp for each namespace. If {@link #prepareBackup(Set)}
+     * In order to do this, we must unlock the immutable timestamp for each atlas service. If {@link #prepareBackup(Set)}
      * was not called, we will not have a record of the in-progress backup (and will not have been refreshing
-     * its lock anyway). Thus, we attempt to complete backup only for those namespaces where we have the in-progress
+     * its lock anyway). Thus, we attempt to complete backup only for those atlas services where we have the in-progress
      * backup stored.
      *
-     * @return the namespaces whose backups were successfully completed
+     * @return the atlas services whose backups were successfully completed
      */
-    public Set<Namespace> completeBackup(Set<Namespace> namespaces) {
-        Set<InProgressBackupToken> tokens = namespaces.stream()
+    public Set<AtlasService> completeBackup(Set<AtlasService> atlasServices) {
+        Set<InProgressBackupToken> tokens = atlasServices.stream()
                 .map(inProgressBackups::remove)
                 .filter(Objects::nonNull)
                 .collect(Collectors.toSet());
         lockRefresher.unregisterLocks(tokens);
 
-        Set<Namespace> namespacesWithInProgressBackups =
-                tokens.stream().map(InProgressBackupToken::getNamespace).collect(Collectors.toSet());
-        if (tokens.size() < namespaces.size()) {
-            Set<Namespace> namespacesWithNoInProgressBackup =
-                    Sets.difference(namespaces, namespacesWithInProgressBackups);
+        Set<AtlasService> atlasServicesWithInProgressBackups =
+                tokens.stream().map(InProgressBackupToken::getAtlasService).collect(Collectors.toSet());
+        if (tokens.size() < atlasServices.size()) {
+            Set<AtlasService> atlasServicesWithNoInProgressBackup =
+                    Sets.difference(atlasServices, atlasServicesWithInProgressBackups);
             log.error(
-                    "In progress backups were not found for some namespaces. We will not complete backup for these.",
-                    SafeArg.of("numNamespacesWithBackup", tokens.size()),
-                    SafeArg.of("numNamespacesWithoutBackup", namespacesWithNoInProgressBackup.size()),
-                    SafeArg.of("namespacesWithoutBackup", namespacesWithNoInProgressBackup),
-                    SafeArg.of("allRequestedNamespaces", namespaces));
+                    "In progress backups were not found for some atlasServices. We will not complete backup for these.",
+                    SafeArg.of("numAtlasServicesWithBackup", tokens.size()),
+                    SafeArg.of("numAtlasServicesWithoutBackup", atlasServicesWithNoInProgressBackup.size()),
+                    SafeArg.of("atlasServicesWithoutBackup", atlasServicesWithNoInProgressBackup),
+                    SafeArg.of("allRequestedAtlasServices", atlasServices));
         }
 
         CompleteBackupRequest request = CompleteBackupRequest.of(tokens);
         CompleteBackupResponse response = atlasBackupClient.completeBackup(authHeader, request);
 
-        if (response.getSuccessfulBackups().size() < namespacesWithInProgressBackups.size()) {
-            Set<Namespace> successfulNamespaces = response.getSuccessfulBackups().stream()
-                    .map(CompletedBackup::getNamespace)
+        if (response.getSuccessfulBackups().size() < atlasServicesWithInProgressBackups.size()) {
+            Set<AtlasService> successfulAtlasServices = response.getSuccessfulBackups().stream()
+                    .map(CompletedBackup::getAtlasService)
                     .collect(Collectors.toSet());
-            Set<Namespace> failedNamespaces = Sets.difference(namespacesWithInProgressBackups, successfulNamespaces);
+            Set<AtlasService> failedAtlasServices =
+                    Sets.difference(atlasServicesWithInProgressBackups, successfulAtlasServices);
             log.error(
-                    "Backup did not complete successfully for all namespaces. Check TimeLock logs to debug.",
-                    SafeArg.of("failedNamespaces", failedNamespaces),
-                    SafeArg.of("successfulNamespaces", successfulNamespaces),
-                    SafeArg.of("namespacesWithoutBackup", namespacesWithInProgressBackups));
+                    "Backup did not complete successfully for all atlasServices. Check TimeLock logs to debug.",
+                    SafeArg.of("failedAtlasServices", failedAtlasServices),
+                    SafeArg.of("successfulAtlasServices", successfulAtlasServices),
+                    SafeArg.of("atlasServicesWithoutBackup", atlasServicesWithInProgressBackups));
         }
 
         return response.getSuccessfulBackups().stream()
                 .peek(coordinationServiceRecorder::storeFastForwardState)
                 .peek(backupPersister::storeCompletedBackup)
-                .map(CompletedBackup::getNamespace)
+                .map(CompletedBackup::getAtlasService)
                 .collect(Collectors.toSet());
     }
 }

--- a/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/AtlasBackupService.java
+++ b/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/AtlasBackupService.java
@@ -60,7 +60,7 @@ import java.util.stream.Collectors;
 /**
  *  Service for Atlas backup tasks.
  *  While a single backup operation may encompass multiple namespaces, it is essential that each namespace in a given
- *  request corresponds to a single TimeLock service, since we support a single AtlasBackupClient (this exists on
+ *  request corresponds to the same TimeLock service, since we support a single AtlasBackupClient (this exists on
  *  TimeLock rather than on the backup client side). If the set of AtlasServices in a given request contains
  *  duplicated namespaces (e.g. {(123, namespace), (456, namespace)}), then a SafeIllegalArgumentException will be
  *  thrown.

--- a/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/AtlasRestoreService.java
+++ b/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/AtlasRestoreService.java
@@ -68,7 +68,7 @@ import java.util.stream.Collectors;
 /**
  *  Service for Atlas restore tasks.
  *  While a single restore operation may encompass multiple namespaces, it is essential that each namespace in a given
- *  request corresponds to a single TimeLock service, since we support a single AtlasRestoreClient and
+ *  request corresponds to the same TimeLock service, since we support a single AtlasRestoreClient and
  *  TimelockManagementService (these both exist on TimeLock rather than on the backup client side).
  *  If the set of AtlasServices in a given request contains duplicated namespaces
  *  (e.g. {(123, namespace), (456, namespace)}), then a SafeIllegalArgumentException will be thrown.

--- a/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/BackupPersister.java
+++ b/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/BackupPersister.java
@@ -16,22 +16,22 @@
 
 package com.palantir.atlasdb.backup;
 
+import com.palantir.atlasdb.backup.api.AtlasService;
 import com.palantir.atlasdb.backup.api.CompletedBackup;
 import com.palantir.atlasdb.backup.api.InProgressBackupToken;
 import com.palantir.atlasdb.internalschema.InternalSchemaMetadataState;
-import com.palantir.atlasdb.timelock.api.Namespace;
 import java.util.Optional;
 
 interface BackupPersister {
-    void storeSchemaMetadata(Namespace namespace, InternalSchemaMetadataState internalSchemaMetadataState);
+    void storeSchemaMetadata(AtlasService service, InternalSchemaMetadataState internalSchemaMetadataState);
 
-    Optional<InternalSchemaMetadataState> getSchemaMetadata(Namespace namespace);
+    Optional<InternalSchemaMetadataState> getSchemaMetadata(AtlasService service);
 
     void storeCompletedBackup(CompletedBackup completedBackup);
 
-    Optional<CompletedBackup> getCompletedBackup(Namespace namespace);
+    Optional<CompletedBackup> getCompletedBackup(AtlasService service);
 
     void storeImmutableTimestamp(InProgressBackupToken inProgressBackupToken);
 
-    Optional<Long> getImmutableTimestamp(Namespace namespace);
+    Optional<Long> getImmutableTimestamp(AtlasService service);
 }

--- a/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/InMemoryBackupPersister.java
+++ b/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/InMemoryBackupPersister.java
@@ -16,18 +16,18 @@
 
 package com.palantir.atlasdb.backup;
 
+import com.palantir.atlasdb.backup.api.AtlasService;
 import com.palantir.atlasdb.backup.api.CompletedBackup;
 import com.palantir.atlasdb.backup.api.InProgressBackupToken;
 import com.palantir.atlasdb.internalschema.InternalSchemaMetadataState;
-import com.palantir.atlasdb.timelock.api.Namespace;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 class InMemoryBackupPersister implements BackupPersister {
-    private final Map<Namespace, Long> immutableTimestamps;
-    private final Map<Namespace, InternalSchemaMetadataState> schemaMetadatas;
-    private final Map<Namespace, CompletedBackup> completedBackups;
+    private final Map<AtlasService, Long> immutableTimestamps;
+    private final Map<AtlasService, InternalSchemaMetadataState> schemaMetadatas;
+    private final Map<AtlasService, CompletedBackup> completedBackups;
 
     InMemoryBackupPersister() {
         schemaMetadatas = new ConcurrentHashMap<>();
@@ -36,32 +36,33 @@ class InMemoryBackupPersister implements BackupPersister {
     }
 
     @Override
-    public void storeSchemaMetadata(Namespace namespace, InternalSchemaMetadataState internalSchemaMetadataState) {
-        schemaMetadatas.put(namespace, internalSchemaMetadataState);
+    public void storeSchemaMetadata(
+            AtlasService atlasService, InternalSchemaMetadataState internalSchemaMetadataState) {
+        schemaMetadatas.put(atlasService, internalSchemaMetadataState);
     }
 
     @Override
-    public Optional<InternalSchemaMetadataState> getSchemaMetadata(Namespace namespace) {
-        return Optional.ofNullable(schemaMetadatas.get(namespace));
+    public Optional<InternalSchemaMetadataState> getSchemaMetadata(AtlasService atlasService) {
+        return Optional.ofNullable(schemaMetadatas.get(atlasService));
     }
 
     @Override
     public void storeCompletedBackup(CompletedBackup completedBackup) {
-        completedBackups.put(completedBackup.getNamespace(), completedBackup);
+        completedBackups.put(completedBackup.getAtlasService(), completedBackup);
     }
 
     @Override
-    public Optional<CompletedBackup> getCompletedBackup(Namespace namespace) {
-        return Optional.ofNullable(completedBackups.get(namespace));
+    public Optional<CompletedBackup> getCompletedBackup(AtlasService atlasService) {
+        return Optional.ofNullable(completedBackups.get(atlasService));
     }
 
     @Override
     public void storeImmutableTimestamp(InProgressBackupToken inProgressBackupToken) {
-        immutableTimestamps.put(inProgressBackupToken.getNamespace(), inProgressBackupToken.getImmutableTimestamp());
+        immutableTimestamps.put(inProgressBackupToken.getAtlasService(), inProgressBackupToken.getImmutableTimestamp());
     }
 
     @Override
-    public Optional<Long> getImmutableTimestamp(Namespace namespace) {
-        return Optional.ofNullable(immutableTimestamps.get(namespace));
+    public Optional<Long> getImmutableTimestamp(AtlasService atlasService) {
+        return Optional.ofNullable(immutableTimestamps.get(atlasService));
     }
 }

--- a/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/RestoreRequest.java
+++ b/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/RestoreRequest.java
@@ -18,16 +18,16 @@ package com.palantir.atlasdb.backup;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.palantir.atlasdb.timelock.api.Namespace;
+import com.palantir.atlasdb.backup.api.AtlasService;
 import org.immutables.value.Value;
 
 @JsonDeserialize(as = ImmutableRestoreRequest.class)
 @JsonSerialize(as = ImmutableRestoreRequest.class)
 @Value.Immutable
 public interface RestoreRequest {
-    Namespace oldNamespace();
+    AtlasService oldAtlasService();
 
-    Namespace newNamespace();
+    AtlasService newAtlasService();
 
     class Builder extends ImmutableRestoreRequest.Builder {}
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/backup/ClosingKvsRunner.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/backup/ClosingKvsRunner.java
@@ -16,20 +16,20 @@
 
 package com.palantir.atlasdb.backup;
 
+import com.palantir.atlasdb.backup.api.AtlasService;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
-import com.palantir.atlasdb.timelock.api.Namespace;
 import java.util.function.Function;
 
 final class ClosingKvsRunner implements KvsRunner {
-    private final Function<Namespace, KeyValueService> keyValueServiceFactory;
+    private final Function<AtlasService, KeyValueService> keyValueServiceFactory;
 
-    ClosingKvsRunner(Function<Namespace, KeyValueService> keyValueServiceFactory) {
+    ClosingKvsRunner(Function<AtlasService, KeyValueService> keyValueServiceFactory) {
         this.keyValueServiceFactory = keyValueServiceFactory;
     }
 
     @Override
-    public <T> T run(Namespace namespace, Function<KeyValueService, T> function) {
-        try (KeyValueService kvs = keyValueServiceFactory.apply(namespace)) {
+    public <T> T run(AtlasService atlasService, Function<KeyValueService, T> function) {
+        try (KeyValueService kvs = keyValueServiceFactory.apply(atlasService)) {
             return function.apply(kvs);
         }
     }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/backup/KvsRunner.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/backup/KvsRunner.java
@@ -16,15 +16,15 @@
 
 package com.palantir.atlasdb.backup;
 
+import com.palantir.atlasdb.backup.api.AtlasService;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
-import com.palantir.atlasdb.timelock.api.Namespace;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
 import java.util.function.Function;
 
 public interface KvsRunner {
-    <T> T run(Namespace namespace, Function<KeyValueService, T> function);
+    <T> T run(AtlasService atlasService, Function<KeyValueService, T> function);
 
-    static KvsRunner create(Function<Namespace, KeyValueService> kvsFactory) {
+    static KvsRunner create(Function<AtlasService, KeyValueService> kvsFactory) {
         return new ClosingKvsRunner(kvsFactory);
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/backup/NonClosingKvsRunner.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/backup/NonClosingKvsRunner.java
@@ -16,8 +16,8 @@
 
 package com.palantir.atlasdb.backup;
 
+import com.palantir.atlasdb.backup.api.AtlasService;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
-import com.palantir.atlasdb.timelock.api.Namespace;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
 import java.util.function.Function;
 
@@ -29,7 +29,7 @@ final class NonClosingKvsRunner implements KvsRunner {
     }
 
     @Override
-    public <T> T run(Namespace _namespace, Function<KeyValueService, T> function) {
+    public <T> T run(AtlasService _atlasService, Function<KeyValueService, T> function) {
         return function.apply(txnManager.getKeyValueService());
     }
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
@@ -31,6 +31,7 @@ import com.palantir.atlasdb.backup.ExternalBackupPersister;
 import com.palantir.atlasdb.backup.SimpleBackupAndRestoreResource;
 import com.palantir.atlasdb.backup.api.AtlasBackupClient;
 import com.palantir.atlasdb.backup.api.AtlasRestoreClient;
+import com.palantir.atlasdb.backup.api.AtlasService;
 import com.palantir.atlasdb.blob.BlobSchema;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cleaner.CleanupFollower;
@@ -58,7 +59,6 @@ import com.palantir.atlasdb.sweep.queue.TargetedSweepFollower;
 import com.palantir.atlasdb.sweep.queue.TargetedSweeper;
 import com.palantir.atlasdb.table.description.Schema;
 import com.palantir.atlasdb.timelock.BackupTimeLockServiceView;
-import com.palantir.atlasdb.timelock.api.Namespace;
 import com.palantir.atlasdb.timelock.api.management.TimeLockManagementService;
 import com.palantir.atlasdb.timestamp.SimpleEteTimestampResource;
 import com.palantir.atlasdb.todo.SimpleTodoResource;
@@ -166,7 +166,7 @@ public class AtlasDbEteServer extends Application<AtlasDbEteConfiguration> {
 
         Path backupFolder = Paths.get("/var/data/backup");
         Files.createDirectories(backupFolder);
-        Function<Namespace, Path> backupFolderFactory = _unused -> backupFolder;
+        Function<AtlasService, Path> backupFolderFactory = _unused -> backupFolder;
         ExternalBackupPersister externalBackupPersister = new ExternalBackupPersister(backupFolderFactory);
 
         Function<String, BackupTimeLockServiceView> timelockServices =

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/backup/BackupAndRestoreResource.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/backup/BackupAndRestoreResource.java
@@ -16,8 +16,8 @@
 
 package com.palantir.atlasdb.backup;
 
+import com.palantir.atlasdb.backup.api.AtlasService;
 import com.palantir.atlasdb.backup.api.CompletedBackup;
-import com.palantir.atlasdb.timelock.api.Namespace;
 import com.palantir.processors.AutoDelegate;
 import java.util.Optional;
 import java.util.Set;
@@ -34,35 +34,35 @@ public interface BackupAndRestoreResource {
     @Path("/prepare-backup")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    Set<Namespace> prepareBackup(Set<Namespace> namespaces);
+    Set<AtlasService> prepareBackup(Set<AtlasService> atlasServices);
 
     @POST
     @Path("/complete-backup")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    Set<Namespace> completeBackup(Set<Namespace> namespaces);
+    Set<AtlasService> completeBackup(Set<AtlasService> atlasServices);
 
     @POST
     @Path("/prepare-restore")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    Set<Namespace> prepareRestore(RestoreRequestWithId restoreRequestWithId);
+    Set<AtlasService> prepareRestore(RestoreRequestWithId restoreRequestWithId);
 
     @POST
     @Path("/complete-restore")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    Set<Namespace> completeRestore(RestoreRequestWithId restoreRequestWithId);
+    Set<AtlasService> completeRestore(RestoreRequestWithId restoreRequestWithId);
 
     @POST
     @Path("/immutable-ts")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    Optional<Long> getStoredImmutableTimestamp(Namespace namespace);
+    Optional<Long> getStoredImmutableTimestamp(AtlasService atlasService);
 
     @POST
     @Path("/ff-ts")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    Optional<CompletedBackup> getStoredBackup(Namespace namespace);
+    Optional<CompletedBackup> getStoredBackup(AtlasService atlasService);
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/backup/SimpleBackupAndRestoreResource.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/backup/SimpleBackupAndRestoreResource.java
@@ -17,8 +17,8 @@
 package com.palantir.atlasdb.backup;
 
 import com.google.common.collect.ImmutableSet;
+import com.palantir.atlasdb.backup.api.AtlasService;
 import com.palantir.atlasdb.backup.api.CompletedBackup;
-import com.palantir.atlasdb.timelock.api.Namespace;
 import java.util.Optional;
 import java.util.Set;
 
@@ -37,32 +37,32 @@ public class SimpleBackupAndRestoreResource implements BackupAndRestoreResource 
     }
 
     @Override
-    public Set<Namespace> prepareBackup(Set<Namespace> namespaces) {
-        return atlasBackupService.prepareBackup(namespaces);
+    public Set<AtlasService> prepareBackup(Set<AtlasService> atlasServices) {
+        return atlasBackupService.prepareBackup(atlasServices);
     }
 
     @Override
-    public Set<Namespace> completeBackup(Set<Namespace> namespaces) {
-        return atlasBackupService.completeBackup(namespaces);
+    public Set<AtlasService> completeBackup(Set<AtlasService> atlasServices) {
+        return atlasBackupService.completeBackup(atlasServices);
     }
 
     @Override
-    public Set<Namespace> prepareRestore(RestoreRequestWithId request) {
+    public Set<AtlasService> prepareRestore(RestoreRequestWithId request) {
         return atlasRestoreService.prepareRestore(ImmutableSet.of(request.restoreRequest()), request.backupId());
     }
 
     @Override
-    public Set<Namespace> completeRestore(RestoreRequestWithId request) {
+    public Set<AtlasService> completeRestore(RestoreRequestWithId request) {
         return atlasRestoreService.completeRestore(ImmutableSet.of(request.restoreRequest()), request.backupId());
     }
 
     @Override
-    public Optional<Long> getStoredImmutableTimestamp(Namespace namespace) {
-        return externalBackupPersister.getImmutableTimestamp(namespace);
+    public Optional<Long> getStoredImmutableTimestamp(AtlasService atlasService) {
+        return externalBackupPersister.getImmutableTimestamp(atlasService);
     }
 
     @Override
-    public Optional<CompletedBackup> getStoredBackup(Namespace namespace) {
-        return externalBackupPersister.getCompletedBackup(namespace);
+    public Optional<CompletedBackup> getStoredBackup(AtlasService atlasService) {
+        return externalBackupPersister.getCompletedBackup(atlasService);
     }
 }

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/BackupAndRestoreEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/BackupAndRestoreEteTest.java
@@ -23,7 +23,9 @@ import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.backup.BackupAndRestoreResource;
 import com.palantir.atlasdb.backup.RestoreRequest;
 import com.palantir.atlasdb.backup.RestoreRequestWithId;
+import com.palantir.atlasdb.backup.api.AtlasService;
 import com.palantir.atlasdb.backup.api.CompletedBackup;
+import com.palantir.atlasdb.backup.api.ServiceId;
 import com.palantir.atlasdb.timelock.api.Namespace;
 import com.palantir.atlasdb.timestamp.EteTimestampResource;
 import com.palantir.atlasdb.todo.ImmutableTodo;
@@ -39,7 +41,9 @@ import org.junit.Test;
 public class BackupAndRestoreEteTest {
     private static final Todo TODO = ImmutableTodo.of("some stuff to do");
     private static final Namespace NAMESPACE = Namespace.of("atlasete");
+    private static final AtlasService ATLAS_SERVICE = AtlasService.of(ServiceId.of("a"), NAMESPACE);
     private static final ImmutableSet<Namespace> NAMESPACES = ImmutableSet.of(NAMESPACE);
+    private static final ImmutableSet<AtlasService> ATLAS_SERVICES = ImmutableSet.of(ATLAS_SERVICE);
 
     private final TodoResource todoClient = EteSetup.createClientToSingleNode(TodoResource.class);
     private final BackupAndRestoreResource backupResource =
@@ -49,29 +53,29 @@ public class BackupAndRestoreEteTest {
     @Test
     public void canPrepareBackup() {
         addTodo();
-        assertThat(backupResource.getStoredImmutableTimestamp(NAMESPACE)).isEmpty();
+        assertThat(backupResource.getStoredImmutableTimestamp(ATLAS_SERVICE)).isEmpty();
 
-        Set<Namespace> preparedNamespaces = backupResource.prepareBackup(NAMESPACES);
-        assertThat(preparedNamespaces).containsExactly(NAMESPACE);
+        Set<AtlasService> preparedAtlasServices = backupResource.prepareBackup(ATLAS_SERVICES);
+        assertThat(preparedAtlasServices).containsExactly(ATLAS_SERVICE);
 
         // verify we persisted the immutable timestamp to disk
-        assertThat(backupResource.getStoredImmutableTimestamp(NAMESPACE)).isNotEmpty();
+        assertThat(backupResource.getStoredImmutableTimestamp(ATLAS_SERVICE)).isNotEmpty();
     }
 
     @Test
     public void canCompletePreparedBackup() {
         addTodo();
-        backupResource.prepareBackup(NAMESPACES);
+        backupResource.prepareBackup(ATLAS_SERVICES);
 
         Long immutableTimestamp =
-                backupResource.getStoredImmutableTimestamp(NAMESPACE).orElseThrow();
+                backupResource.getStoredImmutableTimestamp(ATLAS_SERVICE).orElseThrow();
 
-        assertThat(backupResource.getStoredBackup(NAMESPACE)).isEmpty();
+        assertThat(backupResource.getStoredBackup(ATLAS_SERVICE)).isEmpty();
 
-        Set<Namespace> completedNamespaces = backupResource.completeBackup(NAMESPACES);
-        assertThat(completedNamespaces).containsExactly(NAMESPACE);
+        Set<AtlasService> completedAtlasServices = backupResource.completeBackup(ATLAS_SERVICES);
+        assertThat(completedAtlasServices).containsExactly(ATLAS_SERVICE);
 
-        Optional<CompletedBackup> storedBackup = backupResource.getStoredBackup(NAMESPACE);
+        Optional<CompletedBackup> storedBackup = backupResource.getStoredBackup(ATLAS_SERVICE);
         assertThat(storedBackup).isNotEmpty();
         assertThat(storedBackup.get().getImmutableTimestamp()).isEqualTo(immutableTimestamp);
     }
@@ -79,27 +83,27 @@ public class BackupAndRestoreEteTest {
     @Test
     public void canPrepareAndCompleteRestore() {
         addTodo();
-        backupResource.prepareBackup(NAMESPACES);
-        backupResource.completeBackup(NAMESPACES);
+        backupResource.prepareBackup(ATLAS_SERVICES);
+        backupResource.completeBackup(ATLAS_SERVICES);
 
         assertThat(timestampClient.getFreshTimestamp()).isGreaterThan(0L);
 
         String backupId = "backupId";
         RestoreRequest restoreRequest = RestoreRequest.builder()
-                .oldNamespace(NAMESPACE)
-                .newNamespace(NAMESPACE)
+                .oldAtlasService(ATLAS_SERVICE)
+                .newAtlasService(ATLAS_SERVICE)
                 .build();
-        Set<Namespace> preparedNamespaces =
+        Set<AtlasService> preparedAtlasServices =
                 backupResource.prepareRestore(RestoreRequestWithId.of(restoreRequest, backupId));
-        assertThat(preparedNamespaces).containsExactly(NAMESPACE);
+        assertThat(preparedAtlasServices).containsExactly(ATLAS_SERVICE);
 
         // verify TimeLock is disabled
         assertThatRemoteExceptionThrownBy(timestampClient::getFreshTimestamp)
                 .isGeneratedFromErrorType(ErrorType.INTERNAL);
 
-        Set<Namespace> completedNamespaces =
+        Set<AtlasService> completedAtlasServices =
                 backupResource.completeRestore(RestoreRequestWithId.of(restoreRequest, backupId));
-        assertThat(completedNamespaces).containsExactly(NAMESPACE);
+        assertThat(completedAtlasServices).containsExactly(ATLAS_SERVICE);
 
         // verify TimeLock is re-enabled
         assertThat(timestampClient.getFreshTimestamp()).isGreaterThan(0L);

--- a/timelock-api/src/main/conjure/timelock-api.yml
+++ b/timelock-api/src/main/conjure/timelock-api.yml
@@ -122,24 +122,40 @@ types:
         fields:
           leaderTimes: map<Namespace, LeaderTime>
       # backup and restore
+      ServiceId:
+        package: com.palantir.atlasdb.backup.api
+        alias: string
+      AtlasService:
+        package: com.palantir.atlasdb.backup.api
+        fields:
+          serviceId: ServiceId
+          namespace: Namespace
       InProgressBackupToken:
         package: com.palantir.atlasdb.backup.api
         fields:
-          namespace: Namespace
+          atlasService: AtlasService
           lockToken: LockToken
           immutableTimestamp: Long
           backupStartTimestamp: Long
       CompletedBackup:
         package: com.palantir.atlasdb.backup.api
         fields:
-          namespace: Namespace
+          atlasService: AtlasService
           immutableTimestamp: Long
           backupStartTimestamp: Long
           backupEndTimestamp: Long
+      RestoredService:
+        package: com.palantir.atlasdb.backup.api
+        fields:
+          restoredAtlasService: AtlasService
+          backupRestoredFrom: CompletedBackup
+        docs: |
+          Mapping from the atlas service being restored into, to the backup we're restoring.
+          Note that the atlas service might not be the same as the atlas service originally backed up.
       PrepareBackupRequest:
         package: com.palantir.atlasdb.backup.api
         fields:
-          namespaces: set<Namespace>
+          atlasServices: set<AtlasService>
       PrepareBackupResponse:
         package: com.palantir.atlasdb.backup.api
         fields:
@@ -163,15 +179,12 @@ types:
       CompleteRestoreRequest:
         package: com.palantir.atlasdb.backup.api
         fields:
-          completedBackups:
-            type: map<Namespace, CompletedBackup>
-            docs: |
-              Mapping from the namespace being restored into, to the backup we're restoring.
-              Note that the namespace might not be the same as the namespace originally backed up.
+          restoredServices:
+            type: set<RestoredService>
       CompleteRestoreResponse:
         package: com.palantir.atlasdb.backup.api
         fields:
-          successfulNamespaces: set<Namespace>
+          successfulServices: set<AtlasService>
 
 services:
   AtlasBackupClient:

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/backup/AtlasBackupResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/backup/AtlasBackupResource.java
@@ -146,7 +146,6 @@ public class AtlasBackupResource implements UndertowAtlasBackupClient {
     }
 
     private ListenableFuture<Optional<RefreshLockResponseV2>> refreshBackupAsync(InProgressBackupToken token) {
-        // TODO(gs): handle AtlasService -> Timelock???
         Namespace namespace = token.getAtlasService().getNamespace();
         return Futures.transform(
                 timelock(namespace).refreshLockLeases(ImmutableSet.of(token.getLockToken())),
@@ -222,7 +221,6 @@ public class AtlasBackupResource implements UndertowAtlasBackupClient {
 
     private CompletedBackup fetchFastForwardTimestamp(InProgressBackupToken backupToken) {
         AtlasService atlasService = backupToken.getAtlasService();
-        // TODO(gs): this is DEFINITELY broken
         long fastForwardTimestamp = timelock(atlasService.getNamespace()).getFreshTimestamp();
         return CompletedBackup.builder()
                 .atlasService(atlasService)


### PR DESCRIPTION
**Goals (and why)**:
Some deployments have multiple TimeLock instances, and these instances can have duplicated namespace names (e.g. a `test-atlas-client`  namespace on both `production` and `staging` TimeLock services.
The internal backup service was encountering validation failures in such an environment, because a `Function<Namespace, KeyValueService>` would lead to collisions.

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
The Atlas backup and restore services now take AtlasService arguments rather than Namespace arguments. An AtlasService is a Namespace paired with a ServiceId (a String).
==COMMIT_MSG==

**Implementation Description (bullets)**:
- Added AtlasService (and a few related conjure objects)
- Propagated this throughout the backup/restore ecosystem

**Testing (What was existing testing like?  What have you done to improve it?)**:
Many unit/ETE tests changed

**Concerns (what feedback would you like?)**:
We have a limitation here: each AtlasBackupService and AtlasRestoreService instance knows about a single AtlasBackupClient / AtlasRestoreClient (on the TimeLock side). Thus, for deployments with multiple TL instances, we will need to create multiple AtlasBackup/RestoreService instances. The responsibility for creating the correct mapping will exist on the internal backup service's side, and we will only be able to detect issues in certain instances (see javadoc).

**Where should we start reviewing?**: It's mostly renames, go top down I guess?

**Priority (whenever / two weeks / yesterday)**: ASAP

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
