### PR TITLE
ETE uses adoptopenjdk/openjdk11:x86_64-debian-jre-11.0.18_10

### DIFF
--- a/atlasdb-ete-tests/Dockerfile
+++ b/atlasdb-ete-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:debian-jre
+FROM adoptopenjdk/openjdk11:x86_64-debian-jre-11.0.18_10
 
 ENV DOCKERIZE_VERSION v0.2.0
 


### PR DESCRIPTION
## General
**Before this PR**:
[ETE tests are failing to pull the adoptopenjdk/openjdk11:debian-jre container image, for example excavator](https://app.circleci.com/pipelines/github/palantir/atlasdb/11716/workflows/47ef6016-f6e5-42ae-ae0e-04926453c5e4/jobs/41617) https://github.com/palantir/atlasdb/pull/6423:
```
com.palantir.docker.compose.execution.DockerExecutionException: 'docker-compose build' returned exit code 1
The output was:
timelock uses an image, skipping
cassandra uses an image, skipping
Building ete1
Sending build context to Docker daemon  205.5MB

Step 1/9 : FROM adoptopenjdk/openjdk11:debian-jre
debian-jre: Pulling from adoptopenjdk/openjdk11
no matching manifest for linux/amd64 in the manifest list entries
Service 'ete1' failed to build : Build failed
```

This seems to be due to the [latest `adoptopenjdk/openjdk11:debian-jre` container image only publishing `linux/arm/v7` architecture image](https://hub.docker.com/r/adoptopenjdk/openjdk11/tags?page=1&name=debian-jre) and no `linux/amd64`, see https://github.com/AdoptOpenJDK/openjdk-docker/issues/629 

![image](https://user-images.githubusercontent.com/54594/214359981-6c8f5576-dbfa-4ea9-ae05-40992fa776f5.png)


**After this PR**:
Temporarily pin to specific `adoptopenjdk/openjdk11:x86_64-debian-jre-11.0.18_10` for ETE tests until more generic image tags are available or migrate to something like corretto images.
==COMMIT_MSG==
ETE uses `adoptopenjdk/openjdk11:x86_64-debian-jre-11.0.18_10`
==COMMIT_MSG==

**Priority**: P0

**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
