### PR TITLE
Use Integer for replicationFactor

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceRuntimeConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceRuntimeConfig.java
@@ -52,7 +52,7 @@ public abstract class CassandraKeyValueServiceRuntimeConfig implements KeyValueS
     }
 
     @Value.Default
-    public int replicationFactor() {
+    public Integer replicationFactor() {
         // Temporary sentinel while users may provide replication factor in install or runtime config, and we don't want
         // to break existing runtime configs just yet by making this mandatory.
         // The merged config `CassandraReloadableKeyValueServiceRuntimeConfig` verifies that at least 1 of the install

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraReloadableKeyValueServiceRuntimeConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraReloadableKeyValueServiceRuntimeConfig.java
@@ -81,7 +81,7 @@ public final class CassandraReloadableKeyValueServiceRuntimeConfig
     }
 
     @Override
-    public int replicationFactor() {
+    public Integer replicationFactor() {
         return installConfig.replicationFactor().orElseGet(runtimeConfig::replicationFactor);
     }
 


### PR DESCRIPTION
Migrating the `replicationFactor` configuration has proved difficult given our typical default product configurations.

Typically our default product configurations are configured to use the Cassandra KVS. Because Cassandra is the only KVS that has a runtime configuration, installations that do not use Cassandra overwrite the install configuration but not the runtime configuration. This works because the runtime configuration deserializes successfully and then is never used.

However, the replication factor value comes from discovery:
```
replicationFactor: "{{(discovered.cassandra-replication-factor + [null])[0]}}"
```

So after moving the replication factor configuration to the runtime configuration, the runtime configuration no longer deserializes on these installations because `null` cannot be deserialized to `int`

We could handle this by putting the default value in config:
```
replicationFactor: "{{(discovered.cassandra-replication-factor + [-1])[0]}}"
```
However this has a couple downsides:
- It requires services to copy the default here, which requires them to know the value and introduces the potential to use an incorrect value.
- This doesn't work due to a bug in our configuration rendering logic (see https://g.p.b/foundry/multipass/pull/14587). Fixing this big is risky as there may be services relying on this buggy beahvior.

Instead, this PR changes the type of this field from `int` to `Integer`. This allows `null` values and because this field is annotated with `@Value.Default`, the immutables implementation will use the default value if the configuration value is `null`.