### PR TITLE
[TTS/Backup & Restore] Prevent rollout of TTS without consideration of backup and restore

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionConstants.java
@@ -25,6 +25,7 @@ import com.palantir.atlasdb.table.description.TableMetadata;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.service.TransactionStatus;
 import com.palantir.atlasdb.transaction.service.TransactionStatuses;
+import com.palantir.logsafe.Preconditions;
 
 public final class TransactionConstants {
     private TransactionConstants() {
@@ -62,6 +63,7 @@ public final class TransactionConstants {
     public static final int DIRECT_ENCODING_TRANSACTIONS_SCHEMA_VERSION = 1;
     public static final int TICKETS_ENCODING_TRANSACTIONS_SCHEMA_VERSION = 2;
     public static final int TWO_STAGE_ENCODING_TRANSACTIONS_SCHEMA_VERSION = 3;
+
     public static final int TTS_TRANSACTIONS_SCHEMA_VERSION = 4;
     public static final ImmutableSet<Integer> SUPPORTED_TRANSACTIONS_SCHEMA_VERSIONS = ImmutableSet.of(
             DIRECT_ENCODING_TRANSACTIONS_SCHEMA_VERSION,
@@ -101,4 +103,13 @@ public final class TransactionConstants {
             .explicitCompressionBlockSizeKB(64)
             .denselyAccessedWideRows(true)
             .build();
+
+    static {
+        Preconditions.checkState(
+                !SUPPORTED_TRANSACTIONS_SCHEMA_VERSIONS.contains(TTS_TRANSACTIONS_SCHEMA_VERSION),
+                "Supporting Transactions Table Sweep WILL require changes to internal backup and restore workflows;"
+                    + " failure to do so may only be discoverable at restore time in some implementations. This check"
+                    + " MUST NOT be removed without knowledge that suitable changes have been made to these"
+                    + " workflows.");
+    }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionConstants.java
@@ -26,6 +26,7 @@ import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.service.TransactionStatus;
 import com.palantir.atlasdb.transaction.service.TransactionStatuses;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
 
 public final class TransactionConstants {
     private TransactionConstants() {
@@ -110,6 +111,8 @@ public final class TransactionConstants {
                 "Supporting Transactions Table Sweep WILL require changes to internal backup and restore workflows;"
                     + " failure to do so may only be discoverable at restore time in some implementations. This check"
                     + " MUST NOT be removed without knowledge that suitable changes have been made to these"
-                    + " workflows.");
+                    + " workflows.",
+                SafeArg.of("supportedTransactionsSchemaVersions", SUPPORTED_TRANSACTIONS_SCHEMA_VERSIONS),
+                SafeArg.of("transactionsTableSweepSchemaVersion", TTS_TRANSACTIONS_SCHEMA_VERSION));
     }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionConstants.java
@@ -64,7 +64,6 @@ public final class TransactionConstants {
     public static final int DIRECT_ENCODING_TRANSACTIONS_SCHEMA_VERSION = 1;
     public static final int TICKETS_ENCODING_TRANSACTIONS_SCHEMA_VERSION = 2;
     public static final int TWO_STAGE_ENCODING_TRANSACTIONS_SCHEMA_VERSION = 3;
-
     public static final int TTS_TRANSACTIONS_SCHEMA_VERSION = 4;
     public static final ImmutableSet<Integer> SUPPORTED_TRANSACTIONS_SCHEMA_VERSIONS = ImmutableSet.of(
             DIRECT_ENCODING_TRANSACTIONS_SCHEMA_VERSION,


### PR DESCRIPTION
## General
**Before this PR**:
If work on TTS continues, we can just allow users to use it, potentially without thinking of the consequences for backup and restore; furthermore, @mswintermeyer informs me that he is aware of a failure mode that manifests only at restore time (which is generally when you don't want to find out that your backup story doesn't work)!

**After this PR**:
==COMMIT_MSG==
Enabling users to use TTS will require an explicit removal of a check that asks one to consider internal backup and restore workflows.
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**: 
- Is a static check the best way to do this? All tests will fail; it might be nicer to do a compile time check if that's feasible though the ways I thought of to accomplish that seem unnecessarily tricky.

**Is documentation needed?**: No

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: Yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: No

**Does this PR need a schema migration?** No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: That TTS development is suspended.

**What was existing testing like? What have you done to improve it?**: No - the version of the code that fails this doesn't exist!

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: No complex concurrency 

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: No resources

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: Nothing happens

**Has the safety of all log arguments been decided correctly?**: Yes

**Will this change significantly affect our spending on metrics or logs?**: No

**How would I tell that this PR does not work in production? (monitors, etc.)**: Things explode

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: Rollback

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**: No

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**: No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**: Well, if we finish TTS _and_ account for the backup story...

## Development Process
**Where should we start reviewing?**: Small

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: It's not

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju
@mswintermeyer 

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
