### PR TITLE
Fix: Don't run scrub, even once, if scrub is disabled

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Scrubber.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Scrubber.java
@@ -240,7 +240,7 @@ public class Scrubber {
     @VisibleForTesting
     void runBackgroundScrubTask(final TransactionManager txManager) {
         if (!isScrubEnabled.get()) {
-            log.debug("Not running scrub, are we are currently during banned hours.");
+            log.debug("Not running scrub as we are currently during banned hours.");
             return;
         }
         log.debug("Starting scrub task");

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Scrubber.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Scrubber.java
@@ -239,6 +239,10 @@ public class Scrubber {
 
     @VisibleForTesting
     void runBackgroundScrubTask(final TransactionManager txManager) {
+        if (!isScrubEnabled.get()) {
+            log.debug("Not running scrub, are we are currently during banned hours.");
+            return;
+        }
         log.debug("Starting scrub task");
 
         // Warning: Let T be the hard delete transaction that triggered a scrub, and let S be its

--- a/changelog/@unreleased/pr-6024.v2.yml
+++ b/changelog/@unreleased/pr-6024.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fixed an issue where we would run an iteration of scrub, even if it
+    was disabled.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6024


### PR DESCRIPTION
_No, I don't want no scrubs
A scrub is a background process unloved by me
Hanging out the passenger side of the large internal product
Eating resources for tea_

Fixes PDS-262852

**Goals (and why)**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixed an issue where we would run an iteration of scrub, even if it was disabled.
==COMMIT_MSG==

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
