### PR TITLE
[PDS-321180] Permit Cluster Switches/Additions, Where New Nodes Agree With Old Nodes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
       - attach_workspace: { at: . }
       - add_ssh_keys:
           fingerprints:
-            - "20:d7:2c:43:a2:d9:38:86:45:c0:70:cc:c9:87:95:5b"
+            - "b6:ba:27:37:84:8f:eb:b0:ee:0b:7c:c1:fc:18:32:5f"
       - run: sudo apt-get update
       - run: sudo apt-get install python python3-pip
       - run:

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidator.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidator.java
@@ -300,13 +300,6 @@ public final class CassandraTopologyValidator {
         }
     }
 
-    @Value.Immutable
-    public interface ClusterAgreementHistory {
-        int consecutiveQuorumFailures();
-
-        Optional<ConsistentClusterTopology> lastAgreedTopology();
-    }
-
     enum ClusterTopologyResultType {
         CONSENSUS,
         DISSENT,

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidator.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidator.java
@@ -16,7 +16,11 @@
 
 package com.palantir.atlasdb.keyvalue.cassandra;
 
-import com.github.rholder.retry.*;
+import com.github.rholder.retry.RetryException;
+import com.github.rholder.retry.Retryer;
+import com.github.rholder.retry.RetryerBuilder;
+import com.github.rholder.retry.StopStrategies;
+import com.github.rholder.retry.WaitStrategies;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Iterables;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidator.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidator.java
@@ -163,9 +163,11 @@ public final class CassandraTopologyValidator {
         switch (topologyFromCurrentServers.type()) {
             case CONSENSUS:
                 quorumFailures.set(0);
-                Preconditions.checkState(topologyFromCurrentServers.agreedTopology().isPresent(),
+                Preconditions.checkState(
+                        topologyFromCurrentServers.agreedTopology().isPresent(),
                         "Expected to have a consistent topology for a CONSENSUS result, but did not.");
-                ConsistentClusterTopology topology = topologyFromCurrentServers.agreedTopology().get();
+                ConsistentClusterTopology topology =
+                        topologyFromCurrentServers.agreedTopology().get();
                 return EntryStream.of(newServersWithoutSoftFailures)
                         .removeValues(result -> result.type() == HostIdResult.Type.SUCCESS
                                 && result.hostIds().equals(topology.hostIds()))
@@ -179,7 +181,8 @@ public final class CassandraTopologyValidator {
                 // In the event of no quorum, we need to trust the new servers at some point since in containerised
                 // deployments things can actually move on like that between refreshes.
                 if (quorumFailures.incrementAndGet() >= 10) {
-                    log.warn("We have not been able to get a quorum of the existing Cassandra nodes for ten "
+                    log.warn(
+                            "We have not been able to get a quorum of the existing Cassandra nodes for ten "
                                     + "attempts. Based on this, we are just going to look at the remaining hosts and "
                                     + "accept their consensus, if they have one.",
                             SafeArg.of("currentServersWithoutSoftFailures", currentServersWithoutSoftFailures),
@@ -189,12 +192,15 @@ public final class CassandraTopologyValidator {
                             .agreedTopology()
                             .<Set<CassandraServer>>map(newServerTopology ->
                                     // Do not add new servers which were unreachable
-                                    Sets.difference(newServersWithoutSoftFailures.keySet(), newServerTopology.serversInConsensus()))
+                                    Sets.difference(
+                                            newServersWithoutSoftFailures.keySet(),
+                                            newServerTopology.serversInConsensus()))
                             .orElseGet(newServersWithoutSoftFailures::keySet);
                 }
                 return newServersWithoutSoftFailures.keySet();
             default:
-                throw new SafeIllegalStateException("Unexpected cluster topology result type",
+                throw new SafeIllegalStateException(
+                        "Unexpected cluster topology result type",
                         SafeArg.of("type", topologyFromCurrentServers.type()));
         }
     }
@@ -306,6 +312,7 @@ public final class CassandraTopologyValidator {
     @Value.Immutable
     public interface ClusterTopologyResult {
         ClusterTopologyResultType type();
+
         Optional<ConsistentClusterTopology> agreedTopology();
 
         static ClusterTopologyResult consensus(ConsistentClusterTopology consistentClusterTopology) {
@@ -320,6 +327,7 @@ public final class CassandraTopologyValidator {
                     .type(ClusterTopologyResultType.DISSENT)
                     .build();
         }
+
         static ClusterTopologyResult noQuorum() {
             return ImmutableClusterTopologyResult.builder()
                     .type(ClusterTopologyResultType.NO_QUORUM)

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidatorTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidatorTest.java
@@ -238,7 +238,7 @@ public final class CassandraTopologyValidatorTest {
         }
         assertThat(validator.getNewHostsWithInconsistentTopologies(newCassandraServers, allHosts))
                 .as("new hosts can be added if old hosts repeatedly fail to have quorum")
-                .containsExactlyElementsOf(newCassandraServers);
+                .isEmpty();
 
     }
 

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidatorTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidatorTest.java
@@ -239,7 +239,6 @@ public final class CassandraTopologyValidatorTest {
         assertThat(validator.getNewHostsWithInconsistentTopologies(newCassandraServers, allHosts))
                 .as("new hosts can be added if old hosts repeatedly fail to have quorum")
                 .isEmpty();
-
     }
 
     @Test

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidatorTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidatorTest.java
@@ -241,7 +241,7 @@ public final class CassandraTopologyValidatorTest {
         Map<CassandraServer, CassandraClientPoolingContainer> oldHosts = EntryStream.of(allHosts)
                 .filterKeys(key -> OLD_HOSTS.contains(key.cassandraHostName()))
                 .toMap();
-        Set<CassandraServer> oldCassandraServers = filterServers(allHosts, OLD_HOSTS::contains);
+        Set<CassandraServer> oldCassandraServers = oldHosts.keySet();
         Set<CassandraServer> newCassandraServers = filterServers(allHosts, NEW_HOSTS::contains);
         Set<String> hostsOffline = ImmutableSet.of(OLD_HOST_ONE);
         setHostIds(filterContainers(allHosts, hostsOffline::contains), HostIdResult.hardFailure());
@@ -267,9 +267,9 @@ public final class CassandraTopologyValidatorTest {
         Set<String> hostsOffline = ImmutableSet.of(OLD_HOST_ONE);
         setHostIds(filterContainers(allHosts, hostsOffline::contains), HostIdResult.hardFailure());
 
-        setHostIds(filterContainers(newHosts, server -> !hostsOffline.contains(server)), HostIdResult.success(UUIDS));
+        setHostIds(filterContainers(newHosts, Predicate.not(hostsOffline::contains)), HostIdResult.success(UUIDS));
         setHostIds(
-                filterContainers(oldHosts, server -> !hostsOffline.contains(server)),
+                filterContainers(oldHosts, Predicate.not(hostsOffline::contains)),
                 HostIdResult.success(DIFFERENT_UUIDS));
 
         validator.getNewHostsWithInconsistentTopologies(oldCassandraServers, oldHosts);


### PR DESCRIPTION
## General
**Before this PR**:
If a Cassandra cluster [A, B, C] changes its IPs to [D, E, F] within two minutes / the Cassandra client pool refresh interval, it is possible that the cluster will enter a stuck state where it is not possible to recover without bouncing the service. This is because the cluster correctly re-discovers [D, E, F] from configuration, but the host validation check we have will reject this change because there is no quorum among the cluster (we have three topology proposals and three unreachables).

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
In the event there is no quorum, we check the new nodes for their perspective of what the cluster should look like. If new nodes are in agreement and their agreement matches the agreed-upon host IDs that the old nodes agreed on, we consider them to be consistent.
==COMMIT_MSG==

**Priority**: P2 - there is a temporary workaround for the immediate burning issue of the day around preventing fast rolls, but this is pretty high still.

**Concerns / possible downsides (what feedback would you like?)**:
- Does this actually fix the problem: can we recover from a cluster [A, B, C] changing to [D, E, F]? I think so: we will make the cluster [A, B, C, D, E, F] (and in practice we will only really talk to D, E, F because A, B, C are block-listed). In any case, on a subsequent refresh when we pick one of D, E, F from which to refresh the token ring we'll be able to remove A, B, C.

**Is documentation needed?**: No

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: Yes - Cassandra client pooling logic is in-memory on each node.

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: Not really?

**Does this PR need a schema migration?** No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: Not much

**What was existing testing like? What have you done to improve it?**: Added unit tests for relevant cases.

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: No complex asynchronous code here. The topology validator is called from a single-threaded executor.

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: It doesn't?

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: We can recover from an ABC -> DEF change; also, there's plenty of logging.

**Has the safety of all log arguments been decided correctly?**: Yes, I think so.

**Will this change significantly affect our spending on metrics or logs?**: No

**How would I tell that this PR does not work in production? (monitors, etc.)**: ABC -> DEF is still bad

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: Rollback

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**: -

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**: No

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**: No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**: No

## Development Process
**Where should we start reviewing?**: CassandraTopologyValidator

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: No

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
