### PR TITLE
remove some unneeded spans

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoader.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoader.java
@@ -133,17 +133,15 @@ final class CellLoader {
                         SafeArg.of("ipPort", hostAndCells.getKey()));
             }
 
-            try (CloseableTracer tracer = CloseableTracer.startSpan("getLoadWithTsTasksForSingleHost")) {
-                tasks.addAll(getLoadWithTsTasksForSingleHost(
-                        kvsMethodName,
-                        hostAndCells.getKey(),
-                        tableRef,
-                        hostAndCells.getValue(),
-                        startTs,
-                        loadAllTs,
-                        visitor,
-                        consistency));
-            }
+            tasks.addAll(getLoadWithTsTasksForSingleHost(
+                    kvsMethodName,
+                    hostAndCells.getKey(),
+                    tableRef,
+                    hostAndCells.getValue(),
+                    startTs,
+                    loadAllTs,
+                    visitor,
+                    consistency));
         }
 
         taskRunner.runAllTasksCancelOnFailure(tasks);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TaskRunner.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TaskRunner.java
@@ -53,9 +53,7 @@ class TaskRunner {
 
         List<ListenableFuture<V>> futures = new ArrayList<>(tasks.size());
         for (Callable<V> task : tasks) {
-            DetachedSpan detachedSpan = DetachedSpan.start("task");
-            ListenableFuture<V> future = listeningExecutor.submit(task);
-            futures.add(attachDetachedSpanCompletion(detachedSpan, future, listeningExecutor));
+            futures.add(listeningExecutor.submit(task));
         }
         try {
             List<V> results = new ArrayList<>(tasks.size());


### PR DESCRIPTION
## General
We had several spans that did not add value to traces.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Remove spans for task and getLoadWithTsTasksForSingleHost
==COMMIT_MSG==

**Priority**:
P2

**Concerns / possible downsides (what feedback would you like?)**:
Unintended consequences of removing these spans (unlikely) 
In certain cases these span add value (more likely)

**Is documentation needed?**:
No

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No

**Does this PR need a schema migration?**
No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
i am assuming these spans are used in trace logging and not used by the actual business code

**What was existing testing like? What have you done to improve it?**:
None

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
It does not

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
It does not

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Look at datadog and verify that after the upgrade we are no longer seeing spans for these tasks

**Has the safety of all log arguments been decided correctly?**:
We are removing logs only, so shouldnt be relevant

**Will this change significantly affect our spending on metrics or logs?**:
It will hopefully reduce spend (small)

**How would I tell that this PR does not work in production? (monitors, etc.)**:
Datadog logs still appear

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Rollback should be fine

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
NA

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No additional risk

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No

## Development Process
**Where should we start reviewing?**:
Either file is fine

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:


**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
