### PR TITLE
[Runtime Config] Part 2d: Wiring Cassandra non-Async and Async KVS

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsAsyncFallbackMechanismsTests.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsAsyncFallbackMechanismsTests.java
@@ -73,7 +73,8 @@ public class CassandraKvsAsyncFallbackMechanismsTests {
 
     @Test
     public void testGetFallBackNotNeeded() {
-        when(factory.constructAsyncKeyValueService(any(), any(), eq(AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC)))
+        when(factory.constructAsyncKeyValueService(
+                        any(), any(), any(), any(), eq(AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC)))
                 .thenReturn(Optional.of(asyncKeyValueService));
 
         CassandraKeyValueServiceConfig config = ImmutableCassandraKeyValueServiceConfig.builder()
@@ -89,7 +90,8 @@ public class CassandraKvsAsyncFallbackMechanismsTests {
 
     @Test
     public void testGetFallingBackToSynchronous() {
-        when(factory.constructAsyncKeyValueService(any(), any(), eq(AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC)))
+        when(factory.constructAsyncKeyValueService(
+                        any(), any(), any(), any(), eq(AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC)))
                 .thenReturn(Optional.empty());
 
         CassandraKeyValueServiceConfig config = ImmutableCassandraKeyValueServiceConfig.builder()

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -42,6 +42,7 @@ import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceRuntimeConfig;
 import com.palantir.atlasdb.cassandra.CassandraMutationTimestampProvider;
 import com.palantir.atlasdb.cassandra.CassandraMutationTimestampProviders;
+import com.palantir.atlasdb.cassandra.CassandraServersConfigs.CassandraServersConfig;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.AsyncKeyValueService;
 import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
@@ -68,6 +69,7 @@ import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolImpl.StartupChecks;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServices.StartTsResultsCollector;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraVerifier.CassandraVerifierConfig;
+import com.palantir.atlasdb.keyvalue.cassandra.async.client.creation.ClusterFactory.CassandraClusterConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.cas.CheckAndSetRunner;
 import com.palantir.atlasdb.keyvalue.cassandra.paging.RowGetter;
 import com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer;
@@ -371,8 +373,14 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             Logger log,
             boolean initializeAsync) {
         try {
+            CassandraClusterConfig clusterConfig = CassandraClusterConfig.of(config);
             Optional<AsyncKeyValueService> asyncKeyValueService = config.asyncKeyValueServiceFactory()
-                    .constructAsyncKeyValueService(metricsManager, config, initializeAsync);
+                    .constructAsyncKeyValueService(
+                            metricsManager,
+                            config.getKeyspaceOrThrow(),
+                            config::servers,
+                            clusterConfig,
+                            initializeAsync);
 
             return createAndInitialize(
                     metricsManager,
@@ -449,18 +457,26 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     }
 
     private static ExecutorService createBlockingThreadpool(
-            CassandraKeyValueServiceConfig config, MetricsManager metricsManager) {
+            CassandraKeyValueServiceConfig config,
+            MetricsManager metricsManager) {
         return config.thriftExecutorServiceFactory()
-                .orElseGet(() -> instrumentedFixedThreadPoolSupplier(config, metricsManager.getTaggedRegistry()))
+                .orElseGet(() -> instrumentedFixedThreadPoolSupplier(
+                        config.servers(),
+                        config.poolSize(),
+                        config.maxConnectionBurstSize(),
+                        metricsManager.getTaggedRegistry()))
                 .get();
     }
 
     private static Supplier<ExecutorService> instrumentedFixedThreadPoolSupplier(
-            CassandraKeyValueServiceConfig config, TaggedMetricRegistry registry) {
+            CassandraServersConfig serversConfig,
+            int poolSize,
+            int maxConnectionBurstSize,
+            TaggedMetricRegistry registry) {
         return () -> {
-            int numberOfThriftHosts = config.servers().numberOfThriftHosts();
-            int corePoolSize = config.poolSize() * numberOfThriftHosts;
-            int maxPoolSize = config.maxConnectionBurstSize() * numberOfThriftHosts;
+            int numberOfThriftHosts = serversConfig.numberOfThriftHosts();
+            int corePoolSize = poolSize * numberOfThriftHosts;
+            int maxPoolSize = maxConnectionBurstSize * numberOfThriftHosts;
             return Tracers.wrap(
                     "Atlas Cassandra KVS",
                     MetricRegistries.instrument(

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -378,8 +378,8 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                     .constructAsyncKeyValueService(
                             metricsManager,
                             config.getKeyspaceOrThrow(),
-                            config::servers,
                             clusterConfig,
+                            config.servers(),
                             initializeAsync);
 
             return createAndInitialize(
@@ -457,8 +457,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     }
 
     private static ExecutorService createBlockingThreadpool(
-            CassandraKeyValueServiceConfig config,
-            MetricsManager metricsManager) {
+            CassandraKeyValueServiceConfig config, MetricsManager metricsManager) {
         return config.thriftExecutorServiceFactory()
                 .orElseGet(() -> instrumentedFixedThreadPoolSupplier(
                         config.servers(),

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/CassandraAsyncKeyValueServiceFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/CassandraAsyncKeyValueServiceFactory.java
@@ -21,13 +21,12 @@ import com.palantir.atlasdb.keyvalue.api.AsyncKeyValueService;
 import com.palantir.atlasdb.keyvalue.cassandra.async.client.creation.ClusterFactory.CassandraClusterConfig;
 import com.palantir.atlasdb.util.MetricsManager;
 import java.util.Optional;
-import java.util.function.Supplier;
 
 public interface CassandraAsyncKeyValueServiceFactory {
     Optional<AsyncKeyValueService> constructAsyncKeyValueService(
             MetricsManager metricsManager,
             String keyspace,
-            Supplier<CassandraServersConfig> cassandraServersConfigSupplier,
             CassandraClusterConfig cassandraClusterConfig,
+            CassandraServersConfig cassandraServersConfig,
             boolean initializeAsync);
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/CassandraAsyncKeyValueServiceFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/CassandraAsyncKeyValueServiceFactory.java
@@ -16,12 +16,18 @@
 
 package com.palantir.atlasdb.keyvalue.cassandra.async;
 
-import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
+import com.palantir.atlasdb.cassandra.CassandraServersConfigs.CassandraServersConfig;
 import com.palantir.atlasdb.keyvalue.api.AsyncKeyValueService;
+import com.palantir.atlasdb.keyvalue.cassandra.async.client.creation.ClusterFactory.CassandraClusterConfig;
 import com.palantir.atlasdb.util.MetricsManager;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 public interface CassandraAsyncKeyValueServiceFactory {
     Optional<AsyncKeyValueService> constructAsyncKeyValueService(
-            MetricsManager metricsManager, CassandraKeyValueServiceConfig config, boolean initializeAsync);
+            MetricsManager metricsManager,
+            String keyspace,
+            Supplier<CassandraServersConfig> cassandraServersConfigSupplier,
+            CassandraClusterConfig cassandraClusterConfig,
+            boolean initializeAsync);
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/DefaultCassandraAsyncKeyValueServiceFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/DefaultCassandraAsyncKeyValueServiceFactory.java
@@ -33,7 +33,6 @@ import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.tracing.Tracers;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
-import java.util.function.Supplier;
 
 public final class DefaultCassandraAsyncKeyValueServiceFactory implements CassandraAsyncKeyValueServiceFactory {
     public static final CassandraAsyncKeyValueServiceFactory DEFAULT =
@@ -49,16 +48,13 @@ public final class DefaultCassandraAsyncKeyValueServiceFactory implements Cassan
     public Optional<AsyncKeyValueService> constructAsyncKeyValueService(
             MetricsManager metricsManager,
             String keyspace,
-            Supplier<CassandraServersConfig> cassandraServersConfigSupplier,
             CassandraClusterConfig cassandraClusterConfig,
+            CassandraServersConfig cassandraServersConfig,
             boolean initializeAsync) {
         Optional<CqlClient> cqlClient = cqlClientFactory.constructClient(
-                metricsManager.getTaggedRegistry(),
-                cassandraServersConfigSupplier,
-                cassandraClusterConfig,
-                initializeAsync);
+                metricsManager.getTaggedRegistry(), cassandraServersConfig, cassandraClusterConfig, initializeAsync);
 
-        ExecutorService executorService = cassandraServersConfigSupplier.get().accept(new Visitor<ExecutorService>() {
+        ExecutorService executorService = cassandraServersConfig.accept(new Visitor<ExecutorService>() {
             @Override
             public ExecutorService visit(DefaultConfig defaultConfig) {
                 return MoreExecutors.newDirectExecutorService();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/DefaultCassandraAsyncKeyValueServiceFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/DefaultCassandraAsyncKeyValueServiceFactory.java
@@ -19,12 +19,13 @@ package com.palantir.atlasdb.keyvalue.cassandra.async;
 import com.codahale.metrics.InstrumentedExecutorService;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.util.concurrent.MoreExecutors;
-import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
+import com.palantir.atlasdb.cassandra.CassandraServersConfigs.CassandraServersConfig;
 import com.palantir.atlasdb.cassandra.CassandraServersConfigs.CqlCapableConfig;
 import com.palantir.atlasdb.cassandra.CassandraServersConfigs.DefaultConfig;
 import com.palantir.atlasdb.cassandra.CassandraServersConfigs.Visitor;
 import com.palantir.atlasdb.futures.AtlasFutures;
 import com.palantir.atlasdb.keyvalue.api.AsyncKeyValueService;
+import com.palantir.atlasdb.keyvalue.cassandra.async.client.creation.ClusterFactory.CassandraClusterConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.async.client.creation.CqlClientFactory;
 import com.palantir.atlasdb.keyvalue.cassandra.async.client.creation.DefaultCqlClientFactory;
 import com.palantir.atlasdb.util.MetricsManager;
@@ -32,6 +33,7 @@ import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.tracing.Tracers;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
 
 public final class DefaultCassandraAsyncKeyValueServiceFactory implements CassandraAsyncKeyValueServiceFactory {
     public static final CassandraAsyncKeyValueServiceFactory DEFAULT =
@@ -45,11 +47,18 @@ public final class DefaultCassandraAsyncKeyValueServiceFactory implements Cassan
 
     @Override
     public Optional<AsyncKeyValueService> constructAsyncKeyValueService(
-            MetricsManager metricsManager, CassandraKeyValueServiceConfig config, boolean initializeAsync) {
-        Optional<CqlClient> cqlClient =
-                cqlClientFactory.constructClient(metricsManager.getTaggedRegistry(), config, initializeAsync);
+            MetricsManager metricsManager,
+            String keyspace,
+            Supplier<CassandraServersConfig> cassandraServersConfigSupplier,
+            CassandraClusterConfig cassandraClusterConfig,
+            boolean initializeAsync) {
+        Optional<CqlClient> cqlClient = cqlClientFactory.constructClient(
+                metricsManager.getTaggedRegistry(),
+                cassandraServersConfigSupplier,
+                cassandraClusterConfig,
+                initializeAsync);
 
-        ExecutorService executorService = config.servers().accept(new Visitor<ExecutorService>() {
+        ExecutorService executorService = cassandraServersConfigSupplier.get().accept(new Visitor<ExecutorService>() {
             @Override
             public ExecutorService visit(DefaultConfig defaultConfig) {
                 return MoreExecutors.newDirectExecutorService();
@@ -63,13 +72,14 @@ public final class DefaultCassandraAsyncKeyValueServiceFactory implements Cassan
                 return tracingExecutorService(
                         "Atlas Cassandra Async KVS",
                         instrumentExecutorService(
-                                createThreadPool(cqlCapableConfig.cqlHosts().size() * config.poolSize()),
+                                createThreadPool(
+                                        cqlCapableConfig.cqlHosts().size() * cassandraClusterConfig.poolSize()),
                                 metricsManager));
             }
         });
 
-        return cqlClient.map(client -> CassandraAsyncKeyValueService.create(
-                config.getKeyspaceOrThrow(), client, AtlasFutures.futuresCombiner(executorService)));
+        return cqlClient.map(client ->
+                CassandraAsyncKeyValueService.create(keyspace, client, AtlasFutures.futuresCombiner(executorService)));
     }
 
     /**

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/client/creation/CqlClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/client/creation/CqlClientFactory.java
@@ -21,12 +21,11 @@ import com.palantir.atlasdb.keyvalue.cassandra.async.CqlClient;
 import com.palantir.atlasdb.keyvalue.cassandra.async.client.creation.ClusterFactory.CassandraClusterConfig;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.util.Optional;
-import java.util.function.Supplier;
 
 public interface CqlClientFactory {
     Optional<CqlClient> constructClient(
             TaggedMetricRegistry taggedMetricRegistry,
-            Supplier<CassandraServersConfig> cassandraServersConfigSupplier,
+            CassandraServersConfig cassandraServersConfigSupplier,
             CassandraClusterConfig cassandraClusterConfig,
             boolean initializeAsync);
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/client/creation/CqlClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/client/creation/CqlClientFactory.java
@@ -16,12 +16,17 @@
 
 package com.palantir.atlasdb.keyvalue.cassandra.async.client.creation;
 
-import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
+import com.palantir.atlasdb.cassandra.CassandraServersConfigs.CassandraServersConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.async.CqlClient;
+import com.palantir.atlasdb.keyvalue.cassandra.async.client.creation.ClusterFactory.CassandraClusterConfig;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 public interface CqlClientFactory {
     Optional<CqlClient> constructClient(
-            TaggedMetricRegistry taggedMetricRegistry, CassandraKeyValueServiceConfig config, boolean initializeAsync);
+            TaggedMetricRegistry taggedMetricRegistry,
+            Supplier<CassandraServersConfig> cassandraServersConfigSupplier,
+            CassandraClusterConfig cassandraClusterConfig,
+            boolean initializeAsync);
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/client/creation/DefaultCqlClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/client/creation/DefaultCqlClientFactory.java
@@ -48,10 +48,10 @@ public class DefaultCqlClientFactory implements CqlClientFactory {
     @Override
     public Optional<CqlClient> constructClient(
             TaggedMetricRegistry taggedMetricRegistry,
-            Supplier<CassandraServersConfig> cassandraServersConfigSupplier,
+            CassandraServersConfig cassandraServersConfig,
             CassandraClusterConfig cassandraClusterConfig,
             boolean initializeAsync) {
-        return CassandraServersConfigs.getCqlCapableConfigIfValid(cassandraServersConfigSupplier.get())
+        return CassandraServersConfigs.getCqlCapableConfigIfValid(cassandraServersConfig)
                 .map(cqlCapableConfig -> {
                     Set<InetSocketAddress> servers = cqlCapableConfig.cqlHosts();
                     Cluster cluster = new ClusterFactory(cqlClusterBuilderFactory)

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/client/creation/DefaultCqlClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/client/creation/DefaultCqlClientFactory.java
@@ -17,7 +17,6 @@
 package com.palantir.atlasdb.keyvalue.cassandra.async.client.creation;
 
 import com.datastax.driver.core.Cluster;
-import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.CassandraServersConfigs;
 import com.palantir.atlasdb.cassandra.CassandraServersConfigs.CassandraServersConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.async.CqlClient;
@@ -48,10 +47,11 @@ public class DefaultCqlClientFactory implements CqlClientFactory {
 
     @Override
     public Optional<CqlClient> constructClient(
-            TaggedMetricRegistry taggedMetricRegistry, CassandraKeyValueServiceConfig config, boolean initializeAsync) {
-        CassandraClusterConfig cassandraClusterConfig = CassandraClusterConfig.of(config);
-        CassandraServersConfig cassandraServersConfig = config.servers();
-        return CassandraServersConfigs.getCqlCapableConfigIfValid(cassandraServersConfig)
+            TaggedMetricRegistry taggedMetricRegistry,
+            Supplier<CassandraServersConfig> cassandraServersConfigSupplier,
+            CassandraClusterConfig cassandraClusterConfig,
+            boolean initializeAsync) {
+        return CassandraServersConfigs.getCqlCapableConfigIfValid(cassandraServersConfigSupplier.get())
                 .map(cqlCapableConfig -> {
                     Set<InetSocketAddress> servers = cqlCapableConfig.cqlHosts();
                     Cluster cluster = new ClusterFactory(cqlClusterBuilderFactory)

--- a/changelog/@unreleased/pr-6025.v2.yml
+++ b/changelog/@unreleased/pr-6025.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: '`CqlFactory` and `CassandraAsyncKeyValueService` now take the relevant
+    configuration values when constructing, rather than an entire `CassandraKeyValueServiceConfig`
+    instance.'
+  links:
+  - https://github.com/palantir/atlasdb/pull/6025


### PR DESCRIPTION
**Goals (and why)**:
Moving away from passing around configs everywhere to just the things that are needed. This simplifies part 3, which will be to start using RuntimeConfig#servers() instead of install config.

This does not yet make KVS support reloadable config, just makes that change easier.
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
`CqlFactory` and `CassandraAsyncKeyValueService` now take the relevant configuration values when constructing, rather than an entire `CassandraKeyValueServiceConfig` instance.
==COMMIT_MSG==

**Implementation Description (bullets)**:
* Uses the relevant config values, rather than the entire config. This makes passing around runtime servers much easier.

**Testing (What was existing testing like?  What have you done to improve it?)**:
* Fixed existing tests

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
