### PR TITLE
[Drop Keyspace] Oracle Part 3a: Add OracleTableNameGetter interface for mocks 

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameGetter.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameGetter.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,122 +13,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.palantir.atlasdb.keyvalue.dbkvs;
 
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionSupplier;
-import com.palantir.atlasdb.keyvalue.dbkvs.impl.DbKvs;
 import com.palantir.common.exception.TableMappingNotFoundException;
-import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.UnsafeArg;
-import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Set;
-import java.util.stream.Collectors;
-import org.apache.commons.lang3.StringUtils;
 
-public final class OracleTableNameGetter {
-    private final String tablePrefix;
-    private final String overflowTablePrefix;
-    private final OracleTableNameMapper oracleTableNameMapper;
-    private final OracleTableNameUnmapper oracleTableNameUnmapper;
-    private final boolean useTableMapping;
+public interface OracleTableNameGetter {
+    String generateShortTableName(ConnectionSupplier connectionSupplier, TableReference tableRef);
 
-    private OracleTableNameGetter(
-            OracleDdlConfig config, OracleTableNameMapper tableNameMapper, OracleTableNameUnmapper tableNameUnmapper) {
-        this.tablePrefix = config.tablePrefix();
-        this.overflowTablePrefix = config.overflowTablePrefix();
-        this.useTableMapping = config.useTableMapping();
+    String generateShortOverflowTableName(ConnectionSupplier connectionSupplier, TableReference tableRef);
 
-        this.oracleTableNameMapper = tableNameMapper;
-        this.oracleTableNameUnmapper = tableNameUnmapper;
-    }
+    String getInternalShortTableName(ConnectionSupplier connectionSupplier, TableReference tableRef)
+            throws TableMappingNotFoundException;
 
-    public static OracleTableNameGetter createDefault(OracleDdlConfig config) {
-        return new OracleTableNameGetter(config, new OracleTableNameMapper(), new OracleTableNameUnmapper());
-    }
+    String getInternalShortOverflowTableName(ConnectionSupplier connectionSupplier, TableReference tableRef)
+            throws TableMappingNotFoundException;
 
-    public static OracleTableNameGetter createForTests(
-            OracleDdlConfig config, OracleTableNameMapper tableNameMapper, OracleTableNameUnmapper tableNameUnmapper) {
-        return new OracleTableNameGetter(config, tableNameMapper, tableNameUnmapper);
-    }
+    Set<TableReference> getTableReferencesFromShortTableNames(
+            ConnectionSupplier connectionSupplier, Set<String> shortTableNames) throws TableMappingNotFoundException;
 
-    public String generateShortTableName(ConnectionSupplier connectionSupplier, TableReference tableRef) {
-        if (useTableMapping) {
-            return oracleTableNameMapper.getShortPrefixedTableName(connectionSupplier, tablePrefix, tableRef);
-        }
-        return getPrefixedTableName(tableRef);
-    }
+    Set<TableReference> getTableReferencesFromShortOverflowTableNames(
+            ConnectionSupplier connectionSupplier, Set<String> shortTableNames) throws TableMappingNotFoundException;
 
-    public String generateShortOverflowTableName(ConnectionSupplier connectionSupplier, TableReference tableRef) {
-        if (useTableMapping) {
-            return oracleTableNameMapper.getShortPrefixedTableName(connectionSupplier, overflowTablePrefix, tableRef);
-        }
-        return getPrefixedOverflowTableName(tableRef);
-    }
+    String getPrefixedTableName(TableReference tableRef);
 
-    public String getInternalShortTableName(ConnectionSupplier connectionSupplier, TableReference tableRef)
-            throws TableMappingNotFoundException {
-        if (useTableMapping) {
-            return oracleTableNameUnmapper.getShortTableNameFromMappingTable(connectionSupplier, tablePrefix, tableRef);
-        }
-        return getPrefixedTableName(tableRef);
-    }
+    String getPrefixedOverflowTableName(TableReference tableRef);
 
-    public String getInternalShortOverflowTableName(ConnectionSupplier connectionSupplier, TableReference tableRef)
-            throws TableMappingNotFoundException {
-        if (useTableMapping) {
-            return oracleTableNameUnmapper.getShortTableNameFromMappingTable(
-                    connectionSupplier, overflowTablePrefix, tableRef);
-        }
-        return getPrefixedOverflowTableName(tableRef);
-    }
-
-    public Set<TableReference> getTableReferencesFromShortTableNames(
-            ConnectionSupplier connectionSupplier, Set<String> shortTableNames) throws TableMappingNotFoundException {
-        return getTableReferencesFromShortTableNamesWithPrefix(connectionSupplier, shortTableNames, tablePrefix);
-    }
-
-    public Set<TableReference> getTableReferencesFromShortOverflowTableNames(
-            ConnectionSupplier connectionSupplier, Set<String> shortTableNames) throws TableMappingNotFoundException {
-        return getTableReferencesFromShortTableNamesWithPrefix(
-                connectionSupplier, shortTableNames, overflowTablePrefix);
-    }
-
-    private Set<TableReference> getTableReferencesFromShortTableNamesWithPrefix(
-            ConnectionSupplier connectionSupplier, Set<String> shortTableNames, String tablePrefixToStrip)
-            throws TableMappingNotFoundException {
-        Set<String> longTableNames = getLongTableNamesFromTableNames(connectionSupplier, shortTableNames);
-        return longTableNames.stream()
-                .peek(tableName -> {
-                    if (!StringUtils.startsWithIgnoreCase(tableName, tablePrefixToStrip)) {
-                        throw new SafeIllegalArgumentException(
-                                "Long table name does not begin with prefix",
-                                UnsafeArg.of("tableName", tableName),
-                                SafeArg.of("prefix", tablePrefixToStrip));
-                    }
-                })
-                .map(tableName -> StringUtils.removeStartIgnoreCase(tableName, tablePrefixToStrip))
-                .map(TableReference::fromInternalTableName)
-                .collect(Collectors.toSet());
-    }
-
-    private Set<String> getLongTableNamesFromTableNames(
-            ConnectionSupplier connectionSupplier, Set<String> shortTableNames) throws TableMappingNotFoundException {
-        if (useTableMapping) {
-            return oracleTableNameUnmapper.getLongTableNamesFromMappingTable(connectionSupplier, shortTableNames);
-        }
-        return shortTableNames;
-    }
-
-    public String getPrefixedTableName(TableReference tableRef) {
-        return tablePrefix + DbKvs.internalTableName(tableRef);
-    }
-
-    public String getPrefixedOverflowTableName(TableReference tableRef) {
-        return overflowTablePrefix + DbKvs.internalTableName(tableRef);
-    }
-
-    public void clearCacheForTable(String fullTableName) {
-        oracleTableNameUnmapper.clearCacheForTable(fullTableName);
-    }
+    void clearCacheForTable(String fullTableName);
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameGetterImpl.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameGetterImpl.java
@@ -1,0 +1,143 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.dbkvs;
+
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionSupplier;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.DbKvs;
+import com.palantir.common.exception.TableMappingNotFoundException;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+
+public final class OracleTableNameGetterImpl implements OracleTableNameGetter {
+    private final String tablePrefix;
+    private final String overflowTablePrefix;
+    private final OracleTableNameMapper oracleTableNameMapper;
+    private final OracleTableNameUnmapper oracleTableNameUnmapper;
+    private final boolean useTableMapping;
+
+    private OracleTableNameGetterImpl(
+            OracleDdlConfig config, OracleTableNameMapper tableNameMapper, OracleTableNameUnmapper tableNameUnmapper) {
+        this.tablePrefix = config.tablePrefix();
+        this.overflowTablePrefix = config.overflowTablePrefix();
+        this.useTableMapping = config.useTableMapping();
+
+        this.oracleTableNameMapper = tableNameMapper;
+        this.oracleTableNameUnmapper = tableNameUnmapper;
+    }
+
+    public static OracleTableNameGetter createDefault(OracleDdlConfig config) {
+        return new OracleTableNameGetterImpl(config, new OracleTableNameMapper(), new OracleTableNameUnmapper());
+    }
+
+    public static OracleTableNameGetter createForTests(
+            OracleDdlConfig config, OracleTableNameMapper tableNameMapper, OracleTableNameUnmapper tableNameUnmapper) {
+        return new OracleTableNameGetterImpl(config, tableNameMapper, tableNameUnmapper);
+    }
+
+    @Override
+    public String generateShortTableName(ConnectionSupplier connectionSupplier, TableReference tableRef) {
+        if (useTableMapping) {
+            return oracleTableNameMapper.getShortPrefixedTableName(connectionSupplier, tablePrefix, tableRef);
+        }
+        return getPrefixedTableName(tableRef);
+    }
+
+    @Override
+    public String generateShortOverflowTableName(ConnectionSupplier connectionSupplier, TableReference tableRef) {
+        if (useTableMapping) {
+            return oracleTableNameMapper.getShortPrefixedTableName(connectionSupplier, overflowTablePrefix, tableRef);
+        }
+        return getPrefixedOverflowTableName(tableRef);
+    }
+
+    @Override
+    public String getInternalShortTableName(ConnectionSupplier connectionSupplier, TableReference tableRef)
+            throws TableMappingNotFoundException {
+        if (useTableMapping) {
+            return oracleTableNameUnmapper.getShortTableNameFromMappingTable(connectionSupplier, tablePrefix, tableRef);
+        }
+        return getPrefixedTableName(tableRef);
+    }
+
+    @Override
+    public String getInternalShortOverflowTableName(ConnectionSupplier connectionSupplier, TableReference tableRef)
+            throws TableMappingNotFoundException {
+        if (useTableMapping) {
+            return oracleTableNameUnmapper.getShortTableNameFromMappingTable(
+                    connectionSupplier, overflowTablePrefix, tableRef);
+        }
+        return getPrefixedOverflowTableName(tableRef);
+    }
+
+    @Override
+    public Set<TableReference> getTableReferencesFromShortTableNames(
+            ConnectionSupplier connectionSupplier, Set<String> shortTableNames) throws TableMappingNotFoundException {
+        return getTableReferencesFromShortTableNamesWithPrefix(connectionSupplier, shortTableNames, tablePrefix);
+    }
+
+    @Override
+    public Set<TableReference> getTableReferencesFromShortOverflowTableNames(
+            ConnectionSupplier connectionSupplier, Set<String> shortTableNames) throws TableMappingNotFoundException {
+        return getTableReferencesFromShortTableNamesWithPrefix(
+                connectionSupplier, shortTableNames, overflowTablePrefix);
+    }
+
+    private Set<TableReference> getTableReferencesFromShortTableNamesWithPrefix(
+            ConnectionSupplier connectionSupplier, Set<String> shortTableNames, String tablePrefixToStrip)
+            throws TableMappingNotFoundException {
+        Set<String> longTableNames = getLongTableNamesFromTableNames(connectionSupplier, shortTableNames);
+        return longTableNames.stream()
+                .peek(tableName -> {
+                    if (!StringUtils.startsWithIgnoreCase(tableName, tablePrefixToStrip)) {
+                        throw new SafeIllegalArgumentException(
+                                "Long table name does not begin with prefix",
+                                UnsafeArg.of("tableName", tableName),
+                                SafeArg.of("prefix", tablePrefixToStrip));
+                    }
+                })
+                .map(tableName -> StringUtils.removeStartIgnoreCase(tableName, tablePrefixToStrip))
+                .map(TableReference::fromInternalTableName)
+                .collect(Collectors.toSet());
+    }
+
+    private Set<String> getLongTableNamesFromTableNames(
+            ConnectionSupplier connectionSupplier, Set<String> shortTableNames) throws TableMappingNotFoundException {
+        if (useTableMapping) {
+            return oracleTableNameUnmapper.getLongTableNamesFromMappingTable(connectionSupplier, shortTableNames);
+        }
+        return shortTableNames;
+    }
+
+    @Override
+    public String getPrefixedTableName(TableReference tableRef) {
+        return tablePrefix + DbKvs.internalTableName(tableRef);
+    }
+
+    @Override
+    public String getPrefixedOverflowTableName(TableReference tableRef) {
+        return overflowTablePrefix + DbKvs.internalTableName(tableRef);
+    }
+
+    @Override
+    public void clearCacheForTable(String fullTableName) {
+        oracleTableNameUnmapper.clearCacheForTable(fullTableName);
+    }
+}

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
@@ -65,6 +65,7 @@ import com.palantir.atlasdb.keyvalue.dbkvs.H2DdlConfig;
 import com.palantir.atlasdb.keyvalue.dbkvs.ImmutablePostgresDdlConfig;
 import com.palantir.atlasdb.keyvalue.dbkvs.OracleDdlConfig;
 import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameGetter;
+import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameGetterImpl;
 import com.palantir.atlasdb.keyvalue.dbkvs.PostgresDdlConfig;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.batch.AccumulatorStrategies;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.batch.BatchingStrategies;
@@ -222,7 +223,7 @@ public final class DbKvs extends AbstractKeyValueService implements DbKeyValueSe
 
     private static DbKvs createOracle(
             ExecutorService executor, OracleDdlConfig oracleDdlConfig, SqlConnectionSupplier connections) {
-        OracleTableNameGetter tableNameGetter = OracleTableNameGetter.createDefault(oracleDdlConfig);
+        OracleTableNameGetter tableNameGetter = OracleTableNameGetterImpl.createDefault(oracleDdlConfig);
         OraclePrefixedTableNames prefixedTableNames = new OraclePrefixedTableNames(tableNameGetter);
         TableValueStyleCache valueStyleCache = new TableValueStyleCache();
         DbTableFactory tableFactory = new OracleDbTableFactory(

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameGetterImplTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameGetterImplTest.java
@@ -38,7 +38,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public class OracleTableNameGetterTest {
+public class OracleTableNameGetterImplTest {
     private static final OracleDdlConfig TABLE_MAPPING_DDL_CONFIG = ImmutableOracleDdlConfig.builder()
             .overflowMigrationState(OverflowMigrationState.UNSTARTED)
             .useTableMapping(true)
@@ -68,9 +68,9 @@ public class OracleTableNameGetterTest {
     @Before
     public void before() {
         tableMappingTableNameGetter =
-                OracleTableNameGetter.createForTests(TABLE_MAPPING_DDL_CONFIG, tableNameMapper, tableNameUnmapper);
-        nonTableMappingTableNameGetter =
-                OracleTableNameGetter.createForTests(NON_TABLE_MAPPING_DDL_CONFIG, tableNameMapper, tableNameUnmapper);
+                OracleTableNameGetterImpl.createForTests(TABLE_MAPPING_DDL_CONFIG, tableNameMapper, tableNameUnmapper);
+        nonTableMappingTableNameGetter = OracleTableNameGetterImpl.createForTests(
+                NON_TABLE_MAPPING_DDL_CONFIG, tableNameMapper, tableNameUnmapper);
     }
 
     @Test


### PR DESCRIPTION
## General
**Before this PR**:
We made OracleTableNameGetter final in the last PR, but this means you can't mock it anymore.

_and_ you can't mock OracleTableNameUnmapper anyway for createForTests due to package privateness.

**After this PR**:
So I just made an interface and work with that.
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**: P1

**Concerns / possible downsides (what feedback would you like?)**:
There are alternatives:
* Allow mocking final
* Undo making it final
* Make TableNameUnmapper public and try and mock through that.

**Is documentation needed?**:
No

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
Kinda, except I've verified that no one else is using OracleTableNameGetter (and we made the ABI break last time anyway)
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
That no one is secretly using it
**What was existing testing like? What have you done to improve it?**:
Just fixedup
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
No change
**Has the safety of all log arguments been decided correctly?**:
N/A
**Will this change significantly affect our spending on metrics or logs?**:
N/A
**How would I tell that this PR does not work in production? (monitors, etc.)**:
We would really see this in compile failures
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Rollback
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No
## Development Process
**Where should we start reviewing?**:
OracleTableNameGetter
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
N/A
**Please tag any other people who should be aware of this PR**:


<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
