### PR TITLE
[PDS-336637, PDS-335142 and friends] Verify a new server list against a previously accepted topology, if one exists, by tracking the origin of new cass servers

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -69,3 +69,29 @@ acceptedBreaks:
         \ com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig, com.palantir.refreshable.Refreshable<com.palantir.atlasdb.cassandra.CassandraKeyValueServiceRuntimeConfig>,\
         \ com.palantir.atlasdb.keyvalue.cassandra.Blacklist, com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraClientPoolMetrics)"
       justification: "Removing unused ABR code"
+  "0.801.0":
+    com.palantir.atlasdb:atlasdb-cassandra:
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter java.util.Set<com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer>\
+        \ com.palantir.atlasdb.keyvalue.cassandra.CassandraTopologyValidator::getNewHostsWithInconsistentTopologiesAndRetry(===java.util.Set<com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer>===,\
+        \ java.util.Map<com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer,\
+        \ com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer>,\
+        \ java.time.Duration, java.time.Duration)"
+      new: "parameter java.util.Set<com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer>\
+        \ com.palantir.atlasdb.keyvalue.cassandra.CassandraTopologyValidator::getNewHostsWithInconsistentTopologiesAndRetry(===java.util.Map<com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer,\
+        \ com.palantir.atlasdb.keyvalue.cassandra.CassandraServerOrigin>===, java.util.Map<com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer,\
+        \ com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer>,\
+        \ java.time.Duration, java.time.Duration)"
+      justification: "Internal Cassandra KVS APIs"
+    - code: "java.method.returnTypeChanged"
+      old: "method com.google.common.collect.ImmutableSet<com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer>\
+        \ com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraService::getCurrentServerListFromConfig()"
+      new: "method com.google.common.collect.ImmutableMap<com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer,\
+        \ com.palantir.atlasdb.keyvalue.cassandra.CassandraServerOrigin> com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraService::getCurrentServerListFromConfig()"
+      justification: "Internal Cassandra KVS APIs"
+    - code: "java.method.returnTypeChanged"
+      old: "method com.google.common.collect.ImmutableSet<com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer>\
+        \ com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraService::refreshTokenRangesAndGetServers()"
+      new: "method com.google.common.collect.ImmutableMap<com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer,\
+        \ com.palantir.atlasdb.keyvalue.cassandra.CassandraServerOrigin> com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraService::refreshTokenRangesAndGetServers()"
+      justification: "Internal Cassandra KVS APIs"

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -387,9 +387,9 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
         if (serversToAdd.isEmpty()) {
             return Set.of();
         }
-
+        Set<CassandraServer> serversToAddWithoutOrigin = serversToAdd.keySet();
         Map<CassandraServer, CassandraClientPoolingContainer> serversToAddContainers =
-                getContainerForNewServers(serversToAdd.keySet());
+                getContainerForNewServers(serversToAddWithoutOrigin);
 
         Preconditions.checkArgument(
                 Sets.intersection(currentContainers.keySet(), serversToAddContainers.keySet())
@@ -412,7 +412,7 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
                         serversToAdd, allContainers, Duration.ofSeconds(5), Duration.ofMinutes(1));
 
         Set<CassandraServer> validatedServersToAdd =
-                Sets.difference(serversToAdd.keySet(), newHostsWithDifferingTopology);
+                Sets.difference(serversToAddWithoutOrigin, newHostsWithDifferingTopology);
         validatedServersToAdd.forEach(server -> cassandra.addPool(server, serversToAddContainers.get(server)));
         newHostsWithDifferingTopology.forEach(
                 server -> absentHostTracker.trackAbsentCassandraServer(server, serversToAddContainers.get(server)));

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -364,9 +364,9 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
         Preconditions.checkState(
                 !getCurrentPools().isEmpty() || serversToAdd.isEmpty(),
                 "No servers were successfully added to the pool. This means we could not come to a consensus on"
-                        + " cluster topology, and the client cannot connect as there are no valid hosts. This state should"
-                        + " be transient (<5 minutes), and if it is not, indicates that the user may have accidentally"
-                        + " configured AltasDB to use two separate Cassandra clusters (i.e., user-led split brain).",
+                    + " cluster topology, and the client cannot connect as there are no valid hosts. This state should"
+                    + " be transient (<5 minutes), and if it is not, indicates that the user may have accidentally"
+                    + " configured AltasDB to use two separate Cassandra clusters (i.e., user-led split brain).",
                 SafeArg.of("serversToAdd", CassandraLogHelper.collectionOfHosts(serversToAdd.keySet())));
 
         logRefreshedHosts(validatedServersToAdd, serversToShutdown, absentServers);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraServerOrigin.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraServerOrigin.java
@@ -1,7 +1,38 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.palantir.atlasdb.keyvalue.cassandra;
+
+import com.google.common.collect.ImmutableMap;
+import com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
 public enum CassandraServerOrigin {
     CONFIG,
     LAST_KNOWN,
     TOKEN_RANGE;
+
+    public static ImmutableMap<CassandraServer, CassandraServerOrigin> mapAllServersToOrigin(
+            Set<CassandraServer> servers, CassandraServerOrigin origin) {
+        return mapAllServersToOrigin(servers.stream(), origin);
+    }
+
+    public static ImmutableMap<CassandraServer, CassandraServerOrigin> mapAllServersToOrigin(
+            Stream<CassandraServer> servers, CassandraServerOrigin origin) {
+        return servers.collect(ImmutableMap.toImmutableMap(Function.identity(), _v -> origin));
+    }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraServerOrigin.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraServerOrigin.java
@@ -1,0 +1,7 @@
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+public enum CassandraServerOrigin {
+    CONFIG,
+    LAST_KNOWN,
+    TOKEN_RANGE;
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidator.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidator.java
@@ -155,28 +155,46 @@ public final class CassandraTopologyValidator {
         // This means currently we've no servers or no server without the get_host_ids endpoint.
         // Therefore, we need to come to a consensus on the new servers.
         if (currentServersWithoutSoftFailures.isEmpty()) {
-            Optional<ConsistentClusterTopology> maybeTopology = maybeGetConsistentClusterTopology(
+            ClusterTopologyResult topologyResultFromNewServers =
+                    maybeGetConsistentClusterTopology(newServersWithoutSoftFailures);
+            Map<CassandraServer, HostIdResult> newServersWithoutAnyFailures = EntryStream.of(
                             newServersWithoutSoftFailures)
-                    .agreedTopology();
-            maybeTopology.ifPresent(pastConsistentTopology::set);
-
-            return maybeTopology
-                    .<Set<CassandraServer>>map(topology ->
-                            Sets.difference(newServersWithoutSoftFailures.keySet(), topology.serversInConsensus()))
-                    .orElseGet(newServersWithoutSoftFailures::keySet);
+                    .filterValues(result -> result.type() == HostIdResult.Type.SUCCESS)
+                    .toMap();
+            return getNewHostsWithInconsistentTopologiesFromTopologyResult(
+                    topologyResultFromNewServers,
+                    newServersWithoutSoftFailures,
+                    newServersWithoutAnyFailures,
+                    newlyAddedHosts,
+                    allHosts.keySet());
         }
 
         // If a consensus can be reached from the current servers, filter all new servers which have the same set of
         // host ids. Accept dissent as such, but permit
         ClusterTopologyResult topologyFromCurrentServers =
                 maybeGetConsistentClusterTopology(currentServersWithoutSoftFailures);
-        switch (topologyFromCurrentServers.type()) {
+
+        return getNewHostsWithInconsistentTopologiesFromTopologyResult(
+                topologyFromCurrentServers,
+                newServersWithoutSoftFailures,
+                newServersWithoutSoftFailures,
+                newlyAddedHosts,
+                allHosts.keySet());
+    }
+
+    private Set<CassandraServer> getNewHostsWithInconsistentTopologiesFromTopologyResult(
+            ClusterTopologyResult topologyResult,
+            Map<CassandraServer, HostIdResult> newServersWithoutSoftFailures,
+            Map<CassandraServer, HostIdResult> serversToConsiderWhenNoQuorumPresent,
+            Set<CassandraServer> newlyAddedHosts,
+            Set<CassandraServer> allHosts) {
+        switch (topologyResult.type()) {
             case CONSENSUS:
                 Preconditions.checkState(
-                        topologyFromCurrentServers.agreedTopology().isPresent(),
+                        topologyResult.agreedTopology().isPresent(),
                         "Expected to have a consistent topology for a CONSENSUS result, but did not.");
                 ConsistentClusterTopology topology =
-                        topologyFromCurrentServers.agreedTopology().get();
+                        topologyResult.agreedTopology().get();
                 pastConsistentTopology.set(topology);
                 return EntryStream.of(newServersWithoutSoftFailures)
                         .removeValues(result -> result.type() == HostIdResult.Type.SUCCESS
@@ -196,14 +214,14 @@ public final class CassandraTopologyValidator {
                     return newServersWithoutSoftFailures.keySet();
                 }
                 Optional<ConsistentClusterTopology> maybeTopology = maybeGetConsistentClusterTopology(
-                                newServersWithoutSoftFailures)
+                                serversToConsiderWhenNoQuorumPresent)
                         .agreedTopology();
                 if (maybeTopology.isEmpty()) {
                     log.info(
-                            "No quorum was detected among old servers, and new servers were also not in"
-                                    + " agreement. Not adding new servers in this case.",
+                            "No quorum was detected in original set of servers, and the filtered set of servers were"
+                                    + " also not in agreement. Not adding new servers in this case.",
                             SafeArg.of("newServers", CassandraLogHelper.collectionOfHosts(newlyAddedHosts)),
-                            SafeArg.of("allServers", CassandraLogHelper.collectionOfHosts(allHosts.keySet())));
+                            SafeArg.of("allServers", CassandraLogHelper.collectionOfHosts(allHosts)));
                     return newServersWithoutSoftFailures.keySet();
                 }
                 ConsistentClusterTopology newNodesAgreedTopology = maybeTopology.get();
@@ -211,28 +229,28 @@ public final class CassandraTopologyValidator {
                         .hostIds()
                         .equals(pastConsistentTopology.get().hostIds())) {
                     log.info(
-                            "No quorum was detected among old servers. While new servers could reach a consensus, this"
-                                + " differed from the last agreed value among the old servers. Not adding new servers"
-                                + " in this case.",
+                            "No quorum was detected among the original set of servers. While a filtered set of"
+                                    + " servers could reach a consensus, this differed from the last agreed value"
+                                    + " among the old servers. Not adding new servers in this case.",
                             SafeArg.of("pastConsistentTopology", pastConsistentTopology.get()),
                             SafeArg.of("newNodesAgreedTopology", newNodesAgreedTopology),
                             SafeArg.of("newServers", CassandraLogHelper.collectionOfHosts(newlyAddedHosts)),
-                            SafeArg.of("allServers", CassandraLogHelper.collectionOfHosts(allHosts.keySet())));
+                            SafeArg.of("allServers", CassandraLogHelper.collectionOfHosts(allHosts)));
                     return newServersWithoutSoftFailures.keySet();
                 }
                 log.info(
-                        "No quorum was detected among old servers. New servers reached a consensus that matched the"
-                            + " last agreed value among the old servers. Adding new servers that were in consensus.",
+                        "No quorum was detected among the original set of servers. A filtered set of servers reached"
+                                + " a consensus that matched the last agreed value among the old servers. Adding new"
+                                + " servers that were in consensus.",
                         SafeArg.of("pastConsistentTopology", pastConsistentTopology.get()),
                         SafeArg.of("newNodesAgreedTopology", newNodesAgreedTopology),
                         SafeArg.of("newServers", CassandraLogHelper.collectionOfHosts(newlyAddedHosts)),
-                        SafeArg.of("allServers", CassandraLogHelper.collectionOfHosts(allHosts.keySet())));
+                        SafeArg.of("allServers", CassandraLogHelper.collectionOfHosts(allHosts)));
                 return Sets.difference(
                         newServersWithoutSoftFailures.keySet(), newNodesAgreedTopology.serversInConsensus());
             default:
                 throw new SafeIllegalStateException(
-                        "Unexpected cluster topology result type",
-                        SafeArg.of("type", topologyFromCurrentServers.type()));
+                        "Unexpected cluster topology result type", SafeArg.of("type", topologyResult.type()));
         }
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidator.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidator.java
@@ -166,7 +166,7 @@ public final class CassandraTopologyValidator {
                     topologyResultFromNewServers,
                     newServersWithoutSoftFailures,
                     newServersFromConfig,
-                    newlyAddedHosts.keySet(),
+                    newlyAddedHostsWithoutOrigin,
                     allHosts.keySet());
         }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidator.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidator.java
@@ -170,7 +170,8 @@ public final class CassandraTopologyValidator {
         }
 
         // If a consensus can be reached from the current servers, filter all new servers which have the same set of
-        // host ids. Accept dissent as such, but permit
+        // host ids. Accept dissent as such, but permit new servers if they are in quorum _and_ match the previously
+        // accepted set of host IDs
         ClusterTopologyResult topologyFromCurrentServers =
                 maybeGetConsistentClusterTopology(currentServersWithoutSoftFailures);
 

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
@@ -668,9 +668,10 @@ public final class CassandraClientPoolTest {
                 ImmutableDefaultConfig.builder().addAllThriftHosts(servers).build();
         when(runtimeConfig.servers()).thenReturn(config);
         when(cassandra.getCurrentServerListFromConfig())
-                .thenReturn(config.accept(CassandraServersConfigs.ThriftHostsExtractingVisitor.INSTANCE).stream()
-                        .map(CassandraServer::of)
-                        .collect(ImmutableMap.toImmutableMap(Function.identity(), _v -> CassandraServerOrigin.CONFIG)));
+                .thenReturn(CassandraServerOrigin.mapAllServersToOrigin(
+                        config.accept(CassandraServersConfigs.ThriftHostsExtractingVisitor.INSTANCE).stream()
+                                .map(CassandraServer::of),
+                        CassandraServerOrigin.CONFIG));
     }
 
     private void setupHostsWithConsistentTopology() {

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
@@ -448,14 +448,15 @@ public final class CassandraClientPoolTest {
         setCassandraServersTo(CASS_SERVER_1, CASS_SERVER_2);
 
         CassandraClientPoolImpl pool = createClientPool();
-        Set<CassandraServer> serversToAdd = Set.of(CASS_SERVER_1);
+        ImmutableMap<CassandraServer, CassandraServerOrigin> serversToAdd =
+                ImmutableMap.of(CASS_SERVER_1, CassandraServerOrigin.TOKEN_RANGE);
         assertThat(poolServers).containsOnlyKeys(CASS_SERVER_1, CASS_SERVER_2);
         assertThatLoggableExceptionThrownBy(
                         () -> pool.validateNewHostsTopologiesAndMaybeAddToPool(poolServers, serversToAdd))
                 .isInstanceOf(SafeIllegalArgumentException.class)
                 .hasMessageContaining("The current pool of servers should not have any server(s) that are being added.")
                 .hasExactlyArgs(
-                        SafeArg.of("serversToAdd", CassandraLogHelper.collectionOfHosts(serversToAdd)),
+                        SafeArg.of("serversToAdd", CassandraLogHelper.collectionOfHosts(serversToAdd.keySet())),
                         SafeArg.of("currentServers", CassandraLogHelper.collectionOfHosts(poolServers.keySet())));
     }
 
@@ -470,9 +471,9 @@ public final class CassandraClientPoolTest {
         CassandraClientPoolingContainer container1 = currentPoolSnapshot.get(CASS_SERVER_1);
         verifyNoInteractions(container1);
 
-        cassandraClientPool.setServersInPoolTo(ImmutableSet.of(CASS_SERVER_3));
+        cassandraClientPool.setServersInPoolTo(ImmutableMap.of(CASS_SERVER_3, CassandraServerOrigin.TOKEN_RANGE));
         // The refresh will mark absence of host1 beyond limit of tolerance
-        cassandraClientPool.setServersInPoolTo(ImmutableSet.of(CASS_SERVER_3));
+        cassandraClientPool.setServersInPoolTo(ImmutableMap.of(CASS_SERVER_3, CassandraServerOrigin.TOKEN_RANGE));
         assertThat(cassandraClientPool.getCurrentPools()).containsOnlyKeys(CASS_SERVER_3);
         verify(container1).shutdownPooling();
     }
@@ -487,7 +488,9 @@ public final class CassandraClientPoolTest {
 
     private void setCassandraServersTo(CassandraServer... servers) {
         when(cassandra.refreshTokenRangesAndGetServers())
-                .thenReturn(Arrays.stream(servers).collect(ImmutableSet.toImmutableSet()));
+                .thenReturn(Arrays.stream(servers)
+                        .collect(ImmutableMap.toImmutableMap(
+                                Function.identity(), _v -> CassandraServerOrigin.TOKEN_RANGE)));
     }
 
     private CassandraClientPoolImpl createClientPool() {
@@ -667,7 +670,7 @@ public final class CassandraClientPoolTest {
         when(cassandra.getCurrentServerListFromConfig())
                 .thenReturn(config.accept(CassandraServersConfigs.ThriftHostsExtractingVisitor.INSTANCE).stream()
                         .map(CassandraServer::of)
-                        .collect(ImmutableSet.toImmutableSet()));
+                        .collect(ImmutableMap.toImmutableMap(Function.identity(), _v -> CassandraServerOrigin.CONFIG)));
     }
 
     private void setupHostsWithConsistentTopology() {

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidatorTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidatorTest.java
@@ -308,6 +308,8 @@ public final class CassandraTopologyValidatorTest {
                 .forEach(container ->
                         setHostIds(ImmutableSet.of(container), HostIdResult.success(Set.of(uuidIterator.next()))));
 
+        // This is _not_ supposed to be the standard quorum calculation ((n / 2) + 1), but instead the amount of
+        // hosts that need to be offline to _prevent_ quorum
         assertThat(hostsOffline).hasSizeGreaterThanOrEqualTo((ALL_HOSTS.size() + 1) / 2);
         assertThat(validator.getNewHostsWithInconsistentTopologies(
                         mapToTokenRangeOrigin(newCassandraServers), allHosts))

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidatorTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidatorTest.java
@@ -81,7 +81,10 @@ public final class CassandraTopologyValidatorTest {
                         HostIdResult.success(Set.of(uuidIterator.next())),
                         HostIdResult.success(UUIDS)));
         assertThat(validator.getNewHostsWithInconsistentTopologiesAndRetry(
-                        allHosts.keySet(), allHosts, Duration.ofMillis(1), Duration.ofSeconds(20)))
+                        mapToTokenRangeOrigin(allHosts.keySet()),
+                        allHosts,
+                        Duration.ofMillis(1),
+                        Duration.ofSeconds(20)))
                 .isEmpty();
     }
 
@@ -93,7 +96,7 @@ public final class CassandraTopologyValidatorTest {
                 .values()
                 .forEach(container -> setHostIds(Set.of(container), HostIdResult.success(Set.of(uuidIterator.next()))));
         assertThat(validator.getNewHostsWithInconsistentTopologiesAndRetry(
-                        allHosts.keySet(), allHosts, Duration.ofMillis(1), Duration.ofMillis(1)))
+                        mapToTokenRangeOrigin(allHosts.keySet()), allHosts, Duration.ofMillis(1), Duration.ofMillis(1)))
                 .isNotEmpty();
         assertThat(metrics.validationFailures().getCount()).isEqualTo(1);
         assertThat(metrics.validationLatency().getCount()).isEqualTo(1);
@@ -104,7 +107,10 @@ public final class CassandraTopologyValidatorTest {
         Map<CassandraServer, CassandraClientPoolingContainer> allHosts = setupHosts(NEW_HOSTS);
         doReturn(allHosts.keySet()).when(validator).getNewHostsWithInconsistentTopologies(any(), any());
         assertThat(validator.getNewHostsWithInconsistentTopologiesAndRetry(
-                        allHosts.keySet(), setupHosts(NEW_HOSTS), Duration.ofMillis(1), Duration.ofMillis(1)))
+                        mapToTokenRangeOrigin(allHosts.keySet()),
+                        setupHosts(NEW_HOSTS),
+                        Duration.ofMillis(1),
+                        Duration.ofMillis(1)))
                 .containsExactlyInAnyOrderElementsOf(allHosts.keySet());
     }
 
@@ -114,21 +120,24 @@ public final class CassandraTopologyValidatorTest {
         doReturn(allHosts.keySet()).when(validator).getNewHostsWithInconsistentTopologies(any(), any());
         when(validator.getNewHostsWithInconsistentTopologies(any(), any())).thenReturn(allHosts.keySet());
         assertThat(validator.getNewHostsWithInconsistentTopologiesAndRetry(
-                        allHosts.keySet(), setupHosts(NEW_HOSTS), Duration.ofMillis(1), Duration.ofMillis(1)))
+                        mapToTokenRangeOrigin(allHosts.keySet()),
+                        setupHosts(NEW_HOSTS),
+                        Duration.ofMillis(1),
+                        Duration.ofMillis(1)))
                 .isNotEmpty();
         verify(validator, atLeast(2)).getNewHostsWithInconsistentTopologies(any(), any());
     }
 
     @Test
     public void returnsEmptyWhenGivenNoServers() {
-        assertThat(validator.getNewHostsWithInconsistentTopologies(ImmutableSet.of(), ImmutableMap.of()))
+        assertThat(validator.getNewHostsWithInconsistentTopologies(ImmutableMap.of(), ImmutableMap.of()))
                 .isEmpty();
     }
 
     @Test
     public void throwsWhenAllHostsDoesNotContainNewHosts() {
         assertThatThrownBy(() -> validator.getNewHostsWithInconsistentTopologies(
-                        ImmutableSet.of(createCassandraServer("foo")), ImmutableMap.of()))
+                        mapToTokenRangeOrigin(ImmutableSet.of(createCassandraServer("foo"))), ImmutableMap.of()))
                 .isInstanceOf(SafeIllegalArgumentException.class);
     }
 
@@ -136,7 +145,7 @@ public final class CassandraTopologyValidatorTest {
     public void returnsEmptyWhenOnlyNewServersAndAllHaveSameHostIds() {
         Map<CassandraServer, CassandraClientPoolingContainer> allHosts = setupHosts(NEW_HOSTS);
         setHostIds(allHosts.values(), DEFAULT_RESULT);
-        assertThat(validator.getNewHostsWithInconsistentTopologies(allHosts.keySet(), allHosts))
+        assertThat(validator.getNewHostsWithInconsistentTopologies(mapToTokenRangeOrigin(allHosts.keySet()), allHosts))
                 .isEmpty();
     }
 
@@ -149,7 +158,7 @@ public final class CassandraTopologyValidatorTest {
         setHostIds(
                 filterContainers(allHosts, NEW_HOST_ONE::equals),
                 HostIdResult.success(ImmutableSet.of("uuid3", "uuid2")));
-        assertThat(validator.getNewHostsWithInconsistentTopologies(allHosts.keySet(), allHosts))
+        assertThat(validator.getNewHostsWithInconsistentTopologies(mapToTokenRangeOrigin(allHosts.keySet()), allHosts))
                 .containsExactlyElementsOf(allHosts.keySet());
     }
 
@@ -163,7 +172,7 @@ public final class CassandraTopologyValidatorTest {
         setHostIds(
                 filterContainers(allHosts, OLD_HOSTS::contains),
                 HostIdResult.success(ImmutableSet.of("uuid3", "uuid2")));
-        assertThat(validator.getNewHostsWithInconsistentTopologies(newServers, allHosts))
+        assertThat(validator.getNewHostsWithInconsistentTopologies(mapToTokenRangeOrigin(newServers), allHosts))
                 .containsExactlyElementsOf(newServers);
     }
 
@@ -175,7 +184,7 @@ public final class CassandraTopologyValidatorTest {
         setHostIds(filterContainers(allHosts, badHostFilter), HostIdResult.success(ImmutableSet.of("uuid3", "uuid2")));
         Set<CassandraServer> newServers = filterServers(allHosts, NEW_HOSTS::contains);
         Set<CassandraServer> badNewHosts = filterServers(allHosts, badHostFilter);
-        assertThat(validator.getNewHostsWithInconsistentTopologies(newServers, allHosts))
+        assertThat(validator.getNewHostsWithInconsistentTopologies(mapToTokenRangeOrigin(newServers), allHosts))
                 .containsExactlyElementsOf(badNewHosts);
     }
 
@@ -183,7 +192,7 @@ public final class CassandraTopologyValidatorTest {
     public void validateNewlyAddedHostsAddsAllHostsIfNoHostHasEndpoint() {
         Map<CassandraServer, CassandraClientPoolingContainer> allHosts = setupHosts(NEW_HOSTS);
         setHostIds(allHosts.values(), HostIdResult.softFailure());
-        assertThat(validator.getNewHostsWithInconsistentTopologies(allHosts.keySet(), allHosts))
+        assertThat(validator.getNewHostsWithInconsistentTopologies(mapToTokenRangeOrigin(allHosts.keySet()), allHosts))
                 .isEmpty();
     }
 
@@ -194,7 +203,7 @@ public final class CassandraTopologyValidatorTest {
         setHostIds(
                 filterContainers(allHosts, server -> !hostWithEndpoint.contains(server)), HostIdResult.softFailure());
         setHostIds(filterContainers(allHosts, hostWithEndpoint::contains), DEFAULT_RESULT);
-        assertThat(validator.getNewHostsWithInconsistentTopologies(allHosts.keySet(), allHosts))
+        assertThat(validator.getNewHostsWithInconsistentTopologies(mapToTokenRangeOrigin(allHosts.keySet()), allHosts))
                 .isEmpty();
     }
 
@@ -206,7 +215,7 @@ public final class CassandraTopologyValidatorTest {
                 filterContainers(allHosts, server -> !hostsWithEndpoints.contains(server)), HostIdResult.softFailure());
         setHostIds(filterContainers(allHosts, hostsWithEndpoints::contains), DEFAULT_RESULT);
         assertThat(validator.getNewHostsWithInconsistentTopologies(
-                        filterServers(allHosts, NEW_HOSTS::contains), allHosts))
+                        mapToTokenRangeOrigin(filterServers(allHosts, NEW_HOSTS::contains)), allHosts))
                 .isEmpty();
     }
 
@@ -219,7 +228,7 @@ public final class CassandraTopologyValidatorTest {
         setHostIds(filterContainers(allHosts, NEW_HOST_ONE::equals), HostIdResult.success(Set.of("uuid")));
         setHostIds(filterContainers(allHosts, OLD_HOST_ONE::equals), DEFAULT_RESULT);
         assertThat(validator.getNewHostsWithInconsistentTopologies(
-                        filterServers(allHosts, NEW_HOSTS::contains), allHosts))
+                        mapToTokenRangeOrigin(filterServers(allHosts, NEW_HOSTS::contains)), allHosts))
                 .containsExactlyElementsOf(filterServers(allHosts, NEW_HOST_ONE::equals));
     }
 
@@ -230,7 +239,8 @@ public final class CassandraTopologyValidatorTest {
         Set<String> hostsOffline = ImmutableSet.of(OLD_HOST_ONE, OLD_HOST_TWO);
         setHostIds(filterContainers(allHosts, hostsOffline::contains), HostIdResult.hardFailure());
         setHostIds(filterContainers(allHosts, server -> !hostsOffline.contains(server)), HostIdResult.success(UUIDS));
-        assertThat(validator.getNewHostsWithInconsistentTopologies(newCassandraServers, allHosts))
+        assertThat(validator.getNewHostsWithInconsistentTopologies(
+                        mapToTokenRangeOrigin(newCassandraServers), allHosts))
                 .as("no new hosts added if old hosts do not have quorum")
                 .containsExactlyElementsOf(newCassandraServers);
     }
@@ -246,8 +256,9 @@ public final class CassandraTopologyValidatorTest {
         setHostIds(filterContainers(allHosts, hostsOffline::contains), HostIdResult.hardFailure());
         setHostIds(filterContainers(allHosts, server -> !hostsOffline.contains(server)), HostIdResult.success(UUIDS));
 
-        validator.getNewHostsWithInconsistentTopologies(oldCassandraServers, oldHosts);
-        assertThat(validator.getNewHostsWithInconsistentTopologies(newCassandraServers, allHosts))
+        validator.getNewHostsWithInconsistentTopologies(mapToTokenRangeOrigin(oldCassandraServers), oldHosts);
+        assertThat(validator.getNewHostsWithInconsistentTopologies(
+                        mapToTokenRangeOrigin(newCassandraServers), allHosts))
                 .as("accepts quorum from new hosts if they have the same host IDs")
                 .isEmpty();
     }
@@ -272,8 +283,9 @@ public final class CassandraTopologyValidatorTest {
                 filterContainers(oldHosts, Predicate.not(hostsOffline::contains)),
                 HostIdResult.success(DIFFERENT_UUIDS));
 
-        validator.getNewHostsWithInconsistentTopologies(oldCassandraServers, oldHosts);
-        assertThat(validator.getNewHostsWithInconsistentTopologies(newCassandraServers, allHosts))
+        validator.getNewHostsWithInconsistentTopologies(mapToTokenRangeOrigin(oldCassandraServers), oldHosts);
+        assertThat(validator.getNewHostsWithInconsistentTopologies(
+                        mapToTokenRangeOrigin(newCassandraServers), allHosts))
                 .as("does not accept quorum from new hosts if they have different host IDs")
                 .containsExactlyElementsOf(newCassandraServers);
     }
@@ -288,7 +300,7 @@ public final class CassandraTopologyValidatorTest {
         Set<CassandraServer> newCassandraServers = filterServers(allHosts, NEW_HOSTS::contains);
 
         setHostIds(filterContainers(allHosts, OLD_HOSTS::contains), HostIdResult.success(UUIDS));
-        validator.getNewHostsWithInconsistentTopologies(oldCassandraServers, oldHosts);
+        validator.getNewHostsWithInconsistentTopologies(mapToTokenRangeOrigin(oldCassandraServers), oldHosts);
 
         Set<String> hostsOffline = OLD_HOSTS;
         setHostIds(filterContainers(allHosts, hostsOffline::contains), HostIdResult.hardFailure());
@@ -297,7 +309,8 @@ public final class CassandraTopologyValidatorTest {
                         setHostIds(ImmutableSet.of(container), HostIdResult.success(Set.of(uuidIterator.next()))));
 
         assertThat(hostsOffline).hasSizeGreaterThanOrEqualTo((ALL_HOSTS.size() + 1) / 2);
-        assertThat(validator.getNewHostsWithInconsistentTopologies(newCassandraServers, allHosts))
+        assertThat(validator.getNewHostsWithInconsistentTopologies(
+                        mapToTokenRangeOrigin(newCassandraServers), allHosts))
                 .as("rejects all servers when no quorum from all hosts and no quorum on new hosts")
                 .isEqualTo(newCassandraServers);
     }
@@ -311,7 +324,7 @@ public final class CassandraTopologyValidatorTest {
         Set<CassandraServer> newCassandraServers = filterServers(allHosts, NEW_HOSTS::contains);
 
         setHostIds(filterContainers(allHosts, OLD_HOSTS::contains), HostIdResult.success(UUIDS));
-        validator.getNewHostsWithInconsistentTopologies(oldCassandraServers, oldHosts);
+        validator.getNewHostsWithInconsistentTopologies(mapToTokenRangeOrigin(oldCassandraServers), oldHosts);
 
         Set<String> hostsOffline = OLD_HOSTS;
         setHostIds(filterContainers(allHosts, hostsOffline::contains), HostIdResult.hardFailure());
@@ -320,7 +333,8 @@ public final class CassandraTopologyValidatorTest {
                 HostIdResult.success(DIFFERENT_UUIDS));
 
         assertThat(hostsOffline).hasSizeGreaterThanOrEqualTo((ALL_HOSTS.size() + 1) / 2);
-        assertThat(validator.getNewHostsWithInconsistentTopologies(newCassandraServers, allHosts))
+        assertThat(validator.getNewHostsWithInconsistentTopologies(
+                        mapToTokenRangeOrigin(newCassandraServers), allHosts))
                 .as("rejects all servers when no quorum from all hosts and no quorum on available hosts")
                 .isEqualTo(newCassandraServers);
     }
@@ -334,14 +348,15 @@ public final class CassandraTopologyValidatorTest {
         Set<CassandraServer> newCassandraServers = filterServers(allHosts, NEW_HOSTS::contains);
 
         setHostIds(filterContainers(allHosts, OLD_HOSTS::contains), HostIdResult.success(UUIDS));
-        validator.getNewHostsWithInconsistentTopologies(oldCassandraServers, oldHosts);
+        validator.getNewHostsWithInconsistentTopologies(mapToTokenRangeOrigin(oldCassandraServers), oldHosts);
 
         Set<String> hostsOffline = OLD_HOSTS;
         setHostIds(filterContainers(allHosts, hostsOffline::contains), HostIdResult.hardFailure());
         setHostIds(filterContainers(allHosts, server -> !hostsOffline.contains(server)), HostIdResult.success(UUIDS));
 
         assertThat(hostsOffline).hasSizeGreaterThanOrEqualTo((ALL_HOSTS.size() + 1) / 2);
-        assertThat(validator.getNewHostsWithInconsistentTopologies(newCassandraServers, allHosts))
+        assertThat(validator.getNewHostsWithInconsistentTopologies(
+                        mapToTokenRangeOrigin(newCassandraServers), allHosts))
                 .as("accepts quorum from new hosts if they have the same host IDs as old topology")
                 .isEmpty();
     }
@@ -355,21 +370,24 @@ public final class CassandraTopologyValidatorTest {
         Set<CassandraServer> allCassandraServers = allHosts.keySet();
 
         setHostIds(filterContainers(allHosts, OLD_HOSTS::contains), HostIdResult.success(UUIDS));
-        validator.getNewHostsWithInconsistentTopologies(oldCassandraServers, oldHosts);
+        validator.getNewHostsWithInconsistentTopologies(mapToTokenRangeOrigin(oldCassandraServers), oldHosts);
 
         Set<String> hostsOffline = OLD_HOSTS;
         setHostIds(filterContainers(allHosts, hostsOffline::contains), HostIdResult.hardFailure());
         setHostIds(filterContainers(allHosts, server -> !hostsOffline.contains(server)), HostIdResult.success(UUIDS));
 
         assertThat(hostsOffline).hasSizeGreaterThanOrEqualTo((ALL_HOSTS.size() + 1) / 2);
-        assertThat(validator.getNewHostsWithInconsistentTopologies(allCassandraServers, allHosts))
-                .as("accepts quorum from new hosts if they have the same host IDs as old topology when no current"
+        assertThat(validator.getNewHostsWithInconsistentTopologies(
+                        splitHostOriginBetweenLastKnownAndConfig(
+                                oldCassandraServers, Sets.difference(allCassandraServers, oldCassandraServers)),
+                        allHosts))
+                .as("accepts quorum from config hosts if they have the same host IDs as old topology when no current"
                         + " servers")
                 .isEqualTo(oldCassandraServers);
     }
 
     @Test
-    public void returnsAllNewHostsIfNoConsensusOnAvailableHostsWhenNoQuorumAndNoCurrentServers() {
+    public void returnsAllNewHostsIfNoConsensusOnConfigHostsWhenNoQuorumAndNoCurrentServers() {
         Iterator<String> uuidIterator = UUIDS.iterator();
         Map<CassandraServer, CassandraClientPoolingContainer> allHosts = setupHosts(ALL_HOSTS);
         Map<CassandraServer, CassandraClientPoolingContainer> oldHosts =
@@ -378,7 +396,7 @@ public final class CassandraTopologyValidatorTest {
         Set<CassandraServer> allCassandraServers = allHosts.keySet();
 
         setHostIds(filterContainers(allHosts, OLD_HOSTS::contains), HostIdResult.success(UUIDS));
-        validator.getNewHostsWithInconsistentTopologies(oldCassandraServers, oldHosts);
+        validator.getNewHostsWithInconsistentTopologies(mapToTokenRangeOrigin(oldCassandraServers), oldHosts);
 
         Set<String> hostsOffline = OLD_HOSTS;
         setHostIds(filterContainers(allHosts, hostsOffline::contains), HostIdResult.hardFailure());
@@ -387,13 +405,16 @@ public final class CassandraTopologyValidatorTest {
                         setHostIds(ImmutableSet.of(container), HostIdResult.success(Set.of(uuidIterator.next()))));
 
         assertThat(hostsOffline).hasSizeGreaterThanOrEqualTo((ALL_HOSTS.size() + 1) / 2);
-        assertThat(validator.getNewHostsWithInconsistentTopologies(allCassandraServers, allHosts))
+        assertThat(validator.getNewHostsWithInconsistentTopologies(
+                        splitHostOriginBetweenLastKnownAndConfig(
+                                oldCassandraServers, Sets.difference(allCassandraServers, oldCassandraServers)),
+                        allHosts))
                 .as("rejects all servers when no quorum from all hosts and no quorum on available hosts")
                 .isEqualTo(allCassandraServers);
     }
 
     @Test
-    public void returnsAllNewHostsIfConsensusOnAvailableHostsDiffersFromPreviousWhenNoQuorumAndNoCurrentServers() {
+    public void returnsAllNewHostsIfConsensusOnConfigHostsDiffersFromPreviousWhenNoQuorumAndNoCurrentServers() {
         Map<CassandraServer, CassandraClientPoolingContainer> allHosts = setupHosts(ALL_HOSTS);
         Map<CassandraServer, CassandraClientPoolingContainer> oldHosts =
                 filterServerToContainerMap(allHosts, OLD_HOSTS::contains);
@@ -401,7 +422,7 @@ public final class CassandraTopologyValidatorTest {
         Set<CassandraServer> allCassandraServers = allHosts.keySet();
 
         setHostIds(filterContainers(allHosts, OLD_HOSTS::contains), HostIdResult.success(UUIDS));
-        validator.getNewHostsWithInconsistentTopologies(oldCassandraServers, oldHosts);
+        validator.getNewHostsWithInconsistentTopologies(mapToTokenRangeOrigin(oldCassandraServers), oldHosts);
 
         Set<String> hostsOffline = OLD_HOSTS;
         setHostIds(filterContainers(allHosts, hostsOffline::contains), HostIdResult.hardFailure());
@@ -410,7 +431,11 @@ public final class CassandraTopologyValidatorTest {
                 HostIdResult.success(DIFFERENT_UUIDS));
 
         assertThat(hostsOffline).hasSizeGreaterThanOrEqualTo((ALL_HOSTS.size() + 1) / 2);
-        assertThat(validator.getNewHostsWithInconsistentTopologies(allCassandraServers, allHosts))
+
+        assertThat(validator.getNewHostsWithInconsistentTopologies(
+                        splitHostOriginBetweenLastKnownAndConfig(
+                                oldCassandraServers, Sets.difference(allCassandraServers, oldCassandraServers)),
+                        allHosts))
                 .as("rejects all servers when no quorum from all hosts and no quorum on available hosts")
                 .isEqualTo(allCassandraServers);
     }
@@ -425,7 +450,7 @@ public final class CassandraTopologyValidatorTest {
         Set<String> hostsOffline = ImmutableSet.of(NEW_HOST_ONE, NEW_HOST_TWO);
         setHostIds(filterContainers(allHosts, hostsOffline::contains), HostIdResult.hardFailure());
         setHostIds(filterContainers(allHosts, server -> !hostsOffline.contains(server)), HostIdResult.success(UUIDS));
-        assertThat(validator.getNewHostsWithInconsistentTopologies(allHosts.keySet(), allHosts))
+        assertThat(validator.getNewHostsWithInconsistentTopologies(mapToTokenRangeOrigin(allHosts.keySet()), allHosts))
                 .containsExactlyElementsOf(allHosts.keySet());
     }
 
@@ -435,7 +460,7 @@ public final class CassandraTopologyValidatorTest {
         setHostIds(filterContainers(allHosts, NEW_HOSTS::contains), HostIdResult.success(UUIDS));
         setHostIds(filterContainers(allHosts, OLD_HOSTS::contains), HostIdResult.softFailure());
         assertThat(validator.getNewHostsWithInconsistentTopologies(
-                        filterServers(allHosts, NEW_HOSTS::contains), allHosts))
+                        mapToTokenRangeOrigin(filterServers(allHosts, NEW_HOSTS::contains)), allHosts))
                 .isEmpty();
     }
 
@@ -507,5 +532,17 @@ public final class CassandraTopologyValidatorTest {
                 .map(CassandraTopologyValidatorTest::createCassandraServer)
                 .mapToEntry(server -> mock(CassandraClientPoolingContainer.class))
                 .toMap();
+    }
+
+    private static Map<CassandraServer, CassandraServerOrigin> splitHostOriginBetweenLastKnownAndConfig(
+            Set<CassandraServer> lastKnownHosts, Set<CassandraServer> configHosts) {
+        return ImmutableMap.<CassandraServer, CassandraServerOrigin>builder()
+                .putAll(CassandraServerOrigin.mapAllServersToOrigin(lastKnownHosts, CassandraServerOrigin.LAST_KNOWN))
+                .putAll(CassandraServerOrigin.mapAllServersToOrigin(configHosts, CassandraServerOrigin.CONFIG))
+                .buildOrThrow();
+    }
+
+    private static Map<CassandraServer, CassandraServerOrigin> mapToTokenRangeOrigin(Set<CassandraServer> servers) {
+        return CassandraServerOrigin.mapAllServersToOrigin(servers, CassandraServerOrigin.TOKEN_RANGE);
     }
 }

--- a/changelog/@unreleased/pr-6455.v2.yml
+++ b/changelog/@unreleased/pr-6455.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: AtlasDB clients can now recover after receiving a dissenting response
+    to a Cassandra Topology check.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6455


### PR DESCRIPTION
This differs from #6455 by using the config server list instead of just available hosts when redoing the quorum check
## General
**Before this PR**:
https://github.com/palantir/atlasdb/pull/6415 added a feature to accept a new set of servers even if there's no quorum, iff the new set of servers have quorum and match the last accepted topology. This was added to handle cases where a bunch of nodes are down, but we want to add a new set.

However, the above PR inadvertantly missed wiring in the case when the cassandra client pool is empty. This happens on startup, but can also happen when the servers in the client pool are marked absent for when the set of desired servers does not contain the existing servers., which happens when QUORUM = 2, as noted in the P0s linked above. (And historically, we mark them not absent the next time we refresh successfully). There's a thing on should we even be marking so many things absent if it leaves the client pool empty, but I'd like to discuss that with the team on Monday.

Currently, when dissent occurs and the client pool is emptied, we are completely unable to recover. This is because there are no nodes we can reach to get the token range (which is how Atlas does discovery), and so we used the last set of IPs and union that with the set of servers from config (i.e., skylab discovery).

Especially in Cross-VPC setups like our dog-fooding stack, the last of set of IPs are unreachable, whereas the config provided URIs are discoverable.
Since the number of IPs = number of config provided URIs, then we have exactly half the nodes unreachable. After we fixed the quorum calculation (https://github.com/palantir/atlasdb/pull/6427), this meant that we could no longer reach consensus, and, since we didn't check against a previous topology in this case, we would never refresh.

A test that I added that fails:
![Screenshot 2023-02-24 at 15 09 09](https://user-images.githubusercontent.com/1812764/221214037-5428cd97-d7e9-47fc-9b00-52b59091df00.png)

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
AtlasDB clients can now recover after receiving a dissenting response to a Cassandra Topology check.
==COMMIT_MSG==

**Priority**: P1, there are P0s and the method of getting out (bouncing) is pretty painful in some cases.

**Concerns / possible downsides (what feedback would you like?)**:
The whole point of this check is to avoid split brain situations. Given the escape hatch of only checking the config servers, this does increase the risk of allowing split-brain. The principle of checking against the last valid topology should mitigate that.

Please let me know if there are other edge cases that I've missed!

**Is documentation needed?**:
This behaviour matches the actual docs
## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
That we can safely proceed by just checking the available hosts, since we'll eventually refresh again after getting at least one host, retrieve the token range, and get the full list of hosts.

**What was existing testing like? What have you done to improve it?**:
The original tests didn't actually test the no quorum case! I've addressed that. Please do check with a debugger if you want to be convinced

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Recovery after a Quorum = 2 incident
**Has the safety of all log arguments been decided correctly?**:
No logging changed
**Will this change significantly affect our spending on metrics or logs?**:
No
**How would I tell that this PR does not work in production? (monitors, etc.)**:
Either we still don't recover, or worse, we allow a split-brain when we shouldn't
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Rollback is not straightforward.
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
@jeremyk-91 as the next on-call (I'm the current)
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No
## Development Process
**Where should we start reviewing?**:
CassandraTopologyValidator
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
N/A
**Please tag any other people who should be aware of this PR**:


<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
