### PR TITLE
Bump Timelock and disable API guesser

### DIFF
--- a/lock-api-objects/build.gradle
+++ b/lock-api-objects/build.gradle
@@ -27,7 +27,7 @@ recommendedProductDependencies {
     productDependency {
         productGroup = 'com.palantir.timelock'
         productName = 'timelock-server'
-        minimumVersion = '0.476.0'
+        minimumVersion = '0.1161.0'
         maximumVersion = '0.x.x'
     }
 }

--- a/lock-api/src/main/java/com/palantir/lock/client/DialogueAdaptingConjureTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/DialogueAdaptingConjureTimelockService.java
@@ -24,8 +24,6 @@ import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponse;
 import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponseV2;
 import com.palantir.atlasdb.timelock.api.ConjureLockRequest;
 import com.palantir.atlasdb.timelock.api.ConjureLockResponse;
-import com.palantir.atlasdb.timelock.api.ConjureLockToken;
-import com.palantir.atlasdb.timelock.api.ConjureLockTokenV2;
 import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksRequest;
 import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksRequestV2;
 import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksResponse;
@@ -35,7 +33,6 @@ import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsRequest;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
 import com.palantir.atlasdb.timelock.api.ConjureTimelockService;
 import com.palantir.atlasdb.timelock.api.ConjureTimelockServiceBlocking;
-import com.palantir.atlasdb.timelock.api.ConjureTimestampRange;
 import com.palantir.atlasdb.timelock.api.ConjureUnlockRequest;
 import com.palantir.atlasdb.timelock.api.ConjureUnlockRequestV2;
 import com.palantir.atlasdb.timelock.api.ConjureUnlockResponse;
@@ -45,28 +42,19 @@ import com.palantir.atlasdb.timelock.api.GetCommitTimestampRequest;
 import com.palantir.atlasdb.timelock.api.GetCommitTimestampResponse;
 import com.palantir.atlasdb.timelock.api.GetCommitTimestampsRequest;
 import com.palantir.atlasdb.timelock.api.GetCommitTimestampsResponse;
-import com.palantir.conjure.java.api.errors.RemoteException;
-import com.palantir.conjure.java.api.errors.UnknownRemoteException;
 import com.palantir.lock.v2.LeaderTime;
 import com.palantir.tokens.auth.AuthHeader;
-import java.util.Set;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 public class DialogueAdaptingConjureTimelockService implements ConjureTimelockService {
     private final ConjureTimelockServiceBlocking dialogueDelegate;
     private final ConjureTimelockServiceBlockingMetrics conjureTimelockServiceBlockingMetrics;
-
-    private final ServerApiVersionGuesser serverApiVersionGuesser;
 
     public DialogueAdaptingConjureTimelockService(
             ConjureTimelockServiceBlocking dialogueDelegate,
             ConjureTimelockServiceBlockingMetrics conjureTimelockServiceBlockingMetrics) {
         this.dialogueDelegate = dialogueDelegate;
         this.conjureTimelockServiceBlockingMetrics = conjureTimelockServiceBlockingMetrics;
-        this.serverApiVersionGuesser = new ServerApiVersionGuesser();
     }
 
     @Override
@@ -87,24 +75,12 @@ public class DialogueAdaptingConjureTimelockService implements ConjureTimelockSe
     @Override
     public ConjureGetFreshTimestampsResponseV2 getFreshTimestampsV2(
             AuthHeader authHeader, String namespace, ConjureGetFreshTimestampsRequestV2 request) {
-        return serverApiVersionGuesser.runUnderSuspicion(
-                () -> dialogueDelegate.getFreshTimestampsV2(authHeader, namespace, request), () -> {
-                    ConjureGetFreshTimestampsResponse response = dialogueDelegate.getFreshTimestamps(
-                            authHeader, namespace, ConjureGetFreshTimestampsRequest.of(request.get()));
-                    return ConjureGetFreshTimestampsResponseV2.of(ConjureTimestampRange.of(
-                            response.getInclusiveLower(),
-                            response.getInclusiveUpper() - response.getInclusiveLower() + 1));
-                });
+        return dialogueDelegate.getFreshTimestampsV2(authHeader, namespace, request);
     }
 
     @Override
     public ConjureSingleTimestamp getFreshTimestamp(AuthHeader authHeader, String namespace) {
-        return serverApiVersionGuesser.runUnderSuspicion(
-                () -> dialogueDelegate.getFreshTimestamp(authHeader, namespace), () -> {
-                    ConjureGetFreshTimestampsResponse response = dialogueDelegate.getFreshTimestamps(
-                            authHeader, namespace, ConjureGetFreshTimestampsRequest.of(1));
-                    return ConjureSingleTimestamp.of(response.getInclusiveLower());
-                });
+        return dialogueDelegate.getFreshTimestamp(authHeader, namespace);
     }
 
     @Override
@@ -135,14 +111,7 @@ public class DialogueAdaptingConjureTimelockService implements ConjureTimelockSe
     @Override
     public ConjureRefreshLocksResponseV2 refreshLocksV2(
             AuthHeader authHeader, String namespace, ConjureRefreshLocksRequestV2 request) {
-        return serverApiVersionGuesser.runUnderSuspicion(
-                () -> dialogueDelegate.refreshLocksV2(authHeader, namespace, request), () -> {
-                    ConjureRefreshLocksRequest v1Request = ConjureRefreshLocksRequest.of(fromV2Tokens(request.get()));
-                    ConjureRefreshLocksResponse lockResponse =
-                            dialogueDelegate.refreshLocks(authHeader, namespace, v1Request);
-                    return ConjureRefreshLocksResponseV2.of(
-                            toV2Tokens(lockResponse.getRefreshedTokens()), lockResponse.getLease());
-                });
+        return dialogueDelegate.refreshLocksV2(authHeader, namespace, request);
     }
 
     @Override
@@ -152,13 +121,7 @@ public class DialogueAdaptingConjureTimelockService implements ConjureTimelockSe
 
     @Override
     public ConjureUnlockResponseV2 unlockV2(AuthHeader authHeader, String namespace, ConjureUnlockRequestV2 request) {
-        return serverApiVersionGuesser.runUnderSuspicion(
-                () -> dialogueDelegate.unlockV2(authHeader, namespace, request), () -> {
-                    ConjureUnlockRequest v1Request = ConjureUnlockRequest.of(fromV2Tokens(request.get()));
-                    return ConjureUnlockResponseV2.of(toV2Tokens(dialogueDelegate
-                            .unlock(authHeader, namespace, v1Request)
-                            .getTokens()));
-                });
+        return dialogueDelegate.unlockV2(authHeader, namespace, request);
     }
 
     @Override
@@ -180,66 +143,6 @@ public class DialogueAdaptingConjureTimelockService implements ConjureTimelockSe
         } catch (RuntimeException e) {
             meterSupplier.get().mark();
             throw e;
-        }
-    }
-
-    private Set<ConjureLockTokenV2> toV2Tokens(Set<ConjureLockToken> v1Tokens) {
-        return v1Tokens.stream()
-                .map(token -> ConjureLockTokenV2.of(token.getRequestId()))
-                .collect(Collectors.toSet());
-    }
-
-    private Set<ConjureLockToken> fromV2Tokens(Set<ConjureLockTokenV2> v2Tokens) {
-        return v2Tokens.stream().map(token -> ConjureLockToken.of(token.get())).collect(Collectors.toSet());
-    }
-
-    private static final class ServerApiVersionGuesser {
-        private static final int NOT_FOUND = 404;
-        private static final double ATTEMPT_NEW_PROBABILITY_WHEN_SUSPECTING_OLD = 0.001;
-
-        private final AtomicBoolean suspectOldVersion;
-
-        private ServerApiVersionGuesser() {
-            this.suspectOldVersion = new AtomicBoolean();
-        }
-
-        public <T> T runUnderSuspicion(Supplier<T> newFunction, Supplier<T> legacyFunction) {
-            if (shouldUseNewEndpoint()) {
-                return runNewFunctionFirst(newFunction, legacyFunction);
-            }
-            return legacyFunction.get();
-        }
-
-        private boolean shouldUseNewEndpoint() {
-            if (suspectOldVersion.get()) {
-                return ThreadLocalRandom.current().nextDouble() < ATTEMPT_NEW_PROBABILITY_WHEN_SUSPECTING_OLD;
-            }
-            return true;
-        }
-
-        private <T> T runNewFunctionFirst(Supplier<T> newFunction, Supplier<T> legacyFunction) {
-            try {
-                T candidateOutput = newFunction.get();
-                if (suspectOldVersion.get()) {
-                    suspectOldVersion.set(false);
-                }
-                return candidateOutput;
-            } catch (RemoteException remoteException) {
-                if (remoteException.getStatus() != NOT_FOUND) {
-                    throw remoteException;
-                }
-                return suspectOldVersionAndCallLegacy(legacyFunction);
-            } catch (UnknownRemoteException unknownRemoteException) {
-                if (unknownRemoteException.getStatus() != NOT_FOUND) {
-                    throw unknownRemoteException;
-                }
-                return suspectOldVersionAndCallLegacy(legacyFunction);
-            }
-        }
-
-        private <T> T suspectOldVersionAndCallLegacy(Supplier<T> legacyFunction) {
-            suspectOldVersion.set(true);
-            return legacyFunction.get();
         }
     }
 }


### PR DESCRIPTION
## General
**Before this PR**:
It's been a while since we rolled out the new lock endpoints, and it seems likely that Timelock will be on the newer version now. Additionally, large internal product has a tendency to create their TimelockClient in a custom way that does not respect the dialogue adapter, and thus they are exposed to the risk of not using the new API.

**After this PR**:
==COMMIT_MSG==
Bump Timelock dependency to 0.1161.0, and remove probabilistic usage of V1 versus V2 endpoints; now, V2 endpoints will be used exclusively as they are known to exist (via the product dependency).
==COMMIT_MSG==

**Priority**:
P1

**Concerns / possible downsides (what feedback would you like?)**:
* Are we ready to introduce this bump? I think so - it's already causing internal problems.
* Did I remove any essential logic?
* Is this the correct minimum version of Timelock?

**Is documentation needed?**:
No

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No, but it does force the usage of new API endpoints, but we have a dependency bump to achieve this.

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No

**Does this PR need a schema migration?**
No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
That we can depend upon Timelock 0.1161.0.

**What was existing testing like? What have you done to improve it?**:
N/A

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Nothing would break!

**Has the safety of all log arguments been decided correctly?**:
No changes

**Will this change significantly affect our spending on metrics or logs?**:
No

**How would I tell that this PR does not work in production? (monitors, etc.)**:
Nothing would work

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Yes

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No

## Development Process
**Where should we start reviewing?**:
Diff

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
N/A

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
