### PR TITLE
[Drop Keyspace] Oracle Part 4: Sqlite Oracle Adapter for tests

### DIFF
--- a/atlasdb-dbkvs-tests/build.gradle
+++ b/atlasdb-dbkvs-tests/build.gradle
@@ -21,6 +21,7 @@ dependencies {
   testImplementation 'joda-time:joda-time'
   testImplementation 'org.apache.commons:commons-lang3'
   testImplementation 'org.awaitility:awaitility'
+  testImplementation 'org.xerial:sqlite-jdbc'
   testImplementation project(':atlasdb-api')
   testImplementation project(':atlasdb-client')
   testImplementation project(':atlasdb-config')
@@ -31,6 +32,9 @@ dependencies {
   testImplementation 'org.mockito:mockito-core'
   testImplementation 'com.palantir.docker.compose:docker-compose-rule-junit4'
   testImplementation 'junit:junit'
+
+  testAnnotationProcessor 'org.immutables:value'
+  testCompileOnly 'org.immutables:value::annotations'
 }
 
 task postgresTest(type: Test) {

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/SqliteOracleAdapter.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/SqliteOracleAdapter.java
@@ -1,0 +1,266 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.dbkvs.impl.oracle;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.endsWith;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+
+import com.google.common.collect.ImmutableSet;
+import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.DbKvs;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.SimpleTimedSqlConnectionSupplier;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.SqlConnectionSupplier;
+import com.palantir.common.base.FunctionCheckedException;
+import com.palantir.exception.PalantirSqlException;
+import com.palantir.nexus.db.ConnectionSupplier;
+import com.palantir.nexus.db.sql.SqlConnection;
+import com.palantir.util.file.TempFileUtils;
+import java.io.File;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Collection;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.immutables.value.Value;
+
+public final class SqliteOracleAdapter implements ConnectionSupplier {
+    public static final TableReference METADATA_TABLE = AtlasDbConstants.DEFAULT_ORACLE_METADATA_TABLE;
+
+    private final File sqliteFileLocation;
+
+    SqliteOracleAdapter() throws IOException {
+        sqliteFileLocation = TempFileUtils.createTempFile("sqlite", "db");
+    }
+
+    @Override
+    public Connection get() throws PalantirSqlException {
+        try {
+            return applyPragma(DriverManager.getConnection(getConnectionUrl()));
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void close() {
+        sqliteFileLocation.delete();
+    }
+
+    public <T> T runWithConnection(FunctionCheckedException<Connection, T, SQLException> task) {
+        try (Connection connection = DriverManager.getConnection(getConnectionUrl())) {
+            return task.apply(applyPragma(connection));
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public SqlConnectionSupplier createSqlConnectionSupplier() {
+        return new SqliteSqlConnectionSupplier(this);
+    }
+
+    public void initializeMetadataAndMappingTables() {
+        runWithConnection(connection -> {
+            Statement statement = connection.createStatement();
+
+            statement.executeUpdate("CREATE TABLE IF NOT EXISTS all_tables (table_name VARCHAR(128) NOT NULL, "
+                    + "owner VARCHAR(32) NOT NULL, PRIMARY KEY (table_name, owner))");
+
+            statement.executeUpdate("CREATE TABLE IF NOT EXISTS " + AtlasDbConstants.ORACLE_NAME_MAPPING_TABLE
+                    + "(table_name VARCHAR(128) NOT NULL, "
+                    + "short_table_name VARCHAR(128) NOT NULL, PRIMARY KEY (table_name))");
+
+            return null;
+        });
+        OracleTableInitializer oti = new OracleTableInitializer(
+                new com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionSupplier(createSqlConnectionSupplier()), null);
+        oti.createMetadataTable(METADATA_TABLE.getQualifiedName());
+    }
+
+    public TableDetails createTable(String prefix, String tableName, String owner) {
+        Namespace namespace = Namespace.create(prefix + owner);
+        TableReference tableReference = TableReference.create(namespace, tableName);
+
+        String reversibleTableName = prefix + DbKvs.internalTableName(tableReference);
+
+        // We don't actually shrink it, but we do add a unique identifier to mimic the counting that ddltable does
+        String physicalTableName =
+                reversibleTableName + UUID.randomUUID().toString().replace("-", "");
+
+        // We don't use ddlTable createTable since we want the table name to insert into allTables, and extracting
+        // that is quite painful
+        return runWithConnection(connection -> {
+            PreparedStatement insertAllTables =
+                    connection.prepareStatement("INSERT INTO all_tables VALUES (upper(?), " + "upper(?))");
+            insertAllTables.setString(1, physicalTableName);
+            insertAllTables.setString(2, owner);
+            insertAllTables.executeUpdate();
+
+            String createTableSql = "CREATE TABLE %s (k VARCHAR(128) PRIMARY KEY, value VARCHAR(32))";
+            Statement createNewTable = connection.createStatement();
+            createNewTable.executeUpdate(String.format(createTableSql, physicalTableName));
+
+            PreparedStatement ps = connection.prepareStatement(
+                    "INSERT INTO " + METADATA_TABLE.getQualifiedName() + " (table_name, table_size) VALUES (?, ?)");
+            ps.setString(1, tableReference.getQualifiedName());
+            ps.setInt(2, 1);
+            ps.executeUpdate();
+
+            PreparedStatement tableNameMapping = connection.prepareStatement("INSERT INTO "
+                    + AtlasDbConstants.ORACLE_NAME_MAPPING_TABLE + "(table_name, short_table_name) VALUES (?, ?)");
+            tableNameMapping.setString(1, reversibleTableName);
+            tableNameMapping.setString(2, physicalTableName);
+            tableNameMapping.executeUpdate();
+            return TableDetails.builder()
+                    .tableReference(tableReference)
+                    .physicalTableName(physicalTableName)
+                    .reversibleTableName(reversibleTableName)
+                    .build();
+        });
+    }
+
+    public void refreshTableList() {
+        runWithConnection(connection -> {
+            connection
+                    .createStatement()
+                    .executeUpdate("DELETE FROM all_tables WHERE lower(table_name) "
+                            + "NOT IN"
+                            + " (SELECT lower(name) as table_name FROM sqlite_schema WHERE type = 'table')");
+            return null;
+        });
+    }
+
+    public Set<String> listAllTables() {
+        return runWithConnection(connection -> {
+            PreparedStatement statement = connection.prepareStatement("SELECT name FROM "
+                    + "sqlite_schema WHERE "
+                    + "type ='table' AND name NOT LIKE 'sqlite_%' AND name != 'all_tables' AND name != ? AND name != "
+                    + "?");
+            statement.setString(1, METADATA_TABLE.getQualifiedName());
+            statement.setString(2, AtlasDbConstants.ORACLE_NAME_MAPPING_TABLE);
+            ResultSet resultSet = statement.executeQuery();
+
+            ImmutableSet.Builder<String> tableNames = ImmutableSet.builder();
+            while (resultSet.next()) {
+                tableNames.add(resultSet.getString("name"));
+            }
+            return tableNames.build();
+        });
+    }
+
+    public Set<TableReference> listAllTablesWithMetadata() {
+        return runWithConnection(connection -> {
+            PreparedStatement statement = connection.prepareStatement("SELECT table_name FROM " + METADATA_TABLE);
+            ResultSet resultSet = statement.executeQuery();
+
+            ImmutableSet.Builder<TableReference> tableNames = ImmutableSet.builder();
+            while (resultSet.next()) {
+                tableNames.add(TableReference.createFromFullyQualifiedName(resultSet.getString("table_name")));
+            }
+            return tableNames.build();
+        });
+    }
+
+    public Set<String> listAllTablesWithMapping() {
+        return runWithConnection(connection -> {
+            PreparedStatement statement =
+                    connection.prepareStatement("SELECT table_name FROM " + AtlasDbConstants.ORACLE_NAME_MAPPING_TABLE);
+            ResultSet resultSet = statement.executeQuery();
+
+            ImmutableSet.Builder<String> tableNames = ImmutableSet.builder();
+            while (resultSet.next()) {
+                tableNames.add(resultSet.getString("table_name"));
+            }
+            return tableNames.build();
+        });
+    }
+
+    private Connection applyPragma(Connection connection) throws SQLException {
+        connection.createStatement().executeUpdate("PRAGMA case_sensitive_like = true;");
+        return connection;
+    }
+
+    private String getConnectionUrl() {
+        return "jdbc:sqlite:" + sqliteFileLocation.getAbsolutePath();
+    }
+
+    private static class SqliteSqlConnectionSupplier implements SqlConnectionSupplier {
+        private final SqlConnectionSupplier delegate;
+
+        SqliteSqlConnectionSupplier(ConnectionSupplier delegate) {
+            this.delegate = new SimpleTimedSqlConnectionSupplier(delegate);
+        }
+
+        @Override
+        public SqlConnection get() {
+            return marshalOracleQueryToSqlite(delegate.get());
+        }
+
+        @Override
+        public void close() throws PalantirSqlException {
+            delegate.close();
+        }
+
+        private SqlConnection marshalOracleQueryToSqlite(SqlConnection sqlConnection) {
+            SqlConnection spy = spy(sqlConnection);
+            doAnswer(invocation -> {
+                        String sql = invocation.getArgument(0);
+                        String strippedSql = StringUtils.removeEnd(sql, "PURGE");
+                        sqlConnection.executeUnregisteredQuery(strippedSql);
+                        return null;
+                    })
+                    .when(spy)
+                    .executeUnregisteredQuery(endsWith("PURGE"), any());
+            return spy;
+        }
+    }
+
+    @Value.Immutable
+    interface TableDetails {
+        String reversibleTableName();
+
+        String physicalTableName();
+
+        TableReference tableReference();
+
+        static ImmutableTableDetails.Builder builder() {
+            return ImmutableTableDetails.builder();
+        }
+
+        static Set<String> mapToReversibleTableNames(Collection<TableDetails> tableDetails) {
+            return tableDetails.stream().map(TableDetails::reversibleTableName).collect(Collectors.toSet());
+        }
+
+        static Set<String> mapToPhysicalTableNames(Collection<TableDetails> tableDetails) {
+            return tableDetails.stream().map(TableDetails::physicalTableName).collect(Collectors.toSet());
+        }
+
+        static Set<TableReference> mapToTableReferences(Collection<TableDetails> tableDetails) {
+            return tableDetails.stream().map(TableDetails::tableReference).collect(Collectors.toSet());
+        }
+    }
+}

--- a/commons-db/src/main/java/com/palantir/nexus/db/DBType.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/DBType.java
@@ -30,7 +30,8 @@ public enum DBType {
     // AJ: the oracle jdbc url is missing a final "paren" - processing in DBMgr will fix this...
     ORACLE("oracle.jdbc.driver.OracleDriver", "SELECT 1 FROM dual", true),
     POSTGRESQL("org.postgresql.Driver", "SELECT 1", true),
-    H2_MEMORY("org.h2.Driver", "SELECT 1", true);
+    H2_MEMORY("org.h2.Driver", "SELECT 1", true),
+    SQLITE("org.sqlite.JDBC", "SELECT 1", false);
 
     private final String driver;
     private final String testQuery;
@@ -82,6 +83,9 @@ public enum DBType {
         }
         if (url.startsWith("jdbc:h2:mem:")) {
             return H2_MEMORY;
+        }
+        if (url.startsWith("jdbc:sqlite")) {
+            return SQLITE;
         }
         throw new SafeRuntimeException("Unable to parse JDBC URL");
     }

--- a/commons-db/src/main/java/com/palantir/nexus/db/DBType.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/DBType.java
@@ -31,6 +31,7 @@ public enum DBType {
     ORACLE("oracle.jdbc.driver.OracleDriver", "SELECT 1 FROM dual", true),
     POSTGRESQL("org.postgresql.Driver", "SELECT 1", true),
     H2_MEMORY("org.h2.Driver", "SELECT 1", true),
+    // Sqlite is _only_ used for tests. Please see {@link SqliteOracleAdapter}.
     SQLITE("org.sqlite.JDBC", "SELECT 1", false);
 
     private final String driver;


### PR DESCRIPTION
## General
**Before this PR**:
We can't drop Oracle "keyspaces" automatically, so there's no easy way to clean up stale data right now.

For reference, the final implementation will look something like: https://github.com/palantir/atlasdb/compare/mdaudali/prototype/oracledeletion?expand=1, of which 1300 lines are tests, the other 400 implementation... (Tests will get cleaned up as I make PRs.)

For this PR: This is just test harness for the next PR. Running tests in Oracle is non-trivial locally, and also we don't have as much flexibility for setup and harness (without a bunch more work). Sooo, I use sqlite for unit testing drop table - with Oracle integration tests. 

**After this PR**:
This PR provides a class to provide sql connections to Sqlite that can support _some_ of the Oracle specific syntax (by ignoring it...), as well as some meta information that we rely on that Oracle auto creates (things like all_tables)

This PR doesn't aim to make Sqlite act the same way with limits e.t.c!

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**: P1

**Concerns / possible downsides (what feedback would you like?)**:
Are there any other differences worth reconciling in this harness?
Is this worth it? IMO yes, because it enabled some easier unit tests, but does add some complexity and it's not strictly the state of the world - I just didn't want to be dealing with pure mocked DBs.

**Is documentation needed?**:
No

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
No
**What was existing testing like? What have you done to improve it?**:
Adds harness
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
No
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
No
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Tests work correctly
**Has the safety of all log arguments been decided correctly?**:
N/A
**Will this change significantly affect our spending on metrics or logs?**:
No
**How would I tell that this PR does not work in production? (monitors, etc.)**:
Tests fail and correctness of the prod code crumbles
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
rollback
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
Not this one
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
Not this one
## Development Process
**Where should we start reviewing?**:
SqliteOracleAdapter
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
N/A
**Please tag any other people who should be aware of this PR**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
