### PR TITLE
Minor tracing perf tweak & add row counting on getRange

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueService.java
@@ -55,6 +55,7 @@ import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.tracing.CloseableTracer;
 import com.palantir.tracing.DetachedSpan;
+import com.palantir.tracing.Tracer;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
 import java.util.Collection;
 import java.util.List;
@@ -62,6 +63,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Consumer;
 
 /**
@@ -309,7 +311,21 @@ public final class TracingKeyValueService extends ForwardingObject implements Ke
         @SuppressWarnings("MustBeClosedChecker")
         ClosableIterator<RowResult<Value>> result = delegate().getRange(tableRef, rangeRequest, timestamp);
 
-        return attachDetachedSpanCompletion(detachedSpan, result, sink -> sink.tableRef(tableRef));
+        // Only instrument observable traces
+        if (Tracer.isTraceObservable()) {
+            LongAdder rowCount = new LongAdder();
+
+            result = result.map(value -> {
+                rowCount.increment();
+                return value;
+            });
+            result = attachDetachedSpanCompletion(detachedSpan, result, sink -> {
+                sink.tableRef(tableRef);
+                sink.longValue("rows", rowCount.sum());
+            });
+        }
+
+        return result;
     }
 
     @Override
@@ -564,6 +580,10 @@ public final class TracingKeyValueService extends ForwardingObject implements Ke
             ListenableFuture<V> future,
             Executor tracingExecutorService,
             Consumer<TagConsumer> tagTranslator) {
+        if (!Tracer.isTraceObservable()) {
+            return future;
+        }
+
         Futures.addCallback(
                 future,
                 new FutureCallback<V>() {
@@ -593,6 +613,10 @@ public final class TracingKeyValueService extends ForwardingObject implements Ke
     @MustBeClosed
     private static <V> ClosableIterator<V> attachDetachedSpanCompletion(
             DetachedSpan detachedSpan, ClosableIterator<V> closableIterator, Consumer<TagConsumer> tagTranslator) {
+        if (!Tracer.isTraceObservable()) {
+            return closableIterator;
+        }
+
         // We'll possibly be completing in a different unrelated thread, so we have no chance to restore the original;
         // this is a known limitation of the async trace statistics. We still want to clear the current statistics.
         TraceStatistic original = TraceStatistics.getCurrentAndClear();

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueService.java
@@ -304,11 +304,11 @@ public final class TracingKeyValueService extends ForwardingObject implements Ke
 
     @Override
     @MustBeClosed
+    @SuppressWarnings("MustBeClosedChecker")
     public ClosableIterator<RowResult<Value>> getRange(
             TableReference tableRef, RangeRequest rangeRequest, long timestamp) {
         DetachedSpan detachedSpan = DetachedSpan.start("atlasdb-kvs.getRange");
 
-        @SuppressWarnings("MustBeClosedChecker")
         ClosableIterator<RowResult<Value>> result = delegate().getRange(tableRef, rangeRequest, timestamp);
 
         // Only instrument observable traces

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueServiceTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueServiceTest.java
@@ -306,9 +306,8 @@ public class TracingKeyValueServiceTest {
     @Test
     @SuppressWarnings("MustBeClosed")
     public void getRange() throws Exception {
-        RowResult<Value> rowResult = RowResult.of(CELL, VALUE);
-        ClosableIterator<RowResult<Value>> expectedResult =
-                ClosableIterators.wrapWithEmptyClose(List.of(rowResult).iterator());
+        ClosableIterator<RowResult<Value>> expectedResult = ClosableIterators.wrapWithEmptyClose(
+                List.of(RowResult.of(CELL, VALUE)).iterator());
 
         RangeRequest rangeRequest = RangeRequest.all();
         when(delegate.getRange(TABLE_REF, rangeRequest, TIMESTAMP)).thenReturn(expectedResult);
@@ -334,9 +333,8 @@ public class TracingKeyValueServiceTest {
     @Test
     @SuppressWarnings("MustBeClosed")
     public void getRange_withTrackedByteReads() {
-        RowResult<Value> rowResult = RowResult.of(CELL, VALUE);
-        ClosableIterator<RowResult<Value>> expectedResult =
-                ClosableIterators.wrapWithEmptyClose(List.of(rowResult).iterator());
+        ClosableIterator<RowResult<Value>> expectedResult = ClosableIterators.wrapWithEmptyClose(
+                List.of(RowResult.of(CELL, VALUE)).iterator());
 
         RangeRequest rangeRequest = RangeRequest.all();
         when(delegate.getRange(TABLE_REF, rangeRequest, TIMESTAMP)).thenReturn(expectedResult);

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueServiceTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueServiceTest.java
@@ -306,7 +306,7 @@ public class TracingKeyValueServiceTest {
     @Test
     @SuppressWarnings("MustBeClosed")
     public void getRange() throws Exception {
-        RowResult<Value> rowResult = mock(RowResult.class);
+        RowResult<Value> rowResult = RowResult.of(CELL, VALUE);
         ClosableIterator<RowResult<Value>> expectedResult =
                 ClosableIterators.wrapWithEmptyClose(List.of(rowResult).iterator());
 
@@ -333,8 +333,8 @@ public class TracingKeyValueServiceTest {
 
     @Test
     @SuppressWarnings("MustBeClosed")
-    public void getRange_withTrackedByteReads() throws Exception {
-        RowResult<Value> rowResult = mock(RowResult.class);
+    public void getRange_withTrackedByteReads() {
+        RowResult<Value> rowResult = RowResult.of(CELL, VALUE);
         ClosableIterator<RowResult<Value>> expectedResult =
                 ClosableIterators.wrapWithEmptyClose(List.of(rowResult).iterator());
 

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueServiceTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueServiceTest.java
@@ -44,6 +44,7 @@ import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.tracing.TestSpanObserver;
 import com.palantir.atlasdb.tracing.TraceStatistics;
 import com.palantir.common.base.ClosableIterator;
+import com.palantir.common.base.ClosableIterators;
 import com.palantir.tracing.Tracer;
 import com.palantir.tracing.api.SpanType;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
@@ -305,7 +306,10 @@ public class TracingKeyValueServiceTest {
     @Test
     @SuppressWarnings("MustBeClosed")
     public void getRange() throws Exception {
-        ClosableIterator<RowResult<Value>> expectedResult = mock(ClosableIterator.class);
+        RowResult<Value> rowResult = mock(RowResult.class);
+        ClosableIterator<RowResult<Value>> expectedResult =
+                ClosableIterators.wrapWithEmptyClose(List.of(rowResult).iterator());
+
         RangeRequest rangeRequest = RangeRequest.all();
         when(delegate.getRange(TABLE_REF, rangeRequest, TIMESTAMP)).thenReturn(expectedResult);
 
@@ -314,10 +318,15 @@ public class TracingKeyValueServiceTest {
         // Trace-logging should be async
         assertThat(observer.spans()).isEmpty();
 
+        // "Read" one row
+        assertThat(result.hasNext()).isTrue();
+        result.next();
+        assertThat(result.hasNext()).isFalse();
+
         // Close to trigger span logging
         result.close();
 
-        checkSpan("atlasdb-kvs.getRange", ImmutableMap.of("table", "{table}"));
+        checkSpan("atlasdb-kvs.getRange", ImmutableMap.of("table", "{table}", "rows", "1"));
         verify(delegate).getRange(TABLE_REF, rangeRequest, TIMESTAMP);
         verifyNoMoreInteractions(delegate);
     }
@@ -325,7 +334,10 @@ public class TracingKeyValueServiceTest {
     @Test
     @SuppressWarnings("MustBeClosed")
     public void getRange_withTrackedByteReads() throws Exception {
-        ClosableIterator<RowResult<Value>> expectedResult = mock(ClosableIterator.class);
+        RowResult<Value> rowResult = mock(RowResult.class);
+        ClosableIterator<RowResult<Value>> expectedResult =
+                ClosableIterators.wrapWithEmptyClose(List.of(rowResult).iterator());
+
         RangeRequest rangeRequest = RangeRequest.all();
         when(delegate.getRange(TABLE_REF, rangeRequest, TIMESTAMP)).thenReturn(expectedResult);
 
@@ -339,7 +351,7 @@ public class TracingKeyValueServiceTest {
         // Close to trigger span logging
         result.close();
 
-        checkSpan("atlasdb-kvs.getRange", ImmutableMap.of("table", "{table}", "atlasdb.bytesRead", "42"));
+        checkSpan("atlasdb-kvs.getRange", ImmutableMap.of("table", "{table}", "rows", "0", "atlasdb.bytesRead", "42"));
         verify(delegate).getRange(TABLE_REF, rangeRequest, TIMESTAMP);
         verifyNoMoreInteractions(delegate);
     }

--- a/changelog/@unreleased/pr-6200.v2.yml
+++ b/changelog/@unreleased/pr-6200.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add row count tag to getRange trace spans.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6200


### PR DESCRIPTION
## General
**Before this PR**:
For range requests we get the amount of data, but not the amount of rows. While not blocking, this information is easy to construct with the current framework.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add row count tag to getRange trace spans.
==COMMIT_MSG==

**Priority**:
Low; it's nice to have rolled out, but not critical.

**Concerns / possible downsides (what feedback would you like?)**:
N/A

**Is documentation needed?**:
N/A

## Compatibility

**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
N/A

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
N/A

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
N/A

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
N/A

**Does this PR need a schema migration?**
N/A

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
N/A

**What was existing testing like? What have you done to improve it?**:
N/A

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Look at produced traces

**Has the safety of all log arguments been decided correctly?**:
N/A

**Will this change significantly affect our spending on metrics or logs?**:
No, this will have a very minor impact on the amount of bytes produced in trace logs.

**How would I tell that this PR does not work in production? (monitors, etc.)**:
N/A

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Yes, rollback is easy (just revert the PR)

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
N/A

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
N/A

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
N/A

## Development Process
**Where should we start reviewing?**:
N/A

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
N/A

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
