### PR TITLE
Downgrade noisy info logs

### DIFF
--- a/changelog/@unreleased/pr-6041.v2.yml
+++ b/changelog/@unreleased/pr-6041.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: '`Lock request timed out` and `All references currently watched` log
+    lines have been downgraded from `INFO` to `DEBUG`.'
+  links:
+  - https://github.com/palantir/atlasdb/pull/6041

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LockAcquirer.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LockAcquirer.java
@@ -110,7 +110,9 @@ public class LockAcquirer implements AutoCloseable {
                 unlockAll();
             });
             result.onTimeout(() -> {
-                log.info("Lock request timed out", SafeArg.of("requestId", requestId));
+                if (log.isDebugEnabled()) {
+                    log.debug("Lock request timed out", SafeArg.of("requestId", requestId));
+                }
                 unlockAll();
             });
         }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockWatchingServiceImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockWatchingServiceImpl.java
@@ -85,10 +85,12 @@ public class LockWatchingServiceImpl implements LockWatchingService {
                 UnsafeArg.of("references", changedWatches.references())));
         changes.ifPresent(this::logLockWatchEvent);
         Set<LockWatchReference> allReferences = watches.get().references();
-        log.info(
-                "All references currently watched",
-                SafeArg.of("sizeOfReferences", allReferences.size()),
-                UnsafeArg.of("allWatchedTables", allReferences));
+        if (log.isDebugEnabled()) {
+            log.debug(
+                    "All references currently watched",
+                    SafeArg.of("sizeOfReferences", allReferences.size()),
+                    UnsafeArg.of("allWatchedTables", allReferences));
+        }
     }
 
     @Override


### PR DESCRIPTION
**Goals (and why)**:
==COMMIT_MSG==
`Lock request timed out` and `All references currently watched` log lines have been downgraded from `INFO` to `DEBUG`.
==COMMIT_MSG==

**Concerns (what feedback would you like?)**:
Do we _ever_ care about these log lines in the day to day?

**Where should we start reviewing?**:
Diff

**Priority (whenever / two weeks / yesterday)**:
Whenever

