### PR TITLE
Optimize CassandraService::getKnownPort

### DIFF
--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
@@ -33,6 +33,7 @@ import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.refreshable.Refreshable;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
@@ -267,6 +268,17 @@ public class CassandraServiceTest {
                         .satisfies(server -> assertThat(desired).contains(server));
             }
         }
+    }
+
+    @Test
+    public void ports() throws Exception {
+        assertThat(CassandraService.onlyPort(List.of(1, 1, 1).iterator())).isEqualTo(1);
+        assertThat(CassandraService.onlyPort(
+                        IntStream.generate(() -> 4224).boxed().limit(15).iterator()))
+                .isEqualTo(4224);
+        assertThatThrownBy(() -> CassandraService.onlyPort(List.of(1, 2, 1).iterator()))
+                .isInstanceOf(UnknownHostException.class)
+                .hasMessageContaining("No single known port");
     }
 
     private Set<CassandraServer> getRecommendedHostsFromAThousandTrials(

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
@@ -272,11 +272,12 @@ public class CassandraServiceTest {
 
     @Test
     public void ports() throws Exception {
-        assertThat(CassandraService.onlyPort(List.of(1, 1, 1).iterator())).isEqualTo(1);
-        assertThat(CassandraService.onlyPort(
-                        IntStream.generate(() -> 4224).boxed().limit(15).iterator()))
-                .isEqualTo(4224);
-        assertThatThrownBy(() -> CassandraService.onlyPort(List.of(1, 2, 1).iterator()))
+        assertThat(CassandraService.onlyPort(List.of(1, 1, 1))).isEqualTo(1);
+        assertThat(IntStream.generate(() -> 4224).boxed().limit(15).collect(Collectors.toList()))
+                .hasSize(15)
+                .satisfies(cluster ->
+                        assertThat(CassandraService.onlyPort(cluster)).isEqualTo(4224));
+        assertThatThrownBy(() -> CassandraService.onlyPort(List.of(1, 2, 1)))
                 .isInstanceOf(UnknownHostException.class)
                 .hasMessageContaining("No single known port");
     }

--- a/changelog/@unreleased/pr-6451.v2.yml
+++ b/changelog/@unreleased/pr-6451.v2.yml
@@ -1,0 +1,9 @@
+type: improvement
+improvement:
+  description: |-
+    While reviewing JFR from some high volume AtlasDB client services (think mountains), I noticed they spend a significant amount of time verifying that the Cassandra ports are the same in
+    `com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraService.getKnownPort():300`.
+
+    We can optimize this for the happy path where the port is known and consistent for a ~10x improvement.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6451


### PR DESCRIPTION
## General
**Before this PR**:

While reviewing JFR from some high volume AtlasDB client services (think 🎿 ⛰️ ), I noticed they spend a significant amount of time verifying that the Cassandra ports are the same in `com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraService.getKnownPort():300`.

We can optimize this for the happy path where the port is known and consistent for a ~10x improvement.

Example JFR showing significant cost from `com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraService.getKnownPort():300`:
```
Stack Trace                                                                                                                                        Count  Percentage
HashMap$Node[] java.util.HashMap.resize():702                                                                                                      339         100 %
Object java.util.HashMap.putVal(int, Object, Object, boolean, boolean):627                                                                         289        85.3 %
   Object java.util.HashMap.put(Object, Object):610                                                                                                274        80.8 %
      boolean java.util.HashSet.add(Object):221                                                                                                    125        36.9 %
         void java.util.stream.Collectors$$Lambda$6+0x800000011.1380052087.accept(Object, Object):-1                                               71         20.9 %
            void java.util.stream.ReduceOps$3ReducingSink.accept(Object):169                                                                       71         20.9 %
            void java.util.stream.ReferencePipeline$3$1.accept(Object):197                                                                         56         16.5 %
               void java.util.stream.StreamSpliterators$WrappingSpliterator$$Lambda$837+0x00000008010fd230.439636632.accept(Object):-1             34           10 %
                  void java.util.stream.ReferencePipeline$3$1.accept(Object):197                                                                   34           10 %
                  void java.util.concurrent.ConcurrentHashMap$KeySpliterator.forEachRemaining(Consumer):3573                                       34           10 %
                  void java.util.stream.AbstractPipeline.copyInto(Sink, Spliterator):509                                                           34           10 %
                  Sink java.util.stream.AbstractPipeline.wrapAndCopyInto(Sink, Spliterator):499                                                    34           10 %
                  void java.util.stream.StreamSpliterators$WrappingSpliterator.forEachRemaining(Consumer):310                                      34           10 %
                  void java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Consumer):734                                                   34           10 %
                  void java.util.stream.AbstractPipeline.copyInto(Sink, Spliterator):509                                                           34           10 %
                  Sink java.util.stream.AbstractPipeline.wrapAndCopyInto(Sink, Spliterator):499                                                    34           10 %
                  Object java.util.stream.ReduceOps$ReduceOp.evaluateSequential(PipelineHelper, Spliterator):921                                   34           10 %
                  Object java.util.stream.AbstractPipeline.evaluate(TerminalOp):234                                                                34           10 %
                  Object java.util.stream.ReferencePipeline.collect(Collector):682                                                                 34           10 %
                  int com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraService.getKnownPort():300                                             34           10 %
                  ImmutableSet com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraService.getReachableProxies(String):287                       34           10 %
                  CassandraServer com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraService.getAddressForHost(String):282                      34           10 %
                  CassandraServer com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraService.getAddressForHostThrowUnchecked(String):272        34           10 %
                  Object com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraService$$Lambda$1912+0x00000008015970b0.347044555.apply(Object):-1  29         8.55 %
                     Map$Entry com.palantir.common.streams.KeyedStream.lambda$mapKeys$5(Function, Object, Object):100                              29         8.55 %
                     Object com.palantir.common.streams.KeyedStream$$Lambda$812+0x00000008011485c0.1106043431.apply(Object, Object):-1             29         8.55 %
                     Map$Entry com.palantir.common.streams.KeyedStreamImpl.lambda$mapEntries$1(BiFunction, Map$Entry):56                           29         8.55 %
                     Object com.palantir.common.streams.KeyedStreamImpl$$Lambda$813+0x00000008011487f8.1581066085.apply(Object):-1                 29         8.55 %
                     void java.util.stream.ReferencePipeline$3$1.accept(Object):197                                                                29         8.55 %
                     void java.util.stream.ReferencePipeline$3$1.accept(Object):197                                                                29         8.55 %
                     void java.util.stream.ReferencePipeline$3$1.accept(Object):197                                                                29         8.55 %
                     void java.util.stream.ReferencePipeline$3$1.accept(Object):197                                                                29         8.55 %
                     void java.util.ArrayList$ArrayListSpliterator.forEachRemaining(Consumer):1625                                                 29         8.55 %
                     void java.util.stream.AbstractPipeline.copyInto(Sink, Spliterator):509                                                        29         8.55 %
                     Sink java.util.stream.AbstractPipeline.wrapAndCopyInto(Sink, Spliterator):499                                                 29         8.55 %
                     Object java.util.stream.ReduceOps$ReduceOp.evaluateSequential(PipelineHelper, Spliterator):921                                29         8.55 %
                     Object java.util.stream.AbstractPipeline.evaluate(TerminalOp):234                                                             29         8.55 %
                     Object java.util.stream.ReferencePipeline.collect(Supplier, BiConsumer, BiConsumer):693                                       29         8.55 %
                     Map com.palantir.common.streams.KeyedStreamImpl.collectTo(Supplier):45                                                        29         8.55 %
                     Map com.palantir.common.streams.KeyedStream.collectToMap():175                                                                29         8.55 %
                     ImmutableSet com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraService.refreshTokenRangesAndGetServers():151              29         8.55 %
                     void com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolImpl.refreshPool():333                                        29         8.55 %
                     void com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolImpl.lambda$tryInitialize$3():250                             29         8.55 %
                     void com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolImpl$$Lambda$1205+0x000000080126aa48.1036126146.run():-1      29         8.55 %
                     Object java.util.concurrent.Executors$RunnableAdapter.call():539                                                              29         8.55 %
                     boolean java.util.concurrent.FutureTask.runAndReset():305                                                                     29         8.55 %
                     void java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run():305                                           29         8.55 %
                     void java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor$Worker):1136                                        29         8.55 %
                     void java.util.concurrent.ThreadPoolExecutor$Worker.run():635                                                                 29         8.55 %
                     void com.palantir.tritium.metrics.TaggedMetricsThreadFactory$InstrumentedTask.run():69                                        29         8.55 %
                     void java.lang.Thread.run():833                                                                                               29         8.55 %
```


**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
While reviewing JFR from some high volume AtlasDB client services (think mountains), I noticed they spend a significant amount of time verifying that the Cassandra ports are the same in
`com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraService.getKnownPort():300`.

We can optimize this for the happy path where the port is known and consistent for a ~10x improvement.
==COMMIT_MSG==


Benchmark comparing implementations:
```
JDK 17.0.6, OpenJDK 64-Bit Server VM, 17.0.6+10-LTS on Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz
Benchmark                 (size)  Mode  Cnt    Score     Error  Units
UniqueBenchmark.iterator       3  avgt    3   12.171 ±   3.288  ns/op
UniqueBenchmark.iterator      30  avgt    3   41.256 ±  23.744  ns/op
UniqueBenchmark.stream         3  avgt    3  103.783 ±  35.310  ns/op
UniqueBenchmark.stream        30  avgt    3  619.450 ± 245.551  ns/op
```

```java
@BenchmarkMode(Mode.AverageTime)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@Warmup(iterations = 2, time = 1, timeUnit = TimeUnit.SECONDS)
@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
@Fork(1)
@State(Scope.Benchmark)
@SuppressWarnings({"designforextension", "NullAway", "CheckStyle"})
public class UniqueBenchmark {

    static int only(Iterable<? extends Integer> iterable) throws UnknownHostException {
        Iterator<? extends Integer> iterator = iterable.iterator();
        if (!iterator.hasNext()) {
            throw new UnknownHostException("No single known port");
        }
        int port = iterator.next();
        while (iterator.hasNext()) {
            if (port != iterator.next()) {
                throw new UnknownHostException("No single known port");
            }
        }
        return port;
    }

    static int only(Stream<Integer> stream) throws UnknownHostException {
        Set<Integer> set = stream.collect(Collectors.toSet());
        if (set.size() == 1) {
            return set.iterator().next();
        }
        throw new UnknownHostException("No single known port");
    }

    @Param({"3", "30"})
    int size;

    private List<Integer> ints;

    @Setup
    public void setup() {
        ints = IntStream.generate(() -> 7001).limit(size).boxed().collect(Collectors.toList());
    }

    @Benchmark
    public Integer iterator() throws UnknownHostException {
        return only(ints);
    }

    @Benchmark
    public Integer stream() throws UnknownHostException {
        return only(ints.stream());
    }
}
```



**Priority**:

**Concerns / possible downsides (what feedback would you like?)**: correctness, implementation, testing

**Is documentation needed?**: no

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
