### PR TITLE
Improve ThreadDumps and StackTraceUtils

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/util/debug/StackTraceUtils.java
+++ b/atlasdb-commons/src/main/java/com/palantir/util/debug/StackTraceUtils.java
@@ -162,12 +162,16 @@ public final class StackTraceUtils {
         StackTraceElement[] stackTrace = info.getStackTrace();
         for (int i = 0; i < stackTrace.length && i < MAX_FRAMES; i++) {
             StackTraceElement ste = stackTrace[i];
-            sb.append(INDENT + "at " + ste.toString());
+            sb.append(INDENT + "at ").append(ste.toString());
             sb.append(LINE_ENDING);
 
             while (curLock < stackDepths.length && i == stackDepths[curLock]) {
                 String[] lockName = lockedMonitors[curLock].toString().split("@");
-                sb.append(INDENT + " - locked <" + lockName[1] + "> (a " + lockName[0] + ")");
+                sb.append(INDENT + " - locked <")
+                        .append(lockName[1])
+                        .append("> (a ")
+                        .append(lockName[0])
+                        .append(")");
                 sb.append(LINE_ENDING);
                 curLock++;
             }
@@ -185,8 +189,12 @@ public final class StackTraceUtils {
         // The thread priority here is a lie, but automated thread dump analyzer samurai
         // requires it and ThreadInfo does not provide it. The nid is also a lie, but
         // Thread Dump Analyzer requires it.
-        dump.append("\"" + ti.getThreadName() + "\" prio=10 tid=0x" + Long.toHexString(ti.getThreadId()) + " nid="
-                + ti.getThreadId());
+        dump.append("\"")
+                .append(ti.getThreadName())
+                .append("\" prio=10 tid=0x")
+                .append(Long.toHexString(ti.getThreadId()))
+                .append(" nid=")
+                .append(ti.getThreadId());
 
         // These are a best effort match to what kill -3 would report as the status. It's not perfect, but
         // samurai will parse it correctly.
@@ -221,15 +229,27 @@ public final class StackTraceUtils {
                 dump.append(" terminated");
                 break;
         }
-        dump.append(LINE_ENDING + "  java.lang.Thread.State: " + ti.getThreadState());
+        dump.append(LINE_ENDING + "  java.lang.Thread.State: ").append(ti.getThreadState());
 
         if (ti.getLockName() != null) {
             String[] lockName = ti.getLockName().split("@");
             if (ti.getThreadState() == Thread.State.BLOCKED) {
-                dump.append(LINE_ENDING + INDENT + " - waiting to lock <" + lockName[1] + "> (a " + lockName[0] + ")");
+                dump.append(LINE_ENDING + INDENT + " - waiting to lock <")
+                        .append(lockName[1])
+                        .append("> (a ")
+                        .append(lockName[0])
+                        .append(")");
             } else {
-                dump.append(LINE_ENDING + INDENT + " - waiting on <" + lockName[1] + "> (a " + lockName[0] + ")");
-                dump.append(LINE_ENDING + INDENT + " - locked <" + lockName[1] + "> (a " + lockName[0] + ")");
+                dump.append(LINE_ENDING + INDENT + " - waiting on <")
+                        .append(lockName[1])
+                        .append("> (a ")
+                        .append(lockName[0])
+                        .append(")");
+                dump.append(LINE_ENDING + INDENT + " - locked <")
+                        .append(lockName[1])
+                        .append("> (a ")
+                        .append(lockName[0])
+                        .append(")");
             }
         }
         if (ti.isSuspended()) {
@@ -240,7 +260,10 @@ public final class StackTraceUtils {
         }
         dump.append(LINE_ENDING);
         if (ti.getLockOwnerName() != null) {
-            dump.append(INDENT + " owned by " + ti.getLockOwnerName() + " tid=" + ti.getLockOwnerId());
+            dump.append(INDENT + " owned by ")
+                    .append(ti.getLockOwnerName())
+                    .append(" tid=")
+                    .append(ti.getLockOwnerId());
             dump.append(LINE_ENDING);
         }
     }
@@ -413,19 +436,27 @@ public final class StackTraceUtils {
         }
 
         private void appendSummarizedNamesToResult(StringBuilder resultStackTrace) {
-            resultStackTrace.append(
-                    summarizedNames.size() + " " + pluralizeWord("thread", summarizedNames.size()) + " summarized");
+            resultStackTrace
+                    .append(summarizedNames.size())
+                    .append(" ")
+                    .append(pluralizeWord("thread", summarizedNames.size()))
+                    .append(" summarized");
             if (!summarizedNames.isEmpty()) {
                 resultStackTrace.append(": ");
                 resultStackTrace.append(lineEnding);
                 for (int i = 0; i < summarizedNames.size() - 1; i++) {
                     String currSummarizedName = summarizedNames.get(i);
-                    resultStackTrace.append("\t" + currSummarizedName + "\n");
+                    resultStackTrace.append("\t").append(currSummarizedName).append("\n");
                 }
                 String lastSummarizedName = summarizedNames.get(summarizedNames.size() - 1);
-                resultStackTrace.append("\t" + lastSummarizedName);
+                resultStackTrace.append("\t").append(lastSummarizedName);
             }
-            resultStackTrace.append(lineEnding + boringCount + " " + pluralizeWord("thread", boringCount) + " omitted");
+            resultStackTrace
+                    .append(lineEnding)
+                    .append(boringCount)
+                    .append(" ")
+                    .append(pluralizeWord("thread", boringCount))
+                    .append(" omitted");
         }
 
         private String createHeader(String serverName) {

--- a/atlasdb-commons/src/main/java/com/palantir/util/debug/StackTraceUtils.java
+++ b/atlasdb-commons/src/main/java/com/palantir/util/debug/StackTraceUtils.java
@@ -258,7 +258,7 @@ public final class StackTraceUtils {
             int nextStartingIndex = index + 1;
             index = trace.indexOf("com.palantir", nextStartingIndex);
         }
-        score += POINTS_PER_LINE * trace.split(LINE_ENDING).length;
+        score += POINTS_PER_LINE * trace.chars().filter(x -> x == '\n').sum();
         return score;
     }
 

--- a/atlasdb-commons/src/main/java/com/palantir/util/debug/StackTraceUtils.java
+++ b/atlasdb-commons/src/main/java/com/palantir/util/debug/StackTraceUtils.java
@@ -496,8 +496,11 @@ public final class StackTraceUtils {
         }
 
         private String getFirstLineOfTrace(String trace) {
-            String[] traceLines = trace.split("\n");
-            return traceLines[0];
+            int index = trace.indexOf('\n');
+            if (index > -1) {
+                return trace.substring(0, index);
+            }
+            return "";
         }
     }
 }

--- a/atlasdb-commons/src/main/java/com/palantir/util/debug/ThreadDumps.java
+++ b/atlasdb-commons/src/main/java/com/palantir/util/debug/ThreadDumps.java
@@ -22,7 +22,7 @@ import java.lang.management.ThreadMXBean;
 import javax.management.JMException;
 
 @SuppressWarnings("checkstyle")
-// WARNING: This class was copied verbatim from an internal product. We are aware that the code quality is not great
+// WARNING: This class was copied verbatim from an internal product. We are aware that the code quality is not great,
 // and we lack tests, however this is covered by testing in the internal product
 // DO NOT CHANGE THIS CLASS!
 public class ThreadDumps {
@@ -33,9 +33,7 @@ public class ThreadDumps {
                     serverName, //$NON-NLS-1$
                     StackTraceUtils.getStackTraceForConnection(ManagementFactory.getPlatformMBeanServer()),
                     false);
-        } catch (JMException e) {
-            return fallbackThreadDump(serverName);
-        } catch (IOException e) {
+        } catch (JMException | IOException e) {
             return fallbackThreadDump(serverName);
         }
     }

--- a/atlasdb-commons/src/main/java/com/palantir/util/debug/ThreadDumps.java
+++ b/atlasdb-commons/src/main/java/com/palantir/util/debug/ThreadDumps.java
@@ -54,13 +54,13 @@ public class ThreadDumps {
             if (info.getLockName() != null) {
                 switch (info.getThreadState()) {
                     case BLOCKED:
-                        dump.append("\r\n\t-  blocked on " + info.getLockName()); // $NON-NLS-1$
+                        dump.append("\r\n\t-  blocked on ").append(info.getLockName()); // $NON-NLS-1$
                         break;
                     case WAITING:
-                        dump.append("\r\n\t-  waiting on " + info.getLockName()); // $NON-NLS-1$
+                        dump.append("\r\n\t-  waiting on ").append(info.getLockName()); // $NON-NLS-1$
                         break;
                     case TIMED_WAITING:
-                        dump.append("\r\n\t-  waiting on " + info.getLockName()); // $NON-NLS-1$
+                        dump.append("\r\n\t-  timed waiting on ").append(info.getLockName()); // $NON-NLS-1$
                         break;
                     default:
                         break;


### PR DESCRIPTION
**Goals (and why)**:
As noted in 
https://github.com/palantir/atlasdb/pull/6084#issuecomment-1157434783 `StackTraceUtils#score` is quite expensive `split`ting the full stacktrace on newlines twice for each sort comparison.

<img width="1309" alt="image" src="https://user-images.githubusercontent.com/518196/174037348-763049b1-4b71-4526-ae53-e5c441947030.png">

==COMMIT_MSG==
Improve ThreadDumps and StackTraceUtils

Reduce large string copies and splits as part of generating programmatic thread dumps.
==COMMIT_MSG==

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
