### PR TITLE
Fix #6430: Flakes in the Timestamp Test

### DIFF
--- a/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestTimestampCommand.java
+++ b/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestTimestampCommand.java
@@ -277,7 +277,7 @@ public class TestTimestampCommand {
     }
 
     private long getWallClockTimestamp(Scanner scanner) {
-        String line = scanner.findInLine(".*Wall\\sclock\\sdatetime.*\\s(\\d+.*)");
+        String line = findFirstLineMatching(scanner, ".*Wall\\sclock\\sdatetime.*\\s(\\d+.*)");
         List<String> parts = Splitter.on(' ').splitToList(line);
         return ISODateTimeFormat.dateTime()
                 .parseDateTime(parts.get(parts.size() - 1))
@@ -285,9 +285,18 @@ public class TestTimestampCommand {
     }
 
     private long getTimestampFromStdout(Scanner scanner) {
-        String line = scanner.findInLine(".*timestamp\\sis\\:\\s(\\d+.*)");
+        String line = findFirstLineMatching(scanner, ".*timestamp\\sis\\:\\s(\\d+.*)");
         List<String> parts = Splitter.on(' ').splitToList(line);
         return Long.parseLong(parts.get(parts.size() - 1));
+    }
+
+    private String findFirstLineMatching(Scanner scanner, String pattern) {
+        String line = scanner.findInLine(pattern);
+        while (line == null) {
+            scanner.nextLine();
+            line = scanner.findInLine(pattern);
+        }
+        return line;
     }
 
     private long getTimestampFromFile(String fileString) throws IOException {


### PR DESCRIPTION
## General
**Before this PR**:
See #6430 (h/t @schlosna) - the timestamp CLI test fails sometimes

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
The cause of the timestamp CLI test failing, in the instances we saw it, should be fixed
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**: Not much

**Is documentation needed?**: No

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: Yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: No

**Does this PR need a schema migration?** No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: **That we don't really care that much about these tests.** The solution I implemented is pretty hacky.
 
**What was existing testing like? What have you done to improve it?**: I think I fixed the tests!

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: NA

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: No

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: Flake rate goes down

**Has the safety of all log arguments been decided correctly?**: Yes

**Will this change significantly affect our spending on metrics or logs?**: No

**How would I tell that this PR does not work in production? (monitors, etc.)**: Flakes still occur

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: Rollback

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**: -

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**: No

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**: No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**: Probably not

## Development Process
**Where should we start reviewing?**: The one file

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
