### PR TITLE
Formalize LockRequest retrying behaviour

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
@@ -131,6 +131,9 @@ public interface TransactionManager extends AutoCloseable {
     /**
      * This method is basically the same as {@link #runTaskWithRetry(TransactionTask)} but it will
      * acquire locks right before the transaction is created and release them after the task is complete.
+     * If the lock request provided has a blocking mode of type {@link com.palantir.lock.BlockingMode#DO_NOT_BLOCK},
+     * the lock request will NOT be retried if it fails. Otherwise, the lock request will be retried on failure for a
+     * finite number of times (though users must of course be prepared for the case where all retries fail).
      * <p>
      * The created transaction will not commit successfully if these locks are invalid by the time commit is run.
      *

--- a/changelog/@unreleased/pr-6031.v2.yml
+++ b/changelog/@unreleased/pr-6031.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Formalise the behaviour around retrying of lock requests when users
+    provide a `Supplier<LockRequest>` to `runTaskWithLocksWithRetry()`.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6031


### PR DESCRIPTION
**Goals (and why)**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Formalise the behaviour around retrying of lock requests when users provide a `Supplier<LockRequest>` to `runTaskWithLocksWithRetry()`.
==COMMIT_MSG==

**Implementation Description (bullets)**: Add some docs

**Testing (What was existing testing like?  What have you done to improve it?)**: Nothing more than already existing tests. Not a production code change.

**Concerns (what feedback would you like?)**:
- It feels a bit leaky, though this behaviour is being relied upon. The alternative of adding an explicit mechanism through which users specify their retrying mode feels overkill.

**Where should we start reviewing?**: small

**Priority (whenever / two weeks / yesterday)**: whenever - though we should get this in as it's small, and this behaviour *is* relied upon.

@azarum for SA