### PR TITLE
Mdaudali/nicer api for configs

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraAtlasDbFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraAtlasDbFactory.java
@@ -16,7 +16,6 @@
 package com.palantir.atlasdb.cassandra;
 
 import com.google.auto.service.AutoService;
-import com.google.common.annotations.VisibleForTesting;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
@@ -34,7 +33,6 @@ import com.palantir.atlasdb.versions.AtlasDbVersion;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
-import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.refreshable.Refreshable;
 import com.palantir.timestamp.ManagedTimestampService;
 import com.palantir.timestamp.PersistentTimestampServiceImpl;
@@ -45,7 +43,6 @@ import java.util.function.LongSupplier;
 
 @AutoService(AtlasDbFactory.class)
 public class CassandraAtlasDbFactory implements AtlasDbFactory {
-
     @Override
     public KeyValueService createRawKeyValueService(
             MetricsManager metricsManager,
@@ -56,16 +53,16 @@ public class CassandraAtlasDbFactory implements AtlasDbFactory {
             LongSupplier freshTimestampSource,
             boolean initializeAsync) {
         AtlasDbVersion.ensureVersionReported();
-        CassandraKeyValueServiceConfig configWithNamespace = getConfigWithNamespace(config, namespace);
-        // Safety: CassandraReloadableKVSRuntimeConfig is a subtype of CassandraKVSRuntimeConfig, but Refreshable isn't
-        // covariant in the generic type arg, so the cast is required.
-        Refreshable<CassandraKeyValueServiceRuntimeConfig> mergedRuntimeConfig = createMergedKeyValueServiceConfig(
-                        configWithNamespace, preprocessKvsRuntimeConfig(runtimeConfig))
-                .map(CassandraKeyValueServiceRuntimeConfig.class::cast);
+        CassandraKeyValueServiceConfigs configs =
+                CassandraKeyValueServiceConfigs.fromKeyValueServiceConfigsOrThrow(config, runtimeConfig);
+
+        CassandraKeyValueServiceConfigs configsWithNamespace = configs.copyWithKeyspace(
+                OptionalResolver.resolve(namespace, configs.installConfig().namespace()));
+
         return CassandraKeyValueServiceImpl.create(
                 metricsManager,
-                configWithNamespace,
-                mergedRuntimeConfig,
+                configsWithNamespace.installConfig(),
+                configsWithNamespace.runtimeConfig(),
                 CassandraMutationTimestampProviders.singleLongSupplierBacked(freshTimestampSource),
                 initializeAsync);
     }
@@ -73,62 +70,17 @@ public class CassandraAtlasDbFactory implements AtlasDbFactory {
     @Override
     public DerivedSnapshotConfig createDerivedSnapshotConfig(
             KeyValueServiceConfig config, Optional<KeyValueServiceRuntimeConfig> runtimeConfigSnapshot) {
+        CassandraKeyValueServiceConfigs configs = CassandraKeyValueServiceConfigs.fromKeyValueServiceConfigsOrThrow(
+                config, Refreshable.only(runtimeConfigSnapshot));
+
         CassandraReloadableKeyValueServiceRuntimeConfig runtimeConfig =
                 CassandraReloadableKeyValueServiceRuntimeConfig.fromConfigs(
-                                toCassandraConfig(config),
-                                preprocessKvsRuntimeConfig(Refreshable.only(runtimeConfigSnapshot)))
+                                configs.installConfig(), configs.runtimeConfig())
                         .get();
         return DerivedSnapshotConfig.builder()
                 .concurrentGetRangesThreadPoolSize(runtimeConfig.concurrentGetRangesThreadPoolSize())
                 .defaultGetRangesConcurrencyOverride(runtimeConfig.defaultGetRangesConcurrency())
                 .build();
-    }
-
-    @VisibleForTesting
-    Refreshable<CassandraReloadableKeyValueServiceRuntimeConfig> createMergedKeyValueServiceConfig(
-            CassandraKeyValueServiceConfig config, Refreshable<CassandraKeyValueServiceRuntimeConfig> runtimeConfig) {
-        return CassandraReloadableKeyValueServiceRuntimeConfig.fromConfigs(config, runtimeConfig);
-    }
-
-    private static CassandraKeyValueServiceConfig toCassandraConfig(KeyValueServiceConfig config) {
-        Preconditions.checkArgument(
-                config instanceof CassandraKeyValueServiceConfig,
-                "Invalid KeyValueServiceConfig. Expected a KeyValueServiceConfig of type"
-                        + " CassandraKeyValueServiceConfig, but found a different type.",
-                SafeArg.of("configType", config.getClass()));
-        return (CassandraKeyValueServiceConfig) config;
-    }
-
-    @VisibleForTesting
-    Refreshable<CassandraKeyValueServiceRuntimeConfig> preprocessKvsRuntimeConfig(
-            Refreshable<Optional<KeyValueServiceRuntimeConfig>> runtimeConfig) {
-        Refreshable<KeyValueServiceRuntimeConfig> refreshableConfig = runtimeConfig.map(
-                maybeConfig -> maybeConfig.orElseGet(CassandraKeyValueServiceRuntimeConfig::getDefault));
-        return RefreshableWithInitialDefault.of(
-                refreshableConfig,
-                CassandraAtlasDbFactory::castOrThrow,
-                CassandraKeyValueServiceRuntimeConfig.getDefault());
-    }
-
-    private static CassandraKeyValueServiceRuntimeConfig castOrThrow(Object value) {
-        if (!(value instanceof CassandraKeyValueServiceRuntimeConfig)) {
-            throw new SafeIllegalArgumentException(
-                    "Invalid KeyValueServiceRuntimeConfig. Expected a KeyValueServiceRuntimeConfig of"
-                            + " type CassandraKeyValueServiceRuntimeConfig. Using latest valid"
-                            + " CassandraKeyValueServiceRuntimeConfig.",
-                    SafeArg.of("configClass", value.getClass()));
-        }
-        return (CassandraKeyValueServiceRuntimeConfig) value;
-    }
-
-    @VisibleForTesting
-    CassandraKeyValueServiceConfig getConfigWithNamespace(KeyValueServiceConfig config, Optional<String> namespace) {
-        CassandraKeyValueServiceConfig cassandraConfig = toCassandraConfig(config);
-
-        String desiredKeyspace = OptionalResolver.resolve(namespace, cassandraConfig.keyspace());
-        CassandraKeyValueServiceConfig configWithNamespace =
-                CassandraKeyValueServiceConfigs.copyWithKeyspace(cassandraConfig, desiredKeyspace);
-        return configWithNamespace;
     }
 
     @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfigs.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfigs.java
@@ -15,16 +15,86 @@
  */
 package com.palantir.atlasdb.cassandra;
 
-public final class CassandraKeyValueServiceConfigs {
-    private CassandraKeyValueServiceConfigs() {
-        // Utility class
+import com.palantir.atlasdb.spi.KeyValueServiceConfig;
+import com.palantir.atlasdb.spi.KeyValueServiceRuntimeConfig;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import com.palantir.refreshable.Refreshable;
+import com.palantir.util.OptionalResolver;
+import java.util.Optional;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface CassandraKeyValueServiceConfigs {
+    CassandraKeyValueServiceConfig installConfig();
+
+    Refreshable<CassandraKeyValueServiceRuntimeConfig> runtimeConfig();
+
+    static Optional<CassandraKeyValueServiceConfigs> fromKeyValueServiceConfigs(
+            KeyValueServiceConfig install, Refreshable<Optional<KeyValueServiceRuntimeConfig>> runtimeConfig) {
+        if (install.type().equals(CassandraKeyValueServiceConfig.TYPE)) {
+            CassandraKeyValueServiceConfig cassInstall = (CassandraKeyValueServiceConfig) install;
+            Refreshable<KeyValueServiceRuntimeConfig> kvsRuntime = runtimeConfig.map(
+                    maybeConfig -> maybeConfig.orElseGet(CassandraKeyValueServiceRuntimeConfig::getDefault));
+
+            Refreshable<CassandraKeyValueServiceRuntimeConfig> cassRuntime = RefreshableWithInitialDefault.of(
+                    kvsRuntime,
+                    CassandraKeyValueServiceConfigs::castOrThrow,
+                    CassandraKeyValueServiceRuntimeConfig.getDefault());
+
+            // Safety: CassandraReloadableKVSRuntimeConfig is a subtype of CassandraKVSRuntimeConfig, but Refreshable
+            // isn't
+            // covariant in the generic type arg, so the cast is required.
+            Refreshable<CassandraKeyValueServiceRuntimeConfig> mergedConfig =
+                    CassandraReloadableKeyValueServiceRuntimeConfig.fromConfigs(cassInstall, cassRuntime)
+                            .map(CassandraKeyValueServiceRuntimeConfig.class::cast);
+
+            return Optional.of(builder()
+                    .installConfig(cassInstall)
+                    .runtimeConfig(mergedConfig)
+                    .build());
+        } else {
+            return Optional.empty();
+        }
     }
 
-    public static CassandraKeyValueServiceConfig copyWithKeyspace(
-            CassandraKeyValueServiceConfig cassandraConfig, String recommendedKeyspace) {
-        return ImmutableCassandraKeyValueServiceConfig.builder()
-                .from(cassandraConfig)
-                .keyspace(recommendedKeyspace)
+    static CassandraKeyValueServiceConfigs fromKeyValueServiceConfigsOrThrow(
+            KeyValueServiceConfig install, Refreshable<Optional<KeyValueServiceRuntimeConfig>> runtimeConfig) {
+        return fromKeyValueServiceConfigs(install, runtimeConfig)
+                .orElseThrow(() -> new SafeIllegalArgumentException(
+                        "Invalid KeyValueServiceConfig. Expected a KeyValueServiceConfig of type"
+                                + " CassandraKeyValueServiceConfig, but found a different type.",
+                        SafeArg.of("configType", install.type())));
+    }
+
+    default CassandraKeyValueServiceConfigs copyWithKeyspace(String recommendedKeyspace) {
+        return builder()
+                .from(this)
+                .installConfig(ImmutableCassandraKeyValueServiceConfig.builder()
+                        .from(this.installConfig())
+                        .keyspace(recommendedKeyspace)
+                        .build())
                 .build();
+    }
+
+    default CassandraKeyValueServiceConfigs copyWithResolvedKeyspaceOrThrow(Optional<String> maybeKeyspace) {
+        String desiredKeyspace =
+                OptionalResolver.resolve(maybeKeyspace, installConfig().keyspace());
+        return this.copyWithKeyspace(desiredKeyspace);
+    }
+
+    static ImmutableCassandraKeyValueServiceConfigs.Builder builder() {
+        return ImmutableCassandraKeyValueServiceConfigs.builder();
+    }
+
+    private static CassandraKeyValueServiceRuntimeConfig castOrThrow(Object value) {
+        if (!(value instanceof CassandraKeyValueServiceRuntimeConfig)) {
+            throw new SafeIllegalArgumentException(
+                    "Invalid KeyValueServiceRuntimeConfig. Expected a KeyValueServiceRuntimeConfig of"
+                            + " type CassandraKeyValueServiceRuntimeConfig. Using latest valid"
+                            + " CassandraKeyValueServiceRuntimeConfig.",
+                    SafeArg.of("configClass", value.getClass()));
+        }
+        return (CassandraKeyValueServiceRuntimeConfig) value;
     }
 }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfigsTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfigsTest.java
@@ -17,45 +17,61 @@ package com.palantir.atlasdb.cassandra;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.palantir.atlasdb.config.AtlasDbConfigs;
+import com.palantir.atlasdb.spi.KeyValueServiceConfigHelper;
 import com.palantir.atlasdb.spi.KeyValueServiceRuntimeConfig;
+import com.palantir.refreshable.Refreshable;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Optional;
 import org.junit.Test;
 
 public class CassandraKeyValueServiceConfigsTest {
     private static final String KEYSPACE = "ks";
     private static final String KEYSPACE_2 = "ks2";
-    private static final ImmutableSet<InetSocketAddress> SERVERS =
+    private static final ImmutableSet<InetSocketAddress> SERVERS_ADDRESSES =
             ImmutableSet.of(InetSocketAddress.createUnresolved("foo", 42));
+    public static final ImmutableDefaultConfig SERVERS = ImmutableDefaultConfig.builder()
+            .addAllThriftHosts(SERVERS_ADDRESSES)
+            .build();
     private static final CassandraCredentialsConfig CREDENTIALS = ImmutableCassandraCredentialsConfig.builder()
             .username("username")
             .password("password")
             .build();
     private static final CassandraKeyValueServiceConfig CONFIG_WITHOUT_KEYSPACE =
             ImmutableCassandraKeyValueServiceConfig.builder()
+                    .replicationFactor(10)
+                    .servers(SERVERS)
                     .credentials(CREDENTIALS)
                     .build();
     private static final CassandraKeyValueServiceConfig CONFIG_WITH_KEYSPACE =
             ImmutableCassandraKeyValueServiceConfig.builder()
+                    .replicationFactor(10)
+                    .servers(SERVERS)
                     .keyspace(KEYSPACE)
                     .credentials(CREDENTIALS)
                     .build();
 
+    private static final CassandraKeyValueServiceConfigs CONFIGS_WITHOUT_KEYSPACE =
+            CassandraKeyValueServiceConfigs.fromKeyValueServiceConfigsOrThrow(
+                    CONFIG_WITHOUT_KEYSPACE, Refreshable.only(Optional.empty()));
+
+    private static final CassandraKeyValueServiceConfigs CONFIGS_WITH_KEYSPACE =
+            CassandraKeyValueServiceConfigs.fromKeyValueServiceConfigsOrThrow(
+                    CONFIG_WITH_KEYSPACE, Refreshable.only(Optional.empty()));
+
     @Test
-    public void canDeserialize() throws IOException, URISyntaxException {
+    public void canDeserialize() throws IOException {
         CassandraKeyValueServiceConfig testConfig = ImmutableCassandraKeyValueServiceConfig.builder()
-                .servers(ImmutableDefaultConfig.builder()
-                        .addAllThriftHosts(SERVERS)
-                        .build())
-                .addressTranslation(ImmutableMap.of("test", Iterables.getOnlyElement(SERVERS)))
+                .servers(SERVERS)
+                .addressTranslation(ImmutableMap.of("test", Iterables.getOnlyElement(SERVERS_ADDRESSES)))
                 .replicationFactor(1)
                 .credentials(CREDENTIALS)
                 .build();
@@ -69,24 +85,73 @@ public class CassandraKeyValueServiceConfigsTest {
     }
 
     @Test
-    public void canAddKeyspace() {
-        CassandraKeyValueServiceConfig newConfig =
-                CassandraKeyValueServiceConfigs.copyWithKeyspace(CONFIG_WITHOUT_KEYSPACE, KEYSPACE);
-        assertThat(newConfig.getKeyspaceOrThrow()).isEqualTo(KEYSPACE);
+    public void copyWithKeyspaceCanAddKeyspace() {
+        CassandraKeyValueServiceConfigs newConfigs = CONFIGS_WITHOUT_KEYSPACE.copyWithKeyspace(KEYSPACE);
+        assertThat(newConfigs.installConfig().getKeyspaceOrThrow()).isEqualTo(KEYSPACE);
     }
 
     @Test
-    public void otherPropertiesConservedWhenAddingKeyspace() {
-        CassandraKeyValueServiceConfig newConfig =
-                CassandraKeyValueServiceConfigs.copyWithKeyspace(CONFIG_WITHOUT_KEYSPACE, KEYSPACE);
-        assertThat(newConfig.credentials()).isEqualTo(CREDENTIALS);
+    public void copyWithKeyspacePreserversOtherProperties() {
+        CassandraKeyValueServiceConfigs newConfigs = CONFIGS_WITHOUT_KEYSPACE.copyWithKeyspace(KEYSPACE);
+        assertThat(newConfigs.installConfig().credentials()).isEqualTo(CREDENTIALS);
     }
 
     @Test
-    public void canReplaceKeyspace() {
-        CassandraKeyValueServiceConfig newConfig =
-                CassandraKeyValueServiceConfigs.copyWithKeyspace(CONFIG_WITH_KEYSPACE, KEYSPACE_2);
-        assertThat(newConfig.getKeyspaceOrThrow()).isEqualTo(KEYSPACE_2);
+    public void copyWithKeyspaceCanReplaceKeyspace() {
+        CassandraKeyValueServiceConfigs newConfigs = CONFIGS_WITHOUT_KEYSPACE.copyWithKeyspace(KEYSPACE_2);
+        assertThat(newConfigs.installConfig().getKeyspaceOrThrow()).isEqualTo(KEYSPACE_2);
+    }
+
+    @Test
+    public void fromKeyValueServiceConfigsOrThrowThrowsWhenPreprocessingNonCassandraKvsConfig() {
+        assertThatThrownBy(() -> {
+                    KeyValueServiceConfigHelper keyValueServiceConfig = () -> "Fake KVS";
+                    CassandraKeyValueServiceConfigs.fromKeyValueServiceConfigsOrThrow(
+                            keyValueServiceConfig, Refreshable.only(Optional.empty()));
+                })
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void fromKeyValueServiceConfigsReturnsEmptyWhenPreprocessingNonCassandraKvsConfig() {
+        KeyValueServiceConfigHelper keyValueServiceConfig = () -> "Fake KVS";
+        assertThat(CassandraKeyValueServiceConfigs.fromKeyValueServiceConfigs(
+                        keyValueServiceConfig, Refreshable.only(Optional.empty())))
+                .isEmpty();
+    }
+
+    @Test
+    public void copyWithResolvedKeyspaceOrThrowThrowsWhenPreprocessingConfigWithNoKeyspaceAndNoNamespace() {
+        assertThatThrownBy(() -> CONFIGS_WITHOUT_KEYSPACE.copyWithResolvedKeyspaceOrThrow(Optional.empty()))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void copyWithResolvedKeyspaceOrThrowThrowsWhenPreprocessingConfigWithKeyspaceAndDifferentNamespace() {
+        assertThatThrownBy(() -> CONFIGS_WITH_KEYSPACE.copyWithResolvedKeyspaceOrThrow(Optional.of(KEYSPACE_2)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void copyWithResolvedKeyspaceOrThrowResolvesConfigWithOriginalKeyspaceIfNoNamespaceProvided() {
+        CassandraKeyValueServiceConfigs newConfigs =
+                CONFIGS_WITH_KEYSPACE.copyWithResolvedKeyspaceOrThrow(Optional.empty());
+        assertThat(newConfigs.installConfig().getKeyspaceOrThrow())
+                .isEqualTo(CONFIG_WITH_KEYSPACE.getKeyspaceOrThrow());
+    }
+
+    @Test
+    public void copyWithResolvedKeyspaceOrThrowResolvesConfigWithNamespaceIfNoKeyspaceProvided() {
+        CassandraKeyValueServiceConfigs newConfigs =
+                CONFIGS_WITHOUT_KEYSPACE.copyWithResolvedKeyspaceOrThrow(Optional.of(KEYSPACE));
+        assertThat(newConfigs.installConfig().getKeyspaceOrThrow()).isEqualTo(KEYSPACE);
+    }
+
+    @Test
+    public void copyWithResolvedKeyspaceOrThrowResolvesConfigIfKeyspaceAndNamespaceProvidedAndMatch() {
+        CassandraKeyValueServiceConfigs newConfigs =
+                CONFIGS_WITH_KEYSPACE.copyWithResolvedKeyspaceOrThrow(Optional.of(KEYSPACE));
+        assertThat(newConfigs.installConfig().getKeyspaceOrThrow()).isEqualTo(KEYSPACE);
     }
 
     @Test
@@ -99,9 +164,7 @@ public class CassandraKeyValueServiceConfigsTest {
                         .singleQueryLoadBatchLimit(424242)
                         .build())
                 .conservativeRequestExceptionHandler(true)
-                .servers(ImmutableDefaultConfig.builder()
-                        .addAllThriftHosts(SERVERS)
-                        .build())
+                .servers(SERVERS)
                 .replicationFactor(1)
                 .build();
 
@@ -112,6 +175,28 @@ public class CassandraKeyValueServiceConfigsTest {
                 new File(configUrl.getPath()), CassandraKeyValueServiceRuntimeConfig.class);
 
         assertThat(deserializedConfig).isEqualTo(expectedConfig);
+    }
+
+    @Test
+    public void fromKeyValueServiceConfigMergesInstallAndRuntime() {
+        CassandraKeyValueServiceConfigs configs = CassandraKeyValueServiceConfigs.fromKeyValueServiceConfigsOrThrow(
+                CONFIG_WITHOUT_KEYSPACE,
+                Refreshable.only(Optional.of(ImmutableCassandraKeyValueServiceRuntimeConfig.builder()
+                        .replicationFactor(1010101)
+                        .build())));
+        assertThat(configs.runtimeConfig().get().replicationFactor())
+                .isEqualTo(configs.installConfig().replicationFactor().orElseThrow());
+    }
+
+    @Test
+    public void emptyRuntimeConfigShouldResolveToDefaultConfig() {
+        CassandraKeyValueServiceConfigs returnedConfigs =
+                CassandraKeyValueServiceConfigs.fromKeyValueServiceConfigsOrThrow(
+                        CONFIG_WITHOUT_KEYSPACE, Refreshable.only(Optional.empty()));
+
+        assertThat(returnedConfigs.runtimeConfig().get().mutationBatchCount())
+                .describedAs("Empty config should resolve to default")
+                .isEqualTo(CassandraKeyValueServiceRuntimeConfig.getDefault().mutationBatchCount());
     }
 
     @Test


### PR DESCRIPTION
**Goals (and why)**:
Part 2 for https://github.com/palantir/atlasdb/pull/6063
c.f also https://github.com/palantir/atlasdb/pull/6062 and example on Alta: https://github.palantir.build/foundry/alta/pull/5261

While porting over Alta and reviewing rescue changes, I realised that handling Cassandra Atlas Db config is a nightmare and prone to mistakes, especially given all the nasty casts everywhere.

This PR aims to provide an immutable for dealing with both install and runtime configs from a base key value service configs. It also handles the merging transparently, so users don't need to know they should construct some reloading config.

_I have not taken an initial pass, will do so Monday_

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
`CassandraKeyValueServiceConfigs` enables library users to manage their `CassandraKeyValueService(Runtime)Config`, including handling construction of any merging variants.
==COMMIT_MSG==

**Implementation Description (bullets)**:
- Expose a `CassandraKeyValueServiceConfigs` immutable that casts and builds the relevant reloading configs.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Moved relevant CassandraAtlasDbFactory tests to CassandraKeyValueServiceConfigs
- I have checked internal search tools to verify that nowhere that won't be refactored by the runtime config change will be negatively affected by this change.

**Concerns (what feedback would you like?)**:
- Any API issues?

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
