### PR TITLE
Add @Nullable to (Batch)ColumnRangeSelection and the puncher store

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/BatchColumnRangeSelection.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/BatchColumnRangeSelection.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.encoding.PtBytes;
 import java.io.Serializable;
 import java.util.regex.Pattern;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public final class BatchColumnRangeSelection implements Serializable {
     private static final long serialVersionUID = 1L;
@@ -40,8 +41,8 @@ public final class BatchColumnRangeSelection implements Serializable {
 
     @JsonCreator
     public static BatchColumnRangeSelection create(
-            @JsonProperty("startCol") byte[] startCol,
-            @JsonProperty("endCol") byte[] endCol,
+            @JsonProperty("startCol") byte @Nullable [] startCol,
+            @JsonProperty("endCol") byte @Nullable [] endCol,
             @JsonProperty("batchHint") int batchHint) {
         return new BatchColumnRangeSelection(new ColumnRangeSelection(startCol, endCol), batchHint);
     }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/ColumnRangeSelection.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/ColumnRangeSelection.java
@@ -26,6 +26,7 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.regex.Pattern;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class ColumnRangeSelection implements Serializable {
     private static final long serialVersionUID = 1L;
@@ -36,7 +37,8 @@ public class ColumnRangeSelection implements Serializable {
     private final byte[] endCol;
 
     @JsonCreator
-    public ColumnRangeSelection(@JsonProperty("startCol") byte[] startCol, @JsonProperty("endCol") byte[] endCol) {
+    public ColumnRangeSelection(
+            @JsonProperty("startCol") byte @Nullable [] startCol, @JsonProperty("endCol") byte @Nullable [] endCol) {
         this.startCol = Objects.requireNonNullElse(startCol, PtBytes.EMPTY_BYTE_ARRAY);
         this.endCol = Objects.requireNonNullElse(endCol, PtBytes.EMPTY_BYTE_ARRAY);
         if (!isValidRange(this.startCol, this.endCol)) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/KeyValueServicePuncherStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/KeyValueServicePuncherStore.java
@@ -41,6 +41,7 @@ import java.util.Iterator;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Immutable;
 
@@ -185,7 +186,7 @@ public final class KeyValueServicePuncherStore implements PuncherStore {
      * within the specified bounds.
      */
     public static Optional<MillisAndMaybeTimestamp> getMillisForTimestampWithinBounds(
-            KeyValueService kvs, long timestamp, MillisAndMaybeTimestamp lowerBound, long upperBound) {
+            KeyValueService kvs, long timestamp, @Nullable MillisAndMaybeTimestamp lowerBound, long upperBound) {
         MillisAndMaybeTimestamp lowerBoundToUse =
                 Optional.ofNullable(lowerBound).orElseGet(() -> findOlder(kvs, timestamp, upperBound));
 


### PR DESCRIPTION
NullAway internally complains that we're passing nulls, but these methods explicitly allow for nulls