### PR TITLE
Use AtlasDbDependencyException when no hosts available

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/RetryLimitReachedException.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/RetryLimitReachedException.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 
 public class RetryLimitReachedException extends AtlasDbDependencyException implements SafeLoggable {
+
     private static final String MESSAGE = "Request was retried and failed each time for the request.";
 
     private final int numRetries;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
@@ -303,16 +303,11 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
         }
     }
 
-    static class ClientCreationFailedException extends AtlasDbDependencyException {
+    static final class ClientCreationFailedException extends AtlasDbDependencyException {
         private static final long serialVersionUID = 1L;
 
         ClientCreationFailedException(String message, Exception cause) {
             super(message, cause);
-        }
-
-        @Override
-        public Exception getCause() {
-            return (Exception) super.getCause();
         }
     }
 

--- a/atlasdb-commons/src/main/java/com/palantir/exception/NotInitializedException.java
+++ b/atlasdb-commons/src/main/java/com/palantir/exception/NotInitializedException.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 public class NotInitializedException extends AtlasDbDependencyException implements SafeLoggable {
 
-    private static final String EXCEPTION_MESSAGE =
+    private static final String MESSAGE =
             "The object is not yet initialized, and as a result, all calls to it will fail. Interactions with this"
                     + " object should not take place until after initialization has completed. For example, if your"
                     + " service that handles REST requests relies on this object, it should not service REST requests"
@@ -33,19 +33,19 @@ public class NotInitializedException extends AtlasDbDependencyException implemen
     private final String objectNotInitialized;
 
     public NotInitializedException(@Safe String objectNotInitialized) {
-        super(EXCEPTION_MESSAGE);
+        super(MESSAGE);
         this.objectNotInitialized = objectNotInitialized;
     }
 
     public NotInitializedException(@Safe String objectNotInitialized, Throwable throwable) {
-        super(EXCEPTION_MESSAGE, throwable);
+        super(MESSAGE, throwable);
         this.objectNotInitialized = objectNotInitialized;
     }
 
     @Override
     @Safe
     public String getLogMessage() {
-        return EXCEPTION_MESSAGE;
+        return MESSAGE;
     }
 
     @Override

--- a/changelog/@unreleased/pr-6473.v2.yml
+++ b/changelog/@unreleased/pr-6473.v2.yml
@@ -1,6 +1,6 @@
 type: improvement
 improvement:
   description: When no Cassandra hosts are available, AtlasDB throws `AtlasDbDependencyException`
-    instead of `SafeIllegalArgumentException`.
+    instead of `SafeIllegalStateException`.
   links:
   - https://github.com/palantir/atlasdb/pull/6473

--- a/changelog/@unreleased/pr-6473.v2.yml
+++ b/changelog/@unreleased/pr-6473.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: When no Cassandra hosts are available, AtlasDB throws `AtlasDbDependencyException`
+    instead of `SafeIllegalArgumentException`.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6473

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/InvalidAcceptorCacheKeyException.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/InvalidAcceptorCacheKeyException.java
@@ -24,18 +24,18 @@ import java.util.List;
 
 public class InvalidAcceptorCacheKeyException extends Exception implements SafeLoggable {
 
-    private static final String ERROR_MESSAGE = "Provided acceptor cache key is either invalid/expired.";
+    private static final String MESSAGE = "Provided acceptor cache key is either invalid/expired.";
 
     private final AcceptorCacheKey cacheKey;
 
     public InvalidAcceptorCacheKeyException(AcceptorCacheKey cacheKey) {
-        super(ERROR_MESSAGE);
+        super(MESSAGE);
         this.cacheKey = cacheKey;
     }
 
     @Override
     public String getLogMessage() {
-        return ERROR_MESSAGE;
+        return MESSAGE;
     }
 
     @Override


### PR DESCRIPTION
**Before this PR**:

Our internal server library attempts to categorize exceptions thrown in API endpoints to determine if the exception came from within a service or from a dependency.

This categorization logic treats `AtlasDbDependencyException` as an external RPC error rather than an internal error. This is  the same label applied to Conjure's `RemoteException`.

When Cassandra loses quorum, callers first receive `RetryLimitReachedException`, which is correctly categorized as an external RPC error.

However, if Cassandra does not regain quorum, then all hosts become blacklisted and these errors instead manifest as `SafeIllegalStateException` and are incorrectly categorized as internal errors.

This results in noisy monitors for product teams that have opted-in to the more strict internal errors monitor.

**After this PR**:

When there are no hosts available, `CassandraService` throws an exception that extends `AtlasDbDependencyException` to ensure these errors are categorized properly.

This PR also includes a couple other small clean up changes to use a consistent pattern in our `AtlasDbDependencyException` subclasses.