### PR TITLE
[Runtime Config][Part 2b] Wiring up Cassandra Verifier

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
@@ -104,7 +104,14 @@ public class CassandraClientPoolIntegrationTest {
     public void testSanitiseReplicationFactorPassesForTheKeyspace() {
         clientPool.run(client -> {
             try {
-                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client, CASSANDRA.getConfig());
+                CassandraKeyValueServiceConfig config = CASSANDRA.getConfig();
+                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(
+                        client,
+                        config.getKeyspaceOrThrow(),
+                        config.servers(),
+                        config.replicationFactor(),
+                        config.ignoreNodeTopologyChecks(),
+                        config.ignoreDatacenterConfigurationChecks());
             } catch (TException e) {
                 fail("currentRf On Keyspace does not Match DesiredRf");
             }
@@ -116,10 +123,14 @@ public class CassandraClientPoolIntegrationTest {
     public void testSanitiseReplicationFactorFailsAfterManipulatingReplicationFactorInConfig() {
         clientPool.run(client -> {
             try {
+                CassandraKeyValueServiceConfig config = CASSANDRA.getConfig();
                 CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(
                         client,
-                        ImmutableCassandraKeyValueServiceConfig.copyOf(CASSANDRA.getConfig())
-                                .withReplicationFactor(modifiedReplicationFactor));
+                        config.getKeyspaceOrThrow(),
+                        config.servers(),
+                        modifiedReplicationFactor,
+                        config.ignoreNodeTopologyChecks(),
+                        config.ignoreDatacenterConfigurationChecks());
                 fail("currentRf On Keyspace Matches DesiredRf after manipulating the cassandra config");
             } catch (Exception e) {
                 assertReplicationFactorMismatchError(e);
@@ -133,7 +144,14 @@ public class CassandraClientPoolIntegrationTest {
         changeReplicationFactor(modifiedReplicationFactor);
         clientPool.run(client -> {
             try {
-                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client, CASSANDRA.getConfig());
+                CassandraKeyValueServiceConfig config = CASSANDRA.getConfig();
+                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(
+                        client,
+                        config.getKeyspaceOrThrow(),
+                        config.servers(),
+                        config.replicationFactor(),
+                        config.ignoreNodeTopologyChecks(),
+                        config.ignoreDatacenterConfigurationChecks());
                 fail("currentRf On Keyspace Matches DesiredRf after manipulating the cassandra keyspace");
             } catch (Exception e) {
                 assertReplicationFactorMismatchError(e);

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Range;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.containers.CassandraResource;
+import com.palantir.atlasdb.keyvalue.cassandra.CassandraVerifier.CassandraKeyspaceConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer;
 import com.palantir.atlasdb.keyvalue.cassandra.pool.HostLocation;
 import com.palantir.atlasdb.util.MetricsManager;
@@ -102,16 +103,12 @@ public class CassandraClientPoolIntegrationTest {
 
     @Test
     public void testSanitiseReplicationFactorPassesForTheKeyspace() {
+        CassandraKeyspaceConfig cassandraKeyspaceConfig = CassandraKeyspaceConfig.of(CASSANDRA.getConfig());
         clientPool.run(client -> {
             try {
-                CassandraKeyValueServiceConfig config = CASSANDRA.getConfig();
                 CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(
                         client,
-                        config.getKeyspaceOrThrow(),
-                        config.servers(),
-                        config.replicationFactor(),
-                        config.ignoreNodeTopologyChecks(),
-                        config.ignoreDatacenterConfigurationChecks());
+                        cassandraKeyspaceConfig);
             } catch (TException e) {
                 fail("currentRf On Keyspace does not Match DesiredRf");
             }
@@ -121,16 +118,14 @@ public class CassandraClientPoolIntegrationTest {
 
     @Test
     public void testSanitiseReplicationFactorFailsAfterManipulatingReplicationFactorInConfig() {
+        CassandraKeyspaceConfig cassandraKeyspaceConfig = CassandraKeyspaceConfig.of(CASSANDRA.getConfig());
+
         clientPool.run(client -> {
             try {
                 CassandraKeyValueServiceConfig config = CASSANDRA.getConfig();
                 CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(
                         client,
-                        config.getKeyspaceOrThrow(),
-                        config.servers(),
-                        modifiedReplicationFactor,
-                        config.ignoreNodeTopologyChecks(),
-                        config.ignoreDatacenterConfigurationChecks());
+                        cassandraKeyspaceConfig);
                 fail("currentRf On Keyspace Matches DesiredRf after manipulating the cassandra config");
             } catch (Exception e) {
                 assertReplicationFactorMismatchError(e);
@@ -142,16 +137,13 @@ public class CassandraClientPoolIntegrationTest {
     @Test
     public void testSanitiseReplicationFactorFailsAfterManipulatingReplicationFactorOnCassandra() throws TException {
         changeReplicationFactor(modifiedReplicationFactor);
+        CassandraKeyspaceConfig cassandraKeyspaceConfig = CassandraKeyspaceConfig.of(CASSANDRA.getConfig());
         clientPool.run(client -> {
             try {
                 CassandraKeyValueServiceConfig config = CASSANDRA.getConfig();
                 CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(
                         client,
-                        config.getKeyspaceOrThrow(),
-                        config.servers(),
-                        config.replicationFactor(),
-                        config.ignoreNodeTopologyChecks(),
-                        config.ignoreDatacenterConfigurationChecks());
+                        cassandraKeyspaceConfig);
                 fail("currentRf On Keyspace Matches DesiredRf after manipulating the cassandra keyspace");
             } catch (Exception e) {
                 assertReplicationFactorMismatchError(e);

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
@@ -106,9 +106,7 @@ public class CassandraClientPoolIntegrationTest {
         CassandraKeyspaceConfig cassandraKeyspaceConfig = CassandraKeyspaceConfig.of(CASSANDRA.getConfig());
         clientPool.run(client -> {
             try {
-                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(
-                        client,
-                        cassandraKeyspaceConfig);
+                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client, cassandraKeyspaceConfig);
             } catch (TException e) {
                 fail("currentRf On Keyspace does not Match DesiredRf");
             }
@@ -123,9 +121,7 @@ public class CassandraClientPoolIntegrationTest {
         clientPool.run(client -> {
             try {
                 CassandraKeyValueServiceConfig config = CASSANDRA.getConfig();
-                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(
-                        client,
-                        cassandraKeyspaceConfig);
+                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client, cassandraKeyspaceConfig);
                 fail("currentRf On Keyspace Matches DesiredRf after manipulating the cassandra config");
             } catch (Exception e) {
                 assertReplicationFactorMismatchError(e);
@@ -141,9 +137,7 @@ public class CassandraClientPoolIntegrationTest {
         clientPool.run(client -> {
             try {
                 CassandraKeyValueServiceConfig config = CASSANDRA.getConfig();
-                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(
-                        client,
-                        cassandraKeyspaceConfig);
+                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client, cassandraKeyspaceConfig);
                 fail("currentRf On Keyspace Matches DesiredRf after manipulating the cassandra keyspace");
             } catch (Exception e) {
                 assertReplicationFactorMismatchError(e);

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
@@ -118,11 +118,12 @@ public class CassandraClientPoolIntegrationTest {
     @Test
     public void testSanitiseReplicationFactorFailsAfterManipulatingReplicationFactorInConfig() {
         CassandraKeyspaceVerifierConfig cassandraKeyspaceVerifierConfig =
-                CassandraKeyspaceVerifierConfig.of(CASSANDRA.getConfig());
+                ImmutableCassandraKeyspaceVerifierConfig.copyOf(
+                                CassandraKeyspaceVerifierConfig.of(CASSANDRA.getConfig()))
+                        .withReplicationFactor(modifiedReplicationFactor);
 
         clientPool.run(client -> {
             try {
-                CassandraKeyValueServiceConfig config = CASSANDRA.getConfig();
                 CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client, cassandraKeyspaceVerifierConfig);
                 fail("currentRf On Keyspace Matches DesiredRf after manipulating the cassandra config");
             } catch (Exception e) {
@@ -139,7 +140,6 @@ public class CassandraClientPoolIntegrationTest {
                 CassandraKeyspaceVerifierConfig.of(CASSANDRA.getConfig());
         clientPool.run(client -> {
             try {
-                CassandraKeyValueServiceConfig config = CASSANDRA.getConfig();
                 CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client, cassandraKeyspaceVerifierConfig);
                 fail("currentRf On Keyspace Matches DesiredRf after manipulating the cassandra keyspace");
             } catch (Exception e) {

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
@@ -24,7 +24,7 @@ import com.google.common.collect.Range;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.containers.CassandraResource;
-import com.palantir.atlasdb.keyvalue.cassandra.CassandraVerifier.CassandraKeyspaceVerifierConfig;
+import com.palantir.atlasdb.keyvalue.cassandra.CassandraVerifier.CassandraVerifierConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer;
 import com.palantir.atlasdb.keyvalue.cassandra.pool.HostLocation;
 import com.palantir.atlasdb.util.MetricsManager;
@@ -103,7 +103,7 @@ public class CassandraClientPoolIntegrationTest {
 
     @Test
     public void testSanitiseReplicationFactorPassesForTheKeyspace() {
-        CassandraKeyspaceVerifierConfig verifierConfig = CassandraKeyspaceVerifierConfig.of(CASSANDRA.getConfig());
+        CassandraVerifierConfig verifierConfig = CassandraVerifierConfig.of(CASSANDRA.getConfig());
         clientPool.run(client -> {
             try {
                 CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client, verifierConfig);
@@ -116,8 +116,8 @@ public class CassandraClientPoolIntegrationTest {
 
     @Test
     public void testSanitiseReplicationFactorFailsAfterManipulatingReplicationFactorInConfig() {
-        CassandraKeyspaceVerifierConfig verifierConfig = CassandraKeyspaceVerifierConfig.builder()
-                .from(CassandraKeyspaceVerifierConfig.of(CASSANDRA.getConfig()))
+        CassandraVerifierConfig verifierConfig = CassandraVerifierConfig.builder()
+                .from(CassandraVerifierConfig.of(CASSANDRA.getConfig()))
                 .replicationFactor(modifiedReplicationFactor)
                 .build();
 
@@ -135,7 +135,7 @@ public class CassandraClientPoolIntegrationTest {
     @Test
     public void testSanitiseReplicationFactorFailsAfterManipulatingReplicationFactorOnCassandra() throws TException {
         changeReplicationFactor(modifiedReplicationFactor);
-        CassandraKeyspaceVerifierConfig verifierConfig = CassandraKeyspaceVerifierConfig.of(CASSANDRA.getConfig());
+        CassandraVerifierConfig verifierConfig = CassandraVerifierConfig.of(CASSANDRA.getConfig());
         clientPool.run(client -> {
             try {
                 CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client, verifierConfig);

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
@@ -24,7 +24,7 @@ import com.google.common.collect.Range;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.containers.CassandraResource;
-import com.palantir.atlasdb.keyvalue.cassandra.CassandraVerifier.CassandraKeyspaceConfig;
+import com.palantir.atlasdb.keyvalue.cassandra.CassandraVerifier.CassandraKeyspaceVerifierConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer;
 import com.palantir.atlasdb.keyvalue.cassandra.pool.HostLocation;
 import com.palantir.atlasdb.util.MetricsManager;
@@ -103,10 +103,11 @@ public class CassandraClientPoolIntegrationTest {
 
     @Test
     public void testSanitiseReplicationFactorPassesForTheKeyspace() {
-        CassandraKeyspaceConfig cassandraKeyspaceConfig = CassandraKeyspaceConfig.of(CASSANDRA.getConfig());
+        CassandraKeyspaceVerifierConfig cassandraKeyspaceVerifierConfig =
+                CassandraKeyspaceVerifierConfig.of(CASSANDRA.getConfig());
         clientPool.run(client -> {
             try {
-                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client, cassandraKeyspaceConfig);
+                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client, cassandraKeyspaceVerifierConfig);
             } catch (TException e) {
                 fail("currentRf On Keyspace does not Match DesiredRf");
             }
@@ -116,12 +117,13 @@ public class CassandraClientPoolIntegrationTest {
 
     @Test
     public void testSanitiseReplicationFactorFailsAfterManipulatingReplicationFactorInConfig() {
-        CassandraKeyspaceConfig cassandraKeyspaceConfig = CassandraKeyspaceConfig.of(CASSANDRA.getConfig());
+        CassandraKeyspaceVerifierConfig cassandraKeyspaceVerifierConfig =
+                CassandraKeyspaceVerifierConfig.of(CASSANDRA.getConfig());
 
         clientPool.run(client -> {
             try {
                 CassandraKeyValueServiceConfig config = CASSANDRA.getConfig();
-                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client, cassandraKeyspaceConfig);
+                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client, cassandraKeyspaceVerifierConfig);
                 fail("currentRf On Keyspace Matches DesiredRf after manipulating the cassandra config");
             } catch (Exception e) {
                 assertReplicationFactorMismatchError(e);
@@ -133,11 +135,12 @@ public class CassandraClientPoolIntegrationTest {
     @Test
     public void testSanitiseReplicationFactorFailsAfterManipulatingReplicationFactorOnCassandra() throws TException {
         changeReplicationFactor(modifiedReplicationFactor);
-        CassandraKeyspaceConfig cassandraKeyspaceConfig = CassandraKeyspaceConfig.of(CASSANDRA.getConfig());
+        CassandraKeyspaceVerifierConfig cassandraKeyspaceVerifierConfig =
+                CassandraKeyspaceVerifierConfig.of(CASSANDRA.getConfig());
         clientPool.run(client -> {
             try {
                 CassandraKeyValueServiceConfig config = CASSANDRA.getConfig();
-                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client, cassandraKeyspaceConfig);
+                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client, cassandraKeyspaceVerifierConfig);
                 fail("currentRf On Keyspace Matches DesiredRf after manipulating the cassandra keyspace");
             } catch (Exception e) {
                 assertReplicationFactorMismatchError(e);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -27,7 +27,7 @@ import com.palantir.async.initializer.AsyncInitializer;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceRuntimeConfig;
-import com.palantir.atlasdb.keyvalue.cassandra.CassandraVerifier.CassandraKeyspaceVerifierConfig;
+import com.palantir.atlasdb.keyvalue.cassandra.CassandraVerifier.CassandraVerifierConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraClientPoolMetrics;
 import com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer;
 import com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraService;
@@ -356,7 +356,7 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
 
     @VisibleForTesting
     void runOneTimeStartupChecks() {
-        CassandraKeyspaceVerifierConfig verifierConfig = CassandraKeyspaceVerifierConfig.of(config);
+        CassandraVerifierConfig verifierConfig = CassandraVerifierConfig.of(config);
         try {
             CassandraVerifier.ensureKeyspaceExistsAndIsUpToDate(this, verifierConfig);
         } catch (Exception e) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -27,6 +27,7 @@ import com.palantir.async.initializer.AsyncInitializer;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceRuntimeConfig;
+import com.palantir.atlasdb.keyvalue.cassandra.CassandraVerifier.CassandraKeyspaceConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraClientPoolMetrics;
 import com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer;
 import com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraService;
@@ -355,8 +356,9 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
 
     @VisibleForTesting
     void runOneTimeStartupChecks() {
+        CassandraKeyspaceConfig cassandraKeyspaceConfig = CassandraKeyspaceConfig.of(config);
         try {
-            CassandraVerifier.ensureKeyspaceExistsAndIsUpToDate(this, config);
+            CassandraVerifier.ensureKeyspaceExistsAndIsUpToDate(this, cassandraKeyspaceConfig);
         } catch (Exception e) {
             log.error("Startup checks failed, was not able to create the keyspace or ensure it already existed.", e);
             throw new RuntimeException(e);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -27,7 +27,7 @@ import com.palantir.async.initializer.AsyncInitializer;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceRuntimeConfig;
-import com.palantir.atlasdb.keyvalue.cassandra.CassandraVerifier.CassandraKeyspaceConfig;
+import com.palantir.atlasdb.keyvalue.cassandra.CassandraVerifier.CassandraKeyspaceVerifierConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraClientPoolMetrics;
 import com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer;
 import com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraService;
@@ -356,9 +356,9 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
 
     @VisibleForTesting
     void runOneTimeStartupChecks() {
-        CassandraKeyspaceConfig cassandraKeyspaceConfig = CassandraKeyspaceConfig.of(config);
+        CassandraKeyspaceVerifierConfig cassandraKeyspaceVerifierConfig = CassandraKeyspaceVerifierConfig.of(config);
         try {
-            CassandraVerifier.ensureKeyspaceExistsAndIsUpToDate(this, cassandraKeyspaceConfig);
+            CassandraVerifier.ensureKeyspaceExistsAndIsUpToDate(this, cassandraKeyspaceVerifierConfig);
         } catch (Exception e) {
             log.error("Startup checks failed, was not able to create the keyspace or ensure it already existed.", e);
             throw new RuntimeException(e);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -356,9 +356,9 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
 
     @VisibleForTesting
     void runOneTimeStartupChecks() {
-        CassandraKeyspaceVerifierConfig cassandraKeyspaceVerifierConfig = CassandraKeyspaceVerifierConfig.of(config);
+        CassandraKeyspaceVerifierConfig verifierConfig = CassandraKeyspaceVerifierConfig.of(config);
         try {
-            CassandraVerifier.ensureKeyspaceExistsAndIsUpToDate(this, cassandraKeyspaceVerifierConfig);
+            CassandraVerifier.ensureKeyspaceExistsAndIsUpToDate(this, verifierConfig);
         } catch (Exception e) {
             log.error("Startup checks failed, was not able to create the keyspace or ensure it already existed.", e);
             throw new RuntimeException(e);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -1989,9 +1989,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         CassandraKeyspaceConfig cassandraKeyspaceConfig = CassandraKeyspaceConfig.of(config);
         return clientPool.runWithRetry(client -> {
             try {
-                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(
-                        client,
-                        cassandraKeyspaceConfig);
+                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client, cassandraKeyspaceConfig);
                 return true;
             } catch (Exception e) {
                 log.warn("The config and Cassandra cluster do not agree on the replication factor.", e);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -67,7 +67,7 @@ import com.palantir.atlasdb.keyvalue.api.TimestampRangeDelete;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolImpl.StartupChecks;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServices.StartTsResultsCollector;
-import com.palantir.atlasdb.keyvalue.cassandra.CassandraVerifier.CassandraKeyspaceConfig;
+import com.palantir.atlasdb.keyvalue.cassandra.CassandraVerifier.CassandraKeyspaceVerifierConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.cas.CheckAndSetRunner;
 import com.palantir.atlasdb.keyvalue.cassandra.paging.RowGetter;
 import com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer;
@@ -1986,10 +1986,10 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     }
 
     private boolean doesConfigReplicationFactorMatchWithCluster() {
-        CassandraKeyspaceConfig cassandraKeyspaceConfig = CassandraKeyspaceConfig.of(config);
+        CassandraKeyspaceVerifierConfig cassandraKeyspaceVerifierConfig = CassandraKeyspaceVerifierConfig.of(config);
         return clientPool.runWithRetry(client -> {
             try {
-                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client, cassandraKeyspaceConfig);
+                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client, cassandraKeyspaceVerifierConfig);
                 return true;
             } catch (Exception e) {
                 log.warn("The config and Cassandra cluster do not agree on the replication factor.", e);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -1990,7 +1990,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     private boolean doesConfigReplicationFactorMatchWithCluster() {
         return clientPool.runWithRetry(client -> {
             try {
-                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client, this.keyspaceVerifierConfig);
+                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client, keyspaceVerifierConfig);
                 return true;
             } catch (Exception e) {
                 log.warn("The config and Cassandra cluster do not agree on the replication factor.", e);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -67,6 +67,7 @@ import com.palantir.atlasdb.keyvalue.api.TimestampRangeDelete;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolImpl.StartupChecks;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServices.StartTsResultsCollector;
+import com.palantir.atlasdb.keyvalue.cassandra.CassandraVerifier.CassandraKeyspaceConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.cas.CheckAndSetRunner;
 import com.palantir.atlasdb.keyvalue.cassandra.paging.RowGetter;
 import com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer;
@@ -1985,15 +1986,12 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     }
 
     private boolean doesConfigReplicationFactorMatchWithCluster() {
+        CassandraKeyspaceConfig cassandraKeyspaceConfig = CassandraKeyspaceConfig.of(config);
         return clientPool.runWithRetry(client -> {
             try {
                 CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(
                         client,
-                        config.getKeyspaceOrThrow(),
-                        config.servers(),
-                        config.replicationFactor(),
-                        config.ignoreNodeTopologyChecks(),
-                        config.ignoreDatacenterConfigurationChecks());
+                        cassandraKeyspaceConfig);
                 return true;
             } catch (Exception e) {
                 log.warn("The config and Cassandra cluster do not agree on the replication factor.", e);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -378,15 +378,18 @@ public final class CassandraVerifier {
     }
 
     static void currentRfOnKeyspaceMatchesDesiredRf(
-            CassandraClient client,
-            CassandraKeyspaceConfig cassandraKeyspaceConfig)
-            throws TException {
+            CassandraClient client, CassandraKeyspaceConfig cassandraKeyspaceConfig) throws TException {
         KsDef ks = client.describe_keyspace(cassandraKeyspaceConfig.keyspace());
-        Set<String> dcs =
-                sanityCheckDatacenters(client, cassandraKeyspaceConfig.servers(), cassandraKeyspaceConfig.replicationFactor(),
-                        cassandraKeyspaceConfig.ignoreNodeTopologyChecks());
+        Set<String> dcs = sanityCheckDatacenters(
+                client,
+                cassandraKeyspaceConfig.servers(),
+                cassandraKeyspaceConfig.replicationFactor(),
+                cassandraKeyspaceConfig.ignoreNodeTopologyChecks());
         sanityCheckReplicationFactor(
-                ks, cassandraKeyspaceConfig.replicationFactor(), dcs, cassandraKeyspaceConfig.ignoreDatacenterConfigurationChecks());
+                ks,
+                cassandraKeyspaceConfig.replicationFactor(),
+                dcs,
+                cassandraKeyspaceConfig.ignoreDatacenterConfigurationChecks());
     }
 
     static void sanityCheckReplicationFactor(

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -55,7 +55,7 @@ import org.immutables.value.Value;
 public final class CassandraVerifier {
     private static final SafeLogger log = SafeLoggerFactory.get(CassandraVerifier.class);
     private static final KsDef SIMPLE_RF_TEST_KS_DEF = new KsDef(
-            CassandraConstants.SIMPLE_RF_TEST_KEYSPACE, CassandraConstants.SIMPLE_STRATEGY, ImmutableList.of())
+                    CassandraConstants.SIMPLE_RF_TEST_KEYSPACE, CassandraConstants.SIMPLE_STRATEGY, ImmutableList.of())
             .setStrategy_options(ImmutableMap.of(CassandraConstants.REPLICATION_FACTOR_OPTION, "1"));
     private static final String SIMPLE_PARTITIONING_ERROR_MSG = "This cassandra cluster is running using the simple "
             + "partitioning strategy. This partitioner is not rack aware and is not intended for use on prod. "

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -50,11 +50,12 @@ import org.apache.cassandra.thrift.NotFoundException;
 import org.apache.cassandra.thrift.TokenRange;
 import org.apache.commons.lang3.Validate;
 import org.apache.thrift.TException;
+import org.immutables.value.Value;
 
 public final class CassandraVerifier {
     private static final SafeLogger log = SafeLoggerFactory.get(CassandraVerifier.class);
     private static final KsDef SIMPLE_RF_TEST_KS_DEF = new KsDef(
-                    CassandraConstants.SIMPLE_RF_TEST_KEYSPACE, CassandraConstants.SIMPLE_STRATEGY, ImmutableList.of())
+            CassandraConstants.SIMPLE_RF_TEST_KEYSPACE, CassandraConstants.SIMPLE_STRATEGY, ImmutableList.of())
             .setStrategy_options(ImmutableMap.of(CassandraConstants.REPLICATION_FACTOR_OPTION, "1"));
     private static final String SIMPLE_PARTITIONING_ERROR_MSG = "This cassandra cluster is running using the simple "
             + "partitioning strategy. This partitioner is not rack aware and is not intended for use on prod. "
@@ -76,10 +77,14 @@ public final class CassandraVerifier {
         return null;
     };
 
-    static Set<String> sanityCheckDatacenters(CassandraClient client, CassandraKeyValueServiceConfig config) {
-        return sanityCheckedDatacenters.get(config.servers(), _kvsConfig -> {
+    static Set<String> sanityCheckDatacenters(
+            CassandraClient client,
+            CassandraServersConfig cassandraServersConfig,
+            int replicationFactor,
+            boolean ignoreNodeTopologyChecks) {
+        return sanityCheckedDatacenters.get(cassandraServersConfig, _kvsConfig -> {
             try {
-                return sanityCheckDatacentersInternal(client, config);
+                return sanityCheckDatacentersInternal(client, replicationFactor, ignoreNodeTopologyChecks);
             } catch (TException e) {
                 throw Throwables.throwUncheckedException(e);
             }
@@ -87,7 +92,7 @@ public final class CassandraVerifier {
     }
 
     private static Set<String> sanityCheckDatacentersInternal(
-            CassandraClient client, CassandraKeyValueServiceConfig config) throws TException {
+            CassandraClient client, int replicationFactor, boolean ignoreNodeTopologyChecks) throws TException {
         createSimpleRfTestKeyspaceIfNotExists(client);
 
         Multimap<String, String> datacenterToRack = HashMultimap.create();
@@ -99,9 +104,10 @@ public final class CassandraVerifier {
             }
         }
 
-        if (clusterHasExactlyOneDatacenter(datacenterToRack) && config.replicationFactor() > 1) {
-            checkNodeTopologyIsSet(config, datacenterToRack);
-            checkMoreRacksThanRfOrFewerHostsThanRf(config, hosts, datacenterToRack);
+        if (clusterHasExactlyOneDatacenter(datacenterToRack) && replicationFactor > 1) {
+            checkNodeTopologyIsSet(datacenterToRack, ignoreNodeTopologyChecks);
+            checkMoreRacksThanRfOrFewerHostsThanRf(
+                    hosts, replicationFactor, datacenterToRack, ignoreNodeTopologyChecks);
         }
 
         return datacenterToRack.keySet();
@@ -124,8 +130,11 @@ public final class CassandraVerifier {
     }
 
     private static void checkMoreRacksThanRfOrFewerHostsThanRf(
-            CassandraKeyValueServiceConfig config, Set<String> hosts, Multimap<String, String> dcRack) {
-        if (dcRack.values().size() < config.replicationFactor() && hosts.size() > config.replicationFactor()) {
+            Set<String> hosts,
+            int replicationFactor,
+            Multimap<String, String> dcRack,
+            boolean ignoreNodeTopologyChecks) {
+        if (dcRack.values().size() < replicationFactor && hosts.size() > replicationFactor) {
             logErrorOrThrow(
                     "The cassandra cluster only has one DC, "
                             + "and is set up with less racks than the desired number of replicas, "
@@ -134,11 +143,11 @@ public final class CassandraVerifier {
                             + "would not be placed correctly for the failure tolerance you want. "
                             + "If you fully understand how NetworkTopology replica placement strategy will be placing "
                             + "your replicas, feel free to set the 'ignoreNodeTopologyChecks' KVS config option.",
-                    config.ignoreNodeTopologyChecks());
+                    ignoreNodeTopologyChecks);
         }
     }
 
-    private static void checkNodeTopologyIsSet(CassandraKeyValueServiceConfig config, Multimap<String, String> dcRack) {
+    private static void checkNodeTopologyIsSet(Multimap<String, String> dcRack, boolean ignoreNodeTopologyChecks) {
         if (clusterHasExactlyOneRack(dcRack)) {
             String datacenter = Iterables.getOnlyElement(dcRack.keySet());
             String rack = Iterables.getOnlyElement(dcRack.values());
@@ -149,7 +158,7 @@ public final class CassandraVerifier {
                                 + "before running with a replication factor higher than 1. "
                                 + "If you're running in some sort of environment where nodes have no known correlated "
                                 + "failure patterns, you can set the 'ignoreNodeTopologyChecks' KVS config option.",
-                        config.ignoreNodeTopologyChecks());
+                        ignoreNodeTopologyChecks);
             }
         }
     }
@@ -193,28 +202,31 @@ public final class CassandraVerifier {
         }
     }
 
-    static void ensureKeyspaceExistsAndIsUpToDate(CassandraClientPool clientPool, CassandraKeyValueServiceConfig config)
-            throws TException {
-        createKeyspace(config);
-        updateExistingKeyspace(clientPool, config);
+    static void ensureKeyspaceExistsAndIsUpToDate(
+            CassandraClientPool clientPool, CassandraKeyspaceConfig cassandraKeyspaceConfig) throws TException {
+        createKeyspace(cassandraKeyspaceConfig);
+        updateExistingKeyspace(clientPool, cassandraKeyspaceConfig);
     }
 
-    private static void createKeyspace(CassandraKeyValueServiceConfig config) throws TException {
+    private static void createKeyspace(CassandraKeyspaceConfig cassandraKeyspaceConfig) throws TException {
         // We can't use the pool yet because it does things like setting the connection's keyspace for us
-        if (!attemptToCreateKeyspace(config)) {
+        if (!attemptToCreateKeyspace(cassandraKeyspaceConfig)) {
             throw new TException("No host tried was able to create the keyspace requested.");
         }
     }
 
-    private static boolean attemptToCreateKeyspace(CassandraKeyValueServiceConfig config) {
-        Set<InetSocketAddress> thriftHosts = config.servers().accept(new ThriftHostsExtractingVisitor());
+    private static boolean attemptToCreateKeyspace(CassandraKeyspaceConfig cassandraKeyspaceConfig) {
+        Set<InetSocketAddress> thriftHosts =
+                cassandraKeyspaceConfig.servers().accept(new ThriftHostsExtractingVisitor());
 
-        return thriftHosts.stream().anyMatch(host -> attemptToCreateIfNotExists(config, host));
+        return thriftHosts.stream().anyMatch(host -> attemptToCreateIfNotExists(host, cassandraKeyspaceConfig));
     }
 
-    private static boolean attemptToCreateIfNotExists(CassandraKeyValueServiceConfig config, InetSocketAddress host) {
+    private static boolean attemptToCreateIfNotExists(
+            InetSocketAddress host, CassandraKeyspaceConfig cassandraKeyspaceConfig) {
         try {
-            return keyspaceAlreadyExists(host, config) || attemptToCreateKeyspaceOnHost(host, config);
+            return keyspaceAlreadyExists(host, cassandraKeyspaceConfig)
+                    || attemptToCreateKeyspaceOnHost(host, cassandraKeyspaceConfig);
         } catch (Exception exception) {
             log.warn(
                     "Couldn't use host {} to create keyspace."
@@ -229,29 +241,35 @@ public final class CassandraVerifier {
     }
 
     // swallows the expected TException subtype NotFoundException, throws connection problem related ones
-    private static boolean keyspaceAlreadyExists(InetSocketAddress host, CassandraKeyValueServiceConfig config)
-            throws TException {
-        try (CassandraClient client = CassandraClientFactory.getClientInternal(host, config)) {
-            client.describe_keyspace(config.getKeyspaceOrThrow());
+    private static boolean keyspaceAlreadyExists(
+            InetSocketAddress host, CassandraKeyspaceConfig cassandraKeyspaceConfig) throws TException {
+        try (CassandraClient client =
+                CassandraClientFactory.getClientInternal(host, cassandraKeyspaceConfig.clientConfig())) {
+            client.describe_keyspace(cassandraKeyspaceConfig.keyspace());
             CassandraKeyValueServices.waitForSchemaVersions(
-                    config.schemaMutationTimeoutMillis(), client, "while checking if schemas diverged on startup");
+                    cassandraKeyspaceConfig.schemaMutationTimeoutMillis(),
+                    client,
+                    "while checking if schemas diverged on startup");
             return true;
         } catch (NotFoundException e) {
             return false;
         }
     }
 
-    private static boolean attemptToCreateKeyspaceOnHost(InetSocketAddress host, CassandraKeyValueServiceConfig config)
-            throws TException {
-        try (CassandraClient client = CassandraClientFactory.getClientInternal(host, config)) {
-            KsDef ksDef = createKsDefForFresh(client, config);
+    private static boolean attemptToCreateKeyspaceOnHost(
+            InetSocketAddress host, CassandraKeyspaceConfig cassandraKeyspaceConfig) throws TException {
+        try (CassandraClient client =
+                CassandraClientFactory.getClientInternal(host, cassandraKeyspaceConfig.clientConfig())) {
+            KsDef ksDef = createKsDefForFresh(client, cassandraKeyspaceConfig);
             client.system_add_keyspace(ksDef);
-            log.info("Created keyspace: {}", SafeArg.of("keyspace", config.getKeyspaceOrThrow()));
+            log.info("Created keyspace: {}", SafeArg.of("keyspace", cassandraKeyspaceConfig.keyspace()));
             CassandraKeyValueServices.waitForSchemaVersions(
-                    config.schemaMutationTimeoutMillis(), client, "after adding the initial empty keyspace");
+                    cassandraKeyspaceConfig.schemaMutationTimeoutMillis(),
+                    client,
+                    "after adding the initial empty keyspace");
             return true;
         } catch (InvalidRequestException e) {
-            boolean keyspaceAlreadyExists = keyspaceAlreadyExists(host, config);
+            boolean keyspaceAlreadyExists = keyspaceAlreadyExists(host, cassandraKeyspaceConfig);
             if (!keyspaceAlreadyExists) {
                 log.info(
                         "Encountered an invalid request exception {} when attempting to create a keyspace"
@@ -265,89 +283,119 @@ public final class CassandraVerifier {
         }
     }
 
-    private static void updateExistingKeyspace(CassandraClientPool clientPool, CassandraKeyValueServiceConfig config)
-            throws TException {
+    private static void updateExistingKeyspace(
+            CassandraClientPool clientPool, CassandraKeyspaceConfig cassandraKeyspaceConfig) throws TException {
         clientPool.runWithRetry((FunctionCheckedException<CassandraClient, Void, TException>) client -> {
-            KsDef originalKsDef = client.describe_keyspace(config.getKeyspaceOrThrow());
+            KsDef originalKsDef = client.describe_keyspace(cassandraKeyspaceConfig.keyspace());
             // there was an existing keyspace
             // check and make sure it's definition is up to date with our config
             KsDef modifiedKsDef = originalKsDef.deepCopy();
-            checkAndSetReplicationFactor(client, modifiedKsDef, config);
+            checkAndSetReplicationFactor(client, modifiedKsDef, cassandraKeyspaceConfig);
 
             if (!modifiedKsDef.equals(originalKsDef)) {
                 // Can't call system_update_keyspace to update replication factor if CfDefs are set
                 modifiedKsDef.setCf_defs(ImmutableList.of());
                 client.system_update_keyspace(modifiedKsDef);
                 CassandraKeyValueServices.waitForSchemaVersions(
-                        config.schemaMutationTimeoutMillis(), client, "after updating the existing keyspace");
+                        cassandraKeyspaceConfig.schemaMutationTimeoutMillis(),
+                        client,
+                        "after updating the existing keyspace");
             }
             return null;
         });
     }
 
-    static KsDef createKsDefForFresh(CassandraClient client, CassandraKeyValueServiceConfig config) {
-        KsDef ksDef = new KsDef(config.getKeyspaceOrThrow(), CassandraConstants.NETWORK_STRATEGY, ImmutableList.of());
-        Set<String> dcs = sanityCheckDatacenters(client, config);
-        ksDef.setStrategy_options(Maps.asMap(dcs, ignore -> String.valueOf(config.replicationFactor())));
+    static KsDef createKsDefForFresh(CassandraClient client, CassandraKeyspaceConfig cassandraKeyspaceConfig) {
+        KsDef ksDef =
+                new KsDef(cassandraKeyspaceConfig.keyspace(), CassandraConstants.NETWORK_STRATEGY, ImmutableList.of());
+        Set<String> dcs = sanityCheckDatacenters(
+                client,
+                cassandraKeyspaceConfig.servers(),
+                cassandraKeyspaceConfig.replicationFactor(),
+                cassandraKeyspaceConfig.ignoreNodeTopologyChecks());
+        ksDef.setStrategy_options(
+                Maps.asMap(dcs, ignore -> String.valueOf(cassandraKeyspaceConfig.replicationFactor())));
         ksDef.setDurable_writes(true);
         return ksDef;
     }
 
     static KsDef checkAndSetReplicationFactor(
-            CassandraClient client, KsDef ksDef, CassandraKeyValueServiceConfig config) {
+            CassandraClient client, KsDef ksDef, CassandraKeyspaceConfig cassandraKeyspaceConfig) {
         KsDef result = ksDef;
         Set<String> datacenters;
         if (Objects.equals(result.getStrategy_class(), CassandraConstants.SIMPLE_STRATEGY)) {
-            datacenters = getDcForSimpleStrategy(client, result, config);
-            result = setNetworkStrategyIfCheckedTopology(result, config, datacenters);
+            datacenters = getDcForSimpleStrategy(client, result, cassandraKeyspaceConfig);
+            result = setNetworkStrategyIfCheckedTopology(
+                    result, datacenters, cassandraKeyspaceConfig.ignoreNodeTopologyChecks());
         } else {
-            datacenters = sanityCheckDatacenters(client, config);
+            datacenters = sanityCheckDatacenters(
+                    client,
+                    cassandraKeyspaceConfig.servers(),
+                    cassandraKeyspaceConfig.replicationFactor(),
+                    cassandraKeyspaceConfig.ignoreNodeTopologyChecks());
         }
 
-        sanityCheckReplicationFactor(result, config, datacenters);
+        sanityCheckReplicationFactor(
+                result,
+                cassandraKeyspaceConfig.replicationFactor(),
+                datacenters,
+                cassandraKeyspaceConfig.ignoreDatacenterConfigurationChecks());
         return result;
     }
 
     private static Set<String> getDcForSimpleStrategy(
-            CassandraClient client, KsDef ksDef, CassandraKeyValueServiceConfig config) {
-        checkKsDefRfEqualsOne(ksDef, config);
-        Set<String> datacenters = sanityCheckDatacenters(client, config);
-        checkOneDatacenter(config, datacenters);
+            CassandraClient client, KsDef ksDef, CassandraKeyspaceConfig cassandraKeyspaceConfig) {
+        checkKsDefRfEqualsOne(ksDef, cassandraKeyspaceConfig.ignoreNodeTopologyChecks());
+        Set<String> datacenters = sanityCheckDatacenters(
+                client,
+                cassandraKeyspaceConfig.servers(),
+                cassandraKeyspaceConfig.replicationFactor(),
+                cassandraKeyspaceConfig.ignoreNodeTopologyChecks());
+        checkOneDatacenter(datacenters, cassandraKeyspaceConfig.ignoreNodeTopologyChecks());
         return datacenters;
     }
 
     private static KsDef setNetworkStrategyIfCheckedTopology(
-            KsDef ksDef, CassandraKeyValueServiceConfig config, Set<String> datacenters) {
-        if (!config.ignoreNodeTopologyChecks()) {
+            KsDef ksDef, Set<String> datacenters, boolean ignoreNodeTopologyChecks) {
+        if (!ignoreNodeTopologyChecks) {
             ksDef.setStrategy_class(CassandraConstants.NETWORK_STRATEGY);
             ksDef.setStrategy_options(ImmutableMap.of(Iterables.getOnlyElement(datacenters), "1"));
         }
         return ksDef;
     }
 
-    private static void checkKsDefRfEqualsOne(KsDef ks, CassandraKeyValueServiceConfig config) {
+    private static void checkKsDefRfEqualsOne(KsDef ks, boolean ignoreNodeTopologyChecks) {
         int currentRf = Integer.parseInt(ks.getStrategy_options().get(CassandraConstants.REPLICATION_FACTOR_OPTION));
         if (currentRf != 1) {
-            logErrorOrThrow(SIMPLE_PARTITIONING_ERROR_MSG, config.ignoreNodeTopologyChecks());
+            logErrorOrThrow(SIMPLE_PARTITIONING_ERROR_MSG, ignoreNodeTopologyChecks);
         }
     }
 
-    private static void checkOneDatacenter(CassandraKeyValueServiceConfig config, Set<String> datacenters) {
+    private static void checkOneDatacenter(Set<String> datacenters, boolean ignoreNodeTopologyChecks) {
         if (datacenters.size() > 1) {
-            logErrorOrThrow(SIMPLE_PARTITIONING_ERROR_MSG, config.ignoreNodeTopologyChecks());
+            logErrorOrThrow(SIMPLE_PARTITIONING_ERROR_MSG, ignoreNodeTopologyChecks);
         }
     }
 
-    static void currentRfOnKeyspaceMatchesDesiredRf(CassandraClient client, CassandraKeyValueServiceConfig config)
+    static void currentRfOnKeyspaceMatchesDesiredRf(
+            CassandraClient client,
+            String keyspace,
+            CassandraServersConfig cassandraServersConfig,
+            int replicationFactor,
+            boolean ignoreNodeTopologyChecks,
+            boolean ignoreDatacetreConfigurationChecks)
             throws TException {
-        KsDef ks = client.describe_keyspace(config.getKeyspaceOrThrow());
-        Set<String> dcs = sanityCheckDatacenters(client, config);
-        sanityCheckReplicationFactor(ks, config, dcs);
+        KsDef ks = client.describe_keyspace(keyspace);
+        Set<String> dcs =
+                sanityCheckDatacenters(client, cassandraServersConfig, replicationFactor, ignoreNodeTopologyChecks);
+        sanityCheckReplicationFactor(ks, replicationFactor, dcs, ignoreDatacetreConfigurationChecks);
     }
 
-    static void sanityCheckReplicationFactor(KsDef ks, CassandraKeyValueServiceConfig config, Set<String> dcs) {
+    static void sanityCheckReplicationFactor(
+            KsDef ks, int replicationFactor, Set<String> dcs, boolean ignoreDatacentreConfigurationChecks) {
         Set<String> scopedDownDcs = checkRfsSpecifiedAndScopeDownDcs(dcs, ks.getStrategy_options());
-        checkRfsMatchConfig(ks, config, scopedDownDcs, ks.getStrategy_options());
+        checkRfsMatchConfig(
+                ks, replicationFactor, scopedDownDcs, ks.getStrategy_options(), ignoreDatacentreConfigurationChecks);
     }
 
     private static Set<String> checkRfsSpecifiedAndScopeDownDcs(Set<String> dcs, Map<String, String> strategyOptions) {
@@ -355,16 +403,53 @@ public final class CassandraVerifier {
     }
 
     private static void checkRfsMatchConfig(
-            KsDef ks, CassandraKeyValueServiceConfig config, Set<String> dcs, Map<String, String> strategyOptions) {
+            KsDef ks,
+            int replicationFactor,
+            Set<String> dcs,
+            Map<String, String> strategyOptions,
+            boolean ignoreDatacenterConfigurationChecks) {
         for (String datacenter : dcs) {
-            if (Integer.parseInt(strategyOptions.get(datacenter)) != config.replicationFactor()) {
+            if (Integer.parseInt(strategyOptions.get(datacenter)) != replicationFactor) {
                 logErrorOrThrow(
                         "Your current Cassandra keyspace (" + ks.getName()
                                 + ") has a replication factor not matching your Atlas Cassandra configuration."
                                 + " Change them to match, but be mindful of what steps you'll need to"
                                 + " take to correctly repair or cleanup existing data in your cluster.",
-                        config.ignoreDatacenterConfigurationChecks());
+                        ignoreDatacenterConfigurationChecks);
             }
+        }
+    }
+
+    @Value.Immutable
+    interface CassandraKeyspaceConfig {
+        String keyspace();
+
+        CassandraKeyValueServiceConfig clientConfig();
+
+        CassandraServersConfig servers();
+
+        int replicationFactor();
+
+        boolean ignoreNodeTopologyChecks();
+
+        boolean ignoreDatacenterConfigurationChecks();
+
+        int schemaMutationTimeoutMillis();
+
+        static CassandraKeyspaceConfig of(CassandraKeyValueServiceConfig config) {
+            return builder()
+                    .keyspace(config.getKeyspaceOrThrow())
+                    .schemaMutationTimeoutMillis(config.schemaMutationTimeoutMillis())
+                    .servers(config.servers())
+                    .ignoreDatacenterConfigurationChecks(config.ignoreDatacenterConfigurationChecks())
+                    .ignoreNodeTopologyChecks(config.ignoreNodeTopologyChecks())
+                    .replicationFactor(config.replicationFactor())
+                    .clientConfig(config)
+                    .build();
+        }
+
+        static ImmutableCassandraKeyspaceConfig.Builder builder() {
+            return ImmutableCassandraKeyspaceConfig.builder();
         }
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -379,16 +379,14 @@ public final class CassandraVerifier {
 
     static void currentRfOnKeyspaceMatchesDesiredRf(
             CassandraClient client,
-            String keyspace,
-            CassandraServersConfig cassandraServersConfig,
-            int replicationFactor,
-            boolean ignoreNodeTopologyChecks,
-            boolean ignoreDatacetreConfigurationChecks)
+            CassandraKeyspaceConfig cassandraKeyspaceConfig)
             throws TException {
-        KsDef ks = client.describe_keyspace(keyspace);
+        KsDef ks = client.describe_keyspace(cassandraKeyspaceConfig.keyspace());
         Set<String> dcs =
-                sanityCheckDatacenters(client, cassandraServersConfig, replicationFactor, ignoreNodeTopologyChecks);
-        sanityCheckReplicationFactor(ks, replicationFactor, dcs, ignoreDatacetreConfigurationChecks);
+                sanityCheckDatacenters(client, cassandraKeyspaceConfig.servers(), cassandraKeyspaceConfig.replicationFactor(),
+                        cassandraKeyspaceConfig.ignoreNodeTopologyChecks());
+        sanityCheckReplicationFactor(
+                ks, cassandraKeyspaceConfig.replicationFactor(), dcs, cassandraKeyspaceConfig.ignoreDatacenterConfigurationChecks());
     }
 
     static void sanityCheckReplicationFactor(

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -429,6 +429,7 @@ public final class CassandraVerifier {
     interface CassandraKeyspaceVerifierConfig {
         String keyspace();
 
+        // TODO(mdaudali): Use a scoped down config object for Cassandra Clients
         CassandraKeyValueServiceConfig clientConfig();
 
         CassandraServersConfig servers();

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifierTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifierTest.java
@@ -63,7 +63,7 @@ public class CassandraVerifierTest {
         CassandraServersConfig cassandraServersConfig =
                 setTopologyAndGetServersConfig(defaultTopology(HOST_1), defaultTopology(HOST_2));
         assertThatThrownBy(() -> CassandraVerifier.sanityCheckDatacenters(
-                client, cassandraServersConfig, DEFAULT_REPLICATION_FACTOR, ENABLE_NODE_TOPOLOGY_CHECKS))
+                        client, cassandraServersConfig, DEFAULT_REPLICATION_FACTOR, ENABLE_NODE_TOPOLOGY_CHECKS))
                 .isInstanceOf(IllegalStateException.class);
     }
 
@@ -72,7 +72,7 @@ public class CassandraVerifierTest {
         CassandraServersConfig cassandraServersConfig =
                 setTopologyAndGetServersConfig(defaultTopology(HOST_1), defaultTopology(HOST_2));
         assertThat(CassandraVerifier.sanityCheckDatacenters(
-                client, cassandraServersConfig, SINGLE_REPLICATION_FACTOR, ENABLE_NODE_TOPOLOGY_CHECKS))
+                        client, cassandraServersConfig, SINGLE_REPLICATION_FACTOR, ENABLE_NODE_TOPOLOGY_CHECKS))
                 .containsExactly(CassandraConstants.DEFAULT_DC);
     }
 
@@ -83,7 +83,7 @@ public class CassandraVerifierTest {
         setTopologyAndGetServersConfig(createDetails(DC_1, RACK_1, HOST_1));
 
         assertThat(CassandraVerifier.sanityCheckDatacenters(
-                client, cassandraServersConfig, DEFAULT_REPLICATION_FACTOR, ENABLE_NODE_TOPOLOGY_CHECKS))
+                        client, cassandraServersConfig, DEFAULT_REPLICATION_FACTOR, ENABLE_NODE_TOPOLOGY_CHECKS))
                 .containsExactly(DC_1);
     }
 
@@ -96,7 +96,7 @@ public class CassandraVerifierTest {
                 createDetails(DC_1, RACK_1, HOST_4));
 
         assertThatThrownBy(() -> CassandraVerifier.sanityCheckDatacenters(
-                client, cassandraServersConfig, DEFAULT_REPLICATION_FACTOR, ENABLE_NODE_TOPOLOGY_CHECKS))
+                        client, cassandraServersConfig, DEFAULT_REPLICATION_FACTOR, ENABLE_NODE_TOPOLOGY_CHECKS))
                 .isInstanceOf(IllegalStateException.class);
     }
 
@@ -126,7 +126,7 @@ public class CassandraVerifierTest {
                 defaultDcDetails(RACK_1, HOST_3),
                 defaultDcDetails(RACK_2, HOST_4));
         assertThatThrownBy(() -> CassandraVerifier.sanityCheckDatacenters(
-                client, cassandraServersConfig, DEFAULT_REPLICATION_FACTOR, ENABLE_NODE_TOPOLOGY_CHECKS))
+                        client, cassandraServersConfig, DEFAULT_REPLICATION_FACTOR, ENABLE_NODE_TOPOLOGY_CHECKS))
                 .isInstanceOf(IllegalStateException.class);
     }
 
@@ -140,7 +140,7 @@ public class CassandraVerifierTest {
         int replicationFactor = 2;
 
         assertThat(CassandraVerifier.sanityCheckDatacenters(
-                client, cassandraServersConfig, replicationFactor, ENABLE_NODE_TOPOLOGY_CHECKS))
+                        client, cassandraServersConfig, replicationFactor, ENABLE_NODE_TOPOLOGY_CHECKS))
                 .containsExactly(CassandraConstants.DEFAULT_DC);
     }
 
@@ -153,7 +153,7 @@ public class CassandraVerifierTest {
                 defaultDcDetails(RACK_2, HOST_1));
 
         assertThat(CassandraVerifier.sanityCheckDatacenters(
-                client, cassandraServersConfig, DEFAULT_REPLICATION_FACTOR, ENABLE_NODE_TOPOLOGY_CHECKS))
+                        client, cassandraServersConfig, DEFAULT_REPLICATION_FACTOR, ENABLE_NODE_TOPOLOGY_CHECKS))
                 .containsExactly(CassandraConstants.DEFAULT_DC);
     }
 
@@ -166,7 +166,7 @@ public class CassandraVerifierTest {
                 createDetails(DC_2, RACK_1, HOST_4));
 
         assertThat(CassandraVerifier.sanityCheckDatacenters(
-                client, cassandraServersConfig, DEFAULT_REPLICATION_FACTOR, ENABLE_NODE_TOPOLOGY_CHECKS))
+                        client, cassandraServersConfig, DEFAULT_REPLICATION_FACTOR, ENABLE_NODE_TOPOLOGY_CHECKS))
                 .containsExactlyInAnyOrder(DC_1, DC_2);
     }
 
@@ -284,10 +284,10 @@ public class CassandraVerifierTest {
         KsDef ksDef = new KsDef("test", CassandraConstants.SIMPLE_STRATEGY, ImmutableList.of());
         ksDef.setStrategy_options(ImmutableMap.of(DC_1, "1", DC_2, "2"));
         assertThatThrownBy(() -> CassandraVerifier.sanityCheckReplicationFactor(
-                ksDef,
-                SINGLE_REPLICATION_FACTOR,
-                ImmutableSortedSet.of(DC_1, DC_2),
-                ignoreDatacentreConfigurationChecks))
+                        ksDef,
+                        SINGLE_REPLICATION_FACTOR,
+                        ImmutableSortedSet.of(DC_1, DC_2),
+                        ignoreDatacentreConfigurationChecks))
                 .isInstanceOf(IllegalStateException.class);
     }
 

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifierTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifierTest.java
@@ -36,7 +36,11 @@ import org.apache.cassandra.thrift.TokenRange;
 import org.apache.thrift.TException;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
+@RunWith(MockitoJUnitRunner.class)
 public class CassandraVerifierTest {
     private static final String DC_1 = "dc1";
     private static final String DC_2 = "dc2";
@@ -53,7 +57,8 @@ public class CassandraVerifierTest {
     private static final int DEFAULT_REPLICATION_FACTOR = 3;
     private static final int SINGLE_REPLICATION_FACTOR = 1;
 
-    private CassandraClient client = mock(CassandraClient.class);
+    @Mock
+    private CassandraClient client;
 
     @Before
     public void beforeEach() {

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifierTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifierTest.java
@@ -47,6 +47,8 @@ public class CassandraVerifierTest {
     private static final String RACK_1 = "test_rack1";
     private static final String RACK_2 = "test_rack2";
     private static final String RACK_3 = "test_rack3";
+
+    // This constant is used as a value for ignoreNodeTopologyChecks. Therefore, to enable checks, the value is false.
     private static final boolean ENABLE_NODE_TOPOLOGY_CHECKS = false;
     private static final int DEFAULT_REPLICATION_FACTOR = 3;
     private static final int SINGLE_REPLICATION_FACTOR = 1;

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifierTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifierTest.java
@@ -197,8 +197,8 @@ public class CassandraVerifierTest {
 
     @Test
     public void simpleStrategyOneDcHighRfThrows() throws TException {
-        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaults()
-                .build();
+        CassandraVerifierConfig verifierConfig =
+                getVerifierConfigBuilderWithDefaults().build();
         KsDef ksDef = new KsDef("test", CassandraConstants.SIMPLE_STRATEGY, ImmutableList.of());
         ksDef.setStrategy_options(ImmutableMap.of(CassandraConstants.REPLICATION_FACTOR_OPTION, "3"));
 

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifierTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifierTest.java
@@ -182,7 +182,6 @@ public class CassandraVerifierTest {
         CassandraKeyspaceVerifierConfig cassandraKeyspaceVerifierConfig =
                 getCassandraKeyspaceVerifierConfigBuilderWithDefaults()
                         .servers(cassandraServersConfig)
-                        .replicationFactor(DEFAULT_REPLICATION_FACTOR)
                         .build();
 
         KsDef ksDef = CassandraVerifier.createKsDefForFresh(client, cassandraKeyspaceVerifierConfig);
@@ -214,7 +213,6 @@ public class CassandraVerifierTest {
         CassandraKeyspaceVerifierConfig cassandraKeyspaceVerifierConfig =
                 getCassandraKeyspaceVerifierConfigBuilderWithDefaults()
                         .servers(ImmutableDefaultConfig.of())
-                        .replicationFactor(DEFAULT_REPLICATION_FACTOR)
                         .build();
         KsDef ksDef = new KsDef("test", CassandraConstants.SIMPLE_STRATEGY, ImmutableList.of());
         ksDef.setStrategy_options(ImmutableMap.of(CassandraConstants.REPLICATION_FACTOR_OPTION, "3"));
@@ -276,7 +274,6 @@ public class CassandraVerifierTest {
         CassandraKeyspaceVerifierConfig cassandraKeyspaceVerifierConfig =
                 getCassandraKeyspaceVerifierConfigBuilderWithDefaults()
                         .servers(cassandraServersConfig)
-                        .replicationFactor(DEFAULT_REPLICATION_FACTOR)
                         .build();
 
         KsDef ksDef = new KsDef("test", CassandraConstants.NETWORK_STRATEGY, ImmutableList.of());
@@ -332,6 +329,7 @@ public class CassandraVerifierTest {
         return CassandraKeyspaceVerifierConfig.builder()
                 .clientConfig(mock(CassandraKeyValueServiceConfig.class))
                 .keyspace("test")
+                .replicationFactor(DEFAULT_REPLICATION_FACTOR)
                 .ignoreNodeTopologyChecks(ENABLE_NODE_TOPOLOGY_CHECKS)
                 .ignoreDatacenterConfigurationChecks(false)
                 .schemaMutationTimeoutMillis(0);

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifierTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifierTest.java
@@ -198,7 +198,6 @@ public class CassandraVerifierTest {
     @Test
     public void simpleStrategyOneDcHighRfThrows() throws TException {
         CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaults()
-                .servers(ImmutableDefaultConfig.of())
                 .build();
         KsDef ksDef = new KsDef("test", CassandraConstants.SIMPLE_STRATEGY, ImmutableList.of());
         ksDef.setStrategy_options(ImmutableMap.of(CassandraConstants.REPLICATION_FACTOR_OPTION, "3"));

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifierTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifierTest.java
@@ -80,7 +80,6 @@ public class CassandraVerifierTest {
     public void nonDefaultDcAndHighRfSucceeds() throws TException {
         CassandraServersConfig cassandraServersConfig =
                 setTopologyAndGetServersConfig(createDetails(DC_1, RACK_1, HOST_1));
-        setTopologyAndGetServersConfig(createDetails(DC_1, RACK_1, HOST_1));
 
         assertThat(CassandraVerifier.sanityCheckDatacenters(
                         client, cassandraServersConfig, DEFAULT_REPLICATION_FACTOR, ENABLE_NODE_TOPOLOGY_CHECKS))
@@ -209,7 +208,7 @@ public class CassandraVerifierTest {
     }
 
     @Test
-    public void simpleStrategyOneDcHighRfThrows() throws TException {
+    public void simpleStrategyOneDcHighRfThrows() {
         CassandraKeyspaceVerifierConfig cassandraKeyspaceVerifierConfig =
                 getCassandraKeyspaceVerifierConfigBuilderWithDefaults()
                         .servers(ImmutableDefaultConfig.of())


### PR DESCRIPTION
**Goals (and why)**:
Moving away from passing around configs everywhere to just the things that are needed. This simplifies part 3, which will be to start using `RuntimeConfig#servers()` instead of install config.

Most CassVerifier methods now take a `CassandraVerifierConfig` object which scopes down to just the relevant config options that are needed. When wiring up, we only need to change the utility constructor for `CassandraVerifierConfig` to load servers from the runtime config, rather than passing the runtime config to each method.

==COMMIT_MSG==
==COMMIT_MSG==

**Implementation Description (bullets)**:
* CassandraVerifier methods now either take in just the relevant information from config, or a `CassandraKeyspaceVerifierConfig` which is scoped down.
* The tests have also been updated

**Testing (What was existing testing like?  What have you done to improve it?)**:
* No new tests, but updated to pass the relevant parameters instead of mocking the entire config.

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
