### PR TITLE
[PDS-295687] Explicitly declare corner cases in KVS get APIs as undefined behaviour

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/Cell.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/Cell.java
@@ -18,7 +18,6 @@ package com.palantir.atlasdb.keyvalue.api;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
-import com.google.common.primitives.Bytes;
 import com.google.common.primitives.UnsignedBytes;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.logsafe.Preconditions;
@@ -34,7 +33,9 @@ import java.util.Comparator;
 import javax.annotation.Nonnull;
 
 /**
- * Represents a cell in the key-value store.
+ * Represents a cell in the key-value store. A cell consists of a non-empty row and column name that each individually
+ * have length at most {@link #MAX_NAME_LENGTH}.
+ *
  * @see Value
  * @see Bytes
  */

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -52,7 +52,8 @@ public interface KeyValueService extends AutoCloseable, AsyncKeyValueService {
     Collection<? extends KeyValueService> getDelegates();
 
     /**
-     * Gets values from the key-value store.
+     * Gets values from the key-value store. Note that rows and columns must be non-empty: behaviour is
+     * undefined when any of the rows or any of the columns in the column selection are the empty byte array.
      *
      * @param tableRef the name of the table to retrieve values from.
      * @param rows set containing the rows to retrieve values for.
@@ -72,7 +73,8 @@ public interface KeyValueService extends AutoCloseable, AsyncKeyValueService {
 
     /**
      * Gets values from the key-value store for the specified rows and column range
-     * as separate iterators for each row.
+     * as separate iterators for each row. Note that rows and columns must be non-empty: behaviour is undefined when
+     * any of the rows or any of the columns in the column selection are the empty byte array.
      *
      * @param tableRef the name of the table to retrieve values from.
      * @param rows set containing the rows to retrieve values for. Behavior is undefined if {@code rows}
@@ -95,7 +97,8 @@ public interface KeyValueService extends AutoCloseable, AsyncKeyValueService {
      * Gets values from the key-value store for the specified rows and column range as a single iterator. This method
      * should be at least as performant as
      * {@link #getRowsColumnRange(TableReference, Iterable, BatchColumnRangeSelection, long)}, and may be more
-     * performant in some cases.
+     * performant in some cases. Note that rows and columns must be non-empty: behaviour is undefined when
+     * any of the rows or any of the columns in the column selection are the empty byte array.
      *
      * @param tableRef the name of the table to retrieve values from.
      * @param rows set containing the rows to retrieve values for. Behavior is undefined if {@code rows}

--- a/changelog/@unreleased/pr-6267.v2.yml
+++ b/changelog/@unreleased/pr-6267.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Passing empty rows or columns to KVS.get() methods is now explicitly
+    called out as undefined behaviour.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6267


### PR DESCRIPTION
## General
**Before this PR**:
`kvs.get()` called with empty columns throws in Cassandra, though (serendipitously?) returns OK in other key-value-services. I don't know what exactly calling with empty rows does right now, but that is also a strange case.
Note that because all of the `put` methods to a KVS require `Cell` based input, no actual empty rows or columns can be written to the KVS.

**After this PR**:
==COMMIT_MSG==
Passing empty rows or columns to KVS.get() methods are now explicitly called out as undefined behaviour.
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**:
- Mainly: is the reasoning for this change sound?

**Is documentation needed?**: This is a docs change

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: Yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: No

**Does this PR need a schema migration?** No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: That there _never was_ a way to write a cell with empty row or column to the underlying tables. I didn't find anything on the KVS interface that says so.

**What was existing testing like? What have you done to improve it?**: I don't know, but this is docs only

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: Doesn't have such code

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: Nope

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: No behavioural change

**Has the safety of all log arguments been decided correctly?**: No new logging args

**Will this change significantly affect our spending on metrics or logs?**: No

**How would I tell that this PR does not work in production? (monitors, etc.)**: You wouldn't

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: Rollback... or realistically, look elsewhere for the source of the badness

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**: No

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**: No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**: I don't know. If we want to allow such rows?

## Development Process
**Where should we start reviewing?**: The one file

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: It's not

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
