### PR TITLE
[AtomicTable] Fix old bug

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/atomic/SimpleCommitTimestampAtomicTable.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/atomic/SimpleCommitTimestampAtomicTable.java
@@ -65,7 +65,7 @@ public class SimpleCommitTimestampAtomicTable implements AtomicTable<Long, Trans
     @Override
     public ListenableFuture<Map<Long, TransactionStatus>> get(Iterable<Long> cells) {
         Map<Long, Cell> startTsToCell = StreamSupport.stream(cells.spliterator(), false)
-                .collect(Collectors.toMap(x -> x, encodingStrategy::encodeStartTimestampAsCell));
+                .collect(Collectors.toMap(x -> x, encodingStrategy::encodeStartTimestampAsCell, (val, _ignore) -> val));
 
         ListenableFuture<Map<Cell, Value>> result = kvs.getAsync(
                 tableRef, startTsToCell.values().stream().collect(Collectors.toMap(x -> x, _ignore -> Long.MAX_VALUE)));

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/atomic/SimpleCommitTimestampAtomicTableTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/atomic/SimpleCommitTimestampAtomicTableTest.java
@@ -114,6 +114,20 @@ public class SimpleCommitTimestampAtomicTableTest {
         assertThat(result.get(3L)).isEqualTo(TransactionConstants.IN_PROGRESS);
     }
 
+    @Test
+    public void doesNotThrowForDuplicateValues() throws ExecutionException, InterruptedException {
+        ImmutableMap<Long, TransactionStatus> inputs = ImmutableMap.of(1L, TransactionStatuses.committed(2L));
+        atomicTable.updateMultiple(inputs);
+
+        // does not throw any exception
+        Map<Long, TransactionStatus> result =
+                atomicTable.get(ImmutableList.of(1L, 1L, 3L)).get();
+
+        assertThat(result).hasSize(2);
+        assertThat(TransactionStatuses.getCommitTimestamp(result.get(1L))).hasValue(2L);
+        assertThat(result.get(3L)).isEqualTo(TransactionConstants.IN_PROGRESS);
+    }
+
     private AtomicTable<Long, TransactionStatus> createPueTable() {
         return new SimpleCommitTimestampAtomicTable(
                 new InMemoryKeyValueService(true),

--- a/changelog/@unreleased/pr-6272.v2.yml
+++ b/changelog/@unreleased/pr-6272.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '`SimpleCommitTimestampAtomicTable#get` is defensive against duplicates.'
+  links:
+  - https://github.com/palantir/atlasdb/pull/6272


### PR DESCRIPTION
## General
**Before this PR**:
The `get` api takes in an iterable and is not defensive against duplicates.
This is a problem as there can always be multiple values mapping to same start timestamp. 

**After this PR**:
`SimpleCommitTimestampAtomicTable#get` is defensive against duplicates.

**Priority**:
Today please

**Concerns / possible downsides (what feedback would you like?)**:
Did I miss something

**Is documentation needed?**:
No

## Compatibility
~**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:~

~**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:~

~**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:~

~**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:~

~**Does this PR need a schema migration?**~

## Testing and Correctness
~**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:~

**What was existing testing like? What have you done to improve it?**:
Added tests

~**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Large internal product should be happy when calling `findOrphanedSweepSentinels `.

~**Has the safety of all log arguments been decided correctly?**:~

~**Will this change significantly affect our spending on metrics or logs?**:~

~**How would I tell that this PR does not work in production? (monitors, etc.)**:~

~**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:~

~**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:~~

## Scale
~**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:~

~**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:~

~**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:~

## Development Process
**Where should we start reviewing?**:
`SimpleCommitTimestampAtomicTable`

~**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:~

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
