### PR TITLE
Cassandra CellLoader lazily computes read-only result lists

### DIFF
--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoaderTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoaderTest.java
@@ -1,0 +1,46 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.junit.Test;
+
+public class CellLoaderTest {
+
+    @Test
+    public void flattenReadOnlyLists() {
+        List<List<String>> lists = ImmutableList.of(
+                ImmutableList.of("A1"),
+                ImmutableList.of("B1", "B2", "B3"),
+                ImmutableList.of(),
+                ImmutableList.of("D1", "D2"));
+        List<String> zipped = CellLoader.flattenReadOnlyLists(lists);
+        assertThat(zipped)
+                .hasSize(6)
+                .containsExactly("A1", "B1", "B2", "B3", "D1", "D2")
+                .element(5)
+                .isEqualTo("D2");
+
+        assertThat(zipped.get(4)).isEqualTo("D1");
+        assertThatThrownBy(() -> zipped.get(-1)).isInstanceOf(IndexOutOfBoundsException.class);
+        assertThatThrownBy(() -> zipped.get(6)).isInstanceOf(IndexOutOfBoundsException.class);
+    }
+}

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoaderTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoaderTest.java
@@ -42,5 +42,10 @@ public class CellLoaderTest {
         assertThat(zipped.get(4)).isEqualTo("D1");
         assertThatThrownBy(() -> zipped.get(-1)).isInstanceOf(IndexOutOfBoundsException.class);
         assertThatThrownBy(() -> zipped.get(6)).isInstanceOf(IndexOutOfBoundsException.class);
+        assertThatThrownBy(() -> zipped.add("Z")).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> zipped.add(0, "Z")).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> zipped.set(0, "Z")).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> zipped.remove(0)).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> zipped.remove("A1")).isInstanceOf(UnsupportedOperationException.class);
     }
 }

--- a/changelog/@unreleased/pr-6054.v2.yml
+++ b/changelog/@unreleased/pr-6054.v2.yml
@@ -1,0 +1,9 @@
+type: improvement
+improvement:
+  description: |-
+    Cassandra CellLoader lazily computes read-only result lists
+
+    Avoid excessive collection copies when processing Cassandra results in
+    CellLoader to avoid memory allocation and GC pressure on hot code paths.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6054


### PR DESCRIPTION
In JFR profiles of high volume AtlasDB client, we see significant memory allocations from AtlasDB Cassandra `CellLoader`:


```
Object[] java.util.ArrayList.grow(int)
   Object[] java.util.ArrayList.grow()
      void java.util.ArrayList.add(Object, Object[], int)
      boolean java.util.ArrayList.add(Object)
      void java.util.stream.Collectors$$Lambda$72+0x0000000800b639f8.1229202732.accept(Object, Object)
         void java.util.stream.ReduceOps$3ReducingSink.accept(Object)
         void java.util.ArrayList$ArrayListSpliterator.forEachRemaining(Consumer)
            void java.util.stream.ReferencePipeline$Head.forEach(Consumer)
            void java.util.stream.ReferencePipeline$7$1.accept(Object)
            void java.util.ArrayList$ArrayListSpliterator.forEachRemaining(Consumer)
            void java.util.stream.AbstractPipeline.copyInto(Sink, Spliterator)
            Sink java.util.stream.AbstractPipeline.wrapAndCopyInto(Sink, Spliterator)
            Object java.util.stream.ReduceOps$ReduceOp.evaluateSequential(PipelineHelper, Spliterator)
            Object java.util.stream.AbstractPipeline.evaluate(TerminalOp)
            Object java.util.stream.ReferencePipeline.collect(Collector)
            List com.palantir.atlasdb.keyvalue.cassandra.CellLoader$1.lambda$apply$0(List)
            Object com.palantir.atlasdb.keyvalue.cassandra.CellLoader$1$$Lambda$2035+0x00000008017d5388.724065389.apply(Object)
            Object com.google.common.collect.Maps$9.transformEntry(Object, Object)
            Object com.google.common.collect.Maps$12.getValue()
            byte[] com.palantir.atlasdb.keyvalue.cassandra.ResultsExtractor.extractResults(Map, long, ColumnSelection)
            void com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServices$StartTsResultsCollector.visit(Map)
            void com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServices$StartTsResultsCollector.visit(Object)
            Void com.palantir.atlasdb.keyvalue.cassandra.CellLoader$1.apply(CassandraClient)
            Object com.palantir.atlasdb.keyvalue.cassandra.CellLoader$1.apply(Object)
            Object com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer.lambda$runWithGoodResource$0(FunctionCheckedException, CassandraClient)
            Object com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer$$Lambda$1070+0x0000000801312cc0.976285053.call()
            Object com.palantir.util.TimedRunner.lambda$run$0(TimedRunner$TaskContext)
            Object com.palantir.util.TimedRunner$$Lambda$1073+0x0000000801313dd8.1287861906.call()
            Object com.palantir.tritium.metrics.TaggedMetricsExecutorService$TaggedMetricsCallable.call()
            void java.util.concurrent.FutureTask.run()
            void com.palantir.common.concurrent.PTExecutors.lambda$wrapRunnable$2(Map, Runnable)
            void com.palantir.common.concurrent.PTExecutors$$Lambda$945+0x00000008011c7a40.1193797116.run()
            void com.palantir.tracing.Tracers$TracingAwareRunnable.run()
            void com.palantir.common.concurrent.ForwardingRunnableFuture.run()
            void com.palantir.nylon.threads.RenamingExecutorService$RenamingRunnable.run()
            void org.jboss.threads.EnhancedViewExecutor$EnhancedViewExecutorRunnable.run()
            void java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor$Worker)
            void java.util.concurrent.ThreadPoolExecutor$Worker.run()
            void com.palantir.tritium.metrics.TaggedMetricsThreadFactory$InstrumentedTask.run()
            void java.lang.Thread.run()
```

**Goals (and why)**:
==COMMIT_MSG==
Cassandra CellLoader lazily computes read-only result lists

Avoid excessive collection copies when processing Cassandra results in
CellLoader to avoid memory allocation and GC pressure on hot code paths.
==COMMIT_MSG==

**Implementation Description (bullets)**: Lazily join list of lists

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**: This assumes provided lists' sizes do not change (which they do not under current use).

**Where should we start reviewing?**: CellLoader

**Priority (whenever / two weeks / yesterday)**: whenever

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
