### PR TITLE
Endpoint verification for thrift connections 

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -392,6 +392,15 @@ public interface CassandraKeyValueServiceConfig extends KeyValueServiceConfig {
         return Math.min(8, concurrentGetRangesThreadPoolSize() / 2);
     }
 
+    /**
+     * Verify Cassandra hostname or ip address match any of the addresses listed in the servers certificate.
+     * Currently, this is only used by Thrift.
+     */
+    @Value.Default
+    default boolean enableEndpointVerification() {
+        return false;
+    }
+
     @JsonIgnore
     @Value.Derived
     default boolean usingSsl() {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
@@ -222,7 +222,8 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
 
     // InetSocketAddress may be in an unresolved state, and if so, let's attempt to resolve it.
     @SuppressWarnings({"ReverseDnsLookup", "DnsLookup"})
-    private static Optional<InetAddress> maybeResolveAddress(InetSocketAddress inetSocketAddress) {
+    @VisibleForTesting
+    static Optional<InetAddress> maybeResolveAddress(InetSocketAddress inetSocketAddress) {
         return Optional.ofNullable(inetSocketAddress.getAddress())
                 .or(() -> Optional.ofNullable(
                         new InetSocketAddress(inetSocketAddress.getHostName(), inetSocketAddress.getPort())

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
@@ -18,15 +18,18 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 import com.codahale.metrics.Timer;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.google.common.annotations.VisibleForTesting;
 import com.palantir.atlasdb.cassandra.CassandraCredentialsConfig;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.ImmutableCassandraClientConfig.SocketTimeoutMillisBuildStage;
+import com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.common.annotations.ImmutablesStyles.StagedBuilderStyle;
 import com.palantir.common.exception.AtlasDbDependencyException;
 import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
 import com.palantir.conjure.java.config.ssl.SslSocketFactories;
+import com.palantir.exception.SafeSSLPeerUnverifiedException;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
@@ -35,20 +38,25 @@ import com.palantir.logsafe.logger.SafeLoggerFactory;
 import com.palantir.util.TimedRunner;
 import com.palantir.util.TimedRunner.TaskContext;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
+import one.util.streamex.StreamEx;
 import org.apache.cassandra.thrift.AuthenticationRequest;
 import org.apache.cassandra.thrift.Cassandra;
 import org.apache.cassandra.thrift.Cassandra.Client;
 import org.apache.commons.pool2.BasePooledObjectFactory;
 import org.apache.commons.pool2.PooledObject;
 import org.apache.commons.pool2.impl.DefaultPooledObject;
+import org.apache.http.conn.ssl.StrictHostnameVerifier;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TProtocol;
@@ -63,17 +71,19 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
     private static final LoadingCache<SslConfiguration, SSLSocketFactory> sslSocketFactoryCache =
             Caffeine.newBuilder().weakValues().build(SslSocketFactories::createSslSocketFactory);
 
+    private static final StrictHostnameVerifier hostnameVerifier = new StrictHostnameVerifier();
+
     private final MetricsManager metricsManager;
-    private final InetSocketAddress addr;
+    private final CassandraServer cassandraServer;
     private final CassandraClientConfig clientConfig;
     private final SSLSocketFactory sslSocketFactory;
     private final TimedRunner timedRunner;
     private final TSocketFactory tSocketFactory;
 
     public CassandraClientFactory(
-            MetricsManager metricsManager, InetSocketAddress addr, CassandraClientConfig clientConfig) {
+            MetricsManager metricsManager, CassandraServer cassandraServer, CassandraClientConfig clientConfig) {
         this.metricsManager = metricsManager;
-        this.addr = addr;
+        this.cassandraServer = cassandraServer;
         this.clientConfig = clientConfig;
         this.sslSocketFactory = createSslSocketFactory(clientConfig.sslConfiguration());
         this.timedRunner = TimedRunner.create(clientConfig.timeoutOnConnectionClose());
@@ -85,7 +95,8 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
         try {
             return instrumentClient(getRawClientWithKeyspaceSet());
         } catch (Exception e) {
-            String message = String.format("Failed to construct client for %s/%s", addr, clientConfig.keyspace());
+            String message = String.format(
+                    "Failed to construct client for %s/%s", cassandraServer.proxy(), clientConfig.keyspace());
             if (clientConfig.usingSsl()) {
                 message += " over SSL";
             }
@@ -111,7 +122,7 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
             if (log.isDebugEnabled()) {
                 log.debug(
                         "Created new client for {}/{}{}{}",
-                        SafeArg.of("address", CassandraLogHelper.host(addr)),
+                        SafeArg.of("address", CassandraLogHelper.host(cassandraServer.proxy())),
                         UnsafeArg.of("keyspace", clientConfig.keyspace()),
                         SafeArg.of("usingSsl", clientConfig.usingSsl() ? " over SSL" : ""),
                         UnsafeArg.of(
@@ -125,10 +136,10 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
         }
     }
 
-    static CassandraClient getClientInternal(InetSocketAddress addr, CassandraClientConfig clientConfig)
+    static CassandraClient getClientInternal(CassandraServer cassandraServer, CassandraClientConfig clientConfig)
             throws TException {
         return new CassandraClientImpl(getRawClient(
-                addr,
+                cassandraServer,
                 clientConfig,
                 createSslSocketFactory(clientConfig.sslConfiguration()),
                 TSocketFactory.Default.INSTANCE));
@@ -144,17 +155,17 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
     private Cassandra.Client getRawClientWithTimedCreation() throws TException {
         Timer clientCreation = metricsManager.registerOrGetTimer(CassandraClientFactory.class, "clientCreation");
         try (Timer.Context timer = clientCreation.time()) {
-            return getRawClient(addr, clientConfig, sslSocketFactory, tSocketFactory);
+            return getRawClient(cassandraServer, clientConfig, sslSocketFactory, tSocketFactory);
         }
     }
 
     private static Cassandra.Client getRawClient(
-            InetSocketAddress addr,
+            CassandraServer cassandraServer,
             CassandraClientConfig clientConfig,
             SSLSocketFactory sslSocketFactory,
             TSocketFactory tSocketFactory)
             throws TException {
-
+        InetSocketAddress addr = cassandraServer.proxy();
         TSocket thriftSocket =
                 tSocketFactory.create(addr.getHostString(), addr.getPort(), clientConfig.socketTimeoutMillis());
         thriftSocket.open();
@@ -171,6 +182,7 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
             try {
                 SSLSocket socket = (SSLSocket) sslSocketFactory.createSocket(
                         thriftSocket.getSocket(), addr.getHostString(), addr.getPort(), true);
+                verifyEndpoint(cassandraServer, socket.getSession(), clientConfig.enableEndpointVerification());
                 thriftSocket = tSocketFactory.create(socket);
                 success = true;
             } catch (IOException e) {
@@ -208,6 +220,43 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
         client.login(new AuthenticationRequest(credsMap));
     }
 
+    // InetSocketAddress may be in an unresolved state, and if so, let's attempt to resolve it.
+    @SuppressWarnings({"ReverseDnsLookup", "DnsLookup"})
+    private static Optional<InetAddress> maybeResolveAddress(InetSocketAddress inetSocketAddress) {
+        return Optional.ofNullable(inetSocketAddress.getAddress())
+                .or(() -> Optional.ofNullable(
+                        new InetSocketAddress(inetSocketAddress.getHostName(), inetSocketAddress.getPort())
+                                .getAddress()));
+    }
+
+    /**
+     * Verifies that the current SSL connection hostname/ip address matches what the certificate has served.
+     * This will check both ip address/hostname, and perform (reverse) dns lookups respectively, if hostname
+     * or ip address are not present when supplied.
+     */
+    @VisibleForTesting
+    static void verifyEndpoint(CassandraServer cassandraServer, SSLSession session, boolean throwOnFailure)
+            throws SafeSSLPeerUnverifiedException {
+        InetSocketAddress proxySocketAddress = cassandraServer.proxy();
+        Optional<InetAddress> proxy = maybeResolveAddress(proxySocketAddress);
+        Set<String> validAddresses = proxy.map(
+                        address -> Set.of(address.getHostAddress(), cassandraServer.cassandraHostName()))
+                .orElseGet(() -> Set.of(cassandraServer.cassandraHostName()));
+        boolean endpointVerified =
+                StreamEx.of(validAddresses).anyMatch(address -> hostnameVerifier.verify(address, session));
+
+        if (!endpointVerified && throwOnFailure) {
+            log.error(
+                    "Endpoint verification failed for host, closing connection.",
+                    UnsafeArg.of("cassandraServer", cassandraServer));
+            throw new SafeSSLPeerUnverifiedException(
+                    "Endpoint verification failed for host.", SafeArg.of("cassandraServer", cassandraServer));
+        }
+        if (!endpointVerified) {
+            log.warn("Endpoint verification failed for host.", SafeArg.of("cassandraServer", cassandraServer));
+        }
+    }
+
     @Override
     public boolean validateObject(PooledObject<CassandraClient> client) {
         try {
@@ -216,7 +265,7 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
             log.info(
                     "Failed when attempting to validate a Cassandra client in the Cassandra client pool."
                             + " Defensively believing that this object is NOT valid.",
-                    SafeArg.of("cassandraClient", CassandraLogHelper.host(addr)),
+                    SafeArg.of("cassandraClient", CassandraLogHelper.host(cassandraServer.proxy())),
                     t);
             return false;
         }
@@ -233,7 +282,7 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
             log.debug(
                     "Attempting to close transport for client {} of host {}",
                     UnsafeArg.of("client", client),
-                    SafeArg.of("cassandraClient", CassandraLogHelper.host(addr)));
+                    SafeArg.of("cassandraClient", CassandraLogHelper.host(cassandraServer.proxy())));
         }
         try {
             TaskContext<Void> taskContext =
@@ -244,7 +293,7 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
                 log.debug(
                         "Failed to close transport for client {} of host {}",
                         UnsafeArg.of("client", client),
-                        SafeArg.of("cassandraClient", CassandraLogHelper.host(addr)),
+                        SafeArg.of("cassandraClient", CassandraLogHelper.host(cassandraServer.proxy())),
                         t);
             }
             throw new SafeRuntimeException("Threw while attempting to close transport for client", t);
@@ -253,7 +302,7 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
             log.debug(
                     "Closed transport for client {} of host {}",
                     UnsafeArg.of("client", client),
-                    SafeArg.of("cassandraClient", CassandraLogHelper.host(addr)));
+                    SafeArg.of("cassandraClient", CassandraLogHelper.host(cassandraServer.proxy())));
         }
     }
 
@@ -297,6 +346,8 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
 
         boolean usingSsl();
 
+        boolean enableEndpointVerification();
+
         Optional<SslConfiguration> sslConfiguration();
 
         String keyspace();
@@ -310,6 +361,7 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
                     .initialSocketQueryTimeoutMillis(config.initialSocketQueryTimeoutMillis())
                     .credentials(config.credentials())
                     .usingSsl(config.usingSsl())
+                    .enableEndpointVerification(config.enableEndpointVerification())
                     .keyspace(config.getKeyspaceOrThrow())
                     .timeoutOnConnectionClose(config.timeoutOnConnectionClose())
                     .sslConfiguration(config.sslConfiguration())

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
@@ -220,8 +220,9 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
 
     /**
      * Verifies that the current SSL connection hostname/ip address matches what the certificate has served.
-     * This will check both ip address/hostname, and perform (reverse) dns lookups respectively, if hostname
-     * or ip address are not present when supplied.
+     * This will check both ip address/hostname, and uses the IP address associated with the socket, rather
+     * that what has been provided. Hostname/ip address are both need to be checked, as historically we've
+     * connected to Cassandra directly using IP addresses, and therefore need to support such cases.
      */
     @VisibleForTesting
     static void verifyEndpoint(CassandraServer cassandraServer, SSLSocket socket, boolean throwOnFailure)

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -521,7 +521,7 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
     private void sanityCheckRingConsistency() {
         Multimap<Set<TokenRange>, CassandraServer> tokenRangesToServer = HashMultimap.create();
         for (CassandraServer host : getCachedServers()) {
-            try (CassandraClient client = CassandraClientFactory.getClientInternal(host.proxy(), clientConfig)) {
+            try (CassandraClient client = CassandraClientFactory.getClientInternal(host, clientConfig)) {
                 try {
                     client.describe_keyspace(config.getKeyspaceOrThrow());
                 } catch (NotFoundException e) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -291,7 +291,8 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Cassand
      */
     private GenericObjectPool<CassandraClient> createClientPool() {
         CassandraClientConfig clientConfig = CassandraClientConfig.of(config);
-        CassandraClientFactory cassandraClientFactory = new CassandraClientFactory(metricsManager, proxy, clientConfig);
+        CassandraClientFactory cassandraClientFactory =
+                new CassandraClientFactory(metricsManager, cassandraServer, clientConfig);
         GenericObjectPoolConfig<CassandraClient> poolConfig = new GenericObjectPoolConfig<>();
 
         poolConfig.setMinIdle(config.poolSize());

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactoryTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactoryTest.java
@@ -70,7 +70,6 @@ public class CassandraClientFactoryTest {
                     .build());
 
     private static final InetAddress DEFAULT_ADDRESS = mockInetAddress("1.2.3.4");
-    ;
 
     private CassandraClient client = mock(CassandraClient.class);
     private PooledObject<CassandraClient> pooledClient = new DefaultPooledObject<>(client);

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactoryTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactoryTest.java
@@ -75,26 +75,26 @@ public class CassandraClientFactoryTest {
     private PooledObject<CassandraClient> pooledClient = new DefaultPooledObject<>(client);
 
     @Test
-    public void validateObject_reliesOnOpennessOfUnderlyingTransport() {
+    public void validateObjectReliesOnOpennessOfUnderlyingTransport() {
         when(client.getOutputProtocol()).thenReturn(new TCompactProtocol(new TMemoryInputTransport(), 31337, 131072));
         assertThat(FACTORY.validateObject(pooledClient)).isTrue();
     }
 
     @Test
-    public void validateObject_doesNotPropagateExceptionsThrown() {
+    public void validateObjectDoesNotPropagateExceptionsThrown() {
         when(client.getOutputProtocol()).thenThrow(new RuntimeException());
         assertThat(FACTORY.validateObject(pooledClient)).isFalse();
     }
 
     @Test
-    public void verifyEndpoint_doesNotThrow_whenHostnameInCertificate() {
+    public void verifyEndpointDoesNotThrowWhenHostnameInCertificate() {
         SSLSocket sslSocket = createSSLSocket(DEFAULT_SERVER, DEFAULT_ADDRESS);
         assertThatCode(() -> CassandraClientFactory.verifyEndpoint(DEFAULT_SERVER, sslSocket, true))
                 .doesNotThrowAnyException();
     }
 
     @Test
-    public void verifyEndpoint_throws_onlyWhenConfiguredAndHostnameOrIpNotPresent() {
+    public void verifyEndpointThrowsOnlyWhenConfiguredAndHostnameOrIpNotPresent() {
         SSLSocket sslSocket = createSSLSocket(DEFAULT_SERVER, DEFAULT_ADDRESS);
         assertThatThrownBy(() -> CassandraClientFactory.verifyEndpoint(SERVER_TWO, sslSocket, true))
                 .isInstanceOf(SafeSSLPeerUnverifiedException.class);
@@ -103,7 +103,7 @@ public class CassandraClientFactoryTest {
     }
 
     @Test
-    public void verifyEndpoint_doesNotThrow_whenHostnameNotPresentButIpIs() {
+    public void verifyEndpointDoesNotThrowWhenHostnameNotPresentButIpIs() {
         String ipAddress = "1.1.1.1";
         String hostname = "foo-bar";
         InetSocketAddress inetSocketAddress = mockInetSocketAddress(ipAddress);

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactoryTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactoryTest.java
@@ -76,13 +76,13 @@ public class CassandraClientFactoryTest {
     private PooledObject<CassandraClient> pooledClient = new DefaultPooledObject<>(client);
 
     @Test
-    public void reliesOnOpennessOfUnderlyingTransport() {
+    public void validateObject_reliesOnOpennessOfUnderlyingTransport() {
         when(client.getOutputProtocol()).thenReturn(new TCompactProtocol(new TMemoryInputTransport(), 31337, 131072));
         assertThat(FACTORY.validateObject(pooledClient)).isTrue();
     }
 
     @Test
-    public void doesNotPropagateExceptionsThrown() {
+    public void validateObject_doesNotPropagateExceptionsThrown() {
         when(client.getOutputProtocol()).thenThrow(new RuntimeException());
         assertThat(FACTORY.validateObject(pooledClient)).isFalse();
     }

--- a/atlasdb-commons/src/main/java/com/palantir/exception/SafeSSLPeerUnverifiedException.java
+++ b/atlasdb-commons/src/main/java/com/palantir/exception/SafeSSLPeerUnverifiedException.java
@@ -1,0 +1,49 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.exception;
+
+import com.google.errorprone.annotations.CompileTimeConstant;
+import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.Safe;
+import com.palantir.logsafe.SafeLoggable;
+import com.palantir.logsafe.exceptions.SafeExceptions;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import javax.net.ssl.SSLPeerUnverifiedException;
+
+public final class SafeSSLPeerUnverifiedException extends SSLPeerUnverifiedException implements SafeLoggable {
+
+    private final String logMessage;
+    private final List<Arg<?>> arguments;
+
+    public SafeSSLPeerUnverifiedException(@CompileTimeConstant String message, Arg<?>... arguments) {
+        super(SafeExceptions.renderMessage(message, arguments));
+        this.logMessage = message;
+        this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));
+    }
+
+    @Override
+    public @Safe String getLogMessage() {
+        return logMessage;
+    }
+
+    @Override
+    public List<Arg<?>> getArgs() {
+        return arguments;
+    }
+}

--- a/atlasdb-commons/src/test/java/com/palantir/exception/SafeSSLPeerUnverifiedExceptionTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/exception/SafeSSLPeerUnverifiedExceptionTest.java
@@ -1,0 +1,32 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.logsafe.UnsafeArg;
+import org.junit.Test;
+
+public class SafeSSLPeerUnverifiedExceptionTest {
+    @Test
+    public void messageRemovesUnsafeArgs() {
+        String badArgKey = "bad-arg";
+        String badArgValue = "iamdangerous!";
+        assertThat(new SafeSSLPeerUnverifiedException("foo", UnsafeArg.of(badArgKey, badArgValue)).getLogMessage())
+                .doesNotContain(badArgValue);
+    }
+}

--- a/atlasdb-commons/src/test/java/com/palantir/exception/SafeSSLPeerUnverifiedExceptionTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/exception/SafeSSLPeerUnverifiedExceptionTest.java
@@ -18,6 +18,7 @@ package com.palantir.exception;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import org.junit.Test;
 
@@ -26,16 +27,17 @@ public class SafeSSLPeerUnverifiedExceptionTest {
     private static final String badArgKey = "bad-arg";
     private static final String badArgValue = "iamdangerous!";
     private static final UnsafeArg<String> unsafeArg = UnsafeArg.of(badArgKey, badArgValue);
+    private static final SafeArg<String> safeArg = SafeArg.of("good", "good-value");
 
     @Test
-    public void logMessage_doesNotHaveUnsafeArgs() {
+    public void getLogMessageDoesNotHaveUnsafeArgs() {
         assertThat(new SafeSSLPeerUnverifiedException("foo", unsafeArg).getLogMessage())
                 .doesNotContain(badArgValue);
     }
 
     @Test
-    public void getArgs_hasProvidedArgs() {
-        assertThat(new SafeSSLPeerUnverifiedException("foo", unsafeArg).getArgs())
-                .containsExactly(unsafeArg);
+    public void getArgsHasProvidedArgs() {
+        assertThat(new SafeSSLPeerUnverifiedException("foo", unsafeArg, safeArg).getArgs())
+                .containsExactlyInAnyOrder(unsafeArg, safeArg);
     }
 }

--- a/atlasdb-commons/src/test/java/com/palantir/exception/SafeSSLPeerUnverifiedExceptionTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/exception/SafeSSLPeerUnverifiedExceptionTest.java
@@ -22,11 +22,20 @@ import com.palantir.logsafe.UnsafeArg;
 import org.junit.Test;
 
 public class SafeSSLPeerUnverifiedExceptionTest {
+
+    private static final String badArgKey = "bad-arg";
+    private static final String badArgValue = "iamdangerous!";
+    private static final UnsafeArg<String> unsafeArg = UnsafeArg.of(badArgKey, badArgValue);
+
     @Test
-    public void messageRemovesUnsafeArgs() {
-        String badArgKey = "bad-arg";
-        String badArgValue = "iamdangerous!";
-        assertThat(new SafeSSLPeerUnverifiedException("foo", UnsafeArg.of(badArgKey, badArgValue)).getLogMessage())
+    public void logMessage_doesNotHaveUnsafeArgs() {
+        assertThat(new SafeSSLPeerUnverifiedException("foo", unsafeArg).getLogMessage())
                 .doesNotContain(badArgValue);
+    }
+
+    @Test
+    public void getArgs_hasProvidedArgs() {
+        assertThat(new SafeSSLPeerUnverifiedException("foo", unsafeArg).getArgs())
+                .containsExactly(unsafeArg);
     }
 }

--- a/changelog/@unreleased/pr-6288.v2.yml
+++ b/changelog/@unreleased/pr-6288.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Clients can now enable endpoint verification for their Thrift connections.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6288


### PR DESCRIPTION
## General
**Before this PR**:
Endpoint verification would not occur for Thrift connections.

**After this PR**:
Clients can now enable endpoint verification for thrift connections. The check will always run, but only fail hard in-cases when it is enabled. We check explicitly for the hostname we've mapped to the IP (either by reverse DNS or provided via hostname mappings table) and the IP associated with the socket; only one is required to be present for this check to pass. This should satisfy both the legacy case of only using IP addresses, and the usage of proxies as we will also validate hostnames. 
==COMMIT_MSG==
Clients can now enable endpoint verification for their Thrift connections. 
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
