### PR TITLE
CassandraServer memoizes lazily computed hash code

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServer.java
@@ -22,7 +22,7 @@ import java.net.InetSocketAddress;
 import java.util.Set;
 import org.immutables.value.Value;
 
-@Value.Immutable
+@Value.Immutable(lazyhash = true)
 public interface CassandraServer {
     @Value.Parameter
     String cassandraHostName();

--- a/changelog/@unreleased/pr-6065.v2.yml
+++ b/changelog/@unreleased/pr-6065.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: CassandraServer memoizes lazily computed hash code
+  links:
+  - https://github.com/palantir/atlasdb/pull/6065


### PR DESCRIPTION
**Goals (and why)**:
CassandraServer memoizes lazily computed hash code to avoid expensive recomputing of `ImmutableCassandraServer#hashCode()` as seen in some JFRs as this is on hot code cell read code paths to determine which Cassandra nodes to target for gets.

![image](https://user-images.githubusercontent.com/54594/170873983-d09d8832-b775-4341-b076-95540fc2574e.png)

==COMMIT_MSG==
CassandraServer memoizes lazily computed hash code
==COMMIT_MSG==

**Implementation Description (bullets)**: [`@Value.Immutable(lazyhash = true)`](https://immutables.github.io/immutable.html#lazy-computation-of-hashcode)

**Testing (What was existing testing like?  What have you done to improve it?)**: 

**Concerns (what feedback would you like?)**: are there other immutables being used as Map/Set/Cache keys that we should consider as well?

**Where should we start reviewing?**: `CassandraServer.java`

**Priority (whenever / two weeks / yesterday)**: whenever

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
