### PR TITLE
Use the default shared metric registry for Hikari metrics

### DIFF
--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
@@ -167,7 +167,7 @@ public abstract class ConnectionConfig {
 
         config.setPoolName(getConnectionPoolName());
         config.setRegisterMbeans(true);
-        config.setMetricRegistry(SharedMetricRegistries.getOrCreate("com.palantir.metrics"));
+        config.setMetricRegistry(SharedMetricRegistries.tryGetDefault());
 
         config.setMinimumIdle(getMinConnections());
         config.setMaximumPoolSize(getMaxConnections());

--- a/changelog/@unreleased/pr-6166.v2.yml
+++ b/changelog/@unreleased/pr-6166.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Use the default shared metric registry for Hikari metrics.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6166


### PR DESCRIPTION
**Before this PR**:

Hikari metrics are added to a shared metric registry that is never consumed.

**After this PR**:

Hikari metrics are added to the default shared metric registry that is configured by our server library.