### PR TITLE
[PDS-283304] Fix TimeLock Async Initialisation Race Condition

### DIFF
--- a/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentTimestampServiceImpl.java
+++ b/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentTimestampServiceImpl.java
@@ -80,8 +80,8 @@ public class PersistentTimestampServiceImpl implements PersistentTimestampServic
     }
 
     private void tryInitialize() {
-        long latestTimestamp = store.getUpperLimit();
         PersistentUpperLimit upperLimit = new PersistentUpperLimit(store);
+        long latestTimestamp = upperLimit.get();
         timestamp = new PersistentTimestamp(upperLimit, latestTimestamp);
     }
 

--- a/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceMockingTest.java
+++ b/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceMockingTest.java
@@ -85,7 +85,8 @@ public class PersistentTimestampServiceMockingTest {
         TimestampBoundStore timestampBoundStore = mock(TimestampBoundStore.class);
         when(timestampBoundStore.getUpperLimit()).thenReturn(INITIAL_TIMESTAMP);
 
-        PersistentTimestampService persistentTimestampService = PersistentTimestampServiceImpl.create(timestampBoundStore);
+        PersistentTimestampService persistentTimestampService =
+                PersistentTimestampServiceImpl.create(timestampBoundStore);
         long freshTimestamp = persistentTimestampService.getFreshTimestamp();
 
         assertThat(freshTimestamp).isGreaterThan(INITIAL_TIMESTAMP);

--- a/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceMockingTest.java
+++ b/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceMockingTest.java
@@ -17,9 +17,11 @@ package com.palantir.timestamp;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.AdditionalMatchers.geq;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import org.junit.Test;
@@ -76,5 +78,19 @@ public class PersistentTimestampServiceMockingTest {
     public void shouldRejectFastForwardToTheSentinelValue() {
         assertThatThrownBy(() -> timestampService.fastForwardTimestamp(TimestampManagementService.SENTINEL_TIMESTAMP))
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void getsAndStoresUpperLimitExactlyOnceOnInitialisation() {
+        TimestampBoundStore timestampBoundStore = mock(TimestampBoundStore.class);
+        when(timestampBoundStore.getUpperLimit()).thenReturn(INITIAL_TIMESTAMP);
+
+        PersistentTimestampService persistentTimestampService = PersistentTimestampServiceImpl.create(timestampBoundStore);
+        long freshTimestamp = persistentTimestampService.getFreshTimestamp();
+
+        assertThat(freshTimestamp).isGreaterThan(INITIAL_TIMESTAMP);
+        verify(timestampBoundStore).getUpperLimit();
+        verify(timestampBoundStore).storeUpperLimit(geq(freshTimestamp));
+        verifyNoMoreInteractions(timestampBoundStore);
     }
 }


### PR DESCRIPTION
## General
**Before this PR**:
There is a race condition that can cause **SEVERE DATA CORRUPTION**(TM) upon a TimeLock leader election, though the likelihood of this is low. I claim this is because of a bug in `PersistentTimestampServiceImpl#tryInitialize()`:

```
    private void tryInitialize() {
        long latestTimestamp = store.getUpperLimit();
        PersistentUpperLimit upperLimit = new PersistentUpperLimit(store);
        timestamp = new PersistentTimestamp(upperLimit, latestTimestamp);
    }
```

It is also worth considering the constructor of `PersistentUpperLimit`:

```
    public PersistentUpperLimit(TimestampBoundStore boundStore) {
        this.store = boundStore;
        this.currentLimit = boundStore.getUpperLimit();
    }
```

The problem here is that two separate sequential calls are made to `TimestampBoundStore#getUpperLimit()` and these _can_ return different values. Although the creation of these objects should only happen when a node is the leader, requests that were made on a node that had just lost leadership, where the request has already passed the leadership check, are still allowed to proceed. It is thus possible that the `latestTimestamp` and the `upperLimit` passed in to `PersistentTimestamp` are out of sync.

With this in place, the new `PersistentTimestampServiceImpl` effectively believes that it is free to give out the range of timestamps in between `latestTimestamp` and `upperLimit`, even though these timestamps could have been given out by requests that made it past the leadership check on the outgoing leader. This is consistent with us seeing failures in the first timestamp or first few timestamps of a given reservation.

More concretely, consider the following sequence of events, where `[A, B, C]` is a TimeLock cluster.

```
A is the leader
A has reserved the timestamps [1, ..., 1MM] at sequence 1
B misses a ping from A, and proposes leadership
B wins the new leader election
A lost leadership, *BUT* any requests on A that have already passed the leadership check are still allowed to proceed
B starts creating its timestamp service: it reads the latest timestamp from the store at 1MM.
A reaches the end of its reserved timestamp window, and proposes [1MM + 1, ..., 2MM] at sequence 2 successfully
B now creates its PersistentUpperLimit, which reads a currentLimit of 2MM.
A returns the timestamp 1MM + 1 to an outstanding request
B receives a timestamp request: since 1MM is less than 2MM, it is safe to give out 1MM + 1
B returns the timestamp 1MM + 1 to a new timestamp request
```

This violates TimeLock's monotonic guarantees, since the request that started on B after `1MM + 1` was returned from A also returned `1MM + 1`. In practice, this self resolves after the allocation buffer that A originally reserved had been fully utilised - though it's visible much sooner because of the client side integrity checks.

**After this PR**:
The aforementioned race condition is handled correctly: state internal to the persistent timestamp service is initialised with a single read. In the event that we read 2MM, we correctly propose the new range [2MM + 1, 3MM]; in the event that we read 1MM, we notice that the bound changed underneath us and give up leadership. While the latter can result in a bit of leadership thrashing, it is correct.

==COMMIT_MSG==
Fixed a long-standing race condition in TimeLock around the creation of the persistent timestamp service. Previously, this could have caused TimeLock in an HA setting to give out timestamps multiple times.
==COMMIT_MSG==

**Priority**: Dev P0 🔥 

**Concerns / possible downsides (what feedback would you like?)**:
- I'm fairly confident this is an improvement, but does my fix still leave vulnerabilities?

**Is documentation needed?**: No.

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: Yes - during a blue-green we still run the risk of this bug manifesting when a blue node becomes the leader, but interaction in terms of Paxos is generally unchanged.

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: No

**Does this PR need a schema migration?** No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: Not much

**What was existing testing like? What have you done to improve it?**: There weren't any tests that caught this case - I have added one in the mocking tests to verify getUpperLimit() is called just once, and storeUpperLimit() is called when releasing a timestamp.

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: Not too much (this PR relies on the Paxos bound store code _being_ correct, but in any case is no worse than the old behaviour).

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: No

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: The metric for clocks-went-backwards events should fire less frequently.

**Has the safety of all log arguments been decided correctly?**: Yes, vacuously

**Will this change significantly affect our spending on metrics or logs?**: No

**How would I tell that this PR does not work in production? (monitors, etc.)**: We may see more instances of these in metrics, and TimestampViolations files tickets on us if it happens.

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: Yeah, just rollback.

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**: Not any more than the existing code already does.

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**: No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**: Probably not. There is something around reworking timelock to more efficiently handle a change of leadership underneath us eventually, but that's way out of scope of this and will require quite a bit of work I think.

## Development Process
**Where should we start reviewing?**: PersistentTimestamp

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: No.

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
