### PR TITLE
Better logging for endpoint verification

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
@@ -227,8 +227,7 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
     @VisibleForTesting
     static void verifyEndpoint(CassandraServer cassandraServer, SSLSocket socket, boolean throwOnFailure)
             throws SafeSSLPeerUnverifiedException {
-        Set<String> endpointsToCheck =
-                ImmutableSet.of(socket.getInetAddress().getHostAddress(), cassandraServer.cassandraHostName());
+        Set<String> endpointsToCheck = getEndpointsToCheck(cassandraServer, socket);
         boolean endpointVerified =
                 endpointsToCheck.stream().anyMatch(address -> hostnameVerifier.verify(address, socket.getSession()));
 
@@ -239,6 +238,11 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
                         "Endpoint verification failed for host.", SafeArg.of("endpointsToCheck", endpointsToCheck));
             }
         }
+    }
+
+    @VisibleForTesting
+    static Set<String> getEndpointsToCheck(CassandraServer cassandraServer, SSLSocket socket) {
+        return ImmutableSet.of(socket.getInetAddress().getHostAddress(), cassandraServer.cassandraHostName());
     }
 
     @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
@@ -239,10 +239,10 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
             return;
         }
         if (!endpointVerified) {
-            log.warn("Endpoint verification failed for host.", SafeArg.of("endpointsToCheck", endpointsToCheck));
+            log.warn("Endpoint verification failed for host.", SafeArg.of("endpointsChecked", endpointsToCheck));
             if (throwOnFailure) {
                 throw new SafeSSLPeerUnverifiedException(
-                        "Endpoint verification failed for host.", SafeArg.of("endpointsToCheck", endpointsToCheck));
+                        "Endpoint verification failed for host.", SafeArg.of("endpointsChecked", endpointsToCheck));
             }
         }
     }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
@@ -228,13 +228,15 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
      */
     @VisibleForTesting
     static void verifyEndpoint(CassandraServer cassandraServer, SSLSocket socket, boolean throwOnFailure)
-            throws SafeSSLPeerUnverifiedException, SocketException {
+            throws SafeSSLPeerUnverifiedException {
         Set<String> endpointsToCheck = getEndpointsToCheck(cassandraServer, socket);
         boolean endpointVerified =
                 endpointsToCheck.stream().anyMatch(address -> hostnameVerifier.verify(address, socket.getSession()));
         if (socket.isClosed()) {
             if (throwOnFailure) {
-                throw new SocketException("Unable to verify hostnames as socket is closed.");
+                throw new SafeSSLPeerUnverifiedException(
+                        "Unable to verify endpoints as socket is closed.",
+                        SafeArg.of("endpoint", socket.getInetAddress()));
             }
             return;
         }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactoryTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactoryTest.java
@@ -115,11 +115,13 @@ public class CassandraClientFactoryTest {
     }
 
     @Test
-    public void verifyEndpointDoesNotThrownWhenHostnameIpAreDuplicates() {
-        CassandraServer cassandraServer = CassandraServer.of(InetSocketAddress.createUnresolved("1.2.3.4", 4000));
+    public void getEndpointsToCheckDeduplicatesMatchingHostnameIp() {
+        CassandraServer cassandraServer =
+                CassandraServer.of(InetSocketAddress.createUnresolved(DEFAULT_ADDRESS.getHostAddress(), 4000));
         SSLSocket sslSocket = createSSLSocket(cassandraServer, DEFAULT_ADDRESS);
-        assertThatCode(() -> CassandraClientFactory.verifyEndpoint(cassandraServer, sslSocket, true))
-                .doesNotThrowAnyException();
+        assertThat(CassandraClientFactory.getEndpointsToCheck(cassandraServer, sslSocket))
+                .isNotEmpty()
+                .containsExactly(DEFAULT_ADDRESS.getHostAddress());
     }
 
     @SuppressWarnings("ReverseDnsLookup")

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactoryTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactoryTest.java
@@ -30,7 +30,6 @@ import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.exception.SafeSSLPeerUnverifiedException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.net.SocketException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
@@ -120,7 +119,7 @@ public class CassandraClientFactoryTest {
         SSLSocket sslSocket = createSSLSocket(DEFAULT_SERVER, DEFAULT_ADDRESS);
         when(sslSocket.isClosed()).thenReturn(true);
         assertThatThrownBy(() -> CassandraClientFactory.verifyEndpoint(DEFAULT_SERVER, sslSocket, true))
-                .isInstanceOf(SocketException.class);
+                .isInstanceOf(SafeSSLPeerUnverifiedException.class);
     }
 
     @Test

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactoryTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactoryTest.java
@@ -124,6 +124,14 @@ public class CassandraClientFactoryTest {
                 .containsExactly(DEFAULT_ADDRESS.getHostAddress());
     }
 
+    @Test
+    public void getEndpointsToCheckPerformsNoDeduplicationWhenHostnameIpDiffer() {
+        SSLSocket sslSocket = createSSLSocket(DEFAULT_SERVER, DEFAULT_ADDRESS);
+        assertThat(CassandraClientFactory.getEndpointsToCheck(DEFAULT_SERVER, sslSocket))
+                .isNotEmpty()
+                .containsExactlyInAnyOrder(DEFAULT_SERVER.cassandraHostName(), DEFAULT_ADDRESS.getHostAddress());
+    }
+
     @SuppressWarnings("ReverseDnsLookup")
     private static InetSocketAddress mockInetSocketAddress(String ipAddress) {
         InetAddress inetAddress = mockInetAddress(ipAddress);

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactoryTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactoryTest.java
@@ -114,6 +114,14 @@ public class CassandraClientFactoryTest {
                 .doesNotThrowAnyException();
     }
 
+    @Test
+    public void verifyEndpointDoesNotThrownWhenHostnameIpAreDuplicates() {
+        CassandraServer cassandraServer = CassandraServer.of(InetSocketAddress.createUnresolved("1.2.3.4", 4000));
+        SSLSocket sslSocket = createSSLSocket(cassandraServer, DEFAULT_ADDRESS);
+        assertThatCode(() -> CassandraClientFactory.verifyEndpoint(cassandraServer, sslSocket, true))
+                .doesNotThrowAnyException();
+    }
+
     @SuppressWarnings("ReverseDnsLookup")
     private static InetSocketAddress mockInetSocketAddress(String ipAddress) {
         InetAddress inetAddress = mockInetAddress(ipAddress);

--- a/changelog/@unreleased/pr-6314.v2.yml
+++ b/changelog/@unreleased/pr-6314.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: If hostname/ip address are duplicates, only check one when performing
+    endpoint verification.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6314


### PR DESCRIPTION
## General
**Before this PR**:
The exact endpoints in which we check for in the certificate chain are not logged. In addition, if the hostname/ip address are duplicates, then we check them twice in the failure case. In addition, the hostname verification check would initiate the socket's connection, before setting Thrift socket settings. In practice this had little effect, but may cause confusion later on.

**After this PR**:
Log the exact endpoints we checked when performing hostname verification, and only logs if this the socket has not closed. If the socket has closed, and `throwOnException` is true, then `SafeSSLPeerUnverifiedException` will throw. Only verify endpoints after thrift socket settings have been applied. 
==COMMIT_MSG==
When verifying endpoints, throw a separate exception if the socket is closed, and de-dupcliate hostname/ip if they're identical. 
==COMMIT_MSG==

**Priority**:
P1

**Concerns / possible downsides (what feedback would you like?)**:
- Throws when performing deduplication (confirmed that this is NOT the case already :) )

**Is documentation needed?**:
No

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No

**Does this PR need a schema migration?**
No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
N/A

**What was existing testing like? What have you done to improve it?**:
Before we did not test set deduplication explicitly. 

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Logs

**Has the safety of all log arguments been decided correctly?**:
Yes

**Will this change significantly affect our spending on metrics or logs?**:
No

**How would I tell that this PR does not work in production? (monitors, etc.)**:
Logs

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Rollback

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**: N/A

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No

## Development Process
**Where should we start reviewing?**:
Now

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
