### PR TITLE
[TTS] | Fix CFS api - II

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/atomic/AtomicOperationResult.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/atomic/AtomicOperationResult.java
@@ -22,7 +22,7 @@ import org.immutables.value.Value;
 
 @Unsafe
 @Value.Immutable
-public interface AtomicUpdateResult {
+public interface AtomicOperationResult {
     boolean isSuccess();
 
     // Todo(snanda): we need unified exceptions
@@ -36,14 +36,14 @@ public interface AtomicUpdateResult {
                 "Should be either successful or failure with exception.");
     }
 
-    static AtomicUpdateResult failure(RuntimeException ex) {
-        return ImmutableAtomicUpdateResult.builder()
+    static AtomicOperationResult failure(RuntimeException ex) {
+        return ImmutableAtomicOperationResult.builder()
                 .isSuccess(false)
                 .maybeException(ex)
                 .build();
     }
 
-    static AtomicUpdateResult success() {
-        return ImmutableAtomicUpdateResult.builder().isSuccess(false).build();
+    static AtomicOperationResult success() {
+        return ImmutableAtomicOperationResult.builder().isSuccess(false).build();
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/atomic/InstrumentedConsensusForgettingStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/atomic/InstrumentedConsensusForgettingStore.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
-;
 
 /**
  * In general, the purpose of this class at least in its current form is to evaluate the requirement (or lack

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/atomic/PueConsensusForgettingStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/atomic/PueConsensusForgettingStore.java
@@ -74,7 +74,7 @@ public class PueConsensusForgettingStore implements ConsensusForgettingStore {
     /**
      * Note that changing this method may invalidate existing tests in
      * ResilientCommitTimestampPutUnlessExistsTableTest.
-     * @return
+     * @return check and touch result for each individual cell.
      */
     @Override
     public Map<Cell, AtomicOperationResult> checkAndTouch(Map<Cell, byte[]> values) {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/atomic/ResilientCommitTimestampAtomicTableTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/atomic/ResilientCommitTimestampAtomicTableTest.java
@@ -457,9 +457,10 @@ public class ResilientCommitTimestampAtomicTableTest {
         /**
          * We rely on the fact that {@link PueConsensusForgettingStore} uses the default
          * implementation of {@link ConsensusForgettingStore#checkAndTouch(Map)}
+         * @return
          */
         @Override
-        public void checkAndTouch(Cell cell, byte[] value) throws CheckAndSetException {
+        public AtomicOperationResult checkAndTouch(Cell cell, byte[] value) {
             if (commitUnderUs) {
                 super.put(ImmutableMap.of(cell, encodingStrategy.transformStagingToCommitted(value)));
             }
@@ -470,6 +471,7 @@ public class ResilientCommitTimestampAtomicTableTest {
             super.checkAndTouch(cell, value);
             clockLong.getAndAccumulate(millisForPue, Long::sum);
             concurrentTouches.decrementAndGet();
+            return null;
         }
 
         /**


### PR DESCRIPTION
## General
We were ignoring the result from check and touch operation in `ConsensusForgettingStore`

**After this PR**:
We explicitly have a return type for atomic check and touch requests
We do not use the exceptions for flow control

**Priority**:
Early next week

**Concerns / possible downsides (what feedback would you like?)**:
Is there any major reason I missed for not doing this?
The batched endpoint, even if it send a single request to underlying kvs, will be treated as a batch of single requests and hence returns a map of results.

**Is documentation needed?**:
Will be adding docs

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
These apis, I _expect_, are internal to transactions protocol and generally nobody should rely on these.

~**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:~

~**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:~

~**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:~

~**Does this PR need a schema migration?**~

## Testing and Correctness
~**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:~

**What was existing testing like? What have you done to improve it?**:
Will be adding tests.

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
We have explicitly made the atomic update requests synchronous.

~**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:~

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
The main change here is that flow is not controlled via exceptions, rather an explicit result model. i do not expect to see any changes in prod for schema <= 3. For transactions on schema > 3, this is vital for correctness. We will be closely keeping an eye on the perf.  

~**Has the safety of all log arguments been decided correctly?**:~

~**Will this change significantly affect our spending on metrics or logs?**:~

~**How would I tell that this PR does not work in production? (monitors, etc.)**:~

~**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:~

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
No

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
We might compromise latency in favor of reducing Cass req volume

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
Not more than what we were already doing

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
Could harm latency 

## Development Process
**Where should we start reviewing?**:
`ConsensusForgettingStore`

~**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:~

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
