### PR TITLE
[PDS-335555] getRange() and Friends Return Unwanted Columns From Local Writes

### DIFF
--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -693,8 +693,8 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
     @Test
     public void getRangeRetainsOnlyRelevantColumnsFromLocalWrites() {
         byte[] row = "row".getBytes(StandardCharsets.UTF_8);
-        byte[] firstColumn = "james".getBytes(StandardCharsets.UTF_8);
-        byte[] secondColumn = "jakub".getBytes(StandardCharsets.UTF_8);
+        byte[] firstColumn = "jakub".getBytes(StandardCharsets.UTF_8);
+        byte[] secondColumn = "james".getBytes(StandardCharsets.UTF_8);
         byte[] thirdColumn = "jeremy".getBytes(StandardCharsets.UTF_8);
         byte[] fourthColumn = "jolyon".getBytes(StandardCharsets.UTF_8);
         Cell firstCell = Cell.create(row, firstColumn);

--- a/changelog/@unreleased/pr-6461.v2.yml
+++ b/changelog/@unreleased/pr-6461.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: All versions of `getRange()` and `getRanges()` now correctly longer
+    include locally written columns that do not match the provided `ColumnSelection`
+    in their `RowResult`s.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6461

--- a/changelog/@unreleased/pr-6461.v2.yml
+++ b/changelog/@unreleased/pr-6461.v2.yml
@@ -1,6 +1,6 @@
 type: fix
 fix:
-  description: All versions of `getRange()` and `getRanges()` now correctly longer
+  description: All versions of `getRange()` and `getRanges()` now correctly no longer
     include locally written columns that do not match the provided `ColumnSelection`
     in their `RowResult`s.
   links:


### PR DESCRIPTION
## General
**Before this PR**:
If I call `getRange()` or `getRanges()` and the range includes some row `R` to which I had written some column `C`, `C` is always returned in the included row-results _even if_ the column selection on the range requests mean that I shouldn't include `C`. The tests probably explain this better.

I read the ticket, poked at the client code on the ticket for a bit... and this dropped out.

**After this PR**:
==COMMIT_MSG==
All versions of `getRange()` and `getRanges()` now correctly longer include locally written columns that do not match the provided `ColumnSelection` in their `RowResult`s.
==COMMIT_MSG==

**Priority**: It's a correctness bug, can you say **SEVERE DATA CORRUPTION** (TM)? In all honesty not so bad since I expect in most cases the user will just ignore the unasked-for-cells, but this needs to be fixed. It's also causing problems on the linked ticket.

**Concerns / possible downsides (what feedback would you like?)**:
- Is there a risk that the performance of adding the Maps.filterKeys(...) which _does_ add an additional layer of indirection poses a problem? I think not since we're talking to a database anyway, but I'm aware it is another layer.
- Does anyone rely on the old behaviour, and if so is it unfair to say that this kind of break is nonetheless acceptable?

**Is documentation needed?**: No.

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: I wouldn't say so

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: Yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: No external dependencies

**Does this PR need a schema migration?** No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: Not much

**What was existing testing like? What have you done to improve it?**: Added tests that previously fail and now pass!

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: Not this time - the code is convoluted, but not concurrent.

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: Nope.

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: For the aforementioned ticket, the workflows can go ahead smoothly.

**Has the safety of all log arguments been decided correctly?**: No changes here

**Will this change significantly affect our spending on metrics or logs?**: Nope

**How would I tell that this PR does not work in production? (monitors, etc.)**: Nothing special on this I'm afraid :/

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: Rollback

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**: _Maybe_ - see Concern 1, though I doubt it.

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**: No.

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**: Probably not.

## Development Process
**Where should we start reviewing?**: The tests, as they explain what exactly the problem is.

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: No.

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
