### PR TITLE
Reduce allocations from observability

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -27,3 +27,10 @@ acceptedBreaks:
       new: "method org.apache.thrift.transport.TSocket com.palantir.atlasdb.keyvalue.cassandra.InstrumentedTSocket.Factory::create(java.lang.String,\
         \ int, int)"
       justification: "revert"
+  "0.782.0":
+    com.palantir.atlasdb:atlasdb-cassandra:
+    - code: "java.method.returnTypeChanged"
+      old: "method com.palantir.atlasdb.keyvalue.cassandra.CassandraLogHelper.HostAndIpAddress\
+        \ com.palantir.atlasdb.keyvalue.cassandra.CassandraLogHelper::host(java.net.InetSocketAddress)"
+      new: "method java.lang.String com.palantir.atlasdb.keyvalue.cassandra.CassandraLogHelper::host(java.net.InetSocketAddress)"
+      justification: "Internal logging diagnostics"

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -27,10 +27,3 @@ acceptedBreaks:
       new: "method org.apache.thrift.transport.TSocket com.palantir.atlasdb.keyvalue.cassandra.InstrumentedTSocket.Factory::create(java.lang.String,\
         \ int, int)"
       justification: "revert"
-  "0.782.0":
-    com.palantir.atlasdb:atlasdb-cassandra:
-    - code: "java.method.returnTypeChanged"
-      old: "method com.palantir.atlasdb.keyvalue.cassandra.CassandraLogHelper.HostAndIpAddress\
-        \ com.palantir.atlasdb.keyvalue.cassandra.CassandraLogHelper::host(java.net.InetSocketAddress)"
-      new: "method java.lang.String com.palantir.atlasdb.keyvalue.cassandra.CassandraLogHelper::host(java.net.InetSocketAddress)"
-      justification: "Internal logging diagnostics"

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -496,7 +496,7 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
                     (cassandraServer, exception) -> errorBuilderForEntireCluster.append(String.format(
                             "\tServer: %s was marked unreachable via proxy: %s, with exception: %s%n",
                             cassandraServer.cassandraHostName(),
-                            cassandraServer.proxy().getHostString(),
+                            CassandraLogHelper.host(cassandraServer.proxy()),
                             exception.toString())));
         }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -117,12 +117,13 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Cassand
     public <V, K extends Exception> V runWithPooledResource(FunctionCheckedException<CassandraClient, V, K> fn)
             throws K {
         final String origName = Thread.currentThread().getName();
-        ThreadNames.setThreadName(
-                Thread.currentThread(),
-                origName
-                        + " calling cassandra host " + proxy.getHostString() + ':' + proxy.getPort()
-                        + " started at " + Instant.now()
-                        + " - " + count.getAndIncrement());
+        String newThreadName = origName + " to cassandra " + proxy.getHostString() + ':' + proxy.getPort() + " - "
+                + count.getAndIncrement();
+        if (log.isDebugEnabled()) {
+            // the timestamp is expensive to stringify, only add to thread names when debugging
+            newThreadName += " started at " + Instant.now();
+        }
+        ThreadNames.setThreadName(Thread.currentThread(), newThreadName);
         try {
             openRequests.getAndIncrement();
             return runWithGoodResource(fn);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
@@ -18,8 +18,7 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.Interner;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Range;
@@ -42,11 +41,10 @@ public final class CassandraLogHelper {
     }
 
     // Cache instances as there should be a relatively small, generally fixed number of Cassandra servers.
-    private static final LoadingCache<HostAndIpAddress, String> hostAddressToString =
-            Caffeine.newBuilder().maximumSize(1_000).build(HostAndIpAddress::toString);
+    private static final Interner<HostAndIpAddress> hostAddresses = Interner.newWeakInterner();
 
-    public static String host(InetSocketAddress host) {
-        return hostAddressToString.get(hostAndIp(host));
+    public static HostAndIpAddress host(InetSocketAddress host) {
+        return hostAddresses.intern(hostAndIp(host));
     }
 
     static Collection<String> collectionOfHosts(Collection<CassandraServer> hosts) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.github.benmanes.caffeine.cache.Interner;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeMap;
@@ -44,7 +43,10 @@ public final class CassandraLogHelper {
     private static final Interner<HostAndIpAddress> hostAddresses = Interner.newWeakInterner();
 
     public static HostAndIpAddress host(InetSocketAddress host) {
-        return hostAddresses.intern(hostAndIp(host));
+        String hostString = host.getHostString().toLowerCase(Locale.ROOT);
+        InetAddress inetAddress = host.getAddress();
+        String ip = (inetAddress == null) ? null : /* unresolved IP */ inetAddress.getHostAddress();
+        return hostAddresses.intern(ImmutableHostAndIpAddress.of(hostString, ip));
     }
 
     static Collection<String> collectionOfHosts(Collection<CassandraServer> hosts) {
@@ -114,13 +116,5 @@ public final class CassandraLogHelper {
         public final String toString() {
             return asString();
         }
-    }
-
-    @VisibleForTesting
-    static HostAndIpAddress hostAndIp(InetSocketAddress address) {
-        InetAddress inetAddress = address.getAddress();
-        String host = address.getHostString().toLowerCase(Locale.ROOT);
-        String ip = (inetAddress == null) ? null : /* unresolved IP */ inetAddress.getHostAddress();
-        return ImmutableHostAndIpAddress.of(host, ip);
     }
 }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelperTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelperTest.java
@@ -85,8 +85,9 @@ public class CassandraLogHelperTest {
     public void unresolvedHost() {
         ObjectMapper objectMapper = new ObjectMapper();
         InetSocketAddress address = InetSocketAddress.createUnresolved("localhost", 1234);
-        assertThat(CassandraLogHelper.host(address)).isEqualTo("localhost");
-        assertThat(CassandraLogHelper.hostAndIp(address)).satisfies(hostAndIpAddress -> {
+        assertThat(CassandraLogHelper.host(address)).satisfies(hostAndIpAddress -> {
+            HostAndIpAddress host2 = CassandraLogHelper.host(address);
+            assertThat(hostAndIpAddress).isNotNull().isEqualTo(host2).isSameAs(host2);
             assertThat(hostAndIpAddress.host()).isEqualTo("localhost");
             assertThat(hostAndIpAddress.ipAddress()).isNull();
             assertThat(hostAndIpAddress)
@@ -107,8 +108,9 @@ public class CassandraLogHelperTest {
     public void resolvedHost() {
         ObjectMapper objectMapper = new ObjectMapper();
         InetSocketAddress address = new InetSocketAddress("localhost", 1234);
-        assertThat(CassandraLogHelper.host(address)).isEqualTo("localhost/127.0.0.1");
-        assertThat(CassandraLogHelper.hostAndIp(address)).satisfies(hostAndIpAddress -> {
+        assertThat(CassandraLogHelper.host(address)).satisfies(hostAndIpAddress -> {
+            HostAndIpAddress host2 = CassandraLogHelper.host(address);
+            assertThat(hostAndIpAddress).isNotNull().isEqualTo(host2).isSameAs(host2);
             assertThat(hostAndIpAddress.host()).isEqualTo("localhost");
             assertThat(hostAndIpAddress.ipAddress()).isEqualTo("127.0.0.1");
             assertThat(hostAndIpAddress)

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelperTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelperTest.java
@@ -81,24 +81,24 @@ public class CassandraLogHelperTest {
 
     @Test
     public void unresolvedHost() {
-        assertThat(CassandraLogHelper.host(InetSocketAddress.createUnresolved("localhost", 1234)))
-                .satisfies(hostAndIpAddress -> {
-                    assertThat(hostAndIpAddress.host()).isEqualTo("localhost");
-                    assertThat(hostAndIpAddress.ipAddress()).isNull();
-                })
-                .asString()
-                .isEqualTo("HostAndIpAddress{host=localhost}");
+        InetSocketAddress address = InetSocketAddress.createUnresolved("localhost", 1234);
+        assertThat(CassandraLogHelper.host(address)).isEqualTo("localhost");
+        assertThat(CassandraLogHelper.HostAndIpAddress.fromAddress(address)).satisfies(hostAndIpAddress -> {
+            assertThat(hostAndIpAddress.host()).isEqualTo("localhost");
+            assertThat(hostAndIpAddress.ipAddress()).isNull();
+            assertThat(hostAndIpAddress.asString()).isEqualTo("localhost");
+        });
     }
 
     @Test
     @SuppressWarnings("DnsLookup") // we want the DNS lookup to resolve localhost
     public void resolvedHost() {
-        assertThat(CassandraLogHelper.host(new InetSocketAddress("localhost", 1234)))
-                .satisfies(hostAndIpAddress -> {
-                    assertThat(hostAndIpAddress.host()).isEqualTo("localhost");
-                    assertThat(hostAndIpAddress.ipAddress()).isEqualTo("127.0.0.1");
-                })
-                .asString()
-                .isEqualTo("HostAndIpAddress{host=localhost, ipAddress=127.0.0.1}");
+        InetSocketAddress address = new InetSocketAddress("localhost", 1234);
+        assertThat(CassandraLogHelper.host(address)).isEqualTo("localhost/127.0.0.1");
+        assertThat(CassandraLogHelper.HostAndIpAddress.fromAddress(address)).satisfies(hostAndIpAddress -> {
+            assertThat(hostAndIpAddress.host()).isEqualTo("localhost");
+            assertThat(hostAndIpAddress.ipAddress()).isEqualTo("127.0.0.1");
+            assertThat(hostAndIpAddress.asString()).isEqualTo("localhost/127.0.0.1");
+        });
     }
 }

--- a/changelog/@unreleased/pr-6409.v2.yml
+++ b/changelog/@unreleased/pr-6409.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Reduce allocations from observability
+  links:
+  - https://github.com/palantir/atlasdb/pull/6409


### PR DESCRIPTION
## General
**Before this PR**:

In JFRs from some high volume services, there are some places allocating for observability (e.g. Cassandra query thread names with timestamp, Cassandra host/ip log arguments, TableReference internal name toString) that could be reduced to make less work for GC.

![image](https://user-images.githubusercontent.com/54594/208268380-d13f7d7c-ed93-48ff-92ba-56ad43119ec7.png)


**After this PR**:
==COMMIT_MSG==
Reduce allocations from observability
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
