### PR TITLE
Add config to allow for altering table

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfig.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfig.java
@@ -28,12 +28,11 @@ import com.palantir.db.oracle.JdbcHandler;
 import com.palantir.db.oracle.NativeOracleJdbcHandler;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
-import org.immutables.value.Value;
-
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
+import org.immutables.value.Value;
 
 @JsonDeserialize(as = ImmutableOracleDdlConfig.class)
 @JsonSerialize(as = ImmutableOracleDdlConfig.class)

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfig.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfig.java
@@ -28,10 +28,12 @@ import com.palantir.db.oracle.JdbcHandler;
 import com.palantir.db.oracle.NativeOracleJdbcHandler;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
+import org.immutables.value.Value;
+
 import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
-import org.immutables.value.Value;
 
 @JsonDeserialize(as = ImmutableOracleDdlConfig.class)
 @JsonSerialize(as = ImmutableOracleDdlConfig.class)
@@ -118,6 +120,21 @@ public abstract class OracleDdlConfig extends DdlConfig {
      */
     @JsonProperty("forceTableMappingIAmOnThePersistenceTeamAndKnowWhatIAmDoing")
     public abstract Optional<Boolean> forceTableMapping();
+
+    /**
+     * This should only be used in the case that metadata or the underlying schema in Oracle mismatch for a table.
+     * Adding a table reference here will perform either an alter, or to allow the metadata to be updated on startup.
+     *
+     * Generally speaking the operation is safe to perform, although it's on the operator to determine what the side
+     * effects are. For example, if the issue arose as two services are configured to use this table, but only one is
+     * performing table mapping, then it is expected that this could break one of the services. However, that condition
+     * still satisfies the status quo, thus it's on the configurator to determine if this change is safe to make.
+     */
+    @JsonProperty("alterTablesOrMetadataToMatchOnStartupAndIKnowWhatIAmDoing")
+    @Value.Default
+    public List<TableReference> alterTablesOrMetadataToMatch() {
+        return List.of();
+    }
 
     @Override
     public final String type() {


### PR DESCRIPTION
## General
**Before this PR**:
It was not possible to configure which tables to alter in oracle config

**After this PR**:
==COMMIT_MSG==
Add configuration option to Oracle which will alter table schema or metadata to match. 
==COMMIT_MSG==

**Priority**:
P2

**Concerns / possible downsides (what feedback would you like?)**:
- API break/backwards compatibility (should be ok --  OracleDdlConfig is in the same package as OracleDdlTable)
- Thoughts on comment 

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No

**Does this PR need a schema migration?**
No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
None

**What was existing testing like? What have you done to improve it?**: 
None, as this is just a change on the config interface

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
N/A

**Has the safety of all log arguments been decided correctly?**:
N/A

**Will this change significantly affect our spending on metrics or logs?**:
No

**How would I tell that this PR does not work in production? (monitors, etc.)**:
N/A

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
If an override is specified for the config, then this first needs to be rolled back before we rollback the underlying service

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A -- this feature won't be used as of yet so shouldn't be important :) 

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No

## Development Process
**Where should we start reviewing?**:
Soon :) 

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
