### PR TITLE
Bd/async sweep queue write

### DIFF
--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
@@ -143,6 +143,8 @@ public class TransactionManagerModule {
                 ConflictTracer.NO_OP,
                 DefaultMetricsFilterEvaluationContext.createDefault(),
                 Optional.empty(),
-                knowledge);
+                knowledge,
+                Executors.newSingleThreadExecutor(new NamedThreadFactory(
+                        TransactionManagerModule.class + "-write-to-sweep-queue-executor", true)));
     }
 }

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
@@ -142,6 +142,7 @@ public class TestTransactionManagerModule {
                 ConflictTracer.NO_OP,
                 DefaultMetricsFilterEvaluationContext.createDefault(),
                 Optional.empty(),
-                knowledge);
+                knowledge,
+                PTExecutors.newSingleThreadExecutor(true));
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/DefaultTaskExecutors.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/DefaultTaskExecutors.java
@@ -46,4 +46,15 @@ final class DefaultTaskExecutors {
                 new NamedThreadFactory("atlas-delete-executor", true),
                 new ThreadPoolExecutor.AbortPolicy());
     }
+
+    static ExecutorService createDefaultWriteToSweepQueueExecutor() {
+        return PTExecutors.newThreadPoolExecutor(
+                8,
+                8,
+                DEFAULT_IDLE_TIMEOUT.toMillis(),
+                TimeUnit.MILLISECONDS,
+                new LinkedBlockingQueue<>(DEFAULT_QUEUE_CAPACITY),
+                new NamedThreadFactory("atlas-write-to-sweep-queue-executor", true),
+                new ThreadPoolExecutor.AbortPolicy());
+    }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -162,7 +162,8 @@ public class SerializableTransaction extends SnapshotTransaction {
             Supplier<TransactionConfig> transactionConfig,
             ConflictTracer conflictTracer,
             TableLevelMetricsController tableLevelMetricsController,
-            TransactionKnowledgeComponents knowledge) {
+            TransactionKnowledgeComponents knowledge,
+            ExecutorService writeToSweepQueueExecutor) {
         super(
                 metricsManager,
                 keyValueService,
@@ -189,7 +190,8 @@ public class SerializableTransaction extends SnapshotTransaction {
                 transactionConfig,
                 conflictTracer,
                 tableLevelMetricsController,
-                knowledge);
+                knowledge,
+                writeToSweepQueueExecutor);
     }
 
     @Override
@@ -870,7 +872,8 @@ public class SerializableTransaction extends SnapshotTransaction {
                 transactionConfig,
                 conflictTracer,
                 tableLevelMetricsController,
-                knowledge) {
+                knowledge,
+                writeToSweepQueueExecutor) {
             @Override
             protected TransactionScopedCache getCache() {
                 return lockWatchManager.getReadOnlyTransactionScopedCache(SerializableTransaction.this.getTimestamp());

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -438,7 +438,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 conflictTracer,
                 metricsFilterEvaluationContext,
                 sharedGetRangesPoolSize,
-                knowledge);
+                knowledge,
+                DefaultTaskExecutors.createDefaultWriteToSweepQueueExecutor());
 
         if (shouldInstrument) {
             transactionManager = AtlasDbMetrics.instrumentTimed(
@@ -493,7 +494,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 ConflictTracer.NO_OP,
                 DefaultMetricsFilterEvaluationContext.createDefault(),
                 Optional.empty(),
-                knowledge);
+                knowledge,
+                DefaultTaskExecutors.createDefaultWriteToSweepQueueExecutor());
     }
 
     public SerializableTransactionManager(
@@ -519,7 +521,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
             ConflictTracer conflictTracer,
             MetricsFilterEvaluationContext metricsFilterEvaluationContext,
             Optional<Integer> sharedGetRangesPoolSize,
-            TransactionKnowledgeComponents knowledge) {
+            TransactionKnowledgeComponents knowledge,
+            ExecutorService writeToSweepQueueExecutor) {
         super(
                 metricsManager,
                 keyValueService,
@@ -543,7 +546,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 conflictTracer,
                 metricsFilterEvaluationContext,
                 sharedGetRangesPoolSize,
-                knowledge);
+                knowledge,
+                writeToSweepQueueExecutor);
         this.conflictTracer = conflictTracer;
     }
 
@@ -579,7 +583,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 transactionConfig,
                 conflictTracer,
                 tableLevelMetricsController,
-                knowledge);
+                knowledge,
+                writeToSweepQueueExecutor);
     }
 
     @VisibleForTesting

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ShouldNotDeleteAndRollbackTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ShouldNotDeleteAndRollbackTransaction.java
@@ -82,7 +82,8 @@ public class ShouldNotDeleteAndRollbackTransaction extends SnapshotTransaction {
             ExecutorService getRangesExecutor,
             int defaultGetRangesConcurrency,
             Supplier<TransactionConfig> transactionConfig,
-            TransactionKnowledgeComponents knowledge) {
+            TransactionKnowledgeComponents knowledge,
+            ExecutorService writeToSweepQueueExecutor) {
         super(
                 metricsManager,
                 keyValueService,
@@ -109,7 +110,8 @@ public class ShouldNotDeleteAndRollbackTransaction extends SnapshotTransaction {
                 transactionConfig,
                 ConflictTracer.NO_OP,
                 new SimpleTableLevelMetricsController(metricsManager),
-                knowledge);
+                knowledge,
+                writeToSweepQueueExecutor);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -270,9 +270,9 @@ public class SnapshotTransaction extends AbstractTransaction
     protected final TransactionKnowledgeComponents knowledge;
 
     /**
-     * @param immutableTimestamp        If we find a row written before the immutableTimestamp we don't need to grab a read
-     *                                  lock for it because we know that no writers exist.
-     * @param preCommitCondition        This check must pass for this transaction to commit.
+     * @param immutableTimestamp   If we find a row written before the immutableTimestamp we don't need to grab a read
+     *                             lock for it because we know that no writers exist.
+     * @param preCommitCondition   This check must pass for this transaction to commit.
      */
     /* package */ SnapshotTransaction(
             MetricsManager metricsManager,

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
@@ -167,7 +167,8 @@ public abstract class AbstractSerializableTransactionTest extends AbstractTransa
                 () -> ImmutableTransactionConfig.builder().build(),
                 ConflictTracer.NO_OP,
                 new SimpleTableLevelMetricsController(metricsManager),
-                knowledge) {
+                knowledge,
+                MoreExecutors.newDirectExecutorService()) {
             @Override
             protected Map<Cell, byte[]> transformGetsForTesting(Map<Cell, byte[]> map) {
                 return Maps.transformValues(map, byte[]::clone);

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/CommitLockTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/CommitLockTest.java
@@ -185,7 +185,8 @@ public class CommitLockTest extends TransactionTestSetup {
                 () -> TRANSACTION_CONFIG,
                 ConflictTracer.NO_OP,
                 new SimpleTableLevelMetricsController(metricsManager),
-                knowledge) {
+                knowledge,
+                MoreExecutors.newDirectExecutorService()) {
             @Override
             protected Map<Cell, byte[]> transformGetsForTesting(Map<Cell, byte[]> map) {
                 return Maps.transformValues(map, byte[]::clone);

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -71,7 +71,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
             TimestampCache timestampCache,
             MultiTableSweepQueueWriter sweepQueue,
             TransactionKnowledgeComponents knowledge,
-            ExecutorService deleteExecutor) {
+            ExecutorService deleteExecutor,
+            ExecutorService writeToSweepQueueExecutor) {
         this(
                 metricsManager,
                 keyValueService,
@@ -85,7 +86,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 deleteExecutor,
                 WrapperWithTracker.TRANSACTION_NO_OP,
                 WrapperWithTracker.KEY_VALUE_SERVICE_NO_OP,
-                knowledge);
+                knowledge,
+                writeToSweepQueueExecutor);
     }
 
     @SuppressWarnings("Indentation") // Checkstyle complains about lambda in constructor.
@@ -122,7 +124,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 ConflictTracer.NO_OP,
                 DefaultMetricsFilterEvaluationContext.createDefault(),
                 Optional.empty(),
-                knowledge);
+                knowledge,
+                MoreExecutors.newDirectExecutorService());
         this.transactionWrapper = WrapperWithTracker.TRANSACTION_NO_OP;
         this.keyValueServiceWrapper = WrapperWithTracker.KEY_VALUE_SERVICE_NO_OP;
     }
@@ -141,7 +144,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
             ExecutorService deleteExecutor,
             WrapperWithTracker<CallbackAwareTransaction> transactionWrapper,
             WrapperWithTracker<KeyValueService> keyValueServiceWrapper,
-            TransactionKnowledgeComponents knowledge) {
+            TransactionKnowledgeComponents knowledge,
+            ExecutorService writeToSweepQueueExecutor) {
         super(
                 metricsManager,
                 createAssertKeyValue(keyValueService, lockService),
@@ -165,7 +169,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 ConflictTracer.NO_OP,
                 DefaultMetricsFilterEvaluationContext.createDefault(),
                 Optional.empty(),
-                knowledge);
+                knowledge,
+                writeToSweepQueueExecutor);
         this.transactionWrapper = transactionWrapper;
         this.keyValueServiceWrapper = keyValueServiceWrapper;
     }
@@ -224,7 +229,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                         transactionConfig,
                         ConflictTracer.NO_OP,
                         tableLevelMetricsController,
-                        knowledge),
+                        knowledge,
+                        writeToSweepQueueExecutor),
                 pathTypeTracker);
     }
 

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTestSetup.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTestSetup.java
@@ -217,6 +217,7 @@ public abstract class TransactionTestSetup {
                 timestampCache,
                 MultiTableSweepQueueWriter.NO_OP,
                 knowledge,
+                MoreExecutors.newDirectExecutorService(),
                 MoreExecutors.newDirectExecutorService());
     }
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
@@ -121,6 +121,7 @@ public class AtlasDbTestCase {
                 DefaultTimestampCache.createForTests(),
                 sweepQueue,
                 knowledge,
+                MoreExecutors.newDirectExecutorService(),
                 MoreExecutors.newDirectExecutorService());
     }
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/TableMigratorTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/TableMigratorTest.java
@@ -102,6 +102,7 @@ public class TableMigratorTest extends AtlasDbTestCase {
                 DefaultTimestampCache.createForTests(),
                 MultiTableSweepQueueWriter.NO_OP,
                 TransactionKnowledgeComponents.createForTests(kvs2, metricsManager.getTaggedRegistry()),
+                MoreExecutors.newDirectExecutorService(),
                 MoreExecutors.newDirectExecutorService());
         kvs2.createTable(tableRef, definition.toTableMetadata().persistToBytes());
         kvs2.createTable(namespacedTableRef, definition.toTableMetadata().persistToBytes());
@@ -140,6 +141,7 @@ public class TableMigratorTest extends AtlasDbTestCase {
                 DefaultTimestampCache.createForTests(),
                 MultiTableSweepQueueWriter.NO_OP,
                 TransactionKnowledgeComponents.createForTests(kvs2, metricsManager.getTaggedRegistry()),
+                MoreExecutors.newDirectExecutorService(),
                 MoreExecutors.newDirectExecutorService());
         final MutableLong count = new MutableLong();
         for (final TableReference name : Lists.newArrayList(tableRef, namespacedTableRef)) {

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
@@ -75,6 +75,7 @@ public class SnapshotTransactionManagerTest {
 
     private final MetricsManager metricsManager = MetricsManagers.createForTests();
     private final ExecutorService deleteExecutor = Executors.newSingleThreadExecutor();
+    private final ExecutorService writeToSweepQueueExecutor = Executors.newSingleThreadExecutor();
 
     @ClassRule
     public static InMemoryTimeLockRule services = new InMemoryTimeLockRule();
@@ -111,7 +112,8 @@ public class SnapshotTransactionManagerTest {
                 ConflictTracer.NO_OP,
                 DefaultMetricsFilterEvaluationContext.createDefault(),
                 Optional.empty(),
-                knowledge);
+                knowledge,
+                writeToSweepQueueExecutor);
     }
 
     @Test
@@ -168,7 +170,8 @@ public class SnapshotTransactionManagerTest {
                 ConflictTracer.NO_OP,
                 DefaultMetricsFilterEvaluationContext.createDefault(),
                 Optional.empty(),
-                knowledge);
+                knowledge,
+                writeToSweepQueueExecutor);
         newTransactionManager.close(); // should not throw
     }
 
@@ -299,6 +302,7 @@ public class SnapshotTransactionManagerTest {
                 ConflictTracer.NO_OP,
                 DefaultMetricsFilterEvaluationContext.createDefault(),
                 Optional.empty(),
-                knowledge);
+                knowledge,
+                writeToSweepQueueExecutor);
     }
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -356,7 +356,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 MoreExecutors.newDirectExecutorService(),
                 transactionWrapper,
                 keyValueServiceWrapper,
-                knowledge);
+                knowledge,
+                MoreExecutors.newDirectExecutorService());
     }
 
     @Test
@@ -452,7 +453,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                         () -> transactionConfig,
                         ConflictTracer.NO_OP,
                         tableLevelMetricsController,
-                        knowledge),
+                        knowledge,
+                        MoreExecutors.newDirectExecutorService()),
                 pathTypeTracker);
         assertThatThrownBy(() -> snapshot.get(TABLE, ImmutableSet.of(cell))).isInstanceOf(RuntimeException.class);
 
@@ -484,7 +486,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 MoreExecutors.newDirectExecutorService(),
                 transactionWrapper,
                 keyValueServiceWrapper,
-                knowledge);
+                knowledge,
+                MoreExecutors.newDirectExecutorService());
 
         ScheduledExecutorService service = PTExecutors.newScheduledThreadPool(20);
 
@@ -971,7 +974,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 executor,
                 transactionWrapper,
                 keyValueServiceWrapper,
-                knowledge);
+                knowledge,
+                MoreExecutors.newDirectExecutorService());
 
         Supplier<PreCommitCondition> conditionSupplier = mock(Supplier.class);
         when(conditionSupplier.get()).thenReturn(ALWAYS_FAILS_CONDITION).thenReturn(PreCommitConditions.NO_OP);
@@ -2283,7 +2287,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 () -> transactionConfig,
                 ConflictTracer.NO_OP,
                 tableLevelMetricsController,
-                knowledge);
+                knowledge,
+                MoreExecutors.newDirectExecutorService());
         return transactionWrapper.apply(transaction, pathTypeTracker);
     }
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/TransactionManagerTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/TransactionManagerTest.java
@@ -267,7 +267,8 @@ public class TransactionManagerTest extends TransactionTestSetup {
                 ConflictTracer.NO_OP,
                 DefaultMetricsFilterEvaluationContext.createDefault(),
                 Optional.empty(),
-                knowledge);
+                knowledge,
+                MoreExecutors.newDirectExecutorService());
 
         when(timelock.getFreshTimestamp()).thenReturn(1L);
         when(timelock.lockImmutableTimestamp())

--- a/changelog/@unreleased/pr-6347.v2.yml
+++ b/changelog/@unreleased/pr-6347.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Perform sweep queue writes in parallel with the rest of the commit
+    stage.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6347


### PR DESCRIPTION
## General
Around 20-25% of the overall time spent doing various atlas operations is taken up by writing to the sweep queue.

Whilst it's not ideal to drop values, I'm not convinced it's worth spending so much of our time here.

Instead here I'm making that sweep queue write happen concurrently with other things we're doing.

<img width="844" alt="image" src="https://user-images.githubusercontent.com/24711/199298776-d964c0ee-a2a4-41a1-b868-4e6fd45ca576.png">

Note that these spans show typical numbers for a commitStage (though often the sweep queue write is a higher proportion).

==COMMIT_MSG==
Perform sweep queue writes in parallel with the rest of the commit stage.
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:
 - How bad is it to actually potentially drop sweep queue writes here (albeit with low probability)?
 - Sizing of the thread pool - I don't have good intuition on how this should be set?
 - or, whether there's a better way to get the concurrency here? Or some existing alta utility for this kind of thing.

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
no

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
no

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
n/a

**Does this PR need a schema migration?**
no

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
not sure - would value input here

**What was existing testing like? What have you done to improve it?**:
n/a

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
It does contain asynchronous code, but it's pretty simple.

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
n/a

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
I'd like to see an overall ~20% perf increase across the board of anything interacting with our service layered on top of atlas.

**Has the safety of all log arguments been decided correctly?**:
n/a

**Will this change significantly affect our spending on metrics or logs?**:
no

**How would I tell that this PR does not work in production? (monitors, etc.)**:
n/a

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
yes

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
n/a

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
no

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
no

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
n/a

## Development Process
**Where should we start reviewing?**:
SnapshotTransaction changes, followed by the place where I make the executor service. The rest is just plumbing.

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
n/a

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
