### PR TITLE
record metric when unable to acquire locks for targeted sweep

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/TargetedSweeper.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/TargetedSweeper.java
@@ -277,7 +277,10 @@ public class TargetedSweeper implements MultiTableSweepQueueWriter, BackgroundSw
                 return maybeLock
                         .map(targetedSweeperLock ->
                                 SweepIterationResults.success(processShard(targetedSweeperLock.getShardAndStrategy())))
-                        .orElseGet(SweepIterationResults::unableToAcquireShard);
+                        .orElseGet(() -> {
+                            metrics.registerOccurrenceOf(sweepStrategy, SweepOutcome.UNABLE_TO_ACQUIRE_LOCKS);
+                            return SweepIterationResults.unableToAcquireShard();
+                        });
             } catch (InsufficientConsistencyException e) {
                 metrics.registerOccurrenceOf(sweepStrategy, SweepOutcome.NOT_ENOUGH_DB_NODES_ONLINE);
                 logException(e, maybeLock);


### PR DESCRIPTION
## General
**Before this PR**:
We don't record when we fail to acquire locks

**After this PR**:
For internal monitoring, it would be good to identify if sweep is running but cannot acquire the lock!

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**: P1

**Concerns / possible downsides (what feedback would you like?)**:
Will this cause a storm of metrics?

**Is documentation needed?**:
No
## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
That we accidentally forgot to have this metric type, rather than intentionally avoided this.
**What was existing testing like? What have you done to improve it?**:
N/A
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
there are now metrics for unable to acquire locks
**Has the safety of all log arguments been decided correctly?**:
N/a
**Will this change significantly affect our spending on metrics or logs?**:
I don't think so....
**How would I tell that this PR does not work in production? (monitors, etc.)**:
There are no metrics
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Rollback or fix
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
Again, I don't believe this should publish more than other metrics we have
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No
## Development Process
**Where should we start reviewing?**:
It's 2 lines
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
No
**Please tag any other people who should be aware of this PR**:
@jeremyk-91


<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
