### PR TITLE
PDS-293560: Handle TableMappingNotFoundException

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/common/base/Throwables.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/base/Throwables.java
@@ -76,7 +76,7 @@ public final class Throwables {
     /**
      *  Returns true iff an exception of type causeClass exists somewhere in the causal chain.
      */
-    public static <T extends Throwable> boolean hasCause(T throwable, Class<? extends T> causeClass) {
+    public static <T extends Throwable> boolean hasCauseInCausalChain(T throwable, Class<? extends T> causeClass) {
         return com.google.common.base.Throwables.getCausalChain(throwable).stream()
                 .anyMatch(causeClass::isInstance);
     }

--- a/atlasdb-commons/src/main/java/com/palantir/common/base/Throwables.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/base/Throwables.java
@@ -73,6 +73,14 @@ public final class Throwables {
         return throwable;
     }
 
+    /**
+     *  Returns true iff an exception of type causeClass exists somewhere in the causal chain.
+     */
+    public static <T extends Throwable> boolean hasCause(T throwable, Class<? extends T> causeClass) {
+        return com.google.common.base.Throwables.getCausalChain(throwable).stream()
+                .anyMatch(causeClass::isInstance);
+    }
+
     private static String extractMessageSafely(Throwable ex) {
         if (ex instanceof SafeLoggable) {
             return ((SafeLoggable) ex).getLogMessage();

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Scrubber.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Scrubber.java
@@ -75,6 +75,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import javax.annotation.concurrent.GuardedBy;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 /**
  * Scrubs individuals cells on-demand.
@@ -574,7 +575,10 @@ public class Scrubber {
         try {
             return tryScrubBatchOfCells(txManager, scrubTimestamp, transactionType, tableRef, cells);
         } catch (IllegalArgumentException ex) {
-            if (ex.getCause() instanceof TableMappingNotFoundException) {
+            // This won't work with Cassandra, but we consider this acceptable because the Scrubber is generally
+            // not used with Cassandra - note that we don't have access to the "table not found" exception currently
+            // thrown by thrift here.
+            if (ExceptionUtils.hasCause(ex, TableMappingNotFoundException.class)) {
                 // The table was deleted from under us - ignore this case.
                 log.info(
                         "Caught a TableMappingNotFoundException during scrubbing. This means that "

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Scrubber.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Scrubber.java
@@ -577,7 +577,7 @@ public class Scrubber {
             // This won't work with Cassandra, but we consider this acceptable because the Scrubber is generally
             // not used with Cassandra - note that we don't have access to the "table not found" exception currently
             // thrown by thrift here.
-            if (Throwables.hasCause(ex, TableMappingNotFoundException.class)) {
+            if (Throwables.hasCauseInCausalChain(ex, TableMappingNotFoundException.class)) {
                 // The table was deleted from under us - ignore this case.
                 log.info(
                         "Caught a TableMappingNotFoundException during scrubbing. This means that "

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Scrubber.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Scrubber.java
@@ -75,7 +75,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import javax.annotation.concurrent.GuardedBy;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 
 /**
  * Scrubs individuals cells on-demand.
@@ -578,7 +577,7 @@ public class Scrubber {
             // This won't work with Cassandra, but we consider this acceptable because the Scrubber is generally
             // not used with Cassandra - note that we don't have access to the "table not found" exception currently
             // thrown by thrift here.
-            if (ExceptionUtils.hasCause(ex, TableMappingNotFoundException.class)) {
+            if (Throwables.hasCause(ex, TableMappingNotFoundException.class)) {
                 // The table was deleted from under us - ignore this case.
                 log.info(
                         "Caught a TableMappingNotFoundException during scrubbing. This means that "

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/cleaner/ScrubberTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/cleaner/ScrubberTest.java
@@ -116,21 +116,7 @@ public class ScrubberTest {
         Cell cell3 = Cell.create(new byte[] {3}, new byte[] {4});
         TableReference tableRef = TableReference.createFromFullyQualifiedName("foo.bar");
         kvs.createTable(tableRef, new byte[] {});
-        kvs.putWithTimestamps(
-                tableRef,
-                ImmutableMultimap.<Cell, Value>builder()
-                        .put(cell1, Value.create(new byte[] {3}, 10))
-                        .put(cell1, Value.create(new byte[] {4}, 20))
-                        .put(cell2, Value.create(new byte[] {4}, 30))
-                        .put(cell2, Value.create(new byte[] {5}, 40))
-                        .put(cell2, Value.create(new byte[] {6}, 50))
-                        .put(cell3, Value.create(new byte[] {7}, 60))
-                        .build());
-        transactions.putUnlessExists(10, 15);
-        transactions.putUnlessExists(20, 25);
-        transactions.putUnlessExists(30, 35);
-        transactions.putUnlessExists(50, 55);
-        transactions.putUnlessExists(60, 65);
+        putValues(tableRef, cell1, cell2, cell3);
         scrubStore.queueCellsForScrubbing(ImmutableMultimap.of(cell1, tableRef), 10, 100);
         scrubStore.queueCellsForScrubbing(ImmutableMultimap.of(cell1, tableRef), 20, 100);
         scrubStore.queueCellsForScrubbing(ImmutableMultimap.of(cell2, tableRef), 40, 100);
@@ -150,6 +136,21 @@ public class ScrubberTest {
         Cell cell3 = Cell.create(new byte[] {3}, new byte[] {4});
         TableReference tableRef = TableReference.createFromFullyQualifiedName("foo.bar");
         kvs.createTable(tableRef, new byte[] {});
+        putValues(tableRef, cell1, cell2, cell3);
+        scrubStore.queueCellsForScrubbing(ImmutableMultimap.of(cell1, tableRef), 20, 100);
+        scrubStore.queueCellsForScrubbing(ImmutableMultimap.of(cell2, tableRef), 50, 100);
+        scrubStore.queueCellsForScrubbing(ImmutableMultimap.of(cell3, tableRef), 60, 100);
+
+        kvs.dropTable(tableRef);
+
+        scrubber.runBackgroundScrubTask(null);
+
+        List<SortedMap<Long, Multimap<TableReference, Cell>>> scrubQueue =
+                BatchingVisitables.copyToList(scrubStore.getBatchingVisitableScrubQueue(Long.MAX_VALUE, null, null));
+        assertThat(scrubQueue).isEmpty();
+    }
+
+    private void putValues(TableReference tableRef, Cell cell1, Cell cell2, Cell cell3) {
         kvs.putWithTimestamps(
                 tableRef,
                 ImmutableMultimap.<Cell, Value>builder()
@@ -165,17 +166,6 @@ public class ScrubberTest {
         transactions.putUnlessExists(30, 35);
         transactions.putUnlessExists(50, 55);
         transactions.putUnlessExists(60, 65);
-        scrubStore.queueCellsForScrubbing(ImmutableMultimap.of(cell1, tableRef), 20, 100);
-        scrubStore.queueCellsForScrubbing(ImmutableMultimap.of(cell2, tableRef), 50, 100);
-        scrubStore.queueCellsForScrubbing(ImmutableMultimap.of(cell3, tableRef), 60, 100);
-
-        kvs.dropTable(tableRef);
-
-        scrubber.runBackgroundScrubTask(null);
-
-        List<SortedMap<Long, Multimap<TableReference, Cell>>> scrubQueue =
-                BatchingVisitables.copyToList(scrubStore.getBatchingVisitableScrubQueue(Long.MAX_VALUE, null, null));
-        assertThat(scrubQueue).isEmpty();
     }
 
     private Scrubber getScrubber(

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/cleaner/ScrubberTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/cleaner/ScrubberTest.java
@@ -143,6 +143,41 @@ public class ScrubberTest {
         assertThat(scrubQueue).isEmpty();
     }
 
+    @Test
+    public void scrubberIsResilientToTableDeletion() {
+        Cell cell1 = Cell.create(new byte[] {1}, new byte[] {2});
+        Cell cell2 = Cell.create(new byte[] {2}, new byte[] {3});
+        Cell cell3 = Cell.create(new byte[] {3}, new byte[] {4});
+        TableReference tableRef = TableReference.createFromFullyQualifiedName("foo.bar");
+        kvs.createTable(tableRef, new byte[] {});
+        kvs.putWithTimestamps(
+                tableRef,
+                ImmutableMultimap.<Cell, Value>builder()
+                        .put(cell1, Value.create(new byte[] {3}, 10))
+                        .put(cell1, Value.create(new byte[] {4}, 20))
+                        .put(cell2, Value.create(new byte[] {4}, 30))
+                        .put(cell2, Value.create(new byte[] {5}, 40))
+                        .put(cell2, Value.create(new byte[] {6}, 50))
+                        .put(cell3, Value.create(new byte[] {7}, 60))
+                        .build());
+        transactions.putUnlessExists(10, 15);
+        transactions.putUnlessExists(20, 25);
+        transactions.putUnlessExists(30, 35);
+        transactions.putUnlessExists(50, 55);
+        transactions.putUnlessExists(60, 65);
+        scrubStore.queueCellsForScrubbing(ImmutableMultimap.of(cell1, tableRef), 20, 100);
+        scrubStore.queueCellsForScrubbing(ImmutableMultimap.of(cell2, tableRef), 50, 100);
+        scrubStore.queueCellsForScrubbing(ImmutableMultimap.of(cell3, tableRef), 60, 100);
+
+        kvs.dropTable(tableRef);
+
+        scrubber.runBackgroundScrubTask(null);
+
+        List<SortedMap<Long, Multimap<TableReference, Cell>>> scrubQueue =
+                BatchingVisitables.copyToList(scrubStore.getBatchingVisitableScrubQueue(Long.MAX_VALUE, null, null));
+        assertThat(scrubQueue).isEmpty();
+    }
+
     private Scrubber getScrubber(
             KeyValueService keyValueService, ScrubberStore scrubberStore, TransactionService transactionService) {
         return Scrubber.create(

--- a/changelog/@unreleased/pr-6195.v2.yml
+++ b/changelog/@unreleased/pr-6195.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fixed a bug where the background scrubber would fail if an item on
+    its queue referred to a table that was deleted in the meantime.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6195


### PR DESCRIPTION
## General
**Before this PR**:
In PDS-293560, scrub encountered difficulties when entries in its queue corresponded to tables that had been deleted since their entries were added to the queue.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixed a bug where the background scrubber would fail if an item on its queue referred to a table that was deleted in the meantime.
==COMMIT_MSG==

**Priority**: This week

**Concerns / possible downsides (what feedback would you like?)**: Any more refactorings appropriate/wanted for Scrubber? I've taken a light-handed approach so far.

**Is documentation needed?**: No

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: Yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: No

**Does this PR need a schema migration?** No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: No

**What was existing testing like? What have you done to improve it?**: Added a test to show a table being deleted in between scrub queueing and scrub processing

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: Yes

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: Not failing out from background scrub should help with memory consumption

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: Scrub would function more consistently at the places detailed

**Has the safety of all log arguments been decided correctly?**: Yes (LoggingArgs used)

**Will this change significantly affect our spending on metrics or logs?**: No

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: Yes

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**: N/A

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**: No

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**: No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**: No

## Development Process
**Where should we start reviewing?**: Scrubber.java

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: N/A

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
