### PR TITLE
Fix connection config

### DIFF
--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
@@ -26,12 +26,13 @@ import com.palantir.nexus.db.pool.InterceptorDataSource;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.SQLExceptionOverride;
 import com.zaxxer.hikari.util.DriverDataSource;
+import org.immutables.value.Value;
+
+import javax.sql.DataSource;
 import java.sql.Connection;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
-import javax.sql.DataSource;
-import org.immutables.value.Value;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonSubTypes({
@@ -153,6 +154,7 @@ public abstract class ConnectionConfig {
      * Please refer to <a href="https://github.com/brettwooldridge/HikariCP#infrequently-used">HikariCP</a>
      * before overriding.
      * */
+    @Value.Default
     public Optional<Long> initializeFailTimeoutMillis() {
         return Optional.empty();
     }

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
@@ -26,13 +26,12 @@ import com.palantir.nexus.db.pool.InterceptorDataSource;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.SQLExceptionOverride;
 import com.zaxxer.hikari.util.DriverDataSource;
-import org.immutables.value.Value;
-
-import javax.sql.DataSource;
 import java.sql.Connection;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
+import javax.sql.DataSource;
+import org.immutables.value.Value;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonSubTypes({

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
@@ -154,10 +154,7 @@ public abstract class ConnectionConfig {
      * Please refer to <a href="https://github.com/brettwooldridge/HikariCP#infrequently-used">HikariCP</a>
      * before overriding.
      * */
-    @Value.Default
-    public Optional<Long> initializeFailTimeoutMillis() {
-        return Optional.empty();
-    }
+    public abstract Optional<Long> initializeFailTimeoutMillis();
 
     @JsonIgnore
     @Value.Lazy

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/PostgresConfigLoadingTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/PostgresConfigLoadingTest.java
@@ -15,17 +15,18 @@
  */
 package com.palantir.atlasdb.keyvalue.dbkvs.impl;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.palantir.atlasdb.config.AtlasDbConfig;
 import com.palantir.atlasdb.config.AtlasDbConfigs;
 import com.palantir.atlasdb.keyvalue.dbkvs.DbKeyValueServiceConfig;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 import com.palantir.nexus.db.pool.config.ConnectionConfig;
+import org.junit.Test;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
-import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PostgresConfigLoadingTest {
     @Test
@@ -43,6 +44,13 @@ public class PostgresConfigLoadingTest {
     public void testHikariConnectTimeout() throws IOException {
         ConnectionConfig connectionConfig = getConnectionConfig();
         verifyHikariProperty(connectionConfig, "connectTimeout", connectionConfig.getConnectionTimeoutSeconds());
+    }
+
+    @Test
+    public void testInitFailTimeout() throws IOException {
+        ConnectionConfig connectionConfig = getConnectionConfig();
+        assertThat(connectionConfig.initializeFailTimeoutMillis())
+                .hasValue(10L);
     }
 
     @Test

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/PostgresConfigLoadingTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/PostgresConfigLoadingTest.java
@@ -15,18 +15,17 @@
  */
 package com.palantir.atlasdb.keyvalue.dbkvs.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.palantir.atlasdb.config.AtlasDbConfig;
 import com.palantir.atlasdb.config.AtlasDbConfigs;
 import com.palantir.atlasdb.keyvalue.dbkvs.DbKeyValueServiceConfig;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 import com.palantir.nexus.db.pool.config.ConnectionConfig;
-import org.junit.Test;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.Test;
 
 public class PostgresConfigLoadingTest {
     @Test
@@ -49,8 +48,7 @@ public class PostgresConfigLoadingTest {
     @Test
     public void testInitFailTimeout() throws IOException {
         ConnectionConfig connectionConfig = getConnectionConfig();
-        assertThat(connectionConfig.initializeFailTimeoutMillis())
-                .hasValue(10L);
+        assertThat(connectionConfig.initializeFailTimeoutMillis()).hasValue(10L);
     }
 
     @Test

--- a/atlasdb-dbkvs/src/test/resources/postgresTestConfig.yml
+++ b/atlasdb-dbkvs/src/test/resources/postgresTestConfig.yml
@@ -12,6 +12,7 @@ atlasdb:
       dbPassword: testpassword
       connectionTimeoutSeconds: 5
       socketTimeoutSeconds: 30
+      initializeFailTimeoutMillis: 10
       connectionParameters:
         foo: 100
         bar: baz

--- a/changelog/@unreleased/pr-6174.v2.yml
+++ b/changelog/@unreleased/pr-6174.v2.yml
@@ -1,5 +1,7 @@
 type: improvement
 improvement:
-  description: 'Fix ConnectionConfig#initializeFailTimeoutMillis '
+  description: Makes the `initializeFailTimeoutMillis` method a configurable property
+    of `ConnectionConfig` i.e. `initializeFailTimeoutMillis` can be overridden in
+    `ConnectionConfig`.
   links:
   - https://github.com/palantir/atlasdb/pull/6174

--- a/changelog/@unreleased/pr-6174.v2.yml
+++ b/changelog/@unreleased/pr-6174.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: 'Fix ConnectionConfig#initializeFailTimeoutMillis '
+  links:
+  - https://github.com/palantir/atlasdb/pull/6174


### PR DESCRIPTION
## General
**Before this PR**:
https://github.com/palantir/atlasdb/pull/6140
Did not annotate property with value.default which is why the field was not recognized

**After this PR**:
Fixes that issue

**Priority**:
Before end of week would be good

**Concerns / possible downsides (what feedback would you like?)**:
Up to the client to override with caution.

**Is documentation needed?**:
No

## Compatibility
~**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:~

~**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:~

~**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:~

~**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:~

~**Does this PR need a schema migration?**~

## Testing and Correctness
~**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:~

~**What was existing testing like? What have you done to improve it?**:~

~**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:~

~**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:~

## Execution
~**How would I tell this PR works in production? (Metrics, logs, etc.)**:~

~**Has the safety of all log arguments been decided correctly?**:~

~**Will this change significantly affect our spending on metrics or logs?**:~

**How would I tell that this PR does not work in production? (monitors, etc.)**:
The config flat controls whether the pool will "fail fast" if the Hikari connection pool cannot be seeded with an initial connection successfully.

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Revert config

~**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:~

## Scale
~**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:~

~**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:~

~**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:~

## Development Process
**Where should we start reviewing?**:
ConnectionConfig

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
