### PR TITLE
Use protoc x86_64 on Apple M1 aarch64

### DIFF
--- a/atlasdb-client-protobufs/build.gradle
+++ b/atlasdb-client-protobufs/build.gradle
@@ -2,9 +2,12 @@ apply from: "../gradle/shared.gradle"
 
 apply plugin: 'com.google.protobuf'
 
+// The protoc version atlasdb uses does not yet support Apple M1 aarch64
+// (see https://github.com/protocolbuffers/protobuf/issues/8062), so use x86_64.
+def protocArch = 'osx-aarch_64'.equals(osdetector.classifier) ? 'osx-x86_64' : osdetector.classifier
 protobuf {
   protoc {
-    artifact = "com.google.protobuf:protoc:${libVersions.protoc}"
+    artifact = "com.google.protobuf:protoc:${libVersions.protoc}:${protocArch}"
   }
 }
 

--- a/examples/profile-client-protobufs/build.gradle
+++ b/examples/profile-client-protobufs/build.gradle
@@ -4,9 +4,12 @@ group = 'com.palantir.atlasdb.examples'
 
 apply plugin: 'com.google.protobuf'
 
+// The protoc version atlasdb uses does not yet support Apple M1 aarch64
+// (see https://github.com/protocolbuffers/protobuf/issues/8062), so use x86_64.
+def protocArch = 'osx-aarch_64'.equals(osdetector.classifier) ? 'osx-x86_64' : osdetector.classifier
 protobuf {
   protoc {
-    artifact = "com.google.protobuf:protoc:${libVersions.protoc}"
+    artifact = "com.google.protobuf:protoc:${libVersions.protoc}:${protocArch}"
   }
 }
 

--- a/leader-election-api-protobufs/build.gradle
+++ b/leader-election-api-protobufs/build.gradle
@@ -2,9 +2,12 @@ apply from: "../gradle/shared.gradle"
 
 apply plugin: 'com.google.protobuf'
 
+// The protoc version atlasdb uses does not yet support Apple M1 aarch64
+// (see https://github.com/protocolbuffers/protobuf/issues/8062), so use x86_64.
+def protocArch = 'osx-aarch_64'.equals(osdetector.classifier) ? 'osx-x86_64' : osdetector.classifier
 protobuf {
   protoc {
-    artifact = "com.google.protobuf:protoc:${libVersions.protoc}"
+    artifact = "com.google.protobuf:protoc:${libVersions.protoc}:${protocArch}"
   }
 }
 


### PR DESCRIPTION
**Goals (and why)**:
==COMMIT_MSG==
Use protoc x86_64 on Apple M1 aarch64

The old protoc version 3.5.1 atlasdb uses does not yet support Apple M1 aarch64
(see https://github.com/protocolbuffers/protobuf/issues/8062), so use x86_64 until
atlasdb upgrades to protoc 3.18.0+ which add osx-aarch_64.
==COMMIT_MSG==

**Implementation Description (bullets)**: Use protoc x86_64 on Apple M1 aarch64, otherwise use protoc for default `osdetector.classifier`

**Testing (What was existing testing like?  What have you done to improve it?)**: build locally on Apple M1 

**Concerns (what feedback would you like?)**: I don't know why AtlasDB's protoc dependency is so ancient (3.5.1), but [didn't want to bump it yet until understanding implications](https://fs.blog/chestertons-fence/)

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
