### PR TITLE
create test case which shows quorum calculation is wrong

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidator.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidator.java
@@ -212,8 +212,8 @@ public final class CassandraTopologyValidator {
                         .equals(pastConsistentTopology.get().hostIds())) {
                     log.info(
                             "No quorum was detected among old servers. While new servers could reach a consensus, this"
-                                + " differed from the last agreed value among the old servers. Not adding new servers"
-                                + " in this case.",
+                                    + " differed from the last agreed value among the old servers. Not adding new servers"
+                                    + " in this case.",
                             SafeArg.of("pastConsistentTopology", pastConsistentTopology.get()),
                             SafeArg.of("newNodesAgreedTopology", newNodesAgreedTopology),
                             SafeArg.of("newServers", CassandraLogHelper.collectionOfHosts(newlyAddedHosts)),
@@ -222,7 +222,7 @@ public final class CassandraTopologyValidator {
                 }
                 log.info(
                         "No quorum was detected among old servers. New servers reached a consensus that matched the"
-                            + " last agreed value among the old servers. Adding new servers that were in consensus.",
+                                + " last agreed value among the old servers. Adding new servers that were in consensus.",
                         SafeArg.of("pastConsistentTopology", pastConsistentTopology.get()),
                         SafeArg.of("newNodesAgreedTopology", newNodesAgreedTopology),
                         SafeArg.of("newServers", CassandraLogHelper.collectionOfHosts(newlyAddedHosts)),
@@ -264,7 +264,7 @@ public final class CassandraTopologyValidator {
 
         // Only consider hosts that have the endpoint for quorum calculations.
         // Otherwise, we will never add hosts when we're in a mixed state
-        int quorum = (hostIdsByServerWithoutSoftFailures.size() + 1) / 2;
+        int quorum = (hostIdsByServerWithoutSoftFailures.size() / 2) + 1;
 
         // If too many hosts are unreachable, then we cannot come to a consensus
         if (hostIdsWithoutFailures.size() < quorum) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidator.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidator.java
@@ -212,8 +212,8 @@ public final class CassandraTopologyValidator {
                         .equals(pastConsistentTopology.get().hostIds())) {
                     log.info(
                             "No quorum was detected among old servers. While new servers could reach a consensus, this"
-                                    + " differed from the last agreed value among the old servers. Not adding new servers"
-                                    + " in this case.",
+                                + " differed from the last agreed value among the old servers. Not adding new servers"
+                                + " in this case.",
                             SafeArg.of("pastConsistentTopology", pastConsistentTopology.get()),
                             SafeArg.of("newNodesAgreedTopology", newNodesAgreedTopology),
                             SafeArg.of("newServers", CassandraLogHelper.collectionOfHosts(newlyAddedHosts)),
@@ -222,7 +222,7 @@ public final class CassandraTopologyValidator {
                 }
                 log.info(
                         "No quorum was detected among old servers. New servers reached a consensus that matched the"
-                                + " last agreed value among the old servers. Adding new servers that were in consensus.",
+                            + " last agreed value among the old servers. Adding new servers that were in consensus.",
                         SafeArg.of("pastConsistentTopology", pastConsistentTopology.get()),
                         SafeArg.of("newNodesAgreedTopology", newNodesAgreedTopology),
                         SafeArg.of("newServers", CassandraLogHelper.collectionOfHosts(newlyAddedHosts)),

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidatorTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidatorTest.java
@@ -280,7 +280,11 @@ public final class CassandraTopologyValidatorTest {
 
     @Test
     public void validateNewlyAddedHostsNoNewHostsAddedIfNewHostsDoNotHaveQuorumAndNoCurrentServers() {
-        Map<CassandraServer, CassandraClientPoolingContainer> allHosts = setupHosts(NEW_HOSTS);
+        Set<String> hosts = ImmutableSet.<String>builder()
+                .addAll(NEW_HOSTS)
+                .add(OLD_HOST_ONE)
+                .build();
+        Map<CassandraServer, CassandraClientPoolingContainer> allHosts = setupHosts(hosts);
         Set<String> hostsOffline = ImmutableSet.of(NEW_HOST_ONE, NEW_HOST_TWO);
         setHostIds(filterContainers(allHosts, hostsOffline::contains), HostIdResult.hardFailure());
         setHostIds(filterContainers(allHosts, server -> !hostsOffline.contains(server)), HostIdResult.success(UUIDS));

--- a/changelog/@unreleased/pr-6427.v2.yml
+++ b/changelog/@unreleased/pr-6427.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: 'Fixes bug where quorum calculation was incorrect for topology validation. '
+  links:
+  - https://github.com/palantir/atlasdb/pull/6427


### PR DESCRIPTION
## General
**Before this PR**:
Quorum was incorrectly calculated when performing topology validation.

**After this PR**:
==COMMIT_MSG==
Quorum is now correctly calculated when validating cluster topology. 
==COMMIT_MSG==

**Priority**:
P1

**Concerns / possible downsides (what feedback would you like?)**:
N/A

**Is documentation needed?**:
N/A

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
N/A

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No

**Does this PR need a schema migration?**
No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
None

**What was existing testing like? What have you done to improve it?**:
Improved test to show why quorum calculation is wrong

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Logs

**Has the safety of all log arguments been decided correctly?**:
N/A

**Will this change significantly affect our spending on metrics or logs?**:
No

**How would I tell that this PR does not work in production? (monitors, etc.)**:
Logs

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Yes can just rollback

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No

## Development Process
**Where should we start reviewing?**:
ASAP

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
