### PR TITLE
[TTS] Force enable sweep queue writes

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -178,7 +178,6 @@ public final class AtlasDbConstants {
     public static final int DEFAULT_SWEEP_WRITE_THRESHOLD = 1 << 12;
     public static final long DEFAULT_SWEEP_WRITE_SIZE_THRESHOLD = 1 << 25;
 
-    public static final boolean DEFAULT_ENABLE_SWEEP_QUEUE_WRITES = true;
     public static final boolean DEFAULT_ENABLE_TARGETED_SWEEP = true;
     public static final int LEGACY_DEFAULT_TARGETED_SWEEP_SHARDS = 1;
     public static final int DEFAULT_TARGETED_SWEEP_SHARDS = 16;

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfig.java
@@ -44,8 +44,7 @@ public abstract class AtlasDbRuntimeConfig {
     }
 
     /**
-     * Live reloadable configurations for targeted sweep. If the enableSweepQueueWrites parameter of
-     * {@link AtlasDbConfig#targetedSweep()} is not set to true, this configuration will be ignored.
+     * Live reloadable configurations for targeted sweep.
      */
     @Value.Default
     public TargetedSweepRuntimeConfig targetedSweep() {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/ShouldRunBackgroundSweepSupplier.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/ShouldRunBackgroundSweepSupplier.java
@@ -25,7 +25,7 @@ import java.util.function.Supplier;
  *
  * <ul>
  *     <li>if the background sweeper has been explicitly enabled or disabled, use that setting;</li>
- *     <li>otherwise if Targeted Sweep is writing to the sweep queue, disable background sweep</li>
+ *     <li>otherwise disable background sweep</li>
  * </ul>
  */
 public class ShouldRunBackgroundSweepSupplier implements BooleanSupplier {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/ShouldRunBackgroundSweepSupplier.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/ShouldRunBackgroundSweepSupplier.java
@@ -30,15 +30,13 @@ import java.util.function.Supplier;
  */
 public class ShouldRunBackgroundSweepSupplier implements BooleanSupplier {
     private final Supplier<SweepConfig> runtimeConfigSupplier;
-    private final boolean sweepQueueWritesEnabled;
 
-    public ShouldRunBackgroundSweepSupplier(Supplier<SweepConfig> runtimeConfig, boolean sweepQueueWritesEnabled) {
+    public ShouldRunBackgroundSweepSupplier(Supplier<SweepConfig> runtimeConfig) {
         this.runtimeConfigSupplier = runtimeConfig;
-        this.sweepQueueWritesEnabled = sweepQueueWritesEnabled;
     }
 
     @Override
     public boolean getAsBoolean() {
-        return runtimeConfigSupplier.get().enabled().orElse(!sweepQueueWritesEnabled);
+        return runtimeConfigSupplier.get().enabled().orElse(false);
     }
 }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -403,7 +403,7 @@ public abstract class TransactionManagers {
                     // to
                     // at least retain the option to perform background sweep, which requires updating the priority
                     // table.
-                    if (!targetedSweepIsFullyEnabled(config(), runtime)) {
+                    if (!targetedSweepIsEnabled(runtime)) {
                         kvs = SweepStatsKeyValueService.create(
                                 kvs,
                                 new TimelockTimestampServiceAdapter(lockAndTimestampServices.timelock()),
@@ -659,10 +659,8 @@ public abstract class TransactionManagers {
                         || transactionConfig.lockImmutableTsOnReadOnlyTransactions());
     }
 
-    private static boolean targetedSweepIsFullyEnabled(
-            AtlasDbConfig installConfig, Supplier<AtlasDbRuntimeConfig> runtime) {
-        return installConfig.targetedSweep().enableSweepQueueWrites()
-                && runtime.get().targetedSweep().enabled();
+    private static boolean targetedSweepIsEnabled(Supplier<AtlasDbRuntimeConfig> runtime) {
+        return runtime.get().targetedSweep().enabled();
     }
 
     private TransactionComponents createTransactionComponents(
@@ -826,12 +824,11 @@ public abstract class TransactionManagers {
                 config.initializeAsync(),
                 sweepBatchConfigSource);
 
-        boolean sweepQueueWritesEnabled = config.targetedSweep().enableSweepQueueWrites();
         BackgroundSweeperImpl backgroundSweeper = BackgroundSweeperImpl.create(
                 metricsManager,
                 sweepBatchConfigSource,
                 new ShouldRunBackgroundSweepSupplier(
-                        () -> runtimeConfigSupplier.get().sweep(), sweepQueueWritesEnabled)::getAsBoolean,
+                        () -> runtimeConfigSupplier.get().sweep())::getAsBoolean,
                 () -> runtimeConfigSupplier.get().sweep().sweepThreads(),
                 () -> runtimeConfigSupplier.get().sweep().pauseMillis(),
                 () -> runtimeConfigSupplier.get().sweep().sweepPriorityOverrides(),
@@ -956,9 +953,6 @@ public abstract class TransactionManagers {
             TargetedSweepInstallConfig install,
             Follower follower,
             Supplier<TargetedSweepRuntimeConfig> runtime) {
-        if (!install.enableSweepQueueWrites()) {
-            return MultiTableSweepQueueWriter.NO_OP;
-        }
         return TargetedSweeper.createUninitialized(metricsManager, runtime, install, ImmutableList.of(follower));
     }
 

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/ShouldRunBackgroundSweepSupplierTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/ShouldRunBackgroundSweepSupplierTest.java
@@ -20,22 +20,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.palantir.atlasdb.sweep.queue.config.ImmutableTargetedSweepInstallConfig;
 import com.palantir.atlasdb.sweep.queue.config.ImmutableTargetedSweepRuntimeConfig;
-import com.palantir.atlasdb.sweep.queue.config.TargetedSweepInstallConfig;
 import com.palantir.atlasdb.sweep.queue.config.TargetedSweepRuntimeConfig;
 import java.util.function.Supplier;
 import org.junit.Test;
 
 public class ShouldRunBackgroundSweepSupplierTest {
-    private static final TargetedSweepInstallConfig SWEEP_QUEUE_WRITES_ENABLED =
-            ImmutableTargetedSweepInstallConfig.builder()
-                    .enableSweepQueueWrites(true)
-                    .build();
-    private static final TargetedSweepInstallConfig SWEEP_QUEUE_WRITES_DISABLED =
-            ImmutableTargetedSweepInstallConfig.builder()
-                    .enableSweepQueueWrites(false)
-                    .build();
 
     private static final TargetedSweepRuntimeConfig TARGETED_SWEEP_ENABLED =
             ImmutableTargetedSweepRuntimeConfig.builder().enabled(true).build();
@@ -49,35 +39,25 @@ public class ShouldRunBackgroundSweepSupplierTest {
 
     @Test
     public void disableBackgroundSweepIfBackgroundSweepExplicitlyDisabled() {
-        assertThat(runBackgroundSweep(SWEEP_QUEUE_WRITES_DISABLED, TARGETED_SWEEP_DISABLED, BACKGROUND_SWEEP_DISABLED))
+        assertThat(runBackgroundSweep(TARGETED_SWEEP_DISABLED, BACKGROUND_SWEEP_DISABLED))
                 .isFalse();
-        assertThat(runBackgroundSweep(SWEEP_QUEUE_WRITES_ENABLED, TARGETED_SWEEP_ENABLED, BACKGROUND_SWEEP_DISABLED))
+        assertThat(runBackgroundSweep(TARGETED_SWEEP_ENABLED, BACKGROUND_SWEEP_DISABLED))
                 .isFalse();
     }
 
     @Test
     public void enableBackgroundSweepIfBackgroundSweepExplicitlyEnabled() {
-        assertThat(runBackgroundSweep(SWEEP_QUEUE_WRITES_DISABLED, TARGETED_SWEEP_DISABLED, BACKGROUND_SWEEP_ENABLED))
+        assertThat(runBackgroundSweep(TARGETED_SWEEP_DISABLED, BACKGROUND_SWEEP_ENABLED))
                 .isTrue();
-        assertThat(runBackgroundSweep(SWEEP_QUEUE_WRITES_ENABLED, TARGETED_SWEEP_ENABLED, BACKGROUND_SWEEP_ENABLED))
+        assertThat(runBackgroundSweep(TARGETED_SWEEP_ENABLED, BACKGROUND_SWEEP_ENABLED))
                 .isTrue();
     }
 
     @Test
-    public void disableBackgroundSweepIfNotSetAndTargetedSweepQueueWritesEnabled() {
-        assertThat(runBackgroundSweep(SWEEP_QUEUE_WRITES_ENABLED, TARGETED_SWEEP_DISABLED, BACKGROUND_SWEEP_UNSET))
+    public void disableBackgroundSweepIfNotSet() {
+        assertThat(runBackgroundSweep(TARGETED_SWEEP_DISABLED, BACKGROUND_SWEEP_UNSET))
                 .isFalse();
-    }
-
-    @Test
-    public void enableBackgroundSweepIfNotSetAndTargetedSweepQueueWritesDisabled() {
-        assertThat(runBackgroundSweep(SWEEP_QUEUE_WRITES_DISABLED, TARGETED_SWEEP_ENABLED, BACKGROUND_SWEEP_UNSET))
-                .isTrue();
-    }
-
-    @Test
-    public void disableBackgroundSweepIfNotSetAndTargetedSweepFullyEnabled() {
-        assertThat(runBackgroundSweep(SWEEP_QUEUE_WRITES_ENABLED, TARGETED_SWEEP_ENABLED, BACKGROUND_SWEEP_UNSET))
+        assertThat(runBackgroundSweep(TARGETED_SWEEP_ENABLED, BACKGROUND_SWEEP_UNSET))
                 .isFalse();
     }
 
@@ -104,8 +84,7 @@ public class ShouldRunBackgroundSweepSupplierTest {
                 .isTrue();
     }
 
-    private static boolean runBackgroundSweep(
-            TargetedSweepInstallConfig tsInstall, TargetedSweepRuntimeConfig tsRuntime, SweepConfig bgSweepConfig) {
+    private static boolean runBackgroundSweep(TargetedSweepRuntimeConfig tsRuntime, SweepConfig bgSweepConfig) {
         return new ShouldRunBackgroundSweepSupplier(
                         () -> createRuntimeConfig(tsRuntime, bgSweepConfig).sweep())
                 .getAsBoolean();

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/ShouldRunBackgroundSweepSupplierTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/ShouldRunBackgroundSweepSupplierTest.java
@@ -91,7 +91,7 @@ public class ShouldRunBackgroundSweepSupplierTest {
                 .thenReturn(createRuntimeConfig(TARGETED_SWEEP_ENABLED, BACKGROUND_SWEEP_ENABLED));
 
         ShouldRunBackgroundSweepSupplier supplier = new ShouldRunBackgroundSweepSupplier(
-                () -> runtimeConfigSupplier.get().sweep(), SWEEP_QUEUE_WRITES_ENABLED.enableSweepQueueWrites());
+                () -> runtimeConfigSupplier.get().sweep());
 
         assertThat(supplier.getAsBoolean())
                 .as("TARGETED_SWEEP_ENABLED, BACKGROUND_SWEEP_UNSET")
@@ -107,7 +107,7 @@ public class ShouldRunBackgroundSweepSupplierTest {
     private static boolean runBackgroundSweep(
             TargetedSweepInstallConfig tsInstall, TargetedSweepRuntimeConfig tsRuntime, SweepConfig bgSweepConfig) {
         return new ShouldRunBackgroundSweepSupplier(
-                        () -> createRuntimeConfig(tsRuntime, bgSweepConfig).sweep(), tsInstall.enableSweepQueueWrites())
+                        () -> createRuntimeConfig(tsRuntime, bgSweepConfig).sweep())
                 .getAsBoolean();
     }
 

--- a/atlasdb-ete-tests/docker/conf/atlasdb-ete.multiple-cassandra-async.yml
+++ b/atlasdb-ete-tests/docker/conf/atlasdb-ete.multiple-cassandra-async.yml
@@ -11,7 +11,7 @@ server:
 
 atlasdb:
   targetedSweep:
-    enableSweepQueueWrites: false
+    enableSweepQueueWrites: true
   keyValueService:
     type: cassandra
     ssl: false

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/config/TargetedSweepInstallConfig.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/config/TargetedSweepInstallConfig.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.sweep.queue.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Preconditions;
@@ -28,17 +29,16 @@ import org.immutables.value.Value;
 @Value.Immutable
 public class TargetedSweepInstallConfig {
     /**
-     * If true, information for targeted sweep will be persisted to the sweep queue. This is necessary to be able to
-     * run targeted sweep.
-     *
-     * Once you decide to use targeted sweep, DO NOT set this to false without consulting with the AtlasDB team. Doing
-     * so will cause targeted sweep to not be aware of any writes occurring while this is false, and you will have to
-     * use legacy sweep to sweep those writes. If you wish to pause targeted sweep, that can be done by setting the live
-     * reloadable {@link TargetedSweepRuntimeConfig#enabled()} parameter to false.
+     * @deprecated Disabling sweep queue writes is not supported anymore in order to maintain correctness while running
+     * transactions4.
+     * If you wish to pause targeted sweep, that can be done by setting the live reloadable
+     * {@link TargetedSweepRuntimeConfig#enabled()} parameter to true.
      */
+    @Deprecated
+    @JsonIgnore
     @Value.Default
     public boolean enableSweepQueueWrites() {
-        return AtlasDbConstants.DEFAULT_ENABLE_SWEEP_QUEUE_WRITES;
+        return true;
     }
 
     /**

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/config/TargetedSweepInstallConfig.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/config/TargetedSweepInstallConfig.java
@@ -15,7 +15,8 @@
  */
 package com.palantir.atlasdb.sweep.queue.config;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Preconditions;
@@ -27,6 +28,7 @@ import org.immutables.value.Value;
 @JsonDeserialize(as = ImmutableTargetedSweepInstallConfig.class)
 @JsonSerialize(as = ImmutableTargetedSweepInstallConfig.class)
 @Value.Immutable
+@JsonIgnoreProperties("enableSweepQueueWrites")
 public class TargetedSweepInstallConfig {
     /**
      * @deprecated Disabling sweep queue writes is not supported anymore in order to maintain correctness while running
@@ -36,7 +38,7 @@ public class TargetedSweepInstallConfig {
      */
     @Deprecated
     @Value.Default
-    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @JsonIgnore
     public boolean enableSweepQueueWrites() {
         return true;
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/config/TargetedSweepInstallConfig.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/config/TargetedSweepInstallConfig.java
@@ -15,7 +15,7 @@
  */
 package com.palantir.atlasdb.sweep.queue.config;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Preconditions;
@@ -35,8 +35,8 @@ public class TargetedSweepInstallConfig {
      * {@link TargetedSweepRuntimeConfig#enabled()} parameter to true.
      */
     @Deprecated
-    @JsonIgnore
     @Value.Default
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     public boolean enableSweepQueueWrites() {
         return true;
     }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
@@ -674,36 +674,21 @@ public class TransactionManagersTest {
     }
 
     @Test
-    public void kvsRecordsSweepStatsIfBothSweepQueueWritesAndTargetedSweepDisabled() {
-        KeyValueService keyValueService = initializeKeyValueServiceWithSweepSettings(false, false);
+    public void kvsRecordsSweepStatsIfTargetedSweepDisabled() {
+        KeyValueService keyValueService = initializeKeyValueServiceWithSweepSettings(false);
         assertThat(isSweepStatsKvsPresentInDelegatingChain(keyValueService)).isTrue();
     }
 
     @Test
-    public void kvsRecordsSweepStatsIfSweepQueueWritesDisabledButTargetedSweepEnabled() {
-        KeyValueService keyValueService = initializeKeyValueServiceWithSweepSettings(false, true);
-        assertThat(isSweepStatsKvsPresentInDelegatingChain(keyValueService)).isTrue();
-    }
-
-    @Test
-    public void kvsRecordsSweepStatsIfSweepQueueWritesEnabledButTargetedSweepDisabled() {
-        KeyValueService keyValueService = initializeKeyValueServiceWithSweepSettings(true, false);
-        assertThat(isSweepStatsKvsPresentInDelegatingChain(keyValueService)).isTrue();
-    }
-
-    @Test
-    public void kvsDoesNotRecordSweepStatsIfSweepQueueWritesAndTargetedSweepEnabled() {
-        KeyValueService keyValueService = initializeKeyValueServiceWithSweepSettings(true, true);
+    public void kvsDoesNotRecordSweepStatsIfTargetedSweepEnabled() {
+        KeyValueService keyValueService = initializeKeyValueServiceWithSweepSettings(true);
         assertThat(isSweepStatsKvsPresentInDelegatingChain(keyValueService)).isFalse();
     }
 
-    private KeyValueService initializeKeyValueServiceWithSweepSettings(
-            boolean enableSweepQueueWrites, boolean enableTargetedSweep) {
+    private KeyValueService initializeKeyValueServiceWithSweepSettings(boolean enableTargetedSweep) {
         AtlasDbConfig installConfig = ImmutableAtlasDbConfig.builder()
                 .keyValueService(new InMemoryAtlasDbConfig())
-                .targetedSweep(ImmutableTargetedSweepInstallConfig.builder()
-                        .enableSweepQueueWrites(enableSweepQueueWrites)
-                        .build())
+                .targetedSweep(ImmutableTargetedSweepInstallConfig.builder().build())
                 .build();
         AtlasDbRuntimeConfig atlasDbRuntimeConfig = ImmutableAtlasDbRuntimeConfig.builder()
                 .targetedSweep(ImmutableTargetedSweepRuntimeConfig.builder()

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
@@ -375,12 +375,10 @@ public class TransactionManagersTest {
     }
 
     @Test
-    public void canDropTablesWhenSweepQueueWritesAreDisabled() {
+    public void canDropTables() {
         AtlasDbConfig inMemoryNoQueueWrites = ImmutableAtlasDbConfig.builder()
                 .keyValueService(new InMemoryAtlasDbConfig())
-                .targetedSweep(ImmutableTargetedSweepInstallConfig.builder()
-                        .enableSweepQueueWrites(false)
-                        .build())
+                .targetedSweep(ImmutableTargetedSweepInstallConfig.builder().build())
                 .build();
         KeyValueService kvs = TransactionManagers.builder()
                 .config(inMemoryNoQueueWrites)

--- a/changelog/@unreleased/pr-6127.v2.yml
+++ b/changelog/@unreleased/pr-6127.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '[TTS] Force enable sweep queue writes.'
+  links:
+  - https://github.com/palantir/atlasdb/pull/6127

--- a/changelog/@unreleased/pr-6127.v2.yml
+++ b/changelog/@unreleased/pr-6127.v2.yml
@@ -1,5 +1,7 @@
 type: improvement
 improvement:
-  description: '[TTS] Force enable sweep queue writes.'
+  description: "[TTS] Force enables sweep queue writes.\nThe change is not expected
+    to impact background sweep BUT it could lead to build up of additional data in
+    the sweep shards if targeted sweep remains disabled for a long time. "
   links:
   - https://github.com/palantir/atlasdb/pull/6127


### PR DESCRIPTION
## General
**Before this PR**:
It was allowed to disable sweep queue writes.

**After this PR**:
1. Sweep writes cannot be disabled

**Priority**:
Before next week is good

**Concerns / possible downsides (what feedback would you like?)**:
- Sweep queue writes can lead to build up of sweep queue which is basically redundant data if sweep is disabled
- Cannot turn off sweep queue writes

**Is documentation needed?**:
I have modified the docs

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
All internal products have moved to using TS (Note that it is possible to have manual overrides)

**Does this PR need a schema migration?**
No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
TS is turned on everywhere with very few exceptions, if any.

**What was existing testing like? What have you done to improve it?**:
Audited and modified the existing tests

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
No

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
N/A

**Has the safety of all log arguments been decided correctly?**:
N/A

**Will this change significantly affect our spending on metrics or logs?**:
N/A

**How would I tell that this PR does not work in production? (monitors, etc.)**:
Use sweep metrics board

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Roll off AtlasDb version

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
TS is already and has been enabled for this product for a few years now

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
Additional writes to sweep queue if this was explicitly disabled before.

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
None that I can think of

## Development Process
**Where should we start reviewing?**:
TSweepRuntimeConfig

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
N/A

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
