### PR TITLE
RowColumnRangeExtractor uses smaller presized IdentityHashMaps

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/RowColumnRangeExtractor.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/RowColumnRangeExtractor.java
@@ -107,12 +107,12 @@ final class RowColumnRangeExtractor {
                 long ts = pair.rhSide;
                 if (ts < startTs) {
                     Cell cell = Cell.create(row, pair.lhSide);
-                    LinkedHashMap<Cell, Value> cellToValue = collector.get(row);
-                    if (cellToValue == null) {
-                        cellToValue = collector.computeIfAbsent(row, _b -> new LinkedHashMap<>(1));
-                    }
-                    if (cellToValue.putIfAbsent(cell, Value.create(c.getColumn().getValue(), ts)) != null) {
+                    LinkedHashMap<Cell, Value> cellToValue =
+                            collector.computeIfAbsent(row, _b -> new LinkedHashMap<>(1));
+                    if (cellToValue.containsKey(cell)) {
                         notLatestVisibleValueCellFilterCounter.get().inc();
+                    } else {
+                        cellToValue.put(cell, Value.create(c.getColumn().getValue(), ts));
                     }
                 } else {
                     notLatestVisibleValueCellFilterCounter.get().inc();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/RowColumnRangeExtractor.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/RowColumnRangeExtractor.java
@@ -16,31 +16,36 @@
 package com.palantir.atlasdb.keyvalue.cassandra;
 
 import com.codahale.metrics.Counter;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.Maps;
-import com.palantir.atlasdb.AtlasDbMetricNames;
+import com.palantir.atlasdb.AtlasDbMetricNames.CellFilterMetrics;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.util.Pair;
 import java.nio.ByteBuffer;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;
 
 @SuppressWarnings("IllegalType") // explicitly need LinkedHashMap for insertion ordering contract
-class RowColumnRangeExtractor {
-    static class RowColumnRangeResult {
+final class RowColumnRangeExtractor {
+    private RowColumnRangeExtractor() {}
+
+    static final class RowColumnRangeResult {
         private final Map<byte[], LinkedHashMap<Cell, Value>> results;
         private final Map<byte[], Column> rowsToLastCompositeColumns;
         private final Set<byte[]> emptyRows;
         private final Map<byte[], Integer> rowsToRawColumnCount;
 
-        RowColumnRangeResult(
+        private RowColumnRangeResult(
                 Map<byte[], LinkedHashMap<Cell, Value>> results,
                 Map<byte[], Column> rowsToLastCompositeColumns,
                 Set<byte[]> emptyRows,
@@ -68,19 +73,21 @@ class RowColumnRangeExtractor {
         }
     }
 
-    private final IdentityHashMap<byte[], LinkedHashMap<Cell, Value>> collector = new IdentityHashMap<>();
-    private final IdentityHashMap<byte[], Column> rowsToLastCompositeColumns = new IdentityHashMap<>();
-    private final IdentityHashMap<byte[], Integer> rowsToRawColumnCount = new IdentityHashMap<>();
-    private final Set<byte[]> emptyRows = Collections.newSetFromMap(new IdentityHashMap<>());
-    private final Counter notLatestVisibleValueCellFilterCounter;
+    static RowColumnRangeResult extract(
+            Collection<byte[]> canonicalRows,
+            Map<ByteBuffer, List<ColumnOrSuperColumn>> colsByKey,
+            long startTs,
+            MetricsManager metricsManager) {
+        IdentityHashMap<byte[], LinkedHashMap<Cell, Value>> collector = new IdentityHashMap<>(canonicalRows.size());
+        IdentityHashMap<byte[], Column> rowsToLastCompositeColumns = new IdentityHashMap<>(canonicalRows.size());
+        IdentityHashMap<byte[], Integer> rowsToRawColumnCount = new IdentityHashMap<>(canonicalRows.size());
+        Set<byte[]> emptyRows = Collections.newSetFromMap(new IdentityHashMap<>(0));
 
-    RowColumnRangeExtractor(MetricsManager metricsManager) {
-        notLatestVisibleValueCellFilterCounter = metricsManager.registerOrGetCounter(
-                RowColumnRangeExtractor.class, AtlasDbMetricNames.CellFilterMetrics.NOT_LATEST_VISIBLE_VALUE);
-    }
+        // lazily create counter to avoid overhead when not needed
+        Supplier<Counter> notLatestVisibleValueCellFilterCounter =
+                Suppliers.memoize(() -> metricsManager.registerOrGetCounter(
+                        RowColumnRangeExtractor.class, CellFilterMetrics.NOT_LATEST_VISIBLE_VALUE));
 
-    public void extractResults(
-            Iterable<byte[]> canonicalRows, Map<ByteBuffer, List<ColumnOrSuperColumn>> colsByKey, long startTs) {
         // Make sure returned maps are keyed by the given rows
         Map<ByteBuffer, byte[]> canonicalRowsByHash = Maps.uniqueIndex(canonicalRows, ByteBuffer::wrap);
         for (Map.Entry<ByteBuffer, List<ColumnOrSuperColumn>> colEntry : colsByKey.entrySet()) {
@@ -88,37 +95,30 @@ class RowColumnRangeExtractor {
             byte[] row = canonicalRowsByHash.get(ByteBuffer.wrap(rawRow));
             List<ColumnOrSuperColumn> columns = colEntry.getValue();
 
-            if (!columns.isEmpty()) {
+            if (columns.isEmpty()) {
+                emptyRows.add(row);
+            } else {
                 rowsToLastCompositeColumns.put(
                         row, columns.get(columns.size() - 1).getColumn());
-            } else {
-                emptyRows.add(row);
             }
             rowsToRawColumnCount.put(row, columns.size());
             for (ColumnOrSuperColumn c : columns) {
                 Pair<byte[], Long> pair = CassandraKeyValueServices.decomposeName(c.getColumn());
-                internalExtractResult(startTs, row, pair.lhSide, c.getColumn().getValue(), pair.rhSide);
+                if (pair.rhSide < startTs) {
+                    Value previous = collector
+                            .computeIfAbsent(row, _bytes -> new LinkedHashMap<>()) // explicitly maintain returned order
+                            .put(
+                                    Cell.create(row, pair.lhSide),
+                                    Value.create(c.getColumn().getValue(), pair.rhSide));
+                    if (previous != null) {
+                        notLatestVisibleValueCellFilterCounter.get().inc();
+                    }
+                } else {
+                    notLatestVisibleValueCellFilterCounter.get().inc();
+                }
             }
         }
-    }
 
-    private void internalExtractResult(long startTs, byte[] row, byte[] col, byte[] val, long ts) {
-        if (ts < startTs) {
-            Cell cell = Cell.create(row, col);
-            if (!collector.containsKey(row)) {
-                collector.put(row, new LinkedHashMap<>());
-                collector.get(row).put(cell, Value.create(val, ts));
-            } else if (!collector.get(row).containsKey(cell)) {
-                collector.get(row).put(cell, Value.create(val, ts));
-            } else {
-                notLatestVisibleValueCellFilterCounter.inc();
-            }
-        } else {
-            notLatestVisibleValueCellFilterCounter.inc();
-        }
-    }
-
-    public RowColumnRangeResult getRowColumnRangeResult() {
         return new RowColumnRangeResult(collector, rowsToLastCompositeColumns, emptyRows, rowsToRawColumnCount);
     }
 }

--- a/changelog/@unreleased/pr-6136.v2.yml
+++ b/changelog/@unreleased/pr-6136.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: RowColumnRangeExtractor uses smaller presized IdentityHashMaps
+  links:
+  - https://github.com/palantir/atlasdb/pull/6136


### PR DESCRIPTION
## General
**Before this PR**:
Atlas Cassandra clients processing lots of `multiget_slice` requests allocate significant `Object[]` as part of constructing multiple `IdentityHashMap<byte[], V>` for each page of results.

![image](https://user-images.githubusercontent.com/54594/179149837-a2e359b3-bbcd-48cc-8cbb-b644407a27ce.png)


**After this PR**:
We presize the `IdentityHashMap`s to the expected number of rows we're getting, and simplify the `RowColumnRangeExtractor` extract API.
==COMMIT_MSG==
RowColumnRangeExtractor uses smaller presized IdentityHashMaps
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**: Does this seem like reasonable performance change and refactor?

**Is documentation needed?**: no

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: Changes the Java API for `RowColumnRangeExtractor` slightly, but it is all package private and I do not see any non-Atlas changes that would be impacted.

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: no

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: n/a

**Does this PR need a schema migration?** no

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**: these code paths are hit by existing Cassandra ETE tests and some unit tests.

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: n/a

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: n/a

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: 

**Has the safety of all log arguments been decided correctly?**: n/a

**Will this change significantly affect our spending on metrics or logs?**: n/a

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
