### PR TITLE
[Transaction Table Sweep] Part 3: Extract TicketsCellEncodingStrategy From Transactions2

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/encoding/TicketsCellEncodingStrategy.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/encoding/TicketsCellEncodingStrategy.java
@@ -22,6 +22,15 @@ import com.palantir.atlasdb.table.description.ValueType;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
+/**
+ * We divide the first PARTITIONING_QUANTUM timestamps among the first ROW_PER_QUANTUM rows.
+ * We aim to distribute start timestamps as evenly as possible among these rows as numbers increase, by taking the
+ * least significant bits of the timestamp and using that as the row number. For example, we would store values that
+ * might be associated with the timestamps 1, ROW_PER_QUANTUM + 1, 2 * ROW_PER_QUANTUM + 1 etc. in the same row.
+ *
+ * We store the row name as a bit-wise reversed version of the row number to ensure even distribution in key-value
+ * services that rely on consistent hashing or similar mechanisms for partitioning.
+ */
 public class TicketsCellEncodingStrategy implements CellEncodingStrategy {
     private final long partitioningQuantum;
     private final long rowsPerQuantum;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/encoding/TicketsCellEncodingStrategy.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/encoding/TicketsCellEncodingStrategy.java
@@ -16,9 +16,12 @@
 
 package com.palantir.atlasdb.transaction.encoding;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
@@ -36,8 +39,27 @@ public class TicketsCellEncodingStrategy implements CellEncodingStrategy {
     private final long rowsPerQuantum;
 
     public TicketsCellEncodingStrategy(long partitioningQuantum, long rowsPerQuantum) {
+        Preconditions.checkArgument(
+                rowsPerQuantum > 0,
+                "Number of rows per quantum must be positive",
+                SafeArg.of("rowsPerQuantum", rowsPerQuantum));
+        Preconditions.checkArgument(
+                partitioningQuantum >= rowsPerQuantum,
+                "Must have at least one cell per row after partitioning",
+                SafeArg.of("rowsPerQuantum", rowsPerQuantum),
+                SafeArg.of("partitioningQuantum", partitioningQuantum));
         this.partitioningQuantum = partitioningQuantum;
         this.rowsPerQuantum = rowsPerQuantum;
+    }
+
+    @VisibleForTesting
+    long getPartitioningQuantum() {
+        return partitioningQuantum;
+    }
+
+    @VisibleForTesting
+    long getRowsPerQuantum() {
+        return rowsPerQuantum;
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/encoding/TicketsCellEncodingStrategy.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/encoding/TicketsCellEncodingStrategy.java
@@ -75,8 +75,7 @@ public class TicketsCellEncodingStrategy implements CellEncodingStrategy {
     }
 
     public Stream<byte[]> getRowSetCoveringTimestampRange(long fromInclusive, long toInclusive) {
-        long startRow =
-                startTimestampToRow(fromInclusive - ((fromInclusive % partitioningQuantum) % rowsPerQuantum));
+        long startRow = startTimestampToRow(fromInclusive - ((fromInclusive % partitioningQuantum) % rowsPerQuantum));
         long endRow = startTimestampToRow(
                 toInclusive + rowsPerQuantum - ((toInclusive % partitioningQuantum) % rowsPerQuantum) - 1);
         return LongStream.rangeClosed(startRow, endRow).mapToObj(TicketsCellEncodingStrategy::rowToBytes);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/encoding/TicketsCellEncodingStrategy.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/encoding/TicketsCellEncodingStrategy.java
@@ -1,0 +1,84 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.encoding;
+
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.table.description.ValueType;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+public class TicketsCellEncodingStrategy implements CellEncodingStrategy {
+    private final long partitioningQuantum;
+    private final long rowsPerQuantum;
+
+    public TicketsCellEncodingStrategy(long partitioningQuantum, long rowsPerQuantum) {
+        this.partitioningQuantum = partitioningQuantum;
+        this.rowsPerQuantum = rowsPerQuantum;
+    }
+
+    @Override
+    public Cell encodeStartTimestampAsCell(long startTimestamp) {
+        byte[] rowName = encodeRowName(startTimestamp);
+        byte[] columnName = encodeColumnName(startTimestamp);
+        return Cell.create(rowName, columnName);
+    }
+
+    @Override
+    public long decodeCellAsStartTimestamp(Cell cell) {
+        long rowComponent = decodeRowName(cell.getRowName());
+        long columnComponent = decodeColumnName(cell.getColumnName());
+
+        return (rowComponent / rowsPerQuantum) * partitioningQuantum
+                + columnComponent * rowsPerQuantum
+                + rowComponent % rowsPerQuantum;
+    }
+
+    private byte[] encodeRowName(long startTimestamp) {
+        return rowToBytes(startTimestampToRow(startTimestamp));
+    }
+
+    private long startTimestampToRow(long startTimestamp) {
+        return (startTimestamp / partitioningQuantum) * rowsPerQuantum
+                + (startTimestamp % partitioningQuantum) % rowsPerQuantum;
+    }
+
+    private static byte[] rowToBytes(long row) {
+        return PtBytes.toBytes(Long.reverse(row));
+    }
+
+    private byte[] encodeColumnName(long startTimestamp) {
+        long column = (startTimestamp % partitioningQuantum) / rowsPerQuantum;
+        return ValueType.VAR_LONG.convertFromJava(column);
+    }
+
+    private static long decodeRowName(byte[] rowName) {
+        return Long.reverse(PtBytes.toLong(rowName));
+    }
+
+    private static long decodeColumnName(byte[] columnName) {
+        return (long) ValueType.VAR_LONG.convertToJava(columnName, 0);
+    }
+
+    public Stream<byte[]> getRowSetCoveringTimestampRange(long fromInclusive, long toInclusive) {
+        long startRow =
+                startTimestampToRow(fromInclusive - ((fromInclusive % partitioningQuantum) % rowsPerQuantum));
+        long endRow = startTimestampToRow(
+                toInclusive + rowsPerQuantum - ((toInclusive % partitioningQuantum) % rowsPerQuantum) - 1);
+        return LongStream.rangeClosed(startRow, endRow).mapToObj(TicketsCellEncodingStrategy::rowToBytes);
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/encoding/TicketsEncodingStrategy.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/encoding/TicketsEncodingStrategy.java
@@ -25,15 +25,8 @@ import java.util.stream.Stream;
 /**
  * The ticketing algorithm distributes timestamps among rows and dynamic columns to avoid hot-spotting.
  *
- * We divide the first PARTITIONING_QUANTUM timestamps among the first ROW_PER_QUANTUM rows.
- * We aim to distribute start timestamps as evenly as possible among these rows as numbers increase, by taking the
- * least significant bits of the timestamp and using that as the row number. For example, we would store timestamps
- * 1, ROW_PER_QUANTUM + 1, 2 * ROW_PER_QUANTUM + 1 etc. in the same row.
- *
- * We store the row name as a bit-wise reversed version of the row number to ensure even distribution in key-value
- * services that rely on consistent hashing or similar mechanisms for partitioning.
- *
- * We also use a delta encoding for the commit timestamp as these differences are expected to be small.
+ * For the row and column partitioning, please consult {@link TicketsCellEncodingStrategy} for more details.
+ * We use a delta encoding for the commit timestamp as these differences are expected to be small.
  *
  * A long is 9 bytes at most, so one row here consists of at most 4 longs -> 36 bytes, and an individual row
  * is probabilistically below 1M dynamic column keys. A row is expected to be less than 14M (56M worst case).

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/encoding/TicketsCellEncodingStrategyTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/encoding/TicketsCellEncodingStrategyTest.java
@@ -1,0 +1,125 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.encoding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+import org.junit.Test;
+
+public class TicketsCellEncodingStrategyTest {
+    private final long SMALL_QUANTUM = 100L;
+    private final long SMALL_NUMBER_OF_ROWS = 5L;
+    private final TicketsCellEncodingStrategy SMALL_QUANTUM_STRATEGY =
+            new TicketsCellEncodingStrategy(SMALL_QUANTUM, SMALL_NUMBER_OF_ROWS);
+
+    private final long LARGE_QUANTUM = 1_000_000_000L;
+    private final long LARGE_NUMBER_OF_ROWS = 1_000L;
+    private final TicketsCellEncodingStrategy LARGE_QUANTUM_STRATEGY =
+            new TicketsCellEncodingStrategy(LARGE_QUANTUM, LARGE_NUMBER_OF_ROWS);
+
+    private final Set<TicketsCellEncodingStrategy> STRATEGIES =
+            ImmutableSet.of(SMALL_QUANTUM_STRATEGY, LARGE_QUANTUM_STRATEGY);
+
+    @Test
+    public void partitioningParametersMustBePositive() {
+        assertThatThrownBy(() -> new TicketsCellEncodingStrategy(0L, 0L))
+                .isInstanceOf(SafeIllegalArgumentException.class)
+                .hasMessageContaining("Number of rows per quantum must be positive");
+        assertThatThrownBy(() -> new TicketsCellEncodingStrategy(10L, 0L))
+                .isInstanceOf(SafeIllegalArgumentException.class)
+                .hasMessageContaining("Number of rows per quantum must be positive");
+        assertThatThrownBy(() -> new TicketsCellEncodingStrategy(10L, -5L))
+                .isInstanceOf(SafeIllegalArgumentException.class)
+                .hasMessageContaining("Number of rows per quantum must be positive");
+        assertThatThrownBy(() -> new TicketsCellEncodingStrategy(0L, 10L))
+                .isInstanceOf(SafeIllegalArgumentException.class)
+                .hasMessageContaining("Must have at least one cell per row after partitioning");
+    }
+
+    @Test
+    public void mustHaveAtLeastAsManyRowsPerPartitioningQuantum() {
+        assertThatCode(() -> new TicketsCellEncodingStrategy(50L, 50L)).doesNotThrowAnyException();
+        assertThatThrownBy(() -> new TicketsCellEncodingStrategy(50L, 51L))
+                .isInstanceOf(SafeIllegalArgumentException.class)
+                .hasMessageContaining("Must have at least one cell per row after partitioning");
+    }
+
+    @Test
+    public void encodingAndDecodingTimestampsIsIdempotent() {
+        STRATEGIES.forEach(strategy -> {
+            ImmutableList<Long> testCases = ImmutableList.of(
+                    1L,
+                    strategy.getPartitioningQuantum() / 2,
+                    strategy.getPartitioningQuantum() - 1,
+                    strategy.getPartitioningQuantum(),
+                    strategy.getPartitioningQuantum() + 1,
+                    3 * strategy.getPartitioningQuantum() - 1,
+                    4 * strategy.getPartitioningQuantum(),
+                    5 * strategy.getPartitioningQuantum() + 1);
+            testCases.forEach(testCase -> assertThat(
+                            strategy.decodeCellAsStartTimestamp(strategy.encodeStartTimestampAsCell(testCase)))
+                    .isEqualTo(testCase));
+        });
+    }
+
+    @Test
+    public void valuesSpacedNumRowsApartAreInTheSamePartition() {
+        long timestamp = 3;
+        STRATEGIES.forEach(strategy -> {
+            Cell baseCell = strategy.encodeStartTimestampAsCell(timestamp);
+            Cell numRowsAddedCell = strategy.encodeStartTimestampAsCell(timestamp + strategy.getRowsPerQuantum());
+            Cell threeTimesNumRowsAddedCell =
+                    strategy.encodeStartTimestampAsCell(timestamp + 3 * strategy.getRowsPerQuantum());
+            assertThat(baseCell.getRowName()).isEqualTo(numRowsAddedCell.getRowName());
+            assertThat(baseCell.getColumnName()).isNotEqualTo(numRowsAddedCell.getColumnName());
+
+            assertThat(baseCell.getRowName()).isEqualTo(threeTimesNumRowsAddedCell.getRowName());
+            assertThat(baseCell.getColumnName()).isNotEqualTo(threeTimesNumRowsAddedCell.getColumnName());
+        });
+    }
+
+    @Test
+    public void getRowNamesRangeDrawsFromCorrectPartitions() {
+        long lowerBound = 3 * LARGE_QUANTUM_STRATEGY.getPartitioningQuantum() - 3;
+        long upperBound = 17 * LARGE_QUANTUM_STRATEGY.getPartitioningQuantum() + 1;
+
+        List<Long> rowsReturned = LARGE_QUANTUM_STRATEGY
+                .getRowSetCoveringTimestampRange(lowerBound, upperBound)
+                .map(PtBytes::toLong)
+                .map(Long::reverse)
+                .collect(Collectors.toList());
+        // We could potentially be smarter here (e.g. technically only the first two rows in the 18th block of the
+        // large quantum strategy are required), but we don't currently do that.
+        assertThat(rowsReturned)
+                .hasSameElementsAs(LongStream.range(
+                                2 * LARGE_QUANTUM_STRATEGY.getRowsPerQuantum(),
+                                18 * LARGE_QUANTUM_STRATEGY.getRowsPerQuantum())
+                        .boxed()
+                        .collect(Collectors.toList()));
+    }
+}


### PR DESCRIPTION
## General
**Before this PR**:
The way cells are striped into `PARTITIONING_QUANTUM` many buckets is an internal detail of `TicketsEncodingStrategy` and is not reusable outside that class.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
We now expose a `TicketsCellEncodingStrategy`, which is needed for *A*, the aborted timestamps store, in transactions table sweep.
==COMMIT_MSG==

**Priority**: P1

**Concerns / possible downsides (what feedback would you like?)**:
- The way the comment was split across the classes felt a bit iffy. Does the explanation still make sense?

**Is documentation needed?**: No.

## Compatibility
~**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:~

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: It SHOULDN'T, but please check that I haven't done anything silly.

~**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:~

~**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:~

~**Does this PR need a schema migration?**~

## Testing and Correctness
~**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:~

**What was existing testing like? What have you done to improve it?**:
There are existing tests for the encoding strategy for Transactions 2 that still run.

~**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:~

~**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:~

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: No regression in TransactionService metrics would be sufficient.

~**Has the safety of all log arguments been decided correctly?**:~

~**Will this change significantly affect our spending on metrics or logs?**:~

~**How would I tell that this PR does not work in production? (monitors, etc.)**:~

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: Rollback

~**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:~

## Scale
~**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:~

~**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:~

~**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:~

## Development Process
**Where should we start reviewing?**: TicketsEncodingStrategy the original, probably

~**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:~

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju
