### PR TITLE
Have better async initialisation tests

### DIFF
--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/keyvalue/impl/AsyncInitializeableInMemoryKvs.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/keyvalue/impl/AsyncInitializeableInMemoryKvs.java
@@ -25,16 +25,20 @@ import java.time.Duration;
 
 public final class AsyncInitializeableInMemoryKvs extends AsyncInitializer implements AutoDelegate_KeyValueService {
     private final InMemoryKeyValueService delegate;
+    private final boolean eventuallySucceed;
     volatile boolean initializationShouldSucceed;
 
-    private AsyncInitializeableInMemoryKvs(InMemoryKeyValueService delegate, boolean initializationShouldSucceed) {
+    private AsyncInitializeableInMemoryKvs(
+            InMemoryKeyValueService delegate, boolean initializationShouldSucceed, boolean eventuallySucceed) {
         this.delegate = delegate;
         this.initializationShouldSucceed = initializationShouldSucceed;
+        this.eventuallySucceed = eventuallySucceed;
     }
 
-    public static KeyValueService createAndStartInit(boolean initializeAsync) {
+    public static KeyValueService createAndStartInit(boolean initializeAsync, boolean eventuallySucceed) {
         InMemoryKeyValueService kvs = new InMemoryKeyValueService(false);
-        AsyncInitializeableInMemoryKvs wrapper = new AsyncInitializeableInMemoryKvs(kvs, !initializeAsync);
+        AsyncInitializeableInMemoryKvs wrapper =
+                new AsyncInitializeableInMemoryKvs(kvs, !initializeAsync, eventuallySucceed);
         wrapper.initialize(initializeAsync);
         return wrapper.isInitialized() ? wrapper.delegate() : wrapper;
     }
@@ -52,7 +56,7 @@ public final class AsyncInitializeableInMemoryKvs extends AsyncInitializer imple
 
     @Override
     protected void cleanUpOnInitFailure() {
-        initializationShouldSucceed = true;
+        initializationShouldSucceed = eventuallySucceed;
     }
 
     @Override

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/memory/InMemoryAsyncAtlasDbConfig.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/memory/InMemoryAsyncAtlasDbConfig.java
@@ -15,18 +15,21 @@
  */
 package com.palantir.atlasdb.memory;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.service.AutoService;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 import com.palantir.atlasdb.spi.SharedResourcesConfig;
 import java.util.Optional;
 import org.immutables.value.Value;
 
-@JsonTypeName(InMemoryAsyncAtlasDbConfig.TYPE)
 @AutoService(KeyValueServiceConfig.class)
 public final class InMemoryAsyncAtlasDbConfig implements KeyValueServiceConfig {
     public static final String TYPE = "memory-async";
+
+    private final boolean eventuallySucceed;
+
+    public InMemoryAsyncAtlasDbConfig(boolean eventuallySucceed) {
+        this.eventuallySucceed = eventuallySucceed;
+    }
 
     @Override
     public String type() {
@@ -58,9 +61,11 @@ public final class InMemoryAsyncAtlasDbConfig implements KeyValueServiceConfig {
     }
 
     @Override
-    @JsonIgnore
-    @Value.Default
     public Optional<String> namespace() {
         return Optional.of("test");
+    }
+
+    public boolean eventuallySucceed() {
+        return eventuallySucceed;
     }
 }

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/memory/InMemoryAsyncAtlasDbFactory.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/memory/InMemoryAsyncAtlasDbFactory.java
@@ -44,14 +44,15 @@ public class InMemoryAsyncAtlasDbFactory implements AtlasDbFactory {
     @Override
     public KeyValueService createRawKeyValueService(
             MetricsManager unusedMetricsManager,
-            KeyValueServiceConfig unusedConfig,
+            KeyValueServiceConfig config,
             Refreshable<Optional<KeyValueServiceRuntimeConfig>> unusedRuntimeConfig,
             Optional<LeaderConfig> unusedLeaderConfig,
             Optional<String> unused,
             LongSupplier unusedLongSupplier,
             boolean initializeAsync) {
         AtlasDbVersion.ensureVersionReported();
-        return AsyncInitializeableInMemoryKvs.createAndStartInit(initializeAsync);
+        InMemoryAsyncAtlasDbConfig asyncConfig = (InMemoryAsyncAtlasDbConfig) config;
+        return AsyncInitializeableInMemoryKvs.createAndStartInit(initializeAsync, asyncConfig.eventuallySucceed());
     }
 
     @Override


### PR DESCRIPTION
## General
**Before this PR**:
There was an async initialisation test that verified that we can initially perform transactions even if the KVS is initially uninitialised. This test failed to catch the break in #6212 because the KVS would initialise quickly enough that the method that assumes synchronous initialisation succeeded. This PR adds a test that would have deterministically failed.

**Priority**:
before we merge a fixed version of #6212 

**Concerns / possible downsides (what feedback would you like?)**:
None really. This is not the fix I originally wanted, but the wiring of a deterministic scheduler into the async initialisation integration test is too messy and this does the job

**Is documentation needed?**:
no

(test changes only) 

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
