### PR TITLE
Remove unnecessary atlasdb-processors dependency

### DIFF
--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -22,7 +22,6 @@ dependencies {
   explicitShadow project(":atlasdb-api")
   explicitShadow project(":atlasdb-client")
   explicitShadow project(":atlasdb-impl-shared")
-  explicitShadow project(":atlasdb-processors")
   explicitShadow project(":commons-api")
   explicitShadow project(':timestamp-impl')
   explicitShadow ('com.palantir.cassandra:cassandra-thrift') {


### PR DESCRIPTION
`atlasdb-processors` is just an annotation processor whose annotations have `SOURCE` retention and thus is not needed at runtime.