### PR TITLE
Fixes bug where duplicate cassandra servers were specified

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -13,3 +13,9 @@ acceptedBreaks:
     - code: "java.class.removed"
       old: "interface com.palantir.atlasdb.transaction.api.expectations.ExpectationsStatistics"
       justification: "removing TEX until ready"
+  "0.774.0":
+    com.palantir.atlasdb:atlasdb-cassandra:
+    - code: "java.method.removed"
+      old: "method <T> java.util.Map<java.lang.String, T> com.palantir.atlasdb.keyvalue.cassandra.CassandraLogHelper::mapOfHosts(java.util.Map<com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer,\
+        \ T>)"
+      justification: "internal api, same package"

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
@@ -24,21 +24,15 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
-import one.util.streamex.EntryStream;
 import org.apache.cassandra.thrift.TokenRange;
 import org.immutables.value.Value;
 
 public final class CassandraLogHelper {
     private CassandraLogHelper() {
         // Utility class.
-    }
-
-    public static <T> Map<String, T> mapOfHosts(Map<CassandraServer, T> hosts) {
-        return EntryStream.of(hosts).mapKeys(CassandraServer::cassandraHostName).toMap();
     }
 
     public static HostAndIpAddress host(InetSocketAddress host) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidator.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidator.java
@@ -223,7 +223,7 @@ public final class CassandraTopologyValidator {
                         || result.type() == HostIdResult.Type.HARD_FAILURE)) {
             log.warn(
                     "While fetching host id from hosts, some reported soft and hard failures.",
-                    SafeArg.of("results", CassandraLogHelper.mapOfHosts(results)));
+                    SafeArg.of("results", results));
         }
 
         return EntryStream.of(results)

--- a/changelog/@unreleased/pr-6383.v2.yml
+++ b/changelog/@unreleased/pr-6383.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fixes bug where log message would cause a duplicate key exception when
+    performing cassandra topology validation.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6383


### PR DESCRIPTION
## General
**Before this PR**:
Pretty log host id return types. 

**After this PR**:
==COMMIT_MSG==
Fixes bug where log message would cause a duplicate key exception when performing cassandra topology validation.
==COMMIT_MSG==

**Priority**:
P0

**Concerns / possible downsides (what feedback would you like?)**:
Logs are ugly but that's ok as this could break production. I think long term fix here is de-duping hosts correctly when adding/removing cassandra servers 

**Is documentation needed?**:
no

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No

**Does this PR need a schema migration?**
No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
None

**What was existing testing like? What have you done to improve it?**:
None

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Log message can be read! 

**Has the safety of all log arguments been decided correctly?**:
Yes

**Will this change significantly affect our spending on metrics or logs?**:
No

**How would I tell that this PR does not work in production? (monitors, etc.)**:
Logs

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Yes, just revert PR 

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
