### PR TITLE
[LW] Add further telemetry when clearing caches

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/CacheStoreImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/CacheStoreImpl.java
@@ -81,7 +81,6 @@ final class CacheStoreImpl implements CacheStore {
 
     @Override
     public void reset() {
-        log.info("Clearing all cache state");
         cacheMap.clear();
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
@@ -17,7 +17,6 @@
 package com.palantir.atlasdb.keyvalue.api.cache;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.palantir.atlasdb.keyvalue.api.AtlasLockDescriptorUtils;
@@ -257,12 +256,19 @@ public final class LockWatchValueScopingCacheImpl implements LockWatchValueScopi
 
     private synchronized void clearCache(
             TransactionsLockWatchUpdate updateForTransactions, Optional<LockWatchVersion> latestVersionFromUpdate) {
+        LockWatchEvent firstEvent = null;
+        LockWatchEvent lastEvent = null;
+        List<LockWatchEvent> events = updateForTransactions.events();
+        if (!events.isEmpty()) {
+            firstEvent = events.get(0);
+            lastEvent = events.get(events.size() - 1);
+        }
         log.info(
                 "Clearing all value cache state",
                 SafeArg.of("currentVersion", currentVersion),
                 SafeArg.of("latestUpdateFromUpdate", latestVersionFromUpdate),
-                SafeArg.of("firstEventSequence", Iterables.getFirst(updateForTransactions.events(), null)),
-                SafeArg.of("lastEventSequence", Iterables.getLast(updateForTransactions.events(), null)));
+                SafeArg.of("firstEventSequence", firstEvent),
+                SafeArg.of("lastEventSequence", lastEvent));
         valueStore.reset();
         snapshotStore.reset();
         cacheStore.reset();

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
@@ -195,10 +195,11 @@ public final class LockWatchValueScopingCacheImpl implements LockWatchValueScopi
         Multimap<Sequence, StartTimestamp> reversedMap = createSequenceTimestampMultimap(updateForTransactions);
 
         // Without this block, updates with no events would not store a snapshot.
-        currentVersion.map(LockWatchVersion::version).map(Sequence::of).ifPresent(sequence -> Optional.of(
-                        reversedMap.get(sequence))
-                .ifPresent(startTimestamps ->
-                        snapshotStore.storeSnapshot(sequence, startTimestamps, valueStore.getSnapshot())));
+        currentVersion
+                .map(LockWatchVersion::version)
+                .map(Sequence::of)
+                .ifPresent(sequence ->
+                        snapshotStore.storeSnapshot(sequence, reversedMap.get(sequence), valueStore.getSnapshot()));
 
         updateForTransactions.events().stream().filter(this::isNewEvent).forEach(event -> {
             valueStore.applyEvent(event);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
@@ -37,14 +37,13 @@ import com.palantir.lock.watch.TransactionsLockWatchUpdate;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
-
-import javax.annotation.concurrent.ThreadSafe;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.annotation.concurrent.ThreadSafe;
 
 @ThreadSafe
 public final class LockWatchValueScopingCacheImpl implements LockWatchValueScopingCache {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/SnapshotStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/SnapshotStore.java
@@ -24,7 +24,7 @@ import java.util.Optional;
 /**
  * Stores snapshots of the cache taken at the sequence corresponding to the provided start timestamp. De-duplicates in
  * the case of multiple start timestamps corresponding to a single sequence (which is likely as they are batched),
- * and and removes snapshots when they are no longer referenced by any live start timestamps.
+ * and removes snapshots when they are no longer referenced by any live start timestamps.
  */
 public interface SnapshotStore {
     /**

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/SnapshotStoreImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/SnapshotStoreImpl.java
@@ -90,9 +90,8 @@ final class SnapshotStoreImpl implements SnapshotStore {
 
     @Override
     public void removeTimestamp(StartTimestamp timestamp) {
-        Optional.ofNullable(timestampMap.remove(timestamp)).ifPresent(sequence -> {
-            liveSequences.remove(sequence, timestamp);
-        });
+        Optional.ofNullable(timestampMap.remove(timestamp))
+                .ifPresent(sequence -> liveSequences.remove(sequence, timestamp));
 
         if (retentionRateLimiter.tryAcquire()) {
             retentionSnapshots();

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -218,11 +218,11 @@ import javax.validation.constraints.NotNull;
             openTransactionCounter.inc(transactions.size());
             return transactions;
         } catch (Throwable t) {
+            responses.forEach(response -> lockWatchManager.removeTransactionStateFromCache(
+                    response.startTimestampAndPartition().timestamp()));
             timelockService.tryUnlock(responses.stream()
                     .map(response -> response.immutableTimestamp().getLock())
                     .collect(Collectors.toSet()));
-            responses.forEach(response -> lockWatchManager.removeTransactionStateFromCache(
-                    response.startTimestampAndPartition().timestamp()));
             throw Throwables.rewrapAndThrowUncheckedException(t);
         }
     }

--- a/changelog/@unreleased/pr-6038.v2.yml
+++ b/changelog/@unreleased/pr-6038.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Add more information when clearing the lock watch value cache.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6038


### PR DESCRIPTION
**Goals (and why)**:
==COMMIT_MSG==
Add more information when clearing the lock watch value cache.
==COMMIT_MSG==

**Implementation Description (bullets)**:
* Add more safe args when clearing the cache
* Couple of drive-by fixes

**Testing (What was existing testing like?  What have you done to improve it?)**:
N/A

**Concerns (what feedback would you like?)**:
Any regressions? I doubt it, but possibly in the extreme case if we're logging super super hard.

**Where should we start reviewing?**:
Diff

**Priority (whenever / two weeks / yesterday)**:
ASAP!

