### PR TITLE
[Drop Keyspace] Discovery for NamespaceDeleterFactory

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/namespacedeleter/NamespaceDeleterFactory.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/namespacedeleter/NamespaceDeleterFactory.java
@@ -1,0 +1,29 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.namespacedeleter;
+
+import com.palantir.atlasdb.spi.KeyValueServiceConfig;
+import com.palantir.atlasdb.spi.KeyValueServiceRuntimeConfig;
+import com.palantir.refreshable.Refreshable;
+import java.util.Optional;
+
+public interface NamespaceDeleterFactory {
+    String getType();
+
+    NamespaceDeleter createNamespaceDeleter(
+            KeyValueServiceConfig config, Refreshable<Optional<KeyValueServiceRuntimeConfig>> runtimeConfig);
+}

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/spi/KeyValueServiceConfig.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/spi/KeyValueServiceConfig.java
@@ -18,7 +18,6 @@ package com.palantir.atlasdb.spi;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import java.util.Optional;
-import org.immutables.value.Value;
 
 /**
  * Marker interface for various AtlasDb KeyValueService config objects.
@@ -38,8 +37,5 @@ public interface KeyValueServiceConfig {
      * you've acknowledged the risks and side effects mentioned in the relevant NamespaceDeleter docs (e.g.,
      * CassandraNamespaceDeleter)
      */
-    @Value.Default // Without this annotation, implementors cannot add this property as part of an immutable builder.
-    default boolean enableNamespaceDeletionDangerousIKnowWhatIAmDoing() {
-        return false;
-    }
+    boolean enableNamespaceDeletionDangerousIKnowWhatIAmDoing();
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/spi/KeyValueServiceConfig.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/spi/KeyValueServiceConfig.java
@@ -15,9 +15,11 @@
  */
 package com.palantir.atlasdb.spi;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import java.util.Optional;
+import org.immutables.value.Value;
 
 /**
  * Marker interface for various AtlasDb KeyValueService config objects.
@@ -29,4 +31,17 @@ public interface KeyValueServiceConfig {
     Optional<String> namespace();
 
     Optional<SharedResourcesConfig> sharedResourcesConfig();
+
+    /**
+     * Enables construction of {@link com.palantir.atlasdb.namespacedeleter.NamespaceDeleter} via a
+     * {@link com.palantir.atlasdb.namespacedeleter.NamespaceDeleterFactory} through AtlasDbServiceDiscovery, which
+     * can be used to delete all data for a namespace in the KVS. This is dangerous, and must only be used once
+     * you've acknowledged the risks and side effects mentioned in the relevant NamespaceDeleter docs (e.g.,
+     * CassandraNamespaceDeleter)
+     */
+    @Value.Default
+    @JsonProperty("enableNamespaceDeletionDangerousIKnowWhatIAmDoing")
+    default boolean enableNamespaceDeletion() {
+        return false;
+    }
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/spi/KeyValueServiceConfig.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/spi/KeyValueServiceConfig.java
@@ -15,7 +15,6 @@
  */
 package com.palantir.atlasdb.spi;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import java.util.Optional;
@@ -39,9 +38,8 @@ public interface KeyValueServiceConfig {
      * you've acknowledged the risks and side effects mentioned in the relevant NamespaceDeleter docs (e.g.,
      * CassandraNamespaceDeleter)
      */
-    @Value.Default
-    @JsonProperty("enableNamespaceDeletionDangerousIKnowWhatIAmDoing")
-    default boolean enableNamespaceDeletion() {
+    @Value.Default // Without this annotation, implementors cannot add this property as part of an immutable builder.
+    default boolean enableNamespaceDeletionDangerousIKnowWhatIAmDoing() {
         return false;
     }
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/spi/KeyValueServiceConfigHelper.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/spi/KeyValueServiceConfigHelper.java
@@ -34,4 +34,9 @@ public interface KeyValueServiceConfigHelper extends KeyValueServiceConfig {
     default Optional<SharedResourcesConfig> sharedResourcesConfig() {
         return Optional.empty();
     }
+
+    @Override
+    default boolean enableNamespaceDeletionDangerousIKnowWhatIAmDoing() {
+        return false;
+    }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -407,6 +407,12 @@ public interface CassandraKeyValueServiceConfig extends KeyValueServiceConfig {
         return ssl().orElseGet(sslConfiguration()::isPresent);
     }
 
+    @Override
+    @Value.Default
+    default boolean enableNamespaceDeletionDangerousIKnowWhatIAmDoing() {
+        return false;
+    }
+
     @Value.Check
     default void check() {
         double evictionCheckProportion = proportionConnectionsToCheckPerEvictionRun();

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfigsTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfigsTest.java
@@ -73,6 +73,7 @@ public class CassandraKeyValueServiceConfigsTest {
                 .addressTranslation(ImmutableMap.of("test", Iterables.getOnlyElement(SERVER_ADDRESSES)))
                 .replicationFactor(1)
                 .credentials(CREDENTIALS)
+                .enableNamespaceDeletionDangerousIKnowWhatIAmDoing(true)
                 .build();
 
         URL configUrl =

--- a/atlasdb-cassandra/src/test/resources/testConfig.yml
+++ b/atlasdb-cassandra/src/test/resources/testConfig.yml
@@ -7,3 +7,4 @@
   credentials:
     username: username
     password: password
+  enableNamespaceDeletionDangerousIKnowWhatIAmDoing: true

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/AtlasDbServiceDiscovery.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/AtlasDbServiceDiscovery.java
@@ -16,6 +16,7 @@
 
 package com.palantir.atlasdb.factory;
 
+import com.palantir.atlasdb.namespacedeleter.NamespaceDeleterFactory;
 import com.palantir.atlasdb.spi.AtlasDbFactory;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 import com.palantir.atlasdb.timestamp.DbTimeLockFactory;
@@ -35,6 +36,11 @@ public final class AtlasDbServiceDiscovery {
 
     public static DbTimeLockFactory createDbTimeLockFactoryOfCorrectType(KeyValueServiceConfig config) {
         return createAtlasDbServiceOfCorrectType(config, DbTimeLockFactory::getType, DbTimeLockFactory.class);
+    }
+
+    public static NamespaceDeleterFactory createNamespaceDeleterFactoryOfCorrectType(KeyValueServiceConfig config) {
+        return createAtlasDbServiceOfCorrectType(
+                config, NamespaceDeleterFactory::getType, NamespaceDeleterFactory.class);
     }
 
     private static <T> T createAtlasDbServiceOfCorrectType(

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/AtlasDbServiceDiscovery.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/AtlasDbServiceDiscovery.java
@@ -39,6 +39,10 @@ public final class AtlasDbServiceDiscovery {
     }
 
     public static NamespaceDeleterFactory createNamespaceDeleterFactoryOfCorrectType(KeyValueServiceConfig config) {
+        if (!config.enableNamespaceDeletion()) {
+            throw new SafeIllegalStateException("Cannot construct a NamespaceDeleterFactory when keyValueService"
+                    + ".enableNamespaceDeletionDangerousIKnowWhatIAmDoing is false.");
+        }
         return createAtlasDbServiceOfCorrectType(
                 config, NamespaceDeleterFactory::getType, NamespaceDeleterFactory.class);
     }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/AtlasDbServiceDiscovery.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/AtlasDbServiceDiscovery.java
@@ -39,7 +39,7 @@ public final class AtlasDbServiceDiscovery {
     }
 
     public static NamespaceDeleterFactory createNamespaceDeleterFactoryOfCorrectType(KeyValueServiceConfig config) {
-        if (!config.enableNamespaceDeletion()) {
+        if (!config.enableNamespaceDeletionDangerousIKnowWhatIAmDoing()) {
             throw new SafeIllegalStateException("Cannot construct a NamespaceDeleterFactory when keyValueService"
                     + ".enableNamespaceDeletionDangerousIKnowWhatIAmDoing is false.");
         }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbConfig.java
@@ -53,6 +53,11 @@ public final class InMemoryAtlasDbConfig implements KeyValueServiceConfig {
     }
 
     @Override
+    public boolean enableNamespaceDeletionDangerousIKnowWhatIAmDoing() {
+        return false;
+    }
+
+    @Override
     public int hashCode() {
         return InMemoryAtlasDbConfig.class.hashCode();
     }

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/AtlasDbServiceDiscoveryTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/AtlasDbServiceDiscoveryTest.java
@@ -26,7 +26,7 @@ import com.palantir.refreshable.Refreshable;
 import java.util.Optional;
 import org.junit.Test;
 
-public class AtlasDbServiceDiscoveryTest {
+public final class AtlasDbServiceDiscoveryTest {
     private final KeyValueServiceConfigHelper kvsConfig = () -> AutoServiceAnnotatedAtlasDbFactory.TYPE;
     private final KeyValueServiceConfigHelper invalidKvsConfig = () -> "should not be found kvs";
     private final Refreshable<Optional<KeyValueServiceRuntimeConfig>> runtimeConfig =

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/AtlasDbServiceDiscoveryTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/AtlasDbServiceDiscoveryTest.java
@@ -83,7 +83,7 @@ public final class AtlasDbServiceDiscoveryTest {
         }
 
         @Override
-        public boolean enableNamespaceDeletion() {
+        public boolean enableNamespaceDeletionDangerousIKnowWhatIAmDoing() {
             return enableDeletion;
         }
     }

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/AutoServiceAnnotatedNamespaceDeleterFactory.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/AutoServiceAnnotatedNamespaceDeleterFactory.java
@@ -26,7 +26,7 @@ import com.palantir.refreshable.Refreshable;
 import java.util.Optional;
 
 @AutoService(NamespaceDeleterFactory.class)
-public class AutoServiceAnnotatedNamespaceDeleterFactory implements NamespaceDeleterFactory {
+public final class AutoServiceAnnotatedNamespaceDeleterFactory implements NamespaceDeleterFactory {
     public static final String TYPE = "not-a-real-db";
     private static final NamespaceDeleter NAMESPACE_DELETER = mock(NamespaceDeleter.class);
 

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/AutoServiceAnnotatedNamespaceDeleterFactory.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/AutoServiceAnnotatedNamespaceDeleterFactory.java
@@ -1,0 +1,43 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.factory;
+
+import static org.mockito.Mockito.mock;
+
+import com.google.auto.service.AutoService;
+import com.palantir.atlasdb.namespacedeleter.NamespaceDeleter;
+import com.palantir.atlasdb.namespacedeleter.NamespaceDeleterFactory;
+import com.palantir.atlasdb.spi.KeyValueServiceConfig;
+import com.palantir.atlasdb.spi.KeyValueServiceRuntimeConfig;
+import com.palantir.refreshable.Refreshable;
+import java.util.Optional;
+
+@AutoService(NamespaceDeleterFactory.class)
+public class AutoServiceAnnotatedNamespaceDeleterFactory implements NamespaceDeleterFactory {
+    public static final String TYPE = "not-a-real-db";
+    private static final NamespaceDeleter NAMESPACE_DELETER = mock(NamespaceDeleter.class);
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    @Override
+    public NamespaceDeleter createNamespaceDeleter(
+            KeyValueServiceConfig config, Refreshable<Optional<KeyValueServiceRuntimeConfig>> runtimeConfig) {
+        return NAMESPACE_DELETER;
+    }
+}

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/memory/InMemoryAsyncAtlasDbConfig.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/memory/InMemoryAsyncAtlasDbConfig.java
@@ -56,6 +56,11 @@ public final class InMemoryAsyncAtlasDbConfig implements KeyValueServiceConfig {
     }
 
     @Override
+    public boolean enableNamespaceDeletionDangerousIKnowWhatIAmDoing() {
+        return false;
+    }
+
+    @Override
     public int hashCode() {
         return InMemoryAsyncAtlasDbConfig.class.hashCode();
     }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/DbKeyValueServiceConfig.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/DbKeyValueServiceConfig.java
@@ -67,6 +67,12 @@ public abstract class DbKeyValueServiceConfig implements KeyValueServiceConfig {
 
     abstract Optional<Integer> defaultGetRangesConcurrency();
 
+    @Override
+    @Value.Default
+    public boolean enableNamespaceDeletionDangerousIKnowWhatIAmDoing() {
+        return false;
+    }
+
     @Value.Check
     public void checkKvsPoolSize() {
         sharedResourcesConfig()


### PR DESCRIPTION
## General
**Before this PR**:
We can't create a namespace deleter factory, because it doesn't exist. Clients could create a raw namespace deleter themselves, but as with all atlasdb stuff, we want to dynamically discover the correct deleter from config,

We also want to feature flag deletion behind a config flag, because this is dangerous! 
**After this PR**:
Enable creating namespace deleters via namespace deleter factories through AtlasdbServiceDiscovery
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**: P1

**Concerns / possible downsides (what feedback would you like?)**:
This throws when trying to create the factory, not at the level of creating the namespace deleters.
I reckon this is fine, since if you're intentionally bypassing the discovery then you know what you're signing up for, and it's gated with an install config anyway so you need to restart to be able to create deleters.
Could return an optional, but it's a bit faffy and if you're using deleters, you'll add this to service conf not overrides!
**Is documentation needed?**:
Nope other than javadoc, we don't _really_ want people using this atm
## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
no
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
None
**What was existing testing like? What have you done to improve it?**:
There was none, I added some
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Can construct namespace deleter factories
**Has the safety of all log arguments been decided correctly?**:
No args
**Will this change significantly affect our spending on metrics or logs?**:
No
**How would I tell that this PR does not work in production? (monitors, etc.)**:
Can create deleters without config, fail to create deleters
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Rollback / don't use it
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No
## Development Process
**Where should we start reviewing?**:
NamespaceDeleterFactory and AtlasDbServiceDiscovery
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
N/A
**Please tag any other people who should be aware of this PR**:


<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
