### PR TITLE
[TEX] Part 5: TrackingKeyValueService, tracking iterator exception handling

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/expectations/TrackingIterator.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/expectations/TrackingIterator.java
@@ -17,11 +17,15 @@
 package com.palantir.atlasdb.transaction.impl.expectations;
 
 import com.google.common.collect.ForwardingIterator;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.util.Iterator;
 import java.util.function.Consumer;
 import java.util.function.ToLongFunction;
 
 public class TrackingIterator<T, I extends Iterator<T>> extends ForwardingIterator<T> {
+    private static final SafeLogger log = SafeLoggerFactory.get(TrackingIterator.class);
+
     private final I delegate;
     private final ToLongFunction<T> measurer;
     private final Consumer<Long> tracker;
@@ -40,7 +44,13 @@ public class TrackingIterator<T, I extends Iterator<T>> extends ForwardingIterat
     @Override
     public T next() {
         T result = delegate.next();
-        tracker.accept(measurer.applyAsLong(result));
+
+        try {
+            tracker.accept(measurer.applyAsLong(result));
+        } catch (Exception exception) {
+            log.warn("Data tracking failed", exception);
+        }
+
         return result;
     }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/expectations/TrackingClosableIteratorTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/expectations/TrackingClosableIteratorTest.java
@@ -17,9 +17,13 @@
 package com.palantir.atlasdb.transaction.impl.expectations;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.palantir.common.base.ClosableIterator;
@@ -89,6 +93,32 @@ public final class TrackingClosableIteratorTest {
         trackingIterator.close();
         verify(iterator).close();
         verifyNoMoreInteractions(iterator);
+    }
+
+    @Test
+    public void trackingIteratorForwardsValuesDespiteExceptionAtMeasurement() {
+        ToLongFunction<String> measurer = spy(STRING_LENGTH_MEASURER);
+        when(measurer.applyAsLong(anyString())).thenThrow(RuntimeException.class);
+
+        ClosableIterator<String> trackingIterator =
+                new TrackingClosableIterator<>(createClosableStringIterator(), NO_OP, measurer);
+
+        assertThat(trackingIterator)
+                .toIterable()
+                .containsExactlyElementsOf(ImmutableList.copyOf(createClosableStringIterator()));
+    }
+
+    @Test
+    public void trackingIteratorForwardsValuesDespiteExceptionAtConsumption() {
+        Consumer<Long> consumer = spy(NO_OP);
+        doThrow(RuntimeException.class).when(consumer).accept(anyLong());
+
+        ClosableIterator<String> trackingIterator =
+                new TrackingClosableIterator<>(createClosableStringIterator(), consumer, STRING_LENGTH_MEASURER);
+
+        assertThat(trackingIterator)
+                .toIterable()
+                .containsExactlyElementsOf(ImmutableList.copyOf(createClosableStringIterator()));
     }
 
     private static ClosableIterator<String> createClosableStringIterator() {


### PR DESCRIPTION
## General
**After this PR**:
Tracking iterators forward values from the delegate even when exceptions arise (more general throwable not caught though)

**Priority**:
P2

**Concerns / possible downsides (what feedback would you like?)**:
Too much useless logging, shouldn't be the case (this PR is maybe just being too defensive)

**Is documentation needed?**:
No

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
N/A

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
N/A

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
N/A

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
N/A

**Does this PR need a schema migration?**
N/A

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
N/A

**What was existing testing like? What have you done to improve it?**:
Added two tests

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
N/A

**Has the safety of all log arguments been decided correctly?**:
N/A

**Will this change significantly affect our spending on metrics or logs?**:
N/A

**How would I tell that this PR does not work in production? (monitors, etc.)**:
User transaction gets fail because of tracking (iterator specific, other PRs error handle in other spots)

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
recall and rollback

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
N/A

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
N/A

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
I use `log.warn` every time measuring/consuming fails in the wrapping iterator's next, tmi?

## Development Process
**Where should we start reviewing?**:
TrackingIterator.java

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
N/A