### PR TITLE
Replace linked lists with array lists

### DIFF
--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -47,6 +47,7 @@ dependencies {
   implementation 'com.palantir.tritium:tritium-metrics'
   implementation 'com.palantir.tritium:tritium-registry'
   implementation 'io.dropwizard.metrics:metrics-core'
+  implementation 'one.util:streamex'
   implementation 'org.apache.commons:commons-lang3'
   implementation 'org.apache.thrift:libthrift'
   implementation 'org.slf4j:slf4j-api'

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -661,7 +661,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             final CassandraServer host, final TableReference tableRef, final List<byte[]> rows, final long startTs)
             throws Exception {
 
-        ListMultimap<ByteBuffer, ColumnOrSuperColumn> result = ArrayListMultimap.create();
+        ListMultimap<ByteBuffer, ColumnOrSuperColumn> result = ArrayListMultimap.create(rows.size(), 1);
 
         List<KeyPredicate> query = rows.stream()
                 .map(row -> keyPredicate(

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -19,13 +19,13 @@ import com.datastax.driver.core.exceptions.DriverInternalError;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Functions;
 import com.google.common.base.Predicates;
+import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
-import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -135,6 +135,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
+import one.util.streamex.EntryStream;
 import org.apache.cassandra.thrift.CASResult;
 import org.apache.cassandra.thrift.CfDef;
 import org.apache.cassandra.thrift.Column;
@@ -660,7 +661,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             final CassandraServer host, final TableReference tableRef, final List<byte[]> rows, final long startTs)
             throws Exception {
 
-        final ListMultimap<ByteBuffer, ColumnOrSuperColumn> result = LinkedListMultimap.create();
+        ListMultimap<ByteBuffer, ColumnOrSuperColumn> result = ArrayListMultimap.create();
 
         List<KeyPredicate> query = rows.stream()
                 .map(row -> keyPredicate(
@@ -669,17 +670,10 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                 .collect(Collectors.toList());
 
         while (!query.isEmpty()) {
-            ListMultimap<ByteBuffer, ColumnOrSuperColumn> partialResult = KeyedStream.stream(
-                            getForKeyPredicates(host, tableRef, query, startTs))
-                    .filter(cells -> !cells.isEmpty())
-                    .flatMap(Collection::stream)
-                    .collectToMultimap(LinkedListMultimap::create);
-
-            result.putAll(partialResult);
-
-            query = KeyedStream.stream(Multimaps.asMap(partialResult))
-                    .map((row, cells) -> keyPredicate(row, getNextLexicographicalSlicePredicate(cells)))
-                    .values()
+            query = EntryStream.of(getForKeyPredicates(host, tableRef, query, startTs))
+                    .filterValues(cells -> !cells.isEmpty())
+                    .peekKeyValue(result::putAll)
+                    .mapKeyValue((row, cells) -> keyPredicate(row, getNextLexicographicalSlicePredicate(cells)))
                     .collect(Collectors.toList());
         }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -20,12 +20,12 @@ import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
-import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
@@ -685,7 +685,7 @@ public class SerializableTransaction extends SnapshotTransaction {
             Map<ByteBuffer, ConcurrentMap<BatchColumnRangeSelection, byte[]>> columnRangeEnds =
                     tableAndColumnRangeEnds.getValue();
 
-            Multimap<BatchColumnRangeSelection, byte[]> rangesToRows = LinkedListMultimap.create();
+            Multimap<BatchColumnRangeSelection, byte[]> rangesToRows = ArrayListMultimap.create();
             for (Map.Entry<ByteBuffer, ConcurrentMap<BatchColumnRangeSelection, byte[]>> rowAndRangeEnds :
                     columnRangeEnds.entrySet()) {
                 byte[] row = rowAndRangeEnds.getKey().array();

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -149,7 +149,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -1349,9 +1348,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
 
         getCounter(AtlasDbMetricNames.SNAPSHOT_TRANSACTION_CELLS_READ, tableRef).inc(rawResults.size());
 
-        // LinkedList is chosen for fast append operation since we just add to this collection.
-        @SuppressWarnings("JdkObsolete")
-        Collection<Map.Entry<Cell, T>> resultsAccumulator = new LinkedList<>();
+        Collection<Map.Entry<Cell, T>> resultsAccumulator = new ArrayList<>();
 
         if (AtlasDbConstants.HIDDEN_TABLES.contains(tableRef)) {
             Preconditions.checkState(allowHiddenTableAccess, "hidden tables cannot be read in this transaction");


### PR DESCRIPTION
## Before this PR
AtlasDB uses linked lists in a couple places.

I noticed this while analyzing a heap dump from an OOM of one of our highest volume services due to a request that read a large amount of data. This service was running with 4GB of heap memory and `LinkedListMultimap$Node` has one of the highest amounts of shallow heap at 272 MB.

![Screen Shot 2022-08-12 at 11 16 52 AM](https://user-images.githubusercontent.com/5273164/184419970-bc8588fd-9160-4804-ba99-05b5166f8539.png)

## After this PR
AtlasDB uses array lists instead of linked lists.

There is almost no good reason to use linked lists. Linked lists are much worse for CPU caches and require more memory allocation because of the need to allocate nodes. The amortized constant append costs of an array list are sufficient in almost every case.