### PR TITLE
Make thread dump configurable

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
@@ -305,6 +305,11 @@ public abstract class AtlasDbConfig {
         return false;
     }
 
+    @Value.Default
+    public boolean collectThreadDumpOnInit() {
+        return true;
+    }
+
     @Value.Check
     protected final void check() {
         checkLeaderAndTimelockBlocks();

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
@@ -305,8 +305,15 @@ public abstract class AtlasDbConfig {
         return false;
     }
 
+    /**
+     * Configure stack trace collection during timestamp service initialisation. Enabled by default.
+     *
+     * Timestamp service is expected to be initialised only once.
+     * Stack traces are collected and stored in temporary file when
+     * another initialisation occurred to help with debugging.
+     */
     @Value.Default
-    public boolean collectThreadDumpOnInit() {
+    public boolean collectThreadDumpOnTimestampServiceInit() {
         return true;
     }
 

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplier.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplier.java
@@ -54,6 +54,7 @@ public class ServiceDiscoveringAtlasSupplier {
     private final Supplier<ManagedTimestampService> timestampService;
     private final Supplier<TimestampStoreInvalidator> timestampStoreInvalidator;
     private final DerivedSnapshotConfig derivedSnapshotConfig;
+    private final boolean collectThreadDumps;
 
     public ServiceDiscoveringAtlasSupplier(
             MetricsManager metricsManager,
@@ -63,8 +64,10 @@ public class ServiceDiscoveringAtlasSupplier {
             Optional<String> namespace,
             Optional<TableReference> tableReferenceOverride,
             boolean initializeAsync,
+            boolean collectThreadDumpOnInit,
             LongSupplier timestampSupplier) {
         this.leaderConfig = leaderConfig;
+        this.collectThreadDumps = collectThreadDumpOnInit;
 
         AtlasDbFactory atlasFactory = AtlasDbServiceDiscovery.createAtlasFactoryOfCorrectType(config);
         keyValueService = Suppliers.memoize(() -> atlasFactory.createRawKeyValueService(
@@ -90,10 +93,12 @@ public class ServiceDiscoveringAtlasSupplier {
                         + "thread {}. This should only happen once.",
                 SafeArg.of("threadName", Thread.currentThread().getName()));
 
-        if (timestampServiceCreationInfo == null) {
-            timestampServiceCreationInfo = ThreadDumps.programmaticThreadDump();
-        } else {
-            handleMultipleTimestampFetch();
+        if (collectThreadDumps) {
+            if (timestampServiceCreationInfo == null) {
+                timestampServiceCreationInfo = ThreadDumps.programmaticThreadDump();
+            } else {
+                handleMultipleTimestampFetch();
+            }
         }
 
         return timestampService.get();

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -365,7 +365,7 @@ public abstract class TransactionManagers {
                 config().namespace(),
                 Optional.empty(),
                 config().initializeAsync(),
-                config().collectThreadDumpOnInit(),
+                config().collectThreadDumpOnTimestampServiceInit(),
                 adapter);
         DerivedSnapshotConfig derivedSnapshotConfig = atlasFactory.getDerivedSnapshotConfig();
 

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -299,6 +299,7 @@ public abstract class TransactionManagers {
             Set<Schema> schemas, Optional<LockAndTimestampServiceFactory> maybeFactory) {
         AtlasDbConfig config = ImmutableAtlasDbConfig.builder()
                 .keyValueService(new InMemoryAtlasDbConfig())
+                .collectThreadDumpOnInit(false)
                 .build();
         return builder()
                 .config(config)
@@ -364,6 +365,7 @@ public abstract class TransactionManagers {
                 config().namespace(),
                 Optional.empty(),
                 config().initializeAsync(),
+                config().collectThreadDumpOnInit(),
                 adapter);
         DerivedSnapshotConfig derivedSnapshotConfig = atlasFactory.getDerivedSnapshotConfig();
 

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -299,7 +299,7 @@ public abstract class TransactionManagers {
             Set<Schema> schemas, Optional<LockAndTimestampServiceFactory> maybeFactory) {
         AtlasDbConfig config = ImmutableAtlasDbConfig.builder()
                 .keyValueService(new InMemoryAtlasDbConfig())
-                .collectThreadDumpOnInit(false)
+                .collectThreadDumpOnTimestampServiceInit(false)
                 .build();
         return builder()
                 .config(config)

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplierTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplierTest.java
@@ -98,6 +98,7 @@ public class ServiceDiscoveringAtlasSupplierTest {
                 Optional.empty(),
                 Optional.empty(),
                 AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC,
+                true,
                 AtlasDbFactory.THROWING_FRESH_TIMESTAMP_SOURCE);
     }
 }

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/ServicesConfig.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/ServicesConfig.java
@@ -50,6 +50,7 @@ public abstract class ServicesConfig {
                 atlasDbConfig().namespace(),
                 Optional.empty(),
                 atlasDbConfig().initializeAsync(),
+                true,
                 adapter());
     }
 

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/DbTimestampStoreInvalidatorCreationTest.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/DbTimestampStoreInvalidatorCreationTest.java
@@ -128,6 +128,7 @@ public class DbTimestampStoreInvalidatorCreationTest {
                 Optional.empty(),
                 tableReference,
                 AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC,
+                true,
                 AtlasDbFactory.THROWING_FRESH_TIMESTAMP_SOURCE);
     }
 }

--- a/changelog/0.631.0-rc1/pr-6084.v2.yml
+++ b/changelog/0.631.0-rc1/pr-6084.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Make thread dump configurable
+  links:
+  - https://github.com/palantir/atlasdb/pull/6084

--- a/changelog/@unreleased/pr-6084.v2.yml
+++ b/changelog/@unreleased/pr-6084.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Make thread dump configurable
+  links:
+  - https://github.com/palantir/atlasdb/pull/6084


### PR DESCRIPTION
**Goals (and why)**:
InMemory transaction manager primarily used in tests and recreated before each test. Migration to Java 17 made thread dump collection more expensive.

Disabling thread dump runtime unit tests time from ~14 min to ~8 min.

Before:
<img width="769" alt="image" src="https://user-images.githubusercontent.com/518196/173637441-8fa9a6f7-b3b9-422a-9000-6b908c349304.png">

After:
<img width="756" alt="image" src="https://user-images.githubusercontent.com/518196/173637521-865cbc59-79c2-43bd-8a82-bf9dec192c69.png">


==COMMIT_MSG==
Make thread dump configurable
==COMMIT_MSG==

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
