### PR TITLE
[PDS-321180] [DO NOT MERGE unless discussed!] Revisit decision to not admit new hosts if we can't get a quorum

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidator.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidator.java
@@ -163,9 +163,11 @@ public final class CassandraTopologyValidator {
         switch (topologyFromCurrentServers.type()) {
             case CONSENSUS:
                 quorumFailures.set(0);
-                Preconditions.checkState(topologyFromCurrentServers.agreedTopology().isPresent(),
+                Preconditions.checkState(
+                        topologyFromCurrentServers.agreedTopology().isPresent(),
                         "Expected to have a consistent topology for a CONSENSUS result, but did not.");
-                ConsistentClusterTopology topology = topologyFromCurrentServers.agreedTopology().get();
+                ConsistentClusterTopology topology =
+                        topologyFromCurrentServers.agreedTopology().get();
                 return EntryStream.of(newServersWithoutSoftFailures)
                         .removeValues(result -> result.type() == HostIdResult.Type.SUCCESS
                                 && result.hostIds().equals(topology.hostIds()))
@@ -179,7 +181,8 @@ public final class CassandraTopologyValidator {
                 // In the event of no quorum, we need to trust the new servers at some point since in containerised
                 // deployments things can actually move on like that between refreshes.
                 if (quorumFailures.incrementAndGet() >= 10) {
-                    log.warn("We have not been able to get a quorum of the existing Cassandra nodes for ten "
+                    log.warn(
+                            "We have not been able to get a quorum of the existing Cassandra nodes for ten "
                                     + "attempts. Based on this, we are just going to look at the remaining hosts and "
                                     + "accept their consensus, if they have one.",
                             SafeArg.of("currentServersWithoutSoftFailures", currentServersWithoutSoftFailures),
@@ -189,12 +192,15 @@ public final class CassandraTopologyValidator {
                             .agreedTopology()
                             .<Set<CassandraServer>>map(newServerTopology ->
                                     // Do not add new servers which were unreachable
-                                    Sets.difference(newServersWithoutSoftFailures.keySet(), newServerTopology.serversInConsensus()))
+                                    Sets.difference(
+                                            newServersWithoutSoftFailures.keySet(),
+                                            newServerTopology.serversInConsensus()))
                             .orElseGet(newServersWithoutSoftFailures::keySet);
                 }
                 return newServersWithoutSoftFailures.keySet();
             default:
-                throw new SafeIllegalStateException("Unexpected cluster topology result type",
+                throw new SafeIllegalStateException(
+                        "Unexpected cluster topology result type",
                         SafeArg.of("type", topologyFromCurrentServers.type()));
         }
     }
@@ -306,6 +312,7 @@ public final class CassandraTopologyValidator {
     @Value.Immutable
     public interface ClusterTopologyResult {
         ClusterTopologyResultType type();
+
         Optional<ConsistentClusterTopology> agreedTopology();
 
         static ClusterTopologyResult consensus(ConsistentClusterTopology consistentClusterTopology) {
@@ -320,6 +327,7 @@ public final class CassandraTopologyValidator {
                     .type(ClusterTopologyResultType.DISSENT)
                     .build();
         }
+
         static ClusterTopologyResult noQuorum() {
             return ImmutableClusterTopologyResult.builder()
                     .type(ClusterTopologyResultType.NO_QUORUM)

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidatorTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidatorTest.java
@@ -238,7 +238,7 @@ public final class CassandraTopologyValidatorTest {
         }
         assertThat(validator.getNewHostsWithInconsistentTopologies(newCassandraServers, allHosts))
                 .as("new hosts can be added if old hosts repeatedly fail to have quorum")
-                .containsExactlyElementsOf(newCassandraServers);
+                .isEmpty();
 
     }
 

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidatorTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidatorTest.java
@@ -239,7 +239,6 @@ public final class CassandraTopologyValidatorTest {
         assertThat(validator.getNewHostsWithInconsistentTopologies(newCassandraServers, allHosts))
                 .as("new hosts can be added if old hosts repeatedly fail to have quorum")
                 .isEmpty();
-
     }
 
     @Test


### PR DESCRIPTION
## General
**Before this PR**:
The Cassandra topology validator does not admit new hosts if we fail to get a quorum. This causes issues with containerised deployments: if all nodes bounce too quickly, we will reject new topology changes for the rest of the JVM lifecycle.

More concretely, suppose we have a three node cluster [A, B, C] and the nodes have bounced, changing their IPs so they are [D, E, F]. In this case, while we think the cluster is still [A, B, C] we will try to refresh the token ring, but fail, since all we know is [A, B, C]. Then we also retrieve the current server list from the config, and this now resolves to [D, E, F], and treat our candidate cluster as the union of these [A, B, C, D, E, F]. The servers to _add_ are [D, E, F], but at this point their addition is rejected because we still want to check that they believe the cluster topology matches what a quorum of [A, B, C] think, and "hard failures" to get a quorum are interpreted as, well, failures.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
The Cassandra topology validator does admit new hosts if we fail to get a quorum ten times. When it does this, it polls the new hosts, requiring consensus on a quorum on _their_ end. If this is satisfied, the new hosts are added
==COMMIT_MSG==

**Priority**: High, if we want to use it

**Concerns / possible downsides (what feedback would you like?)**:
- Obviously this is less defensive than the original, but we do need to be resilient to this case. I imagine the fact that we still need a consensus on the new nodes with at least a quorum of them does protect us somewhat.
- Is 10 enough?

**Is documentation needed?**: Not right now.

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: Yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: No

**Does this PR need a schema migration?** No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: Cassandra is deployed in containerised environments

**What was existing testing like? What have you done to improve it?**: Added a unit test for this specific case

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: No

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: No

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: Logs, ability to actually handle the bad case we saw on the ticket.

**Has the safety of all log arguments been decided correctly?**: Yes, servers are safe

**Will this change significantly affect our spending on metrics or logs?**: No

**How would I tell that this PR does not work in production? (monitors, etc.)**: Inability to handle the bad case we saw.

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: Yeah, rollback.

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**: No

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**: No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**: I'm not convinced this is even the right thing to do per se, but it may be needed as a band-aid.

## Development Process
**Where should we start reviewing?**: CTVTest

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: It's not

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
