### PR TITLE
[TS] Make Sweep Resistant to Dropped Tables With Metadata

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -567,7 +567,7 @@ public interface KeyValueService extends AutoCloseable, AsyncKeyValueService {
     Set<TableReference> getAllTableNames();
 
     /**
-     * Gets the metadata for a given table. Also useful for checking to see if a table exists.
+     * Gets the metadata for a given table. This method may not be suitable to determine if a table exists.
      *
      * @return a byte array representing the metadata for the table. Array is empty if no table
      * with the given name exists. Consider {@link TableMetadata#BYTES_HYDRATOR} for hydrating.

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTargetedSweepIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTargetedSweepIntegrationTest.java
@@ -15,9 +15,19 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.containers.CassandraResource;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
 import com.palantir.atlasdb.sweep.AbstractTargetedSweepTest;
+import com.palantir.atlasdb.table.description.TableMetadata;
 import org.junit.ClassRule;
+import org.junit.Test;
 
 public class CassandraTargetedSweepIntegrationTest extends AbstractTargetedSweepTest {
     @ClassRule
@@ -25,5 +35,39 @@ public class CassandraTargetedSweepIntegrationTest extends AbstractTargetedSweep
 
     public CassandraTargetedSweepIntegrationTest() {
         super(CASSANDRA, CASSANDRA);
+    }
+
+    @Test
+    public void targetedSweepIgnoresDroppedTablesWithMetadataPresent() {
+        createTable(TableMetadataPersistence.SweepStrategy.CONSERVATIVE);
+        kvs.createTable(TABLE_TO_BE_DROPPED, TableMetadata.allDefault().persistToBytes());
+
+        put(TABLE_NAME, TEST_CELL, OLD_VALUE, 50);
+        put(TABLE_NAME, TEST_CELL, NEW_VALUE, 150);
+        put(TABLE_TO_BE_DROPPED, TEST_CELL, OLD_VALUE, 100);
+
+        // uncommitted write to table to be dropped
+        Cell uncommitted = Cell.create(PtBytes.toBytes("uncommitted"), PtBytes.toBytes("cell"));
+        kvs.put(TABLE_TO_BE_DROPPED, ImmutableMap.of(uncommitted, PtBytes.toBytes(1L)), 120);
+        sweepQueue.enqueue(
+                ImmutableMap.of(TABLE_TO_BE_DROPPED, ImmutableMap.of(uncommitted, PtBytes.toBytes(1L))), 120);
+
+        // this simulates failure to delete metadata after table was dropped in Cassandra
+        kvs.dropTable(TABLE_TO_BE_DROPPED);
+        kvs.put(
+                AtlasDbConstants.DEFAULT_METADATA_TABLE,
+                ImmutableMap.of(
+                        CassandraKeyValueServices.getMetadataCell(TABLE_TO_BE_DROPPED),
+                        TableMetadata.allDefault().persistToBytes()),
+                System.currentTimeMillis());
+
+        completeSweep(null, 90);
+        assertThat(getValue(TABLE_NAME, 110)).isEqualTo(Value.create(PtBytes.toBytes(OLD_VALUE), 50));
+        assertThat(getValue(TABLE_NAME, 160)).isEqualTo(Value.create(PtBytes.toBytes(NEW_VALUE), 150));
+
+        completeSweep(null, 160);
+        assertThat(getValue(TABLE_NAME, 110))
+                .isEqualTo(Value.create(PtBytes.EMPTY_BYTE_ARRAY, Value.INVALID_VALUE_TIMESTAMP));
+        assertThat(getValue(TABLE_NAME, 160)).isEqualTo(Value.create(PtBytes.toBytes(NEW_VALUE), 150));
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -1530,8 +1530,8 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     }
 
     /**
-     * Gets the metadata for a given table. Also useful for checking to see if a table exists. Requires a quorum of
-     * Cassandra nodes to be reachable.
+     * Gets the metadata for a given table. Do not use this method to see if a table exists as it can return false
+     * positives. Requires a quorum of Cassandra nodes to be reachable.
      *
      * @param tableRef the name of the table to get metadata for.
      *

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueDeleter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueDeleter.java
@@ -71,7 +71,7 @@ public class SweepQueueDeleter {
                             kvs.deleteAllTimestamps(entry.getKey(), maxTimestampByCellPartition);
                         });
             } catch (Exception e) {
-                if (tableWasDropped(entry.getKey())) {
+                if (SweepQueueUtils.tableWasDropped(entry.getKey(), kvs)) {
                     log.debug(
                             "Dropping sweeper work for table {}, which has been dropped.",
                             LoggingArgs.tableRef(entry.getKey()),
@@ -81,10 +81,6 @@ public class SweepQueueDeleter {
                 }
             }
         }
-    }
-
-    private boolean tableWasDropped(TableReference tableRef) {
-        return !kvs.getAllTableNames().contains(tableRef);
     }
 
     private Map<TableReference, Map<Cell, TimestampRangeDelete>> writesPerTable(

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueDeleter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueDeleter.java
@@ -16,7 +16,6 @@
 package com.palantir.atlasdb.sweep.queue;
 
 import com.google.common.collect.Iterables;
-import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
@@ -25,7 +24,6 @@ import com.palantir.atlasdb.logging.LoggingArgs;
 import com.palantir.atlasdb.sweep.Sweeper;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 import java.util.function.Function;
@@ -86,7 +84,7 @@ public class SweepQueueDeleter {
     }
 
     private boolean tableWasDropped(TableReference tableRef) {
-        return Arrays.equals(kvs.getMetadataForTable(tableRef), AtlasDbConstants.EMPTY_TABLE_METADATA);
+        return !kvs.getAllTableNames().contains(tableRef);
     }
 
     private Map<TableReference, Map<Cell, TimestampRangeDelete>> writesPerTable(

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueUtils.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueUtils.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.TargetedSweepMetadata;
 import com.palantir.atlasdb.keyvalue.api.WriteReference;
@@ -127,5 +128,9 @@ public final class SweepQueueUtils {
 
     public static Map<PartitionInfo, List<WriteInfo>> partitioningForNonSweepable(long startTs) {
         return ImmutableMap.of(SweepQueueUtils.nonSweepable(startTs), ImmutableList.of(WriteInfo.of(startTs)));
+    }
+
+    public static boolean tableWasDropped(TableReference tableRef, KeyValueService kvs) {
+        return !kvs.getAllTableNames().contains(tableRef);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableCells.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableCells.java
@@ -24,7 +24,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.PeekingIterator;
 import com.google.common.collect.Streams;
-import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.CellReference;
 import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
@@ -52,7 +51,6 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -330,7 +328,7 @@ public class SweepableCells extends SweepQueueTable {
     }
 
     private boolean tableWasDropped(TableReference tableRef) {
-        return Arrays.equals(kvs.getMetadataForTable(tableRef), AtlasDbConstants.EMPTY_TABLE_METADATA);
+        return !kvs.getAllTableNames().contains(tableRef);
     }
 
     private Collection<WriteInfo> getWritesToSweep(Multimap<Long, WriteInfo> writesByStartTs, SortedSet<Long> startTs) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableCells.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableCells.java
@@ -297,7 +297,7 @@ public class SweepableCells extends SweepQueueTable {
             try {
                 kvs.delete(tableRef, multimap);
             } catch (Exception exception) {
-                if (tableWasDropped(tableRef)) {
+                if (SweepQueueUtils.tableWasDropped(tableRef, kvs)) {
                     // this table no longer exists, but had work to do in the sweep queue still;
                     // don't error out on this batch so that the queue cleans up and doesn't constantly retry forever
                     log.info(
@@ -325,10 +325,6 @@ public class SweepableCells extends SweepQueueTable {
                 .lastSeenCommitTs(lastSeenCommitTs)
                 .processedAll(processedAll)
                 .build();
-    }
-
-    private boolean tableWasDropped(TableReference tableRef) {
-        return !kvs.getAllTableNames().contains(tableRef);
     }
 
     private Collection<WriteInfo> getWritesToSweep(Multimap<Long, WriteInfo> writesByStartTs, SortedSet<Long> startTs) {

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractTargetedSweepTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractTargetedSweepTest.java
@@ -42,12 +42,12 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class AbstractTargetedSweepTest extends AbstractSweepTest {
-    private static final TableReference TABLE_TO_BE_DROPPED = TableReference.createFromFullyQualifiedName("ts.drop");
-    private static final Cell TEST_CELL = Cell.create(PtBytes.toBytes("r"), PtBytes.toBytes("c"));
-    private static final String OLD_VALUE = "old_value";
-    private static final String NEW_VALUE = "new_value";
+    protected static final TableReference TABLE_TO_BE_DROPPED = TableReference.createFromFullyQualifiedName("ts.drop");
+    protected static final Cell TEST_CELL = Cell.create(PtBytes.toBytes("r"), PtBytes.toBytes("c"));
+    protected static final String OLD_VALUE = "old_value";
+    protected static final String NEW_VALUE = "new_value";
     private SpecialTimestampsSupplier timestampsSupplier = mock(SpecialTimestampsSupplier.class);
-    private TargetedSweeper sweepQueue;
+    protected TargetedSweeper sweepQueue;
 
     protected AbstractTargetedSweepTest(KvsManager kvsManager, TransactionManagerManager tmManager) {
         super(kvsManager, tmManager);

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractTargetedSweepTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractTargetedSweepTest.java
@@ -133,7 +133,7 @@ public class AbstractTargetedSweepTest extends AbstractSweepTest {
         assertThat(getLastSeenCommitTimestamp()).hasValue(150L);
     }
 
-    private Value getValue(TableReference tableRef, long ts) {
+    protected Value getValue(TableReference tableRef, long ts) {
         return kvs.get(tableRef, ImmutableMap.of(TEST_CELL, ts)).get(TEST_CELL);
     }
 }

--- a/changelog/@unreleased/pr-6291.v2.yml
+++ b/changelog/@unreleased/pr-6291.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fixed a bug where targeted sweep would get stuck on entries from a
+    table that was dropped if the `_metadata` table update failed.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6291


### PR DESCRIPTION
## General
**Before this PR**:
If we drop a table from Cassandra, but then fail to update the metadata, then sweep is unable to proceed if it finds an entry for this table in the sweep queue.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixed a bug where targeted sweep would get stuck on entries from a table that was dropped if the `_metadata` table update failed. 
==COMMIT_MSG==

**Priority**:
sooner rather than later

**Concerns / possible downsides (what feedback would you like?)**:
This is probably more work, but the other method was just wrong.

**What was existing testing like? What have you done to improve it?**:
Added test, there are existing tests as well

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
We have an instance where we are stuck

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
