### PR TITLE
[TTS] Mark in progress

### DIFF
--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/coordination/CoordinationResource.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/coordination/CoordinationResource.java
@@ -70,6 +70,11 @@ public interface CoordinationResource {
     @Produces(MediaType.APPLICATION_JSON)
     long resetStateAndGetFreshTimestamp();
 
+    @POST
+    @Path("/write-unsafe")
+    @Produces(MediaType.APPLICATION_JSON)
+    void writeToKvsUnsafe(long timestamp);
+
     @Path("/fresh-timestamp")
     @POST // POST because we can't allow caching
     @Produces(MediaType.APPLICATION_JSON)

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/coordination/SimpleCoordinationResource.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/coordination/SimpleCoordinationResource.java
@@ -79,7 +79,6 @@ public final class SimpleCoordinationResource implements CoordinationResource {
             return transactionManager.runTaskThrowOnConflict(tx -> {
                 KeyValueService kvs = transactionManager.getKeyValueService();
                 kvs.createTable(TEST_TABLE, AtlasDbConstants.GENERIC_TABLE_METADATA);
-
                 tx.put(TEST_TABLE, ImmutableMap.of(TEST_CELL, new byte[1]));
                 return true;
             });
@@ -95,6 +94,13 @@ public final class SimpleCoordinationResource implements CoordinationResource {
         kvs.createTable(TEST_TABLE, AtlasDbConstants.GENERIC_TABLE_METADATA);
         kvs.truncateTable(TEST_TABLE);
         return timestampService.getFreshTimestamp();
+    }
+
+    @Override
+    public void writeToKvsUnsafe(long timestamp) {
+        KeyValueService kvs = transactionManager.getKeyValueService();
+        kvs.createTable(TEST_TABLE, AtlasDbConstants.GENERIC_TABLE_METADATA);
+        kvs.put(TEST_TABLE, ImmutableMap.of(TEST_CELL, new byte[1]), timestamp);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -1909,6 +1909,11 @@ public class SnapshotTransaction extends AbstractTransaction
                         "commitCheckingForConflicts",
                         () -> throwIfConflictOnCommit(commitLocksToken, transactionService));
 
+                // Before doing any remote writes, we mark that the transaction is in progress. Until this point, all
+                // writes are buffered in memory.
+                timedAndTraced(
+                        "markingTransactionInProgress", () -> transactionService.markInProgress(getStartTimestamp()));
+
                 // Write to the targeted sweep queue. We must do this before writing to the key value service -
                 // otherwise we may have hanging values that targeted sweep won't know about.
                 timedAndTraced("writingToSweepQueue", () -> sweepQueue.enqueue(writesByTable, getStartTimestamp()));

--- a/changelog/@unreleased/pr-6273.v2.yml
+++ b/changelog/@unreleased/pr-6273.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '[TTS] Mark in progress before doing remote writes.'
+  links:
+  - https://github.com/palantir/atlasdb/pull/6273


### PR DESCRIPTION
## General
**Before this PR**:
We were never marking transactions to be in progress

**After this PR**:
We mark a transaction to be in progress before doing any remote writes.

**Priority**:
Today please

**Concerns / possible downsides (what feedback would you like?)**:
Perf if we ever move to txn schema 4

**Is documentation needed?**:
No

## Compatibility
~**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:~

~**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:~

~**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:~

~**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**
Before actually switching the schema to 4

## Testing and Correctness
~**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:~

~**What was existing testing like? What have you done to improve it?**:~

~**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:~

~**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
~**How would I tell this PR works in production? (Metrics, logs, etc.)**:~

~**Has the safety of all log arguments been decided correctly?**:~

~**Will this change significantly affect our spending on metrics or logs?**:~

**How would I tell that this PR does not work in production? (monitors, etc.)**:
Will be adding in following TTS PRs

~**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:~

~**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:~

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
Could be on transactions 4

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
One extra for transactions 4, currently no-op

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
Could be on transactions 4, hard to give a theoretical estimate.

## Development Process
**Where should we start reviewing?**:
SnapshotTransaction

~**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:~

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
