### PR TITLE
[Drop Keyspace] Oracle Namespace Deleter Factory

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/DbAtlasDbFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/DbAtlasDbFactory.java
@@ -22,6 +22,7 @@ import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionManagerAwareDbKvs;
 import com.palantir.atlasdb.keyvalue.dbkvs.timestamp.InDbTimestampBoundStore;
+import com.palantir.atlasdb.keyvalue.dbkvs.util.DbKeyValueServiceConfigs;
 import com.palantir.atlasdb.spi.AtlasDbFactory;
 import com.palantir.atlasdb.spi.DerivedSnapshotConfig;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
@@ -68,22 +69,14 @@ public class DbAtlasDbFactory implements AtlasDbFactory {
             LongSupplier unusedLongSupplier,
             boolean initializeAsync) {
 
-        return ConnectionManagerAwareDbKvs.create((DbKeyValueServiceConfig) config, runtimeConfig, initializeAsync);
-    }
-
-    private static DbKeyValueServiceConfig toDbKeyValueServiceConfig(KeyValueServiceConfig config) {
-        Preconditions.checkArgument(
-                config instanceof DbKeyValueServiceConfig,
-                "[Unexpected configuration] | DbAtlasDbFactory expects a configuration of type "
-                        + "DbKeyValueServiceConfiguration.",
-                SafeArg.of("configurationClass", config.getClass()));
-        return (DbKeyValueServiceConfig) config;
+        return ConnectionManagerAwareDbKvs.create(
+                DbKeyValueServiceConfigs.toDbKeyValueServiceConfig(config), runtimeConfig, initializeAsync);
     }
 
     @Override
     public DerivedSnapshotConfig createDerivedSnapshotConfig(
             KeyValueServiceConfig config, Optional<KeyValueServiceRuntimeConfig> runtimeConfigSnapshot) {
-        DbKeyValueServiceConfig dbKeyValueServiceConfig = toDbKeyValueServiceConfig(config);
+        DbKeyValueServiceConfig dbKeyValueServiceConfig = DbKeyValueServiceConfigs.toDbKeyValueServiceConfig(config);
         return DerivedSnapshotConfig.builder()
                 .concurrentGetRangesThreadPoolSize(dbKeyValueServiceConfig.concurrentGetRangesThreadPoolSize())
                 .defaultGetRangesConcurrencyOverride(dbKeyValueServiceConfig.defaultGetRangesConcurrency())

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/cleaner/DbKvsNamespaceDeleterFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/cleaner/DbKvsNamespaceDeleterFactory.java
@@ -1,0 +1,104 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.dbkvs.cleaner;
+
+import com.google.auto.service.AutoService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.palantir.atlasdb.keyvalue.dbkvs.DbAtlasDbFactory;
+import com.palantir.atlasdb.keyvalue.dbkvs.DbKeyValueServiceConfig;
+import com.palantir.atlasdb.keyvalue.dbkvs.OracleDdlConfig;
+import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameGetter;
+import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameGetterImpl;
+import com.palantir.atlasdb.keyvalue.dbkvs.cleaner.OracleNamespaceDeleter.OracleNamespaceDeleterParameters;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionSupplier;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.OracleDbTableFactory;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.OraclePrefixedTableNames;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.SqlConnectionSupplier;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.TableValueStyleCache;
+import com.palantir.atlasdb.keyvalue.dbkvs.util.DbKeyValueServiceConfigs;
+import com.palantir.atlasdb.keyvalue.dbkvs.util.SqlConnectionSuppliers;
+import com.palantir.atlasdb.namespacedeleter.NamespaceDeleter;
+import com.palantir.atlasdb.namespacedeleter.NamespaceDeleterFactory;
+import com.palantir.atlasdb.spi.KeyValueServiceConfig;
+import com.palantir.atlasdb.spi.KeyValueServiceRuntimeConfig;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import com.palantir.nexus.db.pool.ConnectionManager;
+import com.palantir.nexus.db.pool.HikariClientPoolConnectionManagers;
+import com.palantir.nexus.db.pool.config.OracleConnectionConfig;
+import com.palantir.refreshable.Refreshable;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+
+@AutoService(NamespaceDeleterFactory.class)
+public final class DbKvsNamespaceDeleterFactory implements NamespaceDeleterFactory {
+    @Override
+    public String getType() {
+        return DbAtlasDbFactory.TYPE;
+    }
+
+    @Override
+    public NamespaceDeleter createNamespaceDeleter(
+            KeyValueServiceConfig config, Refreshable<Optional<KeyValueServiceRuntimeConfig>> runtimeConfig) {
+        DbKeyValueServiceConfig dbKeyValueServiceConfig = DbKeyValueServiceConfigs.toDbKeyValueServiceConfig(config);
+        String dbType = dbKeyValueServiceConfig.ddl().type();
+
+        if (OracleDdlConfig.TYPE.equals(dbType)) {
+            return createOracleNamespaceDeleter(dbKeyValueServiceConfig, runtimeConfig);
+        }
+        throw new SafeIllegalArgumentException(
+                "Dropping a namespace for the given DB type is not supported",
+                SafeArg.of("type", dbType),
+                SafeArg.of("supportedTypes", OracleDdlConfig.TYPE));
+    }
+
+    private NamespaceDeleter createOracleNamespaceDeleter(
+            DbKeyValueServiceConfig config, Refreshable<Optional<KeyValueServiceRuntimeConfig>> runtimeConfig) {
+        OracleDdlConfig ddlConfig = (OracleDdlConfig) config.ddl();
+        OracleConnectionConfig connectionConfig = (OracleConnectionConfig) config.connection();
+
+        OracleTableNameGetter tableNameGetter = OracleTableNameGetterImpl.createDefault(ddlConfig);
+        OraclePrefixedTableNames prefixedTableNames = new OraclePrefixedTableNames(tableNameGetter);
+        TableValueStyleCache cache = new TableValueStyleCache();
+
+        // DDL tables require a compaction executor service. However, namespace deletion doesn't use compaction at
+        // all, so we never use the executor service.
+        ExecutorService executorService = MoreExecutors.newDirectExecutorService();
+        OracleDbTableFactory factory =
+                new OracleDbTableFactory(ddlConfig, tableNameGetter, prefixedTableNames, cache, executorService);
+        ConnectionSupplier connectionSupplier = createConnectionSupplier(config, runtimeConfig);
+
+        OracleNamespaceDeleterParameters parameters = OracleNamespaceDeleterParameters.builder()
+                .userId(connectionConfig.getDbLogin())
+                .tablePrefix(ddlConfig.tablePrefix())
+                .overflowTablePrefix(ddlConfig.overflowTablePrefix())
+                .connectionSupplier(connectionSupplier)
+                .oracleDdlTableFactory(tableReference -> factory.createDdl(tableReference, connectionSupplier))
+                .tableNameGetter(tableNameGetter)
+                .build();
+
+        return new OracleNamespaceDeleter(parameters);
+    }
+
+    private ConnectionSupplier createConnectionSupplier(
+            DbKeyValueServiceConfig config, Refreshable<Optional<KeyValueServiceRuntimeConfig>> runtimeConfig) {
+        ConnectionManager connectionManager = HikariClientPoolConnectionManagers.create(config.connection());
+        SqlConnectionSupplier sqlConnSupplier =
+                SqlConnectionSuppliers.createSimpleConnectionSupplier(connectionManager, config, runtimeConfig);
+        return new ConnectionSupplier(sqlConnSupplier);
+    }
+}

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/OracleDbTableFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/OracleDbTableFactory.java
@@ -54,7 +54,7 @@ public class OracleDbTableFactory implements DbTableFactory {
     }
 
     @Override
-    public DbDdlTable createDdl(TableReference tableRef, ConnectionSupplier conns) {
+    public OracleDdlTable createDdl(TableReference tableRef, ConnectionSupplier conns) {
         return OracleDdlTable.create(
                 tableRef, conns, config, oracleTableNameGetter, valueStyleCache, compactionTimeoutExecutor);
     }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/util/DbKeyValueServiceConfigs.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/util/DbKeyValueServiceConfigs.java
@@ -1,0 +1,48 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.dbkvs.util;
+
+import com.palantir.atlasdb.keyvalue.dbkvs.DbKeyValueServiceConfig;
+import com.palantir.atlasdb.keyvalue.dbkvs.DbKeyValueServiceRuntimeConfig;
+import com.palantir.atlasdb.spi.KeyValueServiceConfig;
+import com.palantir.atlasdb.spi.KeyValueServiceRuntimeConfig;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import java.util.Optional;
+
+public final class DbKeyValueServiceConfigs {
+    private DbKeyValueServiceConfigs() {
+        // Utility
+    }
+
+    public static DbKeyValueServiceConfig toDbKeyValueServiceConfig(KeyValueServiceConfig config) {
+        Preconditions.checkArgument(
+                config instanceof DbKeyValueServiceConfig,
+                "[Unexpected configuration] | DbAtlasDbFactory expects a configuration of type "
+                        + "DbKeyValueServiceConfiguration.",
+                SafeArg.of("configurationClass", config.getClass()));
+        return (DbKeyValueServiceConfig) config;
+    }
+
+    public static Optional<DbKeyValueServiceRuntimeConfig> tryCastToDbKeyValueServiceRuntimeConfig(
+            KeyValueServiceRuntimeConfig runtimeConfig) {
+        if (runtimeConfig instanceof DbKeyValueServiceRuntimeConfig) {
+            return Optional.of((DbKeyValueServiceRuntimeConfig) runtimeConfig);
+        }
+        return Optional.empty();
+    }
+}


### PR DESCRIPTION
## General
**Before this PR**:
No DBKvsNamespaceDeleterFactory
**After this PR**:
DBKvsNamespaceDeleterFactory, but only works for Oracle - postgres coming in another workstream

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**: P1

**Concerns / possible downsides (what feedback would you like?)**:
None really. although I guess I could create a shared connection pool if you recreate the namespace deleter since I'm generally just planning on opening and closing them , but there's not that much benefit given the infrequency of calling namespace deleter methods!

Once there's Postgres support, it's likely worth spinning up separate {Oracle,Postgres}NamespaceDeleterFactory, but not at this point
**Is documentation needed?**:
No
## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
Nah
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
Nah
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
None
**What was existing testing like? What have you done to improve it?**:
N/A
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Can create deleters
**Has the safety of all log arguments been decided correctly?**:
N/A
**Will this change significantly affect our spending on metrics or logs?**:
No
**How would I tell that this PR does not work in production? (monitors, etc.)**:
Cannot create deleters
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Rollback
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
Nah
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
Nope
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
Nope
## Development Process
**Where should we start reviewing?**:
DbKvsNamespaceDeleterFactory
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
N/A
**Please tag any other people who should be aware of this PR**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
