### PR TITLE
Reduce onSuccessfulCommit critical section size

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/AtlasLockDescriptorUtils.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/AtlasLockDescriptorUtils.java
@@ -16,7 +16,6 @@
 
 package com.palantir.atlasdb.keyvalue.api;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Bytes;
 import com.google.protobuf.ByteString;
 import com.palantir.lock.LockDescriptor;
@@ -25,6 +24,7 @@ import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -40,9 +40,12 @@ public final class AtlasLockDescriptorUtils {
     }
 
     public static List<CellReference> candidateCells(LockDescriptor lockDescriptor) {
-        return tryParseTableRef(lockDescriptor)
-                .map(AtlasLockDescriptorUtils::candidateCells)
-                .orElseGet(ImmutableList::of);
+        Optional<TableRefAndRemainder> tableRef = tryParseTableRef(lockDescriptor);
+        //noinspection OptionalIsPresent - avoid Optional#map to avoid Optional allocations
+        if (tableRef.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return candidateCells(tableRef.get());
     }
 
     public static List<CellReference> candidateCells(TableRefAndRemainder parsedLockDescriptor) {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/CurrentValueMetric.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/CurrentValueMetric.java
@@ -16,7 +16,9 @@
 package com.palantir.atlasdb.util;
 
 import com.codahale.metrics.Gauge;
+import javax.annotation.concurrent.ThreadSafe;
 
+@ThreadSafe
 public class CurrentValueMetric<T> implements Gauge<T> {
     volatile T value = null;
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/CacheMetrics.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/CacheMetrics.java
@@ -21,7 +21,9 @@ import com.codahale.metrics.Gauge;
 import com.palantir.atlasdb.AtlasDbMetricNames;
 import com.palantir.atlasdb.util.CurrentValueMetric;
 import com.palantir.atlasdb.util.MetricsManager;
+import javax.annotation.concurrent.ThreadSafe;
 
+@ThreadSafe
 public final class CacheMetrics {
     private final Counter hits;
     private final Counter misses;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
@@ -152,7 +152,7 @@ public final class LockWatchValueScopingCacheImpl implements LockWatchValueScopi
                             .flatMap(List::stream)
                             .collect(ImmutableSet.toImmutableSet());
 
-                    Map<CellReference, CacheValue> toUpdate;
+                    final Map<CellReference, CacheValue> toUpdate;
                     if (invalidatedCells.isEmpty()) {
                         toUpdate = cachedValues;
                     } else {
@@ -228,9 +228,9 @@ public final class LockWatchValueScopingCacheImpl implements LockWatchValueScopi
             }
         }
 
-        for (Long timestamp : updateForTransactions.startTsToSequence().keySet()) {
-            cacheStore.createCache(StartTimestamp.of(timestamp));
-        }
+        updateForTransactions.startTsToSequence().keySet().stream()
+                .map(StartTimestamp::of)
+                .forEach(cacheStore::createCache);
 
         if (valueStore.getSnapshot().hasAnyTablesWatched()) {
             assertNoSnapshotsMissing(reversedMap);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
@@ -136,9 +136,7 @@ public final class LockWatchValueScopingCacheImpl implements LockWatchValueScopi
 
         Map<CellReference, CacheValue> cachedValues = cache.getValueDigest().loadedValues();
         if (!cachedValues.isEmpty()) {
-            CommitUpdate commitUpdate = eventCache.getEventUpdate(startTimestamp);
-
-            commitUpdate.accept(new CommitUpdate.Visitor<Void>() {
+            eventCache.getEventUpdate(startTimestamp).accept(new CommitUpdate.Visitor<Void>() {
                 @Override
                 public Void invalidateAll() {
                     // This might happen due to an election or if we exceeded the maximum number of events held in

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/ClientLogEvents.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/ClientLogEvents.java
@@ -34,7 +34,6 @@ import com.palantir.lock.watch.UnlockEvent;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
-import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -95,8 +94,9 @@ interface ClientLogEvents {
         verifyReturnedEventsEnclosesTransactionVersions(startVersion.version() + 1, endVersion.version());
 
         LockEventVisitor eventVisitor = new LockEventVisitor(commitInfo.map(CommitInfo::commitLockToken));
-        Set<LockDescriptor> locksTakenOut = new HashSet<>();
-        events().events().forEach(event -> locksTakenOut.addAll(event.accept(eventVisitor)));
+        Set<LockDescriptor> locksTakenOut = events().events().stream()
+                .flatMap(event -> event.accept(eventVisitor).stream())
+                .collect(ImmutableSet.toImmutableSet());
         return CommitUpdate.invalidateSome(locksTakenOut);
     }
 

--- a/changelog/@unreleased/pr-6376.v2.yml
+++ b/changelog/@unreleased/pr-6376.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Reduce onSuccessfulCommit critical section size
+  links:
+  - https://github.com/palantir/atlasdb/pull/6376
+

--- a/lock-api/src/main/java/com/palantir/lock/watch/NoOpLockWatchEventCache.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/NoOpLockWatchEventCache.java
@@ -21,11 +21,13 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import javax.annotation.concurrent.ThreadSafe;
 
+@ThreadSafe
 @SuppressWarnings("FinalClass") // mocks
 public class NoOpLockWatchEventCache implements LockWatchEventCache {
     private static final LockWatchVersion FAKE_VERSION = LockWatchVersion.of(UUID.randomUUID(), -1L);
-    private Optional<LockWatchVersion> currentVersion = Optional.empty();
+    private volatile Optional<LockWatchVersion> currentVersion = Optional.empty();
 
     private NoOpLockWatchEventCache() {}
 


### PR DESCRIPTION
## General
**Before this PR**:
In some JFR, seeing significant thread contention and blocking in `com.palantir.atlasdb.keyvalue.api.cache.LockWatchValueScopingCacheImpl.onSuccessfulCommit(long)`. We should be able to reduce the critical section size to improve concurrency and reduce blocking.

![image](https://user-images.githubusercontent.com/54594/201961699-cf9e921d-0c4a-49eb-af4b-d1f7f9b527c8.png)


**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Reduce onSuccessfulCommit critical section size
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:
Are there edge cases and race conditions this does not account for or are not currently tested?

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
