### PR TITLE
Backport: PDS-293560: Handle TableMappingNotFoundException (#6195)

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/common/base/Throwables.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/base/Throwables.java
@@ -73,6 +73,14 @@ public final class Throwables {
         return throwable;
     }
 
+    /**
+     *  Returns true iff an exception of type causeClass exists somewhere in the causal chain.
+     */
+    public static <T extends Throwable> boolean hasCauseInCausalChain(T throwable, Class<? extends T> causeClass) {
+        return com.google.common.base.Throwables.getCausalChain(throwable).stream()
+                .anyMatch(causeClass::isInstance);
+    }
+
     private static String extractMessageSafely(Throwable ex) {
         if (ex instanceof SafeLoggable) {
             return ((SafeLoggable) ex).getLogMessage();

--- a/changelog/@unreleased/pr-6195.v2.yml
+++ b/changelog/@unreleased/pr-6195.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fixed a bug where the background scrubber would fail if an item on
+    its queue referred to a table that was deleted in the meantime.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6195


### PR DESCRIPTION
Fixed a bug where the background scrubber would fail if an item on its queue referred to a table that was deleted in the meantime.

Backport of #6195 for large internal product - clean cherry-pick.