### PR TITLE
Add `RefreshableWithInitialValue` to encapsulate CassAtlasDbFactory runtime config reloading behaviour

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraAtlasDbFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraAtlasDbFactory.java
@@ -45,7 +45,6 @@ import java.util.function.LongSupplier;
 
 @AutoService(AtlasDbFactory.class)
 public class CassandraAtlasDbFactory implements AtlasDbFactory {
-
     @Override
     public KeyValueService createRawKeyValueService(
             MetricsManager metricsManager,

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraAtlasDbFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraAtlasDbFactory.java
@@ -103,13 +103,13 @@ public class CassandraAtlasDbFactory implements AtlasDbFactory {
             Refreshable<Optional<KeyValueServiceRuntimeConfig>> runtimeConfig) {
         Refreshable<KeyValueServiceRuntimeConfig> refreshableConfig = runtimeConfig.map(
                 maybeConfig -> maybeConfig.orElseGet(CassandraKeyValueServiceRuntimeConfig::getDefault));
-        return RefreshableWithInitialDefault.of(
+        return RefreshableWithInitialValue.of(
                 refreshableConfig,
                 CassandraAtlasDbFactory::castOrThrow,
                 CassandraKeyValueServiceRuntimeConfig.getDefault());
     }
 
-    private static CassandraKeyValueServiceRuntimeConfig castOrThrow(Object value) {
+    private static CassandraKeyValueServiceRuntimeConfig castOrThrow(KeyValueServiceRuntimeConfig value) {
         if (!(value instanceof CassandraKeyValueServiceRuntimeConfig)) {
             throw new SafeIllegalArgumentException(
                     "Invalid KeyValueServiceRuntimeConfig. Expected a KeyValueServiceRuntimeConfig of"

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/RefreshableWithInitialDefault.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/RefreshableWithInitialDefault.java
@@ -1,0 +1,66 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.cassandra;
+
+import com.palantir.refreshable.Disposable;
+import com.palantir.refreshable.Refreshable;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+final class RefreshableWithInitialDefault<T> implements Refreshable<T> {
+    private final AtomicReference<Optional<T>> latestValidValue = new AtomicReference<>(Optional.empty());
+    private final Refreshable<T> delegate;
+
+    private <K> RefreshableWithInitialDefault(Refreshable<K> refreshable, Function<K, T> function, T defaultValue) {
+        delegate = refreshable.map(value -> {
+            try {
+                T newValue = function.apply(value);
+                latestValidValue.set(Optional.of(newValue));
+                return newValue;
+            } catch (Exception e) {
+                return latestValidValue.get().orElse(defaultValue);
+            }
+        });
+    }
+
+    public static <K, T> RefreshableWithInitialDefault<T> of(
+            Refreshable<K> refreshable, Function<K, T> function, T defaultValue) {
+        return new RefreshableWithInitialDefault<>(refreshable, function, defaultValue);
+    }
+
+    @Override
+    public T current() {
+        return delegate.current();
+    }
+
+    @Override
+    public T get() {
+        return delegate.get();
+    }
+
+    @Override
+    public Disposable subscribe(Consumer<? super T> consumer) {
+        return delegate.subscribe(consumer);
+    }
+
+    @Override
+    public <R> Refreshable<R> map(Function<? super T, R> function) {
+        return delegate.map(function);
+    }
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/RefreshableWithInitialDefault.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/RefreshableWithInitialDefault.java
@@ -42,11 +42,11 @@ final class RefreshableWithInitialDefault<T> implements Refreshable<T> {
 
     private final SettableRefreshable<T> delegate;
 
-    private <K> RefreshableWithInitialDefault(Refreshable<K> refreshable, Function<K, T> function, T defaultValue) {
+    private <K> RefreshableWithInitialDefault(Refreshable<K> refreshable, Function<K, T> mapper, T defaultValue) {
         delegate = Refreshable.create(defaultValue);
         refreshable.subscribe(value -> {
             try {
-                T newValue = function.apply(value);
+                T newValue = mapper.apply(value);
                 delegate.update(newValue);
             } catch (Exception e) {
                 log.warn("Failed to update refreshable", e);
@@ -55,8 +55,8 @@ final class RefreshableWithInitialDefault<T> implements Refreshable<T> {
     }
 
     public static <K, T> RefreshableWithInitialDefault<T> of(
-            Refreshable<K> refreshable, Function<K, T> function, T defaultValue) {
-        return new RefreshableWithInitialDefault<>(refreshable, function, defaultValue);
+            Refreshable<K> refreshable, Function<K, T> mapper, T defaultValue) {
+        return new RefreshableWithInitialDefault<>(refreshable, mapper, defaultValue);
     }
 
     @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/RefreshableWithInitialValue.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/RefreshableWithInitialValue.java
@@ -25,7 +25,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 /***
- * This refreshable allows you to specify a default value if the initial mapping from another refreshable fails.
+ * This refreshable allows you to specify an initial default value if the initial mapping from another refreshable
+ * fails.
  *
  * {@link CassandraAtlasDbFactory} creates a default runtime config if the initial runtime config is not
  * valid (i.e the refreshable map function throws an exception), and uses the previous refreshable value if a
@@ -37,13 +38,13 @@ import java.util.function.Function;
  * Note: This is only required while {@link CassandraKeyValueServiceRuntimeConfig} has a default. Soon, the runtime
  * config will be required, and so we can simply map (and throw) from the underlying KVS runtime config.
  */
-final class RefreshableWithInitialDefault<T> implements Refreshable<T> {
-    private static final SafeLogger log = SafeLoggerFactory.get(RefreshableWithInitialDefault.class);
+final class RefreshableWithInitialValue<T> implements Refreshable<T> {
+    private static final SafeLogger log = SafeLoggerFactory.get(RefreshableWithInitialValue.class);
 
     private final SettableRefreshable<T> delegate;
 
-    private <K> RefreshableWithInitialDefault(Refreshable<K> refreshable, Function<K, T> mapper, T defaultValue) {
-        delegate = Refreshable.create(defaultValue);
+    private <K> RefreshableWithInitialValue(Refreshable<K> refreshable, Function<K, T> mapper, T initialValue) {
+        delegate = Refreshable.create(initialValue);
         refreshable.subscribe(value -> {
             try {
                 T newValue = mapper.apply(value);
@@ -54,9 +55,9 @@ final class RefreshableWithInitialDefault<T> implements Refreshable<T> {
         });
     }
 
-    public static <K, T> RefreshableWithInitialDefault<T> of(
-            Refreshable<K> refreshable, Function<K, T> mapper, T defaultValue) {
-        return new RefreshableWithInitialDefault<>(refreshable, mapper, defaultValue);
+    public static <K, T> RefreshableWithInitialValue<T> of(
+            Refreshable<K> refreshable, Function<K, T> mapper, T initialValue) {
+        return new RefreshableWithInitialValue<>(refreshable, mapper, initialValue);
     }
 
     @Override

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/RefreshableWithInitialDefaultTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/RefreshableWithInitialDefaultTest.java
@@ -1,0 +1,70 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.cassandra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.palantir.refreshable.Refreshable;
+import com.palantir.refreshable.SettableRefreshable;
+import java.util.function.Function;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RefreshableWithInitialDefaultTest {
+
+    @Mock
+    Function<Integer, String> function;
+
+    @Test
+    public void preservesValidInitialValueIfFollowingValueIsNotValid() {
+        SettableRefreshable<Integer> underlyingRefreshable = Refreshable.create(1);
+        String expectedValue = "hello";
+        when(function.apply(1)).thenReturn(expectedValue);
+        when(function.apply(2)).thenThrow();
+
+        RefreshableWithInitialDefault<String> refreshable =
+                RefreshableWithInitialDefault.of(underlyingRefreshable, function, "bye");
+
+        String initial = refreshable.get();
+
+        underlyingRefreshable.update(2);
+        String updated = refreshable.get();
+
+        assertThat(initial).describedAs("First returned value should be valid").isEqualTo(expectedValue);
+        assertThat(updated)
+                .describedAs("Second returned value should be ignored")
+                .isEqualTo(expectedValue);
+    }
+
+    @Test
+    public void firstValueInvalidShouldResolveToDefault() {
+        SettableRefreshable<Integer> underlyingRefreshable = Refreshable.create(1);
+        String expectedValue = "hello";
+        when(function.apply(1)).thenThrow();
+
+        RefreshableWithInitialDefault<String> refreshable =
+                RefreshableWithInitialDefault.of(underlyingRefreshable, function, expectedValue);
+
+        assertThat(refreshable.get())
+                .describedAs("First invalid value should resolve to default")
+                .isEqualTo(expectedValue);
+    }
+}

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/RefreshableWithInitialValueTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/RefreshableWithInitialValueTest.java
@@ -30,7 +30,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public class RefreshableWithInitialDefaultTest {
+public class RefreshableWithInitialValueTest {
 
     @Mock
     Function<Integer, String> function;
@@ -42,8 +42,7 @@ public class RefreshableWithInitialDefaultTest {
         when(function.apply(1)).thenReturn(expectedValue);
         when(function.apply(2)).thenThrow(new SafeIllegalArgumentException());
 
-        RefreshableWithInitialDefault<String> refreshable =
-                RefreshableWithInitialDefault.of(underlyingRefreshable, function, "bye");
+        Refreshable<String> refreshable = RefreshableWithInitialValue.of(underlyingRefreshable, function, "bye");
         verify(function).apply(1);
         String initial = refreshable.get();
 
@@ -62,8 +61,8 @@ public class RefreshableWithInitialDefaultTest {
         String expectedValue = "hello";
         when(function.apply(1)).thenThrow();
 
-        RefreshableWithInitialDefault<String> refreshable =
-                RefreshableWithInitialDefault.of(underlyingRefreshable, function, expectedValue);
+        Refreshable<String> refreshable =
+                RefreshableWithInitialValue.of(underlyingRefreshable, function, expectedValue);
 
         assertThat(refreshable.get())
                 .describedAs("First invalid value should resolve to default")
@@ -78,8 +77,7 @@ public class RefreshableWithInitialDefaultTest {
         when(function.apply(1)).thenReturn(expectedValue1);
         when(function.apply(2)).thenReturn(expectedValue2);
 
-        RefreshableWithInitialDefault<String> refreshable =
-                RefreshableWithInitialDefault.of(underlyingRefreshable, function, "bye");
+        Refreshable<String> refreshable = RefreshableWithInitialValue.of(underlyingRefreshable, function, "bye");
 
         String initial = refreshable.get();
 


### PR DESCRIPTION
**Goals (and why)**:
CassandraAtlasDbFactory uses some weird internal state to provide its own version of a refreshable. It differs from a normal refreshable in that, if the mapping function throws an exception  _initially_, then a some default value is used (in a refreshable, the first execution failing will just throw an exception)

Why is this needed?
See https://github.com/palantir/atlasdb/pull/6062 for the goal, but I want to provide a nicer API for consumers to manage cassandra configs without worrying about all the merging e.t.c.

Also see: #6064 internal proxy #5261 for an example on internal proxy for the finished version

This is the first part of 2 in the refactor to support that.

Note that this won't be necessary when runtime config is mandatory.


<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
`CassandraAtlasDbFactory` uses a `RefreshableWithInitialValue` when preprocessing the runtime config
==COMMIT_MSG==

**Implementation Description (bullets)**:
- RefreshableWithInitialValue class that just uses the original logic from CassandraAtlasDbFactory
- Migrate the CassandraAtlasDbFactory over to use it

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Added more tests for the refreshable

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
