### PR TITLE
[Drop Keyspace] Oracle Part 2: Reversing table name mappings

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -201,4 +201,6 @@ public final class AtlasDbConstants {
     public static final String SCHEMA_V2_TABLE_NAME = "V2Table";
 
     public static final long ABORTED_TIMESTAMPS_BUCKET_SIZE = 1_000_000;
+
+    public static final int IN_CLAUSE_EXPRESSION_LIMIT = 900;
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -202,5 +202,16 @@ public final class AtlasDbConstants {
 
     public static final long ABORTED_TIMESTAMPS_BUCKET_SIZE = 1_000_000;
 
-    public static final int IN_CLAUSE_EXPRESSION_LIMIT = 900;
+    /**
+     * Oracle has a limit of 1000 expressions within a single IN (...) clause.
+     * See
+     * <a href="https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/IN-Condition.html">these docs</a>
+     *
+     * SQLite (used for tests) also has a limit of 999 in versions prior to 3.32.0 - see
+     * <a href="https://www.sqlite.org/limits.html">here</a>
+     *
+     * In the interest of not running too close to DB limits, we're capping a little earlier than both of the
+     * aforementioned limits.
+     */
+    public static final int MINIMUM_IN_CLAUSE_EXPRESSION_LIMIT = 900;
 }

--- a/atlasdb-dbkvs/build.gradle
+++ b/atlasdb-dbkvs/build.gradle
@@ -34,6 +34,7 @@ dependencies {
   testImplementation 'com.google.guava:guava'
   testImplementation 'com.palantir.conjure.java.runtime:conjure-java-jackson-serialization'
   testImplementation 'com.palantir.safe-logging:safe-logging'
+  testImplementation 'com.palantir.safe-logging:preconditions-assertj'
   testImplementation 'com.zaxxer:HikariCP'
   testImplementation 'org.slf4j:slf4j-api'
   testImplementation project(':atlasdb-commons')

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameGetter.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameGetter.java
@@ -33,11 +33,7 @@ public class OracleTableNameGetter {
     private final OracleTableNameUnmapper oracleTableNameUnmapper;
     private final boolean useTableMapping;
 
-    public OracleTableNameGetter(OracleDdlConfig config) {
-        this(config, new OracleTableNameMapper(), new OracleTableNameUnmapper());
-    }
-
-    public OracleTableNameGetter(
+    private OracleTableNameGetter(
             OracleDdlConfig config, OracleTableNameMapper tableNameMapper, OracleTableNameUnmapper tableNameUnmapper) {
         this.tablePrefix = config.tablePrefix();
         this.overflowTablePrefix = config.overflowTablePrefix();
@@ -45,6 +41,15 @@ public class OracleTableNameGetter {
 
         this.oracleTableNameMapper = tableNameMapper;
         this.oracleTableNameUnmapper = tableNameUnmapper;
+    }
+
+    public static OracleTableNameGetter createDefault(OracleDdlConfig config) {
+        return new OracleTableNameGetter(config, new OracleTableNameMapper(), new OracleTableNameUnmapper());
+    }
+
+    public static OracleTableNameGetter createForTests(
+            OracleDdlConfig config, OracleTableNameMapper tableNameMapper, OracleTableNameUnmapper tableNameUnmapper) {
+        return new OracleTableNameGetter(config, tableNameMapper, tableNameUnmapper);
     }
 
     public String generateShortTableName(ConnectionSupplier connectionSupplier, TableReference tableRef) {

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameGetter.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameGetter.java
@@ -26,7 +26,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
-public class OracleTableNameGetter {
+public final class OracleTableNameGetter {
     private final String tablePrefix;
     private final String overflowTablePrefix;
     private final OracleTableNameMapper oracleTableNameMapper;

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameGetter.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameGetter.java
@@ -110,9 +110,8 @@ public class OracleTableNameGetter {
             ConnectionSupplier connectionSupplier, Set<String> shortTableNames) throws TableMappingNotFoundException {
         if (useTableMapping) {
             return oracleTableNameUnmapper.getLongTableNamesFromMappingTable(connectionSupplier, shortTableNames);
-        } else {
-            return shortTableNames;
         }
+        return shortTableNames;
     }
 
     public String getPrefixedTableName(TableReference tableRef) {

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameGetter.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameGetter.java
@@ -20,6 +20,7 @@ import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionSupplier;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.DbKvs;
 import com.palantir.common.exception.TableMappingNotFoundException;
 import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -97,7 +98,7 @@ public class OracleTableNameGetter {
                     if (!StringUtils.startsWithIgnoreCase(tableName, tablePrefixToStrip)) {
                         throw new SafeIllegalArgumentException(
                                 "Long table name does not begin with prefix",
-                                SafeArg.of("tableName", tableName),
+                                UnsafeArg.of("tableName", tableName),
                                 SafeArg.of("prefix", tablePrefixToStrip));
                     }
                 })

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameUnmapper.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameUnmapper.java
@@ -17,17 +17,22 @@ package com.palantir.atlasdb.keyvalue.dbkvs;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionSupplier;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.DbKvs;
 import com.palantir.common.exception.TableMappingNotFoundException;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import com.palantir.nexus.db.sql.AgnosticResultSet;
 import com.palantir.nexus.db.sql.SqlConnection;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
@@ -71,21 +76,52 @@ class OracleTableNameUnmapper {
         if (shortTableNames.isEmpty()) {
             return Set.of();
         }
+        ImmutableSet.Builder<String> longTableNames = ImmutableSet.builder();
+        for (List<String> batch : Iterables.partition(shortTableNames, AtlasDbConstants.IN_CLAUSE_EXPRESSION_LIMIT)) {
+            longTableNames.addAll(getBatchOfLongTableNamesFromMappingTable(connectionSupplier, batch));
+        }
+        return longTableNames.build();
+    }
 
-        String placeHolders = String.join(",", Collections.nCopies(shortTableNames.size(), "?"));
+    private Set<String> getBatchOfLongTableNamesFromMappingTable(
+            ConnectionSupplier connectionSupplier, Collection<String> shortTableNames)
+            throws TableMappingNotFoundException {
+        String placeHolders = String.join(",", Collections.nCopies(shortTableNames.size(), "LOWER(?)"));
 
         SqlConnection conn = connectionSupplier.get();
+
+        // Our Oracle name mapping table contains entries in the user-provided case. However, we don't necessarily
+        // have the user-supplied casing when calling this method (e.g, the short table names were retrieved from
+        // all_tables, which are stored in caps unless explicitly opted out of on a per-entry basis).
+        // Thus, we need to do a case-insensitive search, implemented by LOWER(x) = LOWER(y). For completeness sake, one
+        // likely also needs to do OR UPPER(x) = UPPER(y), but there's little benefit in doing it here.
+
+        // We use the Oracle LOWER function rather than mapping to lower case on the client to ensure that we're
+        // using the same locale and conversion.
         AgnosticResultSet results = conn.selectResultSetUnregisteredQuery(
                 "SELECT table_name FROM " + AtlasDbConstants.ORACLE_NAME_MAPPING_TABLE + " WHERE"
                         + " LOWER(short_table_name) IN (" + placeHolders + ")",
-                shortTableNames.stream().map(String::toLowerCase).toArray());
-        if (results.size() != shortTableNames.size()) {
-            throw new TableMappingNotFoundException("Some of the tables " + String.join(", ", shortTableNames)
-                    + " do not have a mapping. This might be because these tables do not exist.");
-        }
+                shortTableNames.toArray());
+
+        throwIfResultSetSizeDoesNotMatchExpected(results, shortTableNames);
+
         return results.rows().stream()
                 .map(result -> result.getString("table_name"))
                 .collect(Collectors.toSet());
+    }
+
+    private void throwIfResultSetSizeDoesNotMatchExpected(
+            AgnosticResultSet resultSet, Collection<String> shortTableNames) throws TableMappingNotFoundException {
+        if (resultSet.size() < shortTableNames.size()) {
+            throw new TableMappingNotFoundException("Some of the tables " + String.join(", ", shortTableNames)
+                    + " do not have a mapping. This might be because these tables do not exist.");
+        } else if (resultSet.size() > shortTableNames.size()) {
+            throw new SafeIllegalStateException(
+                    "There are more returned long table names than provided short table"
+                            + " names. This likely indicates a bug in AtlasDB",
+                    SafeArg.of("numLongTables", resultSet.size()),
+                    SafeArg.of("numShortTables", shortTableNames.size()));
+        }
     }
 
     public void clearCacheForTable(String fullTableName) {

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameUnmapper.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameUnmapper.java
@@ -77,7 +77,8 @@ class OracleTableNameUnmapper {
             return Set.of();
         }
         ImmutableSet.Builder<String> longTableNames = ImmutableSet.builder();
-        for (List<String> batch : Iterables.partition(shortTableNames, AtlasDbConstants.IN_CLAUSE_EXPRESSION_LIMIT)) {
+        for (List<String> batch :
+                Iterables.partition(shortTableNames, AtlasDbConstants.MINIMUM_IN_CLAUSE_EXPRESSION_LIMIT)) {
             longTableNames.addAll(getBatchOfLongTableNamesFromMappingTable(connectionSupplier, batch));
         }
         return longTableNames.build();

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameUnmapper.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameUnmapper.java
@@ -76,9 +76,8 @@ class OracleTableNameUnmapper {
 
         SqlConnection conn = connectionSupplier.get();
         AgnosticResultSet results = conn.selectResultSetUnregisteredQuery(
-                "SELECT table_name "
-                        + "FROM " + AtlasDbConstants.ORACLE_NAME_MAPPING_TABLE
-                        + " WHERE LOWER(short_table_name) IN (" + placeHolders + ")",
+                "SELECT table_name FROM " + AtlasDbConstants.ORACLE_NAME_MAPPING_TABLE + " WHERE"
+                        + " LOWER(short_table_name) IN (" + placeHolders + ")",
                 shortTableNames.stream().map(String::toLowerCase).toArray());
         if (results.size() != shortTableNames.size()) {
             throw new TableMappingNotFoundException("Some of the tables " + String.join(", ", shortTableNames)

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
@@ -222,7 +222,7 @@ public final class DbKvs extends AbstractKeyValueService implements DbKeyValueSe
 
     private static DbKvs createOracle(
             ExecutorService executor, OracleDdlConfig oracleDdlConfig, SqlConnectionSupplier connections) {
-        OracleTableNameGetter tableNameGetter = new OracleTableNameGetter(oracleDdlConfig);
+        OracleTableNameGetter tableNameGetter = OracleTableNameGetter.createDefault(oracleDdlConfig);
         OraclePrefixedTableNames prefixedTableNames = new OraclePrefixedTableNames(tableNameGetter);
         TableValueStyleCache valueStyleCache = new TableValueStyleCache();
         DbTableFactory tableFactory = new OracleDbTableFactory(

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameGetterTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameGetterTest.java
@@ -66,9 +66,9 @@ public class OracleTableNameGetterTest {
     @Before
     public void before() {
         tableMappingTableNameGetter =
-                new OracleTableNameGetter(TABLE_MAPPING_DDL_CONFIG, tableNameMapper, tableNameUnmapper);
+                OracleTableNameGetter.createForTests(TABLE_MAPPING_DDL_CONFIG, tableNameMapper, tableNameUnmapper);
         nonTableMappingTableNameGetter =
-                new OracleTableNameGetter(NON_TABLE_MAPPING_DDL_CONFIG, tableNameMapper, tableNameUnmapper);
+                OracleTableNameGetter.createForTests(NON_TABLE_MAPPING_DDL_CONFIG, tableNameMapper, tableNameUnmapper);
     }
 
     @Test

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameGetterTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameGetterTest.java
@@ -1,0 +1,178 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.dbkvs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableSet;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionSupplier;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.OverflowMigrationState;
+import com.palantir.common.exception.TableMappingNotFoundException;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class OracleTableNameGetterTest {
+    private static final OracleDdlConfig TABLE_MAPPING_DDL_CONFIG = ImmutableOracleDdlConfig.builder()
+            .overflowMigrationState(OverflowMigrationState.UNSTARTED)
+            .useTableMapping(true)
+            .build();
+
+    private static final OracleDdlConfig NON_TABLE_MAPPING_DDL_CONFIG = ImmutableOracleDdlConfig.builder()
+            .overflowMigrationState(OverflowMigrationState.UNSTARTED)
+            .useTableMapping(false)
+            .build();
+
+    private static final Set<String> SHORT_TABLE_NAMES = ImmutableSet.of("shortNameOne", "shortNameTwo");
+    private static final Set<TableReference> TABLE_REFERENCES = ImmutableSet.of(
+            TableReference.create(Namespace.create("test"), "world"), TableReference.createWithEmptyNamespace("hello"));
+
+    @Mock
+    private ConnectionSupplier connectionSupplier;
+
+    @Mock
+    private OracleTableNameMapper tableNameMapper;
+
+    @Mock
+    private OracleTableNameUnmapper tableNameUnmapper;
+
+    private OracleTableNameGetter tableMappingTableNameGetter;
+    private OracleTableNameGetter nonTableMappingTableNameGetter;
+
+    @Before
+    public void before() {
+        tableMappingTableNameGetter =
+                new OracleTableNameGetter(TABLE_MAPPING_DDL_CONFIG, tableNameMapper, tableNameUnmapper);
+        nonTableMappingTableNameGetter =
+                new OracleTableNameGetter(NON_TABLE_MAPPING_DDL_CONFIG, tableNameMapper, tableNameUnmapper);
+    }
+
+    @Test
+    public void getTableReferencesFromShortTableNamesTransformsUnmapperNamesWhenMappingEnabled()
+            throws TableMappingNotFoundException {
+        when(tableNameUnmapper.getLongTableNamesFromMappingTable(connectionSupplier, SHORT_TABLE_NAMES))
+                .thenReturn(getLongTableNames());
+        Set<TableReference> tableReferences = tableMappingTableNameGetter.getTableReferencesFromShortTableNames(
+                connectionSupplier, SHORT_TABLE_NAMES);
+
+        assertThat(tableReferences).isEqualTo(TABLE_REFERENCES);
+    }
+
+    @Test
+    public void getTableReferencesFromShortOverflowTableNamesLoadsFromUnmapperWhenMappingEnabled()
+            throws TableMappingNotFoundException {
+        when(tableNameUnmapper.getLongTableNamesFromMappingTable(connectionSupplier, SHORT_TABLE_NAMES))
+                .thenReturn(getLongOverflowTableNames());
+
+        Set<TableReference> tableReferences = tableMappingTableNameGetter.getTableReferencesFromShortOverflowTableNames(
+                connectionSupplier, SHORT_TABLE_NAMES);
+        assertThat(tableReferences).isEqualTo(TABLE_REFERENCES);
+    }
+
+    @Test
+    public void getTableReferencesFromShortTableNamesTransformsProvidedNamesWhenMappingDisabled()
+            throws TableMappingNotFoundException {
+        Set<TableReference> tableReferences = nonTableMappingTableNameGetter.getTableReferencesFromShortTableNames(
+                connectionSupplier, getLongTableNames());
+        assertThat(tableReferences).isEqualTo(TABLE_REFERENCES);
+    }
+
+    @Test
+    public void getTableReferencesFromShortOverflowTableNamesTransformsProvidedNamesWhenMappingDisabled()
+            throws TableMappingNotFoundException {
+        Set<TableReference> tableReferences =
+                nonTableMappingTableNameGetter.getTableReferencesFromShortOverflowTableNames(
+                        connectionSupplier, getLongOverflowTableNames());
+        assertThat(tableReferences).isEqualTo(TABLE_REFERENCES);
+    }
+
+    @Test
+    public void getTableReferencesFromShortTableNamesThrowsIfMappingDoesNotExist()
+            throws TableMappingNotFoundException {
+        when(tableNameUnmapper.getLongTableNamesFromMappingTable(connectionSupplier, SHORT_TABLE_NAMES))
+                .thenThrow(TableMappingNotFoundException.class);
+        assertThatThrownBy(() -> tableMappingTableNameGetter.getTableReferencesFromShortTableNames(
+                        connectionSupplier, SHORT_TABLE_NAMES))
+                .isInstanceOf(TableMappingNotFoundException.class);
+    }
+
+    @Test
+    public void getTableReferencesFromShortOverflowTableNamesThrowsIfMappingDoesNotExist()
+            throws TableMappingNotFoundException {
+        when(tableNameUnmapper.getLongTableNamesFromMappingTable(connectionSupplier, SHORT_TABLE_NAMES))
+                .thenThrow(TableMappingNotFoundException.class);
+        assertThatThrownBy(() -> tableMappingTableNameGetter.getTableReferencesFromShortOverflowTableNames(
+                        connectionSupplier, SHORT_TABLE_NAMES))
+                .isInstanceOf(TableMappingNotFoundException.class);
+    }
+
+    @Test
+    public void getTableReferencesFromShortTableNamesThrowsIfMappedLongNameDoesNotBeginWithPrefix()
+            throws TableMappingNotFoundException {
+        when(tableNameUnmapper.getLongTableNamesFromMappingTable(connectionSupplier, SHORT_TABLE_NAMES))
+                .thenReturn(SHORT_TABLE_NAMES);
+        assertThatThrownBy(() -> tableMappingTableNameGetter.getTableReferencesFromShortTableNames(
+                        connectionSupplier, SHORT_TABLE_NAMES))
+                .isInstanceOf(SafeIllegalArgumentException.class);
+    }
+
+    @Test
+    public void getTableReferencesFromShortOverflowTableNamesThrowsIfMappedLongNameDoesNotBeginWithPrefix()
+            throws TableMappingNotFoundException {
+        when(tableNameUnmapper.getLongTableNamesFromMappingTable(connectionSupplier, SHORT_TABLE_NAMES))
+                .thenReturn(SHORT_TABLE_NAMES);
+        assertThatThrownBy(() -> tableMappingTableNameGetter.getTableReferencesFromShortOverflowTableNames(
+                        connectionSupplier, SHORT_TABLE_NAMES))
+                .isInstanceOf(SafeIllegalArgumentException.class);
+    }
+
+    @Test
+    public void getTableReferencesFromShortTableNamesThrowsIfLongNameDoesNotBeginWithPrefix() {
+        assertThatThrownBy(() -> nonTableMappingTableNameGetter.getTableReferencesFromShortTableNames(
+                        connectionSupplier, SHORT_TABLE_NAMES))
+                .isInstanceOf(SafeIllegalArgumentException.class);
+    }
+
+    @Test
+    public void getTableReferencesFromShortOverflowTableNamesThrowsIfLongNameDoesNotBeginWithPrefix() {
+        assertThatThrownBy(() -> nonTableMappingTableNameGetter.getTableReferencesFromShortOverflowTableNames(
+                        connectionSupplier, SHORT_TABLE_NAMES))
+                .isInstanceOf(SafeIllegalArgumentException.class);
+    }
+
+    private Set<String> getLongOverflowTableNames() {
+        return TABLE_REFERENCES.stream()
+                .map(tableMappingTableNameGetter::getPrefixedOverflowTableName)
+                .collect(Collectors.toSet());
+    }
+
+    private Set<String> getLongTableNames() {
+        return TABLE_REFERENCES.stream()
+                .map(tableMappingTableNameGetter::getPrefixedTableName)
+                .collect(Collectors.toSet());
+    }
+}

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameUnmapperTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameUnmapperTest.java
@@ -24,17 +24,26 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionSupplier;
 import com.palantir.common.exception.TableMappingNotFoundException;
+import com.palantir.nexus.db.DBType;
 import com.palantir.nexus.db.sql.AgnosticResultRow;
 import com.palantir.nexus.db.sql.AgnosticResultSet;
+import com.palantir.nexus.db.sql.AgnosticResultSetImpl;
 import com.palantir.nexus.db.sql.SqlConnection;
 import java.sql.Connection;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -49,27 +58,28 @@ public class OracleTableNameUnmapperTest {
     private static final TableReference TABLE_REF_2 = TableReference.create(TEST_NAMESPACE, LONG_TABLE_NAME + "2");
 
     private OracleTableNameUnmapper oracleTableNameUnmapper;
-    private AgnosticResultSet resultSet;
+    private AgnosticResultSet shortNameResultSet;
     private ConnectionSupplier connectionSupplier;
+    private SqlConnection sqlConnection;
 
     @Before
     public void setup() {
         connectionSupplier = mock(ConnectionSupplier.class);
         oracleTableNameUnmapper = new OracleTableNameUnmapper();
-        SqlConnection sqlConnection = mock(SqlConnection.class);
+        sqlConnection = mock(SqlConnection.class);
         Connection connection = mock(Connection.class);
         when(sqlConnection.getUnderlyingConnection()).thenReturn(connection);
         when(connectionSupplier.get()).thenReturn(sqlConnection);
 
-        resultSet = mock(AgnosticResultSet.class);
+        shortNameResultSet = mock(AgnosticResultSet.class);
         when(sqlConnection.selectResultSetUnregisteredQuery(
                         startsWith("SELECT short_table_name FROM atlasdb_table_names WHERE table_name"), any()))
-                .thenReturn(resultSet);
+                .thenReturn(shortNameResultSet);
     }
 
     @Test
     public void shouldThrowIfTableMappingDoesNotExist() throws TableMappingNotFoundException {
-        when(resultSet.size()).thenReturn(0);
+        when(shortNameResultSet.size()).thenReturn(0);
         assertThatThrownBy(() -> oracleTableNameUnmapper.getShortTableNameFromMappingTable(
                         connectionSupplier, TEST_PREFIX, TABLE_REF))
                 .isInstanceOf(TableMappingNotFoundException.class)
@@ -78,11 +88,11 @@ public class OracleTableNameUnmapperTest {
 
     @Test
     public void shouldReturnIfTableMappingExists() throws TableMappingNotFoundException {
-        when(resultSet.size()).thenReturn(1);
+        when(shortNameResultSet.size()).thenReturn(1);
 
         AgnosticResultRow row = mock(AgnosticResultRow.class);
         when(row.getString(eq("short_table_name"))).thenReturn(SHORT_TABLE_NAME);
-        doReturn(ImmutableList.of(row)).when(resultSet).rows();
+        doReturn(ImmutableList.of(row)).when(shortNameResultSet).rows();
 
         String shortName =
                 oracleTableNameUnmapper.getShortTableNameFromMappingTable(connectionSupplier, TEST_PREFIX, TABLE_REF);
@@ -92,11 +102,11 @@ public class OracleTableNameUnmapperTest {
     @Test
     public void cacheIsActuallyUsed() throws TableMappingNotFoundException {
         // do a normal read
-        when(resultSet.size()).thenReturn(1);
+        when(shortNameResultSet.size()).thenReturn(1);
 
         AgnosticResultRow row = mock(AgnosticResultRow.class);
         when(row.getString(eq("short_table_name"))).thenReturn(SHORT_TABLE_NAME);
-        doReturn(ImmutableList.of(row)).when(resultSet).rows();
+        doReturn(ImmutableList.of(row)).when(shortNameResultSet).rows();
 
         String shortName =
                 oracleTableNameUnmapper.getShortTableNameFromMappingTable(connectionSupplier, TEST_PREFIX, TABLE_REF_2);
@@ -110,5 +120,47 @@ public class OracleTableNameUnmapperTest {
 
         // verify that cache was hit and underlying datastore was _still_ only called once
         verify(row, times(1)).getString("short_table_name");
+    }
+
+    @Test
+    public void getLongTableNamesFromMappingTableReturnsLongNames() throws TableMappingNotFoundException {
+        Map<String, String> shortNamesToLongNames = ImmutableMap.<String, String>builder()
+                .put("shortNameOne", "superLongNameOne")
+                .put("shortNameTwo", "superLongNameTwo")
+                .put("shortNameThree", "superLongNameThree")
+                .build();
+
+        setupShortToLongTableMappingMock(shortNamesToLongNames.values());
+
+        Set<String> longNames = oracleTableNameUnmapper.getLongTableNamesFromMappingTable(
+                connectionSupplier, shortNamesToLongNames.keySet());
+
+        assertThat(longNames).hasSize(shortNamesToLongNames.size());
+        assertThat(longNames).hasSameElementsAs(shortNamesToLongNames.values());
+        verify(sqlConnection)
+                .selectResultSetUnregisteredQuery(
+                        eq("SELECT table_name FROM atlasdb_table_names WHERE short_table_name IN (?,?,?)"), any());
+        verifyNoMoreInteractions(sqlConnection);
+    }
+
+    @Test
+    public void getLongTableNamesThrowsIfPartialResultsReturned() {
+        setupShortToLongTableMappingMock(Set.of("test"));
+
+        assertThatThrownBy(() -> oracleTableNameUnmapper.getLongTableNamesFromMappingTable(
+                        connectionSupplier, Set.of("test", "test_2")))
+                .isInstanceOf(TableMappingNotFoundException.class);
+    }
+
+    private void setupShortToLongTableMappingMock(Collection<String> longTableNames) {
+        when(sqlConnection.selectResultSetUnregisteredQuery(
+                        startsWith("SELECT table_name FROM atlasdb_table_names WHERE short_table_name"), any()))
+                .thenReturn(new AgnosticResultSetImpl(
+                        longTableNames.stream()
+                                .map(x -> (Object) x)
+                                .map(List::of)
+                                .collect(Collectors.toList()),
+                        DBType.ORACLE,
+                        Map.of("table_name", 0)));
     }
 }

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameUnmapperTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameUnmapperTest.java
@@ -155,7 +155,7 @@ public class OracleTableNameUnmapperTest {
     @Test
     public void getLongTableNamesFromMappingTableDoesMultipleQueriesIfMoreTablesThanThreshold()
             throws TableMappingNotFoundException {
-        int numberOfEntries = AtlasDbConstants.IN_CLAUSE_EXPRESSION_LIMIT + 100;
+        int numberOfEntries = AtlasDbConstants.MINIMUM_IN_CLAUSE_EXPRESSION_LIMIT + 100;
         Map<String, String> shortNamesToLongNames = IntStream.range(0, numberOfEntries)
                 .boxed()
                 .collect(Collectors.toMap(i -> "shortName" + i, i -> "longName" + i));
@@ -168,12 +168,13 @@ public class OracleTableNameUnmapperTest {
         verify(sqlConnection)
                 .selectResultSetUnregisteredQuery(
                         eq("SELECT table_name FROM atlasdb_table_names WHERE LOWER(short_table_name) IN ("
-                                + generatePlaceholders(AtlasDbConstants.IN_CLAUSE_EXPRESSION_LIMIT) + ")"),
+                                + generatePlaceholders(AtlasDbConstants.MINIMUM_IN_CLAUSE_EXPRESSION_LIMIT) + ")"),
                         any());
         verify(sqlConnection)
                 .selectResultSetUnregisteredQuery(
                         eq("SELECT table_name FROM atlasdb_table_names WHERE LOWER(short_table_name) IN ("
-                                + generatePlaceholders(numberOfEntries - AtlasDbConstants.IN_CLAUSE_EXPRESSION_LIMIT)
+                                + generatePlaceholders(
+                                        numberOfEntries - AtlasDbConstants.MINIMUM_IN_CLAUSE_EXPRESSION_LIMIT)
                                 + ")"),
                         any());
         verifyNoMoreInteractions(sqlConnection);
@@ -194,7 +195,8 @@ public class OracleTableNameUnmapperTest {
                         + " LOWER(short_table_name)"),
                 any()));
 
-        for (List<String> batch : Iterables.partition(longTableNames, AtlasDbConstants.IN_CLAUSE_EXPRESSION_LIMIT)) {
+        for (List<String> batch :
+                Iterables.partition(longTableNames, AtlasDbConstants.MINIMUM_IN_CLAUSE_EXPRESSION_LIMIT)) {
             ongoingStubbing = ongoingStubbing.thenReturn(new AgnosticResultSetImpl(
                     batch.stream().map(x -> (Object) x).map(List::of).collect(Collectors.toList()),
                     DBType.ORACLE,

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameUnmapperTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameUnmapperTest.java
@@ -146,7 +146,7 @@ public class OracleTableNameUnmapperTest {
                 .selectResultSetUnregisteredQuery(
                         eq("SELECT table_name FROM atlasdb_table_names WHERE LOWER(short_table_name) IN ("
                                 + generatePlaceholders(3) + ")"),
-                        tableNameCaptor);
+                        tableNameCaptor.capture());
 
         assertThat(tableNameCaptor.getAllValues()).containsExactlyInAnyOrderElementsOf(shortNamesToLongNames.keySet());
         verifyNoMoreInteractions(sqlConnection);


### PR DESCRIPTION
## General
**Before this PR**:
We can't drop Oracle "keyspaces" automatically, so there's no easy way to clean up stale data right now.

For reference, the final implementation will look something like: https://github.com/palantir/atlasdb/compare/mdaudali/prototype/oracledeletion?expand=1, of which 1300 lines are tests, the other 400 implementation... (Tests will get cleaned up as I make PRs.)

Specifically for this PR, we need to be able to clean up the metadata and mapping. To do so, we must be able to get the table reference from a physical table name.

**After this PR**:
This PR gives me the table reference from a physical table name.
As the total feature PR is large, this is it's own PR.

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**: P1

**Concerns / possible downsides (what feedback would you like?)**:
Some design decisions outlined, concerns are whether you agree with them!

* There's no caching, since each table will only be unmapped once before deletion
* Dynamic generation of the prepared statements - You can't shove an array into a single `IN (?)`, so you either inline the array with String join(,) or use prepared statements. I went with prepared statements to avoid needing to trust the data entirely, with the small cost of needing to prepare a statement that will only be used once, but only needs one request. The alternative was to say, batch in groups of 3 and use a single prepared statement, but that will require multiple queries for perhaps negative gain.
* For reasons described in the point above - these methods work on sets of table names, whereas other methods in the class work on single table names. I went with a batching method since we're unmapping multiple tables at a time, so there's no reason to be making 20+ queries.
* Oracle stores table data in upper case unless explicitly asked not to at runtime. However, we store internal metadata and mapping in user provided case, which means we need to do case insensitive matching. The easiest way to achieve this is by lower casing (or upper casing) both, but naturally this is locale dependent. We could compare with both lower == lower OR upper == upper to catch languages that have different casing, but that still doesn't provide a true case insensitive search. I'm not entirely sure we need it here? We do fail early if we can't find the mapping
* Failing if there's no prefix - alternatively would be to silently pass it through, but there's a bug if we're loading physical tables without the prefix!

**Is documentation needed?**:
Not at this point
## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
None
**What was existing testing like? What have you done to improve it?**:
Unchanged
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Deletion works
**Has the safety of all log arguments been decided correctly?**:
~Yes~ ~No table names are unsafe!!!! Fixing...~ - Fixed!
**Will this change significantly affect our spending on metrics or logs?**:
N/A
**How would I tell that this PR does not work in production? (monitors, etc.)**:
Deletion doesn't work
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Rollback
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No
## Development Process
**Where should we start reviewing?**:
Unmapper and Getter

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
:/

**Please tag any other people who should be aware of this PR**:


<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
