### PR TITLE
Don't shadow Cassandra dependencies

### DIFF
--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -1,38 +1,23 @@
 apply from: "../gradle/shared.gradle"
-apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'com.palantir.metric-schema'
 apply plugin: 'com.palantir.revapi'
 
-configurations {
-  explicitShadow
-  shadow.extendsFrom(explicitShadow)
-  implementation.extendsFrom(explicitShadow)
-}
-
 dependencies {
-  // does shadowing statically analysed annotations really buy us anything?
-  explicitShadow 'com.google.code.findbugs:findbugs-annotations'
-  explicitShadow 'com.google.code.findbugs:jsr305'
-  explicitShadow 'com.google.guava:guava'
-  explicitShadow 'com.palantir.conjure.java.api:ssl-config'
-  explicitShadow 'com.palantir.conjure.java.runtime:keystores'
-  explicitShadow 'com.palantir.nylon:nylon-threads'
-  explicitShadow 'com.palantir.safe-logging:safe-logging'
-  explicitShadow 'com.palantir.tracing:tracing'
-  explicitShadow 'org.apache.commons:commons-pool2'
-  explicitShadow 'org.jboss.marshalling:jboss-marshalling'
-  explicitShadow project(":atlasdb-api")
-  explicitShadow project(":atlasdb-client")
-  explicitShadow project(":atlasdb-impl-shared")
-  explicitShadow project(":commons-api")
-  explicitShadow project(':timestamp-impl')
-  shadow ('com.palantir.cassandra:cassandra-thrift') {
-    exclude group: 'org.apache.httpcomponents'
-  }
+  implementation 'com.google.guava:guava'
+  implementation 'com.palantir.conjure.java.api:ssl-config'
+  implementation 'com.palantir.conjure.java.runtime:keystores'
+  implementation 'com.palantir.nylon:nylon-threads'
+  implementation 'com.palantir.safe-logging:safe-logging'
+  implementation 'com.palantir.tracing:tracing'
+  implementation 'org.apache.commons:commons-pool2'
+  implementation 'org.jboss.marshalling:jboss-marshalling'
+  implementation project(":atlasdb-api")
+  implementation project(":atlasdb-client")
+  implementation project(":atlasdb-impl-shared")
+  implementation project(":commons-api")
+  implementation project(':timestamp-impl')
   implementation ('com.palantir.cassandra:cassandra-thrift')
-  explicitShadow ('com.datastax.cassandra:cassandra-driver-core') {
-    exclude(group: 'com.codahale.metrics', module: 'metrics-core')
-  }
+  implementation ('com.datastax.cassandra:cassandra-driver-core')
   implementation 'org.apache.httpcomponents.client5:httpclient5'
   implementation 'com.fasterxml.jackson.core:jackson-annotations'
   implementation 'com.fasterxml.jackson.core:jackson-databind'
@@ -99,20 +84,6 @@ dependencies {
   compileOnly project(":atlasdb-processors")
   testCompileOnly 'org.immutables:value::annotations'
 }
-
-shadowJar {
-  mergeServiceFiles()
-  classifier ''
-
-  relocate('org.hibernate', 'shadowed')
-
-  dependencies {
-      include(dependency { false })
-  }
-}
-
-jar.dependsOn shadowJar
-jar.onlyIf { false }
 
 apply plugin: 'com.palantir.sls-recommended-dependencies'
 

--- a/atlasdb-cli/build.gradle
+++ b/atlasdb-cli/build.gradle
@@ -3,7 +3,7 @@ apply from: '../gradle/shared.gradle'
 
 dependencies {
     api project(':atlasdb-cassandra')
-    api project(path: ':atlasdb-dagger', configuration: 'shadow')
+    api project(':atlasdb-dagger')
     api project(':atlasdb-api')
     api project(':atlasdb-client')
     api project(':atlasdb-config')

--- a/atlasdb-dagger/build.gradle
+++ b/atlasdb-dagger/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'com.github.johnrengelman.shadow'
-
 apply from: '../gradle/shared.gradle'
 
 dependencies {
@@ -17,6 +15,7 @@ dependencies {
   implementation project(':atlasdb-config')
   implementation project(':atlasdb-coordination-impl')
   implementation project(':atlasdb-impl-shared')
+  implementation project(':atlasdb-service')
   implementation project(':commons-executors')
   implementation project(':lock-api')
   implementation project(':lock-api-objects')
@@ -31,19 +30,4 @@ dependencies {
   testImplementation 'org.mockito:mockito-core'
   testImplementation 'org.assertj:assertj-core'
 
-  shadow project(':atlasdb-service')
 }
-
-shadowJar {
-  mergeServiceFiles()
-  classifier ''
-
-  relocate('dagger', 'com.palantir.atlasdb.shaded.dagger')
-
-  dependencies {
-    include dependency('com.google.dagger:dagger')
-  }
-}
-
-jar.dependsOn shadowJar
-jar.onlyIf { false }


### PR DESCRIPTION
## Before this PR
Upgrading `libthrift` in https://github.com/palantir/atlasdb/pull/6339 broke consumers because the `libthrift` was not being properly declared in the generated `pom.xml`.

This mangling of dependencies is caused by our use of the `com.github.johnrengelman.shadow` plugin. If we don't shade these dependencies, then `libthrift` correctly appears in the `dependencies` block.

As far I as can tell, there is no reason that we need to shade these dependencies.

## After this PR
AtlasDB no longer shades Cassandra dependencies.

## Concerns
- Is there a specific reason we are shading these dependencies?