### PR TITLE
PDS-264792: Sometimes refuse to follow our leader hints

### DIFF
--- a/atlasdb-tests-shared/src/main/java/com/palantir/timelock/paxos/InMemoryTimelockServices.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/timelock/paxos/InMemoryTimelockServices.java
@@ -162,7 +162,7 @@ public final class InMemoryTimelockServices extends ExternalResource implements 
 
         RedirectRetryTargeter redirectRetryTargeter = timeLockAgent.redirectRetryTargeter();
         ConjureTimelockService conjureTimelockService =
-                ConjureTimelockResource.jersey(redirectRetryTargeter, _unused -> delegate.getTimelockService());
+                ConjureTimelockResource.jersey(redirectRetryTargeter, 0.0, _unused -> delegate.getTimelockService());
         namespacedConjureTimelockService = new NamespacedConjureTimelockServiceImpl(conjureTimelockService, client);
         lockLeaseService = LockLeaseService.create(
                 namespacedConjureTimelockService, new LegacyLeaderTimeGetter(namespacedConjureTimelockService));

--- a/changelog/@unreleased/pr-6032.v2.yml
+++ b/changelog/@unreleased/pr-6032.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: With a 10% probability, TimeLock will now produce a 503 (unavailable)
+    exception rather than a 308 (redirect) pointing towards the node which it believes
+    to be the leader.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6032

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderLearnerNetworkClient.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderLearnerNetworkClient.java
@@ -101,7 +101,15 @@ public class SingleLeaderLearnerNetworkClient implements PaxosLearnerNetworkClie
         }
 
         // force local learner to update
+        log.info(
+                "Teaching ourselves the value () at sequence ()",
+                UnsafeArg.of("value", base16EncodePaxosValue(value)),
+                SafeArg.of("sequence", seq));
         localLearner.learn(seq, value);
+        log.info(
+                "Successfully taught ourselves the value () at sequence () (we assume)",
+                UnsafeArg.of("value", base16EncodePaxosValue(value)),
+                SafeArg.of("sequence", seq));
     }
 
     @Override

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLog.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SqlitePaxosStateLog.java
@@ -74,7 +74,9 @@ public class SqlitePaxosStateLog<V extends Persistable & Versionable> implements
                     SafeArg.of("namespace", namespace),
                     SafeArg.of("useCase", useCase),
                     SafeArg.of("seq", seq),
-                    UnsafeArg.of("value", round));
+                    UnsafeArg.of("value", round),
+                    ex);
+            throw ex;
         }
     }
 
@@ -89,7 +91,9 @@ public class SqlitePaxosStateLog<V extends Persistable & Versionable> implements
                     SafeArg.of("useCase", useCase),
                     SafeArg.of(
                             "seqs",
-                            Streams.stream(rounds).map(PaxosRound::sequence).collect(Collectors.toList())));
+                            Streams.stream(rounds).map(PaxosRound::sequence).collect(Collectors.toList())),
+                    ex);
+            throw ex;
         }
     }
 

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockInstallConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockInstallConfiguration.java
@@ -73,6 +73,22 @@ public interface TimeLockInstallConfiguration {
         return paxos().isNewService();
     }
 
+    /**
+     * TODO(gs): Remove this once PDS-264792 is resolved
+     *
+     * Defines the probability at which, upon receiving a request whilst not being the leader, we
+     * refuse to follow our own leader hint, and return QoS.unavailable().
+     *
+     * This gives us a 95% chance of hitting the correct node in the usual case, and a 5% chance of
+     * escaping from an infinite loop of 308s in the failure case (where our hint is wrong).
+     *
+     * We may want to reduce this if too many redirects make this slow.
+     */
+    @Value.Default
+    default double randomRedirectProbability() {
+        return 0.1;
+    }
+
     static Builder builder() {
         return new Builder();
     }

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockInstallConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockInstallConfiguration.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.palantir.atlasdb.debug.LockDiagnosticConfig;
+import com.palantir.atlasdb.timelock.config.TimeLockConstants;
 import com.palantir.paxos.Client;
 import java.util.Map;
 import org.immutables.value.Value;
@@ -32,7 +33,6 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonIgnoreProperties(value = "asyncLock")
 public interface TimeLockInstallConfiguration {
-
     PaxosInstallConfiguration paxos();
 
     /**
@@ -86,7 +86,7 @@ public interface TimeLockInstallConfiguration {
      */
     @Value.Default
     default double randomRedirectProbability() {
-        return 0.1;
+        return TimeLockConstants.DEFAULT_RANDOM_REDIRECT_PROBABILITY;
     }
 
     static Builder builder() {

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -359,7 +359,8 @@ public class TimeLockAgent {
             Consumer<UndertowService> presentUndertowRegistrar = undertowRegistrar.get();
             registerCorruptionHandlerWrappedService(
                     presentUndertowRegistrar,
-                    ConjureTimelockResource.undertow(redirectRetryTargeter, asyncTimelockServiceGetter));
+                    ConjureTimelockResource.undertow(
+                            redirectRetryTargeter, install.randomRedirectProbability(), asyncTimelockServiceGetter));
             registerCorruptionHandlerWrappedService(
                     presentUndertowRegistrar,
                     ConjureLockWatchingResource.undertow(redirectRetryTargeter, asyncTimelockServiceGetter));
@@ -383,7 +384,8 @@ public class TimeLockAgent {
                     presentUndertowRegistrar,
                     DisabledNamespacesUpdaterResource.undertow(authHeaderValidator, redirectRetryTargeter, namespaces));
         } else {
-            registrar.accept(ConjureTimelockResource.jersey(redirectRetryTargeter, asyncTimelockServiceGetter));
+            registrar.accept(ConjureTimelockResource.jersey(
+                    redirectRetryTargeter, install.randomRedirectProbability(), asyncTimelockServiceGetter));
             registrar.accept(ConjureLockWatchingResource.jersey(redirectRetryTargeter, asyncTimelockServiceGetter));
             registrar.accept(ConjureLockV1Resource.jersey(redirectRetryTargeter, lockServiceGetter));
             registrar.accept(TimeLockPaxosHistoryProviderResource.jersey(corruptionComponents.localHistoryLoader()));

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -363,7 +363,8 @@ public class TimeLockAgent {
                             redirectRetryTargeter, install.randomRedirectProbability(), asyncTimelockServiceGetter));
             registerCorruptionHandlerWrappedService(
                     presentUndertowRegistrar,
-                    ConjureLockWatchingResource.undertow(redirectRetryTargeter, asyncTimelockServiceGetter));
+                    ConjureLockWatchingResource.undertow(
+                            redirectRetryTargeter, install.randomRedirectProbability(), asyncTimelockServiceGetter));
             registerCorruptionHandlerWrappedService(
                     presentUndertowRegistrar, ConjureLockV1Resource.undertow(redirectRetryTargeter, lockServiceGetter));
             registerCorruptionHandlerWrappedService(
@@ -371,7 +372,8 @@ public class TimeLockAgent {
                     TimeLockPaxosHistoryProviderResource.undertow(corruptionComponents.localHistoryLoader()));
             registerCorruptionHandlerWrappedService(
                     presentUndertowRegistrar,
-                    MultiClientConjureTimelockResource.undertow(redirectRetryTargeter, asyncTimelockServiceGetter));
+                    MultiClientConjureTimelockResource.undertow(
+                            redirectRetryTargeter, install.randomRedirectProbability(), asyncTimelockServiceGetter));
             registerCorruptionHandlerWrappedService(
                     presentUndertowRegistrar,
                     AtlasBackupResource.undertow(
@@ -386,11 +388,12 @@ public class TimeLockAgent {
         } else {
             registrar.accept(ConjureTimelockResource.jersey(
                     redirectRetryTargeter, install.randomRedirectProbability(), asyncTimelockServiceGetter));
-            registrar.accept(ConjureLockWatchingResource.jersey(redirectRetryTargeter, asyncTimelockServiceGetter));
+            registrar.accept(ConjureLockWatchingResource.jersey(
+                    redirectRetryTargeter, install.randomRedirectProbability(), asyncTimelockServiceGetter));
             registrar.accept(ConjureLockV1Resource.jersey(redirectRetryTargeter, lockServiceGetter));
             registrar.accept(TimeLockPaxosHistoryProviderResource.jersey(corruptionComponents.localHistoryLoader()));
-            registrar.accept(
-                    MultiClientConjureTimelockResource.jersey(redirectRetryTargeter, asyncTimelockServiceGetter));
+            registrar.accept(MultiClientConjureTimelockResource.jersey(
+                    redirectRetryTargeter, install.randomRedirectProbability(), asyncTimelockServiceGetter));
             registrar.accept(
                     AtlasBackupResource.jersey(authHeaderValidator, redirectRetryTargeter, asyncTimelockServiceGetter));
             registrar.accept(AtlasRestoreResource.jersey(
@@ -444,6 +447,7 @@ public class TimeLockAgent {
                             allNodesDisabledNamespacesUpdater,
                             getAuthHeaderValidator(),
                             redirectRetryTargeter(),
+                            install.randomRedirectProbability(),
                             serviceLifecycleController));
         } else {
             registrar.accept(TimeLockManagementResource.jersey(
@@ -452,6 +456,7 @@ public class TimeLockAgent {
                     allNodesDisabledNamespacesUpdater,
                     getAuthHeaderValidator(),
                     redirectRetryTargeter(),
+                    install.randomRedirectProbability(),
                     serviceLifecycleController));
         }
     }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/ConjureLockWatchingResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/ConjureLockWatchingResource.java
@@ -33,20 +33,27 @@ public final class ConjureLockWatchingResource implements UndertowConjureLockWat
     private final Function<String, AsyncTimelockService> timelockServices;
 
     private ConjureLockWatchingResource(
-            RedirectRetryTargeter redirectRetryTargeter, Function<String, AsyncTimelockService> timelockServices) {
-        this.exceptionHandler = new ConjureResourceExceptionHandler(redirectRetryTargeter);
+            RedirectRetryTargeter redirectRetryTargeter,
+            double randomRedirectProbability,
+            Function<String, AsyncTimelockService> timelockServices) {
+        this.exceptionHandler = new ConjureResourceExceptionHandler(redirectRetryTargeter, randomRedirectProbability);
         this.timelockServices = timelockServices;
     }
 
     public static UndertowService undertow(
-            RedirectRetryTargeter redirectRetryTargeter, Function<String, AsyncTimelockService> timelockServices) {
+            RedirectRetryTargeter redirectRetryTargeter,
+            double randomRedirectProbability,
+            Function<String, AsyncTimelockService> timelockServices) {
         return ConjureLockWatchingServiceEndpoints.of(
-                new ConjureLockWatchingResource(redirectRetryTargeter, timelockServices));
+                new ConjureLockWatchingResource(redirectRetryTargeter, randomRedirectProbability, timelockServices));
     }
 
     public static ConjureLockWatchingService jersey(
-            RedirectRetryTargeter redirectRetryTargeter, Function<String, AsyncTimelockService> timelockServices) {
-        return new JerseyAdapter(new ConjureLockWatchingResource(redirectRetryTargeter, timelockServices));
+            RedirectRetryTargeter redirectRetryTargeter,
+            double randomRedirectProbability,
+            Function<String, AsyncTimelockService> timelockServices) {
+        return new JerseyAdapter(
+                new ConjureLockWatchingResource(redirectRetryTargeter, randomRedirectProbability, timelockServices));
     }
 
     @Override

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/ConjureResourceExceptionHandler.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/ConjureResourceExceptionHandler.java
@@ -21,6 +21,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.atlasdb.http.RedirectRetryTargeter;
+import com.palantir.atlasdb.timelock.config.TimeLockConstants;
 import com.palantir.conjure.java.api.errors.QosException;
 import com.palantir.leader.NotCurrentLeaderException;
 import com.palantir.lock.impl.TooManyRequestsException;
@@ -36,7 +37,7 @@ public class ConjureResourceExceptionHandler {
 
     public ConjureResourceExceptionHandler(RedirectRetryTargeter redirectRetryTargeter) {
         this.redirectRetryTargeter = redirectRetryTargeter;
-        this.randomRedirectProbability = 0.0;
+        this.randomRedirectProbability = TimeLockConstants.DEFAULT_RANDOM_REDIRECT_PROBABILITY;
     }
 
     public ConjureResourceExceptionHandler(

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/ConjureTimelockResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/ConjureTimelockResource.java
@@ -74,14 +74,28 @@ public final class ConjureTimelockResource implements UndertowConjureTimelockSer
         this.timelockServices = timelockServices;
     }
 
+    private ConjureTimelockResource(
+            RedirectRetryTargeter redirectRetryTargeter,
+            double randomRedirectProbability,
+            Function<String, AsyncTimelockService> timelockServices) {
+        this.exceptionHandler = new ConjureResourceExceptionHandler(redirectRetryTargeter, randomRedirectProbability);
+        this.timelockServices = timelockServices;
+    }
+
     public static UndertowService undertow(
-            RedirectRetryTargeter redirectRetryTargeter, Function<String, AsyncTimelockService> timelockServices) {
-        return ConjureTimelockServiceEndpoints.of(new ConjureTimelockResource(redirectRetryTargeter, timelockServices));
+            RedirectRetryTargeter redirectRetryTargeter,
+            double randomRedirectProbability,
+            Function<String, AsyncTimelockService> timelockServices) {
+        return ConjureTimelockServiceEndpoints.of(
+                new ConjureTimelockResource(redirectRetryTargeter, randomRedirectProbability, timelockServices));
     }
 
     public static ConjureTimelockService jersey(
-            RedirectRetryTargeter redirectRetryTargeter, Function<String, AsyncTimelockService> timelockServices) {
-        return new JerseyAdapter(new ConjureTimelockResource(redirectRetryTargeter, timelockServices));
+            RedirectRetryTargeter redirectRetryTargeter,
+            double randomRedirectProbability,
+            Function<String, AsyncTimelockService> timelockServices) {
+        return new JerseyAdapter(
+                new ConjureTimelockResource(redirectRetryTargeter, randomRedirectProbability, timelockServices));
     }
 
     @Override

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/ConjureTimelockResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/ConjureTimelockResource.java
@@ -69,12 +69,6 @@ public final class ConjureTimelockResource implements UndertowConjureTimelockSer
 
     @VisibleForTesting
     ConjureTimelockResource(
-            RedirectRetryTargeter redirectRetryTargeter, Function<String, AsyncTimelockService> timelockServices) {
-        this.exceptionHandler = new ConjureResourceExceptionHandler(redirectRetryTargeter);
-        this.timelockServices = timelockServices;
-    }
-
-    private ConjureTimelockResource(
             RedirectRetryTargeter redirectRetryTargeter,
             double randomRedirectProbability,
             Function<String, AsyncTimelockService> timelockServices) {

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/batch/MultiClientConjureTimelockResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/batch/MultiClientConjureTimelockResource.java
@@ -57,20 +57,27 @@ public final class MultiClientConjureTimelockResource implements UndertowMultiCl
 
     @VisibleForTesting
     MultiClientConjureTimelockResource(
-            RedirectRetryTargeter redirectRetryTargeter, Function<String, AsyncTimelockService> timelockServices) {
-        this.exceptionHandler = new ConjureResourceExceptionHandler(redirectRetryTargeter);
+            RedirectRetryTargeter redirectRetryTargeter,
+            double randomRedirectProbability,
+            Function<String, AsyncTimelockService> timelockServices) {
+        this.exceptionHandler = new ConjureResourceExceptionHandler(redirectRetryTargeter, randomRedirectProbability);
         this.timelockServices = timelockServices;
     }
 
     public static UndertowService undertow(
-            RedirectRetryTargeter redirectRetryTargeter, Function<String, AsyncTimelockService> timelockServices) {
-        return MultiClientConjureTimelockServiceEndpoints.of(
-                new MultiClientConjureTimelockResource(redirectRetryTargeter, timelockServices));
+            RedirectRetryTargeter redirectRetryTargeter,
+            double randomRedirectProbability,
+            Function<String, AsyncTimelockService> timelockServices) {
+        return MultiClientConjureTimelockServiceEndpoints.of(new MultiClientConjureTimelockResource(
+                redirectRetryTargeter, randomRedirectProbability, timelockServices));
     }
 
     public static MultiClientConjureTimelockService jersey(
-            RedirectRetryTargeter redirectRetryTargeter, Function<String, AsyncTimelockService> timelockServices) {
-        return new JerseyAdapter(new MultiClientConjureTimelockResource(redirectRetryTargeter, timelockServices));
+            RedirectRetryTargeter redirectRetryTargeter,
+            double randomRedirectProbability,
+            Function<String, AsyncTimelockService> timelockServices) {
+        return new JerseyAdapter(new MultiClientConjureTimelockResource(
+                redirectRetryTargeter, randomRedirectProbability, timelockServices));
     }
 
     @Override

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/config/TimeLockConstants.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/config/TimeLockConstants.java
@@ -1,0 +1,24 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.timelock.config;
+
+public final class TimeLockConstants {
+    private TimeLockConstants() {
+        // util
+    }
+
+    public static final double DEFAULT_RANDOM_REDIRECT_PROBABILITY = 0.1;
+}

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/TimeLockManagementResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/TimeLockManagementResource.java
@@ -62,12 +62,13 @@ public final class TimeLockManagementResource implements UndertowTimeLockManagem
             TimelockNamespaces timelockNamespaces,
             AuthHeaderValidator authHeaderValidator,
             RedirectRetryTargeter redirectRetryTargeter,
+            double randomRedirectProbability,
             ServiceLifecycleController serviceLifecycleController) {
         this.namespaceLoaders = namespaceLoaders;
         this.allNodesDisabledNamespacesUpdater = allNodesDisabledNamespacesUpdater;
         this.timelockNamespaces = timelockNamespaces;
         this.authHeaderValidator = authHeaderValidator;
-        this.exceptionHandler = new ConjureResourceExceptionHandler(redirectRetryTargeter);
+        this.exceptionHandler = new ConjureResourceExceptionHandler(redirectRetryTargeter, randomRedirectProbability);
         this.serviceLifecycleController = serviceLifecycleController;
     }
 
@@ -77,6 +78,7 @@ public final class TimeLockManagementResource implements UndertowTimeLockManagem
             AllNodesDisabledNamespacesUpdater allNodesDisabledNamespacesUpdater,
             AuthHeaderValidator authHeaderValidator,
             RedirectRetryTargeter redirectRetryTargeter,
+            double randomRedirectProbability,
             ServiceLifecycleController serviceLifecycleController) {
         return new TimeLockManagementResource(
                 createNamespaceLoaders(persistentNamespaceContext),
@@ -84,6 +86,7 @@ public final class TimeLockManagementResource implements UndertowTimeLockManagem
                 timelockNamespaces,
                 authHeaderValidator,
                 redirectRetryTargeter,
+                randomRedirectProbability,
                 serviceLifecycleController);
     }
 
@@ -93,6 +96,7 @@ public final class TimeLockManagementResource implements UndertowTimeLockManagem
             AllNodesDisabledNamespacesUpdater allNodesDisabledNamespacesUpdater,
             AuthHeaderValidator authHeaderValidator,
             RedirectRetryTargeter redirectRetryTargeter,
+            double randomRedirectProbability,
             ServiceLifecycleController serviceLifecycleController) {
         return TimeLockManagementServiceEndpoints.of(TimeLockManagementResource.create(
                 persistentNamespaceContext,
@@ -100,6 +104,7 @@ public final class TimeLockManagementResource implements UndertowTimeLockManagem
                 allNodesDisabledNamespacesUpdater,
                 authHeaderValidator,
                 redirectRetryTargeter,
+                randomRedirectProbability,
                 serviceLifecycleController));
     }
 
@@ -109,6 +114,7 @@ public final class TimeLockManagementResource implements UndertowTimeLockManagem
             AllNodesDisabledNamespacesUpdater allNodesDisabledNamespacesUpdater,
             AuthHeaderValidator authHeaderValidator,
             RedirectRetryTargeter redirectRetryTargeter,
+            double randomRedirectProbability,
             ServiceLifecycleController serviceLifecycleController) {
         return new JerseyAdapter(TimeLockManagementResource.create(
                 persistentNamespaceContext,
@@ -116,6 +122,7 @@ public final class TimeLockManagementResource implements UndertowTimeLockManagem
                 allNodesDisabledNamespacesUpdater,
                 authHeaderValidator,
                 redirectRetryTargeter,
+                randomRedirectProbability,
                 serviceLifecycleController));
     }
 

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/ConjureTimelockResourceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/ConjureTimelockResourceTest.java
@@ -65,7 +65,7 @@ public class ConjureTimelockResourceTest {
 
     @Before
     public void before() {
-        resource = new ConjureTimelockResource(TARGETER, unused -> timelockService);
+        resource = new ConjureTimelockResource(TARGETER, 0.0, unused -> timelockService);
         service = ConjureTimelockResource.jersey(TARGETER, 0.0, unused -> timelockService);
         when(timelockService.leaderTime()).thenReturn(Futures.immediateFuture(leaderTime));
     }

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/ConjureTimelockResourceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/ConjureTimelockResourceTest.java
@@ -66,7 +66,7 @@ public class ConjureTimelockResourceTest {
     @Before
     public void before() {
         resource = new ConjureTimelockResource(TARGETER, unused -> timelockService);
-        service = ConjureTimelockResource.jersey(TARGETER, unused -> timelockService);
+        service = ConjureTimelockResource.jersey(TARGETER, 0.0, unused -> timelockService);
         when(timelockService.leaderTime()).thenReturn(Futures.immediateFuture(leaderTime));
     }
 

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/batch/MultiClientConjureTimelockResourceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/batch/MultiClientConjureTimelockResourceTest.java
@@ -83,7 +83,7 @@ public class MultiClientConjureTimelockResourceTest {
 
     @Before
     public void before() {
-        resource = new MultiClientConjureTimelockResource(TARGETER, this::getServiceForClient);
+        resource = new MultiClientConjureTimelockResource(TARGETER, 0.0, this::getServiceForClient);
     }
 
     @Test

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/management/TimeLockManagementResourceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/management/TimeLockManagementResourceTest.java
@@ -113,6 +113,7 @@ public class TimeLockManagementResourceTest {
                 allNodesDisabledNamespacesUpdater,
                 authHeaderValidator,
                 redirectRetryTargeter,
+                0.0,
                 new ServiceLifecycleController(serviceStopper, PTExecutors.newSingleThreadScheduledExecutor()));
 
         createDirectoryForLeaderForEachClientUseCase(NAMESPACE_1);


### PR DESCRIPTION
**Goals (and why)**:
In PDS-264792, we suspect that two TimeLock nodes each believed that it was not the leader, causing an infinite loop of 308 responses, redirecting the caller to the other non-leader node. 

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
With a 10% probability, TimeLock will now produce a 503 (unavailable) exception rather than a 308 (redirect) pointing towards the node which it believes to be the leader.
==COMMIT_MSG==

**Implementation Description (bullets)**:
- Redirect config
- More logging for failures to teach learners.

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:
Will the extra 503s make things (unacceptably) slower? We should roll this out carefully!
Perhaps we should default P(redirect) to 0.0 while we're testing this out, to avoid RC branches?

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
