### PR TITLE
Include StrictHostnameVerifier on Classpath

### DIFF
--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -24,9 +24,10 @@ dependencies {
   explicitShadow project(":atlasdb-impl-shared")
   explicitShadow project(":commons-api")
   explicitShadow project(':timestamp-impl')
-  explicitShadow ('com.palantir.cassandra:cassandra-thrift') {
+  shadow ('com.palantir.cassandra:cassandra-thrift') {
     exclude group: 'org.apache.httpcomponents'
   }
+  implementation ('com.palantir.cassandra:cassandra-thrift')
   explicitShadow ('com.datastax.cassandra:cassandra-driver-core') {
     exclude(group: 'com.codahale.metrics', module: 'metrics-core')
   }

--- a/changelog/@unreleased/pr-6295.v2.yml
+++ b/changelog/@unreleased/pr-6295.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: AtlasDB now includes an implementation dependency on `org.apache.httpcomponents`
+  links:
+  - https://github.com/palantir/atlasdb/pull/6295


### PR DESCRIPTION
## General
**Before this PR**:
`CassandraClientFactory` would fail to be loaded if users were not incidentally including apache http client as we would get a `NoClassDefFoundError` for `StrictHostnameVerifier` 

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
AtlasDB now includes an implementation dependency on `org.apache.httpcomponents`
==COMMIT_MSG==

**Priority**:
Now

**Concerns / possible downsides (what feedback would you like?)**:
Why was this excluded to begin with?

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
