### PR TITLE
[PDS-269760] Reduce max rows scanned by single Timelock Corruption verifier run from 250 -> 10

### DIFF
--- a/changelog/@unreleased/pr-6048.v2.yml
+++ b/changelog/@unreleased/pr-6048.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Reduce the number of rows read in a single run of the Timelock Local
+    Corruption Detector from 250 to 10.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6048

--- a/timelock-corruption-detection/src/main/java/com/palantir/timelock/history/PaxosLogHistoryProgressTracker.java
+++ b/timelock-corruption-detection/src/main/java/com/palantir/timelock/history/PaxosLogHistoryProgressTracker.java
@@ -28,7 +28,7 @@ import javax.sql.DataSource;
 
 public class PaxosLogHistoryProgressTracker {
     // VisibleForTesting - used in corruption-detection tests
-    public static final int MAX_ROWS_ALLOWED = 250;
+    public static final int MAX_ROWS_ALLOWED = 10;
 
     private final LogVerificationProgressState logVerificationProgressState;
     private final SqlitePaxosStateLogHistory sqlitePaxosStateLogHistory;

--- a/timelock-corruption-detection/src/test/java/com/palantir/timelock/corruption/detection/HistoryAnalyzerTest.java
+++ b/timelock-corruption-detection/src/test/java/com/palantir/timelock/corruption/detection/HistoryAnalyzerTest.java
@@ -74,7 +74,7 @@ public final class HistoryAnalyzerTest {
 
     @Test
     public void detectCorruptionIfLearnedValueIsNotTheGreatestAcceptedValue() {
-        helper.writeLogsOnDefaultLocalAndRemote(9, MAX_ROWS_ALLOWED - 1);
+        helper.writeLogsOnDefaultLocalAndRemote(5, MAX_ROWS_ALLOWED - 1);
         helper.induceGreaterAcceptedValueCorruptionOnDefaultLocalServer(MAX_ROWS_ALLOWED / 2);
 
         List<CompletePaxosHistoryForNamespaceAndUseCase> historyForAll = helper.getHistory();

--- a/timelock-corruption-detection/src/test/java/com/palantir/timelock/history/PaxosLogHistoryProviderTest.java
+++ b/timelock-corruption-detection/src/test/java/com/palantir/timelock/history/PaxosLogHistoryProviderTest.java
@@ -92,7 +92,7 @@ public class PaxosLogHistoryProviderTest {
 
     @Test
     public void canFetchAndCombineHistoriesForLocalAndRemote() {
-        Set<PaxosValue> paxosValues = PaxosSerializationTestUtils.writeToLogs(acceptorLog, learnerLog, 1, 100);
+        Set<PaxosValue> paxosValues = PaxosSerializationTestUtils.writeToLogs(acceptorLog, learnerLog, 1, 9);
 
         int lastVerified = -1;
 
@@ -110,13 +110,13 @@ public class PaxosLogHistoryProviderTest {
                 Iterables.getOnlyElement(completeHistory);
         assertThat(historyForNamespaceAndUseCase.namespace()).isEqualTo(DEFAULT_CLIENT);
         assertSanityWithValuesOfFetchedRecords(
-                historyForNamespaceAndUseCase, DEFAULT_CLIENT, DEFAULT_USE_CASE, 100, paxosValues);
+                historyForNamespaceAndUseCase, DEFAULT_CLIENT, DEFAULT_USE_CASE, 9, paxosValues);
     }
 
     @Test
     public void canFetchAndCombineDiscontinuousLogs() {
-        Set<PaxosValue> paxosValues1 = PaxosSerializationTestUtils.writeToLogs(acceptorLog, learnerLog, 7, 54);
-        Set<PaxosValue> paxosValues2 = PaxosSerializationTestUtils.writeToLogs(acceptorLog, learnerLog, 98, 127);
+        Set<PaxosValue> paxosValues1 = PaxosSerializationTestUtils.writeToLogs(acceptorLog, learnerLog, 1, 4);
+        Set<PaxosValue> paxosValues2 = PaxosSerializationTestUtils.writeToLogs(acceptorLog, learnerLog, 6, 9);
 
         Set<PaxosValue> paxosValues = ImmutableSet.<PaxosValue>builder()
                 .addAll(paxosValues1)
@@ -142,7 +142,7 @@ public class PaxosLogHistoryProviderTest {
                 historyForNamespaceAndUseCase,
                 DEFAULT_CLIENT,
                 DEFAULT_USE_CASE,
-                (54 - 7 + 1) + (127 - 98 + 1),
+                (4 - 1 + 1) + (9 - 6 + 1),
                 paxosValues);
     }
 
@@ -155,8 +155,8 @@ public class PaxosLogHistoryProviderTest {
 
     @Test
     public void canFetchAndCombineHistoriesSinceLastVerifiedState() {
-        Set<PaxosValue> paxosValues = PaxosSerializationTestUtils.writeToLogs(acceptorLog, learnerLog, 1, 100);
-        int lastVerified = 17;
+        Set<PaxosValue> paxosValues = PaxosSerializationTestUtils.writeToLogs(acceptorLog, learnerLog, 1, 9);
+        int lastVerified = 3;
 
         Set<PaxosValue> expectedPaxosValues = paxosValues.stream()
                 .filter(val -> val.getRound() > lastVerified)
@@ -180,11 +180,7 @@ public class PaxosLogHistoryProviderTest {
                 Iterables.getOnlyElement(completeHistory);
 
         assertSanityWithValuesOfFetchedRecords(
-                historyForNamespaceAndUseCase,
-                DEFAULT_CLIENT,
-                DEFAULT_USE_CASE,
-                100 - lastVerified,
-                expectedPaxosValues);
+                historyForNamespaceAndUseCase, DEFAULT_CLIENT, DEFAULT_USE_CASE, 9 - lastVerified, expectedPaxosValues);
     }
 
     @Test
@@ -202,7 +198,7 @@ public class PaxosLogHistoryProviderTest {
         when(remote.getPaxosHistory(any(), any())).thenReturn(PaxosHistoryOnRemote.of(remoteHistory));
 
         List<CompletePaxosHistoryForNamespaceAndUseCase> completeHistory = paxosLogHistoryProvider.getHistory();
-        assertThat(completeHistory).hasSize(100);
+        assertThat(completeHistory).hasSize(9);
 
         Set<NamespaceAndUseCase> namespaceAndUseCasesWithHistory = completeHistory.stream()
                 .map(historyForNamespaceAndUseCase -> {
@@ -225,7 +221,7 @@ public class PaxosLogHistoryProviderTest {
 
     // utils
     private Map<NamespaceAndUseCase, Set<PaxosValue>> writeLogsForRangeOfNamespaceUseCasePairs() {
-        return KeyedStream.of(IntStream.rangeClosed(1, 100).boxed())
+        return KeyedStream.of(IntStream.rangeClosed(1, 9).boxed())
                 .mapEntries((idx, unused) -> {
                     String useCase = String.valueOf(idx);
                     Client client = Client.of(useCase);


### PR DESCRIPTION
**Goals (and why)**:
We've seen instances where timelock starts, loads 250 rows for every namespace, and this ends up consuming 100% of disk read iops and preventing timelock from actually running any Paxos rounds.

We believe that reducing the number of rows read in a single round will prevent this from happening in the future.
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Reduce the number of rows read in a single run of the Timelock Local Corruption Detector from 250 to 10.
==COMMIT_MSG==

**Implementation Description (bullets)**:
* Changed a constant

**Testing (What was existing testing like?  What have you done to improve it?)**:
* Nothing

**Concerns (what feedback would you like?)**:
* Did we also want to decrease the interval between runs?

**Where should we start reviewing?**:
* ASAP

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
