### PR TITLE
CoalescingBatchingEventHandler uses Map<T, Set<DisruptorFuture<R>>>

### DIFF
--- a/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/CoalescingBatchingEventHandler.java
+++ b/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/CoalescingBatchingEventHandler.java
@@ -54,8 +54,9 @@ final class CoalescingBatchingEventHandler<T, R> implements EventHandler<BatchEl
         try {
             Map<T, R> results = function.apply(pending.keySet());
             pending.forEach((argument, futures) -> futures.forEach(future -> {
-                if (results.containsKey(argument)) {
-                    future.set(results.get(argument));
+                R result = results.get(argument);
+                if (result != null || results.containsKey(argument)) {
+                    future.set(result);
                 } else {
                     log.warn(
                             "Coalescing function has violated coalescing function postcondition",

--- a/changelog/@unreleased/pr-6194.v2.yml
+++ b/changelog/@unreleased/pr-6194.v2.yml
@@ -1,0 +1,9 @@
+type: improvement
+improvement:
+  description: |-
+    CoalescingBatchingEventHandler uses Map<T, Set<DisruptorFuture<R>>>
+
+    Flush avoids expensive AbstractMapBasedMultimap.clear() that iterates
+    and clears each value collection.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6194


### PR DESCRIPTION
## General
**Before this PR**:
A JFR from  an AtlasDB heavy service ⛷️ ⛰️  was observed spending significant time iterating through `HashMultimap` value collections via `CoalescingBatchingEventHandler.flush()`. This is due to [`AbstractMapBasedMultimap.clear()` that clears each value collection](https://github.com/google/guava/blob/4312d949967f3fb245636f66437a00dd8c346d38/guava/src/com/google/common/collect/AbstractMapBasedMultimap.java#L274-L277). 

Since the batch handler is on a hot code path and the value collections are not exposed to consumers, we can safely avoid this overhead by using a `Map<T, Set<DisruptorFuture<R>>>` instead of `SetMultimap<T, DisruptorFuture<R>>`

Note that the JFR profile in this case may have some sampling bias as it does not enable `DebugNonSafepoints` per https://github.com/palantir/sls-packaging/pull/1376

![image](https://user-images.githubusercontent.com/54594/185982288-36987e6d-94c1-416c-8728-18b0ab0580d4.png)


**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
CoalescingBatchingEventHandler uses Map<T, Set<DisruptorFuture<R>>>

Flush avoids expensive AbstractMapBasedMultimap.clear() that iterates
and clears each value collection.
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**: 
Code is slightly more complex

**Is documentation needed?**: no

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
no

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
no

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
no

**Does this PR need a schema migration?**
no

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
