### PR TITLE
ABR 23: Store completed backups in parallel

### DIFF
--- a/atlasdb-backup/src/test/java/com/palantir/atlasdb/backup/AtlasBackupServiceTest.java
+++ b/atlasdb-backup/src/test/java/com/palantir/atlasdb/backup/AtlasBackupServiceTest.java
@@ -71,7 +71,7 @@ public class AtlasBackupServiceTest {
     public void setup() {
         backupPersister = new InMemoryBackupPersister();
         atlasBackupService = new AtlasBackupService(
-                authHeader, atlasBackupClient, coordinationServiceRecorder, backupPersister, lockRefresher);
+                authHeader, atlasBackupClient, coordinationServiceRecorder, backupPersister, lockRefresher, 10);
     }
 
     @Test

--- a/changelog/@unreleased/pr-6006.v2.yml
+++ b/changelog/@unreleased/pr-6006.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Storage of completed backup metadata will now happen in parallel.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6006


### PR DESCRIPTION

**Goals (and why)**:
The storage process involves creating a Cassandra KVS, which can be expensive. This was previously done in parallel (in a separate task in the internal backup product), so we should maintain parallelism on the AtlasDB side.
Created a constructor parameter to allow this parallelism to be configurable.

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Storage of completed backup metadata will now happen in parallel.
==COMMIT_MSG==

**Implementation Description (bullets)**:
- parallelise
- gracefully handle exceptions while completing backups (for instance, if the folder was deleted or can not be accessed), giving other services' backups the best chance of completing successfullly.

**Testing (What was existing testing like?  What have you done to improve it?)**: Already testing with multiple namespaces, so this will now do the storage piece in parallel.

**Concerns (what feedback would you like?)**: The future handling was paraphrased from a few other places, where our meta is to collect them all into a map and eventually call AtlasFutures.getUnchecked. Here, we do this immediately. 

**Where should we start reviewing?**: The one file with substantive changes?

**Priority (whenever / two weeks / yesterday)**: should merge today

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
