### PR TITLE
Remove ImmutableMap copy from CassandraService.getRandomHostByActiveConnections(Set)

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.fail;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Range;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceRuntimeConfig;
@@ -71,12 +72,12 @@ public class CassandraClientPoolIntegrationTest {
 
     @Test
     public void testTokenMapping() {
-        Map<Range<LightweightOppToken>, List<CassandraServer>> mapOfRanges =
+        Map<Range<LightweightOppToken>, ImmutableSet<CassandraServer>> mapOfRanges =
                 clientPool.getTokenMap().asMapOfRanges();
         assertThat(mapOfRanges).isNotEmpty();
-        for (Map.Entry<Range<LightweightOppToken>, List<CassandraServer>> entry : mapOfRanges.entrySet()) {
+        for (Map.Entry<Range<LightweightOppToken>, ImmutableSet<CassandraServer>> entry : mapOfRanges.entrySet()) {
             Range<LightweightOppToken> tokenRange = entry.getKey();
-            List<CassandraServer> hosts = entry.getValue();
+            ImmutableSet<CassandraServer> hosts = entry.getValue();
 
             clientPool.getRandomServerForKey("A".getBytes(StandardCharsets.UTF_8));
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/Blacklist.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/Blacklist.java
@@ -16,7 +16,6 @@
 package com.palantir.atlasdb.keyvalue.cassandra;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer;
@@ -26,7 +25,6 @@ import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import com.palantir.refreshable.Refreshable;
 import java.time.Clock;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -108,8 +106,8 @@ public class Blacklist {
         }
     }
 
-    public Set<CassandraServer> filterBlacklistedHostsFrom(Collection<CassandraServer> potentialHosts) {
-        return Sets.difference(ImmutableSet.copyOf(potentialHosts), blacklist.keySet());
+    public Set<CassandraServer> filterBlacklistedHostsFrom(Set<CassandraServer> potentialHosts) {
+        return Sets.difference(potentialHosts, blacklist.keySet());
     }
 
     boolean contains(CassandraServer cassandraServer) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -44,7 +44,6 @@ import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import com.palantir.refreshable.Refreshable;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -302,7 +301,7 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
     }
 
     @VisibleForTesting
-    RangeMap<LightweightOppToken, List<CassandraServer>> getTokenMap() {
+    RangeMap<LightweightOppToken, ImmutableSet<CassandraServer>> getTokenMap() {
         return cassandra.getTokenMap();
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
@@ -49,7 +49,7 @@ public final class CassandraLogHelper {
                 .collect(Collectors.toList());
     }
 
-    public static List<String> tokenMap(RangeMap<LightweightOppToken, List<CassandraServer>> tokenMap) {
+    public static List<String> tokenMap(RangeMap<LightweightOppToken, ? extends Collection<CassandraServer>> tokenMap) {
         return tokenMap.asMapOfRanges().entrySet().stream()
                 .map(rangeListToHostEntry -> String.format(
                         "range from %s to %s is on host %s",

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
@@ -90,7 +90,7 @@ public class CassandraService implements AutoCloseable {
 
     private List<CassandraServer> cassandraHosts;
 
-    private volatile Set<CassandraServer> localHosts = ImmutableSet.of();
+    private volatile ImmutableSet<CassandraServer> localHosts = ImmutableSet.of();
     private final Supplier<Optional<HostLocation>> myLocationSupplier;
     private final Supplier<Map<String, String>> hostnameByIpSupplier;
 
@@ -239,20 +239,20 @@ public class CassandraService implements AutoCloseable {
         }
     }
 
-    private Set<CassandraServer> refreshLocalHosts(List<TokenRange> tokenRanges) {
+    private ImmutableSet<CassandraServer> refreshLocalHosts(List<TokenRange> tokenRanges) {
         Optional<HostLocation> myLocation = myLocationSupplier.get();
 
         if (!myLocation.isPresent()) {
             return ImmutableSet.of();
         }
 
-        Set<CassandraServer> newLocalHosts = tokenRanges.stream()
+        ImmutableSet<CassandraServer> newLocalHosts = tokenRanges.stream()
                 .map(TokenRange::getEndpoint_details)
                 .flatMap(Collection::stream)
                 .filter(details -> isHostLocal(details, myLocation.get()))
                 .map(EndpointDetails::getHost)
                 .map(this::getAddressForHostThrowUnchecked)
-                .collect(Collectors.toSet());
+                .collect(ImmutableSet.toImmutableSet());
 
         if (newLocalHosts.isEmpty()) {
             log.warn("No local hosts found");
@@ -269,7 +269,7 @@ public class CassandraService implements AutoCloseable {
     }
 
     @VisibleForTesting
-    void setLocalHosts(Set<CassandraServer> localHosts) {
+    void setLocalHosts(ImmutableSet<CassandraServer> localHosts) {
         this.localHosts = localHosts;
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
@@ -413,7 +413,8 @@ public class CassandraService implements AutoCloseable {
         return hosts;
     }
 
-    private Optional<CassandraServer> getRandomHostByActiveConnections(Set<CassandraServer> desiredHosts) {
+    @VisibleForTesting
+    Optional<CassandraServer> getRandomHostByActiveConnections(Set<CassandraServer> desiredHosts) {
 
         Set<CassandraServer> localFilteredHosts = maybeFilterLocalHosts(desiredHosts);
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/WeightedServers.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/WeightedServers.java
@@ -16,6 +16,7 @@
 package com.palantir.atlasdb.keyvalue.cassandra.pool;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer;
 import com.palantir.logsafe.Preconditions;
@@ -37,7 +38,7 @@ public final class WeightedServers {
 
     public static WeightedServers create(Map<CassandraServer, CassandraClientPoolingContainer> pools) {
         Preconditions.checkArgument(!pools.isEmpty(), "pools should be non-empty");
-        return new WeightedServers(buildHostsWeightedByActiveConnections(pools));
+        return new WeightedServers(buildHostsWeightedByActiveConnections(ImmutableMap.copyOf(pools)));
     }
 
     /**
@@ -50,7 +51,7 @@ public final class WeightedServers {
      * than the previous key.
      */
     private static NavigableMap<Integer, CassandraServer> buildHostsWeightedByActiveConnections(
-            Map<CassandraServer, CassandraClientPoolingContainer> pools) {
+            ImmutableMap<CassandraServer, CassandraClientPoolingContainer> pools) {
 
         Map<CassandraServer, Integer> openRequestsByHost = Maps.newHashMapWithExpectedSize(pools.size());
         int totalOpenRequests = 0;

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
@@ -246,9 +246,10 @@ public class CassandraServiceTest {
     }
 
     @Test
-    public void random() {
+    public void getRandomHostByActiveConnections() {
         Set<CassandraServer> servers = generateServers(24);
-        try (CassandraService service = clientPoolWithParams(servers, servers, 0.0)) {
+        try (CassandraService service = clientPoolWithParams(servers, servers, 1.0)) {
+            service.setLocalHosts(servers.stream().limit(8).collect(ImmutableSet.toImmutableSet()));
             Set<CassandraServer> desired = servers.stream().limit(3).collect(Collectors.toSet());
             for (int i = 0; i < 1_000_000; i++) {
                 assertThat(service.getRandomHostByActiveConnections(desired)).isPresent();

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
@@ -245,6 +245,25 @@ public class CassandraServiceTest {
         assertThat(suggestedHosts).containsExactlyInAnyOrderElementsOf(allHosts);
     }
 
+    @Test
+    public void random() {
+        Set<CassandraServer> servers = generateServers(24);
+        try (CassandraService service = clientPoolWithParams(servers, servers, 0.0)) {
+            Set<CassandraServer> desired = servers.stream().limit(3).collect(Collectors.toSet());
+            for (int i = 0; i < 1_000_000; i++) {
+                assertThat(service.getRandomHostByActiveConnections(desired)).isPresent();
+            }
+        }
+    }
+
+    private Set<CassandraServer> generateServers(int size) {
+        ImmutableSet.Builder<CassandraServer> servers = ImmutableSet.builder();
+        for (int i = 0; i < size; i++) {
+            servers.add(CassandraServer.of(InetSocketAddress.createUnresolved("10.0.0." + i, DEFAULT_PORT)));
+        }
+        return servers.build();
+    }
+
     private Set<CassandraServer> getRecommendedHostsFromAThousandTrials(
             CassandraService cassandra, Set<CassandraServer> hosts) {
         return IntStream.range(0, 1_000)

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
@@ -62,8 +62,8 @@ public class CassandraServiceTest {
 
     @Test
     public void shouldOnlyReturnLocalHosts() {
-        Set<CassandraServer> hosts = ImmutableSet.of(SERVER_1, SERVER_2);
-        Set<CassandraServer> localHosts = ImmutableSet.of(SERVER_1);
+        ImmutableSet<CassandraServer> hosts = ImmutableSet.of(SERVER_1, SERVER_2);
+        ImmutableSet<CassandraServer> localHosts = ImmutableSet.of(SERVER_1);
 
         CassandraService cassandra = clientPoolWithServersAndParams(hosts, 1.0);
 

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/CassandraRepairEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/CassandraRepairEteTest.java
@@ -23,6 +23,7 @@ import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.policies.DefaultRetryPolicy;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeMap;
 import com.google.common.collect.RangeSet;
@@ -278,7 +279,7 @@ public final class CassandraRepairEteTest {
 
     @SuppressWarnings("UnstableApiUsage")
     private Map<CassandraServer, Set<Range<LightweightOppToken>>> invert(
-            RangeMap<LightweightOppToken, List<CassandraServer>> tokenMap) {
+            RangeMap<LightweightOppToken, ImmutableSet<CassandraServer>> tokenMap) {
         Map<CassandraServer, Set<Range<LightweightOppToken>>> invertedMap = new HashMap<>();
         tokenMap.asMapOfRanges()
                 .forEach((range, addresses) -> addresses.forEach(address -> {


### PR DESCRIPTION
**Goals (and why)**:
The `com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraService.getRandomHostByActiveConnections(Set)` method is used heavily by AtlasDB Cassandra read path when identifying which Cassandra nodes to target for requests. Given how hot this path is, there were many unnecessary `ImmutableMap.copyOf(currentPools)`. 

![image](https://user-images.githubusercontent.com/54594/172276863-54ffdfa7-ae00-4217-96e7-2491892b1d95.png)
![image](https://user-images.githubusercontent.com/54594/172282162-34829285-97d9-4071-8298-cfbe494f02ae.png)



==COMMIT_MSG==
Remove ImmutableMap copy from CassandraService.getRandomHostByActiveConnections(Set)
==COMMIT_MSG==

**Implementation Description (bullets)**:

- Iterate over the `ConcurrentHashMap<CassandraServer, CassandraClientPoolingContainer> currentPools` to construct an `ImmutableMap` snapshot of (maybe local) Cassandra nodes.
- Local nodes is always an `ImmutableSet` snapshot view of cluster state.
- Enforces the cluster snapshot added in https://github.com/palantir/atlasdb/pull/5266
- Removes `ImmutableSet` copy when filtering blocked hosts.

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**: 

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
