### PR TITLE
Simplify Cassandra server in thread names

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -618,7 +618,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             tasks.add(AnnotatedCallable.wrapWithThreadName(
                     AnnotationType.PREPEND,
                     "Atlas getRows " + hostAndRows.getValue().size() + " rows from " + tableRef + " on "
-                            + hostAndRows.getKey(),
+                            + hostAndRows.getKey().cassandraHostName(),
                     () -> getRowsForSingleHost(hostAndRows.getKey(), tableRef, hostAndRows.getValue(), startTs)));
         }
         List<Map<Cell, Value>> perHostResults = taskRunner.runAllTasksCancelOnFailure(tasks);
@@ -875,7 +875,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             tasks.add(AnnotatedCallable.wrapWithThreadName(
                     AnnotationType.PREPEND,
                     "Atlas getRowsColumnRange " + hostAndRows.getValue().size() + " rows from " + tableRef + " on "
-                            + hostAndRows.getKey(),
+                            + hostAndRows.getKey().cassandraHostName(),
                     () -> getRowsColumnRangeIteratorForSingleHost(
                             hostAndRows.getKey(),
                             tableRef,
@@ -1211,7 +1211,8 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             final Set<TableReference> tableRefs = extractTableNames(batch);
             tasks.add(AnnotatedCallable.wrapWithThreadName(
                     AnnotationType.PREPEND,
-                    "Atlas multiPut of " + batch.size() + " cells into " + tableRefs + " on " + host,
+                    "Atlas multiPut of " + batch.size() + " cells into " + tableRefs + " on "
+                            + host.cassandraHostName(),
                     () -> multiPutForSingleHostInternal(host, tableRefs, batch, timestamp)));
         }
         return tasks;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellValuePutter.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellValuePutter.java
@@ -99,7 +99,8 @@ public class CellValuePutter {
         for (final Map.Entry<CassandraServer, Map<Cell, Value>> entry : cellsByHost.entrySet()) {
             tasks.add(AnnotatedCallable.wrapWithThreadName(
                     AnnotationType.PREPEND,
-                    "Atlas put " + entry.getValue().size() + " cell values to " + tableRef + " on " + entry.getKey(),
+                    "Atlas put " + entry.getValue().size() + " cell values to " + tableRef + " on "
+                            + entry.getKey().cassandraHostName(),
                     () -> {
                         putForSingleHost(
                                 kvsMethodName,

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServer.java
@@ -38,14 +38,15 @@ public interface CassandraServer {
      * The only proxy that will be used to reach the Cassandra host.
      * */
     @Value.Lazy
+    @Value.Redacted // exclude from toString for thread names & logs
     default InetSocketAddress proxy() {
         // we know the set of proxies contains at least one element
-        return reachableProxyIps().stream().findAny().orElseThrow();
+        return reachableProxyIps().iterator().next();
     }
 
     @Value.Check
     default void check() {
-        Preconditions.checkState(reachableProxyIps().size() > 0, "Must have at least one reachable IP.");
+        Preconditions.checkState(!reachableProxyIps().isEmpty(), "Must have at least one reachable IP.");
     }
 
     static CassandraServer of(InetSocketAddress addr) {

--- a/changelog/@unreleased/pr-6092.v2.yml
+++ b/changelog/@unreleased/pr-6092.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: |-
+    Simplify Cassandra server in thread names
+
+    Avoid including set of Cassandra proxy addresses in thread names
+  links:
+  - https://github.com/palantir/atlasdb/pull/6092


### PR DESCRIPTION
**Goals (and why)**:
Avoid including set of Cassandra proxy addresses in thread names as seen in example:

`Atlas getRowsColumnRange 1 rows from namespace.table on CassandraServer{cassandraHostName=cassandra-123.foo.bar, reachableProxyIps=[cassandra-123.foo.bar/127.0.0.1:9160]} worker task-1234 calling cassandra host cassandra-123.foo.bar/127.0.0.1:9160 started at 2022-06-17T12:00:00.123456789Z - 1234567890`

Additional follow on to https://github.com/palantir/atlasdb/pull/6076

==COMMIT_MSG==
Simplify Cassandra server in thread names

Avoid including set of Cassandra proxy addresses in thread names
==COMMIT_MSG==

**Implementation Description (bullets)**:
Include only `CassandraServer` hostname and remove proxy IPs from generated `ImmutableCassandraServer#toString()`

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
