### PR TITLE
If configured, alter metadata to match schema for oracle dbkvs

### DIFF
--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleAlterTableIntegrationTest.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleAlterTableIntegrationTest.java
@@ -16,6 +16,10 @@
 
 package com.palantir.atlasdb.keyvalue.dbkvs.impl.oracle;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.google.common.collect.Iterables;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.Cell;
@@ -38,16 +42,11 @@ import com.palantir.atlasdb.table.description.TableMetadata;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.common.exception.TableMappingNotFoundException;
 import com.palantir.nexus.db.sql.AgnosticResultSet;
+import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
-
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public final class OracleAlterTableIntegrationTest {
     @ClassRule
@@ -114,7 +113,6 @@ public final class OracleAlterTableIntegrationTest {
         modifyMetadataToNotHaveOverflow();
         // metadata is cached, thus we must create a new kvs to forcefully refresh the cache
         KeyValueService badKvs = createKvs(DbKvsOracleTestSuite.getKvsConfig());
-        badKvs.putMetadataForTable(TABLE_REFERENCE, OLD_TABLE_METADATA.persistToBytes());
         assertThatThrownBy(() -> fetchData(badKvs, DEFAULT_CELL_1, TIMESTAMP_1));
 
         KeyValueService workingKvs = createKvs(CONFIG_WITH_ALTER);

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleAlterTableIntegrationTest.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleAlterTableIntegrationTest.java
@@ -16,10 +16,6 @@
 
 package com.palantir.atlasdb.keyvalue.dbkvs.impl.oracle;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import com.google.common.collect.Iterables;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.Cell;
@@ -42,11 +38,16 @@ import com.palantir.atlasdb.table.description.TableMetadata;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.common.exception.TableMappingNotFoundException;
 import com.palantir.nexus.db.sql.AgnosticResultSet;
-import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public final class OracleAlterTableIntegrationTest {
     @ClassRule
@@ -113,7 +114,7 @@ public final class OracleAlterTableIntegrationTest {
         modifyMetadataToNotHaveOverflow();
         // metadata is cached, thus we must create a new kvs to forcefully refresh the cache
         KeyValueService badKvs = createKvs(DbKvsOracleTestSuite.getKvsConfig());
-        assertThatThrownBy(() -> fetchData(badKvs, DEFAULT_CELL_1, TIMESTAMP_1));
+        assertThatThrownBy(() -> writeData(badKvs, ROW_2, TIMESTAMP_2));
 
         KeyValueService workingKvs = createKvs(CONFIG_WITH_ALTER);
         workingKvs.createTable(TABLE_REFERENCE, EXPECTED_TABLE_METADATA.persistToBytes());

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleAlterTableIntegrationTest.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleAlterTableIntegrationTest.java
@@ -16,6 +16,10 @@
 
 package com.palantir.atlasdb.keyvalue.dbkvs.impl.oracle;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.google.common.collect.Iterables;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.Cell;
@@ -38,16 +42,11 @@ import com.palantir.atlasdb.table.description.TableMetadata;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.common.exception.TableMappingNotFoundException;
 import com.palantir.nexus.db.sql.AgnosticResultSet;
+import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
-
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public final class OracleAlterTableIntegrationTest {
     @ClassRule

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleAlterTableIntegrationTest.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleAlterTableIntegrationTest.java
@@ -16,10 +16,6 @@
 
 package com.palantir.atlasdb.keyvalue.dbkvs.impl.oracle;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import com.google.common.collect.Iterables;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.Cell;
@@ -42,11 +38,16 @@ import com.palantir.atlasdb.table.description.TableMetadata;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.common.exception.TableMappingNotFoundException;
 import com.palantir.nexus.db.sql.AgnosticResultSet;
-import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public final class OracleAlterTableIntegrationTest {
     @ClassRule
@@ -189,7 +190,7 @@ public final class OracleAlterTableIntegrationTest {
                 .updateUnregisteredQuery(
                         "UPDATE " + CONFIG_WITH_ALTER.ddl().metadataTable().getQualifiedName()
                                 + " SET table_size = ? WHERE table_name = ?",
-                        TableValueStyle.OVERFLOW.getId(),
+                        TableValueStyle.RAW.getId(),
                         TABLE_REFERENCE.getQualifiedName());
     }
 

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
@@ -133,6 +133,9 @@ public final class OracleDdlTable implements DbDdlTable {
         }
     }
 
+    /**
+     * @return True if the metadata table altered, false otherwise.
+     */
     private boolean maybeAlterMetadataToHaveOverflow() {
         try {
 

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
@@ -135,17 +135,17 @@ public final class OracleDdlTable implements DbDdlTable {
 
     private boolean maybeAlterMetadataToHaveOverflow() {
         try {
-            String shortTableName = oracleTableNameGetter.getInternalShortTableName(conns, tableRef);
 
-            if (config.alterTablesOrMetadataToMatch().contains(tableRef)
-                    && overflowTableHasMigrated()
-                    && overflowTableExists()
-                    && overflowColumnExists(shortTableName)) {
-                alterMetadataToHaveOverflow();
-                return true;
+            if (config.alterTablesOrMetadataToMatch().contains(tableRef)) {
+                String shortTableName = oracleTableNameGetter.getInternalShortTableName(conns, tableRef);
+                if (overflowTableHasMigrated() && overflowTableExists() && overflowColumnExists(shortTableName)) {
+                    alterMetadataToHaveOverflow();
+                    return true;
+                }
             }
         } catch (TableMappingNotFoundException e) {
-            log.warn("Table mapping expected but not found for table.", UnsafeArg.of("tableRef", tableRef), e);
+            Throwables.rewrapAndThrowUncheckedException(
+                    "Unable to alter table to have overflow column due to a table mapping error.", e);
         }
         return false;
     }

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTableTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTableTest.java
@@ -238,38 +238,26 @@ public final class OracleDdlTableTest {
 
     @Test
     public void createAltersTableIfConfiguredAndOverflowTableExists() throws TableMappingNotFoundException {
-        testAlterTableForMigrationState(OverflowMigrationState.FINISHED);
+        alterTableForMigrationState(OverflowMigrationState.FINISHED);
         verifyTableAltered();
     }
 
     @Test
     public void createDoesNothingWhenAlterSpecifiedButMigrationUnstarted() throws TableMappingNotFoundException {
-        testAlterTableForMigrationState(OverflowMigrationState.UNSTARTED);
+        alterTableForMigrationState(OverflowMigrationState.UNSTARTED);
         verifyTableNotAltered();
     }
 
     @Test
     public void createDoesNothingWhenAlterSpecifiedButMigrationInProgress() throws TableMappingNotFoundException {
-        testAlterTableForMigrationState(OverflowMigrationState.IN_PROGRESS);
+        alterTableForMigrationState(OverflowMigrationState.IN_PROGRESS);
         verifyTableNotAltered();
     }
 
     @Test
     public void createDoesNothingWhenAlterSpecifiedButMigrationFinishing() throws TableMappingNotFoundException {
-        testAlterTableForMigrationState(OverflowMigrationState.FINISHING);
+        alterTableForMigrationState(OverflowMigrationState.FINISHING);
         verifyTableNotAltered();
-    }
-
-    private void testAlterTableForMigrationState(OverflowMigrationState overflowMigrationState)
-            throws TableMappingNotFoundException {
-        createTableAndOverflow();
-        setTableToHaveOverflowColumn(false);
-        setTableValueStyleCacheOverflowConfigForTable(true);
-        OracleDdlTable ddlTable = createOracleDdlTable(ImmutableOracleDdlConfig.builder()
-                .from(TABLE_MAPPING_DEFAULT_CONFIG)
-                .overflowMigrationState(overflowMigrationState)
-                .build());
-        ddlTable.create(createMetadata(true));
     }
 
     @Test
@@ -444,6 +432,18 @@ public final class OracleDdlTableTest {
                 .isInstanceOf(SafeIllegalArgumentException.class)
                 .hasMessageContaining(MISSING_OVERFLOW_EXCEPTION_MESSAGE);
         verifyTableSizeMetadataNotUpdated();
+    }
+
+    private void alterTableForMigrationState(OverflowMigrationState overflowMigrationState)
+            throws TableMappingNotFoundException {
+        createTableAndOverflow();
+        setTableToHaveOverflowColumn(false);
+        setTableValueStyleCacheOverflowConfigForTable(true);
+        OracleDdlTable ddlTable = createOracleDdlTable(ImmutableOracleDdlConfig.builder()
+                .from(TABLE_MAPPING_DEFAULT_CONFIG)
+                .overflowMigrationState(overflowMigrationState)
+                .build());
+        ddlTable.create(createMetadata(true));
     }
 
     private void createTable() throws TableMappingNotFoundException {


### PR DESCRIPTION
## General
**Before this PR**:
Oracle DbKvs could get stuck into a state where the metadata mismatches the underlying table schema, namely for the `overflow` column.

**After this PR**:
==COMMIT_MSG==
When configured, update the metadata to match the expected schema for the specified tables.
==COMMIT_MSG==

**Priority**:
P2

**Concerns / possible downsides (what feedback would you like?)**:
- Safety around updating the metadata (i.e. did we check for all the states that we should explicitly not allow for?)

**Is documentation needed?**:
No

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No. 

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No

**Does this PR need a schema migration?**
No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
N/A

**What was existing testing like? What have you done to improve it?**:
Added an integration test for the change itself

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Logs

**Has the safety of all log arguments been decided correctly?**:
Yes

**Will this change significantly affect our spending on metrics or logs?**:
No

**How would I tell that this PR does not work in production? (monitors, etc.)**:
Logs

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
PR is feature flagged, so it should be safe to roll back! 

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
Most likely no, as again (a) it's feature flagged, (b) this should only occur on table creation, so data size should relatively be small (also reads/write for this table should be broken). 

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No

## Development Process
**Where should we start reviewing?**:
Immediately 

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
