### PR TITLE
Oracle truncate should release space

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
@@ -246,8 +246,8 @@ public final class OracleDdlTable implements DbDdlTable {
     public void truncate() {
         try {
             conns.get()
-                    .executeUnregisteredQuery(
-                            "TRUNCATE TABLE " + oracleTableNameGetter.getInternalShortTableName(conns, tableRef) + " DROP STORAGE");
+                    .executeUnregisteredQuery("TRUNCATE TABLE "
+                            + oracleTableNameGetter.getInternalShortTableName(conns, tableRef) + " DROP STORAGE");
         } catch (TableMappingNotFoundException | RuntimeException e) {
             throw new IllegalStateException(
                     String.format(

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
@@ -247,7 +247,7 @@ public final class OracleDdlTable implements DbDdlTable {
         try {
             conns.get()
                     .executeUnregisteredQuery(
-                            "TRUNCATE TABLE " + oracleTableNameGetter.getInternalShortTableName(conns, tableRef));
+                            "TRUNCATE TABLE " + oracleTableNameGetter.getInternalShortTableName(conns, tableRef) + " DROP STORAGE");
         } catch (TableMappingNotFoundException | RuntimeException e) {
             throw new IllegalStateException(
                     String.format(

--- a/changelog/@unreleased/pr-6255.v2.yml
+++ b/changelog/@unreleased/pr-6255.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Oracle table TRUNCATE now include DROP STORAGE clause to release space
+    back to the tablespace.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6255


### PR DESCRIPTION

## General
Without DROP STORAGE, space consumed by the table remains allocated (but free) to the table and isn't released back to the tablespace after a TRUNCATE.

This is problematic for applications that balloon a table (eg for initial data ingest) but all subsequent use it much smaller scale - we end up with a tonne of wasted space.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Oracle table TRUNCATE now include DROP STORAGE clause to release space back to the tablespace.
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:

The downside is that "DROP STORAGE" will mean if the truncated table actually needs to grow large again, there is a little more work to be done by Oracle to allocate new extents. Relatively speaking to the rest of the insertion, this is minor.

Another risk is that the TRUNCATE operation is slower - rather than just update the high water mark of the table, allocated extents need to have their status changed. Do not expect this to be material - and as it is DDL, it is non-transactional so a timeout won't rollback and retries will be "successful" since there will be nothing to do.

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:
N/A

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Storage allocated to truncated tables will be MINEXTENTS.

**Has the safety of all log arguments been decided correctly?**:
N/A

**Will this change significantly affect our spending on metrics or logs?**:
N/A

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
N/A
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
