### PR TITLE
[TTS] InMemory implementation of MCAS

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/CheckAndSetCompatibility.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/CheckAndSetCompatibility.java
@@ -31,6 +31,8 @@ public interface CheckAndSetCompatibility {
      */
     boolean supportsCheckAndSetOperations();
 
+    boolean supportsMultiCheckAndSetOperations();
+
     /**
      * If false, there are no guarantees that a {@link CheckAndSetException#getActualValues()} or
      * {@link KeyAlreadyExistsException#getExistingKeys()} from exceptions thrown by the the {@link KeyValueService}
@@ -61,10 +63,13 @@ public interface CheckAndSetCompatibility {
         if (!supported) {
             return Unsupported.INSTANCE;
         }
+        boolean multiCas =
+                presentCompatibilities.stream().allMatch(CheckAndSetCompatibility::supportsMultiCheckAndSetOperations);
         boolean detail = presentCompatibilities.stream().allMatch(CheckAndSetCompatibility::supportsDetailOnFailure);
         boolean consistency = presentCompatibilities.stream().allMatch(CheckAndSetCompatibility::consistentOnFailure);
 
         return supportedBuilder()
+                .supportsMultiCheckAndSetOperations(multiCas)
                 .supportsDetailOnFailure(detail)
                 .consistentOnFailure(consistency)
                 .build();
@@ -83,6 +88,11 @@ public interface CheckAndSetCompatibility {
 
         @Override
         public boolean supportsCheckAndSetOperations() {
+            return false;
+        }
+
+        @Override
+        public boolean supportsMultiCheckAndSetOperations() {
             return false;
         }
 

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/CheckAndSetCompatibility.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/CheckAndSetCompatibility.java
@@ -31,7 +31,10 @@ public interface CheckAndSetCompatibility {
      */
     boolean supportsCheckAndSetOperations();
 
-    boolean supportsMultiCheckAndSetOperations();
+    @Value.Default
+    default boolean supportsMultiCheckAndSetOperations() {
+        return false;
+    }
 
     /**
      * If false, there are no guarantees that a {@link CheckAndSetException#getActualValues()} or

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/CheckAndSetCompatibility.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/CheckAndSetCompatibility.java
@@ -16,6 +16,7 @@
 
 package com.palantir.atlasdb.keyvalue.api;
 
+import com.palantir.logsafe.Preconditions;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -57,6 +58,13 @@ public interface CheckAndSetCompatibility {
      * If it is not true, behaviour is undefined.
      */
     boolean consistentOnFailure();
+
+    @Value.Check
+    default void cannotOnlySupportMultiCheckAndSet() {
+        Preconditions.checkArgument(
+                supportsCheckAndSetOperations() || !supportsMultiCheckAndSetOperations(),
+                "Support for MultiCAS implies support for CAS.");
+    }
 
     static CheckAndSetCompatibility intersect(Stream<CheckAndSetCompatibility> compatibilities) {
         Set<CheckAndSetCompatibility> presentCompatibilities = compatibilities.collect(Collectors.toSet());

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -317,6 +317,8 @@ public interface KeyValueService extends AutoCloseable, AsyncKeyValueService {
      * In this case, you can be sure that all your cells have been updated to their new values.
      * In case of failure, there are no guarantees that the operation was not partially applied but the
      * implementations may offer such a guarantee.
+     * Reads concurrent with this operation may see a partially applied update that later succeeds, though
+     * implementations may offer stronger guarantees.
      *
      * If a {@link MultiCheckAndSetException} is thrown, it is likely that the values stored in the cells were not as
      * you expected.

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -1981,6 +1981,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
      * In this case, you can be sure that all your cells have been updated to their new values.
      * If the old cells initially did not have the values you expected, none of the cells will be updated and
      * {@link MultiCheckAndSetException} will be thrown.
+     * Reads concurrent with this operation will not see a partial update.
      *
      * Another thing to note is that the check operation will **only be performed on values of cells that are declared
      * in the set of expected values** i.e. the check operation DOES NOT take updates into account.

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -1936,6 +1936,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     @Override
     public CheckAndSetCompatibility getCheckAndSetCompatibility() {
         return CheckAndSetCompatibility.supportedBuilder()
+                .supportsMultiCheckAndSetOperations(true)
                 .supportsDetailOnFailure(true)
                 .consistentOnFailure(false)
                 .build();

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueService.java
@@ -84,6 +84,7 @@ public abstract class AbstractKeyValueService implements KeyValueService {
     @Override
     public CheckAndSetCompatibility getCheckAndSetCompatibility() {
         return CheckAndSetCompatibility.supportedBuilder()
+                .supportsMultiCheckAndSetOperations(false)
                 .consistentOnFailure(true)
                 .supportsDetailOnFailure(false)
                 .build();

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
@@ -1930,11 +1930,7 @@ public abstract class AbstractKeyValueServiceTest {
         keyValueService.compactInternally(TEST_TABLE);
     }
 
-    @Test
-    public void clusterAvailabilityStatusShouldBeAllAvailable() {
-        assertThat(keyValueService.getClusterAvailabilityStatus()).isEqualTo(ClusterAvailabilityStatus.ALL_AVAILABLE);
-    }
-
+    @SuppressWarnings("JavadocStyleCheck")
     /**
      * 0->0 ---- 2->2 ---- 4->4
      * =>
@@ -1970,6 +1966,12 @@ public abstract class AbstractKeyValueServiceTest {
                         .collectToMap());
     }
 
+    @Test
+    public void clusterAvailabilityStatusShouldBeAllAvailable() {
+        assertThat(keyValueService.getClusterAvailabilityStatus()).isEqualTo(ClusterAvailabilityStatus.ALL_AVAILABLE);
+    }
+
+    @SuppressWarnings("JavadocStyleCheck")
     /**
      * 0->0 1->2 2->2 3->2 4->4
      * fail check for
@@ -2014,6 +2016,7 @@ public abstract class AbstractKeyValueServiceTest {
                         .collectToMap());
     }
 
+    @SuppressWarnings("JavadocStyleCheck")
     /**
      * 0->0 ---- 2->2 ---- 4->4
      * fail check for

--- a/changelog/@unreleased/pr-6243.v2.yml
+++ b/changelog/@unreleased/pr-6243.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '[TTS] InMemory implementation of MCAS'
+  links:
+  - https://github.com/palantir/atlasdb/pull/6243


### PR DESCRIPTION
## General
**Before this PR**:

**After this PR**:
MCAS is implemented
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**:
now

**Concerns / possible downsides (what feedback would you like?)**:
There are two minor concerns:
1. Doesn't really guarantee a consistent view of the world for reads; we don't have this in Cassandra KVS anyway so we should be fine
2. The synchronisation between MCAS and other writes can be poorly performant, but we should have no contention there in normal usage.

**Is documentation needed?**:
No

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
no

**Does this PR need a schema migration?**
no

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
n/a

**What was existing testing like? What have you done to improve it?**:
Existing tests, added a few

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
Of course it's correct 🎖️  This is synchronising the new method with other writes.

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
yes

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
This is mostly for tests

**Has the safety of all log arguments been decided correctly?**:
yes

**Will this change significantly affect our spending on metrics or logs?**:
no

**How would I tell that this PR does not work in production? (monitors, etc.)**:
txn4 being broken in memory

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
either fix or rollback

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
n/a

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No, they do not use in memory KVS. Also, we use fair locks to ensure progress if there is contention.

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
no

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
maybe

## Development Process
**Where should we start reviewing?**:
wherever

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
n/a

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
