### PR TITLE
[Runtime config] Part 2g: Async KVS supports reloading CQL clients

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/AsyncKeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/AsyncKeyValueService.java
@@ -29,6 +29,7 @@ public interface AsyncKeyValueService extends AutoCloseable {
      * @param tableRef        the name of the table to retrieve values from.
      * @param timestampByCell specifies, for each row, the maximum timestamp (exclusive) at which to retrieve that
      *                        row's value.
+     *
      * @return listenable future containing map of retrieved values. Values which do not exist (either because they were
      * deleted or never created in the first place) are simply not returned.
      */
@@ -38,4 +39,8 @@ public interface AsyncKeyValueService extends AutoCloseable {
 
     @Override
     void close();
+
+    default boolean isValid() {
+        return true;
+    }
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/AsyncKeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/AsyncKeyValueService.java
@@ -29,7 +29,6 @@ public interface AsyncKeyValueService extends AutoCloseable {
      * @param tableRef        the name of the table to retrieve values from.
      * @param timestampByCell specifies, for each row, the maximum timestamp (exclusive) at which to retrieve that
      *                        row's value.
-     *
      * @return listenable future containing map of retrieved values. Values which do not exist (either because they were
      * deleted or never created in the first place) are simply not returned.
      */

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/AsyncKeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/AsyncKeyValueService.java
@@ -40,6 +40,18 @@ public interface AsyncKeyValueService extends AutoCloseable {
     @Override
     void close();
 
+    /**
+     * Denotes whether the AsyncKeyValueService is currently capable of handling requests.
+     * Reasons for an AsyncKeyValueService to be invalid include e.g being closed, in the process of being refreshed, or
+     * incorrectly configured.
+     *
+     * Use this value to shortcircuit async requests. However, it is not guaranteed that a {@link #getAsync} call will
+     * not fail even after isValid has returned true - the AsyncKeyValueService may transition to invalid between the
+     * `isValid` call and a `getAsync` call.
+     *
+     * @return true iff the AsyncKeyValueService is currently capable of handling requests at the instant this method
+     * was called, otherwise false.
+     */
     default boolean isValid() {
         return true;
     }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -677,4 +677,10 @@ public interface KeyValueService extends AutoCloseable, AsyncKeyValueService {
     @DoDelegate
     @Deprecated
     List<byte[]> getRowKeysInRange(TableReference tableRef, byte[] startRow, byte[] endRow, int maxResults);
+
+    @DoDelegate
+    @Override
+    default boolean isValid() {
+        return true;
+    }
 }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsAsyncFallbackMechanismsTests.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsAsyncFallbackMechanismsTests.java
@@ -135,7 +135,6 @@ public class CassandraKvsAsyncFallbackMechanismsTests {
 
     @Test
     public void testGetAsyncFallingBackToSynchronousOnInvalidAsyncKvs() {
-        when(asyncKeyValueService.getAsync(any(), any())).thenReturn(Futures.immediateFuture(ImmutableMap.of()));
         when(factory.constructAsyncKeyValueService(
                         any(), any(), any(), any(), eq(AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC)))
                 .thenReturn(asyncKeyValueService);

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsAsyncFallbackMechanismsTests.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsAsyncFallbackMechanismsTests.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -67,8 +68,8 @@ public class CassandraKvsAsyncFallbackMechanismsTests {
 
     @Before
     public void setUp() {
-        when(asyncKeyValueService.getAsync(any(), any())).thenReturn(Futures.immediateFuture(ImmutableMap.of()));
-        when(throwingAsyncKeyValueService.getAsync(any(), any())).thenThrow(new IllegalStateException());
+        lenient().when(asyncKeyValueService.getAsync(any(), any())).thenReturn(Futures.immediateFuture(ImmutableMap.of()));
+        lenient().when(throwingAsyncKeyValueService.getAsync(any(), any())).thenThrow(new IllegalStateException());
     }
 
     @After

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsAsyncFallbackMechanismsTests.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsAsyncFallbackMechanismsTests.java
@@ -86,7 +86,7 @@ public class CassandraKvsAsyncFallbackMechanismsTests {
         when(factory.constructAsyncKeyValueService(
                         any(), any(), any(), any(), eq(AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC)))
                 .thenReturn(asyncKeyValueService);
-
+        when(asyncKeyValueService.isValid()).thenReturn(true);
         CassandraKeyValueServiceConfig config = ImmutableCassandraKeyValueServiceConfig.builder()
                 .from(CASSANDRA_RESOURCE.getConfig())
                 .asyncKeyValueServiceFactory(factory)

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsAsyncFallbackMechanismsTests.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsAsyncFallbackMechanismsTests.java
@@ -162,8 +162,8 @@ public class CassandraKvsAsyncFallbackMechanismsTests {
 
     // TODO: Cleanup!! DO NOT MERGE
     @Test
-    public void testGetAsyncFallingBackToSynchronousOnSessionClosedForExecuteAsync() throws ExecutionException,
-            InterruptedException {
+    public void testGetAsyncFallingBackToSynchronousOnSessionClosedForExecuteAsync()
+            throws ExecutionException, InterruptedException {
         CassandraKeyValueServiceConfig config = CASSANDRA_RESOURCE.getConfig();
         Cluster cluster = spy(new ClusterFactory(CASSANDRA_RESOURCE.getClusterBuilderWithProxy())
                 .constructCluster(CassandraClusterConfig.of(config), config.servers()));
@@ -231,6 +231,4 @@ public class CassandraKvsAsyncFallbackMechanismsTests {
 
         verify(keyValueService).get(TEST_TABLE, TIMESTAMP_BY_CELL);
     }
-
-
 }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsAsyncFallbackMechanismsTests.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsAsyncFallbackMechanismsTests.java
@@ -156,12 +156,12 @@ public class CassandraKvsAsyncFallbackMechanismsTests {
     public void testGetAsyncFallingBackToSynchronousOnSessionClosed() {
         when(asyncKeyValueService.isValid()).thenReturn(false);
         CassandraKeyValueServiceConfig config = CASSANDRA_RESOURCE.getConfig();
-        Cluster cluster = new ClusterFactory(Cluster::builder)
-                .constructCluster(CassandraClusterConfig.of(config), config.servers());
+        Cluster cluster = spy(new ClusterFactory(Cluster::builder)
+                .constructCluster(CassandraClusterConfig.of(config), config.servers()));
         Session session = spy(cluster.connect());
         when(session.isClosed()).thenReturn(true);
+        when(cluster.connect()).thenReturn(session);
         session.close();
-        cluster.close();
         CqlClient cqlClient = CqlClientImpl.create(
                 new DefaultTaggedMetricRegistry(), cluster, mock(CqlCapableConfigTuning.class), false);
         CassandraAsyncKeyValueServiceFactory cassandraAsyncKeyValueServiceFactory =

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsAsyncFallbackMechanismsTests.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsAsyncFallbackMechanismsTests.java
@@ -73,7 +73,8 @@ public class CassandraKvsAsyncFallbackMechanismsTests {
 
     @Test
     public void testGetFallBackNotNeeded() {
-        when(factory.constructAsyncKeyValueService(any(), any(), eq(AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC)))
+        when(factory.constructAsyncKeyValueService(
+                        any(), any(), any(), any(), eq(AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC)))
                 .thenReturn(Optional.of(asyncKeyValueService));
 
         CassandraKeyValueServiceConfig config = ImmutableCassandraKeyValueServiceConfig.builder()
@@ -89,7 +90,8 @@ public class CassandraKvsAsyncFallbackMechanismsTests {
 
     @Test
     public void testGetFallingBackToSynchronous() {
-        when(factory.constructAsyncKeyValueService(any(), any(), eq(AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC)))
+        when(factory.constructAsyncKeyValueService(
+                        any(), any(), any(), any(), eq(AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC)))
                 .thenReturn(Optional.empty());
 
         CassandraKeyValueServiceConfig config = ImmutableCassandraKeyValueServiceConfig.builder()

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsAsyncFallbackMechanismsTests.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsAsyncFallbackMechanismsTests.java
@@ -21,7 +21,6 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -58,7 +57,6 @@ import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -85,14 +83,6 @@ public class CassandraKvsAsyncFallbackMechanismsTests {
     @Mock
     private CassandraAsyncKeyValueServiceFactory factory;
 
-    @Before
-    public void setUp() {
-        lenient()
-                .when(asyncKeyValueService.getAsync(any(), any()))
-                .thenReturn(Futures.immediateFuture(ImmutableMap.of()));
-        lenient().when(throwingAsyncKeyValueService.getAsync(any(), any())).thenThrow(new IllegalStateException());
-    }
-
     @After
     public void tearDown() {
         try {
@@ -105,6 +95,7 @@ public class CassandraKvsAsyncFallbackMechanismsTests {
 
     @Test
     public void testGetAsyncFallBackNotNeeded() {
+        when(asyncKeyValueService.getAsync(any(), any())).thenReturn(Futures.immediateFuture(ImmutableMap.of()));
         when(factory.constructAsyncKeyValueService(
                         any(), any(), any(), any(), eq(AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC)))
                 .thenReturn(asyncKeyValueService);
@@ -123,6 +114,7 @@ public class CassandraKvsAsyncFallbackMechanismsTests {
 
     @Test
     public void testGetAsyncFallingBackToSynchronousOnException() {
+        when(throwingAsyncKeyValueService.getAsync(any(), any())).thenThrow(new IllegalStateException());
         when(throwingAsyncKeyValueService.isValid()).thenReturn(true);
         when(factory.constructAsyncKeyValueService(
                         any(), any(), any(), any(), eq(AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC)))
@@ -143,6 +135,7 @@ public class CassandraKvsAsyncFallbackMechanismsTests {
 
     @Test
     public void testGetAsyncFallingBackToSynchronousOnInvalidAsyncKvs() {
+        when(asyncKeyValueService.getAsync(any(), any())).thenReturn(Futures.immediateFuture(ImmutableMap.of()));
         when(factory.constructAsyncKeyValueService(
                         any(), any(), any(), any(), eq(AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC)))
                 .thenReturn(asyncKeyValueService);

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsAsyncFallbackMechanismsTests.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsAsyncFallbackMechanismsTests.java
@@ -161,15 +161,14 @@ public class CassandraKvsAsyncFallbackMechanismsTests {
                 .constructCluster(CassandraClusterConfig.of(config), config.servers()));
         Session session = spy(cluster.connect());
 
-        doReturn(true).when(session.isClosed());
-        doReturn(session).when(cluster.connect());
+        doReturn(session).when(cluster).connect();
 
         session.close();
 
         CqlClient cqlClient = spy(CqlClientImpl.create(
                 new DefaultTaggedMetricRegistry(), cluster, mock(CqlCapableConfigTuning.class), false));
 
-        doReturn(true).when(cqlClient.isValid());
+        doReturn(true).when(cqlClient).isValid();
         CassandraAsyncKeyValueServiceFactory cassandraAsyncKeyValueServiceFactory =
                 new DefaultCassandraAsyncKeyValueServiceFactory((_ignored1, _ignored2, _ignored3, _ignored4) ->
                         ReloadingCloseableContainer.of(Refreshable.only(0), _ignored -> cqlClient));

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsAsyncFallbackMechanismsTests.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsAsyncFallbackMechanismsTests.java
@@ -120,7 +120,7 @@ public class CassandraKvsAsyncFallbackMechanismsTests {
     @Test
     public void testGetAsyncFallingBackToSynchronousOnInvalidAsyncKvs() {
         when(factory.constructAsyncKeyValueService(
-                any(), any(), any(), any(), eq(AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC)))
+                        any(), any(), any(), any(), eq(AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC)))
                 .thenReturn(asyncKeyValueService);
         when(asyncKeyValueService.isValid()).thenReturn(false);
         CassandraKeyValueServiceConfig config = ImmutableCassandraKeyValueServiceConfig.builder()

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsAsyncFallbackMechanismsTests.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsAsyncFallbackMechanismsTests.java
@@ -68,7 +68,9 @@ public class CassandraKvsAsyncFallbackMechanismsTests {
 
     @Before
     public void setUp() {
-        lenient().when(asyncKeyValueService.getAsync(any(), any())).thenReturn(Futures.immediateFuture(ImmutableMap.of()));
+        lenient()
+                .when(asyncKeyValueService.getAsync(any(), any()))
+                .thenReturn(Futures.immediateFuture(ImmutableMap.of()));
         lenient().when(throwingAsyncKeyValueService.getAsync(any(), any())).thenThrow(new IllegalStateException());
     }
 

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsAsyncFallbackMechanismsTests.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsAsyncFallbackMechanismsTests.java
@@ -21,6 +21,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -108,10 +109,11 @@ public class CassandraKvsAsyncFallbackMechanismsTests {
                 .asyncKeyValueServiceFactory(factory)
                 .build();
 
-        keyValueService = CassandraKeyValueServiceImpl.createForTesting(config);
+        keyValueService = spy(CassandraKeyValueServiceImpl.createForTesting(config));
         keyValueService.getAsync(TEST_TABLE, TIMESTAMP_BY_CELL);
 
         verify(asyncKeyValueService, times(1)).getAsync(any(), any());
+        verify(keyValueService, never()).get(any(), any());
     }
 
     @Test

--- a/atlasdb-cassandra-integration-tests/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/atlasdb-cassandra-integration-tests/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/ReloadingCloseableContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/ReloadingCloseableContainer.java
@@ -101,6 +101,10 @@ public final class ReloadingCloseableContainer<T extends AutoCloseable> implemen
         return runIfNotClosed(refreshableResource, "Attempted to get a resource after the container was closed");
     }
 
+    public boolean isClosed() {
+        return isClosed;
+    }
+
     private <K> K runIfNotClosed(Supplier<K> supplier, @CompileTimeConstant String ifClosedExceptionMessage) {
         if (!isClosed) {
             return runWithIsClosedReadLock(() -> {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -2089,10 +2089,16 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             log.info("Attempted get with no specified cells", LoggingArgs.tableRef(tableRef));
             return Futures.immediateFuture(ImmutableMap.of());
         }
+
         try {
             return asyncKeyValueService.getAsync(tableRef, timestampByCell);
         } catch (IllegalStateException e) {
-            log.info("Invalid async KVS");
+            log.warn(
+                    "Either the CQL config is invalid or not present, or the Async Key Value Store has been closed. If"
+                        + " intending to use getAsync please ensure you have configured AtlasDB to use CQL, and that"
+                        + " the configured set of CQL hosts match the set of Thrift hosts. Defaulting to a synchronous"
+                        + " get",
+                    e);
             return Futures.immediateFuture(this.get(tableRef, timestampByCell));
         }
     }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -42,6 +42,7 @@ import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceRuntimeConfig;
 import com.palantir.atlasdb.cassandra.CassandraMutationTimestampProvider;
 import com.palantir.atlasdb.cassandra.CassandraMutationTimestampProviders;
+import com.palantir.atlasdb.cassandra.CassandraServersConfigs.CassandraServersConfig;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.AsyncKeyValueService;
 import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
@@ -68,6 +69,7 @@ import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolImpl.StartupChecks;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServices.StartTsResultsCollector;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraVerifier.CassandraVerifierConfig;
+import com.palantir.atlasdb.keyvalue.cassandra.async.client.creation.ClusterFactory.CassandraClusterConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.cas.CheckAndSetRunner;
 import com.palantir.atlasdb.keyvalue.cassandra.paging.RowGetter;
 import com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer;
@@ -371,8 +373,14 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             Logger log,
             boolean initializeAsync) {
         try {
+            CassandraClusterConfig clusterConfig = CassandraClusterConfig.of(config);
             Optional<AsyncKeyValueService> asyncKeyValueService = config.asyncKeyValueServiceFactory()
-                    .constructAsyncKeyValueService(metricsManager, config, initializeAsync);
+                    .constructAsyncKeyValueService(
+                            metricsManager,
+                            config.getKeyspaceOrThrow(),
+                            config::servers,
+                            clusterConfig,
+                            initializeAsync);
 
             return createAndInitialize(
                     metricsManager,
@@ -449,18 +457,26 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     }
 
     private static ExecutorService createBlockingThreadpool(
-            CassandraKeyValueServiceConfig config, MetricsManager metricsManager) {
+            CassandraKeyValueServiceConfig config,
+            MetricsManager metricsManager) {
         return config.thriftExecutorServiceFactory()
-                .orElseGet(() -> instrumentedFixedThreadPoolSupplier(config, metricsManager.getTaggedRegistry()))
+                .orElseGet(() -> instrumentedFixedThreadPoolSupplier(
+                        config.servers(),
+                        config.poolSize(),
+                        config.maxConnectionBurstSize(),
+                        metricsManager.getTaggedRegistry()))
                 .get();
     }
 
     private static Supplier<ExecutorService> instrumentedFixedThreadPoolSupplier(
-            CassandraKeyValueServiceConfig config, TaggedMetricRegistry registry) {
+            CassandraServersConfig serversConfig,
+            int poolSize,
+            int maxConnectionBurstSize,
+            TaggedMetricRegistry registry) {
         return () -> {
-            int numberOfThriftHosts = config.servers().numberOfThriftHosts();
-            int corePoolSize = config.poolSize() * numberOfThriftHosts;
-            int maxPoolSize = config.maxConnectionBurstSize() * numberOfThriftHosts;
+            int numberOfThriftHosts = serversConfig.numberOfThriftHosts();
+            int corePoolSize = poolSize * numberOfThriftHosts;
+            int maxPoolSize = maxConnectionBurstSize * numberOfThriftHosts;
             return Tracers.wrap(
                     "Atlas Cassandra KVS",
                     MetricRegistries.instrument(

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -378,8 +378,8 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                     .constructAsyncKeyValueService(
                             metricsManager,
                             config.getKeyspaceOrThrow(),
-                            config::servers,
                             clusterConfig,
+                            config.servers(),
                             initializeAsync);
 
             return createAndInitialize(
@@ -457,8 +457,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     }
 
     private static ExecutorService createBlockingThreadpool(
-            CassandraKeyValueServiceConfig config,
-            MetricsManager metricsManager) {
+            CassandraKeyValueServiceConfig config, MetricsManager metricsManager) {
         return config.thriftExecutorServiceFactory()
                 .orElseGet(() -> instrumentedFixedThreadPoolSupplier(
                         config.servers(),

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
+import com.datastax.driver.core.exceptions.DriverInternalError;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Functions;
 import com.google.common.base.Predicates;
@@ -2103,7 +2104,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                             return this.get(tableRef, timestampByCell);
                         },
                         executor);
-            } catch (IllegalStateException e) {
+            } catch (IllegalStateException | DriverInternalError e) {
                 // If the container is closed, or we've reloaded into an invalid ThrowingCqlClient, after testing for
                 // validity
                 return Futures.immediateFuture(this.get(tableRef, timestampByCell));

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/CassandraAsyncKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/CassandraAsyncKeyValueService.java
@@ -96,6 +96,6 @@ public final class CassandraAsyncKeyValueService implements AsyncKeyValueService
 
     @Override
     public boolean isValid() {
-        return (!cqlClientContainer.isClosed()) && cqlClientContainer.get().isValid();
+        return !cqlClientContainer.isClosed() && cqlClientContainer.get().isValid();
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/CassandraAsyncKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/CassandraAsyncKeyValueService.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,5 +92,10 @@ public final class CassandraAsyncKeyValueService implements AsyncKeyValueService
     public void close() {
         cqlClientContainer.close();
         futuresCombiner.close();
+    }
+
+    @Override
+    public boolean isValid() {
+        return (!cqlClientContainer.isClosed()) && cqlClientContainer.get().isValid();
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/CassandraAsyncKeyValueServiceFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/CassandraAsyncKeyValueServiceFactory.java
@@ -21,13 +21,12 @@ import com.palantir.atlasdb.keyvalue.api.AsyncKeyValueService;
 import com.palantir.atlasdb.keyvalue.cassandra.async.client.creation.ClusterFactory.CassandraClusterConfig;
 import com.palantir.atlasdb.util.MetricsManager;
 import java.util.Optional;
-import java.util.function.Supplier;
 
 public interface CassandraAsyncKeyValueServiceFactory {
     Optional<AsyncKeyValueService> constructAsyncKeyValueService(
             MetricsManager metricsManager,
             String keyspace,
-            Supplier<CassandraServersConfig> cassandraServersConfigSupplier,
             CassandraClusterConfig cassandraClusterConfig,
+            CassandraServersConfig cassandraServersConfig,
             boolean initializeAsync);
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/CassandraAsyncKeyValueServiceFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/CassandraAsyncKeyValueServiceFactory.java
@@ -20,13 +20,13 @@ import com.palantir.atlasdb.cassandra.CassandraServersConfigs.CassandraServersCo
 import com.palantir.atlasdb.keyvalue.api.AsyncKeyValueService;
 import com.palantir.atlasdb.keyvalue.cassandra.async.client.creation.ClusterFactory.CassandraClusterConfig;
 import com.palantir.atlasdb.util.MetricsManager;
-import java.util.Optional;
+import com.palantir.refreshable.Refreshable;
 
 public interface CassandraAsyncKeyValueServiceFactory {
-    Optional<AsyncKeyValueService> constructAsyncKeyValueService(
+    AsyncKeyValueService constructAsyncKeyValueService(
             MetricsManager metricsManager,
             String keyspace,
             CassandraClusterConfig cassandraClusterConfig,
-            CassandraServersConfig cassandraServersConfig,
+            Refreshable<CassandraServersConfig> cassandraServersConfigRefreshable,
             boolean initializeAsync);
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/CassandraAsyncKeyValueServiceFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/CassandraAsyncKeyValueServiceFactory.java
@@ -16,12 +16,18 @@
 
 package com.palantir.atlasdb.keyvalue.cassandra.async;
 
-import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
+import com.palantir.atlasdb.cassandra.CassandraServersConfigs.CassandraServersConfig;
 import com.palantir.atlasdb.keyvalue.api.AsyncKeyValueService;
+import com.palantir.atlasdb.keyvalue.cassandra.async.client.creation.ClusterFactory.CassandraClusterConfig;
 import com.palantir.atlasdb.util.MetricsManager;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 public interface CassandraAsyncKeyValueServiceFactory {
     Optional<AsyncKeyValueService> constructAsyncKeyValueService(
-            MetricsManager metricsManager, CassandraKeyValueServiceConfig config, boolean initializeAsync);
+            MetricsManager metricsManager,
+            String keyspace,
+            Supplier<CassandraServersConfig> cassandraServersConfigSupplier,
+            CassandraClusterConfig cassandraClusterConfig,
+            boolean initializeAsync);
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/CqlClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/CqlClient.java
@@ -27,4 +27,6 @@ public interface CqlClient extends AutoCloseable {
 
     @Override
     void close();
+
+    boolean isValid();
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/CqlClientImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/CqlClientImpl.java
@@ -35,7 +35,8 @@ import com.palantir.atlasdb.keyvalue.cassandra.async.statement.preparing.Stateme
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.util.concurrent.Executor;
 
-public final class CqlClientImpl implements CqlClient {
+@SuppressWarnings({"FinalClass", "Not final for spying in tests"})
+public class CqlClientImpl implements CqlClient {
     private static final class InitializingWrapper extends AsyncInitializer implements AutoDelegate_CqlClient {
 
         private final TaggedMetricRegistry taggedMetricRegistry;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/CqlClientImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/CqlClientImpl.java
@@ -115,7 +115,7 @@ public final class CqlClientImpl implements CqlClient {
 
     @Override
     public boolean isValid() {
-        return session.isClosed();
+        return !session.isClosed();
     }
 
     @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/CqlClientImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/CqlClientImpl.java
@@ -71,6 +71,11 @@ public final class CqlClientImpl implements CqlClient {
                 internalImpl.close();
             }
         }
+
+        @Override
+        public boolean isValid() {
+            return (internalImpl != null) && internalImpl.isValid();
+        }
     }
 
     private final Session session;
@@ -106,6 +111,11 @@ public final class CqlClientImpl implements CqlClient {
         Cluster cluster = session.getCluster();
         session.close();
         cluster.close();
+    }
+
+    @Override
+    public boolean isValid() {
+        return session.isClosed();
     }
 
     @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/CqlClientImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/CqlClientImpl.java
@@ -35,8 +35,7 @@ import com.palantir.atlasdb.keyvalue.cassandra.async.statement.preparing.Stateme
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.util.concurrent.Executor;
 
-@SuppressWarnings({"FinalClass", "Not final for spying in tests"})
-public class CqlClientImpl implements CqlClient {
+public final class CqlClientImpl implements CqlClient {
     private static final class InitializingWrapper extends AsyncInitializer implements AutoDelegate_CqlClient {
 
         private final TaggedMetricRegistry taggedMetricRegistry;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/DefaultCassandraAsyncKeyValueServiceFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/DefaultCassandraAsyncKeyValueServiceFactory.java
@@ -33,7 +33,6 @@ import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.tracing.Tracers;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
-import java.util.function.Supplier;
 
 public final class DefaultCassandraAsyncKeyValueServiceFactory implements CassandraAsyncKeyValueServiceFactory {
     public static final CassandraAsyncKeyValueServiceFactory DEFAULT =
@@ -49,16 +48,13 @@ public final class DefaultCassandraAsyncKeyValueServiceFactory implements Cassan
     public Optional<AsyncKeyValueService> constructAsyncKeyValueService(
             MetricsManager metricsManager,
             String keyspace,
-            Supplier<CassandraServersConfig> cassandraServersConfigSupplier,
             CassandraClusterConfig cassandraClusterConfig,
+            CassandraServersConfig cassandraServersConfig,
             boolean initializeAsync) {
         Optional<CqlClient> cqlClient = cqlClientFactory.constructClient(
-                metricsManager.getTaggedRegistry(),
-                cassandraServersConfigSupplier,
-                cassandraClusterConfig,
-                initializeAsync);
+                metricsManager.getTaggedRegistry(), cassandraServersConfig, cassandraClusterConfig, initializeAsync);
 
-        ExecutorService executorService = cassandraServersConfigSupplier.get().accept(new Visitor<ExecutorService>() {
+        ExecutorService executorService = cassandraServersConfig.accept(new Visitor<ExecutorService>() {
             @Override
             public ExecutorService visit(DefaultConfig defaultConfig) {
                 return MoreExecutors.newDirectExecutorService();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/DefaultCassandraAsyncKeyValueServiceFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/DefaultCassandraAsyncKeyValueServiceFactory.java
@@ -19,12 +19,13 @@ package com.palantir.atlasdb.keyvalue.cassandra.async;
 import com.codahale.metrics.InstrumentedExecutorService;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.util.concurrent.MoreExecutors;
-import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
+import com.palantir.atlasdb.cassandra.CassandraServersConfigs.CassandraServersConfig;
 import com.palantir.atlasdb.cassandra.CassandraServersConfigs.CqlCapableConfig;
 import com.palantir.atlasdb.cassandra.CassandraServersConfigs.DefaultConfig;
 import com.palantir.atlasdb.cassandra.CassandraServersConfigs.Visitor;
 import com.palantir.atlasdb.futures.AtlasFutures;
 import com.palantir.atlasdb.keyvalue.api.AsyncKeyValueService;
+import com.palantir.atlasdb.keyvalue.cassandra.async.client.creation.ClusterFactory.CassandraClusterConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.async.client.creation.CqlClientFactory;
 import com.palantir.atlasdb.keyvalue.cassandra.async.client.creation.DefaultCqlClientFactory;
 import com.palantir.atlasdb.util.MetricsManager;
@@ -32,6 +33,7 @@ import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.tracing.Tracers;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
 
 public final class DefaultCassandraAsyncKeyValueServiceFactory implements CassandraAsyncKeyValueServiceFactory {
     public static final CassandraAsyncKeyValueServiceFactory DEFAULT =
@@ -45,11 +47,18 @@ public final class DefaultCassandraAsyncKeyValueServiceFactory implements Cassan
 
     @Override
     public Optional<AsyncKeyValueService> constructAsyncKeyValueService(
-            MetricsManager metricsManager, CassandraKeyValueServiceConfig config, boolean initializeAsync) {
-        Optional<CqlClient> cqlClient =
-                cqlClientFactory.constructClient(metricsManager.getTaggedRegistry(), config, initializeAsync);
+            MetricsManager metricsManager,
+            String keyspace,
+            Supplier<CassandraServersConfig> cassandraServersConfigSupplier,
+            CassandraClusterConfig cassandraClusterConfig,
+            boolean initializeAsync) {
+        Optional<CqlClient> cqlClient = cqlClientFactory.constructClient(
+                metricsManager.getTaggedRegistry(),
+                cassandraServersConfigSupplier,
+                cassandraClusterConfig,
+                initializeAsync);
 
-        ExecutorService executorService = config.servers().accept(new Visitor<ExecutorService>() {
+        ExecutorService executorService = cassandraServersConfigSupplier.get().accept(new Visitor<ExecutorService>() {
             @Override
             public ExecutorService visit(DefaultConfig defaultConfig) {
                 return MoreExecutors.newDirectExecutorService();
@@ -63,13 +72,14 @@ public final class DefaultCassandraAsyncKeyValueServiceFactory implements Cassan
                 return tracingExecutorService(
                         "Atlas Cassandra Async KVS",
                         instrumentExecutorService(
-                                createThreadPool(cqlCapableConfig.cqlHosts().size() * config.poolSize()),
+                                createThreadPool(
+                                        cqlCapableConfig.cqlHosts().size() * cassandraClusterConfig.poolSize()),
                                 metricsManager));
             }
         });
 
-        return cqlClient.map(client -> CassandraAsyncKeyValueService.create(
-                config.getKeyspaceOrThrow(), client, AtlasFutures.futuresCombiner(executorService)));
+        return cqlClient.map(client ->
+                CassandraAsyncKeyValueService.create(keyspace, client, AtlasFutures.futuresCombiner(executorService)));
     }
 
     /**

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/ThrowingCqlClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/ThrowingCqlClient.java
@@ -24,7 +24,10 @@ public class ThrowingCqlClient implements CqlClient {
 
     @Override
     public <V> ListenableFuture<V> executeQuery(CqlQuerySpec<V> querySpec) {
-        throw new SafeIllegalStateException("CQL config invalid or not provided.");
+        throw new SafeIllegalStateException(
+                "The CQL config is invalid or not present. If intending to use CQL Clients (Async KVS) please ensure "
+                        + "you have AtlasDB to use CQL, and that the configured set of CQL hosts match the set of "
+                        + " Thrift hosts.");
     }
 
     public static ThrowingCqlClient of() {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/ThrowingCqlClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/ThrowingCqlClient.java
@@ -24,7 +24,7 @@ public class ThrowingCqlClient implements CqlClient {
 
     @Override
     public <V> ListenableFuture<V> executeQuery(CqlQuerySpec<V> querySpec) {
-        throw new SafeIllegalStateException("Invalid CQL Config");
+        throw new SafeIllegalStateException("CQL config invalid or not provided.");
     }
 
     public static ThrowingCqlClient of() {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/ThrowingCqlClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/ThrowingCqlClient.java
@@ -35,4 +35,9 @@ public class ThrowingCqlClient implements CqlClient {
     public void close() {
         // no-op, nothing to close
     }
+
+    @Override
+    public boolean isValid() {
+        return false;
+    }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/ThrowingCqlClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/ThrowingCqlClient.java
@@ -1,0 +1,38 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra.async;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.atlasdb.keyvalue.cassandra.async.queries.CqlQuerySpec;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+
+public class ThrowingCqlClient implements CqlClient {
+
+    @Override
+    public <V> ListenableFuture<V> executeQuery(CqlQuerySpec<V> querySpec) {
+        throw new SafeIllegalStateException("Invalid CQL Config");
+    }
+
+    public static ThrowingCqlClient of() {
+        return new ThrowingCqlClient();
+    }
+
+    @Override
+    public void close() {
+        // no-op, nothing to close
+    }
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/ThrowingCqlClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/ThrowingCqlClient.java
@@ -21,6 +21,7 @@ import com.palantir.atlasdb.keyvalue.cassandra.async.queries.CqlQuerySpec;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 
 public class ThrowingCqlClient implements CqlClient {
+    private static final ThrowingCqlClient INSTANCE = new ThrowingCqlClient();
 
     @Override
     public <V> ListenableFuture<V> executeQuery(CqlQuerySpec<V> querySpec) {
@@ -31,7 +32,7 @@ public class ThrowingCqlClient implements CqlClient {
     }
 
     public static ThrowingCqlClient of() {
-        return new ThrowingCqlClient();
+        return INSTANCE;
     }
 
     @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/ThrowingCqlClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/ThrowingCqlClient.java
@@ -25,8 +25,8 @@ public class ThrowingCqlClient implements CqlClient {
     @Override
     public <V> ListenableFuture<V> executeQuery(CqlQuerySpec<V> querySpec) {
         throw new SafeIllegalStateException(
-                "The CQL config is invalid or not present. If intending to use CQL Clients (Async KVS) please ensure "
-                        + "you have AtlasDB to use CQL, and that the configured set of CQL hosts match the set of "
+                "The CQL config is invalid or not present. If intending to use CQL Clients (Async KVS) please ensure"
+                        + " you have AtlasDB to use CQL, and that the configured set of CQL hosts match the set of"
                         + " Thrift hosts.");
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/client/creation/CqlClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/client/creation/CqlClientFactory.java
@@ -17,15 +17,16 @@
 package com.palantir.atlasdb.keyvalue.cassandra.async.client.creation;
 
 import com.palantir.atlasdb.cassandra.CassandraServersConfigs.CassandraServersConfig;
+import com.palantir.atlasdb.cassandra.ReloadingCloseableContainer;
 import com.palantir.atlasdb.keyvalue.cassandra.async.CqlClient;
 import com.palantir.atlasdb.keyvalue.cassandra.async.client.creation.ClusterFactory.CassandraClusterConfig;
+import com.palantir.refreshable.Refreshable;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
-import java.util.Optional;
 
 public interface CqlClientFactory {
-    Optional<CqlClient> constructClient(
+    ReloadingCloseableContainer<CqlClient> constructReloadingClientContainer(
             TaggedMetricRegistry taggedMetricRegistry,
-            CassandraServersConfig cassandraServersConfigSupplier,
+            Refreshable<CassandraServersConfig> cassandraServersConfigRefreshable,
             CassandraClusterConfig cassandraClusterConfig,
             boolean initializeAsync);
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/client/creation/CqlClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/client/creation/CqlClientFactory.java
@@ -21,12 +21,11 @@ import com.palantir.atlasdb.keyvalue.cassandra.async.CqlClient;
 import com.palantir.atlasdb.keyvalue.cassandra.async.client.creation.ClusterFactory.CassandraClusterConfig;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.util.Optional;
-import java.util.function.Supplier;
 
 public interface CqlClientFactory {
     Optional<CqlClient> constructClient(
             TaggedMetricRegistry taggedMetricRegistry,
-            Supplier<CassandraServersConfig> cassandraServersConfigSupplier,
+            CassandraServersConfig cassandraServersConfigSupplier,
             CassandraClusterConfig cassandraClusterConfig,
             boolean initializeAsync);
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/client/creation/CqlClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/client/creation/CqlClientFactory.java
@@ -16,12 +16,17 @@
 
 package com.palantir.atlasdb.keyvalue.cassandra.async.client.creation;
 
-import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
+import com.palantir.atlasdb.cassandra.CassandraServersConfigs.CassandraServersConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.async.CqlClient;
+import com.palantir.atlasdb.keyvalue.cassandra.async.client.creation.ClusterFactory.CassandraClusterConfig;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 public interface CqlClientFactory {
     Optional<CqlClient> constructClient(
-            TaggedMetricRegistry taggedMetricRegistry, CassandraKeyValueServiceConfig config, boolean initializeAsync);
+            TaggedMetricRegistry taggedMetricRegistry,
+            Supplier<CassandraServersConfig> cassandraServersConfigSupplier,
+            CassandraClusterConfig cassandraClusterConfig,
+            boolean initializeAsync);
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/client/creation/DefaultCqlClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/client/creation/DefaultCqlClientFactory.java
@@ -48,10 +48,10 @@ public class DefaultCqlClientFactory implements CqlClientFactory {
     @Override
     public Optional<CqlClient> constructClient(
             TaggedMetricRegistry taggedMetricRegistry,
-            Supplier<CassandraServersConfig> cassandraServersConfigSupplier,
+            CassandraServersConfig cassandraServersConfig,
             CassandraClusterConfig cassandraClusterConfig,
             boolean initializeAsync) {
-        return CassandraServersConfigs.getCqlCapableConfigIfValid(cassandraServersConfigSupplier.get())
+        return CassandraServersConfigs.getCqlCapableConfigIfValid(cassandraServersConfig)
                 .map(cqlCapableConfig -> {
                     Set<InetSocketAddress> servers = cqlCapableConfig.cqlHosts();
                     Cluster cluster = new ClusterFactory(cqlClusterBuilderFactory)

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/client/creation/DefaultCqlClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/async/client/creation/DefaultCqlClientFactory.java
@@ -17,7 +17,6 @@
 package com.palantir.atlasdb.keyvalue.cassandra.async.client.creation;
 
 import com.datastax.driver.core.Cluster;
-import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.CassandraServersConfigs;
 import com.palantir.atlasdb.cassandra.CassandraServersConfigs.CassandraServersConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.async.CqlClient;
@@ -48,10 +47,11 @@ public class DefaultCqlClientFactory implements CqlClientFactory {
 
     @Override
     public Optional<CqlClient> constructClient(
-            TaggedMetricRegistry taggedMetricRegistry, CassandraKeyValueServiceConfig config, boolean initializeAsync) {
-        CassandraClusterConfig cassandraClusterConfig = CassandraClusterConfig.of(config);
-        CassandraServersConfig cassandraServersConfig = config.servers();
-        return CassandraServersConfigs.getCqlCapableConfigIfValid(cassandraServersConfig)
+            TaggedMetricRegistry taggedMetricRegistry,
+            Supplier<CassandraServersConfig> cassandraServersConfigSupplier,
+            CassandraClusterConfig cassandraClusterConfig,
+            boolean initializeAsync) {
+        return CassandraServersConfigs.getCqlCapableConfigIfValid(cassandraServersConfigSupplier.get())
                 .map(cqlCapableConfig -> {
                     Set<InetSocketAddress> servers = cqlCapableConfig.cqlHosts();
                     Cluster cluster = new ClusterFactory(cqlClusterBuilderFactory)

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/async/CassandraAsyncKeyValueServiceTests.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/async/CassandraAsyncKeyValueServiceTests.java
@@ -122,6 +122,7 @@ public class CassandraAsyncKeyValueServiceTests {
 
     @Test
     public void testIsValidFalseWhenClientIsInvalid() {
+        when(cqlClientContainer.isClosed()).thenReturn(false);
         when(cqlClient.isValid()).thenReturn(false);
         assertThat(asyncKeyValueService.isValid()).isFalse();
     }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/async/CassandraAsyncKeyValueServiceTests.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/async/CassandraAsyncKeyValueServiceTests.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.palantir.atlasdb.cassandra.ReloadingCloseableContainer;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.futures.AtlasFutures;
 import com.palantir.atlasdb.keyvalue.api.AsyncKeyValueService;
@@ -34,6 +35,7 @@ import com.palantir.atlasdb.keyvalue.cassandra.async.queries.GetQuerySpec;
 import com.palantir.atlasdb.keyvalue.cassandra.async.queries.ImmutableCqlQueryContext;
 import com.palantir.atlasdb.keyvalue.cassandra.async.queries.ImmutableGetQueryParameters;
 import com.palantir.common.random.RandomBytes;
+import com.palantir.refreshable.Refreshable;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
@@ -63,10 +65,13 @@ public class CassandraAsyncKeyValueServiceTests {
     @Mock
     private CqlClient cqlClient;
 
+    private final ReloadingCloseableContainer<CqlClient> cqlClientContainer =
+            ReloadingCloseableContainer.of(Refreshable.only(Optional.empty()), _ignored -> cqlClient);
+
     @Before
     public void setUp() {
         asyncKeyValueService = CassandraAsyncKeyValueService.create(
-                KEYSPACE, cqlClient, AtlasFutures.futuresCombiner(MoreExecutors.newDirectExecutorService()));
+                KEYSPACE, cqlClientContainer, AtlasFutures.futuresCombiner(MoreExecutors.newDirectExecutorService()));
     }
 
     @After

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/async/CqlClientImplTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/async/CqlClientImplTest.java
@@ -1,0 +1,66 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra.async;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Session;
+import com.palantir.atlasdb.cassandra.CassandraServersConfigs.CqlCapableConfigTuning;
+import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CqlClientImplTest {
+    public static final boolean INITIALIZE_ASYNC = false;
+    private static final TaggedMetricRegistry REGISTRY = new DefaultTaggedMetricRegistry();
+    @Mock
+    private Cluster cluster;
+
+    @Mock
+    private Session session;
+
+    @Mock
+    private CqlCapableConfigTuning cqlCapableConfigTuning;
+
+    @Before
+    public void setUp() {
+        when(cluster.connect()).thenReturn(session);
+    }
+
+    @Test
+    public void cqlClientInvalidWhenSessionIsClosed() {
+        CqlClient cqlClient = CqlClientImpl.create(REGISTRY, cluster,
+                cqlCapableConfigTuning, INITIALIZE_ASYNC);
+        when(session.isClosed()).thenReturn(true);
+        assertThat(cqlClient.isValid()).isFalse();
+    }
+
+    @Test
+    public void cqlClientValidWhenSessionOpen() {
+        CqlClient cqlClient = CqlClientImpl.create(REGISTRY, cluster,
+                cqlCapableConfigTuning, INITIALIZE_ASYNC);
+        when(session.isClosed()).thenReturn(false);
+        assertThat(cqlClient.isValid()).isTrue();
+    }
+}

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/async/CqlClientImplTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/async/CqlClientImplTest.java
@@ -34,6 +34,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class CqlClientImplTest {
     public static final boolean INITIALIZE_ASYNC = false;
     private static final TaggedMetricRegistry REGISTRY = new DefaultTaggedMetricRegistry();
+
     @Mock
     private Cluster cluster;
 
@@ -50,16 +51,14 @@ public class CqlClientImplTest {
 
     @Test
     public void cqlClientInvalidWhenSessionIsClosed() {
-        CqlClient cqlClient = CqlClientImpl.create(REGISTRY, cluster,
-                cqlCapableConfigTuning, INITIALIZE_ASYNC);
+        CqlClient cqlClient = CqlClientImpl.create(REGISTRY, cluster, cqlCapableConfigTuning, INITIALIZE_ASYNC);
         when(session.isClosed()).thenReturn(true);
         assertThat(cqlClient.isValid()).isFalse();
     }
 
     @Test
     public void cqlClientValidWhenSessionOpen() {
-        CqlClient cqlClient = CqlClientImpl.create(REGISTRY, cluster,
-                cqlCapableConfigTuning, INITIALIZE_ASYNC);
+        CqlClient cqlClient = CqlClientImpl.create(REGISTRY, cluster, cqlCapableConfigTuning, INITIALIZE_ASYNC);
         when(session.isClosed()).thenReturn(false);
         assertThat(cqlClient.isValid()).isTrue();
     }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/async/CqlClientImplTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/async/CqlClientImplTest.java
@@ -32,7 +32,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CqlClientImplTest {
-    public static final boolean INITIALIZE_ASYNC = false;
+    private static final boolean INITIALIZE_ASYNC = false;
     private static final TaggedMetricRegistry REGISTRY = new DefaultTaggedMetricRegistry();
 
     @Mock

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/async/ThrowingCqlClientTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/async/ThrowingCqlClientTest.java
@@ -1,0 +1,50 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra.async;
+
+import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptionThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.atlasdb.keyvalue.cassandra.async.queries.CqlQuerySpec;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ThrowingCqlClientTest {
+
+    @Mock
+    CqlQuerySpec<Object> cqlQuerySpec;
+
+    @Test
+    public void executeQueryThrowsException() {
+        assertThatLoggableExceptionThrownBy(() -> ThrowingCqlClient.of().executeQuery(cqlQuerySpec)).isInstanceOf(
+                SafeIllegalStateException.class);
+    }
+
+    @Test
+    public void ofReturnsSameInstanceOnSuccessiveInvocations() {
+        assertThat(ThrowingCqlClient.of()).isSameAs(ThrowingCqlClient.of());
+    }
+
+    @Test
+    public void isValidAlwaysFalse() {
+        assertThat(ThrowingCqlClient.of().isValid()).isFalse();
+    }
+}

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/async/ThrowingCqlClientTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/async/ThrowingCqlClientTest.java
@@ -34,8 +34,8 @@ public class ThrowingCqlClientTest {
 
     @Test
     public void executeQueryThrowsException() {
-        assertThatLoggableExceptionThrownBy(() -> ThrowingCqlClient.of().executeQuery(cqlQuerySpec)).isInstanceOf(
-                SafeIllegalStateException.class);
+        assertThatLoggableExceptionThrownBy(() -> ThrowingCqlClient.of().executeQuery(cqlQuerySpec))
+                .isInstanceOf(SafeIllegalStateException.class);
     }
 
     @Test

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraContainer.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraContainer.java
@@ -36,6 +36,7 @@ import java.net.SocketAddress;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Supplier;
 
 public class CassandraContainer extends Container {
     static final int CASSANDRA_CQL_PORT = 9042;
@@ -130,13 +131,16 @@ public class CassandraContainer extends Container {
                 .servers(ImmutableCqlCapableConfig.builder()
                         .from(cqlCapableConfig)
                         .build())
-                .asyncKeyValueServiceFactory(
-                        new DefaultCassandraAsyncKeyValueServiceFactory(new DefaultCqlClientFactory(
-                                () -> Cluster.builder().withNettyOptions(new SocksProxyNettyOptions(proxyAddress)))))
+                .asyncKeyValueServiceFactory(new DefaultCassandraAsyncKeyValueServiceFactory(
+                        new DefaultCqlClientFactory(getClusterBuilderWithProxy(proxyAddress))))
                 .build();
     }
 
     public String getServiceName() {
         return name;
+    }
+
+    public Supplier<Cluster.Builder> getClusterBuilderWithProxy(SocketAddress proxyAddress) {
+        return () -> Cluster.builder().withNettyOptions(new SocksProxyNettyOptions(proxyAddress));
     }
 }

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraResource.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraResource.java
@@ -16,6 +16,7 @@
 
 package com.palantir.atlasdb.containers;
 
+import com.datastax.driver.core.Cluster;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueService;
@@ -90,5 +91,9 @@ public class CassandraResource extends ExternalResource implements KvsManager, T
 
     public CassandraKeyValueServiceConfig getConfig() {
         return containerInstance.getConfigWithProxy(socksProxy.address());
+    }
+
+    public Supplier<Cluster.Builder> getClusterBuilderWithProxy() {
+        return containerInstance.getClusterBuilderWithProxy(socksProxy.address());
     }
 }

--- a/changelog/@unreleased/pr-6034.v2.yml
+++ b/changelog/@unreleased/pr-6034.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Async KVS now supports reloading a server list. CassandraKeyValueService
+    delegates to a synchronous get if the Async KVS is misconfigured.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6034


### PR DESCRIPTION
**Goals (and why)**:
Async KVS should use a CQL Client that is up to date with the latest server list. We use the ReloadingCloseableContainer to provide the re-creation and management of the new CQL Clients.

If AsyncKVS is misconfigured (i.e not a CqlCapable config), then we continue to delegate to synchronous get. If the client or container is closed, we also delegate to get.

==COMMIT_MSG==
Async KVS now supports reloading a server list. CassandraKeyValueService delegates to a synchronous get if the Async KVS is misconfigured.
==COMMIT_MSG==

**Implementation Description (bullets)**:
* Throwing variant of CQLClient used when the cql config is invalid or missing
* isValid flag to avoid costly exceptions most of the time

**Testing (What was existing testing like?  What have you done to improve it?)**:
* Test that isValid works
* Test that we still properly delegate to sync get

**Concerns (what feedback would you like?)**:
* isValid :(

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
