### PR TITLE
[DNM] RC from 0.754.0 without CassandraClientPoolHostLevelMetric outlier filtering

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraClientPoolHostLevelMetric.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraClientPoolHostLevelMetric.java
@@ -17,12 +17,12 @@
 package com.palantir.atlasdb.keyvalue.cassandra.pool;
 
 public enum CassandraClientPoolHostLevelMetric {
-    MEAN_ACTIVE_TIME_MILLIS("meanActiveTimeMillis", 0.0, 2.0),
-    NUM_IDLE("numIdle", 0.1, 2.0),
-    NUM_ACTIVE("numActive", 0.1, 2.0),
-    CREATED("created", 0.01, 2.0),
-    DESTROYED_BY_EVICTOR("destroyedByEvictor", 0.01, 2.0),
-    DESTROYED("destroyed", 0.01, 2.0);
+    MEAN_ACTIVE_TIME_MILLIS("meanActiveTimeMillis", 0.0, 999_999),
+    NUM_IDLE("numIdle", 0.0, 999_999),
+    NUM_ACTIVE("numActive", 0.0, 999_999),
+    CREATED("created", 0.0, 999_999),
+    DESTROYED_BY_EVICTOR("destroyedByEvictor", 0.0, 999_999),
+    DESTROYED("destroyed", 0.0, 999_999);
 
     public final String metricName;
     public final double minimumMeanThreshold;

--- a/changelog/@unreleased/pr-6385.v2.yml
+++ b/changelog/@unreleased/pr-6385.v2.yml
@@ -1,0 +1,10 @@
+type: fix
+fix:
+  description: |-
+    RC from 0.754.0 without CassandraClientPoolHostLevelMetric outlier filtering
+
+    For RC cut from 0.754.0.
+
+    Effectively no-ops metrics filtering based on outliers.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6385


### PR DESCRIPTION
For RC cut from 0.754.0.

Effectively no-ops metrics filtering based on outliers.