### PR TITLE
Ensure persister calls are re-usable

### DIFF
--- a/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/SchemaApiTestTable.java
+++ b/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/SchemaApiTestTable.java
@@ -323,7 +323,7 @@ public final class SchemaApiTestTable implements
 
         @Override
         public byte[] persistValue() {
-            byte[] bytes = com.palantir.atlasdb.compress.CompressionUtils.compress(new com.palantir.atlasdb.table.description.test.StringValuePersister().persistToBytes(value), com.palantir.atlasdb.table.description.ColumnValueDescription.Compression.NONE);
+            byte[] bytes = com.palantir.atlasdb.compress.CompressionUtils.compress(REUSABLE_PERSISTER.persistToBytes(value), com.palantir.atlasdb.table.description.ColumnValueDescription.Compression.NONE);
             return CompressionUtils.compress(bytes, Compression.NONE);
         }
 
@@ -331,6 +331,7 @@ public final class SchemaApiTestTable implements
         public byte[] persistColumnName() {
             return PtBytes.toCachedBytes("d");
         }
+        private final com.palantir.atlasdb.table.description.test.StringValuePersister REUSABLE_PERSISTER = new com.palantir.atlasdb.table.description.test.StringValuePersister();
 
         public static final Hydrator<Column2> BYTES_HYDRATOR = new Hydrator<Column2>() {
             @Override
@@ -871,5 +872,5 @@ public final class SchemaApiTestTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "Yc3wzX0toIULZ5f1HiKrbw==";
+    static String __CLASS_HASH = "wX/FaKJz8W8PXrcy5U5qlg==";
 }

--- a/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/SchemaApiTestTable.java
+++ b/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/SchemaApiTestTable.java
@@ -296,6 +296,8 @@ public final class SchemaApiTestTable implements
      * </pre>
      */
     public static final class Column2 implements SchemaApiTestNamedColumnValue<com.palantir.atlasdb.table.description.test.StringValue> {
+        private static final com.palantir.atlasdb.table.description.test.StringValuePersister REUSABLE_PERSISTER = new com.palantir.atlasdb.table.description.test.StringValuePersister();
+
         private final com.palantir.atlasdb.table.description.test.StringValue value;
 
         public static Column2 of(com.palantir.atlasdb.table.description.test.StringValue value) {
@@ -331,7 +333,6 @@ public final class SchemaApiTestTable implements
         public byte[] persistColumnName() {
             return PtBytes.toCachedBytes("d");
         }
-        private final com.palantir.atlasdb.table.description.test.StringValuePersister REUSABLE_PERSISTER = new com.palantir.atlasdb.table.description.test.StringValuePersister();
 
         public static final Hydrator<Column2> BYTES_HYDRATOR = new Hydrator<Column2>() {
             @Override
@@ -339,7 +340,6 @@ public final class SchemaApiTestTable implements
                 bytes = CompressionUtils.decompress(bytes, Compression.NONE);
                 return of(REUSABLE_PERSISTER.hydrateFromBytes(com.palantir.atlasdb.compress.CompressionUtils.decompress(bytes, com.palantir.atlasdb.table.description.ColumnValueDescription.Compression.NONE)));
             }
-            private final com.palantir.atlasdb.table.description.test.StringValuePersister REUSABLE_PERSISTER = new com.palantir.atlasdb.table.description.test.StringValuePersister();
         };
 
         @Override
@@ -872,5 +872,5 @@ public final class SchemaApiTestTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "wX/FaKJz8W8PXrcy5U5qlg==";
+    static String __CLASS_HASH = "QMyMGvXpBPDuoeuIdJeLPg==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/ColumnValueDescription.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/ColumnValueDescription.java
@@ -239,7 +239,11 @@ public final class ColumnValueDescription {
         } else if (format == Format.PROTO) {
             result = varName + ".toByteArray()";
         } else if (format == Format.PERSISTER) {
-            result = "new " + canonicalClassName + "().persistToBytes(" + varName + ")";
+            if (isReusablePersister()) {
+                result = "REUSABLE_PERSISTER.persistToBytes(" + varName + ")";
+            } else {
+                result = "new " + canonicalClassName + "().persistToBytes(" + varName + ")";
+            }
         } else {
             result = type.getPersistCode(varName);
         }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/DynamicColumnValueRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/DynamicColumnValueRenderer.java
@@ -47,6 +47,7 @@ public class DynamicColumnValueRenderer extends Renderer {
         javaDoc();
         line("public static final class ", ColumnValue, " implements ColumnValue<", Value, "> {");
         {
+            addReusablePersisterIfApplicable();
             fields();
             line();
             staticFactories();
@@ -142,6 +143,13 @@ public class DynamicColumnValueRenderer extends Renderer {
         line("}");
     }
 
+    private void addReusablePersisterIfApplicable() {
+        if (val.isReusablePersister()) {
+            line(val.getInstantiateReusablePersisterCode(true));
+            line();
+        }
+    }
+
     private void persistValue() {
         line("@Override");
         line("public byte[] persistValue() {");
@@ -168,10 +176,6 @@ public class DynamicColumnValueRenderer extends Renderer {
                     ");");
         }
         line("}");
-
-        if (val.isReusablePersister()) {
-            line(val.getInstantiateReusablePersisterCode(true));
-        }
     }
 
     private void hydrateValue() {
@@ -207,10 +211,6 @@ public class DynamicColumnValueRenderer extends Renderer {
             }
         }
         line("}");
-
-        if (val.isReusablePersister()) {
-            line(val.getInstantiateReusablePersisterCode(true));
-        }
     }
 
     private void getColumnNameFun() {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/DynamicColumnValueRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/DynamicColumnValueRenderer.java
@@ -168,6 +168,10 @@ public class DynamicColumnValueRenderer extends Renderer {
                     ");");
         }
         line("}");
+
+        if (val.isReusablePersister()) {
+            line(val.getInstantiateReusablePersisterCode(true));
+        }
     }
 
     private void hydrateValue() {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/NamedColumnValueRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/NamedColumnValueRenderer.java
@@ -40,6 +40,7 @@ public class NamedColumnValueRenderer extends Renderer {
         javaDoc();
         line("public static final class ", Name, " implements ", tableName, "NamedColumnValue<", TypeName(col), "> {");
         {
+            addReusablePersisterIfApplicable();
             fields();
             line();
             staticFactories();
@@ -156,6 +157,13 @@ public class NamedColumnValueRenderer extends Renderer {
         line("}");
     }
 
+    private void addReusablePersisterIfApplicable() {
+        if (col.getValue().isReusablePersister()) {
+            line(col.getValue().getInstantiateReusablePersisterCode(true));
+            line();
+        }
+    }
+
     private void persistColumnName() {
         line("@Override");
         line("public byte[] persistColumnName() {");
@@ -163,9 +171,6 @@ public class NamedColumnValueRenderer extends Renderer {
             line("return PtBytes.toCachedBytes(", short_name(col), ");");
         }
         line("}");
-        if (col.getValue().isReusablePersister()) {
-            line(col.getValue().getInstantiateReusablePersisterCode(false));
-        }
     }
 
     private void bytesHydrator() {
@@ -205,10 +210,6 @@ public class NamedColumnValueRenderer extends Renderer {
                 }
             }
             line("}");
-
-            if (col.getValue().isReusablePersister()) {
-                line(col.getValue().getInstantiateReusablePersisterCode(false));
-            }
         }
         line("};");
     }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/NamedColumnValueRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/NamedColumnValueRenderer.java
@@ -163,6 +163,9 @@ public class NamedColumnValueRenderer extends Renderer {
             line("return PtBytes.toCachedBytes(", short_name(col), ");");
         }
         line("}");
+        if (col.getValue().isReusablePersister()) {
+            line(col.getValue().getInstantiateReusablePersisterCode(false));
+        }
     }
 
     private void bytesHydrator() {

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/render/TableRendererTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/render/TableRendererTest.java
@@ -78,6 +78,7 @@ public class TableRendererTest {
         String renderedTableDefinition =
                 renderer.render("table", getTableWithUserSpecifiedPersister(TABLE_REF), NO_INDICES);
         assertThat(renderedTableDefinition)
+                .contains("REUSABLE_PERSISTER.persistToBytes")
                 .contains("REUSABLE_PERSISTER.hydrateFromBytes")
                 .contains("private final com.palantir.atlasdb.persister.JsonNodePersister REUSABLE_PERSISTER =");
     }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/render/TableRendererTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/render/TableRendererTest.java
@@ -80,7 +80,7 @@ public class TableRendererTest {
         assertThat(renderedTableDefinition)
                 .contains("REUSABLE_PERSISTER.persistToBytes")
                 .contains("REUSABLE_PERSISTER.hydrateFromBytes")
-                .contains("private final com.palantir.atlasdb.persister.JsonNodePersister REUSABLE_PERSISTER =");
+                .contains("private static final com.palantir.atlasdb.persister.JsonNodePersister REUSABLE_PERSISTER =");
     }
 
     private TableDefinition getTableWithUserSpecifiedPersister(TableReference tableRef) {

--- a/changelog/@unreleased/pr-6079.v2.yml
+++ b/changelog/@unreleased/pr-6079.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Enable re-use of persisters on the write path.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6079


### PR DESCRIPTION
**Goals (and why)**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Enable re-use of persisters on the write path.
==COMMIT_MSG==

**Implementation Description (bullets)**:

The current code enables re-use of persisters when hydrating, but not when persisting. This uses the same implementation to not re-create persisters on every write.

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

It's unclear to me why we supported one path but not the other. Am I missing any assumptions?

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
