### PR TITLE
Fix supplement for CoordinationAwareKnownConcludedTransactionsStore

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/coordinated/CoordinationAwareKnownConcludedTransactionsStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/coordinated/CoordinationAwareKnownConcludedTransactionsStore.java
@@ -25,6 +25,7 @@ import com.palantir.common.streams.KeyedStream;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
+
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -82,6 +83,7 @@ public final class CoordinationAwareKnownConcludedTransactionsStore implements K
             Range<Long> closedTsRangeToConclude, Map<Range<Long>, Integer> timestampRanges) {
         return KeyedStream.stream(timestampRanges)
                 .filter(schemaVersion -> schemaVersion >= TransactionConstants.TTS_TRANSACTIONS_SCHEMA_VERSION)
+                .filterKeys(closedTsRangeToConclude::isConnected)
                 .mapKeys(closedTsRangeToConclude::intersection)
                 .keys()
                 .collect(Collectors.toSet());

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/coordinated/CoordinationAwareKnownConcludedTransactionsStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/knowledge/coordinated/CoordinationAwareKnownConcludedTransactionsStore.java
@@ -25,7 +25,6 @@ import com.palantir.common.streams.KeyedStream;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
-
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/knowledge/coordinated/CoordinationAwareKnownConcludedTransactionsStoreTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/knowledge/coordinated/CoordinationAwareKnownConcludedTransactionsStoreTest.java
@@ -16,6 +16,11 @@
 
 package com.palantir.atlasdb.transaction.knowledge.coordinated;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
 import com.google.common.collect.ImmutableRangeMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Range;
@@ -24,11 +29,6 @@ import com.palantir.atlasdb.internalschema.TimestampPartitioningMap;
 import com.palantir.atlasdb.transaction.impl.TransactionConstants;
 import com.palantir.atlasdb.transaction.knowledge.KnownConcludedTransactionsImpl;
 import org.junit.Test;
-
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public final class CoordinationAwareKnownConcludedTransactionsStoreTest {
     private final KnownConcludedTransactionsImpl delegate = mock(KnownConcludedTransactionsImpl.class);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/knowledge/coordinated/CoordinationAwareKnownConcludedTransactionsStoreTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/knowledge/coordinated/CoordinationAwareKnownConcludedTransactionsStoreTest.java
@@ -92,6 +92,7 @@ public final class CoordinationAwareKnownConcludedTransactionsStoreTest {
         Range<Long> rangeToSupplement = Range.closedOpen(201L, 400L);
         assertThatCode(() -> coordinationAwareStore.addConcludedTimestamps(rangeToSupplement))
                 .doesNotThrowAnyException();
+        verifyNoMoreInteractions(delegate);
     }
 
     @Test

--- a/changelog/@unreleased/pr-6380.v2.yml
+++ b/changelog/@unreleased/pr-6380.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Fix supplement for CoordinationAwareKnownConcludedTransactionsStore
+  links:
+  - https://github.com/palantir/atlasdb/pull/6380


### PR DESCRIPTION
## General
**Before this PR**:
We would attempt to perform a range intersection against all supplements even if ranges did not overlap. This becomes an issue if we ever roll-off of txn4 back to txn3/etc.

**After this PR**:
==COMMIT_MSG==
Only supplement ranges for transactions4 if they have overlap.
==COMMIT_MSG==

**Priority**:
p0

**Concerns / possible downsides (what feedback would you like?)**:
Agree that it's ok for us to filter out ranges that do not intersect with txn4 (I think yes!)

**Is documentation needed?**:
No

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No

**Does this PR need a schema migration?**
No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
That it's safe to ignore a supplement in TTS if the range does not overlap with the coordinators txn4. 

**What was existing testing like? What have you done to improve it?**:
Added a test case that showed the bug! 

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
No

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
No

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Exception isn't thrown when we rollback a transaction schema

**Has the safety of all log arguments been decided correctly?**:
Yes

**Will this change significantly affect our spending on metrics or logs?**:
No

**How would I tell that this PR does not work in production? (monitors, etc.)**:
Logs, from an exception thrown due to two sets not having intersection.

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Yes can just revert

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
