### PR TITLE
Flaky eventLogDoesNotDeadlockUnderConcurrentLoad test retries

### DIFF
--- a/atlasdb-impl-shared/build.gradle
+++ b/atlasdb-impl-shared/build.gradle
@@ -85,6 +85,7 @@ dependencies {
   testImplementation project(':atlasdb-client-protobufs')
   testImplementation project(':commons-annotations')
   testImplementation project(':commons-executors')
+  testImplementation project(':flake-rule')
   testImplementation project(':lock-api')
   testImplementation project(':lock-api-objects')
   testImplementation project(':timelock-api:timelock-api-objects')


### PR DESCRIPTION
## General
**Before this PR**:
The `com.palantir.atlasdb.keyvalue.api.watch.LockWatchEventLogTest#eventLogDoesNotDeadlockUnderConcurrentLoad` test is flaking a lot and causing failures on [develop](https://app.circleci.com/pipelines/github/palantir/atlasdb?branch=develop), [releases (e.g. 0.703.0)](https://app.circleci.com/pipelines/github/palantir/atlasdb/10000/workflows/8479699d-22ad-48f1-8fec-5e37f3b1d854) and PRs:

- https://app.circleci.com/pipelines/github/palantir/atlasdb/10002/workflows/9cab9d39-7bae-4f69-b247-3edb54f5d160/jobs/37331
- https://app.circleci.com/pipelines/github/palantir/atlasdb/10012/workflows/ea15869f-0780-410d-81aa-59fa2a03cd71/jobs/37359

**After this PR**:
==COMMIT_MSG==
Flaky eventLogDoesNotDeadlockUnderConcurrentLoad test retries
==COMMIT_MSG==

**Priority**: P1

**Concerns / possible downsides (what feedback would you like?)**:
We should separately look into *why* the `eventLogDoesNotDeadlockUnderConcurrentLoad` is slow and fix that (or adjust the 100 threads and 200,000 tasks to fit within reasonable test timeframe for CI).

Main downside is potentially longer builds when the test does flake as we'll now retry up to 5 times and increased the executor shutdown waiting from 10 to 15 seconds so overall could add up 65 seconds to build if they all still flake.

**Is documentation needed?**: no

## Development Process
**Where should we start reviewing?**: `LockWatchEventLogTest`

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
