### PR TITLE
[Backport][0.708.x] Bump Timelock and disable API guesser (#6309)

### DIFF
--- a/changelog/@unreleased/pr-6309.v2.yml
+++ b/changelog/@unreleased/pr-6309.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Bump Timelock dependency to 0.1161.0, and remove probabilistic usage
+    of V1 versus V2 endpoints; now, V2 endpoints will be used exclusively as they
+    are known to exist (via the product dependency).
+  links:
+  - https://github.com/palantir/atlasdb/pull/6309

--- a/lock-api-objects/build.gradle
+++ b/lock-api-objects/build.gradle
@@ -27,7 +27,7 @@ recommendedProductDependencies {
     productDependency {
         productGroup = 'com.palantir.timelock'
         productName = 'timelock-server'
-        minimumVersion = '0.476.0'
+        minimumVersion = '0.1144.0'
         maximumVersion = '0.x.x'
     }
 }

--- a/lock-api/src/main/java/com/palantir/lock/client/DialogueAdaptingConjureTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/DialogueAdaptingConjureTimelockService.java
@@ -24,8 +24,6 @@ import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponse;
 import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponseV2;
 import com.palantir.atlasdb.timelock.api.ConjureLockRequest;
 import com.palantir.atlasdb.timelock.api.ConjureLockResponse;
-import com.palantir.atlasdb.timelock.api.ConjureLockToken;
-import com.palantir.atlasdb.timelock.api.ConjureLockTokenV2;
 import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksRequest;
 import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksRequestV2;
 import com.palantir.atlasdb.timelock.api.ConjureRefreshLocksResponse;
@@ -35,7 +33,6 @@ import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsRequest;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
 import com.palantir.atlasdb.timelock.api.ConjureTimelockService;
 import com.palantir.atlasdb.timelock.api.ConjureTimelockServiceBlocking;
-import com.palantir.atlasdb.timelock.api.ConjureTimestampRange;
 import com.palantir.atlasdb.timelock.api.ConjureUnlockRequest;
 import com.palantir.atlasdb.timelock.api.ConjureUnlockRequestV2;
 import com.palantir.atlasdb.timelock.api.ConjureUnlockResponse;
@@ -45,28 +42,19 @@ import com.palantir.atlasdb.timelock.api.GetCommitTimestampRequest;
 import com.palantir.atlasdb.timelock.api.GetCommitTimestampResponse;
 import com.palantir.atlasdb.timelock.api.GetCommitTimestampsRequest;
 import com.palantir.atlasdb.timelock.api.GetCommitTimestampsResponse;
-import com.palantir.conjure.java.api.errors.RemoteException;
-import com.palantir.conjure.java.api.errors.UnknownRemoteException;
 import com.palantir.lock.v2.LeaderTime;
 import com.palantir.tokens.auth.AuthHeader;
-import java.util.Set;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 public class DialogueAdaptingConjureTimelockService implements ConjureTimelockService {
     private final ConjureTimelockServiceBlocking dialogueDelegate;
     private final ConjureTimelockServiceBlockingMetrics conjureTimelockServiceBlockingMetrics;
-
-    private final ServerApiVersionGuesser serverApiVersionGuesser;
 
     public DialogueAdaptingConjureTimelockService(
             ConjureTimelockServiceBlocking dialogueDelegate,
             ConjureTimelockServiceBlockingMetrics conjureTimelockServiceBlockingMetrics) {
         this.dialogueDelegate = dialogueDelegate;
         this.conjureTimelockServiceBlockingMetrics = conjureTimelockServiceBlockingMetrics;
-        this.serverApiVersionGuesser = new ServerApiVersionGuesser();
     }
 
     @Override
@@ -87,24 +75,12 @@ public class DialogueAdaptingConjureTimelockService implements ConjureTimelockSe
     @Override
     public ConjureGetFreshTimestampsResponseV2 getFreshTimestampsV2(
             AuthHeader authHeader, String namespace, ConjureGetFreshTimestampsRequestV2 request) {
-        return serverApiVersionGuesser.runUnderSuspicion(
-                () -> dialogueDelegate.getFreshTimestampsV2(authHeader, namespace, request), () -> {
-                    ConjureGetFreshTimestampsResponse response = dialogueDelegate.getFreshTimestamps(
-                            authHeader, namespace, ConjureGetFreshTimestampsRequest.of(request.get()));
-                    return ConjureGetFreshTimestampsResponseV2.of(ConjureTimestampRange.of(
-                            response.getInclusiveLower(),
-                            response.getInclusiveUpper() - response.getInclusiveLower() + 1));
-                });
+        return dialogueDelegate.getFreshTimestampsV2(authHeader, namespace, request);
     }
 
     @Override
     public ConjureSingleTimestamp getFreshTimestamp(AuthHeader authHeader, String namespace) {
-        return serverApiVersionGuesser.runUnderSuspicion(
-                () -> dialogueDelegate.getFreshTimestamp(authHeader, namespace), () -> {
-                    ConjureGetFreshTimestampsResponse response = dialogueDelegate.getFreshTimestamps(
-                            authHeader, namespace, ConjureGetFreshTimestampsRequest.of(1));
-                    return ConjureSingleTimestamp.of(response.getInclusiveLower());
-                });
+        return dialogueDelegate.getFreshTimestamp(authHeader, namespace);
     }
 
     @Override
@@ -135,14 +111,7 @@ public class DialogueAdaptingConjureTimelockService implements ConjureTimelockSe
     @Override
     public ConjureRefreshLocksResponseV2 refreshLocksV2(
             AuthHeader authHeader, String namespace, ConjureRefreshLocksRequestV2 request) {
-        return serverApiVersionGuesser.runUnderSuspicion(
-                () -> dialogueDelegate.refreshLocksV2(authHeader, namespace, request), () -> {
-                    ConjureRefreshLocksRequest v1Request = ConjureRefreshLocksRequest.of(fromV2Tokens(request.get()));
-                    ConjureRefreshLocksResponse lockResponse =
-                            dialogueDelegate.refreshLocks(authHeader, namespace, v1Request);
-                    return ConjureRefreshLocksResponseV2.of(
-                            toV2Tokens(lockResponse.getRefreshedTokens()), lockResponse.getLease());
-                });
+        return dialogueDelegate.refreshLocksV2(authHeader, namespace, request);
     }
 
     @Override
@@ -152,13 +121,7 @@ public class DialogueAdaptingConjureTimelockService implements ConjureTimelockSe
 
     @Override
     public ConjureUnlockResponseV2 unlockV2(AuthHeader authHeader, String namespace, ConjureUnlockRequestV2 request) {
-        return serverApiVersionGuesser.runUnderSuspicion(
-                () -> dialogueDelegate.unlockV2(authHeader, namespace, request), () -> {
-                    ConjureUnlockRequest v1Request = ConjureUnlockRequest.of(fromV2Tokens(request.get()));
-                    return ConjureUnlockResponseV2.of(toV2Tokens(dialogueDelegate
-                            .unlock(authHeader, namespace, v1Request)
-                            .getTokens()));
-                });
+        return dialogueDelegate.unlockV2(authHeader, namespace, request);
     }
 
     @Override
@@ -180,66 +143,6 @@ public class DialogueAdaptingConjureTimelockService implements ConjureTimelockSe
         } catch (RuntimeException e) {
             meterSupplier.get().mark();
             throw e;
-        }
-    }
-
-    private Set<ConjureLockTokenV2> toV2Tokens(Set<ConjureLockToken> v1Tokens) {
-        return v1Tokens.stream()
-                .map(token -> ConjureLockTokenV2.of(token.getRequestId()))
-                .collect(Collectors.toSet());
-    }
-
-    private Set<ConjureLockToken> fromV2Tokens(Set<ConjureLockTokenV2> v2Tokens) {
-        return v2Tokens.stream().map(token -> ConjureLockToken.of(token.get())).collect(Collectors.toSet());
-    }
-
-    private static final class ServerApiVersionGuesser {
-        private static final int NOT_FOUND = 404;
-        private static final double ATTEMPT_NEW_PROBABILITY_WHEN_SUSPECTING_OLD = 0.001;
-
-        private final AtomicBoolean suspectOldVersion;
-
-        private ServerApiVersionGuesser() {
-            this.suspectOldVersion = new AtomicBoolean();
-        }
-
-        public <T> T runUnderSuspicion(Supplier<T> newFunction, Supplier<T> legacyFunction) {
-            if (shouldUseNewEndpoint()) {
-                return runNewFunctionFirst(newFunction, legacyFunction);
-            }
-            return legacyFunction.get();
-        }
-
-        private boolean shouldUseNewEndpoint() {
-            if (suspectOldVersion.get()) {
-                return ThreadLocalRandom.current().nextDouble() < ATTEMPT_NEW_PROBABILITY_WHEN_SUSPECTING_OLD;
-            }
-            return true;
-        }
-
-        private <T> T runNewFunctionFirst(Supplier<T> newFunction, Supplier<T> legacyFunction) {
-            try {
-                T candidateOutput = newFunction.get();
-                if (suspectOldVersion.get()) {
-                    suspectOldVersion.set(false);
-                }
-                return candidateOutput;
-            } catch (RemoteException remoteException) {
-                if (remoteException.getStatus() != NOT_FOUND) {
-                    throw remoteException;
-                }
-                return suspectOldVersionAndCallLegacy(legacyFunction);
-            } catch (UnknownRemoteException unknownRemoteException) {
-                if (unknownRemoteException.getStatus() != NOT_FOUND) {
-                    throw unknownRemoteException;
-                }
-                return suspectOldVersionAndCallLegacy(legacyFunction);
-            }
-        }
-
-        private <T> T suspectOldVersionAndCallLegacy(Supplier<T> legacyFunction) {
-            suspectOldVersion.set(true);
-            return legacyFunction.get();
         }
     }
 }


### PR DESCRIPTION
Bump Timelock dependency to 0.1161.0, and remove probabilistic usage of V1 versus V2 endpoints; now, V2 endpoints will be used exclusively as they are known to exist (via the product dependency).

Unlike #6312 , this was a clean cherry-pick of #6309 - please see that PR for considerations.

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

