### PR TITLE
[PDS-269760] Learner log check should only do ten things

### DIFF
--- a/timelock-corruption-detection/src/main/java/com/palantir/timelock/corruption/detection/LocalTimestampInvariantsVerifier.java
+++ b/timelock-corruption-detection/src/main/java/com/palantir/timelock/corruption/detection/LocalTimestampInvariantsVerifier.java
@@ -46,7 +46,7 @@ import one.util.streamex.StreamEx;
  * */
 public class LocalTimestampInvariantsVerifier {
     @VisibleForTesting
-    static final int LEARNER_LOG_BATCH_SIZE_LIMIT = 250;
+    static final int LEARNER_LOG_BATCH_SIZE_LIMIT = 10;
 
     public static final long MIN_SEQUENCE_TO_BE_VERIFIED = Long.MIN_VALUE;
 

--- a/timelock-corruption-detection/src/test/java/com/palantir/timelock/corruption/detection/LocalTimestampInvariantsVerifierTest.java
+++ b/timelock-corruption-detection/src/test/java/com/palantir/timelock/corruption/detection/LocalTimestampInvariantsVerifierTest.java
@@ -57,10 +57,10 @@ public class LocalTimestampInvariantsVerifierTest {
 
     @Test
     public void detectsClockWentBackwardsForDiscontinuousLogs() {
-        helper.writeLogsOnDefaultLocalServer(1, 27);
-        helper.writeLogsOnDefaultLocalServer(LEARNER_LOG_BATCH_SIZE_LIMIT, LEARNER_LOG_BATCH_SIZE_LIMIT + 97);
+        helper.writeLogsOnDefaultLocalServer(1, 4);
+        helper.writeLogsOnDefaultLocalServer(LEARNER_LOG_BATCH_SIZE_LIMIT, 2 * LEARNER_LOG_BATCH_SIZE_LIMIT);
 
-        helper.createTimestampInversion(72);
+        helper.createTimestampInversion(8);
         helper.assertClockGoesBackwardsInNextBatch();
     }
 


### PR DESCRIPTION
**Goals (and why)**:
==COMMIT_MSG==
The local timestamp invariant verifier is now more defensive.
==COMMIT_MSG==

**Implementation Description (bullets)**:
- Reduce number of learner logs to fetch in a single call from 250 to 10

**Testing (What was existing testing like?  What have you done to improve it?)**:
- LTIVT + small change to maintain semantics

**Concerns (what feedback would you like?)**:
- Not much.

**Where should we start reviewing?**: small

**Priority (whenever / two weeks / yesterday)**: yesterday 🔥 