### PR TITLE
Add minimum timestamp to TimestampRange

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/ConcludedRangeState.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/ConcludedRangeState.java
@@ -24,6 +24,8 @@ import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.transaction.impl.TransactionConstants;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -51,6 +53,11 @@ public interface ConcludedRangeState {
     }
 
     default ConcludedRangeState copyAndSetMinimumConcludeableTimestamp(long timestamp) {
+        Preconditions.checkArgument(
+                timestamp >= minimumConcludeableTimestamp(),
+                "Must set minimum concludable timestamp to be higher than the present value.",
+                SafeArg.of("currentMinimumConcludeableTimestamp", minimumConcludeableTimestamp()),
+                SafeArg.of("newMinimumConcludeableTimestamp", minimumConcludeableTimestamp()));
         return ImmutableConcludedRangeState.builder()
                 .from(this)
                 .minimumConcludeableTimestamp(timestamp)

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/ConcludedRangeState.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/ConcludedRangeState.java
@@ -50,6 +50,13 @@ public interface ConcludedRangeState {
         return timestampRanges().encloses(timestampRange);
     }
 
+    default ConcludedRangeState copyAndSetMinimumConcludeableTimestamp(long timestamp) {
+        return ImmutableConcludedRangeState.builder()
+                .from(this)
+                .minimumConcludeableTimestamp(timestamp)
+                .build();
+    }
+
     default ConcludedRangeState copyAndAdd(Range<Long> additionalTimestampRange) {
         return copyAndAdd(ImmutableSet.of(additionalTimestampRange));
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/ConcludedRangeState.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/ConcludedRangeState.java
@@ -16,6 +16,7 @@
 
 package com.palantir.atlasdb.transaction.knowledge;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.ImmutableRangeSet;
@@ -40,6 +41,7 @@ public interface ConcludedRangeState {
     @Value.Parameter
     Long minimumConcludeableTimestamp();
 
+    @JsonIgnore
     @Value.Derived
     default Range<Long> minimumConcludeableTimestampRange() {
         return Range.atLeast(minimumConcludeableTimestamp());
@@ -70,7 +72,6 @@ public interface ConcludedRangeState {
 
     default ConcludedRangeState copyAndAdd(Set<Range<Long>> additionalTimestampRanges) {
         Set<Range<Long>> rangesToSupplement = additionalTimestampRanges.stream()
-                .filter(Predicate.not(timestampRanges()::encloses))
                 .filter(minimumConcludeableTimestampRange()::isConnected)
                 .map(minimumConcludeableTimestampRange()::intersection)
                 .filter(Predicate.not(Range::isEmpty))

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactions.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactions.java
@@ -50,6 +50,18 @@ public interface KnownConcludedTransactions {
     void addConcludedTimestamps(Set<Range<Long>> knownConcludedIntervals);
 
     /**
+     * Sets the minimum timestamp required for any range to be concluded.
+     *
+     * The minimum timestamp is used to ensure we do not conclude ranges that are below this timestamp [-∞, ts).
+     * This is necessary for backup/restore, as we must not conclude any ranges post-restore that are before
+     * the fast-forward timestamp. This is to prevent concluding transactions which have written to the KVS,
+     * but had not committed.
+     *
+     * @param timestamp minimum timestamp
+     */
+    void setMinimumConcludableTimestamp(Long timestamp);
+
+    /**
      * Returns the greatest known concluded timestamp for which transaction is known to have concluded. This call
      * relies on local cache. Hence, it is possible for the view to be out of date.
      *

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactionsImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactionsImpl.java
@@ -98,6 +98,11 @@ public final class KnownConcludedTransactionsImpl implements KnownConcludedTrans
         ensureRangesCached(ImmutableRangeSet.copyOf(knownConcludedIntervals));
     }
 
+    @Override
+    public void setMinimumConcludableTimestamp(Long timestamp) {
+        knownConcludedTransactionsStore.setMinimumConcludableTimestamp(timestamp);
+    }
+
     private boolean verifyConcludedRanges(Set<Range<Long>> knownConcludedIntervals) {
         return knownConcludedIntervals.stream().allMatch(this::verifyConcludedRange);
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactionsImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactionsImpl.java
@@ -122,7 +122,7 @@ public final class KnownConcludedTransactionsImpl implements KnownConcludedTrans
     private void updateCacheFromRemote() {
         ensureRangesCached(knownConcludedTransactionsStore
                 .get()
-                .map(TimestampRangeSet::timestampRanges)
+                .map(ConcludedRangeState::timestampRanges)
                 .orElseGet(ImmutableRangeSet::of));
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactionsStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactionsStore.java
@@ -126,7 +126,7 @@ public final class KnownConcludedTransactionsStore {
                     .map(ReadResult::concludedRangeState)
                     .map(newConcludedRangeState::equals)
                     .orElse(false)) {
-                return false;
+                return true;
             }
 
             CheckAndSetRequest checkAndSetRequest = getCheckAndSetRequest(readResult, newConcludedRangeState);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactionsStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactionsStore.java
@@ -121,6 +121,12 @@ public final class KnownConcludedTransactionsStore {
         throw new SafeIllegalStateException("Unable to supplement set of concluded timestamps.");
     }
 
+    /**
+     * Modifies a range that contains the minimum timestamp to have it's lower-bound set (exclusive) to the minimum timestamp.
+     *
+     * This is needed as we do not want to not conclude a range that encompasses the minimum timestamp.
+     * We also do not want to prevent our ability to conclude the subrange which is above the minimum timestamp.
+     */
     @VisibleForTesting
     Range<Long> maybeModifyRangeLowerBoundToMinimumTimestamp(Optional<Long> maybeMinimumTimestamp, Range<Long> range) {
         return maybeMinimumTimestamp

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactionsStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactionsStore.java
@@ -98,10 +98,14 @@ public final class KnownConcludedTransactionsStore {
     }
 
     public void setMinimumConcludableTimestamp(Long timestamp) {
-        boolean checkAndSetSucceeded = checkAndSet(currentRangeState -> ImmutableConcludedRangeState.builder()
-                .from(currentRangeState)
-                .minimumConcludeableTimestamp(timestamp)
-                .build());
+        boolean checkAndSetSucceeded = checkAndSet(currentRangeState -> {
+            log.info(
+                    "Attempting to set minimum concludable range state.",
+                    SafeArg.of("newMinimumConcludeableTimestamp", timestamp),
+                    SafeArg.of(
+                            "currentMinimumConcludeableTimestamp", currentRangeState.minimumConcludeableTimestamp()));
+            return currentRangeState.copyAndSetMinimumConcludeableTimestamp(timestamp);
+        });
         if (!checkAndSetSucceeded) {
             log.warn("Unable to set the minimum concludable timestamp. This may be "
                     + "because the database is momentarily unavailable, or because of particularly high contention.");

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/TimestampRangeSet.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/TimestampRangeSet.java
@@ -31,6 +31,10 @@ import org.immutables.value.Value;
 @JsonDeserialize(as = ImmutableTimestampRangeSet.class)
 @SuppressWarnings("UnstableApiUsage") // RangeSet usage
 public interface TimestampRangeSet {
+
+    @Value.Parameter
+    Long minimumTimestamp();
+
     @Value.Parameter
     RangeSet<Long> timestampRanges();
 
@@ -46,17 +50,20 @@ public interface TimestampRangeSet {
         return ImmutableTimestampRangeSet.builder()
                 .timestampRanges(
                         ImmutableRangeSet.unionOf(Sets.union(timestampRanges().asRanges(), additionalTimestampRanges)))
+                .minimumTimestamp(minimumTimestamp())
                 .build();
     }
 
-    static TimestampRangeSet singleRange(Range<Long> timestampRange) {
+    static TimestampRangeSet singleRange(Range<Long> timestampRange, long minimumTimestamp) {
         return ImmutableTimestampRangeSet.builder()
                 .timestampRanges(ImmutableRangeSet.of(timestampRange))
+                .minimumTimestamp(minimumTimestamp)
                 .build();
     }
 
-    static TimestampRangeSet initRanges(Set<Range<Long>> timestampRanges) {
+    static TimestampRangeSet initRanges(Set<Range<Long>> timestampRanges, long minimumTimestamp) {
         return ImmutableTimestampRangeSet.builder()
+                .minimumTimestamp(minimumTimestamp)
                 .timestampRanges(ImmutableRangeSet.unionOf(timestampRanges))
                 .build();
     }
@@ -64,6 +71,7 @@ public interface TimestampRangeSet {
     static TimestampRangeSet empty() {
         return ImmutableTimestampRangeSet.builder()
                 .timestampRanges(ImmutableRangeSet.of())
+                .minimumTimestamp(0L)
                 .build();
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/coordinated/CoordinationAwareKnownConcludedTransactionsStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/coordinated/CoordinationAwareKnownConcludedTransactionsStore.java
@@ -74,6 +74,11 @@ public final class CoordinationAwareKnownConcludedTransactionsStore implements K
     }
 
     @Override
+    public void setMinimumConcludableTimestamp(Long timestamp) {
+        delegate.setMinimumConcludableTimestamp(timestamp);
+    }
+
+    @Override
     public long lastLocallyKnownConcludedTimestamp() {
         return delegate.lastLocallyKnownConcludedTimestamp();
     }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/knowledge/ConcludedRangeStateTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/knowledge/ConcludedRangeStateTest.java
@@ -16,15 +16,15 @@
 
 package com.palantir.atlasdb.transaction.knowledge;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Range;
 import com.palantir.atlasdb.transaction.impl.TransactionConstants;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import org.junit.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests on this class are fairly lightweight, as they focus primarily on correct deferral to the range-set

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/knowledge/ConcludedRangeStateTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/knowledge/ConcludedRangeStateTest.java
@@ -16,15 +16,15 @@
 
 package com.palantir.atlasdb.transaction.knowledge;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Range;
 import com.palantir.atlasdb.transaction.impl.TransactionConstants;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests on this class are fairly lightweight, as they focus primarily on correct deferral to the range-set
@@ -159,9 +159,9 @@ public class ConcludedRangeStateTest {
 
     @Test
     public void copyAndAddDoesNotAddRangeIfIntersectionIsEmpty() {
-        long upperbound = 50L;
-        Range<Long> range = Range.closedOpen(1L, 50L);
-        assertThat(ConcludedRangeState.initRanges(ImmutableSet.of(), upperbound)
+        long minimumConcludeableTimestamp = 50L;
+        Range<Long> range = Range.closedOpen(1L, minimumConcludeableTimestamp);
+        assertThat(ConcludedRangeState.initRanges(ImmutableSet.of(), minimumConcludeableTimestamp)
                         .copyAndAdd(range)
                         .timestampRanges()
                         .isEmpty())

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/knowledge/ConcludedRangeStateTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/knowledge/ConcludedRangeStateTest.java
@@ -24,17 +24,17 @@ import org.junit.Test;
 
 /**
  * Tests on this class are fairly lightweight, as they focus primarily on correct deferral to the range-set
- * underlying a {@link TimestampRangeSet}.
+ * underlying a {@link ConcludedRangeState}.
  */
 @SuppressWarnings("UnstableApiUsage") // RangeSet
-public class TimestampRangeSetTest {
+public class ConcludedRangeStateTest {
     private static final ImmutableRangeSet<Long> BASE_RANGES = ImmutableRangeSet.<Long>builder()
             .add(Range.openClosed(10L, 20L))
             .add(Range.openClosed(30L, 40L))
             .build();
-    private static final TimestampRangeSet BASE_RANGE_SET = ImmutableTimestampRangeSet.builder()
+    private static final ConcludedRangeState BASE_RANGE_SET = ImmutableConcludedRangeState.builder()
             .timestampRanges(BASE_RANGES)
-            .minimumTimestamp(2515L)
+            .minimumConcludeableTimestamp(2515L)
             .build();
 
     @Test
@@ -66,8 +66,8 @@ public class TimestampRangeSetTest {
     @Test
     public void copyAndAddWorksWithEmptyRange() {
         Range<Long> newRange = Range.openClosed(3L, 71L);
-        assertThat(TimestampRangeSet.empty().copyAndAdd(newRange))
-                .isEqualTo(TimestampRangeSet.singleRange(newRange, 0L));
+        assertThat(ConcludedRangeState.empty().copyAndAdd(newRange))
+                .isEqualTo(ConcludedRangeState.singleRange(newRange, 0L));
     }
 
     @Test
@@ -97,7 +97,7 @@ public class TimestampRangeSetTest {
     @Test
     public void copyAndAddCopiesMinimumTimestamp() {
         Range<Long> randomRange = Range.openClosed(50L, 55L);
-        assertThat(BASE_RANGE_SET.copyAndAdd(randomRange).minimumTimestamp())
-                .isEqualTo(BASE_RANGE_SET.minimumTimestamp());
+        assertThat(BASE_RANGE_SET.copyAndAdd(randomRange).minimumConcludeableTimestamp())
+                .isEqualTo(BASE_RANGE_SET.minimumConcludeableTimestamp());
     }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactionsImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactionsImplTest.java
@@ -112,7 +112,7 @@ public class KnownConcludedTransactionsImplTest {
         verify(knownConcludedTransactionsStore, times(3)).get();
 
         when(knownConcludedTransactionsStore.get())
-                .thenReturn(Optional.of(TimestampRangeSet.singleRange(Range.closed(0L, 100L))));
+                .thenReturn(Optional.of(TimestampRangeSet.singleRange(Range.closed(0L, 100L), 0L)));
         assertThat(defaultKnownConcludedTransactions.isKnownConcluded(2L, Consistency.REMOTE_READ))
                 .isTrue();
         verify(knownConcludedTransactionsStore, times(4)).get();
@@ -144,7 +144,7 @@ public class KnownConcludedTransactionsImplTest {
     @Test
     public void metricPublishesNumberOfDisjointCachedRanges() {
         when(knownConcludedTransactionsStore.get())
-                .thenReturn(Optional.of(TimestampRangeSet.singleRange(Range.closed(0L, 100L))));
+                .thenReturn(Optional.of(TimestampRangeSet.singleRange(Range.closed(0L, 100L), 0L)));
         assertThat(defaultKnownConcludedTransactions.isKnownConcluded(2L, Consistency.REMOTE_READ))
                 .isTrue();
         assertDisjointCacheIntervalMetricIsPublishedAndHasValue(1);
@@ -214,7 +214,7 @@ public class KnownConcludedTransactionsImplTest {
 
     private void setupStoreWithDefaultRange() {
         when(knownConcludedTransactionsStore.get())
-                .thenReturn(Optional.of(TimestampRangeSet.singleRange(DEFAULT_RANGE)));
+                .thenReturn(Optional.of(TimestampRangeSet.singleRange(DEFAULT_RANGE, 0L)));
     }
 
     private void assertDisjointCacheIntervalMetricIsPublishedAndHasValue(int expected) {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactionsImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactionsImplTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Range;
 import com.google.common.util.concurrent.Futures;
+import com.palantir.atlasdb.transaction.impl.TransactionConstants;
 import com.palantir.atlasdb.transaction.knowledge.KnownConcludedTransactions.Consistency;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
@@ -112,7 +113,7 @@ public class KnownConcludedTransactionsImplTest {
         verify(knownConcludedTransactionsStore, times(3)).get();
 
         when(knownConcludedTransactionsStore.get())
-                .thenReturn(Optional.of(TimestampRangeSet.singleRange(Range.closed(0L, 100L), 0L)));
+                .thenReturn(Optional.of(ConcludedRangeState.singleRange(Range.closed(0L, 100L), 0L)));
         assertThat(defaultKnownConcludedTransactions.isKnownConcluded(2L, Consistency.REMOTE_READ))
                 .isTrue();
         verify(knownConcludedTransactionsStore, times(4)).get();
@@ -144,7 +145,7 @@ public class KnownConcludedTransactionsImplTest {
     @Test
     public void metricPublishesNumberOfDisjointCachedRanges() {
         when(knownConcludedTransactionsStore.get())
-                .thenReturn(Optional.of(TimestampRangeSet.singleRange(Range.closed(0L, 100L), 0L)));
+                .thenReturn(Optional.of(ConcludedRangeState.singleRange(Range.closed(0L, 100L), 0L)));
         assertThat(defaultKnownConcludedTransactions.isKnownConcluded(2L, Consistency.REMOTE_READ))
                 .isTrue();
         assertDisjointCacheIntervalMetricIsPublishedAndHasValue(1);
@@ -214,7 +215,8 @@ public class KnownConcludedTransactionsImplTest {
 
     private void setupStoreWithDefaultRange() {
         when(knownConcludedTransactionsStore.get())
-                .thenReturn(Optional.of(TimestampRangeSet.singleRange(DEFAULT_RANGE, 0L)));
+                .thenReturn(Optional.of(
+                        ConcludedRangeState.singleRange(DEFAULT_RANGE, TransactionConstants.LOWEST_POSSIBLE_START_TS)));
     }
 
     private void assertDisjointCacheIntervalMetricIsPublishedAndHasValue(int expected) {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactionsStoreConcurrencyTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactionsStoreConcurrencyTest.java
@@ -77,7 +77,7 @@ public class KnownConcludedTransactionsStoreConcurrencyTest {
 
         List<Optional<TimestampRangeSet>> reads = letTasksRunToCompletion(readFutures, false);
         for (Optional<TimestampRangeSet> read : reads) {
-            assertThat(read).contains(TimestampRangeSet.singleRange(Range.closedOpen(10L, 50L)));
+            assertThat(read).contains(TimestampRangeSet.singleRange(Range.closedOpen(10L, 50L), 0L));
         }
 
         verify(delegateKeyValueService, atMost(50))

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactionsStoreConcurrencyTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactionsStoreConcurrencyTest.java
@@ -91,7 +91,7 @@ public class KnownConcludedTransactionsStoreConcurrencyTest {
         startBlockingKeyValueServiceCalls();
 
         int numThreads = 300;
-        List<Range<Long>> candidateTimestampRanges = LongStream.range(0, numThreads)
+        List<Range<Long>> candidateTimestampRanges = LongStream.range(1, numThreads)
                 .mapToObj(index -> Range.closed(2 * index, 2 * index + 1))
                 .collect(Collectors.toList());
 
@@ -114,7 +114,7 @@ public class KnownConcludedTransactionsStoreConcurrencyTest {
 
         int numThreads = 300;
         int threadsPerRange = 25;
-        List<Range<Long>> candidateTimestampRanges = LongStream.range(0, numThreads / threadsPerRange)
+        List<Range<Long>> candidateTimestampRanges = LongStream.range(1, numThreads / threadsPerRange)
                 .mapToObj(index -> Range.closed(2 * index, 2 * index + 1))
                 .collect(Collectors.toList());
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactionsStoreTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactionsStoreTest.java
@@ -84,4 +84,13 @@ public class KnownConcludedTransactionsStoreTest {
         assertThat(maybeModifiedRange.lowerEndpoint()).isEqualTo(range.lowerEndpoint());
         assertThat(maybeModifiedRange.upperEndpoint()).isEqualTo(range.upperEndpoint());
     }
+
+    @Test
+    public void rangesAreNotModifiedIfMinimumTimestampEmpty() {
+        Range<Long> range = Range.closed(10L, 100L);
+        Range<Long> maybeModifiedRange =
+                knownConcludedTransactionsStore.maybeModifyRangeLowerBoundToMinimumTimestamp(Optional.empty(), range);
+        assertThat(maybeModifiedRange.lowerEndpoint()).isEqualTo(range.lowerEndpoint());
+        assertThat(maybeModifiedRange.upperEndpoint()).isEqualTo(range.upperEndpoint());
+    }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactionsStoreTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactionsStoreTest.java
@@ -27,8 +27,6 @@ import org.junit.Test;
 
 @SuppressWarnings("UnstableApiUsage") // RangeSet usage
 public class KnownConcludedTransactionsStoreTest {
-
-    private static final long MINIMUM_TIMESTAMP = 25l;
     private final KeyValueService keyValueService = new InMemoryKeyValueService(true);
     private final KnownConcludedTransactionsStore knownConcludedTransactionsStore =
             KnownConcludedTransactionsStore.create(keyValueService);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactionsStoreTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactionsStoreTest.java
@@ -22,10 +22,13 @@ import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.collect.Range;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
+import java.util.Optional;
 import org.junit.Test;
 
 @SuppressWarnings("UnstableApiUsage") // RangeSet usage
 public class KnownConcludedTransactionsStoreTest {
+
+    private static final Optional<Long> MINIMUM_TIMESTAMP = Optional.of(25L);
     private final KeyValueService keyValueService = new InMemoryKeyValueService(true);
     private final KnownConcludedTransactionsStore knownConcludedTransactionsStore =
             KnownConcludedTransactionsStore.create(keyValueService);
@@ -39,7 +42,7 @@ public class KnownConcludedTransactionsStoreTest {
     public void canRetrieveStoredRange() {
         knownConcludedTransactionsStore.supplement(Range.closedOpen(1L, 100L));
         assertThat(knownConcludedTransactionsStore.get())
-                .contains(TimestampRangeSet.singleRange(Range.closedOpen(1L, 100L)));
+                .contains(TimestampRangeSet.singleRange(Range.closedOpen(1L, 100L), 0L));
     }
 
     @Test
@@ -47,7 +50,7 @@ public class KnownConcludedTransactionsStoreTest {
         knownConcludedTransactionsStore.supplement(Range.closedOpen(1L, 100L));
         knownConcludedTransactionsStore.supplement(Range.closedOpen(50L, 200L));
         assertThat(knownConcludedTransactionsStore.get())
-                .contains(TimestampRangeSet.singleRange(Range.closedOpen(1L, 200L)));
+                .contains(TimestampRangeSet.singleRange(Range.closedOpen(1L, 200L), 0L));
     }
 
     @Test
@@ -60,6 +63,25 @@ public class KnownConcludedTransactionsStoreTest {
                                 .add(Range.closedOpen(1L, 100L))
                                 .add(Range.closedOpen(150L, 200L))
                                 .build())
+                        .minimumTimestamp(0L)
                         .build());
+    }
+
+    @Test
+    public void rangesThatContainMinimumTimestampModifiedToHaveMinimumTimestampAsLowerBound() {
+        Range<Long> range = Range.closed(10L, 100L);
+        Range<Long> modifiedRange =
+                knownConcludedTransactionsStore.maybeModifyRangeLowerBoundToMinimumTimestamp(MINIMUM_TIMESTAMP, range);
+        assertThat(modifiedRange.lowerEndpoint()).isEqualTo(MINIMUM_TIMESTAMP.get());
+        assertThat(modifiedRange.upperEndpoint()).isEqualTo(range.upperEndpoint());
+    }
+
+    @Test
+    public void rangesThatDoesNotContainMinimumTimestampShouldNotHaveLowerBoundModified() {
+        Range<Long> range = Range.closed(50L, 100L);
+        Range<Long> maybeModifiedRange =
+                knownConcludedTransactionsStore.maybeModifyRangeLowerBoundToMinimumTimestamp(MINIMUM_TIMESTAMP, range);
+        assertThat(maybeModifiedRange.lowerEndpoint()).isEqualTo(range.lowerEndpoint());
+        assertThat(maybeModifiedRange.upperEndpoint()).isEqualTo(range.upperEndpoint());
     }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactionsStoreTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/knowledge/KnownConcludedTransactionsStoreTest.java
@@ -17,12 +17,16 @@
 package com.palantir.atlasdb.transaction.knowledge;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableRangeSet;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Range;
+import com.google.common.collect.RangeSet;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
 import com.palantir.atlasdb.transaction.impl.TransactionConstants;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import org.junit.Test;
 
 @SuppressWarnings("UnstableApiUsage") // RangeSet usage
@@ -65,5 +69,62 @@ public class KnownConcludedTransactionsStoreTest {
                                 .build())
                         .minimumConcludeableTimestamp(TransactionConstants.LOWEST_POSSIBLE_START_TS)
                         .build());
+    }
+
+    @Test
+    public void canSetMinimumConcludableTimestamp() {
+        long minimumTimestamp = 100L;
+        knownConcludedTransactionsStore.setMinimumConcludableTimestamp(minimumTimestamp);
+        assertThat(knownConcludedTransactionsStore.get())
+                .isPresent()
+                .map(ConcludedRangeState::minimumConcludeableTimestamp)
+                .contains(minimumTimestamp);
+    }
+
+    @Test
+    public void throwsWhenTryingToSetMinimumTimestampToASmallerValue() {
+        knownConcludedTransactionsStore.setMinimumConcludableTimestamp(TransactionConstants.LOWEST_POSSIBLE_START_TS);
+        assertThatThrownBy(() -> knownConcludedTransactionsStore.setMinimumConcludableTimestamp(
+                        TransactionConstants.LOWEST_POSSIBLE_START_TS - 1l))
+                .isInstanceOf(SafeIllegalArgumentException.class)
+                .hasMessageContaining("Must set minimum concludable timestamp to be higher than the present value.");
+    }
+
+    @Test
+    public void supplementIgnoresRangesBelowMinimumTimestamp() {
+        long minimumTimestamp = 100L;
+        knownConcludedTransactionsStore.setMinimumConcludableTimestamp(minimumTimestamp);
+        knownConcludedTransactionsStore.supplement(Range.closed(0L, minimumTimestamp - 1));
+        assertThat(knownConcludedTransactionsStore.get())
+                .isPresent()
+                .map(ConcludedRangeState::timestampRanges)
+                .get()
+                .matches(RangeSet::isEmpty);
+    }
+
+    @Test
+    public void supplementModifiesLowerBoundIfOverlapsWithMinimumTimestamp() {
+        long minimumTimestamp = 100L;
+        Range<Long> initialRange = Range.closed(minimumTimestamp - 50, minimumTimestamp + 50);
+        knownConcludedTransactionsStore.setMinimumConcludableTimestamp(minimumTimestamp);
+        knownConcludedTransactionsStore.supplement(initialRange);
+        assertThat(knownConcludedTransactionsStore.get())
+                .isPresent()
+                .map(ConcludedRangeState::timestampRanges)
+                .map(RangeSet::asRanges)
+                .contains(ImmutableSet.of(Range.closed(minimumTimestamp, initialRange.upperEndpoint())));
+    }
+
+    @Test
+    public void settingMinimumConcludableTimestampDoesNotRemovePreviouslySupplementedRanges() {
+        long minimumTimestamp = 100L;
+        Range<Long> initialRange = Range.closed(1L, minimumTimestamp - 1);
+        knownConcludedTransactionsStore.supplement(initialRange);
+        knownConcludedTransactionsStore.setMinimumConcludableTimestamp(minimumTimestamp);
+        assertThat(knownConcludedTransactionsStore.get())
+                .isPresent()
+                .map(ConcludedRangeState::timestampRanges)
+                .map(RangeSet::asRanges)
+                .contains(ImmutableSet.of(initialRange));
     }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/knowledge/TimestampRangeSetTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/knowledge/TimestampRangeSetTest.java
@@ -32,8 +32,10 @@ public class TimestampRangeSetTest {
             .add(Range.openClosed(10L, 20L))
             .add(Range.openClosed(30L, 40L))
             .build();
-    private static final TimestampRangeSet BASE_RANGE_SET =
-            ImmutableTimestampRangeSet.builder().timestampRanges(BASE_RANGES).build();
+    private static final TimestampRangeSet BASE_RANGE_SET = ImmutableTimestampRangeSet.builder()
+            .timestampRanges(BASE_RANGES)
+            .minimumTimestamp(2515L)
+            .build();
 
     @Test
     public void enclosesIdentifiesDirectMatch() {
@@ -64,7 +66,8 @@ public class TimestampRangeSetTest {
     @Test
     public void copyAndAddWorksWithEmptyRange() {
         Range<Long> newRange = Range.openClosed(3L, 71L);
-        assertThat(TimestampRangeSet.empty().copyAndAdd(newRange)).isEqualTo(TimestampRangeSet.singleRange(newRange));
+        assertThat(TimestampRangeSet.empty().copyAndAdd(newRange))
+                .isEqualTo(TimestampRangeSet.singleRange(newRange, 0L));
     }
 
     @Test
@@ -89,5 +92,12 @@ public class TimestampRangeSetTest {
                         .addAll(BASE_RANGES)
                         .add(outsideRange)
                         .build());
+    }
+
+    @Test
+    public void copyAndAddCopiesMinimumTimestamp() {
+        Range<Long> randomRange = Range.openClosed(50L, 55L);
+        assertThat(BASE_RANGE_SET.copyAndAdd(randomRange).minimumTimestamp())
+                .isEqualTo(BASE_RANGE_SET.minimumTimestamp());
     }
 }

--- a/changelog/@unreleased/pr-6379.v2.yml
+++ b/changelog/@unreleased/pr-6379.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Adds support for minimum timestamp for transactions4
+  links:
+  - https://github.com/palantir/atlasdb/pull/6379


### PR DESCRIPTION
## General
**Before this PR**:
For transactions4, we did not have the minimum timestamp for TTS. 

**After this PR**:
==COMMIT_MSG==
Adds support for minimum timestamp for transactions4
==COMMIT_MSG==

**Priority**:
ASAP

**Concerns / possible downsides (what feedback would you like?)**:
- Did I properly modify the range

**Is documentation needed?**:
No

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
Yes, but txn4 is not rolled out yet, so no need to worry. 

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes. 

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No

**Does this PR need a schema migration?**
No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
- Minimum timestamp is only set during restore, otherwise is mostly left alone.

**What was existing testing like? What have you done to improve it?**:
- Added unit tests!

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
I don't think there's a feasible way for us to expose this, unless we expose a metric which tracks the minimum timestamp, and the lowerbound of every range concluded. 

(Even then it wouldn't be clear, as it really only depends when we restore)

**Has the safety of all log arguments been decided correctly?**:
N/A

**Will this change significantly affect our spending on metrics or logs?**:
No

**How would I tell that this PR does not work in production? (monitors, etc.)**:
Same as above

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Absolutely not, as there will be severe data corruption! 

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
Perform a restore. 

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
