### PR TITLE
Batch hint is now marked as nullable for RangeRequest

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/RangeRequest.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/RangeRequest.java
@@ -352,7 +352,7 @@ public final class RangeRequest implements Serializable {
          * this means the batch size will be whatever is passed as the batch size to
          * BatchingVisitable#batchAccept(int, com.palantir.common.base.AbortingVisitor)
          */
-        public Builder batchHint(Integer hint) {
+        public Builder batchHint(@Nullable Integer hint) {
             Preconditions.checkArgument(hint == null || hint > 0);
             batchHint = hint;
             return this;


### PR DESCRIPTION
## General
**Before this PR**:
BatchHint can be null (as specified in docs), but we don't mark it as such. Thus, nullaway complains.
**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**: P2
