### PR TITLE
[PDS-265616] Prevent NotInitializedExceptions from failing the AtlasDB CLI

### DIFF
--- a/atlasdb-dagger/build.gradle
+++ b/atlasdb-dagger/build.gradle
@@ -28,6 +28,9 @@ dependencies {
   annotationProcessor 'org.immutables:value'
   compileOnly 'org.immutables:value::annotations'
 
+  testImplementation 'org.mockito:mockito-core'
+  testImplementation 'org.assertj:assertj-core'
+
   shadow project(':atlasdb-service')
 }
 

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/KeyValueServiceModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/KeyValueServiceModule.java
@@ -53,14 +53,14 @@ public class KeyValueServiceModule {
     @Singleton
     @Named("kvs")
     public KeyValueService provideWrappedKeyValueService(
-            @Named("rawKvs") KeyValueService rawKvs,
+            @Named("initializedRawKvs") KeyValueService initializedRawKvs,
             TimestampService tss,
             ServicesConfig config,
             MetricsManager metricsManager) {
         config.adapter().setTimestampService(tss);
 
         KvsProfilingLogger.setSlowLogThresholdMillis(config.atlasDbConfig().getKvsSlowLogThresholdMillis());
-        KeyValueService kvs = ProfilingKeyValueService.create(rawKvs);
+        KeyValueService kvs = ProfilingKeyValueService.create(initializedRawKvs);
 
         kvs = TracingKeyValueService.create(kvs);
         kvs = AtlasDbMetrics.instrument(metricsManager.getRegistry(), KeyValueService.class, kvs);

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/RawKeyValueServiceModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/RawKeyValueServiceModule.java
@@ -68,6 +68,8 @@ public class RawKeyValueServiceModule {
                 TimeUnit.MILLISECONDS);
         future.whenComplete((_result, _thrown) -> {
             scheduledFuture.cancel(true);
+            // Neither complete, completeExceptionally, nor cancel will throw an InterruptedException when the
+            // interrupt flag is set. Thus, even if cancel sets the interrupt flag, we'll get to the shutdown call.
             executor.shutdown();
         });
         return future;

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/RawKeyValueServiceModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/RawKeyValueServiceModule.java
@@ -17,18 +17,56 @@ package com.palantir.atlasdb.services;
 
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.util.MetricsManager;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
 import dagger.Module;
 import dagger.Provides;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
 @Module
 public class RawKeyValueServiceModule {
+    private static final SafeLogger log = SafeLoggerFactory.get(RawKeyValueServiceModule.class);
+    private static final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+    private static final int DELAY_BETWEEN_INITIALIZATION_CHECKS_MILLIS = 100;
 
     @Provides
     @Singleton
     @Named("rawKvs")
     public KeyValueService provideRawKeyValueService(ServicesConfig config, MetricsManager metricsManager) {
         return config.atlasDbSupplier(metricsManager).getKeyValueService();
+    }
+
+    @Provides
+    @Singleton
+    @Named("initializedRawKvs")
+    public KeyValueService provideInitializedRawKeyValueService(@Named("rawKvs") KeyValueService rawKeyValueService) {
+        return transformToFuture(rawKeyValueService).join();
+    }
+
+    private CompletableFuture<KeyValueService> transformToFuture(KeyValueService keyValueService) {
+        CompletableFuture<KeyValueService> future = new CompletableFuture<>();
+        ScheduledFuture<?> scheduledFuture = executor.scheduleAtFixedRate(
+                () -> {
+                    try {
+                        if (keyValueService.isInitialized()) {
+                            future.complete(keyValueService);
+                        } else {
+                            log.info("Waiting for KeyValueService to initialize");
+                        }
+                    } catch (Exception e) {
+                        future.completeExceptionally(e);
+                    }
+                },
+                0,
+                DELAY_BETWEEN_INITIALIZATION_CHECKS_MILLIS,
+                TimeUnit.MILLISECONDS);
+        future.whenComplete((_result, _thrown) -> scheduledFuture.cancel(true));
+        return future;
     }
 }

--- a/atlasdb-dagger/src/test/java/com/palantir/atlasdb/services/RawKeyValueServiceModuleTest.java
+++ b/atlasdb-dagger/src/test/java/com/palantir/atlasdb/services/RawKeyValueServiceModuleTest.java
@@ -1,0 +1,51 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RawKeyValueServiceModuleTest {
+
+    @Mock
+    KeyValueService keyValueService;
+
+    @Test
+    public void provideInitializedRawKeyValueServiceProvidesInitializedKeyValueService() {
+        when(keyValueService.isInitialized()).thenReturn(false, false, false, true);
+        KeyValueService result = new RawKeyValueServiceModule().provideInitializedRawKeyValueService(keyValueService);
+        assertThat(result.isInitialized()).isTrue();
+    }
+
+    @Test
+    public void provideInitializedRawKeyValueServicePropagatesException() {
+        when(keyValueService.isInitialized()).thenReturn(false);
+        when(keyValueService.isInitialized()).thenThrow(new SafeIllegalStateException("test"));
+        assertThatThrownBy(() -> new RawKeyValueServiceModule().provideInitializedRawKeyValueService(keyValueService))
+                .hasRootCauseInstanceOf(SafeIllegalStateException.class)
+                .hasRootCauseMessage("test");
+    }
+}

--- a/atlasdb-dagger/src/test/java/com/palantir/atlasdb/services/RawKeyValueServiceModuleTest.java
+++ b/atlasdb-dagger/src/test/java/com/palantir/atlasdb/services/RawKeyValueServiceModuleTest.java
@@ -42,8 +42,7 @@ public class RawKeyValueServiceModuleTest {
 
     @Test
     public void provideInitializedRawKeyValueServicePropagatesException() {
-        when(keyValueService.isInitialized()).thenReturn(false);
-        when(keyValueService.isInitialized()).thenThrow(new SafeIllegalStateException("test"));
+        when(keyValueService.isInitialized()).thenReturn(false).thenThrow(new SafeIllegalStateException("test"));
         assertThatThrownBy(() -> new RawKeyValueServiceModule().provideInitializedRawKeyValueService(keyValueService))
                 .hasRootCauseInstanceOf(SafeIllegalStateException.class)
                 .hasRootCauseMessage("test");

--- a/changelog/@unreleased/pr-6188.v2.yml
+++ b/changelog/@unreleased/pr-6188.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: AtlasDB CLI and other Dagger AtlasDB consumers no longer throw `NotInitializedException`
+    when KVS async initialization is enabled.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6188


### PR DESCRIPTION
## General
**Before this PR**:
AtlasDB CLI could fail if KVS async initialization is enabled, _and_ the KVS is used before it is initialized.

This is because use throws a NotInitializedException, which is fatal.
**After this PR**:
The Dagger service used by the CLI actually performs some createTable operations, before returning the KVS. This PR ensures that the KVS is initialized before the kvs wrapper performs operations.

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
AtlasDB CLI and other Dagger AtlasDB consumers no longer throw `NotInitializedException` when KVS async initialization is enabled. 
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**:
Is there a nicer way to wait on the initialization?
Could we just change the standard rawKvs provider to wait for initialization, without needing a second provider? I didn't find a use for the Dagger module outside of the CLI. The approach taken in this PR is safer, since it's not a break, but doesn't clean up tech debt.

**Is documentation needed?**:
No

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
That existing Dagger consumers of the wrapped kvs want an initialized version.
That KVSs eventually initialize.

**What was existing testing like? What have you done to improve it?**:
Previously, there was very very little. For this PR, I've added tests to show that the new provider returns an initialized KVS, and propagates exceptions during the isInitialized check.

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
Wouldn't say it is complex...

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Operators do not complain
**Has the safety of all log arguments been decided correctly?**:
N/A
**Will this change significantly affect our spending on metrics or logs?**:
N/A
**How would I tell that this PR does not work in production? (monitors, etc.)**:
Operators will complain
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Switch off initializeAsync.

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
N/A
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
N/A
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
N/A
## Development Process
**Where should we start reviewing?**:
P2 priority

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
N/A

**Please tag any other people who should be aware of this PR**:
N/A


<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
