### PR TITLE
Try every host when attempting to get the ip to hostname mapping if a failure is hit.

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
@@ -106,8 +106,8 @@ public class CassandraService implements AutoCloseable {
         this.poolMetrics = poolMetrics;
 
         Supplier<Map<String, String>> hostnamesByIpSupplier =
-                new HostnamesByIpSupplier(this::getAllHostsUnlessBlacklisted);
-        this.hostnameByIpSupplier = Suppliers.memoizeWithExpiration(hostnamesByIpSupplier::get, 2, TimeUnit.MINUTES);
+                new HostnamesByIpSupplier(this::getAllNonBlacklistedHosts);
+        this.hostnameByIpSupplier = Suppliers.memoizeWithExpiration(hostnamesByIpSupplier::get, 1, TimeUnit.MINUTES);
     }
 
     public static CassandraService createInitialized(
@@ -369,7 +369,7 @@ public class CassandraService implements AutoCloseable {
         return randomLivingHost.map(pools::get);
     }
 
-    public List<PoolingContainer<CassandraClient>> getAllHostsUnlessBlacklisted() {
+    public List<PoolingContainer<CassandraClient>> getAllNonBlacklistedHosts() {
         ImmutableMap<CassandraServer, CassandraClientPoolingContainer> pools = ImmutableMap.copyOf(getPools());
         return blacklist.filterBlacklistedHostsFrom(pools.keySet()).stream()
                 .map(pools::get)

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
@@ -370,9 +370,11 @@ public class CassandraService implements AutoCloseable {
     }
 
     public List<PoolingContainer<CassandraClient>> getAllHostsUnlessBlacklisted() {
-        Collection<CassandraServer> hosts =
-                blacklist.filterBlacklistedHostsFrom(getPools().keySet());
-        return hosts.stream().map(getPools()::get).collect(Collectors.toList());
+        ImmutableMap<CassandraServer, CassandraClientPoolingContainer> pools = ImmutableMap.copyOf(getPools());
+        return blacklist.filterBlacklistedHostsFrom(pools.keySet()).stream()
+                .map(pools::get)
+                .filter(Objects::nonNull)
+                .collect(ImmutableList.toImmutableList());
     }
 
     public CassandraClientPoolingContainer getRandomGoodHost() {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostnamesByIpSupplier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostnamesByIpSupplier.java
@@ -56,7 +56,7 @@ public final class HostnamesByIpSupplier implements Supplier<Map<String, String>
         return hosts.get().stream()
                 .map(container -> {
                     try {
-                        return Optional.of(container.runWithPooledResource(getHostnamesByIp()));
+                        return Optional.ofNullable(container.runWithPooledResource(getHostnamesByIp()));
                     } catch (Exception e) {
                         log.warn("Could not get hostnames by ip from Cassandra", e);
                         return Optional.<Map<String, String>>empty();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostnamesByIpSupplier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostnamesByIpSupplier.java
@@ -75,7 +75,7 @@ public final class HostnamesByIpSupplier implements Supplier<Map<String, String>
                         e);
             }
 
-            if (timer.elapsed().toNanos() >= timeout.toNanos()) {
+            if (timer.elapsed().compareTo(timeout) >= 0) {
                 log.warn(
                         "Could not find hostnames by IP mapping for pool within timeout",
                         SafeArg.of("poolSize", containers.size()),

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostnamesByIpSupplier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostnamesByIpSupplier.java
@@ -55,7 +55,7 @@ public final class HostnamesByIpSupplier implements Supplier<Map<String, String>
     }
 
     @VisibleForTesting
-    public HostnamesByIpSupplier(Supplier<List<PoolingContainer<CassandraClient>>> hosts, Duration timeout) {
+    HostnamesByIpSupplier(Supplier<List<PoolingContainer<CassandraClient>>> hosts, Duration timeout) {
         this.hosts = hosts;
         this.timeout = timeout;
     }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostnamesByIpSupplierTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostnamesByIpSupplierTest.java
@@ -39,6 +39,7 @@ import org.apache.cassandra.thrift.CqlResult;
 import org.apache.cassandra.thrift.CqlRow;
 import org.apache.cassandra.thrift.KsDef;
 import org.apache.cassandra.thrift.NotFoundException;
+import org.apache.cassandra.thrift.TimedOutException;
 import org.apache.thrift.TException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,8 +51,11 @@ public class HostnamesByIpSupplierTest {
     @Mock
     CassandraClient client;
 
+    @Mock
+    CassandraClient secondaryClient;
+
     private final Supplier<Map<String, String>> hostnamesByIpSupplier =
-            new HostnamesByIpSupplier(() -> new DummyClientPool(client));
+            new HostnamesByIpSupplier(() -> List.of(new DummyClientPool(client), new DummyClientPool(secondaryClient)));
 
     @Test
     public void keyspaceNotAccessibleDoesNotError() throws Exception {
@@ -59,6 +63,24 @@ public class HostnamesByIpSupplierTest {
 
         assertThatCode(hostnamesByIpSupplier::get).doesNotThrowAnyException();
         assertThat(hostnamesByIpSupplier.get()).isEmpty();
+    }
+
+    @Test
+    public void triesMultipleHosts() throws Exception {
+        when(client.describe_keyspace("system_palantir")).thenThrow(new TimedOutException());
+        setupKeyspaceAndTable(secondaryClient);
+        CqlResult cqlResult = createMockCqlResult(ImmutableList.of(
+                ImmutableList.of(
+                        createColumn("ip", PtBytes.toBytes("10.0.0.0")),
+                        createColumn("hostname", PtBytes.toBytes("cassandra-1"))),
+                ImmutableList.of(
+                        createColumn("ip", PtBytes.toBytes("10.0.0.1")),
+                        createColumn("hostname", PtBytes.toBytes("cassandra-2")))));
+        when(secondaryClient.execute_cql3_query(any(), any(), any())).thenReturn(cqlResult);
+
+        Map<String, String> hostnamesByIp = hostnamesByIpSupplier.get();
+        assertThat(hostnamesByIp).containsEntry("10.0.0.0", "cassandra-1");
+        assertThat(hostnamesByIp).containsEntry("10.0.0.1", "cassandra-2");
     }
 
     @Test
@@ -72,7 +94,7 @@ public class HostnamesByIpSupplierTest {
 
     @Test
     public void unexpectedTableFormatDoesNotError() throws Exception {
-        setupKeyspaceAndTable();
+        setupKeyspaceAndTable(client);
         CqlResult cqlResult = createMockCqlResult(ImmutableList.of(ImmutableList.of(
                 createColumn("unknown_name", PtBytes.toBytes("unknown_value")),
                 createColumn("another_unknown_name", PtBytes.toBytes("another_unknown_value")))));
@@ -84,7 +106,7 @@ public class HostnamesByIpSupplierTest {
 
     @Test
     public void hostnamesByIpAreReturnedWhenPresent() throws Exception {
-        setupKeyspaceAndTable();
+        setupKeyspaceAndTable(client);
         CqlResult cqlResult = createMockCqlResult(ImmutableList.of(
                 ImmutableList.of(
                         createColumn("ip", PtBytes.toBytes("10.0.0.0")),
@@ -101,7 +123,7 @@ public class HostnamesByIpSupplierTest {
 
     @Test
     public void unknownColumnsAreIgnored() throws Exception {
-        setupKeyspaceAndTable();
+        setupKeyspaceAndTable(client);
         CqlResult cqlResult = createMockCqlResult(ImmutableList.of(ImmutableList.of(
                 createColumn("ip", PtBytes.toBytes("10.0.0.0")),
                 createColumn("hostname", PtBytes.toBytes("cassandra-1")),
@@ -112,8 +134,8 @@ public class HostnamesByIpSupplierTest {
         assertThat(hostnamesByIp).containsEntry("10.0.0.0", "cassandra-1");
     }
 
-    private void setupKeyspaceAndTable() throws TException {
-        when(client.describe_keyspace("system_palantir"))
+    private void setupKeyspaceAndTable(CassandraClient clientToSetup) throws TException {
+        when(clientToSetup.describe_keyspace("system_palantir"))
                 .thenReturn(new KsDef(
                         "system_palantir", "", ImmutableList.of(new CfDef("system_palantir", "hostnames_by_ip"))));
     }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostnamesByIpSupplierTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostnamesByIpSupplierTest.java
@@ -56,7 +56,7 @@ public class HostnamesByIpSupplierTest {
     CassandraClient secondaryClient;
 
     private final Supplier<Map<String, String>> hostnamesByIpSupplier = new HostnamesByIpSupplier(
-            () -> List.of(new DummyClientPool(client), new DummyClientPool(secondaryClient)), Duration.ofSeconds(10));
+            () -> List.of(new DummyClientPool(client), new DummyClientPool(secondaryClient)), Duration.ofSeconds(2));
 
     @Test
     public void keyspaceNotAccessibleDoesNotError() throws Exception {
@@ -87,7 +87,7 @@ public class HostnamesByIpSupplierTest {
     @Test
     public void returnsEmptyOnTimeout() throws Exception {
         when(client.describe_keyspace("system_palantir")).thenAnswer(_args -> {
-            Thread.sleep(1_000);
+            Thread.sleep(2_001);
             throw new NotFoundException();
         });
         setupKeyspaceAndTable(secondaryClient);

--- a/changelog/@unreleased/pr-6014.v2.yml
+++ b/changelog/@unreleased/pr-6014.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Try every host when attempting to get the ip to hostname mapping if
+    a failure is hit.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6014


### PR DESCRIPTION
**Goals (and why)**:
==COMMIT_MSG==
Try every host when attempting to get the ip to hostname mapping if a failure is hit.
==COMMIT_MSG==

**Implementation Description (bullets)**:
- Obtain the list of Cassandra servers which are alive
- Iterate through the servers, until (most likely 1st) returns a valid response (i.e. not a TimeOutException)
- Return result

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Unit tests, which should be feasible enough to test that retry occurs on multiple hosts..

**Concerns (what feedback would you like?)**:
- Trying every host _can_ be expensive, and querying a quorum of hosts is not much better. In the worst case scenario, it could take `timeout * N` for the task to fail to update the addresses. This would be problematic on very large clusters, running in Kubernetes (as the IP changes are significant here), restarting an entire rack a time. However, this failure condition is so unlikely, I'd argue it should be overlooked (for now). 
As basically: `N * timeout > time to start all nodes in rack Y`, but that assumes we are hitting the timeout exception, rather than something else (i.e. connection refused, which is almost instant).

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:
Yesterday
