### PR TITLE
[WIP TTS] | Aborted Transactions Cache Hack

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -198,6 +198,7 @@ public final class AtlasDbConstants {
     public static final int POSTGRES_TABLE_NAME_CHAR_LIMIT = 63;
 
     public static final int TRANSACTION_TIMESTAMP_LOAD_BATCH_LIMIT = 50_000;
-
     public static final String SCHEMA_V2_TABLE_NAME = "V2Table";
+
+    public static final long ABORTED_TIMESTAMPS_BUCKET_SIZE = 1_000_000;
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/AbortedTimestampStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/AbortedTimestampStore.java
@@ -18,12 +18,12 @@ package com.palantir.atlasdb.transaction.knowledge;
 
 import java.util.Set;
 
-/**
- * Dummy interface while we are blocked.
- * */
-public interface KnownAbortedTransactions {
+public final class AbortedTimestampStore {
 
-    boolean isKnownAborted(long startTimestamp);
+    public Set<Long> getBucket(long bucket) {
+        // Todo(snanda)
+        return null;
+    }
 
-    void addAbortedTimestamps(Set<Long> abortedTimestamps);
+    public void addAbortedTimestamps(Set<Long> abortedTimestamps) {}
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/AbortedTimestampStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/AbortedTimestampStore.java
@@ -18,10 +18,12 @@ package com.palantir.atlasdb.transaction.knowledge;
 
 import java.util.Set;
 
+/**
+ * Dummy impl since we do not have `AbortedTimestampStore` yet.
+ * */
 public final class AbortedTimestampStore {
 
     public Set<Long> getBucket(long bucket) {
-        // Todo(snanda)
         return null;
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/AbortedTimestampStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/AbortedTimestampStore.java
@@ -28,4 +28,8 @@ public final class AbortedTimestampStore {
     }
 
     public void addAbortedTimestamps(Set<Long> abortedTimestamps) {}
+
+    public Set<Long> getAbortedTransactionsInRange(long startInclusive, long endInclusive) {
+        return null;
+    }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/DefaultKnownAbortedTransactions.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/DefaultKnownAbortedTransactions.java
@@ -1,0 +1,99 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.knowledge;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Expiry;
+import com.palantir.atlasdb.AtlasDbConstants;
+import java.time.Duration;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class DefaultKnownAbortedTransactions implements KnownAbortedTransactions {
+    private final KnownConcludedTransactionsStore concludedTransactionsStore;
+    private final AbortedTimestampStore abortedTimestampStore;
+    private final Cache<Long, Set<Long>> cache;
+
+    public DefaultKnownAbortedTransactions(
+            KnownConcludedTransactionsStore concludedTransactionsStore,
+            AbortedTimestampStore abortedTimestampStore) {
+        this.concludedTransactionsStore = concludedTransactionsStore;
+        this.abortedTimestampStore = abortedTimestampStore;
+        this.cache = Caffeine.newBuilder()
+            .maximumSize(100)
+            .expireAfter(new Expiry<Long, Set<Long>>() {
+                @Override
+                public long expireAfterCreate(Long key, Set<Long> value, long currentTime) {
+                    return Long.MAX_VALUE;
+                }
+
+                @Override
+                public long expireAfterUpdate(
+                        Long key, Set<Long> value, long currentTime, long currentDuration) {
+                    return Long.MAX_VALUE;
+                }
+
+                @Override
+                public long expireAfterRead(
+                        Long key, Set<Long> value, long currentTime, long currentDuration) {
+                    // todo(snanda): expiration should be weighted depending on the size of bucket
+                    return Duration.ofSeconds(value.size()).toNanos();
+                }
+            })
+            .build();
+    }
+
+    /**
+     * This method should only be called for concluded transactions.
+     * */
+    @Override
+    public boolean isKnownAborted(long startTimestamp) {
+        long bucketForTimestamp = getBucket(startTimestamp);
+        // todo(snanda): Only cache buckets that are older than the latest one. Though, this is another read on every
+        //  call.
+        long latestBucket = getBucket(concludedTransactionsStore.lastKnownConcludedTransaction());
+        Set<Long> abortedTimestampsInBucket = getAbortedTimestampsInBucket(bucketForTimestamp, latestBucket);
+        return abortedTimestampsInBucket.contains(startTimestamp);
+    }
+
+    @Override
+    public void addAbortedTimestamps(Set<Long> abortedTimestamps) {
+        invalidateBuckets(abortedTimestamps);
+        abortedTimestampStore.addAbortedTimestamps(abortedTimestamps);
+    }
+
+    private void invalidateBuckets(Set<Long> abortedTimestamps) {
+        Set<Long> invalidatedBuckets = abortedTimestamps.stream().map(this::getBucket).collect(Collectors.toSet());
+        cache.invalidateAll(invalidatedBuckets);
+    }
+
+    private Set<Long> getAbortedTimestampsInBucket(long bucket, long latestBucket) {
+        if (bucket < latestBucket) {
+            return cache.get(bucket, this::getAbortedTransactionsRemote);
+        }
+        return getAbortedTransactionsRemote(bucket);
+    }
+
+    private Set<Long> getAbortedTransactionsRemote(long bucket) {
+        return abortedTimestampStore.getBucket(bucket);
+    }
+
+    private long getBucket(long startTimestamp) {
+        return startTimestamp / AtlasDbConstants.ABORTED_TIMESTAMPS_BUCKET_SIZE;
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/DefaultKnownAbortedTransactions.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/DefaultKnownAbortedTransactions.java
@@ -18,11 +18,11 @@ package com.palantir.atlasdb.transaction.knowledge;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.Expiry;
+import com.github.benmanes.caffeine.cache.Weigher;
 import com.palantir.atlasdb.AtlasDbConstants;
-import java.time.Duration;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.checkerframework.checker.index.qual.NonNegative;
 
 public class DefaultKnownAbortedTransactions implements KnownAbortedTransactions {
     private final KnownConcludedTransactionsStore concludedTransactionsStore;
@@ -30,32 +30,13 @@ public class DefaultKnownAbortedTransactions implements KnownAbortedTransactions
     private final Cache<Long, Set<Long>> cache;
 
     public DefaultKnownAbortedTransactions(
-            KnownConcludedTransactionsStore concludedTransactionsStore,
-            AbortedTimestampStore abortedTimestampStore) {
+            KnownConcludedTransactionsStore concludedTransactionsStore, AbortedTimestampStore abortedTimestampStore) {
         this.concludedTransactionsStore = concludedTransactionsStore;
         this.abortedTimestampStore = abortedTimestampStore;
         this.cache = Caffeine.newBuilder()
-            .maximumSize(100)
-            .expireAfter(new Expiry<Long, Set<Long>>() {
-                @Override
-                public long expireAfterCreate(Long key, Set<Long> value, long currentTime) {
-                    return Long.MAX_VALUE;
-                }
-
-                @Override
-                public long expireAfterUpdate(
-                        Long key, Set<Long> value, long currentTime, long currentDuration) {
-                    return Long.MAX_VALUE;
-                }
-
-                @Override
-                public long expireAfterRead(
-                        Long key, Set<Long> value, long currentTime, long currentDuration) {
-                    // todo(snanda): expiration should be weighted depending on the size of bucket
-                    return Duration.ofSeconds(value.size()).toNanos();
-                }
-            })
-            .build();
+                .maximumWeight(100_000)
+                .weigher(EntryWeigher.INSTANCE)
+                .build();
     }
 
     /**
@@ -64,11 +45,18 @@ public class DefaultKnownAbortedTransactions implements KnownAbortedTransactions
     @Override
     public boolean isKnownAborted(long startTimestamp) {
         long bucketForTimestamp = getBucket(startTimestamp);
-        // todo(snanda): Only cache buckets that are older than the latest one. Though, this is another read on every
-        //  call.
+        Set<Long> cachedAbortedTimestamps = getCachedAbortedTimestampsInBucket(bucketForTimestamp);
+        if (cachedAbortedTimestamps.contains(startTimestamp)) {
+            return true;
+        }
+
+        // Try remote fetch if current aborted ts bucket is not immutable.
         long latestBucket = getBucket(concludedTransactionsStore.lastKnownConcludedTransaction());
-        Set<Long> abortedTimestampsInBucket = getAbortedTimestampsInBucket(bucketForTimestamp, latestBucket);
-        return abortedTimestampsInBucket.contains(startTimestamp);
+        if (bucketForTimestamp == latestBucket) {
+            return getAbortedTransactionsRemote(bucketForTimestamp).contains(startTimestamp);
+        }
+
+        return false;
     }
 
     @Override
@@ -78,22 +66,31 @@ public class DefaultKnownAbortedTransactions implements KnownAbortedTransactions
     }
 
     private void invalidateBuckets(Set<Long> abortedTimestamps) {
-        Set<Long> invalidatedBuckets = abortedTimestamps.stream().map(this::getBucket).collect(Collectors.toSet());
+        Set<Long> invalidatedBuckets =
+                abortedTimestamps.stream().map(this::getBucket).collect(Collectors.toSet());
         cache.invalidateAll(invalidatedBuckets);
     }
 
-    private Set<Long> getAbortedTimestampsInBucket(long bucket, long latestBucket) {
-        if (bucket < latestBucket) {
-            return cache.get(bucket, this::getAbortedTransactionsRemote);
-        }
-        return getAbortedTransactionsRemote(bucket);
+    private Set<Long> getCachedAbortedTimestampsInBucket(long bucket) {
+        return cache.get(bucket, this::getAbortedTransactionsRemote);
     }
 
     private Set<Long> getAbortedTransactionsRemote(long bucket) {
-        return abortedTimestampStore.getBucket(bucket);
+        Set<Long> abortedTs = abortedTimestampStore.getBucket(bucket);
+        cache.put(bucket, abortedTs);
+        return abortedTs;
     }
 
     private long getBucket(long startTimestamp) {
         return startTimestamp / AtlasDbConstants.ABORTED_TIMESTAMPS_BUCKET_SIZE;
+    }
+
+    enum EntryWeigher implements Weigher<Long, Set<Long>> {
+        INSTANCE;
+
+        @Override
+        public @NonNegative int weigh(Long key, Set<Long> value) {
+            return value.size();
+        }
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/DefaultKnownAbortedTransactions.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/DefaultKnownAbortedTransactions.java
@@ -22,11 +22,10 @@ import com.github.benmanes.caffeine.cache.Weigher;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.transaction.knowledge.KnownConcludedTransactions.Consistency;
-import org.checkerframework.checker.index.qual.NonNegative;
-import org.immutables.value.Value;
-
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import org.checkerframework.checker.index.qual.NonNegative;
+import org.immutables.value.Value;
 
 public class DefaultKnownAbortedTransactions implements KnownAbortedTransactions {
     private final KnownConcludedTransactions knownConcludedTransactions;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/DefaultKnownAbortedTransactions.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/DefaultKnownAbortedTransactions.java
@@ -75,9 +75,9 @@ public class DefaultKnownAbortedTransactions implements KnownAbortedTransactions
         long newLastKnownConcluded = knownConcludedTransactions.lastKnownConcludedTimestamp();
 
         // we check once again if this bucket can be reliably cached
-        if (bucketForStartTs < getBucket(newLastKnownConcluded)) {
-            return getCachedAbortedTimestampsInBucket(bucketForStartTs);
-        }
+//        if (bucketForStartTs < getBucket(newLastKnownConcluded)) {
+//            return getCachedAbortedTimestampsInBucket(bucketForStartTs);
+//        }
 
         Set<Long> abortedTransactions;
 
@@ -94,7 +94,7 @@ public class DefaultKnownAbortedTransactions implements KnownAbortedTransactions
             // equal bucket but startTs is greater
             // can to range get and append
             Set<Long> newAbortedTransactions = abortedTimestampStore.getAbortedTransactionsInRange(
-                    lastKnownConcludedCached, newLastKnownConcluded);
+                    lastKnownConcludedCached, startTimestamp + 1);
 
             abortedTransactions = ImmutableSet.<Long>builder()
                     .addAll(cache.abortedTransactions())
@@ -115,7 +115,8 @@ public class DefaultKnownAbortedTransactions implements KnownAbortedTransactions
             return;
         }
 
-        softCacheRef.compareAndSet(currentCache, newSoftCacheValue);
+        // can just pass in the lambda to update if bucket / lastConcluded is > prev value
+        softCacheRef.getAndUpdate(currentCache, newSoftCacheValue);
     }
 
     @Override
@@ -163,6 +164,9 @@ public class DefaultKnownAbortedTransactions implements KnownAbortedTransactions
         @Value.Parameter
         long lastKnownConcludedTimestamp();
 
+        // make this mutable
+        // also add lazy bucket value
+        // maybe also max txn in that bucket
         @Value.Parameter
         Set<Long> abortedTransactions();
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/DefaultKnownAbortedTransactions.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/DefaultKnownAbortedTransactions.java
@@ -40,9 +40,6 @@ public class DefaultKnownAbortedTransactions implements KnownAbortedTransactions
                 .build();
     }
 
-    /**
-     * This method should only be called for concluded transactions.
-     * */
     @Override
     public boolean isKnownAborted(long startTimestamp) {
         long bucketForTimestamp = getBucket(startTimestamp);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/DefaultKnownAbortedTransactions.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/DefaultKnownAbortedTransactions.java
@@ -44,7 +44,7 @@ public class DefaultKnownAbortedTransactions implements KnownAbortedTransactions
      * This method should only be called for concluded transactions.
      * */
     @Override
-    public boolean isKnownAborted(long startTimestamp, Consistency consistency) {
+    public boolean isKnownAborted(long startTimestamp) {
         long bucketForTimestamp = getBucket(startTimestamp);
         Set<Long> cachedAbortedTimestamps = getCachedAbortedTimestampsInBucket(bucketForTimestamp);
         if (cachedAbortedTimestamps.contains(startTimestamp)) {
@@ -52,17 +52,17 @@ public class DefaultKnownAbortedTransactions implements KnownAbortedTransactions
         }
 
         // Try remote fetch if current aborted ts bucket is not immutable.
-        if (isBucketMutable(bucketForTimestamp, consistency)) {
+        if (isBucketMutable(bucketForTimestamp)) {
             return getAbortedTransactionsRemote(bucketForTimestamp).contains(startTimestamp);
         }
 
         return false;
     }
 
-    private boolean isBucketMutable(long bucketForTimestamp, Consistency consistency) {
+    private boolean isBucketMutable(long bucketForTimestamp) {
         // using approximation here
         long maxTsInCurrentBucket = ((bucketForTimestamp + 1) * AtlasDbConstants.ABORTED_TIMESTAMPS_BUCKET_SIZE) - 1;
-        return !knownConcludedTransactions.isKnownConcluded(maxTsInCurrentBucket, consistency);
+        return !knownConcludedTransactions.isKnownConcluded(maxTsInCurrentBucket, Consistency.REMOTE_READ);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/DefaultKnownCommittedTransactions.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/DefaultKnownCommittedTransactions.java
@@ -1,0 +1,54 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.knowledge;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.time.Duration;
+
+public class DefaultKnownCommittedTransactions implements KnownCommittedTransactions {
+    private final KnownConcludedTransactions knownConcludedTransactions;
+    private final KnownAbortedTransactions knownAbortedTransactions;
+    private final Cache<Long, Boolean> cache;
+
+    public DefaultKnownCommittedTransactions(
+            KnownConcludedTransactions knownConcludedTransactions, KnownAbortedTransactions knownAbortedTransactions) {
+        this.knownConcludedTransactions = knownConcludedTransactions;
+        this.knownAbortedTransactions = knownAbortedTransactions;
+        this.cache = Caffeine.newBuilder()
+                .maximumSize(5000)
+                .expireAfterAccess(Duration.ofSeconds(5))
+                .build();
+    }
+
+    @Override
+    public boolean isKnownCommitted(long startTimestamp) {
+        return cache.get(startTimestamp, this::isKnownCommittedInternal);
+    }
+
+    private boolean isKnownCommittedInternal(long startTimestamp) {
+        boolean concluded = knownConcludedTransactions.isKnownConcluded(startTimestamp);
+        if (!concluded) {
+            // todo(snanda): check in txn table - if there is a miss then we need to update
+            //  knownConcludedTxns i.e. hit refresh on concludedTs
+            // Map<Long, Set<Long>> is the aborted cache -> bucket -> set of aborted timestamps
+
+            return false;
+        }
+        return !knownAbortedTransactions.isKnownAborted(startTimestamp);
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/DefaultKnownCommittedTransactions.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/DefaultKnownCommittedTransactions.java
@@ -37,10 +37,20 @@ public class DefaultKnownCommittedTransactions implements KnownCommittedTransact
     @Override
     public boolean isKnownCommitted(long startTimestamp) {
         if (!isConcluded(startTimestamp)) {
-            return Optional.ofNullable(transactionService.get(startTimestamp)).isPresent();
+            return getTransactionStateFromTransactionsTable(startTimestamp);
         }
 
         return !knownAbortedTransactions.isKnownAborted(startTimestamp);
+    }
+
+    private boolean getTransactionStateFromTransactionsTable(long startTimestamp) {
+        /**
+         * We have not wired in the transactionService#safeGet() api. Broad idea will be:
+         * case committed ->  return true
+         * case inProgress -> return false
+         * case deleted -> refresh knownConcluded and throw
+         * */
+        return Optional.ofNullable(transactionService.get(startTimestamp)).isPresent();
     }
 
     private boolean isConcluded(long startTimestamp) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/DefaultKnownCommittedTransactions.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/DefaultKnownCommittedTransactions.java
@@ -44,7 +44,7 @@ public class DefaultKnownCommittedTransactions implements KnownCommittedTransact
     }
 
     private boolean isConcluded(long startTimestamp) {
-        return knownConcludedTransactions.isKnownConcluded(startTimestamp, Consistency.LOCAL_READ) ||
-         knownConcludedTransactions.isKnownConcluded(startTimestamp, Consistency.REMOTE_READ);
+        return knownConcludedTransactions.isKnownConcluded(startTimestamp, Consistency.LOCAL_READ)
+                || knownConcludedTransactions.isKnownConcluded(startTimestamp, Consistency.REMOTE_READ);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/DefaultKnownConcludedTransactions.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/DefaultKnownConcludedTransactions.java
@@ -110,6 +110,7 @@ public final class DefaultKnownConcludedTransactions implements KnownConcludedTr
         for (int attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
 
             Cache cachedConcludedTimestamps = cachedConcludedTimestampsRef.get();
+
             ImmutableRangeSet<Long> cachedRanges = cachedConcludedTimestamps.ranges();
 
             if (cachedRanges.enclosesAll(timestampRanges)) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownAbortedTransactions.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownAbortedTransactions.java
@@ -19,11 +19,24 @@ package com.palantir.atlasdb.transaction.knowledge;
 import java.util.Set;
 
 /**
- * Dummy interface while we are blocked.
- * */
+ * Represents a set of start timestamps that belong to transactions that are known to have aborted.
+ */
 public interface KnownAbortedTransactions {
 
+    /**
+     * Returns whether the transaction that started at the provided timestamp is known to have aborted.
+     * This method should only be called for transactions that are known to have concluded.
+     *
+     * @param startTimestamp start timestamp associated with the value we are checking for
+     * @return whether the transaction that started at the provided timestamp is known to have aborted.
+     */
     boolean isKnownAborted(long startTimestamp);
 
+    /**
+     * Registers the fact that any transactions that had startTimestamp in set of timestamps provided have been
+     * aborted. This endpoint is only meant to be called internally by a background task.
+     *
+     * @param abortedTimestamps set of timestamps for which all transactions have been aborted.
+     */
     void addAbortedTimestamps(Set<Long> abortedTimestamps);
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownAbortedTransactions.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownAbortedTransactions.java
@@ -16,6 +16,7 @@
 
 package com.palantir.atlasdb.transaction.knowledge;
 
+import com.palantir.atlasdb.transaction.knowledge.KnownConcludedTransactions.Consistency;
 import java.util.Set;
 
 /**
@@ -23,7 +24,7 @@ import java.util.Set;
  * */
 public interface KnownAbortedTransactions {
 
-    boolean isKnownAborted(long startTimestamp);
+    boolean isKnownAborted(long startTimestamp, Consistency consistency);
 
     void addAbortedTimestamps(Set<Long> abortedTimestamps);
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownAbortedTransactions.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownAbortedTransactions.java
@@ -19,22 +19,22 @@ package com.palantir.atlasdb.transaction.knowledge;
 import java.util.Set;
 
 /**
- * Represents a set of start timestamps that belong to transactions that are known to have aborted.
+ * Represents a set of start timestamps that belong to transactions that are known to have been aborted.
  */
 public interface KnownAbortedTransactions {
 
     /**
-     * Returns whether the transaction that started at the provided timestamp is known to have aborted.
-     * This method should only be called for transactions that are known to have concluded.
+     * For a concluded transaction with the given start timestamp, returns true if it is known that the transaction
+     * has been aborted. Calling this method for a transaction that has not been concluded is undefined.
      *
      * @param startTimestamp start timestamp associated with the value we are checking for
-     * @return whether the transaction that started at the provided timestamp is known to have aborted.
+     * @return whether the transaction that started at the provided timestamp is known to have been aborted.
      */
     boolean isKnownAborted(long startTimestamp);
 
     /**
      * Registers the fact that any transactions that had startTimestamp in set of timestamps provided have been
-     * aborted. This endpoint is only meant to be called internally by a background task.
+     * aborted.
      *
      * @param abortedTimestamps set of timestamps for which all transactions have been aborted.
      */

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownAbortedTransactions.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownAbortedTransactions.java
@@ -1,0 +1,24 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.knowledge;
+
+/**
+ * Dummy interface while we are blocked.
+ * */
+public interface KnownAbortedTransactions {
+    boolean isKnownAborted(long startTimestamp);
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownAbortedTransactions.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownAbortedTransactions.java
@@ -16,7 +16,6 @@
 
 package com.palantir.atlasdb.transaction.knowledge;
 
-import com.palantir.atlasdb.transaction.knowledge.KnownConcludedTransactions.Consistency;
 import java.util.Set;
 
 /**
@@ -24,7 +23,7 @@ import java.util.Set;
  * */
 public interface KnownAbortedTransactions {
 
-    boolean isKnownAborted(long startTimestamp, Consistency consistency);
+    boolean isKnownAborted(long startTimestamp);
 
     void addAbortedTimestamps(Set<Long> abortedTimestamps);
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownCommittedTransactions.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownCommittedTransactions.java
@@ -1,0 +1,27 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.knowledge;
+
+public interface KnownCommittedTransactions {
+    /**
+     * Returns whether the transaction that started at the provided timestamp is known to have committed.
+     *
+     * @param startTimestamp start timestamp associated with the value we are checking for
+     * @return whether the transaction that started at the provided timestamp is known to have committed.
+     */
+    boolean isKnownCommitted(long startTimestamp);
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactions.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactions.java
@@ -1,0 +1,25 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.knowledge;
+
+/**
+ * Just adding a dummy interface here while we are blocked on merging of https://github.com/palantir/atlasdb/pull/6112/files
+ * */
+public interface KnownConcludedTransactions {
+
+    boolean isKnownConcluded(long startTimestamp);
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactions.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactions.java
@@ -41,6 +41,8 @@ public interface KnownConcludedTransactions {
      */
     void addConcludedTimestamps(Range<Long> knownConcludedInterval);
 
+    long lastKnownConcludedTimestamp();
+
     enum Consistency {
         /**
          * Only perform a read from a local cache. This is eventually consistent and the set of known committed

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactionsStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactionsStore.java
@@ -146,6 +146,11 @@ public final class KnownConcludedTransactionsStore {
                 .build());
     }
 
+    public long lastKnownConcludedTransaction() {
+        // todo(snanda)
+        return 0;
+    }
+
     @org.immutables.value.Value.Immutable
     interface ReadResult {
         byte[] valueReadFromDatabase();

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactionsStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactionsStore.java
@@ -146,11 +146,6 @@ public final class KnownConcludedTransactionsStore {
                 .build());
     }
 
-    public long lastKnownConcludedTransaction() {
-        // todo(snanda)
-        return 0;
-    }
-
     @org.immutables.value.Value.Immutable
     interface ReadResult {
         byte[] valueReadFromDatabase();


### PR DESCRIPTION
## General
Adds a new interfaces - `KnownCommittedTimestamps` which in turn relies on `KnownAbortedTimestamps`. 

**After this PR**:
Introduces new interface - `KnownCommittedTimestamps` which in turn relies on `KnownAbortedTimestamps`. 
`KnownAbortedTimestamps` uses bucketed caching. 
KnownCommittedTimestamps is not complete - broadly the algorithm is to look in knownConcluded transactions and fall back on transactions table as the source of truth.

**Priority**:
Before end of week

**Concerns / possible downsides (what feedback would you like?)**:
Is there a race condition I missed in `abortedTimestamps` caching?
Is the case where transaction has not been concluded handled correctly?

**Is documentation needed?**:
Docs added

## Compatibility
~**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:~

~**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:~

~**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:~

~**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:`~

~**Does this PR need a schema migration?**~

## Testing and Correctness
~**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:~

**What was existing testing like? What have you done to improve it?**:
In progress

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
For `KnownAbortedTransactions`, we have bucketed range of timestamps with bucket size = 1million
A bucket is cached upon access. 
A bucket is considered immutable and hence reliable iff greatest timestamp in that bucket has been concluded.
For mutable buckets, it is possible that the set of aborted txns can change which is why we refresh the cache.

We can add another optimization -> check if the highest known aborted > timestamp; if so, we do not have to refresh cache.

~**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:~

## Execution
~**How would I tell this PR works in production? (Metrics, logs, etc.)**:~

~**Has the safety of all log arguments been decided correctly?**:~

**Will this change significantly affect our spending on metrics or logs?**:
No

**How would I tell that this PR does not work in production? (monitors, etc.)**:
This PR does not do any wiring and is therefore not actually functioning.

~**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:~

~**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:~

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
The write of `abortedTxns` component should not be called with high concurrency.
The reads on `abortedTxns` and `committedTxns` can be highly concurrent which is why we have introduced caching for aborted transactions

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
I do not expect database calls to be expensive.
It might be possible that the knownConcluded transactions are not up to date and we need to make db calls to txn table in addition to concludedTxnStore
Another point of contention is that it might take a while for bucket of aborted txns to be concluded which would mean a remote read  for every transaction that has not aborted in the worst case. 

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
I do not _think_ so 

## Development Process
**Where should we start reviewing?**:
KnownAbortedTransactions

~**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:~

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
