### PR TITLE
Add cleanupBackup

### DIFF
--- a/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/AtlasBackupService.java
+++ b/atlasdb-backup/src/main/java/com/palantir/atlasdb/backup/AtlasBackupService.java
@@ -281,8 +281,8 @@ public final class AtlasBackupService implements Closeable {
 
     private void throwIfClosed(Set<AtlasService> atlasServices) {
         if (isClosed) {
-            throw new SafeIllegalStateException("The AtlasBackupService is closed.",
-                    SafeArg.of("atlasServices", atlasServices));
+            throw new SafeIllegalStateException(
+                    "The AtlasBackupService is closed.", SafeArg.of("atlasServices", atlasServices));
         }
     }
 

--- a/atlasdb-backup/src/test/java/com/palantir/atlasdb/backup/AtlasBackupServiceTest.java
+++ b/atlasdb-backup/src/test/java/com/palantir/atlasdb/backup/AtlasBackupServiceTest.java
@@ -134,8 +134,7 @@ public class AtlasBackupServiceTest {
     public void prepareBackupThrowsAfterClose() {
         atlasBackupService.close();
 
-        assertThatLoggableExceptionThrownBy(
-                () -> atlasBackupService.prepareBackup(ImmutableSet.of(ATLAS_SERVICE)))
+        assertThatLoggableExceptionThrownBy(() -> atlasBackupService.prepareBackup(ImmutableSet.of(ATLAS_SERVICE)))
                 .isInstanceOf(SafeIllegalStateException.class)
                 .hasMessageContaining("closed");
     }
@@ -144,8 +143,7 @@ public class AtlasBackupServiceTest {
     public void completeBackupThrowsAfterClose() {
         atlasBackupService.close();
 
-        assertThatLoggableExceptionThrownBy(
-                () -> atlasBackupService.completeBackup(ImmutableSet.of(ATLAS_SERVICE)))
+        assertThatLoggableExceptionThrownBy(() -> atlasBackupService.completeBackup(ImmutableSet.of(ATLAS_SERVICE)))
                 .isInstanceOf(SafeIllegalStateException.class)
                 .hasMessageContaining("closed");
     }
@@ -161,7 +159,7 @@ public class AtlasBackupServiceTest {
     public void closeClosesLockRefresher() {
         Set<InProgressBackupToken> tokens = ImmutableSet.of(IN_PROGRESS);
         when(atlasBackupClient.prepareBackup(
-                authHeader, PrepareBackupRequest.of(ImmutableSet.of(NAMESPACE, OTHER_NAMESPACE))))
+                        authHeader, PrepareBackupRequest.of(ImmutableSet.of(NAMESPACE, OTHER_NAMESPACE))))
                 .thenReturn(PrepareBackupResponse.of(tokens));
 
         atlasBackupService.prepareBackup(ImmutableSet.of(ATLAS_SERVICE, OTHER_ATLAS_SERVICE));

--- a/atlasdb-backup/src/test/java/com/palantir/atlasdb/backup/AtlasBackupServiceTest.java
+++ b/atlasdb-backup/src/test/java/com/palantir/atlasdb/backup/AtlasBackupServiceTest.java
@@ -77,7 +77,13 @@ public class AtlasBackupServiceTest {
     public void setup() {
         backupPersister = new InMemoryBackupPersister();
         atlasBackupService = new AtlasBackupService(
-                authHeader, atlasBackupClient, coordinationServiceRecorder, backupPersister, lockRefresher, executorService, 10);
+                authHeader,
+                atlasBackupClient,
+                coordinationServiceRecorder,
+                backupPersister,
+                lockRefresher,
+                executorService,
+                10);
     }
 
     @Test
@@ -126,7 +132,7 @@ public class AtlasBackupServiceTest {
     public void cleanupBackupCloesLockRefresher() {
         Set<InProgressBackupToken> tokens = ImmutableSet.of(IN_PROGRESS);
         when(atlasBackupClient.prepareBackup(
-                authHeader, PrepareBackupRequest.of(ImmutableSet.of(NAMESPACE, OTHER_NAMESPACE))))
+                        authHeader, PrepareBackupRequest.of(ImmutableSet.of(NAMESPACE, OTHER_NAMESPACE))))
                 .thenReturn(PrepareBackupResponse.of(tokens));
 
         atlasBackupService.prepareBackup(ImmutableSet.of(ATLAS_SERVICE, OTHER_ATLAS_SERVICE));
@@ -160,7 +166,8 @@ public class AtlasBackupServiceTest {
         atlasBackupService.cleanupBackup();
 
         // Complete for OTHER_ATLAS_SERVICE should now fail gracefully
-        assertThat(atlasBackupService.completeBackup(ImmutableSet.of(OTHER_ATLAS_SERVICE))).isEmpty();
+        assertThat(atlasBackupService.completeBackup(ImmutableSet.of(OTHER_ATLAS_SERVICE)))
+                .isEmpty();
     }
 
     @Test

--- a/atlasdb-backup/src/test/java/com/palantir/atlasdb/backup/AtlasBackupServiceTest.java
+++ b/atlasdb-backup/src/test/java/com/palantir/atlasdb/backup/AtlasBackupServiceTest.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.backup;
 
 import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptionThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -147,6 +148,13 @@ public class AtlasBackupServiceTest {
                 () -> atlasBackupService.completeBackup(ImmutableSet.of(ATLAS_SERVICE)))
                 .isInstanceOf(SafeIllegalStateException.class)
                 .hasMessageContaining("closed");
+    }
+
+    @Test
+    public void canCloseTwice() {
+        atlasBackupService.close();
+
+        assertThatCode(() -> atlasBackupService.close()).doesNotThrowAnyException();
     }
 
     @Test

--- a/changelog/@unreleased/pr-6011.v2.yml
+++ b/changelog/@unreleased/pr-6011.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Added AtlasBackupService.cleanupBackup, which must be called at the
+    end of the backup process (including after any intermediate step fails). This
+    function will release any locks that were held during backups.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6011


### PR DESCRIPTION
**Goals (and why)**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Added AtlasBackupService.cleanupBackup, which must be called at the end of the backup process (including after any intermediate step fails). This function will release any locks that were held during backups. 
==COMMIT_MSG==

**Implementation Description (bullets)**:
- Added cleanupBackup
- Some minor refactor/formatting

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Added tests to show that completeBackup will not succeed after cleanupBackup.

**Concerns (what feedback would you like?)**:
- Is this sufficient protection against thread leakage?

**Where should we start reviewing?**: code

**Priority (whenever / two weeks / yesterday)**: yesterday 🔥 

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
