### PR TITLE
Avoid expensive InetSocketAddress#toString()

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -41,7 +41,6 @@ import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.format.DateTimeFormatter;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
@@ -121,8 +120,8 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Cassand
         ThreadNames.setThreadName(
                 Thread.currentThread(),
                 origName
-                        + " calling cassandra host " + proxy
-                        + " started at " + DateTimeFormatter.ISO_INSTANT.format(Instant.now())
+                        + " calling cassandra host " + proxy.getHostString() + ':' + proxy.getPort()
+                        + " started at " + Instant.now()
                         + " - " + count.getAndIncrement());
         try {
             openRequests.getAndIncrement();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -727,7 +727,8 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
 
                     @Override
                     public String toString() {
-                        return "multiget_multislice(" + host + ", " + tableRef + ", " + query.size() + " cells)";
+                        return "multiget_multislice(" + host.cassandraHostName() + ", " + tableRef + ", " + query.size()
+                                + " cells)";
                     }
                 });
     }
@@ -1239,7 +1240,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
 
             @Override
             public String toString() {
-                return "batch_mutate(" + host + ", " + tableRefs + ", " + batch.size() + " values)";
+                return "batch_mutate(" + host.cassandraHostName() + ", " + tableRefs + ", " + batch.size() + " values)";
             }
         });
     }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellDeleter.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellDeleter.java
@@ -109,8 +109,8 @@ class CellDeleter {
 
                 @Override
                 public String toString() {
-                    return "delete_batch_mutate(" + host + ", " + tableRef.getQualifiedName() + ", " + numVersions
-                            + " total versions of " + cellVersionsMap.size() + " keys)";
+                    return "delete_batch_mutate(" + host.cassandraHostName() + ", " + tableRef.getQualifiedName() + ", "
+                            + numVersions + " total versions of " + cellVersionsMap.size() + " keys)";
                 }
             });
         } catch (RetryLimitReachedException e) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoader.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoader.java
@@ -189,8 +189,8 @@ final class CellLoader {
 
                         @Override
                         public String toString() {
-                            return "multiget_multislice(" + cassandraServer + ", " + colFam + ", " + partition.size()
-                                    + " cells)";
+                            return "multiget_multislice(" + cassandraServer.cassandraHostName() + ", " + colFam + ", "
+                                    + partition.size() + " cells)";
                         }
                     });
             tasks.add(AnnotatedCallable.wrapWithThreadName(

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoader.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoader.java
@@ -196,7 +196,8 @@ final class CellLoader {
             tasks.add(AnnotatedCallable.wrapWithThreadName(
                     AnnotationType.PREPEND,
                     "Atlas loadWithTs " + partition.size() + " cells from " + tableRef + " on "
-                            + cassandraServer.cassandraHostName() + " via proxy " + cassandraServer.proxy(),
+                            + cassandraServer.cassandraHostName() + " via proxy "
+                            + CassandraLogHelper.host(cassandraServer.proxy()),
                     multiGetCallable));
         }
         return tasks;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellRangeDeleter.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellRangeDeleter.java
@@ -91,8 +91,8 @@ class CellRangeDeleter {
 
                 @Override
                 public String toString() {
-                    return "delete_timestamp_ranges_batch_mutate(" + server + ", " + tableRef.getQualifiedName() + ", "
-                            + deletes.size() + " column timestamp ranges)";
+                    return "delete_timestamp_ranges_batch_mutate(" + server.cassandraHostName() + ", "
+                            + tableRef.getQualifiedName() + ", " + deletes.size() + " column timestamp ranges)";
                 }
             });
         } catch (RetryLimitReachedException e) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellValuePutter.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellValuePutter.java
@@ -159,8 +159,8 @@ public class CellValuePutter {
 
             @Override
             public String toString() {
-                return "batch_mutate(" + server + ", " + tableRef.getQualifiedName() + ", " + Iterables.size(values)
-                        + " values)";
+                return "batch_mutate(" + server.cassandraHostName() + ", " + tableRef.getQualifiedName() + ", "
+                        + Iterables.size(values) + " values)";
             }
         });
     }

--- a/changelog/@unreleased/pr-6076.v2.yml
+++ b/changelog/@unreleased/pr-6076.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Avoid expensive InetSocketAddress#toString()
+  links:
+  - https://github.com/palantir/atlasdb/pull/6076


### PR DESCRIPTION
**Goals (and why)**:

There are several hot paths which include diagnostic information about the cassandra node being accessed, and this is triggering expensive CPU & memory allocations via invocations of `InetSocketAddress#toString()` which does several string concatenations, for each of the `CassandraServer#reachableProxyIps()`. In many cases, we do not need these proxy IPs, so we should just use the cheap `CassandraServer#cassandraHostName()` for that node.

![image](https://user-images.githubusercontent.com/54594/172859601-836da5ce-5afa-45a7-b368-30804ded4bd7.png)

==COMMIT_MSG==
Avoid expensive InetSocketAddress#toString()
==COMMIT_MSG==

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
