### PR TITLE
CassandraService::getKnownPort uses intStream

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
@@ -17,7 +17,6 @@ package com.palantir.atlasdb.keyvalue.cassandra.pool;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableRangeMap;
@@ -58,13 +57,13 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.PrimitiveIterator.OfInt;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -73,6 +72,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.cassandra.thrift.EndpointDetails;
 import org.apache.cassandra.thrift.TokenRange;
@@ -302,22 +302,23 @@ public class CassandraService implements AutoCloseable {
     }
 
     private int getKnownPort() throws UnknownHostException {
-        // explicitly not using streams due to allocation overhead
-        return onlyPort(FluentIterable.concat(
-                        FluentIterable.from(currentPools.keySet()).transform(CassandraServer::proxy),
-                        getServersSocketAddressesFromConfig())
-                .transform(InetSocketAddress::getPort));
+        // explicitly not collecting to a set to avoid allocation overhead
+        return onlyPort(Stream.concat(
+                        currentPools.keySet().stream().map(CassandraServer::proxy),
+                        getServersSocketAddressesFromConfig().stream())
+                .mapToInt(InetSocketAddress::getPort));
     }
 
     @VisibleForTesting
-    static int onlyPort(Iterable<? extends Integer> iterable) throws UnknownHostException {
-        Iterator<? extends Integer> iterator = iterable.iterator();
+    static int onlyPort(IntStream intStream) throws UnknownHostException {
+        // explicitly avoiding boxing from int -> Integer
+        OfInt iterator = intStream.iterator();
         if (!iterator.hasNext()) {
             throw new UnknownHostException("No single known port");
         }
-        int port = iterator.next();
+        int port = iterator.nextInt();
         while (iterator.hasNext()) {
-            if (port != iterator.next()) {
+            if (port != iterator.nextInt()) {
                 throw new UnknownHostException("No single known port");
             }
         }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
@@ -33,7 +33,6 @@ import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.refreshable.Refreshable;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
@@ -272,12 +271,12 @@ public class CassandraServiceTest {
 
     @Test
     public void ports() throws Exception {
-        assertThat(CassandraService.onlyPort(List.of(1, 1, 1))).isEqualTo(1);
-        assertThat(IntStream.generate(() -> 4224).boxed().limit(15).collect(Collectors.toList()))
-                .hasSize(15)
-                .satisfies(cluster ->
-                        assertThat(CassandraService.onlyPort(cluster)).isEqualTo(4224));
-        assertThatThrownBy(() -> CassandraService.onlyPort(List.of(1, 2, 1)))
+        assertThat(CassandraService.onlyPort(IntStream.of(1, 1, 1))).isEqualTo(1);
+        assertThat(CassandraService.onlyPort(IntStream.generate(() -> 4224).limit(15)))
+                .isEqualTo(4224);
+        assertThat(CassandraService.onlyPort(IntStream.iterate(42, port -> port).limit(10_000_000)))
+                .isEqualTo(42);
+        assertThatThrownBy(() -> CassandraService.onlyPort(IntStream.of(1, 2, 1)))
                 .isInstanceOf(UnknownHostException.class)
                 .hasMessageContaining("No single known port");
     }


### PR DESCRIPTION
## General
**Before this PR**:
https://github.com/palantir/atlasdb/pull/6451 attempted to reduce allocations and overhead of `CassandraService::getKnownPort`; however, some JFR are showing significant allocations from boxed `int` -> `Integer`.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
CassandraService::getKnownPort uses intStream

```
Benchmark                                    (size)  Mode  Cnt     Score      Error   Units
PortBenchmakr.boxedStream                         3  avgt    3    89.652 ±   23.727   ns/op
PortBenchmakr.boxedStream:·gc.alloc.rate.norm     3  avgt    3   464.031 ±    0.020    B/op
PortBenchmakr.intStream                           3  avgt    3    61.106 ±    0.765   ns/op
PortBenchmakr.intStream:·gc.alloc.rate.norm       3  avgt    3   416.023 ±    0.017    B/op
PortBenchmakr.iterator                            3  avgt    3    12.173 ±    0.578   ns/op
PortBenchmakr.iterator:·gc.alloc.rate.norm        3  avgt    3    96.005 ±    0.003    B/op

PortBenchmakr.boxedStream                        30  avgt    3   505.253 ±  129.755   ns/op
PortBenchmakr.boxedStream:·gc.alloc.rate.norm    30  avgt    3   896.081 ±    0.302    B/op
PortBenchmakr.intStream                          30  avgt    3   356.273 ±   24.996   ns/op
PortBenchmakr.intStream:·gc.alloc.rate.norm      30  avgt    3   416.039 ±    0.200    B/op
PortBenchmakr.iterator                           30  avgt    3    29.301 ±    3.872   ns/op
PortBenchmakr.iterator:·gc.alloc.rate.norm       30  avgt    3    96.008 ±    0.008    B/op
```

==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:
In microbenchmarks above, `IntStream` somewhat surprisingly has worse time and allocation overhead than a boxed `Iterator<Integer>`.

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

