### PR TITLE
Reduce number of cycles by 90%

### DIFF
--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLogTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLogTest.java
@@ -440,7 +440,7 @@ public final class LockWatchEventLogTest {
 
         ExecutorService executor = PTExecutors.newFixedThreadPool(100);
         AtomicInteger exceptionsSeen = new AtomicInteger(0);
-        for (int count = 0; count < 200_000; ++count) {
+        for (int count = 0; count < 20_000; ++count) {
             executor.execute(() -> randomEventLogTask(exceptionsSeen));
         }
 


### PR DESCRIPTION
I think this test is likely a good enough stress test as-is; waiting for only 15 seconds for 200k runs across 100 threads seems fairly optimistic.