### PR TITLE
Triggers.getAllTriggers does not allocate when there are no triggers

### DIFF
--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/generation/TriggersTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/generation/TriggersTest.java
@@ -1,0 +1,81 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.table.generation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import com.palantir.atlasdb.transaction.api.Transaction;
+import java.util.List;
+import org.junit.Test;
+
+public class TriggersTest {
+
+    public static final String[] EMPTY_STRING_ARRAY = new String[0];
+
+    @Test
+    public void emptyTriggersDoesNotAllocate() {
+        Transaction mockTxn = mock(Transaction.class);
+        List<Function<? super Transaction, String>> sharedTriggers = ImmutableList.of();
+
+        assertThat(Triggers.getAllTriggers(mockTxn, sharedTriggers, EMPTY_STRING_ARRAY))
+                .hasSize(0)
+                .isSameAs(ImmutableList.of())
+                .isEmpty();
+
+        verifyNoInteractions(mockTxn);
+    }
+
+    @Test
+    public void oneSharedTrigger() {
+        Transaction mockTxn = mock(Transaction.class);
+        List<Function<? super Transaction, String>> sharedTriggers = ImmutableList.of(t -> "1");
+
+        assertThat(Triggers.getAllTriggers(mockTxn, sharedTriggers, EMPTY_STRING_ARRAY))
+                .hasSize(1)
+                .containsExactly("1");
+
+        verifyNoInteractions(mockTxn);
+    }
+
+    @Test
+    public void oneLocalTrigger() {
+        Transaction mockTxn = mock(Transaction.class);
+        List<Function<? super Transaction, String>> sharedTriggers = ImmutableList.of();
+
+        assertThat(Triggers.getAllTriggers(mockTxn, sharedTriggers, new String[] {"l0"}))
+                .hasSize(1)
+                .containsExactly("l0");
+
+        verifyNoInteractions(mockTxn);
+    }
+
+    @Test
+    public void sharedAndLocalTriggers() {
+        Transaction mockTxn = mock(Transaction.class);
+        List<Function<? super Transaction, String>> sharedTriggers = ImmutableList.of(t -> "s1", t -> "s2");
+
+        assertThat(Triggers.getAllTriggers(mockTxn, sharedTriggers, new String[] {"l0"}))
+                .hasSize(3)
+                .containsExactly("l0", "s1", "s2");
+
+        verifyNoInteractions(mockTxn);
+    }
+}

--- a/changelog/@unreleased/pr-6056.v2.yml
+++ b/changelog/@unreleased/pr-6056.v2.yml
@@ -1,0 +1,9 @@
+type: improvement
+improvement:
+  description: |-
+    Triggers.getAllTriggers does not allocate when there are no triggers
+
+    The common case is that a table and transaction does not have any
+    triggers, so we should avoid unnecessary ArrayList allocations.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6056


### PR DESCRIPTION
Noticed some unnecessary `ArrayList` and empty `Object[]` allocations in some JFRs for the common case where generated `*TableFactory.get*Table` callers of `com.palantir.atlasdb.table.generation.Triggers.getAllTriggers(Transaction, List, Object[])` had both empty list & empty array args as there were no triggers on the table or transaction, so we should avoid unnecessary allocations on these hot paths.

**Goals (and why)**:
==COMMIT_MSG==
Triggers.getAllTriggers does not allocate when there are no triggers

The common case is that a table and transaction does not have any
triggers, so we should avoid unnecessary ArrayList allocations.
==COMMIT_MSG==

**Implementation Description (bullets)**: return empty ImmutableList of triggers when there's no triggers to apply

**Testing (What was existing testing like?  What have you done to improve it?)**: added unit test coverage, `emptyTriggersDoesNotAllocate()` fails before change, passes after

**Concerns (what feedback would you like?)**: 

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
