### PR TITLE
add throwable arg to not initialized exception

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/exception/NotInitializedException.java
+++ b/atlasdb-commons/src/main/java/com/palantir/exception/NotInitializedException.java
@@ -20,6 +20,14 @@ import com.palantir.logsafe.SafeArg;
 
 public class NotInitializedException extends AtlasDbDependencyException {
     public NotInitializedException(String objectNotInitialized) {
-        super(String.format("The %s is not initialized yet", SafeArg.of("objectName", objectNotInitialized)));
+        super(exceptionMessage(objectNotInitialized));
+    }
+
+    public NotInitializedException(String objectNotInitialized, Throwable throwable) {
+        super(exceptionMessage(objectNotInitialized), throwable);
+    }
+
+    private static String exceptionMessage(String objectNotInitialized) {
+        return String.format("The %s is not initialized yet", SafeArg.of("objectName", objectNotInitialized));
     }
 }

--- a/changelog/@unreleased/pr-6061.v2.yml
+++ b/changelog/@unreleased/pr-6061.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: NotInitializedException now supports passing in a cause throwable.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6061


### PR DESCRIPTION
**Goals (and why)**:
We need to capture the cause to facilitate debugging
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
`NotInitializedException` now supports passing in a cause throwable.
==COMMIT_MSG==

**Implementation Description (bullets)**:
- There's no rethrowing within this library, so nothing else needed changing.

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
