### PR TITLE
Use javax.annotation.processing.Generated

### DIFF
--- a/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/AllValueTypesTestTable.java
+++ b/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/AllValueTypesTestTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -2131,5 +2131,5 @@ public final class AllValueTypesTestTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "+z9yTY9fbM1RMcCD3o7Eyg==";
+    static String __CLASS_HASH = "HX/idsmO5nvI4dNwqhElWg==";
 }

--- a/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/ApiTestTableFactory.java
+++ b/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/ApiTestTableFactory.java
@@ -7,7 +7,7 @@ import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.table.generation.Triggers;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import java.util.List;
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableFactoryRenderer")
 public final class ApiTestTableFactory {

--- a/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/HashComponentsTestTable.java
+++ b/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/HashComponentsTestTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -786,5 +786,5 @@ public final class HashComponentsTestTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "xtZFNbacNMZC5kfQbmdZNA==";
+    static String __CLASS_HASH = "6A8nqQpTo91wLHqkWIVjAQ==";
 }

--- a/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/SchemaApiTestTable.java
+++ b/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/SchemaApiTestTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -872,5 +872,5 @@ public final class SchemaApiTestTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "QMyMGvXpBPDuoeuIdJeLPg==";
+    static String __CLASS_HASH = "6xC8OJrJfy6LbUB1FiYDug==";
 }

--- a/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/SchemaApiTestV2Table.java
+++ b/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/SchemaApiTestV2Table.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRendererV2")
 @SuppressWarnings({"all", "deprecation"})

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/CompactMetadataTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/CompactMetadataTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -681,5 +681,5 @@ public final class CompactMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "3E7A2G8e28hDNktKg3axyw==";
+    static String __CLASS_HASH = "VridlmiMEcMLIrwQyqcRHQ==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/CompactTableFactory.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/CompactTableFactory.java
@@ -7,7 +7,7 @@ import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.table.generation.Triggers;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import java.util.List;
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableFactoryRenderer")
 public final class CompactTableFactory {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepIdToNameTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepIdToNameTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -754,5 +754,5 @@ public final class SweepIdToNameTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "TCkfqEbhWHCJvC+P6uu7GQ==";
+    static String __CLASS_HASH = "XhY0sfHU7ygS3NHM1+HK7Q==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepNameToIdTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepNameToIdTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -695,5 +695,5 @@ public final class SweepNameToIdTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "kJLS1HqSwziNrdmAGjYEgQ==";
+    static String __CLASS_HASH = "sJD6WdNMiuuJDNsMwkhsvA==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepPriorityTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepPriorityTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -1251,5 +1251,5 @@ public final class SweepPriorityTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "6KPuJywXdva3QK1p1/7JSQ==";
+    static String __CLASS_HASH = "SYJq7EPSrqhI5ojA5DS3vQ==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepShardProgressTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepShardProgressTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -707,5 +707,5 @@ public final class SweepShardProgressTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "HqImXbn8vvcJMhrqHKfZ0w==";
+    static String __CLASS_HASH = "vxDaJU4r7oWggNPDq0Qu6Q==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepTableFactory.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepTableFactory.java
@@ -7,7 +7,7 @@ import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.table.generation.Triggers;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import java.util.List;
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableFactoryRenderer")
 public final class SweepTableFactory {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepableCellsTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepableCellsTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -789,5 +789,5 @@ public final class SweepableCellsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "bhHNMJjv5jVWU5yJZ1BEoA==";
+    static String __CLASS_HASH = "0G8vHXvwR/HGZ0ZrAaeqTQ==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepableTimestampsTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepableTimestampsTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -786,5 +786,5 @@ public final class SweepableTimestampsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "gH5yVvu8VJQMspkIgQi4CA==";
+    static String __CLASS_HASH = "Jw99h/0z3T8JcRN8j6d17w==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/TableClearsTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/TableClearsTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -681,5 +681,5 @@ public final class TableClearsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "7M6FU/3Ys4wUHyxKlBgnYw==";
+    static String __CLASS_HASH = "G5tVqtzNmeGOIdOf4QSySA==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/TargetedSweepTableFactory.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/TargetedSweepTableFactory.java
@@ -7,7 +7,7 @@ import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.table.generation.Triggers;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import java.util.List;
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableFactoryRenderer")
 public final class TargetedSweepTableFactory {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
@@ -81,7 +81,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import javax.annotation.CheckForNull;
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 @SuppressWarnings("checkstyle:all") // too many warnings to fix
 public class StreamStoreRenderer {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/TableClassRendererV2.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/TableClassRendererV2.java
@@ -65,7 +65,7 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 import javax.lang.model.element.Modifier;
 
 public class TableClassRendererV2 {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/TableFactoryRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/TableFactoryRenderer.java
@@ -41,7 +41,7 @@ import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 import javax.lang.model.element.Modifier;
 
 public final class TableFactoryRenderer {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/TableRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/TableRenderer.java
@@ -111,8 +111,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
-import javax.annotation.Generated;
 import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
 
 @SuppressWarnings("checkstyle:all") // too many warnings to fix
 public class TableRenderer {

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/GenericRangeScanTestTable.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/GenericRangeScanTestTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -805,5 +805,5 @@ public final class GenericRangeScanTestTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "HCLe9Gdg96DKj8mZK+n51A==";
+    static String __CLASS_HASH = "kqedl2mBeAbedzXlMy+Imw==";
 }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/GenericTestSchemaTableFactory.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/GenericTestSchemaTableFactory.java
@@ -7,7 +7,7 @@ import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.table.generation.Triggers;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import java.util.List;
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableFactoryRenderer")
 public final class GenericTestSchemaTableFactory {

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/RangeScanTestTable.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/RangeScanTestTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -743,5 +743,5 @@ public final class RangeScanTestTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "1Mzob0NCW7nhDUIDDCSj9w==";
+    static String __CLASS_HASH = "T2bysa8OZ+/WjRrXnIqCPA==";
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/LatestSnapshotTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/LatestSnapshotTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -681,5 +681,5 @@ public final class LatestSnapshotTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "u4WTR7OZjIlcogScLbQXcg==";
+    static String __CLASS_HASH = "1hXp6wqgn1sn1zvk2FNCsA==";
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/NamespacedTodoTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/NamespacedTodoTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -739,5 +739,5 @@ public final class NamespacedTodoTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "C7WE9160VLtCdDQhpeaP2Q==";
+    static String __CLASS_HASH = "u45FW2313LWExLwSpn1QNQ==";
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamHashAidxTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamHashAidxTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -739,5 +739,5 @@ public final class SnapshotsStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "q+ntd9qXxKIp66GprvYkjw==";
+    static String __CLASS_HASH = "PCkKiTatC1CKEn6ZH3wovQ==";
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamIdxTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamIdxTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -739,5 +739,5 @@ public final class SnapshotsStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "aXdjOzIEYiXlsD4TLw7AEg==";
+    static String __CLASS_HASH = "D1MDUfpiS0iyGcBvr58Y8g==";
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamMetadataTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamMetadataTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -706,5 +706,5 @@ public final class SnapshotsStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "X3JFuJds6clwIRfsF6t4XQ==";
+    static String __CLASS_HASH = "CYeYrtJK8/cz/1qm4lAQbw==";
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamStore.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamStore.java
@@ -24,7 +24,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 import javax.annotation.CheckForNull;
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Functions;
 import com.google.common.base.Preconditions;

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamValueTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamValueTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -693,5 +693,5 @@ public final class SnapshotsStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "Fg+h1vWDxZ35ZtW+XJ9P3g==";
+    static String __CLASS_HASH = "VELEHtyEvSAidzHk7HUynw==";
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/TodoSchemaTableFactory.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/TodoSchemaTableFactory.java
@@ -7,7 +7,7 @@ import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.table.generation.Triggers;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import java.util.List;
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableFactoryRenderer")
 public final class TodoSchemaTableFactory {

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/TodoTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/TodoTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -681,5 +681,5 @@ public final class TodoTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "3r55GHWJy0tMGWUUK/aUMg==";
+    static String __CLASS_HASH = "a41wenQu3aKASLvmOEI8kQ==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/AuditedDataTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/AuditedDataTable.java
@@ -18,7 +18,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -681,5 +681,5 @@ public final class AuditedDataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "q1P83AmwW/yrqywQuzeOwQ==";
+    static String __CLASS_HASH = "HWEvAR+se/bt6noPrSI5eQ==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/BlobSchemaTableFactory.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/BlobSchemaTableFactory.java
@@ -7,7 +7,7 @@ import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.table.generation.Triggers;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import java.util.List;
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableFactoryRenderer")
 public final class BlobSchemaTableFactory {

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamHashAidxTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamHashAidxTable.java
@@ -18,7 +18,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -739,5 +739,5 @@ public final class DataStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "2DA26oucpzo61Q1TGNErzg==";
+    static String __CLASS_HASH = "6ODGPI1lqmv77xZs7geJPg==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamIdxTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamIdxTable.java
@@ -18,7 +18,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -753,5 +753,5 @@ public final class DataStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "8Wqohk3F5h9KdHES5oaQFw==";
+    static String __CLASS_HASH = "Rdk+n2nUmS6yWZK9HAk9OA==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamMetadataTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamMetadataTable.java
@@ -18,7 +18,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -720,5 +720,5 @@ public final class DataStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "5OePXxf7hU+eEtRRLN3UqA==";
+    static String __CLASS_HASH = "RPuWa9/Enf/G4yy7WraKvg==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamStore.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamStore.java
@@ -24,7 +24,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 import javax.annotation.CheckForNull;
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Functions;
 import com.google.common.base.Preconditions;

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamValueTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamValueTable.java
@@ -18,7 +18,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -708,5 +708,5 @@ public final class DataStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "3HkS/oQvfojirEAfdSYjnw==";
+    static String __CLASS_HASH = "DS6SuJzRnFffdUrdtO6Guw==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamHashAidxTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamHashAidxTable.java
@@ -18,7 +18,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -739,5 +739,5 @@ public final class HotspottyDataStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "r3vO7ab6nMs3WaXy8R068g==";
+    static String __CLASS_HASH = "SH1UPkfcLa9w8NXZtXW8SQ==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamIdxTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamIdxTable.java
@@ -18,7 +18,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -739,5 +739,5 @@ public final class HotspottyDataStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "1yWYBzo5Mfjj6wZB99V6Ng==";
+    static String __CLASS_HASH = "mpf2q7hm+MfMFLkXqKHb6Q==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamMetadataTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamMetadataTable.java
@@ -18,7 +18,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -706,5 +706,5 @@ public final class HotspottyDataStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "/o0oiRKrpv9bcIlY6oe0Jw==";
+    static String __CLASS_HASH = "Ce61mTEgHfgl6d16rBNwUA==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamStore.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamStore.java
@@ -24,7 +24,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 import javax.annotation.CheckForNull;
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Functions;
 import com.google.common.base.Preconditions;

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamValueTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamValueTable.java
@@ -18,7 +18,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -693,5 +693,5 @@ public final class HotspottyDataStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "92s4qYucKaYQLGes5kWldg==";
+    static String __CLASS_HASH = "qpxadEqMHw8NeLcCZ0b7oA==";
 }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/KeyValueTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/KeyValueTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -743,5 +743,5 @@ public final class KeyValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "OzVTBeZRDN3eNncbksH1sw==";
+    static String __CLASS_HASH = "hup2zbIPEU3UyNMOfe1YNw==";
 }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/StreamTestTableFactory.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/StreamTestTableFactory.java
@@ -7,7 +7,7 @@ import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.table.generation.Triggers;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import java.util.List;
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableFactoryRenderer")
 public final class StreamTestTableFactory {

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamHashAidxTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamHashAidxTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -739,5 +739,5 @@ public final class ValueStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "iYsHQ2Mt1VCa6LRzMCAPrA==";
+    static String __CLASS_HASH = "5cWqgzNsimsjOXwgH7qMXg==";
 }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamIdxTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamIdxTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -739,5 +739,5 @@ public final class ValueStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "dNyGhtgZuzBzy4MfMVZHUw==";
+    static String __CLASS_HASH = "MkCIg9TK7rahg1mYHQmGVQ==";
 }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamMetadataTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamMetadataTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -706,5 +706,5 @@ public final class ValueStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "tK2+58/7MXwY7HM0IxhM4A==";
+    static String __CLASS_HASH = "C96zzv/xJuD8fFjGUzSd4A==";
 }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamStore.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamStore.java
@@ -24,7 +24,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 import javax.annotation.CheckForNull;
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Functions;
 import com.google.common.base.Preconditions;

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamValueTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamValueTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -693,5 +693,5 @@ public final class ValueStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "H/sOYQueA4oRsnJrXjq93A==";
+    static String __CLASS_HASH = "AWqOKaIXG5obDvezpY9QEQ==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/DataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/DataTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -3628,5 +3628,5 @@ public final class DataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "V+fEgUPMi5Tlt2krZeI6Ow==";
+    static String __CLASS_HASH = "rHjWG0+SGxcp7KyF4uN6Tg==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/IndexTestTableFactory.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/IndexTestTableFactory.java
@@ -7,7 +7,7 @@ import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.table.generation.Triggers;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import java.util.List;
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableFactoryRenderer")
 public final class IndexTestTableFactory {

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/TwoColumnsTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/TwoColumnsTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -2198,5 +2198,5 @@ public final class TwoColumnsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "WBRq+UvibY8M0WeF/DkJ8A==";
+    static String __CLASS_HASH = "ZLP1HeIjAhSt/NFAlfaFZw==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/KeyValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/KeyValueTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -681,5 +681,5 @@ public final class KeyValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "rc94YliIsNRqnXhNTeeQxQ==";
+    static String __CLASS_HASH = "FVgUWmuxuVzpOrJIO/DXPQ==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamHashAidxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamHashAidxTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -739,5 +739,5 @@ public final class StreamTestMaxMemStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "XSBb06gykyKROmqQ0U5okA==";
+    static String __CLASS_HASH = "8WWlkvBZIFpNHwUr7wJuXA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamIdxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamIdxTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -739,5 +739,5 @@ public final class StreamTestMaxMemStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "f3+mNJV5GuwYXKdlZSRKag==";
+    static String __CLASS_HASH = "fBsgiTVm3m2sJucODfXkrw==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamMetadataTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -706,5 +706,5 @@ public final class StreamTestMaxMemStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "lxkBgMs/0YB/yfs9lh69Kw==";
+    static String __CLASS_HASH = "YleWz4H842qjJBXcYvLobg==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamStore.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamStore.java
@@ -24,7 +24,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 import javax.annotation.CheckForNull;
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Functions;
 import com.google.common.base.Preconditions;

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamValueTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -693,5 +693,5 @@ public final class StreamTestMaxMemStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "HTNTUWJPFzBpXGmV9VxHdQ==";
+    static String __CLASS_HASH = "1ctM+vcHEi56Rw7hX+plQg==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamHashAidxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamHashAidxTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -739,5 +739,5 @@ public final class StreamTestStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "sXc/2Nb1dUokOGRg3XB1tw==";
+    static String __CLASS_HASH = "A+NE35cfeEnY2MHhBM0Twg==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamIdxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamIdxTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -739,5 +739,5 @@ public final class StreamTestStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "tDuPLj+gsLx7MdDVI4owDQ==";
+    static String __CLASS_HASH = "eaBakAMUdj76AdcnIf29/Q==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamMetadataTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -706,5 +706,5 @@ public final class StreamTestStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "qHEdCKPB6VgXJi/ddskRaw==";
+    static String __CLASS_HASH = "gtouBjIyyNsb/b/qc9pCHA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamStore.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamStore.java
@@ -24,7 +24,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 import javax.annotation.CheckForNull;
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Functions;
 import com.google.common.base.Preconditions;

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamValueTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -693,5 +693,5 @@ public final class StreamTestStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "KSHVtzVJMr79hZ5W7cejyQ==";
+    static String __CLASS_HASH = "Zjb+q9OtKHIGgdeO8BnLSw==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestTableFactory.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestTableFactory.java
@@ -7,7 +7,7 @@ import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.table.generation.Triggers;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import java.util.List;
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableFactoryRenderer")
 public final class StreamTestTableFactory {

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamHashAidxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamHashAidxTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -739,5 +739,5 @@ public final class StreamTestWithHashStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "n5LSn5a3OH6VQMw1J/OB0g==";
+    static String __CLASS_HASH = "X1hqbiqiEZbDU9agjHYzMA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamIdxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamIdxTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -753,5 +753,5 @@ public final class StreamTestWithHashStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "qyp0inY99AIblqjaOb3enw==";
+    static String __CLASS_HASH = "U/6cxNEugWqjJJAs3M94Ew==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamMetadataTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -720,5 +720,5 @@ public final class StreamTestWithHashStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "+CTiiWu+YOVuhh3VLe1XKg==";
+    static String __CLASS_HASH = "nfCYOSFgRw9vgCfK8zepPQ==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamStore.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamStore.java
@@ -24,7 +24,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 import javax.annotation.CheckForNull;
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Functions;
 import com.google.common.base.Preconditions;

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamValueTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -707,5 +707,5 @@ public final class StreamTestWithHashStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "NGUTGhSKPyR4n20j6YxzwA==";
+    static String __CLASS_HASH = "gK5/dTiV0fnsYG3GkVekCA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamHashAidxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamHashAidxTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -739,5 +739,5 @@ public final class TestHashComponentsStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "fFP89KmZHZca2wf2ShWGbw==";
+    static String __CLASS_HASH = "Ki6bqIt1Bc7VLmWbBOyz8w==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamIdxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamIdxTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -753,5 +753,5 @@ public final class TestHashComponentsStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "V0JfxQL/6rnWCU/jZcBSRg==";
+    static String __CLASS_HASH = "1iZU2XfKSsaB+roXMxh1gQ==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamMetadataTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -720,5 +720,5 @@ public final class TestHashComponentsStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "nWGhnxJHTDG9KPTQr9Lp+Q==";
+    static String __CLASS_HASH = "+eCmpk539lJx0Nvz/T4ltw==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamStore.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamStore.java
@@ -24,7 +24,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 import javax.annotation.CheckForNull;
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Functions;
 import com.google.common.base.Preconditions;

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamValueTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -708,5 +708,5 @@ public final class TestHashComponentsStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "OpgayffWbsYSqzi4fI/Qag==";
+    static String __CLASS_HASH = "lib/FOHtmiJ4apr21C/FRA==";
 }

--- a/changelog/@unreleased/pr-6202.v2.yml
+++ b/changelog/@unreleased/pr-6202.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Use javax.annotation.processing.Generated
+  links:
+  - https://github.com/palantir/atlasdb/pull/6202

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/ProfileTableFactory.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/ProfileTableFactory.java
@@ -7,7 +7,7 @@ import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.table.generation.Triggers;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import java.util.List;
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableFactoryRenderer")
 public final class ProfileTableFactory {

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamHashAidxTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamHashAidxTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -739,5 +739,5 @@ public final class UserPhotosStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "Lz3ywZCktSQ3ANOoklDOfg==";
+    static String __CLASS_HASH = "iZ+WrjLjlfsRJ+4PXOxllA==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamIdxTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamIdxTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -739,5 +739,5 @@ public final class UserPhotosStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "FpEa3fs0ZvMZVC8txa0u7w==";
+    static String __CLASS_HASH = "/5EqpAIHVfvrgAAL314Q6g==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamMetadataTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamMetadataTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -706,5 +706,5 @@ public final class UserPhotosStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "XV63us7jbRmQA7+aqtfI9g==";
+    static String __CLASS_HASH = "tIyb2ulllUpil2D9Zl4zpA==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamStore.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamStore.java
@@ -24,7 +24,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 import javax.annotation.CheckForNull;
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Functions;
 import com.google.common.base.Preconditions;

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamValueTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamValueTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -693,5 +693,5 @@ public final class UserPhotosStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "UoztUHiQjLh+pDv9vS1v+Q==";
+    static String __CLASS_HASH = "gyLvhEYvzXXshQvSEEOq3Q==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserProfileTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserProfileTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -236,6 +236,8 @@ public final class UserProfileTable implements
      * </pre>
      */
     public static final class Create implements UserProfileNamedColumnValue<com.palantir.example.profile.schema.CreationData> {
+        private static final com.palantir.example.profile.schema.CreationData.Persister REUSABLE_PERSISTER = new com.palantir.example.profile.schema.CreationData.Persister();
+
         private final com.palantir.example.profile.schema.CreationData value;
 
         public static Create of(com.palantir.example.profile.schema.CreationData value) {
@@ -263,7 +265,7 @@ public final class UserProfileTable implements
 
         @Override
         public byte[] persistValue() {
-            byte[] bytes = com.palantir.atlasdb.compress.CompressionUtils.compress(new com.palantir.example.profile.schema.CreationData.Persister().persistToBytes(value), com.palantir.atlasdb.table.description.ColumnValueDescription.Compression.NONE);
+            byte[] bytes = com.palantir.atlasdb.compress.CompressionUtils.compress(REUSABLE_PERSISTER.persistToBytes(value), com.palantir.atlasdb.table.description.ColumnValueDescription.Compression.NONE);
             return CompressionUtils.compress(bytes, Compression.NONE);
         }
 
@@ -276,7 +278,7 @@ public final class UserProfileTable implements
             @Override
             public Create hydrateFromBytes(byte[] bytes) {
                 bytes = CompressionUtils.decompress(bytes, Compression.NONE);
-                return of(new com.palantir.example.profile.schema.CreationData.Persister().hydrateFromBytes(com.palantir.atlasdb.compress.CompressionUtils.decompress(bytes, com.palantir.atlasdb.table.description.ColumnValueDescription.Compression.NONE)));
+                return of(REUSABLE_PERSISTER.hydrateFromBytes(com.palantir.atlasdb.compress.CompressionUtils.decompress(bytes, com.palantir.atlasdb.table.description.ColumnValueDescription.Compression.NONE)));
             }
         };
 
@@ -296,6 +298,8 @@ public final class UserProfileTable implements
      * </pre>
      */
     public static final class Json implements UserProfileNamedColumnValue<com.fasterxml.jackson.databind.JsonNode> {
+        private static final com.palantir.atlasdb.persister.JsonNodePersister REUSABLE_PERSISTER = new com.palantir.atlasdb.persister.JsonNodePersister();
+
         private final com.fasterxml.jackson.databind.JsonNode value;
 
         public static Json of(com.fasterxml.jackson.databind.JsonNode value) {
@@ -323,7 +327,7 @@ public final class UserProfileTable implements
 
         @Override
         public byte[] persistValue() {
-            byte[] bytes = com.palantir.atlasdb.compress.CompressionUtils.compress(new com.palantir.atlasdb.persister.JsonNodePersister().persistToBytes(value), com.palantir.atlasdb.table.description.ColumnValueDescription.Compression.NONE);
+            byte[] bytes = com.palantir.atlasdb.compress.CompressionUtils.compress(REUSABLE_PERSISTER.persistToBytes(value), com.palantir.atlasdb.table.description.ColumnValueDescription.Compression.NONE);
             return CompressionUtils.compress(bytes, Compression.NONE);
         }
 
@@ -338,7 +342,6 @@ public final class UserProfileTable implements
                 bytes = CompressionUtils.decompress(bytes, Compression.NONE);
                 return of(REUSABLE_PERSISTER.hydrateFromBytes(com.palantir.atlasdb.compress.CompressionUtils.decompress(bytes, com.palantir.atlasdb.table.description.ColumnValueDescription.Compression.NONE)));
             }
-            private final com.palantir.atlasdb.persister.JsonNodePersister REUSABLE_PERSISTER = new com.palantir.atlasdb.persister.JsonNodePersister();
         };
 
         @Override
@@ -3337,5 +3340,5 @@ public final class UserProfileTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "XQx5IMlaY1C+fEZFXzLO7Q==";
+    static String __CLASS_HASH = "3Edl1drru2bGGW0fAmHL/g==";
 }

--- a/gradle/shared.gradle
+++ b/gradle/shared.gradle
@@ -78,7 +78,8 @@ afterEvaluate {
                 logger.info "Processing schemas for ${schema}"
                 javaexec {
                     main schema
-                    classpath sourceSets.test.runtimeClasspath
+                    // need both compile & runtime classpath for schema generation
+                    classpath sourceSets.test.compileClasspath + sourceSets.test.runtimeClasspath
                 }
             }
         }

--- a/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/BenchmarksTableFactory.java
+++ b/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/BenchmarksTableFactory.java
@@ -7,7 +7,7 @@ import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.table.generation.Triggers;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import java.util.List;
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableFactoryRenderer")
 public final class BenchmarksTableFactory {

--- a/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/BlobsSerializableTable.java
+++ b/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/BlobsSerializableTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -681,5 +681,5 @@ public final class BlobsSerializableTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "/tUuzuVxP4izSsze9aTJKg==";
+    static String __CLASS_HASH = "jpbUef6G6FMHoZjbw+bBKQ==";
 }

--- a/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/BlobsTable.java
+++ b/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/BlobsTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -681,5 +681,5 @@ public final class BlobsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "f1OGdw5MY7EKfykqIgqEKQ==";
+    static String __CLASS_HASH = "ebAUSbvXjUAAU8MmEfZdhw==";
 }

--- a/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/KvDynamicColumnsTable.java
+++ b/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/KvDynamicColumnsTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -833,5 +833,5 @@ public final class KvDynamicColumnsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "MAcqq4kEhVxlid7qdHnOlA==";
+    static String __CLASS_HASH = "WonqNwl3FFSJcXG3L2uHcA==";
 }

--- a/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/KvRowsTable.java
+++ b/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/KvRowsTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -799,5 +799,5 @@ public final class KvRowsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "w/ubZQEj31dYSdz4BnjNhA==";
+    static String __CLASS_HASH = "G3l1p9aHW8n32yBnhbylTQ==";
 }

--- a/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/MetadataTable.java
+++ b/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/MetadataTable.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -771,5 +771,5 @@ public final class MetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "kLiNx/eU/XoEb5MP8ToBvg==";
+    static String __CLASS_HASH = "ZnB3dQeFf2sMuVxmdZI9OQ==";
 }


### PR DESCRIPTION
## General
**Before this PR**:
Generated code used legacy `javax.annotation.Generated` annotation that was removed in JDK 9 and replaced by `javax.annotation.processing.Generated`

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Use javax.annotation.processing.Generated
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
