### PR TITLE
Disallow empty table names in schema

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/Schemas.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/Schemas.java
@@ -85,6 +85,9 @@ public final class Schemas {
     }
 
     public static boolean isTableNameValid(String tableName) {
+        if (tableName.isEmpty()) {
+            return false;
+        }
         for (int i = 0; i < tableName.length(); i++) {
             char ch = tableName.charAt(i);
             if (!Character.isLetterOrDigit(ch) && ch != '_') {

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/SchemasTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/SchemasTest.java
@@ -116,6 +116,21 @@ public class SchemasTest {
         verify(kvs).getAllTableNames();
     }
 
+    @Test
+    public void testEmptyTableNameIsNotValid() {
+        assertThat(Schemas.isTableNameValid("")).isFalse();
+    }
+
+    @Test
+    public void testTableNameWithSpecialCharactersIsNotValid() {
+        assertThat(Schemas.isTableNameValid("he.llo")).isFalse();
+    }
+
+    @Test
+    public void testNonEmptyTableNameWithOnlyLettersDigitsAndUnderscoreIsValid() {
+        assertThat(Schemas.isTableNameValid("test_table_name")).isTrue();
+    }
+
     private static TableDefinition getSimpleTableDefinition(TableReference tableRef) {
         return new TableDefinition() {
             {


### PR DESCRIPTION
## General
**Before this PR**:
Empty tables were "accepted" although KVS would likely reject them (except InMemory)

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Empty table names are disallowed
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:
This is technically a breaking change, although most KVS will reject the empty table name (and we don't mind breaking in memory, cc @jeremyk-91)

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
N/A

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
N/A

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
N/A

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
N/A 
**Does this PR need a schema migration?**
N/A
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
That no one is using an empty table name in production.

**What was existing testing like? What have you done to improve it?**:
Added tests for the various invalid table name cases.

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Builds will fail if your schema contains an empty table name

**Has the safety of all log arguments been decided correctly?**:
N/A
**Will this change significantly affect our spending on metrics or logs?**:
N/A
**How would I tell that this PR does not work in production? (monitors, etc.)**:
N/A
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
recall - clients builds will fail so they won't have shipped a product, and can just use a previous version of atlas

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A 
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
N/A
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
N/A
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
N/A
## Development Process
**Where should we start reviewing?**:
Schemas.java
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
N/A
**Please tag any other people who should be aware of this PR**:
@jeremyk-91


<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
