### PR TITLE
[C2B2/TimeLock Serialization] Phase 1a: One Shotters (Server-Side)

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/TimeoutSensitiveConjureTimelockService.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/TimeoutSensitiveConjureTimelockService.java
@@ -17,17 +17,22 @@
 package com.palantir.atlasdb.factory.timelock;
 
 import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsRequest;
+import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsRequestV2;
 import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponse;
+import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponseV2;
 import com.palantir.atlasdb.timelock.api.ConjureLockRequest;
 import com.palantir.atlasdb.timelock.api.ConjureLockResponse;
 import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksRequest;
 import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksResponse;
+import com.palantir.atlasdb.timelock.api.ConjureSingleTimestamp;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsRequest;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
 import com.palantir.atlasdb.timelock.api.ConjureTimelockService;
 import com.palantir.atlasdb.timelock.api.ConjureUnlockRequest;
 import com.palantir.atlasdb.timelock.api.ConjureUnlockResponse;
 import com.palantir.atlasdb.timelock.api.ConjureWaitForLocksResponse;
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampRequest;
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampResponse;
 import com.palantir.atlasdb.timelock.api.GetCommitTimestampsRequest;
 import com.palantir.atlasdb.timelock.api.GetCommitTimestampsResponse;
 import com.palantir.lock.v2.LeaderTime;
@@ -57,6 +62,19 @@ public final class TimeoutSensitiveConjureTimelockService implements ConjureTime
     public ConjureGetFreshTimestampsResponse getFreshTimestamps(
             AuthHeader authHeader, String namespace, ConjureGetFreshTimestampsRequest request) {
         return shortTimeoutProxy.getFreshTimestamps(authHeader, namespace, request);
+    }
+
+    @Override
+    public ConjureGetFreshTimestampsResponseV2 getFreshTimestampsV2(
+            AuthHeader authHeader,
+            String namespace,
+            ConjureGetFreshTimestampsRequestV2 request) {
+        return shortTimeoutProxy.getFreshTimestampsV2(authHeader, namespace, request);
+    }
+
+    @Override
+    public ConjureSingleTimestamp getFreshTimestamp(AuthHeader authHeader, String namespace) {
+        return shortTimeoutProxy.getFreshTimestamp(authHeader, namespace);
     }
 
     @Override
@@ -90,5 +108,13 @@ public final class TimeoutSensitiveConjureTimelockService implements ConjureTime
     public GetCommitTimestampsResponse getCommitTimestamps(
             AuthHeader authHeader, String namespace, GetCommitTimestampsRequest request) {
         return shortTimeoutProxy.getCommitTimestamps(authHeader, namespace, request);
+    }
+
+    @Override
+    public GetCommitTimestampResponse getCommitTimestamp(
+            AuthHeader authHeader,
+            String namespace,
+            GetCommitTimestampRequest request) {
+        return shortTimeoutProxy.getCommitTimestamp(authHeader, namespace, request);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/debug/LockDiagnosticConjureTimelockService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/debug/LockDiagnosticConjureTimelockService.java
@@ -17,17 +17,22 @@
 package com.palantir.atlasdb.debug;
 
 import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsRequest;
+import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsRequestV2;
 import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponse;
+import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponseV2;
 import com.palantir.atlasdb.timelock.api.ConjureLockRequest;
 import com.palantir.atlasdb.timelock.api.ConjureLockResponse;
 import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksRequest;
 import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksResponse;
+import com.palantir.atlasdb.timelock.api.ConjureSingleTimestamp;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsRequest;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
 import com.palantir.atlasdb.timelock.api.ConjureTimelockService;
 import com.palantir.atlasdb.timelock.api.ConjureUnlockRequest;
 import com.palantir.atlasdb.timelock.api.ConjureUnlockResponse;
 import com.palantir.atlasdb.timelock.api.ConjureWaitForLocksResponse;
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampRequest;
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampResponse;
 import com.palantir.atlasdb.timelock.api.GetCommitTimestampsRequest;
 import com.palantir.atlasdb.timelock.api.GetCommitTimestampsResponse;
 import com.palantir.lock.v2.LeaderTime;
@@ -68,6 +73,19 @@ public class LockDiagnosticConjureTimelockService implements ConjureTimelockServ
     public ConjureGetFreshTimestampsResponse getFreshTimestamps(
             AuthHeader authHeader, String namespace, ConjureGetFreshTimestampsRequest request) {
         return conjureDelegate.getFreshTimestamps(authHeader, namespace, request);
+    }
+
+    @Override
+    public ConjureGetFreshTimestampsResponseV2 getFreshTimestampsV2(
+            AuthHeader authHeader,
+            String namespace,
+            ConjureGetFreshTimestampsRequestV2 request) {
+        return conjureDelegate.getFreshTimestampsV2(authHeader, namespace, request);
+    }
+
+    @Override
+    public ConjureSingleTimestamp getFreshTimestamp(AuthHeader authHeader, String namespace) {
+        return conjureDelegate.getFreshTimestamp(authHeader, namespace);
     }
 
     @Override
@@ -117,6 +135,14 @@ public class LockDiagnosticConjureTimelockService implements ConjureTimelockServ
     public GetCommitTimestampsResponse getCommitTimestamps(
             AuthHeader authHeader, String namespace, GetCommitTimestampsRequest request) {
         return conjureDelegate.getCommitTimestamps(authHeader, namespace, request);
+    }
+
+    @Override
+    public GetCommitTimestampResponse getCommitTimestamp(
+            AuthHeader authHeader,
+            String namespace,
+            GetCommitTimestampRequest request) {
+        return conjureDelegate.getCommitTimestamp(authHeader, namespace, request);
     }
 
     private static Optional<Long> tryParseStartTimestamp(String description) {

--- a/lock-api/src/main/java/com/palantir/lock/client/DialogueAdaptingConjureTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/DialogueAdaptingConjureTimelockService.java
@@ -19,11 +19,14 @@ package com.palantir.lock.client;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
 import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsRequest;
+import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsRequestV2;
 import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponse;
+import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponseV2;
 import com.palantir.atlasdb.timelock.api.ConjureLockRequest;
 import com.palantir.atlasdb.timelock.api.ConjureLockResponse;
 import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksRequest;
 import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksResponse;
+import com.palantir.atlasdb.timelock.api.ConjureSingleTimestamp;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsRequest;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
 import com.palantir.atlasdb.timelock.api.ConjureTimelockService;
@@ -31,6 +34,8 @@ import com.palantir.atlasdb.timelock.api.ConjureTimelockServiceBlocking;
 import com.palantir.atlasdb.timelock.api.ConjureUnlockRequest;
 import com.palantir.atlasdb.timelock.api.ConjureUnlockResponse;
 import com.palantir.atlasdb.timelock.api.ConjureWaitForLocksResponse;
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampRequest;
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampResponse;
 import com.palantir.atlasdb.timelock.api.GetCommitTimestampsRequest;
 import com.palantir.atlasdb.timelock.api.GetCommitTimestampsResponse;
 import com.palantir.lock.v2.LeaderTime;
@@ -61,6 +66,21 @@ public class DialogueAdaptingConjureTimelockService implements ConjureTimelockSe
     public ConjureGetFreshTimestampsResponse getFreshTimestamps(
             AuthHeader authHeader, String namespace, ConjureGetFreshTimestampsRequest request) {
         return dialogueDelegate.getFreshTimestamps(authHeader, namespace, request);
+    }
+
+    @Override
+    public ConjureGetFreshTimestampsResponseV2 getFreshTimestampsV2(
+            AuthHeader authHeader,
+            String namespace,
+            ConjureGetFreshTimestampsRequestV2 request) {
+        throw new UnsupportedOperationException("This version of the AtlasDB client should not be using this "
+                + "endpoint!");
+    }
+
+    @Override
+    public ConjureSingleTimestamp getFreshTimestamp(AuthHeader authHeader, String namespace) {
+        throw new UnsupportedOperationException("This version of the AtlasDB client should not be using this "
+                + "endpoint!");
     }
 
     @Override
@@ -97,6 +117,15 @@ public class DialogueAdaptingConjureTimelockService implements ConjureTimelockSe
     public GetCommitTimestampsResponse getCommitTimestamps(
             AuthHeader authHeader, String namespace, GetCommitTimestampsRequest request) {
         return dialogueDelegate.getCommitTimestamps(authHeader, namespace, request);
+    }
+
+    @Override
+    public GetCommitTimestampResponse getCommitTimestamp(
+            AuthHeader authHeader,
+            String namespace,
+            GetCommitTimestampRequest request) {
+        throw new UnsupportedOperationException("This version of the AtlasDB client should not be using this "
+                + "endpoint!");
     }
 
     private <T> T executeInstrumented(

--- a/timelock-api/src/main/conjure/timelock-api.yml
+++ b/timelock-api/src/main/conjure/timelock-api.yml
@@ -62,13 +62,26 @@ types:
           timestamps: PartitionedTimestamps
           lease: Lease
           lockWatchUpdate: LockWatchStateUpdate
+      ConjureSingleTimestamp:
+        alias: Long
+      ConjureTimestampRange:
+        fields:
+          start: Long
+          count: Long
+        docs: |
+          A contiguous range of timestamps, covering the range [start, start + count). This format is chosen to balance
+          efficiency and readability.
       ConjureGetFreshTimestampsRequest:
         fields:
           numTimestamps: integer
+      ConjureGetFreshTimestampsRequestV2:
+        alias: integer
       ConjureGetFreshTimestampsResponse:
         fields:
           inclusiveLower: Long
           inclusiveUpper: Long
+      ConjureGetFreshTimestampsResponseV2:
+        alias: ConjureTimestampRange
       ConjureLockDescriptor:
         alias: binary
       ConjureLockRequest:
@@ -114,6 +127,13 @@ types:
         fields:
           inclusiveLower: Long
           inclusiveUpper: Long
+          lockWatchUpdate: LockWatchStateUpdate
+      GetCommitTimestampRequest:
+        fields:
+          lastKnownVersion: optional<ConjureIdentifiedVersion>
+      GetCommitTimestampResponse:
+        fields:
+          timestamp: Long
           lockWatchUpdate: LockWatchStateUpdate
       LockWatchRequest:
         fields:
@@ -232,6 +252,17 @@ services:
           namespace: string
           request: ConjureGetFreshTimestampsRequest
         returns: ConjureGetFreshTimestampsResponse
+      getFreshTimestampsV2:
+        http: POST /t2/{namespace}
+        args:
+          namespace: string
+          request: ConjureGetFreshTimestampsRequestV2
+        returns: ConjureGetFreshTimestampsResponseV2
+      getFreshTimestamp:
+        http: POST /ts1/{namespace}
+        args:
+          namespace: string
+        returns: ConjureSingleTimestamp
       leaderTime:
         http: POST /lt/{namespace}
         args:
@@ -270,6 +301,12 @@ services:
         docs: |
           Batched endpoint for acquiring commit timestamps (a list of fresh timestamps) and the list of all lock watch
           events since the last known version up to after the commit timestamps have been issued.
+      getCommitTimestamp:
+        http: POST /g1ct/{namespace}
+        args:
+          namespace: string
+          request: GetCommitTimestampRequest
+        returns: GetCommitTimestampResponse
   ConjureLockWatchingService:
     name: Lock Watching service
     default-auth: header

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/ConjureTimelockResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/ConjureTimelockResource.java
@@ -24,7 +24,9 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.atlasdb.futures.AtlasFutures;
 import com.palantir.atlasdb.http.RedirectRetryTargeter;
 import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsRequest;
+import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsRequestV2;
 import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponse;
+import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponseV2;
 import com.palantir.atlasdb.timelock.api.ConjureIdentifiedVersion;
 import com.palantir.atlasdb.timelock.api.ConjureLockDescriptor;
 import com.palantir.atlasdb.timelock.api.ConjureLockRequest;
@@ -32,13 +34,17 @@ import com.palantir.atlasdb.timelock.api.ConjureLockResponse;
 import com.palantir.atlasdb.timelock.api.ConjureLockToken;
 import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksRequest;
 import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksResponse;
+import com.palantir.atlasdb.timelock.api.ConjureSingleTimestamp;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsRequest;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
 import com.palantir.atlasdb.timelock.api.ConjureTimelockService;
 import com.palantir.atlasdb.timelock.api.ConjureTimelockServiceEndpoints;
+import com.palantir.atlasdb.timelock.api.ConjureTimestampRange;
 import com.palantir.atlasdb.timelock.api.ConjureUnlockRequest;
 import com.palantir.atlasdb.timelock.api.ConjureUnlockResponse;
 import com.palantir.atlasdb.timelock.api.ConjureWaitForLocksResponse;
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampRequest;
+import com.palantir.atlasdb.timelock.api.GetCommitTimestampResponse;
 import com.palantir.atlasdb.timelock.api.GetCommitTimestampsRequest;
 import com.palantir.atlasdb.timelock.api.GetCommitTimestampsResponse;
 import com.palantir.atlasdb.timelock.api.SuccessfulLockResponse;
@@ -59,6 +65,7 @@ import com.palantir.lock.v2.WaitForLocksResponse;
 import com.palantir.lock.watch.LockWatchVersion;
 import com.palantir.timestamp.TimestampRange;
 import com.palantir.tokens.auth.AuthHeader;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -93,13 +100,33 @@ public final class ConjureTimelockResource implements UndertowConjureTimelockSer
     @Override
     public ListenableFuture<ConjureGetFreshTimestampsResponse> getFreshTimestamps(
             AuthHeader authHeader, String namespace, ConjureGetFreshTimestampsRequest request) {
+        return getFreshTimestamps(
+                namespace,
+                request.getNumTimestamps(),
+                range -> ConjureGetFreshTimestampsResponse.of(range.getLowerBound(), range.getUpperBound()));
+    }
+
+    @Override
+    public ListenableFuture<ConjureGetFreshTimestampsResponseV2> getFreshTimestampsV2(
+            AuthHeader authHeader, String namespace, ConjureGetFreshTimestampsRequestV2 request) {
+        return getFreshTimestamps(
+                namespace,
+                request.get(),
+                range -> ConjureGetFreshTimestampsResponseV2.of(
+                        ConjureTimestampRange.of(range.getLowerBound(), range.size())));
+    }
+
+    @Override
+    public ListenableFuture<ConjureSingleTimestamp> getFreshTimestamp(AuthHeader authHeader, String namespace) {
+        return getFreshTimestamps(namespace, 1, range -> ConjureSingleTimestamp.of(range.getLowerBound()));
+    }
+
+    private <T> ListenableFuture<T> getFreshTimestamps(
+            String namespace, int timestampsToRetrieve, Function<TimestampRange, T> responseWrappingFunction) {
         return handleExceptions(() -> {
             ListenableFuture<TimestampRange> rangeFuture =
-                    forNamespace(namespace).getFreshTimestampsAsync(request.getNumTimestamps());
-            return Futures.transform(
-                    rangeFuture,
-                    range -> ConjureGetFreshTimestampsResponse.of(range.getLowerBound(), range.getUpperBound()),
-                    MoreExecutors.directExecutor());
+                    forNamespace(namespace).getFreshTimestampsAsync(timestampsToRetrieve);
+            return Futures.transform(rangeFuture, responseWrappingFunction::apply, MoreExecutors.directExecutor());
         });
     }
 
@@ -195,10 +222,28 @@ public final class ConjureTimelockResource implements UndertowConjureTimelockSer
     @Override
     public ListenableFuture<GetCommitTimestampsResponse> getCommitTimestamps(
             AuthHeader authHeader, String namespace, GetCommitTimestampsRequest request) {
-        return handleExceptions(() -> forNamespace(namespace)
-                .getCommitTimestamps(
-                        request.getNumTimestamps(),
-                        request.getLastKnownVersion().map(this::toIdentifiedVersion)));
+        return handleExceptions(() ->
+                getCommitTimestampsInternal(namespace, request.getNumTimestamps(), request.getLastKnownVersion()));
+    }
+
+    @Override
+    public ListenableFuture<GetCommitTimestampResponse> getCommitTimestamp(
+            AuthHeader authHeader, String namespace, GetCommitTimestampRequest request) {
+        return handleExceptions(() -> {
+            ListenableFuture<GetCommitTimestampsResponse> responseFuture =
+                    getCommitTimestampsInternal(namespace, 1, request.getLastKnownVersion());
+            return Futures.transform(
+                    responseFuture,
+                    response ->
+                            GetCommitTimestampResponse.of(response.getInclusiveLower(), response.getLockWatchUpdate()),
+                    MoreExecutors.directExecutor());
+        });
+    }
+
+    private ListenableFuture<GetCommitTimestampsResponse> getCommitTimestampsInternal(
+            String namespace, int numTimestamps, Optional<ConjureIdentifiedVersion> lockWatchVersion) {
+        return forNamespace(namespace)
+                .getCommitTimestamps(numTimestamps, lockWatchVersion.map(this::toIdentifiedVersion));
     }
 
     private AsyncTimelockService forNamespace(String namespace) {
@@ -226,6 +271,17 @@ public final class ConjureTimelockResource implements UndertowConjureTimelockSer
         public ConjureGetFreshTimestampsResponse getFreshTimestamps(
                 AuthHeader authHeader, String namespace, ConjureGetFreshTimestampsRequest request) {
             return unwrap(resource.getFreshTimestamps(authHeader, namespace, request));
+        }
+
+        @Override
+        public ConjureGetFreshTimestampsResponseV2 getFreshTimestampsV2(
+                AuthHeader authHeader, String namespace, ConjureGetFreshTimestampsRequestV2 request) {
+            return unwrap(resource.getFreshTimestampsV2(authHeader, namespace, request));
+        }
+
+        @Override
+        public ConjureSingleTimestamp getFreshTimestamp(AuthHeader authHeader, String namespace) {
+            return unwrap(resource.getFreshTimestamp(authHeader, namespace));
         }
 
         @Override
@@ -259,6 +315,12 @@ public final class ConjureTimelockResource implements UndertowConjureTimelockSer
         public GetCommitTimestampsResponse getCommitTimestamps(
                 AuthHeader authHeader, String namespace, GetCommitTimestampsRequest request) {
             return unwrap(resource.getCommitTimestamps(authHeader, namespace, request));
+        }
+
+        @Override
+        public GetCommitTimestampResponse getCommitTimestamp(
+                AuthHeader authHeader, String namespace, GetCommitTimestampRequest request) {
+            return unwrap(resource.getCommitTimestamp(authHeader, namespace, request));
         }
 
         private static <T> T unwrap(ListenableFuture<T> future) {


### PR DESCRIPTION
## General
**Before this PR**:
TimeLock can only give you getFreshTimestamps(number), even if the number is 1.
Furthermore, it will give you something like `{"startInclusive": 1234567890, "endInclusive": 1234567890}`, or in the case of legitimate batching `{"startInclusive": 1234567890, "endInclusive": 1234567894}`.
A similar issue exists for getCommitTimestamps.
This is inefficient, because at a majority of stacks, the majority of batchable operations still lead to batch sizes of 1, especially for endpoints that are not frequently invoked like getCommitTimestamp.

**After this PR**:
==COMMIT_MSG==
TimeLock exposes three new endpoints:
- getFreshTimestamp, returns one fresh timestamp which is just a number, i.e. `1234567890`.
- getFreshTimestampsV2, returns a range of timestamps in a more efficient encoding: ``{"start": 1234567890, "count": 5}`.
- getCommitTimestamp, returns just a timestamp as opposed to a start/inclusive pair along with the lock watch state update, if relevant.
==COMMIT_MSG==

**Priority**: P1. I want this to be out soon so that it can pass adjudication.

**Concerns / possible downsides (what feedback would you like?)**:
- The response types for getCommitTimestamp and getFershTimestampsV2 are not maximally efficient. Should I have pushed harder on this?

**Is documentation needed?**: No

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: No: this is an additive change.

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: Yes. Blue nodes will not have the endpoint during a blue-green upgrade, but we expect in the next PR for clients to declare a product dependency on the relevant timelock server version.

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: Not this one.

**Does this PR need a schema migration?**: Not here, though we will need one on the timelock server.

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: Not too much. This PR gives bigger wins if batching is rarely done, but still is an improvement in the presence of batching.

**What was existing testing like? What have you done to improve it?**: Not much

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: N/A

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: Hard to say right now, though once the clients are also wired up to use the server-side end points we'll have a clearer idea.

**Has the safety of all log arguments been decided correctly?**: No use of Safe or UnsafeArg here

**Will this change significantly affect our spending on metrics or logs?**: No

**How would I tell that this PR does not work in production? (monitors, etc.)**: 5xx on TimeLock

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: This may have a Schema Bump (TM) on our internal wrapper of the timelock server, which could make rollback a bit trickier. I don't expect us to run into problems out of hours and will be on hand to assist with things in hours

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**: @mdaudali

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**: No, this is believed to be a strict improvement

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**: No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**: Don't really see a better way beyond further optimisation, and that happens if we decide we are spending too much money.

## Development Process
**Where should we start reviewing?**: timelock-api.yml

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: N/A

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
