### PR TITLE
[PDS-265616] Handle runtime config in migration CLI

### DIFF
--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/AbstractCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/AbstractCommand.java
@@ -64,7 +64,7 @@ public abstract class AbstractCommand implements Callable<Integer> {
             name = {"--runtime-config-root"},
             title = "RUNTIME CONFIG ROOT",
             type = OptionType.GLOBAL,
-            description = "field in the config yaml file that contains the atlasdb configuration root")
+            description = "field in the runtime config yaml file that contains the atlasdb configuration root")
     private String runtimeConfigRoot = AtlasDbConfigs.ATLASDB_CONFIG_OBJECT_PATH;
 
     @Option(

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/KvsMigrationCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/KvsMigrationCommand.java
@@ -204,7 +204,7 @@ public class KvsMigrationCommand implements Callable<Integer> {
 
         AtlasDbRuntimeConfig fromRuntimeConfig = loadFromFile(
                         fromRuntimeConfigFile, runtimeConfigRoot, AtlasDbRuntimeConfig.class)
-                .map(this::disableSweep)
+                .map(KvsMigrationCommand::disableSweep)
                 .orElseGet(AtlasDbRuntimeConfig::withSweepDisabled);
 
         ServicesConfigModule scm = ServicesConfigModule.create(makeOfflineIfNecessary(fromConfig), fromRuntimeConfig);
@@ -218,7 +218,7 @@ public class KvsMigrationCommand implements Callable<Integer> {
 
         AtlasDbRuntimeConfig toRuntimeConfig = loadFromFileOrInline(
                         toRuntimeConfigFile, runtimeConfigRoot, inlineRuntimeConfig, AtlasDbRuntimeConfig.class)
-                .map(this::disableSweep)
+                .map(KvsMigrationCommand::disableSweep)
                 .orElseGet(AtlasDbRuntimeConfig::withSweepDisabled);
         ServicesConfigModule scm = ServicesConfigModule.create(makeOfflineIfNecessary(toConfig), toRuntimeConfig);
         return DaggerAtlasDbServices.builder().servicesConfigModule(scm).build();
@@ -231,14 +231,6 @@ public class KvsMigrationCommand implements Callable<Integer> {
                 .build();
     }
 
-    private AtlasDbRuntimeConfig disableSweep(AtlasDbRuntimeConfig atlasDbRuntimeConfig) {
-        return ImmutableAtlasDbRuntimeConfig.builder()
-                .from(atlasDbRuntimeConfig)
-                .sweep(SweepConfig.disabled())
-                .targetedSweep(TargetedSweepRuntimeConfig.disabled())
-                .build();
-    }
-
     private KeyValueServiceMigrator getMigrator(AtlasDbServices fromServices, AtlasDbServices toServices) {
         return KeyValueServiceMigrators.setupMigrator(ImmutableMigratorSpec.builder()
                 .fromServices(fromServices)
@@ -246,6 +238,14 @@ public class KvsMigrationCommand implements Callable<Integer> {
                 .threads(threads)
                 .batchSize(batchSize)
                 .build());
+    }
+
+    private static AtlasDbRuntimeConfig disableSweep(AtlasDbRuntimeConfig atlasDbRuntimeConfig) {
+        return ImmutableAtlasDbRuntimeConfig.builder()
+                .from(atlasDbRuntimeConfig)
+                .sweep(SweepConfig.disabled())
+                .targetedSweep(TargetedSweepRuntimeConfig.disabled())
+                .build();
     }
 
     private static <K> Optional<K> loadFromFileOrInline(

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/KvsMigrationCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/KvsMigrationCommand.java
@@ -251,15 +251,15 @@ public class KvsMigrationCommand implements Callable<Integer> {
     private static <K> Optional<K> loadFromFileOrInline(
             @Nullable File configFile, String fileConfigRoot, @Nullable String inline, Class<K> clazz) {
         return loadFromFile(configFile, fileConfigRoot, clazz).or(() -> Optional.ofNullable(inline)
-                .map(uncheckedIoException(config -> AtlasDbConfigs.loadFromString(config, null, clazz))));
+                .map(rethrowIoExceptionAsUnchecked(config -> AtlasDbConfigs.loadFromString(config, null, clazz))));
     }
 
     private static <K> Optional<K> loadFromFile(@Nullable File configFile, String fileConfigRoot, Class<K> clazz) {
         return Optional.ofNullable(configFile)
-                .map(uncheckedIoException(file -> AtlasDbConfigs.load(file, fileConfigRoot, clazz)));
+                .map(rethrowIoExceptionAsUnchecked(file -> AtlasDbConfigs.load(file, fileConfigRoot, clazz)));
     }
 
-    private static <F, T, K extends IOException> Function<F, T> uncheckedIoException(
+    private static <F, T, K extends IOException> Function<F, T> rethrowIoExceptionAsUnchecked(
             FunctionCheckedException<F, T, K> function) {
         return f -> {
             try {

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/KvsMigrationCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/KvsMigrationCommand.java
@@ -202,10 +202,9 @@ public class KvsMigrationCommand implements Callable<Integer> {
         AtlasDbConfig fromConfig = overrideTransactionTimeoutMillis(
                 loadFromFile(fromConfigFile, configRoot, AtlasDbConfig.class).orElseThrow());
 
-        AtlasDbRuntimeConfig fromRuntimeConfig = loadFromFile(
-                        fromRuntimeConfigFile, runtimeConfigRoot, AtlasDbRuntimeConfig.class)
-                .map(KvsMigrationCommand::disableSweepAndCompaction)
-                .orElseGet(AtlasDbRuntimeConfig::withSweepDisabled);
+        AtlasDbRuntimeConfig fromRuntimeConfig = disableSweepAndCompaction(
+                loadFromFile(fromRuntimeConfigFile, runtimeConfigRoot, AtlasDbRuntimeConfig.class)
+                        .orElseGet(AtlasDbRuntimeConfig::withSweepDisabled));
 
         ServicesConfigModule scm = ServicesConfigModule.create(makeOfflineIfNecessary(fromConfig), fromRuntimeConfig);
         return DaggerAtlasDbServices.builder().servicesConfigModule(scm).build();
@@ -216,10 +215,9 @@ public class KvsMigrationCommand implements Callable<Integer> {
                         toConfigFile, configRoot, inlineConfig, AtlasDbConfig.class)
                 .orElseThrow(() -> new SafeRuntimeException("At least one of -mc / --inline-config is required")));
 
-        AtlasDbRuntimeConfig toRuntimeConfig = loadFromFileOrInline(
+        AtlasDbRuntimeConfig toRuntimeConfig = disableSweepAndCompaction(loadFromFileOrInline(
                         toRuntimeConfigFile, runtimeConfigRoot, inlineRuntimeConfig, AtlasDbRuntimeConfig.class)
-                .map(KvsMigrationCommand::disableSweepAndCompaction)
-                .orElseGet(AtlasDbRuntimeConfig::withSweepDisabled);
+                .orElseGet(AtlasDbRuntimeConfig::withSweepDisabled));
         ServicesConfigModule scm = ServicesConfigModule.create(makeOfflineIfNecessary(toConfig), toRuntimeConfig);
         return DaggerAtlasDbServices.builder().servicesConfigModule(scm).build();
     }

--- a/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestKvsMigrationCommand.java
+++ b/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestKvsMigrationCommand.java
@@ -71,7 +71,7 @@ public class TestKvsMigrationCommand {
     }
 
     @Test
-    public void loadsRuntimeConfigFromFileWithSweepDisabled() throws URISyntaxException, IOException {
+    public void loadsRuntimeConfigFromFileWithSweepAndCompactionDisabled() throws URISyntaxException, IOException {
         String runtimeFilePath = AbstractTestRunner.getResourcePath(InMemoryTestRunner.RUNTIME_CONFIG_LOCATION);
         String[] commandArgs = new String[] {"-frc", runtimeFilePath, "-mrc", runtimeFilePath};
         KvsMigrationCommand command = getCommand(commandArgs, EMPTY_ARGS);
@@ -83,7 +83,8 @@ public class TestKvsMigrationCommand {
     }
 
     @Test
-    public void loadsInlineRuntimeConfigWithSweepDisabledForToService() throws IOException, URISyntaxException {
+    public void loadsInlineRuntimeConfigWithSweepAndCompactionDisabledForToService()
+            throws IOException, URISyntaxException {
         String[] globalArgs = new String[] {"--inline-runtime-config", RUNTIME_CONFIG};
         KvsMigrationCommand command = getCommand(EMPTY_ARGS, globalArgs);
 
@@ -105,8 +106,8 @@ public class TestKvsMigrationCommand {
     }
 
     @Test
-    public void usesDefaultRuntimeConfigWithDisabledSweepWhenFileNorInlineSpecified() {
-        AtlasDbRuntimeConfig expected = AtlasDbRuntimeConfig.withSweepDisabled();
+    public void usesDefaultRuntimeConfigWithSweepAndCompactionDisabledWhenFileNorInlineSpecified() {
+        AtlasDbRuntimeConfig expected = withDisabledSweepAndCompaction(AtlasDbRuntimeConfig.defaultRuntimeConfig());
 
         assertThat(fromServices.getAtlasDbRuntimeConfig()).isEqualTo(expected);
         assertThat(toServices.getAtlasDbRuntimeConfig()).isEqualTo(expected);

--- a/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestKvsMigrationCommand.java
+++ b/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestKvsMigrationCommand.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ObjectArrays;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cli.runner.AbstractTestRunner;
 import com.palantir.atlasdb.cli.runner.InMemoryTestRunner;
+import com.palantir.atlasdb.compact.CompactorConfig;
 import com.palantir.atlasdb.config.AtlasDbConfigs;
 import com.palantir.atlasdb.config.AtlasDbRuntimeConfig;
 import com.palantir.atlasdb.config.ImmutableAtlasDbRuntimeConfig;
@@ -75,7 +76,7 @@ public class TestKvsMigrationCommand {
         String[] commandArgs = new String[] {"-frc", runtimeFilePath, "-mrc", runtimeFilePath};
         KvsMigrationCommand command = getCommand(commandArgs, EMPTY_ARGS);
 
-        AtlasDbRuntimeConfig expected = withDisabledSweep(loadFromFile());
+        AtlasDbRuntimeConfig expected = withDisabledSweepAndCompaction(loadFromFile());
 
         assertThat(command.connectFromServices().getAtlasDbRuntimeConfig()).isEqualTo(expected);
         assertThat(command.connectToServices().getAtlasDbRuntimeConfig()).isEqualTo(expected);
@@ -86,7 +87,7 @@ public class TestKvsMigrationCommand {
         String[] globalArgs = new String[] {"--inline-runtime-config", RUNTIME_CONFIG};
         KvsMigrationCommand command = getCommand(EMPTY_ARGS, globalArgs);
 
-        AtlasDbRuntimeConfig expected = withDisabledSweep(loadFromString());
+        AtlasDbRuntimeConfig expected = withDisabledSweepAndCompaction(loadFromString());
 
         assertThat(command.connectToServices().getAtlasDbRuntimeConfig()).isEqualTo(expected);
     }
@@ -98,7 +99,7 @@ public class TestKvsMigrationCommand {
         String[] globalArgs = new String[] {"--inline-runtime-config", RUNTIME_CONFIG};
         KvsMigrationCommand command = getCommand(commandArgs, globalArgs);
 
-        AtlasDbRuntimeConfig expected = withDisabledSweep(loadFromFile());
+        AtlasDbRuntimeConfig expected = withDisabledSweepAndCompaction(loadFromFile());
 
         assertThat(command.connectFromServices().getAtlasDbRuntimeConfig()).isEqualTo(expected);
     }
@@ -212,11 +213,12 @@ public class TestKvsMigrationCommand {
         return AtlasDbConfigs.loadFromString(RUNTIME_CONFIG, null, AtlasDbRuntimeConfig.class);
     }
 
-    private static AtlasDbRuntimeConfig withDisabledSweep(AtlasDbRuntimeConfig config) {
+    private static AtlasDbRuntimeConfig withDisabledSweepAndCompaction(AtlasDbRuntimeConfig config) {
         return ImmutableAtlasDbRuntimeConfig.builder()
                 .from(config)
                 .sweep(SweepConfig.disabled())
                 .targetedSweep(TargetedSweepRuntimeConfig.disabled())
+                .compact(CompactorConfig.disabled())
                 .build();
     }
 }

--- a/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestKvsMigrationCommand.java
+++ b/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestKvsMigrationCommand.java
@@ -48,6 +48,8 @@ public class TestKvsMigrationCommand {
             + "  enabled: true\n"
             + "targetedSweep:\n"
             + "  enabled: true\n"
+            + "compact:\n"
+            + "  enableCompaction: true\n"
             + "keyValueService:\n"
             + "  type: cassandra\n"
             + "  servers:\n"

--- a/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestKvsMigrationCommand.java
+++ b/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestKvsMigrationCommand.java
@@ -52,6 +52,7 @@ public class TestKvsMigrationCommand {
             + "  servers:\n"
             + "    - 127.0.0.1:1337\n"
             + "  replicationFactor: 21";
+
     private AtlasDbServices fromServices;
     private AtlasDbServices toServices;
 
@@ -74,7 +75,7 @@ public class TestKvsMigrationCommand {
         String[] commandArgs = new String[] {"-frc", runtimeFilePath, "-mrc", runtimeFilePath};
         KvsMigrationCommand command = getCommand(commandArgs, EMPTY_ARGS);
 
-        AtlasDbRuntimeConfig expected = disableSweep(loadFromFile());
+        AtlasDbRuntimeConfig expected = withDisabledSweep(loadFromFile());
 
         assertThat(command.connectFromServices().getAtlasDbRuntimeConfig()).isEqualTo(expected);
         assertThat(command.connectToServices().getAtlasDbRuntimeConfig()).isEqualTo(expected);
@@ -85,7 +86,7 @@ public class TestKvsMigrationCommand {
         String[] globalArgs = new String[] {"--inline-runtime-config", RUNTIME_CONFIG};
         KvsMigrationCommand command = getCommand(EMPTY_ARGS, globalArgs);
 
-        AtlasDbRuntimeConfig expected = disableSweep(loadFromString());
+        AtlasDbRuntimeConfig expected = withDisabledSweep(loadFromString());
 
         assertThat(command.connectToServices().getAtlasDbRuntimeConfig()).isEqualTo(expected);
     }
@@ -97,7 +98,7 @@ public class TestKvsMigrationCommand {
         String[] globalArgs = new String[] {"--inline-runtime-config", RUNTIME_CONFIG};
         KvsMigrationCommand command = getCommand(commandArgs, globalArgs);
 
-        AtlasDbRuntimeConfig expected = disableSweep(loadFromFile());
+        AtlasDbRuntimeConfig expected = withDisabledSweep(loadFromFile());
 
         assertThat(command.connectFromServices().getAtlasDbRuntimeConfig()).isEqualTo(expected);
     }
@@ -211,7 +212,7 @@ public class TestKvsMigrationCommand {
         return AtlasDbConfigs.loadFromString(RUNTIME_CONFIG, null, AtlasDbRuntimeConfig.class);
     }
 
-    private static AtlasDbRuntimeConfig disableSweep(AtlasDbRuntimeConfig config) {
+    private static AtlasDbRuntimeConfig withDisabledSweep(AtlasDbRuntimeConfig config) {
         return ImmutableAtlasDbRuntimeConfig.builder()
                 .from(config)
                 .sweep(SweepConfig.disabled())

--- a/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestKvsMigrationCommand.java
+++ b/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestKvsMigrationCommand.java
@@ -22,11 +22,18 @@ import com.google.common.collect.ObjectArrays;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cli.runner.AbstractTestRunner;
 import com.palantir.atlasdb.cli.runner.InMemoryTestRunner;
+import com.palantir.atlasdb.config.AtlasDbConfigs;
+import com.palantir.atlasdb.config.AtlasDbRuntimeConfig;
+import com.palantir.atlasdb.config.ImmutableAtlasDbRuntimeConfig;
+import com.palantir.atlasdb.config.SweepConfig;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.services.AtlasDbServices;
+import com.palantir.atlasdb.sweep.queue.config.TargetedSweepRuntimeConfig;
+import java.io.File;
+import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -35,12 +42,22 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class TestKvsMigrationCommand {
+    private static final String[] EMPTY_ARGS = new String[] {};
+    private static final String RUNTIME_CONFIG = "sweep:\n"
+            + "  enabled: true\n"
+            + "targetedSweep:\n"
+            + "  enabled: true\n"
+            + "keyValueService:\n"
+            + "  type: cassandra\n"
+            + "  servers:\n"
+            + "    - 127.0.0.1:1337\n"
+            + "  replicationFactor: 21";
     private AtlasDbServices fromServices;
     private AtlasDbServices toServices;
 
     @Before
     public void setupServices() throws Exception {
-        KvsMigrationCommand cmd = getCommand(new String[] {});
+        KvsMigrationCommand cmd = getCommand(EMPTY_ARGS, EMPTY_ARGS);
         fromServices = cmd.connectFromServices();
         toServices = cmd.connectToServices();
     }
@@ -52,14 +69,45 @@ public class TestKvsMigrationCommand {
     }
 
     @Test
-    public void doesNotSweepDuringMigration() {
-        assertThat(fromServices.getAtlasDbRuntimeConfig().sweep().enabled()).contains(false);
-        assertThat(fromServices.getAtlasDbRuntimeConfig().targetedSweep().enabled())
-                .isFalse();
+    public void loadsRuntimeConfigFromFileWithSweepDisabled() throws URISyntaxException, IOException {
+        String runtimeFilePath = AbstractTestRunner.getResourcePath(InMemoryTestRunner.RUNTIME_CONFIG_LOCATION);
+        String[] commandArgs = new String[] {"-frc", runtimeFilePath, "-mrc", runtimeFilePath};
+        KvsMigrationCommand command = getCommand(commandArgs, EMPTY_ARGS);
 
-        assertThat(toServices.getAtlasDbRuntimeConfig().sweep().enabled()).contains(false);
-        assertThat(toServices.getAtlasDbRuntimeConfig().targetedSweep().enabled())
-                .isFalse();
+        AtlasDbRuntimeConfig expected = disableSweep(loadFromFile());
+
+        assertThat(command.connectFromServices().getAtlasDbRuntimeConfig()).isEqualTo(expected);
+        assertThat(command.connectToServices().getAtlasDbRuntimeConfig()).isEqualTo(expected);
+    }
+
+    @Test
+    public void loadsInlineRuntimeConfigWithSweepDisabledForToService() throws IOException, URISyntaxException {
+        String[] globalArgs = new String[] {"--inline-runtime-config", RUNTIME_CONFIG};
+        KvsMigrationCommand command = getCommand(EMPTY_ARGS, globalArgs);
+
+        AtlasDbRuntimeConfig expected = disableSweep(loadFromString());
+
+        assertThat(command.connectToServices().getAtlasDbRuntimeConfig()).isEqualTo(expected);
+    }
+
+    @Test
+    public void loadsFileRuntimeConfigWhenBothInlineAndFileAreSpecified() throws URISyntaxException, IOException {
+        String runtimeFilePath = AbstractTestRunner.getResourcePath(InMemoryTestRunner.RUNTIME_CONFIG_LOCATION);
+        String[] commandArgs = new String[] {"-frc", runtimeFilePath, "-mrc", runtimeFilePath};
+        String[] globalArgs = new String[] {"--inline-runtime-config", RUNTIME_CONFIG};
+        KvsMigrationCommand command = getCommand(commandArgs, globalArgs);
+
+        AtlasDbRuntimeConfig expected = disableSweep(loadFromFile());
+
+        assertThat(command.connectFromServices().getAtlasDbRuntimeConfig()).isEqualTo(expected);
+    }
+
+    @Test
+    public void usesDefaultRuntimeConfigWithDisabledSweepWhenFileNorInlineSpecified() {
+        AtlasDbRuntimeConfig expected = AtlasDbRuntimeConfig.withSweepDisabled();
+
+        assertThat(fromServices.getAtlasDbRuntimeConfig()).isEqualTo(expected);
+        assertThat(toServices.getAtlasDbRuntimeConfig()).isEqualTo(expected);
     }
 
     @Test
@@ -95,10 +143,11 @@ public class TestKvsMigrationCommand {
         checkKvs(toServices, 10, 257);
     }
 
-    private KvsMigrationCommand getCommand(String[] args) throws URISyntaxException {
+    private KvsMigrationCommand getCommand(String[] commandArgs, String[] globalArgs) throws URISyntaxException {
         String filePath = AbstractTestRunner.getResourcePath(InMemoryTestRunner.CONFIG_LOCATION);
         String[] initArgs = new String[] {"migrate", "-fc", filePath, "-mc", filePath};
-        String[] fullArgs = ObjectArrays.concat(initArgs, args, String.class);
+        String[] fullArgs =
+                ObjectArrays.concat(globalArgs, ObjectArrays.concat(initArgs, commandArgs, String.class), String.class);
         return AbstractTestRunner.buildCommand(KvsMigrationCommand.class, fullArgs);
     }
 
@@ -107,7 +156,7 @@ public class TestKvsMigrationCommand {
     }
 
     private int runWithOptions(String... args) throws URISyntaxException {
-        KvsMigrationCommand command = getCommand(args);
+        KvsMigrationCommand command = getCommand(args, EMPTY_ARGS);
         return command.execute(fromServices, toServices);
     }
 
@@ -149,5 +198,24 @@ public class TestKvsMigrationCommand {
 
     private static TableReference getTableRef(int number) {
         return TableReference.create(Namespace.create("ns"), "table" + number);
+    }
+
+    private static AtlasDbRuntimeConfig loadFromFile() throws URISyntaxException, IOException {
+        return AtlasDbConfigs.load(
+                new File(AbstractTestRunner.getResourcePath(InMemoryTestRunner.RUNTIME_CONFIG_LOCATION)),
+                AtlasDbConfigs.ATLASDB_CONFIG_OBJECT_PATH,
+                AtlasDbRuntimeConfig.class);
+    }
+
+    private static AtlasDbRuntimeConfig loadFromString() throws IOException {
+        return AtlasDbConfigs.loadFromString(RUNTIME_CONFIG, null, AtlasDbRuntimeConfig.class);
+    }
+
+    private static AtlasDbRuntimeConfig disableSweep(AtlasDbRuntimeConfig config) {
+        return ImmutableAtlasDbRuntimeConfig.builder()
+                .from(config)
+                .sweep(SweepConfig.disabled())
+                .targetedSweep(TargetedSweepRuntimeConfig.disabled())
+                .build();
     }
 }

--- a/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/runner/InMemoryTestRunner.java
+++ b/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/runner/InMemoryTestRunner.java
@@ -21,6 +21,7 @@ import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 public class InMemoryTestRunner extends AbstractTestRunner {
 
     public static final String CONFIG_LOCATION = "cli_test_config.yml";
+    public static final String RUNTIME_CONFIG_LOCATION = "cli_test_runtime_config.yml";
 
     public InMemoryTestRunner(Class<? extends SingleBackendCommand> cmdClass, String... args) {
         super(cmdClass, args);

--- a/atlasdb-cli/src/test/resources/cli_test_runtime_config.yml
+++ b/atlasdb-cli/src/test/resources/cli_test_runtime_config.yml
@@ -11,6 +11,8 @@ atlasdb:
     enabled: true
   targetedSweep:
     enabled: true
+  compact:
+    enableCompaction: true
   keyValueService:
     type: cassandra
     servers:

--- a/atlasdb-cli/src/test/resources/cli_test_runtime_config.yml
+++ b/atlasdb-cli/src/test/resources/cli_test_runtime_config.yml
@@ -1,0 +1,18 @@
+server:
+  applicationConnectors:
+    - type: http
+      port: 3828
+  adminConnectors:
+    - type: http
+      port: 3829
+
+atlasdb:
+  sweep:
+    enabled: true
+  targetedSweep:
+    enabled: true
+  keyValueService:
+    type: cassandra
+    servers:
+      - 127.0.0.1:1337
+    replicationFactor: 3

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/compact/CompactorConfig.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/compact/CompactorConfig.java
@@ -79,4 +79,9 @@ public interface CompactorConfig {
     static CompactorConfig defaultCompactorConfig() {
         return ImmutableCompactorConfig.builder().build();
     }
+
+    static CompactorConfig disabled() {
+        // Explicitly disabled compaction in case default ever changes.
+        return ImmutableCompactorConfig.builder().enableCompaction(false).build();
+    }
 }

--- a/changelog/@unreleased/pr-6186.v2.yml
+++ b/changelog/@unreleased/pr-6186.v2.yml
@@ -1,0 +1,10 @@
+type: improvement
+improvement:
+  description: AtlasDB CLI Migrate command supports optional `-frc / --fromRuntimeConfig`
+    and `-mrc / --migrateRuntimeConfig` for specifying the runtime config file path
+    for the initial and target KVSs. The optional `--inline-runtime-config` command
+    allows for specifying the runtime config as a string for the initial KVS, and
+    the optional `--runtime-config-root` command allows for specifying the config
+    root within the file.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6186

--- a/docs/source/cluster_management/kvs-migration.rst
+++ b/docs/source/cluster_management/kvs-migration.rst
@@ -136,7 +136,7 @@ Setup
 
 .. code-block:: bash
 
-     ./bin/atlasdb-cli --offline migrate --fromConfig from.yml --migrateConfig to.yml --setup
+     ./bin/atlasdb-cli --offline migrate --fromConfig from.yml [--fromRuntimeConfig fromRuntime.yml] --migrateConfig to.yml [--migrateRuntimeConfig toRuntime.yml] --setup
 
 Running this command will prepare the target KVS for the migration.
 The CLI will first **drop all tables in the target KVS** except atomic tables and Cassandra hidden tables.
@@ -148,7 +148,7 @@ Migrate
 
 .. code-block:: bash
 
-     ./bin/atlasdb-cli --offline migrate --fromConfig from.yml --migrateConfig to.yml --migrate
+     ./bin/atlasdb-cli --offline migrate --fromConfig from.yml [--fromRuntimeConfig fromRuntime.yml] --migrateConfig to.yml [--migrateRuntimeConfig toRuntime.yml] --migrate
 
 Running this command will migrate the actual data from source KVS to target KVS.
 For each table in the source KVS that is not in the list of special tables above, the entire table is transactionally
@@ -172,7 +172,7 @@ Validate
 
 .. code-block:: bash
 
-     ./bin/atlasdb-cli --offline migrate --fromConfig from.yml --migrateConfig to.yml --validate
+     ./bin/atlasdb-cli --offline migrate --fromConfig from.yml [--fromRuntimeConfig fromRuntime.yml] --migrateConfig to.yml [--migrateRuntimeConfig toRuntime.yml] --validate
 
 Running this command will validate the correctness of the migration.
 For each table in the source KVS that can be migrated, except the legacy sweep priority tables, the table is


### PR DESCRIPTION
## General
**Before this PR**:
Runtime config was not supported by the migration command in the AtlasDB CLI. As services migrate over to specifying servers and replicationFactor in the runtime config, this causes the CLI to not work without manual intervention (copying from runtime to install config temporarily)

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
AtlasDB CLI Migrate command supports optional `-frc / --fromRuntimeConfig` and `-mrc / --migrateRuntimeConfig` for specifying the runtime config file path for the initial and target KVSs. The optional `--inline-runtime-config` command allows for specifying the runtime config as a string for the initial KVS, and the optional `--runtime-config-root` command allows for specifying the config root within the file.
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**:
N/A
**Is documentation needed?**:
Yes, added, and will update other docs outside this repo 

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
N/A
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
N/A
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
None
**What was existing testing like? What have you done to improve it?**:
Added more comprehensive tests to show the order of precedence for runtime config sources, and that sweep remains disabled.

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Operators do not complain
**Has the safety of all log arguments been decided correctly?**:
N/A
**Will this change significantly affect our spending on metrics or logs?**:
N/A
**How would I tell that this PR does not work in production? (monitors, etc.)**:
Operators will complain
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Don't use the new parameters / use an older version of the CLI
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
N/A
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
N/A
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
N/A
## Development Process
**Where should we start reviewing?**:
P2 priority

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
N/A

**Please tag any other people who should be aware of this PR**:
N/A

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
