### PR TITLE
[TimeLock Serialisation] Phase 3b2: Lethargy of the Relentless Dusk (Client Side)

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/TimeLockRequestBatcherProviders.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/TimeLockRequestBatcherProviders.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.config;
 
 import com.palantir.lock.client.LeaderTimeCoalescingBatcher;
 import com.palantir.lock.client.MultiClientCommitTimestampGetter;
+import com.palantir.lock.client.MultiClientTimeLockUnlocker;
 import com.palantir.lock.client.MultiClientTransactionStarter;
 import org.immutables.value.Value;
 
@@ -28,4 +29,6 @@ public interface TimeLockRequestBatcherProviders {
     TimeLockRequestBatcherProvider<MultiClientTransactionStarter> startTransactions();
 
     TimeLockRequestBatcherProvider<MultiClientCommitTimestampGetter> commitTimestamps();
+
+    TimeLockRequestBatcherProvider<MultiClientTimeLockUnlocker> unlock();
 }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/DefaultLockAndTimestampServiceFactory.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/DefaultLockAndTimestampServiceFactory.java
@@ -96,7 +96,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import javax.ws.rs.ClientErrorException;
 

--- a/atlasdb-tests-shared/src/main/java/com/palantir/timelock/paxos/InMemoryTimelockServices.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/timelock/paxos/InMemoryTimelockServices.java
@@ -34,6 +34,7 @@ import com.palantir.conjure.java.serialization.ObjectMappers;
 import com.palantir.lock.LockService;
 import com.palantir.lock.client.CommitTimestampGetter;
 import com.palantir.lock.client.LegacyLeaderTimeGetter;
+import com.palantir.lock.client.LegacyLockTokenUnlocker;
 import com.palantir.lock.client.LockLeaseService;
 import com.palantir.lock.client.NamespacedConjureTimelockServiceImpl;
 import com.palantir.lock.client.RemoteTimelockServiceAdapter;
@@ -165,7 +166,9 @@ public final class InMemoryTimelockServices extends ExternalResource implements 
                 ConjureTimelockResource.jersey(redirectRetryTargeter, _unused -> delegate.getTimelockService());
         namespacedConjureTimelockService = new NamespacedConjureTimelockServiceImpl(conjureTimelockService, client);
         lockLeaseService = LockLeaseService.create(
-                namespacedConjureTimelockService, new LegacyLeaderTimeGetter(namespacedConjureTimelockService));
+                namespacedConjureTimelockService,
+                new LegacyLeaderTimeGetter(namespacedConjureTimelockService),
+                new LegacyLockTokenUnlocker(namespacedConjureTimelockService));
     }
 
     @Override

--- a/lock-api/src/main/java/com/palantir/lock/client/LegacyLockTokenUnlocker.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LegacyLockTokenUnlocker.java
@@ -1,0 +1,41 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.client;
+
+import com.palantir.atlasdb.timelock.api.ConjureLockTokenV2;
+import com.palantir.atlasdb.timelock.api.ConjureUnlockRequestV2;
+import java.util.Set;
+
+public class LegacyLockTokenUnlocker implements LockTokenUnlocker {
+    private final NamespacedConjureTimelockService namespacedConjureTimelockService;
+
+    public LegacyLockTokenUnlocker(NamespacedConjureTimelockService namespacedConjureTimelockService) {
+        this.namespacedConjureTimelockService = namespacedConjureTimelockService;
+    }
+
+    @Override
+    public Set<ConjureLockTokenV2> unlock(Set<ConjureLockTokenV2> tokens) {
+        return namespacedConjureTimelockService
+                .unlockV2(ConjureUnlockRequestV2.of(tokens))
+                .get();
+    }
+
+    @Override
+    public void close() {
+        // no op: nothing to close
+    }
+}

--- a/lock-api/src/main/java/com/palantir/lock/client/LockTokenUnlocker.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockTokenUnlocker.java
@@ -1,0 +1,27 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.client;
+
+import com.palantir.atlasdb.timelock.api.ConjureLockTokenV2;
+import java.util.Set;
+
+public interface LockTokenUnlocker extends AutoCloseable {
+    Set<ConjureLockTokenV2> unlock(Set<ConjureLockTokenV2> tokens);
+
+    @Override
+    void close();
+}

--- a/lock-api/src/main/java/com/palantir/lock/client/NamespacedLockTokenUnlocker.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/NamespacedLockTokenUnlocker.java
@@ -1,0 +1,42 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.client;
+
+import com.palantir.atlasdb.timelock.api.ConjureLockTokenV2;
+import com.palantir.atlasdb.timelock.api.Namespace;
+import java.util.Set;
+
+public class NamespacedLockTokenUnlocker implements LockTokenUnlocker {
+    private final Namespace namespace;
+    private final ReferenceTrackingWrapper<MultiClientTimeLockUnlocker> referenceTrackingBatcher;
+
+    public NamespacedLockTokenUnlocker(
+            String namespace, ReferenceTrackingWrapper<MultiClientTimeLockUnlocker> referenceTrackingBatcher) {
+        this.namespace = Namespace.of(namespace);
+        this.referenceTrackingBatcher = referenceTrackingBatcher;
+    }
+
+    @Override
+    public Set<ConjureLockTokenV2> unlock(Set<ConjureLockTokenV2> tokens) {
+        return referenceTrackingBatcher.getDelegate().unlock(namespace, tokens);
+    }
+
+    @Override
+    public void close() {
+        referenceTrackingBatcher.close();
+    }
+}

--- a/lock-api/src/main/java/com/palantir/lock/client/RemoteTimelockServiceAdapter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/RemoteTimelockServiceAdapter.java
@@ -65,9 +65,10 @@ public final class RemoteTimelockServiceAdapter implements TimelockService, Auto
             NamespacedTimelockRpcClient rpcClient,
             NamespacedConjureTimelockService conjureTimelockService,
             LeaderTimeGetter leaderTimeGetter,
-            RequestBatchersFactory batcherFactory) {
+            RequestBatchersFactory batcherFactory,
+            LockTokenUnlocker unlocker) {
         this.rpcClient = rpcClient;
-        this.lockLeaseService = LockLeaseService.create(conjureTimelockService, leaderTimeGetter);
+        this.lockLeaseService = LockLeaseService.create(conjureTimelockService, leaderTimeGetter, unlocker);
         this.transactionStarter = TransactionStarter.create(lockLeaseService, batcherFactory);
         this.commitTimestampGetter = batcherFactory.createBatchingCommitTimestampGetter(lockLeaseService);
         this.conjureTimelockService = conjureTimelockService;
@@ -82,15 +83,17 @@ public final class RemoteTimelockServiceAdapter implements TimelockService, Auto
                 rpcClient,
                 conjureClient,
                 new LegacyLeaderTimeGetter(conjureClient),
-                RequestBatchersFactory.create(lockWatchCache, namespace, Optional.empty()));
+                RequestBatchersFactory.create(lockWatchCache, namespace, Optional.empty()),
+                new LegacyLockTokenUnlocker(conjureClient));
     }
 
     public static RemoteTimelockServiceAdapter create(
             NamespacedTimelockRpcClient rpcClient,
             NamespacedConjureTimelockService conjureClient,
             LeaderTimeGetter leaderTimeGetter,
-            RequestBatchersFactory batcherFactory) {
-        return new RemoteTimelockServiceAdapter(rpcClient, conjureClient, leaderTimeGetter, batcherFactory);
+            RequestBatchersFactory batcherFactory,
+            LockTokenUnlocker unlocker) {
+        return new RemoteTimelockServiceAdapter(rpcClient, conjureClient, leaderTimeGetter, batcherFactory, unlocker);
     }
 
     @Override

--- a/lock-api/src/test/java/com/palantir/lock/client/LockLeaseServiceTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/LockLeaseServiceTest.java
@@ -93,7 +93,7 @@ public class LockLeaseServiceTest {
             ConjureUnlockRequestV2 request = inv.getArgument(0);
             return ConjureUnlockResponseV2.of(request.get());
         });
-        lockLeaseService = new LockLeaseService(timelock, SERVICE_ID, new LegacyLeaderTimeGetter(timelock));
+        lockLeaseService = new LockLeaseService(timelock, SERVICE_ID, new LegacyLeaderTimeGetter(timelock), unlocker);
     }
 
     @Test

--- a/lock-api/src/test/java/com/palantir/lock/client/LockLeaseServiceTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/LockLeaseServiceTest.java
@@ -93,8 +93,8 @@ public class LockLeaseServiceTest {
             ConjureUnlockRequestV2 request = inv.getArgument(0);
             return ConjureUnlockResponseV2.of(request.get());
         });
-        lockLeaseService = new LockLeaseService(timelock, SERVICE_ID, new LegacyLeaderTimeGetter(timelock),
-                new LegacyLockTokenUnlocker(timelock));
+        lockLeaseService = new LockLeaseService(
+                timelock, SERVICE_ID, new LegacyLeaderTimeGetter(timelock), new LegacyLockTokenUnlocker(timelock));
     }
 
     @Test

--- a/lock-api/src/test/java/com/palantir/lock/client/LockLeaseServiceTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/LockLeaseServiceTest.java
@@ -93,7 +93,8 @@ public class LockLeaseServiceTest {
             ConjureUnlockRequestV2 request = inv.getArgument(0);
             return ConjureUnlockResponseV2.of(request.get());
         });
-        lockLeaseService = new LockLeaseService(timelock, SERVICE_ID, new LegacyLeaderTimeGetter(timelock), unlocker);
+        lockLeaseService = new LockLeaseService(timelock, SERVICE_ID, new LegacyLeaderTimeGetter(timelock),
+                new LegacyLockTokenUnlocker(timelock));
     }
 
     @Test

--- a/lock-api/src/test/java/com/palantir/lock/client/MultiClientTimeLockUnlockerTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/MultiClientTimeLockUnlockerTest.java
@@ -84,7 +84,7 @@ public class MultiClientTimeLockUnlockerTest {
                 BatchElement.of(
                         ImmutableUnlockRequest.of(NAMESPACE_1, ImmutableSet.of(CONJURE_TOKEN_2)), secondResultFuture),
                 BatchElement.of(
-                        ImmutableUnlockRequest.of(NAMESPACE_2, ImmutableSet.of(CONJURE_TOKEN_1, CONJURE_TOKEN_3)),
+                        ImmutableUnlockRequest.of(NAMESPACE_2, ImmutableSet.of(CONJURE_TOKEN_2, CONJURE_TOKEN_3)),
                         thirdResultFuture)));
 
         assertThat(Futures.getUnchecked(firstResultFuture)).containsExactly(CONJURE_TOKEN_1);


### PR DESCRIPTION
## General
**Before this PR**:
It isn't actually feasible to wire up atlasdb proxy to autobatch its unlock requests

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Unlock requests across multiple namespaces in atlasdb proxy can be batched by wiring up user config
==COMMIT_MSG==

**Priority**: P2 ($)

**Concerns / possible downsides (what feedback would you like?)**: User latencies might increase by a bit (but this is order of few millis, not particularly high)

**Is documentation needed?**: Not really

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: Yes - they just won't use the new endpoint

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: Timelock to be at least a given version so that the batch endpoint is supported. But this is only true on atlasdb proxy and not on services in general, so this is not the right place to add a product dependency.

**Does this PR need a schema migration?** No.

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: Not much.

**What was existing testing like? What have you done to improve it?**: I'm relying on the existing tests for the refactored path for Legacy. The more complex implementation already has tests for the most part and will be ETE'd in atlasdb-proxy.

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: No such code

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: No

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: Metrics showing usage of new server-side endpoint

**Has the safety of all log arguments been decided correctly?**: No new logging args

**Will this change significantly affect our spending on metrics or logs?**: No

**How would I tell that this PR does not work in production? (monitors, etc.)**: Standard failure monitors.

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: Rollback.

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**: No.

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**: No.

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**: No, I don't think so.

## Development Process
**Where should we start reviewing?**: NamespacedLockTokenUnlocker. In general, develop or regain familiarity with the existing infrastructure for cross-namespace batching, and then check that this checks the right boxes.

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: No.

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
