### PR TITLE
Since Atlas tables are append only, reserve no space for row growth on Oracle

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
@@ -196,7 +196,11 @@ public final class OracleDdlTable implements DbDdlTable {
                         + (needsOverflow ? "overflow   NUMBER(38), " : "")
                         + "  CONSTRAINT " + PrimaryKeyConstraintNames.get(shortTableName)
                         + " PRIMARY KEY (row_name, col_name, ts) "
-                        + ") organization index compress overflow",
+                        + ") "
+                        + "organization index compress "
+                        // Since append only
+                        + "PCTFREE 0 "
+                        + "overflow",
                 OracleErrorConstants.ORACLE_ALREADY_EXISTS_ERROR);
         putTableNameMapping(oracleTableNameGetter.getPrefixedTableName(tableRef), shortTableName);
         return shortTableName;
@@ -209,7 +213,9 @@ public final class OracleDdlTable implements DbDdlTable {
                         + "  id  NUMBER(38) NOT NULL, "
                         + "  val BLOB NOT NULL,"
                         + "  CONSTRAINT " + PrimaryKeyConstraintNames.get(shortOverflowTableName) + " PRIMARY KEY (id)"
-                        + ")",
+                        + ") "
+                        // Since append only
+                        + "PCTFREE 0",
                 OracleErrorConstants.ORACLE_ALREADY_EXISTS_ERROR);
         putTableNameMapping(oracleTableNameGetter.getPrefixedOverflowTableName(tableRef), shortOverflowTableName);
     }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
@@ -198,7 +198,8 @@ public final class OracleDdlTable implements DbDdlTable {
                         + " PRIMARY KEY (row_name, col_name, ts) "
                         + ") "
                         + "organization index compress "
-                        // Since append only
+                        // Since append only completely fill blocks - no benefit in leaving space for updates of rows
+                        // PCTUSED N/A to Index Organized Tables
                         + "PCTFREE 0 "
                         + "overflow",
                 OracleErrorConstants.ORACLE_ALREADY_EXISTS_ERROR);
@@ -214,7 +215,8 @@ public final class OracleDdlTable implements DbDdlTable {
                         + "  val BLOB NOT NULL,"
                         + "  CONSTRAINT " + PrimaryKeyConstraintNames.get(shortOverflowTableName) + " PRIMARY KEY (id)"
                         + ") "
-                        // Since append only
+                        // Since append only completely fill blocks - no benefit in leaving space for updates of rows
+                        // Assume auto segment space management, so PCTUSED ignored
                         + "PCTFREE 0",
                 OracleErrorConstants.ORACLE_ALREADY_EXISTS_ERROR);
         putTableNameMapping(oracleTableNameGetter.getPrefixedOverflowTableName(tableRef), shortOverflowTableName);

--- a/changelog/@unreleased/pr-6489.v2.yml
+++ b/changelog/@unreleased/pr-6489.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Oracle tables (including overflow) will be created with PCTFREE 0.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6489


### PR DESCRIPTION
## General
In Oracle, modified rows are written in place, and current values are stored in UNDO for read consistency (as opposed to Postgres, which writes a copy of the row in the same table with the new values). As a consequence, Oracle has a table level setting PCTFREE which specifies how much space to reserve for row growth - default is 10%.

Since Atlas never modifies existing rows, and always adds with a new timestamp, this space is entirely wasted.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Oracle tables (including overflow) will be created with PCTFREE 0.
==COMMIT_MSG==

**Priority**:
Low

**Concerns / possible downsides (what feedback would you like?)**:
None. This doesn't have any negative impact on fragmentation, because only modified rows can use the space reserved by PCTFREE.

**Is documentation needed?**:
No

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No

**Does this PR need a schema migration?**
Ideally, it would - we would update all existing tables to use this new PCTFREE value. However Oracle doesn't allow PCTFREE to be modified on existing IOT (which are a far bigger source of wasted space than the overflow tables which are ordinary tables), so for the moment, only new tables will get this.

It is possible to use DBMS_REDEFINITION to rebuild IOT with the desired properties (for sites with Oracle Enterprise Edition), to use CREATE TABLE ... AS SELECT * FROM ...; then replace the source table (with the system offline) but these are not generally worth the effort.

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
N/A

**What was existing testing like? What have you done to improve it?**:
N/A

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
select tablename, pct_free from dba_tables;

**Has the safety of all log arguments been decided correctly?**:
N/A

**Will this change significantly affect our spending on metrics or logs?**:
N/A

**How would I tell that this PR does not work in production? (monitors, etc.)**:
N/A

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
N/A

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
This change will reduce scale pressure, as our Atlas table blocks will be more information rich.

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
N/A

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@sfreiberg-palantir
@berler 
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
