### PR TITLE
DbKvs Timelock: support async initialization

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/timestamp/DbTimeLockFactory.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/timestamp/DbTimeLockFactory.java
@@ -40,7 +40,8 @@ public interface DbTimeLockFactory {
             MetricsManager metricManager,
             KeyValueServiceConfig config,
             Refreshable<Optional<KeyValueServiceRuntimeConfig>> runtimeConfig,
-            LeaderConfig leaderConfig);
+            LeaderConfig leaderConfig,
+            boolean initializeAsync);
 
     ManagedTimestampService createManagedTimestampService(
             KeyValueService rawKvs, DbTimestampCreationSetting dbTimestampCreationSetting, boolean initializeAsync);

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/memory/InMemoryDbTimeLockFactory.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/memory/InMemoryDbTimeLockFactory.java
@@ -49,7 +49,8 @@ public class InMemoryDbTimeLockFactory implements DbTimeLockFactory {
             MetricsManager metricManager,
             KeyValueServiceConfig config,
             Refreshable<Optional<KeyValueServiceRuntimeConfig>> runtimeConfig,
-            LeaderConfig leaderConfig) {
+            LeaderConfig leaderConfig,
+            boolean _initializeAsync) {
         return new InMemoryKeyValueService(true);
     }
 

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/RelationalDbTimeLockFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/RelationalDbTimeLockFactory.java
@@ -18,7 +18,6 @@ package com.palantir.atlasdb.keyvalue.dbkvs;
 
 import com.google.auto.service.AutoService;
 import com.google.common.base.Preconditions;
-import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.config.DbTimestampCreationSetting;
 import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
@@ -55,7 +54,8 @@ public class RelationalDbTimeLockFactory implements DbTimeLockFactory {
             MetricsManager metricsManager,
             KeyValueServiceConfig config,
             Refreshable<Optional<KeyValueServiceRuntimeConfig>> runtimeConfig,
-            LeaderConfig leaderConfig) {
+            LeaderConfig leaderConfig,
+            boolean initializeAsync) {
         return delegate.createRawKeyValueService(
                 metricsManager,
                 config,
@@ -63,7 +63,7 @@ public class RelationalDbTimeLockFactory implements DbTimeLockFactory {
                 Optional.of(leaderConfig),
                 Optional.empty(), // This refers to an AtlasDB namespace - we use the config to talk to the db
                 AtlasDbFactory.THROWING_FRESH_TIMESTAMP_SOURCE, // This is how we give out timestamps!
-                AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
+                initializeAsync);
     }
 
     @Override

--- a/timelock-agent/src/main/java/com/palantir/timelock/ServiceDiscoveringDatabaseTimeLockSupplier.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/ServiceDiscoveringDatabaseTimeLockSupplier.java
@@ -52,12 +52,12 @@ public class ServiceDiscoveringDatabaseTimeLockSupplier implements AutoCloseable
             LeaderConfig leaderConfig,
             boolean initializeAsync) {
         DbTimeLockFactory dbTimeLockFactory = AtlasDbServiceDiscovery.createDbTimeLockFactoryOfCorrectType(config);
-        keyValueService = Suppliers.memoize(
-                () -> dbTimeLockFactory.createRawKeyValueService(metricsManager, config, runtimeConfig, leaderConfig, initializeAsync));
+        keyValueService = Suppliers.memoize(() -> dbTimeLockFactory.createRawKeyValueService(
+                metricsManager, config, runtimeConfig, leaderConfig, initializeAsync));
         timestampServiceFactory = creationSetting -> dbTimeLockFactory.createManagedTimestampService(
                 keyValueService.get(), creationSetting, initializeAsync);
-        timestampSeriesProvider = tableRef -> dbTimeLockFactory.createTimestampSeriesProvider(
-                keyValueService.get(), tableRef, initializeAsync);
+        timestampSeriesProvider = tableRef ->
+                dbTimeLockFactory.createTimestampSeriesProvider(keyValueService.get(), tableRef, initializeAsync);
     }
 
     @Override

--- a/timelock-agent/src/main/java/com/palantir/timelock/ServiceDiscoveringDatabaseTimeLockSupplier.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/ServiceDiscoveringDatabaseTimeLockSupplier.java
@@ -49,14 +49,15 @@ public class ServiceDiscoveringDatabaseTimeLockSupplier implements AutoCloseable
             MetricsManager metricsManager,
             KeyValueServiceConfig config,
             Refreshable<Optional<KeyValueServiceRuntimeConfig>> runtimeConfig,
-            LeaderConfig leaderConfig) {
+            LeaderConfig leaderConfig,
+            boolean initializeAsync) {
         DbTimeLockFactory dbTimeLockFactory = AtlasDbServiceDiscovery.createDbTimeLockFactoryOfCorrectType(config);
         keyValueService = Suppliers.memoize(
-                () -> dbTimeLockFactory.createRawKeyValueService(metricsManager, config, runtimeConfig, leaderConfig));
+                () -> dbTimeLockFactory.createRawKeyValueService(metricsManager, config, runtimeConfig, leaderConfig, initializeAsync));
         timestampServiceFactory = creationSetting -> dbTimeLockFactory.createManagedTimestampService(
-                keyValueService.get(), creationSetting, AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
+                keyValueService.get(), creationSetting, initializeAsync);
         timestampSeriesProvider = tableRef -> dbTimeLockFactory.createTimestampSeriesProvider(
-                keyValueService.get(), tableRef, AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
+                keyValueService.get(), tableRef, initializeAsync);
     }
 
     @Override

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/DatabaseTsBoundPersisterConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/DatabaseTsBoundPersisterConfiguration.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 import org.immutables.value.Value;
 
@@ -30,6 +31,12 @@ public abstract class DatabaseTsBoundPersisterConfiguration implements TsBoundPe
 
     @JsonProperty("key-value-service")
     public abstract KeyValueServiceConfig keyValueServiceConfig();
+
+    @JsonProperty("initialize-async")
+    @Value.Default
+    public boolean initializeAsync() {
+        return AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC;
+    }
 
     @Override
     public boolean isLocationallyIncompatible(TsBoundPersisterConfiguration other) {

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -304,7 +304,8 @@ public class TimeLockAgent {
                 metricsManager,
                 timestampBoundPersistence.keyValueServiceConfig(),
                 runtime.map(TimeLockAgent::getKeyValueServiceRuntimeConfig),
-                createLeaderConfig());
+                createLeaderConfig(),
+                timestampBoundPersistence.initializeAsync());
         return ImmutableTimestampStorage.builder()
                 .timestampCreator(new DbBoundTimestampCreator(dbTimeLockSupplier))
                 .persistentNamespaceContext(PersistentNamespaceContexts.dbBound(

--- a/timelock-agent/src/test/java/com/palantir/timelock/ServiceDiscoveringDatabaseTimeLockSupplierTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/ServiceDiscoveringDatabaseTimeLockSupplierTest.java
@@ -51,7 +51,7 @@ public class ServiceDiscoveringDatabaseTimeLockSupplierTest {
 
     private final ServiceDiscoveringDatabaseTimeLockSupplier timeLockSupplier =
             new ServiceDiscoveringDatabaseTimeLockSupplier(
-                    metricsManager, keyValueServiceConfig, Refreshable.only(Optional.empty()), leaderConfig);
+                    metricsManager, keyValueServiceConfig, Refreshable.only(Optional.empty()), leaderConfig, false);
 
     @Test
     public void canGetTimestampServiceForDifferentSeries() {

--- a/timelock-server-distribution/var/conf/timelock-postgres.yml
+++ b/timelock-server-distribution/var/conf/timelock-postgres.yml
@@ -4,6 +4,7 @@ install:
     is-new-service: false
   timestampBoundPersistence:
     type: database
+    initialize-async: true
     key-value-service:
       type: "relational"
       ddl:


### PR DESCRIPTION
Largely for fixing test flakes in a non-prod-affecting way.

Marking DNM as I'd like to run tests on this a few times, and ideally capture us successfully retrying to initialize.

**Goals (and why)**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
