### PR TITLE
[Transaction Table Sweep] Part 2: DefaultKnownConcludedTransactions

### DIFF
--- a/atlasdb-impl-shared/build.gradle
+++ b/atlasdb-impl-shared/build.gradle
@@ -6,6 +6,7 @@ libsDirName = file('build/artifacts')
 
 license {
   exclude '**/ConsensusForgettingStoreMetrics.java'
+  exclude '**/KnownConcludedTransactionsMetrics.java'
   exclude '**/PutUnlessExistsTableMetrics.java'
   exclude '**/TargetedSweepProgressMetrics.java'
   exclude '**/TimestampCorrectnessMetrics.java'

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/DefaultKnownConcludedTransactions.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/DefaultKnownConcludedTransactions.java
@@ -51,19 +51,21 @@ public final class DefaultKnownConcludedTransactions implements KnownConcludedTr
         return null;
     });
 
-    private DefaultKnownConcludedTransactions(KnownConcludedTransactionsStore knownConcludedTransactionsStore,
+    private DefaultKnownConcludedTransactions(
+            KnownConcludedTransactionsStore knownConcludedTransactionsStore,
             KnownConcludedTransactionsMetrics metrics) {
         this.knownConcludedTransactionsStore = knownConcludedTransactionsStore;
         this.cachedConcludedTimestamps = new AtomicReference<>(ImmutableRangeSet.of());
         this.knownConcludedTransactionsMetrics = metrics;
-        metrics.disjointCacheIntervals(() -> cachedConcludedTimestamps.get().asRanges().size());
+        metrics.disjointCacheIntervals(
+                () -> cachedConcludedTimestamps.get().asRanges().size());
     }
 
-    public static KnownConcludedTransactions create(KnownConcludedTransactionsStore knownConcludedTransactionsStore,
+    public static KnownConcludedTransactions create(
+            KnownConcludedTransactionsStore knownConcludedTransactionsStore,
             TaggedMetricRegistry taggedMetricRegistry) {
         DefaultKnownConcludedTransactions store = new DefaultKnownConcludedTransactions(
-                knownConcludedTransactionsStore,
-                KnownConcludedTransactionsMetrics.of(taggedMetricRegistry));
+                knownConcludedTransactionsStore, KnownConcludedTransactionsMetrics.of(taggedMetricRegistry));
         return store;
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/DefaultKnownConcludedTransactions.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/DefaultKnownConcludedTransactions.java
@@ -1,0 +1,103 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.knowledge;
+
+import com.google.common.collect.ImmutableRangeSet;
+import com.google.common.collect.Range;
+import com.google.common.collect.RangeSet;
+import com.palantir.common.concurrent.CoalescingSupplier;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+@SuppressWarnings("UnstableApiUsage") // RangeSet usage
+public final class DefaultKnownConcludedTransactions implements KnownConcludedTransactions {
+    private static final SafeLogger log = SafeLoggerFactory.get(DefaultKnownConcludedTransactions.class);
+    private static final int MAX_ATTEMPTS = 20;
+
+    private final KnownConcludedTransactionsStore knownConcludedTransactionsStore;
+
+    /**
+     * Concurrency: All updates go through {@link #ensureRangesCached(Supplier)} and perform CASes to atomically
+     * evolve the value here. Copy on write should be acceptable given these range-sets are not expected to be large.
+     */
+    private final AtomicReference<ImmutableRangeSet<Long>> cachedConcludedTimestamps;
+
+    private final CoalescingSupplier<Void> cacheUpdater = new CoalescingSupplier<>(() -> {
+        updateCacheFromRemote();
+        return null;
+    });
+
+    public DefaultKnownConcludedTransactions(KnownConcludedTransactionsStore knownConcludedTransactionsStore) {
+        this.knownConcludedTransactionsStore = knownConcludedTransactionsStore;
+        this.cachedConcludedTimestamps = new AtomicReference<>(ImmutableRangeSet.of());
+    }
+
+    @Override
+    public boolean isKnownConcluded(long startTimestamp, Consistency consistency) {
+        if (cachedConcludedTimestamps.get().contains(startTimestamp)) {
+            return true;
+        }
+        if (consistency == Consistency.REMOTE_READ) {
+            return performRemoteReadAndCheckConcluded(startTimestamp);
+        }
+        return false;
+    }
+
+    @Override
+    public void addConcludedTimestamps(Range<Long> knownConcludedInterval) {
+        knownConcludedTransactionsStore.supplement(knownConcludedInterval);
+        ensureRangesCached(() -> ImmutableRangeSet.of(knownConcludedInterval));
+    }
+
+    private boolean performRemoteReadAndCheckConcluded(long startTimestamp) {
+        cacheUpdater.get();
+        return cachedConcludedTimestamps.get().contains(startTimestamp);
+    }
+
+    private void updateCacheFromRemote() {
+        ensureRangesCached(() -> knownConcludedTransactionsStore
+                .get()
+                .map(TimestampRangeSet::timestampRanges)
+                .orElse(ImmutableRangeSet.of()));
+    }
+
+    private void ensureRangesCached(Supplier<RangeSet<Long>> timestampRangesSupplier) {
+        for (int attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+            RangeSet<Long> rangesToAdd = timestampRangesSupplier.get();
+            ImmutableRangeSet<Long> cache = cachedConcludedTimestamps.get();
+            if (cache.enclosesAll(rangesToAdd)) {
+                return;
+            }
+            ImmutableRangeSet<Long> targetCacheValue = ImmutableRangeSet.<Long>builder()
+                    .addAll(cache)
+                    .addAll(rangesToAdd)
+                    .build();
+            if (cachedConcludedTimestamps.compareAndSet(cache, targetCacheValue)) {
+                return;
+            }
+            // Concurrent update; can try again.
+        }
+        log.warn(
+                "Unable to ensure ranges of known concluded transactions were cached.",
+                SafeArg.of("numAttempts", MAX_ATTEMPTS));
+        throw new SafeIllegalStateException("Unable to ensure ranges of known concluded transactions were cached.");
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactions.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactions.java
@@ -29,7 +29,7 @@ public interface KnownConcludedTransactions {
      *
      * @param startTimestamp start timestamp associated with the value we are checking for
      * @param consistency consistency level to use when answering this query
-     * @return whether the transaction that started at the provided timestamp is known to have committed.
+     * @return whether the transaction that started at the provided timestamp is known to have concluded.
      */
     boolean isKnownConcluded(long startTimestamp, Consistency consistency);
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactions.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactions.java
@@ -35,7 +35,7 @@ public interface KnownConcludedTransactions {
 
     /**
      * Registers the fact that any transactions that had started in the provided range have concluded, including
-     * writing this to the database.
+     * writing this to the database. This endpoint is costly, and must not be called with a high level of concurrency.
      *
      * @param knownConcludedInterval range of timestamps in which all transactions must have concluded
      */

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactions.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactions.java
@@ -1,0 +1,57 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.knowledge;
+
+import com.google.common.collect.Range;
+
+/**
+ * Represents a set of start timestamps that belong to transactions that are known to have concluded.
+ * This means that transactions with these start timestamps have either been committed, been aborted, or have not
+ * committed and will not be able to ever commit (though it is not known which of these is actually the case).
+ */
+public interface KnownConcludedTransactions {
+    /**
+     * Returns whether the transaction that started at the provided timestamp is known to have concluded.
+     *
+     * @param startTimestamp start timestamp associated with the value we are checking for
+     * @param consistency consistency level to use when answering this query
+     * @return whether the transaction that started at the provided timestamp is known to have committed.
+     */
+    boolean isKnownConcluded(long startTimestamp, Consistency consistency);
+
+    /**
+     * Registers the fact that any transactions that had started in the provided range have concluded, including
+     * writing this to the database.
+     *
+     * @param knownConcludedInterval range of timestamps in which all transactions must have concluded
+     */
+    void addConcludedTimestamps(Range<Long> knownConcludedInterval);
+
+    enum Consistency {
+        /**
+         * Only perform a read from a local cache. This is eventually consistent and the set of known committed
+         * timestamps for a given namespace only grows, so a 'true' answer to
+         * {@link #isKnownConcluded(long, Consistency)} at this level can be trusted, but a 'false' answer might
+         * actually be knowably committed if one looks in the database.
+         */
+        LOCAL_READ,
+        /**
+         * Perform a remote read against the underlying database if necessary.
+         */
+        REMOTE_READ;
+    }
+}

--- a/atlasdb-impl-shared/src/main/metrics/transactions4-knowledge.yml
+++ b/atlasdb-impl-shared/src/main/metrics/transactions4-knowledge.yml
@@ -1,0 +1,10 @@
+options:
+  javaPackage: 'com.palantir.atlasdb.transaction.knowledge'
+
+namespaces:
+  knownConcludedTransactions:
+    docs: Metrics tracking usage and statistics for the set of known concluded transactions
+    metrics:
+      disjointCacheIntervals:
+        type: gauge
+        docs: The number of disjoint intervals of timestamps tracked in the cache.

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/knowledge/DefaultKnownConcludedTransactionsTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/knowledge/DefaultKnownConcludedTransactionsTest.java
@@ -1,0 +1,149 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.knowledge;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.Range;
+import com.google.common.util.concurrent.Futures;
+import com.palantir.atlasdb.transaction.knowledge.KnownConcludedTransactions.Consistency;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DefaultKnownConcludedTransactionsTest {
+    private static final Range<Long> DEFAULT_RANGE = Range.closed(10L, 100L);
+    private static final Range<Long> ADDITIONAL_RANGE = Range.closed(88L, 200L);
+
+    private final KnownConcludedTransactionsStore knownConcludedTransactionsStore =
+            mock(KnownConcludedTransactionsStore.class);
+    private final DefaultKnownConcludedTransactions defaultKnownConcludedTransactions =
+            new DefaultKnownConcludedTransactions(knownConcludedTransactionsStore);
+
+    @Before
+    public void setUp() {
+        setupStoreWithDefaultRange();
+    }
+
+    @Test
+    public void isKnownConcludedDoesNotPerformDatabaseReadsOnLocalReadConsistency() {
+        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(2L, Consistency.LOCAL_READ)).isFalse();
+        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(84L, Consistency.LOCAL_READ)).isFalse();
+
+        verify(knownConcludedTransactionsStore, never()).get();
+    }
+
+    @Test
+    public void isKnownConcludedPerformsDatabaseReadOnRemoteReadConsistencyAndCanReturnInconclusive() {
+        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(2L, Consistency.REMOTE_READ)).isFalse();
+        verify(knownConcludedTransactionsStore).get();
+    }
+
+    @Test
+    public void isKnownConcludedPerformsDatabaseReadOnRemoteReadConsistencyAndCanReturnConcluded() {
+        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(85L, Consistency.REMOTE_READ)).isTrue();
+        verify(knownConcludedTransactionsStore).get();
+    }
+
+    @Test
+    public void isKnownConcludedDoesNotPerformDatabaseReadIfAnswerAlreadyKnown() {
+        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(85L, Consistency.REMOTE_READ)).isTrue();
+        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(47L, Consistency.REMOTE_READ)).isTrue();
+        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(62L, Consistency.REMOTE_READ)).isTrue();
+        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(DEFAULT_RANGE.upperEndpoint(),
+                Consistency.REMOTE_READ)).isTrue();
+        verify(knownConcludedTransactionsStore).get();
+    }
+
+    @Test
+    public void isKnownConcludedAttemptsToLoadNewInformationIfAnswerNotCurrentlyKnown() {
+        // In each instance, it is possible that external factors have modified the database so that the transaction
+        // becomes known to have concluded, so a remote read is needed on each attempt.
+        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(2L, Consistency.REMOTE_READ)).isFalse();
+        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(2L, Consistency.REMOTE_READ)).isFalse();
+        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(2L, Consistency.REMOTE_READ)).isFalse();
+        verify(knownConcludedTransactionsStore, times(3)).get();
+
+        when(knownConcludedTransactionsStore.get()).thenReturn(Optional.of(TimestampRangeSet.singleRange(Range.closed(0L, 100L))));
+        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(2L, Consistency.REMOTE_READ)).isTrue();
+        verify(knownConcludedTransactionsStore, times(4)).get();
+    }
+
+    @Test
+    public void addConcludedTimestampsSupplementsUnderlyingStore() {
+        defaultKnownConcludedTransactions.addConcludedTimestamps(ADDITIONAL_RANGE);
+        verify(knownConcludedTransactionsStore).supplement(ADDITIONAL_RANGE);
+    }
+
+    @Test
+    public void addConcludedTimestampsFlushesWritesToTheCache() {
+        defaultKnownConcludedTransactions.addConcludedTimestamps(ADDITIONAL_RANGE);
+        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(DEFAULT_RANGE.upperEndpoint() + 1,
+                Consistency.LOCAL_READ)).isTrue();
+        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(DEFAULT_RANGE.upperEndpoint() + 1,
+                Consistency.REMOTE_READ)).isTrue();
+        verify(knownConcludedTransactionsStore, never()).get();
+    }
+
+    @Test
+    public void addConcludedTimestampsConcurrency() throws InterruptedException {
+        int numThreads = 10; // Concurrency should not be too high given this is accessed from background threads.
+        CountDownLatch startTaskLatch = new CountDownLatch(1);
+        ExecutorService taskExecutor = Executors.newCachedThreadPool();
+
+        List<Future<Void>> futures = IntStream.range(0, numThreads)
+                .mapToObj(index -> taskExecutor.submit((Callable<Void>) () -> {
+                    try {
+                        startTaskLatch.await();
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                    defaultKnownConcludedTransactions.addConcludedTimestamps(Range.closed(
+                            index * 10L,
+                            index * 10L + 9));
+                    return null;
+                })).collect(Collectors.toList());
+
+        startTaskLatch.countDown();
+        taskExecutor.shutdown();
+        taskExecutor.awaitTermination(5, TimeUnit.SECONDS);
+        futures.forEach(Futures::getUnchecked);
+
+        IntStream.range(0, numThreads * 10)
+                .forEach(timestamp -> assertThat(defaultKnownConcludedTransactions.isKnownConcluded(timestamp,
+                        Consistency.LOCAL_READ)).isTrue());
+    }
+
+    private void setupStoreWithDefaultRange() {
+        when(knownConcludedTransactionsStore.get()).thenReturn(Optional.of(
+                TimestampRangeSet.singleRange(DEFAULT_RANGE)));
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/knowledge/DefaultKnownConcludedTransactionsTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/knowledge/DefaultKnownConcludedTransactionsTest.java
@@ -55,31 +55,39 @@ public class DefaultKnownConcludedTransactionsTest {
 
     @Test
     public void isKnownConcludedDoesNotPerformDatabaseReadsOnLocalReadConsistency() {
-        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(2L, Consistency.LOCAL_READ)).isFalse();
-        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(84L, Consistency.LOCAL_READ)).isFalse();
+        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(2L, Consistency.LOCAL_READ))
+                .isFalse();
+        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(84L, Consistency.LOCAL_READ))
+                .isFalse();
 
         verify(knownConcludedTransactionsStore, never()).get();
     }
 
     @Test
     public void isKnownConcludedPerformsDatabaseReadOnRemoteReadConsistencyAndCanReturnInconclusive() {
-        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(2L, Consistency.REMOTE_READ)).isFalse();
+        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(2L, Consistency.REMOTE_READ))
+                .isFalse();
         verify(knownConcludedTransactionsStore).get();
     }
 
     @Test
     public void isKnownConcludedPerformsDatabaseReadOnRemoteReadConsistencyAndCanReturnConcluded() {
-        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(85L, Consistency.REMOTE_READ)).isTrue();
+        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(85L, Consistency.REMOTE_READ))
+                .isTrue();
         verify(knownConcludedTransactionsStore).get();
     }
 
     @Test
     public void isKnownConcludedDoesNotPerformDatabaseReadIfAnswerAlreadyKnown() {
-        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(85L, Consistency.REMOTE_READ)).isTrue();
-        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(47L, Consistency.REMOTE_READ)).isTrue();
-        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(62L, Consistency.REMOTE_READ)).isTrue();
-        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(DEFAULT_RANGE.upperEndpoint(),
-                Consistency.REMOTE_READ)).isTrue();
+        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(85L, Consistency.REMOTE_READ))
+                .isTrue();
+        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(47L, Consistency.REMOTE_READ))
+                .isTrue();
+        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(62L, Consistency.REMOTE_READ))
+                .isTrue();
+        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(
+                        DEFAULT_RANGE.upperEndpoint(), Consistency.REMOTE_READ))
+                .isTrue();
         verify(knownConcludedTransactionsStore).get();
     }
 
@@ -87,13 +95,18 @@ public class DefaultKnownConcludedTransactionsTest {
     public void isKnownConcludedAttemptsToLoadNewInformationIfAnswerNotCurrentlyKnown() {
         // In each instance, it is possible that external factors have modified the database so that the transaction
         // becomes known to have concluded, so a remote read is needed on each attempt.
-        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(2L, Consistency.REMOTE_READ)).isFalse();
-        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(2L, Consistency.REMOTE_READ)).isFalse();
-        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(2L, Consistency.REMOTE_READ)).isFalse();
+        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(2L, Consistency.REMOTE_READ))
+                .isFalse();
+        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(2L, Consistency.REMOTE_READ))
+                .isFalse();
+        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(2L, Consistency.REMOTE_READ))
+                .isFalse();
         verify(knownConcludedTransactionsStore, times(3)).get();
 
-        when(knownConcludedTransactionsStore.get()).thenReturn(Optional.of(TimestampRangeSet.singleRange(Range.closed(0L, 100L))));
-        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(2L, Consistency.REMOTE_READ)).isTrue();
+        when(knownConcludedTransactionsStore.get())
+                .thenReturn(Optional.of(TimestampRangeSet.singleRange(Range.closed(0L, 100L))));
+        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(2L, Consistency.REMOTE_READ))
+                .isTrue();
         verify(knownConcludedTransactionsStore, times(4)).get();
     }
 
@@ -106,10 +119,12 @@ public class DefaultKnownConcludedTransactionsTest {
     @Test
     public void addConcludedTimestampsFlushesWritesToTheCache() {
         defaultKnownConcludedTransactions.addConcludedTimestamps(ADDITIONAL_RANGE);
-        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(DEFAULT_RANGE.upperEndpoint() + 1,
-                Consistency.LOCAL_READ)).isTrue();
-        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(DEFAULT_RANGE.upperEndpoint() + 1,
-                Consistency.REMOTE_READ)).isTrue();
+        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(
+                        DEFAULT_RANGE.upperEndpoint() + 1, Consistency.LOCAL_READ))
+                .isTrue();
+        assertThat(defaultKnownConcludedTransactions.isKnownConcluded(
+                        DEFAULT_RANGE.upperEndpoint() + 1, Consistency.REMOTE_READ))
+                .isTrue();
         verify(knownConcludedTransactionsStore, never()).get();
     }
 
@@ -126,24 +141,24 @@ public class DefaultKnownConcludedTransactionsTest {
                     } catch (InterruptedException e) {
                         throw new RuntimeException(e);
                     }
-                    defaultKnownConcludedTransactions.addConcludedTimestamps(Range.closed(
-                            index * 10L,
-                            index * 10L + 9));
+                    defaultKnownConcludedTransactions.addConcludedTimestamps(
+                            Range.closed(index * 10L, index * 10L + 9));
                     return null;
-                })).collect(Collectors.toList());
+                }))
+                .collect(Collectors.toList());
 
         startTaskLatch.countDown();
         taskExecutor.shutdown();
         taskExecutor.awaitTermination(5, TimeUnit.SECONDS);
         futures.forEach(Futures::getUnchecked);
 
-        IntStream.range(0, numThreads * 10)
-                .forEach(timestamp -> assertThat(defaultKnownConcludedTransactions.isKnownConcluded(timestamp,
-                        Consistency.LOCAL_READ)).isTrue());
+        IntStream.range(0, numThreads * 10).forEach(timestamp -> assertThat(
+                        defaultKnownConcludedTransactions.isKnownConcluded(timestamp, Consistency.LOCAL_READ))
+                .isTrue());
     }
 
     private void setupStoreWithDefaultRange() {
-        when(knownConcludedTransactionsStore.get()).thenReturn(Optional.of(
-                TimestampRangeSet.singleRange(DEFAULT_RANGE)));
+        when(knownConcludedTransactionsStore.get())
+                .thenReturn(Optional.of(TimestampRangeSet.singleRange(DEFAULT_RANGE)));
     }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactionsStoreConcurrencyTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactionsStoreConcurrencyTest.java
@@ -80,7 +80,7 @@ public class KnownConcludedTransactionsStoreConcurrencyTest {
             assertThat(read).contains(TimestampRangeSet.singleRange(Range.closedOpen(10L, 50L)));
         }
 
-        verify(delegateKeyValueService, atMost(10))
+        verify(delegateKeyValueService, atMost(50))
                 .get(eq(TransactionConstants.KNOWN_CONCLUDED_TRANSACTIONS_TABLE), anyMap());
     }
 


### PR DESCRIPTION
## General
**Before this PR**:
Although there is a store for persisting timestamp range-sets, this is all in abstract terms.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
There now exists a store for persisting the set of known concluded transactions (known as C in the RFC).
==COMMIT_MSG==

**Priority**: this week

**Concerns / possible downsides (what feedback would you like?)**:
- Do we need more protection against high concurrency in `addConcludedTimestamps`? I'm a bit worried about this. It shouldn't require high concurrency, being updated by the background sweep task, but if we accidentally use it badly we could be in for a bad time.

**Is documentation needed?**: No.

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: No.

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: No.

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: Yes - there are no decisions here.

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: No.

**Does this PR need a schema migration?** No.

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: Not much.

**What was existing testing like? What have you done to improve it?**: The new class here is tested using a mock of the concluded transaction store (though that was tested in part 1).

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: Nothing complex here. We have an `AtomicReference` that is updated with a CAS algorithm, so it's worth having a look at that.

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: No.

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: Nothing right now as it's not exposed.

**Has the safety of all log arguments been decided correctly?**: `numAttempts` is the only log argument and it's safe.

**Will this change significantly affect our spending on metrics or logs?**: No.

**How would I tell that this PR does not work in production? (monitors, etc.)**: Nothing right now as it's not exposed

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: Just rollback

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**: Generally no. Reads go through a coalescing supplier; a deluge of writes could be costly, but should only be initiated by a background thread as noted above.

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**: Eventually as we productionise this we'll want metrics on transaction get and commit.

## Development Process
**Where should we start reviewing?**: KnownConcludedTransactions interface.

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: Nope.

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
