### PR TITLE
[C2B2/TimeLock Serialization] Phase 1b: One Shotters (Client-Side)

### DIFF
--- a/lock-api-objects/build.gradle
+++ b/lock-api-objects/build.gradle
@@ -27,7 +27,7 @@ recommendedProductDependencies {
     productDependency {
         productGroup = 'com.palantir.timelock'
         productName = 'timelock-server'
-        minimumVersion = '0.476.0'
+        minimumVersion = '0.1144.0'
         maximumVersion = '0.x.x'
     }
 }

--- a/lock-api/src/main/java/com/palantir/lock/client/DialogueAdaptingConjureTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/DialogueAdaptingConjureTimelockService.java
@@ -75,14 +75,12 @@ public class DialogueAdaptingConjureTimelockService implements ConjureTimelockSe
     @Override
     public ConjureGetFreshTimestampsResponseV2 getFreshTimestampsV2(
             AuthHeader authHeader, String namespace, ConjureGetFreshTimestampsRequestV2 request) {
-        throw new UnsupportedOperationException(
-                "This version of the AtlasDB client should not be using this endpoint!");
+        return dialogueDelegate.getFreshTimestampsV2(authHeader, namespace, request);
     }
 
     @Override
     public ConjureSingleTimestamp getFreshTimestamp(AuthHeader authHeader, String namespace) {
-        throw new UnsupportedOperationException(
-                "This version of the AtlasDB client should not be using this endpoint!");
+        return dialogueDelegate.getFreshTimestamp(authHeader, namespace);
     }
 
     @Override
@@ -137,8 +135,7 @@ public class DialogueAdaptingConjureTimelockService implements ConjureTimelockSe
     @Override
     public GetCommitTimestampResponse getCommitTimestamp(
             AuthHeader authHeader, String namespace, GetCommitTimestampRequest request) {
-        throw new UnsupportedOperationException(
-                "This version of the AtlasDB client should not be using this endpoint!");
+        return dialogueDelegate.getCommitTimestamp(authHeader, namespace, request);
     }
 
     private <T> T executeInstrumented(

--- a/lock-api/src/main/java/com/palantir/lock/client/LeaderElectionReportingTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LeaderElectionReportingTimelockService.java
@@ -19,12 +19,13 @@ package com.palantir.lock.client;
 import com.codahale.metrics.Snapshot;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
-import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsRequest;
-import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponse;
+import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsRequestV2;
+import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponseV2;
 import com.palantir.atlasdb.timelock.api.ConjureLockRequest;
 import com.palantir.atlasdb.timelock.api.ConjureLockResponse;
 import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksRequest;
 import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksResponse;
+import com.palantir.atlasdb.timelock.api.ConjureSingleTimestamp;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsRequest;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
 import com.palantir.atlasdb.timelock.api.ConjureTimelockService;
@@ -118,8 +119,13 @@ public class LeaderElectionReportingTimelockService implements NamespacedConjure
     }
 
     @Override
-    public ConjureGetFreshTimestampsResponse getFreshTimestamps(ConjureGetFreshTimestampsRequest request) {
-        return delegate.getFreshTimestamps(request);
+    public ConjureGetFreshTimestampsResponseV2 getFreshTimestampsV2(ConjureGetFreshTimestampsRequestV2 request) {
+        return delegate.getFreshTimestampsV2(request);
+    }
+
+    @Override
+    public ConjureSingleTimestamp getFreshTimestamp() {
+        return delegate.getFreshTimestamp();
     }
 
     @Override

--- a/lock-api/src/main/java/com/palantir/lock/client/NamespacedConjureTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/NamespacedConjureTimelockService.java
@@ -16,12 +16,13 @@
 
 package com.palantir.lock.client;
 
-import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsRequest;
-import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponse;
+import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsRequestV2;
+import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponseV2;
 import com.palantir.atlasdb.timelock.api.ConjureLockRequest;
 import com.palantir.atlasdb.timelock.api.ConjureLockResponse;
 import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksRequest;
 import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksResponse;
+import com.palantir.atlasdb.timelock.api.ConjureSingleTimestamp;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsRequest;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
 import com.palantir.atlasdb.timelock.api.ConjureUnlockRequest;
@@ -44,7 +45,9 @@ public interface NamespacedConjureTimelockService {
 
     GetCommitTimestampsResponse getCommitTimestamps(GetCommitTimestampsRequest request);
 
-    ConjureGetFreshTimestampsResponse getFreshTimestamps(ConjureGetFreshTimestampsRequest request);
+    ConjureGetFreshTimestampsResponseV2 getFreshTimestampsV2(ConjureGetFreshTimestampsRequestV2 request);
+
+    ConjureSingleTimestamp getFreshTimestamp();
 
     ConjureStartTransactionsResponse startTransactions(ConjureStartTransactionsRequest request);
 }

--- a/lock-api/src/main/java/com/palantir/lock/client/NamespacedConjureTimelockServiceImpl.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/NamespacedConjureTimelockServiceImpl.java
@@ -16,12 +16,13 @@
 
 package com.palantir.lock.client;
 
-import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsRequest;
-import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponse;
+import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsRequestV2;
+import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponseV2;
 import com.palantir.atlasdb.timelock.api.ConjureLockRequest;
 import com.palantir.atlasdb.timelock.api.ConjureLockResponse;
 import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksRequest;
 import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksResponse;
+import com.palantir.atlasdb.timelock.api.ConjureSingleTimestamp;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsRequest;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
 import com.palantir.atlasdb.timelock.api.ConjureTimelockService;
@@ -49,8 +50,13 @@ public class NamespacedConjureTimelockServiceImpl implements NamespacedConjureTi
     }
 
     @Override
-    public ConjureGetFreshTimestampsResponse getFreshTimestamps(ConjureGetFreshTimestampsRequest request) {
-        return conjureTimelockService.getFreshTimestamps(AUTH_HEADER, namespace, request);
+    public ConjureGetFreshTimestampsResponseV2 getFreshTimestampsV2(ConjureGetFreshTimestampsRequestV2 request) {
+        return conjureTimelockService.getFreshTimestampsV2(AUTH_HEADER, namespace, request);
+    }
+
+    @Override
+    public ConjureSingleTimestamp getFreshTimestamp() {
+        return conjureTimelockService.getFreshTimestamp(AUTH_HEADER, namespace);
     }
 
     @Override

--- a/lock-api/src/main/java/com/palantir/lock/client/RemoteTimelockServiceAdapter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/RemoteTimelockServiceAdapter.java
@@ -16,8 +16,9 @@
 
 package com.palantir.lock.client;
 
-import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsRequest;
-import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponse;
+import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsRequestV2;
+import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponseV2;
+import com.palantir.atlasdb.timelock.api.ConjureTimestampRange;
 import com.palantir.atlasdb.timelock.api.Namespace;
 import com.palantir.lock.v2.ClientLockingOptions;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
@@ -94,7 +95,7 @@ public final class RemoteTimelockServiceAdapter implements TimelockService, Auto
 
     @Override
     public long getFreshTimestamp() {
-        return getFreshTimestamps(1).getLowerBound();
+        return conjureTimelockService.getFreshTimestamp().get();
     }
 
     @Override
@@ -104,9 +105,10 @@ public final class RemoteTimelockServiceAdapter implements TimelockService, Auto
 
     @Override
     public TimestampRange getFreshTimestamps(int numTimestampsRequested) {
-        ConjureGetFreshTimestampsResponse response =
-                conjureTimelockService.getFreshTimestamps(ConjureGetFreshTimestampsRequest.of(numTimestampsRequested));
-        return TimestampRange.createInclusiveRange(response.getInclusiveLower(), response.getInclusiveUpper());
+        ConjureGetFreshTimestampsResponseV2 response =
+                conjureTimelockService.getFreshTimestampsV2(ConjureGetFreshTimestampsRequestV2.of(numTimestampsRequested));
+        ConjureTimestampRange timestampRange = response.get();
+        return TimestampRange.createRangeFromDeltaEncoding(timestampRange.getStart(), timestampRange.getCount());
     }
 
     @Override

--- a/lock-api/src/main/java/com/palantir/lock/client/RemoteTimelockServiceAdapter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/RemoteTimelockServiceAdapter.java
@@ -105,8 +105,8 @@ public final class RemoteTimelockServiceAdapter implements TimelockService, Auto
 
     @Override
     public TimestampRange getFreshTimestamps(int numTimestampsRequested) {
-        ConjureGetFreshTimestampsResponseV2 response =
-                conjureTimelockService.getFreshTimestampsV2(ConjureGetFreshTimestampsRequestV2.of(numTimestampsRequested));
+        ConjureGetFreshTimestampsResponseV2 response = conjureTimelockService.getFreshTimestampsV2(
+                ConjureGetFreshTimestampsRequestV2.of(numTimestampsRequested));
         ConjureTimestampRange timestampRange = response.get();
         return TimestampRange.createRangeFromDeltaEncoding(timestampRange.getStart(), timestampRange.getCount());
     }

--- a/lock-api/src/main/java/com/palantir/lock/client/TimestampCorroboratingTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/TimestampCorroboratingTimelockService.java
@@ -18,12 +18,13 @@ package com.palantir.lock.client;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.palantir.atlasdb.correctness.TimestampCorrectnessMetrics;
-import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsRequest;
-import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponse;
+import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsRequestV2;
+import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponseV2;
 import com.palantir.atlasdb.timelock.api.ConjureLockRequest;
 import com.palantir.atlasdb.timelock.api.ConjureLockResponse;
 import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksRequest;
 import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksResponse;
+import com.palantir.atlasdb.timelock.api.ConjureSingleTimestamp;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsRequest;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
 import com.palantir.atlasdb.timelock.api.ConjureUnlockRequest;
@@ -111,11 +112,20 @@ public final class TimestampCorroboratingTimelockService implements NamespacedCo
     }
 
     @Override
-    public ConjureGetFreshTimestampsResponse getFreshTimestamps(ConjureGetFreshTimestampsRequest request) {
+    public ConjureGetFreshTimestampsResponseV2 getFreshTimestampsV2(ConjureGetFreshTimestampsRequestV2 request) {
         return checkAndUpdateLowerBound(
-                () -> delegate.getFreshTimestamps(request),
-                ConjureGetFreshTimestampsResponse::getInclusiveLower,
-                ConjureGetFreshTimestampsResponse::getInclusiveUpper,
+                () -> delegate.getFreshTimestampsV2(request),
+                response -> response.get().getStart(),
+                response -> response.get().getStart() + response.get().getCount() - 1,
+                OperationType.FRESH_TIMESTAMP);
+    }
+
+    @Override
+    public ConjureSingleTimestamp getFreshTimestamp() {
+        return checkAndUpdateLowerBound(
+                delegate::getFreshTimestamp,
+                ConjureSingleTimestamp::get,
+                ConjureSingleTimestamp::get,
                 OperationType.FRESH_TIMESTAMP);
     }
 

--- a/lock-api/src/test/java/com/palantir/lock/client/LockLeaseServiceTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/LockLeaseServiceTest.java
@@ -28,13 +28,11 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.timelock.api.ConjureLockResponse;
 import com.palantir.atlasdb.timelock.api.ConjureLockToken;
-import com.palantir.atlasdb.timelock.api.ConjureLockTokenV2;
 import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksRequest;
-import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksRequestV2;
-import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksResponseV2;
+import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksResponse;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
-import com.palantir.atlasdb.timelock.api.ConjureUnlockRequestV2;
-import com.palantir.atlasdb.timelock.api.ConjureUnlockResponseV2;
+import com.palantir.atlasdb.timelock.api.ConjureUnlockRequest;
+import com.palantir.atlasdb.timelock.api.ConjureUnlockResponse;
 import com.palantir.atlasdb.timelock.api.SuccessfulLockResponse;
 import com.palantir.atlasdb.timelock.api.UnsuccessfulLockResponse;
 import com.palantir.common.time.NanoTime;
@@ -90,9 +88,9 @@ public class LockLeaseServiceTest {
     public void before() {
         when(lockRequest.getAcquireTimeoutMs()).thenReturn(10L);
         when(timelock.leaderTime()).thenAnswer(inv -> LeaderTime.of(LEADER_ID, time.get()));
-        when(timelock.unlockV2(any())).thenAnswer(inv -> {
-            ConjureUnlockRequestV2 request = inv.getArgument(0);
-            return ConjureUnlockResponseV2.of(request.get());
+        when(timelock.unlock(any())).thenAnswer(inv -> {
+            ConjureUnlockRequest request = inv.getArgument(0);
+            return ConjureUnlockResponse.of(request.getTokens());
         });
         lockLeaseService = new LockLeaseService(timelock, SERVICE_ID, new LegacyLeaderTimeGetter(timelock));
     }
@@ -183,8 +181,7 @@ public class LockLeaseServiceTest {
         assertValid(token);
         lockLeaseService.unlock(ImmutableSet.of(token));
 
-        verify(timelock).unlockV2(ConjureUnlockRequestV2.of(ImmutableSet.of(
-                ConjureLockTokenV2.of(token.serverToken().getRequestId()))));
+        verify(timelock).unlock(ConjureUnlockRequest.of(ImmutableSet.of(token.serverToken())));
     }
 
     @Test
@@ -195,8 +192,7 @@ public class LockLeaseServiceTest {
         assertInvalid(token);
 
         lockLeaseService.unlock(ImmutableSet.of(token));
-        verify(timelock).unlockV2(ConjureUnlockRequestV2.of(ImmutableSet.of(
-                ConjureLockTokenV2.of(token.serverToken().getRequestId()))));
+        verify(timelock).unlock(ConjureUnlockRequest.of(ImmutableSet.of(token.serverToken())));
     }
 
     @Test
@@ -221,9 +217,8 @@ public class LockLeaseServiceTest {
         LeasedLockToken leasedLockToken = LeasedLockToken.of(LOCK_TOKEN, getLease(Duration.ZERO));
         assertInvalid(leasedLockToken);
 
-        ConjureLockTokenV2 v2Token = ConjureLockTokenV2.of(LOCK_TOKEN.getRequestId());
-        when(timelock.refreshLocksV2(ConjureRefreshLocksRequestV2.of(ImmutableSet.of(v2Token))))
-                .thenReturn(ConjureRefreshLocksResponseV2.of(ImmutableSet.of(v2Token), getLease()));
+        when(timelock.refreshLocks(ConjureRefreshLocksRequest.of(ImmutableSet.of(LOCK_TOKEN))))
+                .thenReturn(ConjureRefreshLocksResponse.of(ImmutableSet.of(LOCK_TOKEN), getLease()));
 
         Set<LockToken> refreshed = lockLeaseService.refreshLockLeases(ImmutableSet.of(leasedLockToken));
         verify(timelock).refreshLocks(ConjureRefreshLocksRequest.of(ImmutableSet.of(leasedLockToken.serverToken())));

--- a/timelock-agent/src/main/java/com/palantir/timelock/invariants/TimeLockActivityChecker.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/invariants/TimeLockActivityChecker.java
@@ -35,7 +35,9 @@ public class TimeLockActivityChecker {
 
     public OptionalLong getFreshTimestampFromNodeForClient(String client) {
         try {
-            return OptionalLong.of(conjureTimelockService.getFreshTimestamp(AUTH_HEADER, client).get());
+            return OptionalLong.of(conjureTimelockService
+                    .getFreshTimestamp(AUTH_HEADER, client)
+                    .get());
         } catch (Exception e) {
             log.info(
                     "Suppressed exception when checking TimeLock activity for client {}",

--- a/timelock-agent/src/main/java/com/palantir/timelock/invariants/TimeLockActivityChecker.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/invariants/TimeLockActivityChecker.java
@@ -16,7 +16,6 @@
 
 package com.palantir.timelock.invariants;
 
-import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsRequest;
 import com.palantir.atlasdb.timelock.api.ConjureTimelockService;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
@@ -36,9 +35,7 @@ public class TimeLockActivityChecker {
 
     public OptionalLong getFreshTimestampFromNodeForClient(String client) {
         try {
-            return OptionalLong.of(conjureTimelockService
-                    .getFreshTimestamps(AUTH_HEADER, client, ConjureGetFreshTimestampsRequest.of(1))
-                    .getInclusiveLower());
+            return OptionalLong.of(conjureTimelockService.getFreshTimestamp(AUTH_HEADER, client).get());
         } catch (Exception e) {
             log.info(
                     "Suppressed exception when checking TimeLock activity for client {}",

--- a/timelock-agent/src/test/java/com/palantir/timelock/invariants/TimeLockActivityCheckerTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/invariants/TimeLockActivityCheckerTest.java
@@ -22,8 +22,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsRequest;
-import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponse;
+import com.palantir.atlasdb.timelock.api.ConjureSingleTimestamp;
 import com.palantir.atlasdb.timelock.api.ConjureTimelockService;
 import org.junit.Test;
 
@@ -35,8 +34,7 @@ public class TimeLockActivityCheckerTest {
 
     @Test
     public void ifGetFreshTimestampReturnsTheValueIsPropagated() {
-        when(timelockRpcClient.getFreshTimestamps(any(), eq(CLIENT), eq(ConjureGetFreshTimestampsRequest.of(1))))
-                .thenReturn(ConjureGetFreshTimestampsResponse.of(8L, 8L));
+        when(timelockRpcClient.getFreshTimestamp(any(), eq(CLIENT))).thenReturn(ConjureSingleTimestamp.of(8L));
         assertThat(timeLockActivityChecker.getFreshTimestampFromNodeForClient(CLIENT))
                 .hasValue(8L);
     }

--- a/timestamp-api/src/main/java/com/palantir/timestamp/TimestampRange.java
+++ b/timestamp-api/src/main/java/com/palantir/timestamp/TimestampRange.java
@@ -56,6 +56,15 @@ public class TimestampRange implements Serializable {
     }
 
     /**
+     * Constructs a TimestampRange from a delta encoding: the first parameter is the start of the range and the
+     * second is the number of timestamps present in the range. In practice, this should be equal to [lowerBound,
+     * lowerBound + count).
+     */
+    public static TimestampRange createRangeFromDeltaEncoding(long lowerBound, long count) {
+        return new TimestampRange(lowerBound, lowerBound + count - 1);
+    }
+
+    /**
      * Returns the lower bound of this TimestampRange (inclusive).
      *
      * @return the lower bound of the TimestampRange


### PR DESCRIPTION
- [x] This PR requires a product dependency that can only be specified after #6149 has merged...

## General
**Before this PR**:
TimeLock exposes endpoints to get _one_ timestamp, and a more efficient encoding for its responses, but these are not used by clients.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Clients will now use the more efficient endpoints to request fresh timestamps from timelock.
==COMMIT_MSG==

**Priority**: High ($$$)

**Concerns / possible downsides (what feedback would you like?)**: Not much. Validated on internal herb stack.

**Is documentation needed?**: No, is internal.

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: No (though we require the presence of a new timelock api)

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: Yes.

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: **YES!** We need the timelock server to already have upgraded.

**Does this PR need a schema migration?** No.

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: TimeLock has a required version.

**What was existing testing like? What have you done to improve it?**: I rewired all integration tests to go through the new endpoints.

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: No.

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: No.

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: Metrics for the new methods of ConjureTimelockServiceBlocking will work.

**Has the safety of all log arguments been decided correctly?**: No logging args were added in this PR.

**Will this change significantly affect our spending on metrics or logs?**: No

**How would I tell that this PR does not work in production? (monitors, etc.)**: Nothing beyond standard metrics (failure rates, 500 etc)

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: Rollback. Is straightforward.

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**: No, not really.

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**: No.

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**: If the lock API usage evolves in a certain way, maybe, but we don't see that happening for the foreseeable future.

## Development Process
**Where should we start reviewing?**: small

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: It's not.

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
