### PR TITLE
[PDS-336637, PDS-335142 and friends] Verify a new server list against a previously accepted topology, if one exists

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidator.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidator.java
@@ -155,28 +155,46 @@ public final class CassandraTopologyValidator {
         // This means currently we've no servers or no server without the get_host_ids endpoint.
         // Therefore, we need to come to a consensus on the new servers.
         if (currentServersWithoutSoftFailures.isEmpty()) {
-            Optional<ConsistentClusterTopology> maybeTopology = maybeGetConsistentClusterTopology(
+            ClusterTopologyResult topologyResultFromNewServers =
+                    maybeGetConsistentClusterTopology(newServersWithoutSoftFailures);
+            Map<CassandraServer, HostIdResult> newServersWithoutAnyFailures = EntryStream.of(
                             newServersWithoutSoftFailures)
-                    .agreedTopology();
-            maybeTopology.ifPresent(pastConsistentTopology::set);
-
-            return maybeTopology
-                    .<Set<CassandraServer>>map(topology ->
-                            Sets.difference(newServersWithoutSoftFailures.keySet(), topology.serversInConsensus()))
-                    .orElseGet(newServersWithoutSoftFailures::keySet);
+                    .filterValues(result -> result.type() == HostIdResult.Type.SUCCESS)
+                    .toMap();
+            return getNewHostsWithInconsistentTopologiesFromTopologyResult(
+                    topologyResultFromNewServers,
+                    newServersWithoutSoftFailures,
+                    newServersWithoutAnyFailures,
+                    newlyAddedHosts,
+                    allHosts.keySet());
         }
 
         // If a consensus can be reached from the current servers, filter all new servers which have the same set of
         // host ids. Accept dissent as such, but permit
         ClusterTopologyResult topologyFromCurrentServers =
                 maybeGetConsistentClusterTopology(currentServersWithoutSoftFailures);
-        switch (topologyFromCurrentServers.type()) {
+
+        return getNewHostsWithInconsistentTopologiesFromTopologyResult(
+                topologyFromCurrentServers,
+                newServersWithoutSoftFailures,
+                newServersWithoutSoftFailures,
+                newlyAddedHosts,
+                allHosts.keySet());
+    }
+
+    private Set<CassandraServer> getNewHostsWithInconsistentTopologiesFromTopologyResult(
+            ClusterTopologyResult topologyResult,
+            Map<CassandraServer, HostIdResult> newServersWithoutSoftFailures,
+            Map<CassandraServer, HostIdResult> serversToConsiderWhenNoQuorumPresent,
+            Set<CassandraServer> newlyAddedHosts,
+            Set<CassandraServer> allHosts) {
+        switch (topologyResult.type()) {
             case CONSENSUS:
                 Preconditions.checkState(
-                        topologyFromCurrentServers.agreedTopology().isPresent(),
+                        topologyResult.agreedTopology().isPresent(),
                         "Expected to have a consistent topology for a CONSENSUS result, but did not.");
                 ConsistentClusterTopology topology =
-                        topologyFromCurrentServers.agreedTopology().get();
+                        topologyResult.agreedTopology().get();
                 pastConsistentTopology.set(topology);
                 return EntryStream.of(newServersWithoutSoftFailures)
                         .removeValues(result -> result.type() == HostIdResult.Type.SUCCESS
@@ -196,14 +214,14 @@ public final class CassandraTopologyValidator {
                     return newServersWithoutSoftFailures.keySet();
                 }
                 Optional<ConsistentClusterTopology> maybeTopology = maybeGetConsistentClusterTopology(
-                                newServersWithoutSoftFailures)
+                                serversToConsiderWhenNoQuorumPresent)
                         .agreedTopology();
                 if (maybeTopology.isEmpty()) {
                     log.info(
-                            "No quorum was detected among old servers, and new servers were also not in"
-                                    + " agreement. Not adding new servers in this case.",
+                            "No quorum was detected in original set of servers, and the filtered set of servers were"
+                                    + " also not in agreement. Not adding new servers in this case.",
                             SafeArg.of("newServers", CassandraLogHelper.collectionOfHosts(newlyAddedHosts)),
-                            SafeArg.of("allServers", CassandraLogHelper.collectionOfHosts(allHosts.keySet())));
+                            SafeArg.of("allServers", CassandraLogHelper.collectionOfHosts(allHosts)));
                     return newServersWithoutSoftFailures.keySet();
                 }
                 ConsistentClusterTopology newNodesAgreedTopology = maybeTopology.get();
@@ -211,28 +229,28 @@ public final class CassandraTopologyValidator {
                         .hostIds()
                         .equals(pastConsistentTopology.get().hostIds())) {
                     log.info(
-                            "No quorum was detected among old servers. While new servers could reach a consensus, this"
-                                + " differed from the last agreed value among the old servers. Not adding new servers"
-                                + " in this case.",
+                            "No quorum was detected among the original set of servers. While a filtered set of"
+                                    + " servers could reach a consensus, this differed from the last agreed value"
+                                    + " among the old servers. Not adding new servers in this case.",
                             SafeArg.of("pastConsistentTopology", pastConsistentTopology.get()),
                             SafeArg.of("newNodesAgreedTopology", newNodesAgreedTopology),
                             SafeArg.of("newServers", CassandraLogHelper.collectionOfHosts(newlyAddedHosts)),
-                            SafeArg.of("allServers", CassandraLogHelper.collectionOfHosts(allHosts.keySet())));
+                            SafeArg.of("allServers", CassandraLogHelper.collectionOfHosts(allHosts)));
                     return newServersWithoutSoftFailures.keySet();
                 }
                 log.info(
-                        "No quorum was detected among old servers. New servers reached a consensus that matched the"
-                            + " last agreed value among the old servers. Adding new servers that were in consensus.",
+                        "No quorum was detected among the original set of servers. A filtered set of servers reached"
+                                + " a consensus that matched the last agreed value among the old servers. Adding new"
+                                + " servers that were in consensus.",
                         SafeArg.of("pastConsistentTopology", pastConsistentTopology.get()),
                         SafeArg.of("newNodesAgreedTopology", newNodesAgreedTopology),
                         SafeArg.of("newServers", CassandraLogHelper.collectionOfHosts(newlyAddedHosts)),
-                        SafeArg.of("allServers", CassandraLogHelper.collectionOfHosts(allHosts.keySet())));
+                        SafeArg.of("allServers", CassandraLogHelper.collectionOfHosts(allHosts)));
                 return Sets.difference(
                         newServersWithoutSoftFailures.keySet(), newNodesAgreedTopology.serversInConsensus());
             default:
                 throw new SafeIllegalStateException(
-                        "Unexpected cluster topology result type",
-                        SafeArg.of("type", topologyFromCurrentServers.type()));
+                        "Unexpected cluster topology result type", SafeArg.of("type", topologyResult.type()));
         }
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidator.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidator.java
@@ -170,7 +170,8 @@ public final class CassandraTopologyValidator {
         }
 
         // If a consensus can be reached from the current servers, filter all new servers which have the same set of
-        // host ids. Accept dissent as such, but permit
+        // host ids. Accept dissent as such, but permit new servers if they are in quorum _and_ match the previously
+        // accepted set of host IDs
         ClusterTopologyResult topologyFromCurrentServers =
                 maybeGetConsistentClusterTopology(currentServersWithoutSoftFailures);
 

--- a/changelog/@unreleased/pr-6455.v2.yml
+++ b/changelog/@unreleased/pr-6455.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: AtlasDB clients can now recover after receiving a dissenting response
+    to a Cassandra Topology check.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6455


### PR DESCRIPTION
## General
**Before this PR**:
https://github.com/palantir/atlasdb/pull/6415 added a feature to accept a new set of servers even if there's no quorum, iff the new set of servers have quorum and match the last accepted topology. This was added to handle cases where a bunch of nodes are down, but we want to add a new set.

However, the above PR inadvertantly missed wiring in the case when the cassandra client pool is empty. This happens on startup, but can also happen when the servers in the client pool are marked absent for when the set of desired servers does not contain the existing servers., which happens when QUORUM = 2, as noted in the P0s linked above. (And historically, we mark them not absent the next time we refresh successfully). There's a thing on should we even be marking so many things absent if it leaves the client pool empty, but I'd like to discuss that with the team on Monday.

Currently, when dissent occurs and the client pool is emptied, we are completely unable to recover. This is because there are no nodes we can reach to get the token range (which is how Atlas does discovery), and so we used the last set of IPs and union that with the set of servers from config (i.e., skylab discovery).

Especially in Cross-VPC setups like our dog-fooding stack, the last of set of IPs are unreachable, whereas the config provided URIs are discoverable.
Since the number of IPs = number of config provided URIs, then we have exactly half the nodes unreachable. After we fixed the quorum calculation (https://github.com/palantir/atlasdb/pull/6427), this meant that we could no longer reach consensus, and, since we didn't check against a previous topology in this case, we would never refresh.

A test that I added that fails:
![Screenshot 2023-02-24 at 15 09 09](https://user-images.githubusercontent.com/1812764/221214037-5428cd97-d7e9-47fc-9b00-52b59091df00.png)

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
AtlasDB clients can now recover after receiving a dissenting response to a Cassandra Topology check.
==COMMIT_MSG==

**Priority**: P1, there are P0s and the method of getting out (bouncing) is pretty painful in some cases.

**Concerns / possible downsides (what feedback would you like?)**:
The whole point of this check is to avoid split brain situations. Given the escape hatch of only checking the available servers, this does increase the risk of allowing split-brain. The principle of checking against the last valid topology should mitigate that.

Please let me know if there are other edge cases that I've missed!

**Is documentation needed?**:
This behaviour matches the actual docs
## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
That we can safely proceed by just checking the available hosts, since we'll eventually refresh again after getting at least one host, retrieve the token range, and get the full list of hosts.

**What was existing testing like? What have you done to improve it?**:
The original tests didn't actually test the no quorum case! I've addressed that. Please do check with a debugger if you want to be convinced

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Recovery after a Quorum = 2 incident
**Has the safety of all log arguments been decided correctly?**:
No logging changed
**Will this change significantly affect our spending on metrics or logs?**:
No
**How would I tell that this PR does not work in production? (monitors, etc.)**:
Either we still don't recover, or worse, we allow a split-brain when we shouldn't
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Rollback is not straightforward.
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
@jeremyk-91 as the next on-call (I'm the current)
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No
## Development Process
**Where should we start reviewing?**:
CassandraTopologyValidator
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
N/A
**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju
@zpear 
@mrowbotham 

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
