### PR TITLE
Intern CassandraServer instances

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeMap;
 import com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer;
+import com.palantir.common.annotations.ImmutablesStyles.WeakInterningImmutablesStyle;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Collection;
@@ -80,7 +81,9 @@ public final class CassandraLogHelper {
                 .collect(Collectors.toList());
     }
 
-    @Value.Immutable
+    // Weakly intern instances as there should be a relatively small, generally fixed number of Cassandra servers.
+    @Value.Immutable(lazyhash = true, intern = true, builder = false)
+    @WeakInterningImmutablesStyle
     interface HostAndIpAddress {
         @Value.Parameter
         String host();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServer.java
@@ -17,12 +17,16 @@
 package com.palantir.atlasdb.keyvalue.cassandra.pool;
 
 import com.google.common.collect.ImmutableSet;
+import com.palantir.common.annotations.ImmutablesStyles.WeakInterningImmutablesStyle;
 import com.palantir.logsafe.Preconditions;
 import java.net.InetSocketAddress;
 import java.util.Set;
 import org.immutables.value.Value;
 
-@Value.Immutable(lazyhash = true)
+// Weakly intern instances as there should be a relatively small, generally fixed number of Cassandra servers.
+// This provides cheaper hashCode and equals checks when CassandraServer is used in collections.
+@Value.Immutable(prehash = true, intern = true, builder = false)
+@WeakInterningImmutablesStyle
 public interface CassandraServer {
     @Value.Parameter
     String cassandraHostName();
@@ -59,9 +63,5 @@ public interface CassandraServer {
 
     static CassandraServer of(String hostName, Set<InetSocketAddress> reachableProxies) {
         return ImmutableCassandraServer.of(hostName, reachableProxies);
-    }
-
-    static ImmutableCassandraServer.Builder builder() {
-        return ImmutableCassandraServer.builder();
     }
 }

--- a/atlasdb-commons/src/main/java/com/palantir/common/annotations/ImmutablesStyles.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/annotations/ImmutablesStyles.java
@@ -21,6 +21,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.immutables.value.Value;
+import org.immutables.value.Value.Style.ImplementationVisibility;
 
 public interface ImmutablesStyles {
     @Target({ElementType.PACKAGE, ElementType.TYPE})
@@ -48,4 +49,9 @@ public interface ImmutablesStyles {
     @Retention(RetentionPolicy.SOURCE)
     @Value.Style(attributeBuilderDetection = true)
     @interface AttributeBuilderDetectionStyle {}
+
+    @Target({ElementType.PACKAGE, ElementType.TYPE})
+    @Retention(RetentionPolicy.SOURCE)
+    @Value.Style(weakInterning = true, overshadowImplementation = true, visibility = ImplementationVisibility.PACKAGE)
+    @interface WeakInterningImmutablesStyle {}
 }

--- a/changelog/@unreleased/pr-6176.v2.yml
+++ b/changelog/@unreleased/pr-6176.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: |-
+    Intern CassandraServer instances
+
+    Weakly intern instances as there should be a relatively small, generally fixed number of Cassandra servers.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6176


### PR DESCRIPTION
## General
**Before this PR**:
`ImmutableCassandraServer` instances are created and used as Set elements & Map keys heavily, and would benefit from canonicalizing as there should be a relatively small, generally fixed number of Cassandra servers.


**After this PR**:
Follow on to #6065 to reduce the number of live `CassandraServer` instances and simplify equals checks to identity equality.
==COMMIT_MSG==
Intern CassandraServer instances

Weakly intern instances as there should be a relatively small, generally fixed number of Cassandra servers.
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
