### PR TITLE
SQLString skips cache lookup when not caching unregistered queries

### DIFF
--- a/changelog/@unreleased/pr-6414.v2.yml
+++ b/changelog/@unreleased/pr-6414.v2.yml
@@ -1,5 +1,5 @@
 type: improvement
 improvement:
-  description: SQLString skips cache lookup when not cachine unregistered queries
+  description: SQLString skips cache lookup when not caching unregistered queries
   links:
   - https://github.com/palantir/atlasdb/pull/6414

--- a/changelog/@unreleased/pr-6414.v2.yml
+++ b/changelog/@unreleased/pr-6414.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: SQLString skips cache lookup when not cachine unregistered queries
+  links:
+  - https://github.com/palantir/atlasdb/pull/6414

--- a/commons-db/src/main/java/com/palantir/nexus/db/sql/SQLString.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/sql/SQLString.java
@@ -216,10 +216,14 @@ public class SQLString extends BasicSQLString {
     @SuppressWarnings("GuardedByChecker")
     static FinalSQLString getUnregisteredQuery(String sql) {
         assert !isValidKey(sql) : "Unregistered Queries should not look like keys"; // $NON-NLS-1$
-        FinalSQLString cached = cachedUnregistered.get(canonicalizeStringAndRemoveWhitespaceEntirely(sql));
-        if (null != cached) {
-            callbackOnUse.noteUse((SQLString) cached.delegate);
-            return cached;
+        ImmutableMap<String, FinalSQLString> cache = cachedUnregistered; // volatile read
+        if (!cache.isEmpty()) {
+            String cacheKey = canonicalizeStringAndRemoveWhitespaceEntirely(sql);
+            FinalSQLString cached = cache.get(cacheKey);
+            if (null != cached) {
+                callbackOnUse.noteUse((SQLString) cached.delegate);
+                return cached;
+            }
         }
 
         return new FinalSQLString(new SQLString(sql));


### PR DESCRIPTION
## General
**Before this PR**:

In several JFRs from high volume service running AtlasDB against an RDBMS, there were significant (~2% of overall) allocations of `byte[]`, `String`, and `StringBuilder` originating from the following traces, even though the `com.palantir.nexus.db.sql.SQLString#cachedUnregistered` is an empty `ImmutableMap` so will never cache these queries, so there is no point in generating the cache lookup key:

For example:
```
void java.lang.AbstractStringBuilder.<init>(String)
   void java.lang.StringBuilder.<init>(String)
      String com.palantir.nexus.db.sql.SQLString.canonicalizeString(String, boolean):284
         String com.palantir.nexus.db.sql.SQLString.canonicalizeStringAndRemoveWhitespaceEntirely(String):270
         BasicSQLString$FinalSQLString com.palantir.nexus.db.sql.SQLString.getUnregisteredQuery(String):219
         AgnosticLightResultSet com.palantir.nexus.db.sql.SqlConnectionHelper.selectLightResultSetUnregisteredQueryWithFetchSize(Connection, String, Integer, Object[]):183
```

![image](https://user-images.githubusercontent.com/54594/211893401-8985bf55-b2ba-4d63-8561-0ec22a17b432.png)


**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
SQLString skips cache lookup when not caching unregistered queries
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
