### PR TITLE
Don't add executor metrics by default

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -115,3 +115,21 @@ acceptedBreaks:
     - code: "java.class.removed"
       old: "interface com.palantir.atlasdb.transaction.api.expectations.ExpectationsAwareTransaction"
       justification: "moving out of API"
+  "0.824.0":
+    com.palantir.atlasdb:atlasdb-cassandra:
+    - code: "java.method.numberOfParametersChanged"
+      old: "method java.util.concurrent.ExecutorService com.palantir.atlasdb.keyvalue.impl.AbstractKeyValueService::createFixedThreadPool(java.lang.String,\
+        \ int) @ com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServiceImpl"
+      new: "method java.util.concurrent.ExecutorService com.palantir.atlasdb.keyvalue.impl.AbstractKeyValueService::createFixedThreadPool(com.palantir.tritium.metrics.registry.TaggedMetricRegistry,\
+        \ java.lang.String, int) @ com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServiceImpl"
+      justification: "Protected method"
+    - code: "java.method.numberOfParametersChanged"
+      old: "method java.util.concurrent.ExecutorService com.palantir.atlasdb.keyvalue.impl.AbstractKeyValueService::createThreadPool(java.lang.String,\
+        \ int, int) @ com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServiceImpl"
+      new: "method java.util.concurrent.ExecutorService com.palantir.atlasdb.keyvalue.impl.AbstractKeyValueService::createThreadPool(com.palantir.tritium.metrics.registry.TaggedMetricRegistry,\
+        \ java.lang.String, int, int) @ com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServiceImpl"
+      justification: "Protected method"
+    - code: "java.method.removed"
+      old: "method java.util.concurrent.ExecutorService com.palantir.atlasdb.keyvalue.impl.AbstractKeyValueService::createThreadPoolWihtoutSpans(java.lang.String,\
+        \ int, int) @ com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServiceImpl"
+      justification: "Protected method"

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -108,8 +108,6 @@ import com.palantir.common.streams.KeyedStream;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.refreshable.Refreshable;
-import com.palantir.tracing.Tracers;
-import com.palantir.tritium.metrics.MetricRegistries;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import com.palantir.util.Pair;
 import com.palantir.util.paging.AbstractPagingIterable;
@@ -485,10 +483,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             int numberOfThriftHosts = serversConfig.numberOfThriftHosts();
             int corePoolSize = poolSize * numberOfThriftHosts;
             int maxPoolSize = maxConnectionBurstSize * numberOfThriftHosts;
-            return Tracers.wrap(MetricRegistries.instrument(
-                    registry,
-                    createThreadPoolWihtoutSpans("Atlas Cassandra KVS", corePoolSize, maxPoolSize),
-                    "Atlas Cassandra KVS"));
+            return createThreadPoolWithoutSpans(registry, "Atlas Cassandra KVS", corePoolSize, maxPoolSize);
         };
     }
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueService.java
@@ -39,6 +39,8 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.common.base.ClosableIterator;
 import com.palantir.common.concurrent.PTExecutors;
+import com.palantir.tritium.metrics.MetricRegistries;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -70,38 +72,48 @@ public abstract class AbstractKeyValueService implements KeyValueService {
     /**
      * Creates a fixed thread pool.
      *
-     * @param threadNamePrefix thread name prefix
+     * @param name thread name prefix
      * @param corePoolSize size of the core pool
      * @return a new fixed size thread pool with a keep alive time of 1 minute
      */
-    protected static ExecutorService createFixedThreadPool(String threadNamePrefix, int corePoolSize) {
-        return createThreadPool(threadNamePrefix, corePoolSize, corePoolSize);
+    protected static ExecutorService createFixedThreadPool(
+            TaggedMetricRegistry registry, String name, int corePoolSize) {
+        return createThreadPool(registry, name, corePoolSize, corePoolSize);
     }
 
     /**
      * Creates a thread pool with number of threads between {@code _corePoolSize} and {@code maxPoolSize}.
      *
-     * @param threadNamePrefix thread name prefix
+     * @param name thread name prefix
      * @param _corePoolSize size of the core pool
      * @param maxPoolSize maximum size of the pool
      * @return a new fixed size thread pool with a keep alive time of 1 minute
      */
-    protected static ExecutorService createThreadPool(String threadNamePrefix, int _corePoolSize, int maxPoolSize) {
-        return PTExecutors.newFixedThreadPool(maxPoolSize, threadNamePrefix);
+    protected static ExecutorService createThreadPool(
+            TaggedMetricRegistry registry, String name, int _corePoolSize, int maxPoolSize) {
+        return MetricRegistries.executor()
+                .registry(registry)
+                .name(name)
+                .executor(PTExecutors.newFixedThreadPool(maxPoolSize, name))
+                .build();
     }
 
     /**
      * Creates a thread pool with number of threads between {@code _corePoolSize} and {@code maxPoolSize}.
      * It does not create a span.
      *
-     * @param threadNamePrefix thread name prefix
+     * @param name thread name prefix
      * @param _corePoolSize size of the core pool
      * @param maxPoolSize maximum size of the pool
      * @return a new fixed size thread pool with a keep alive time of 1 minute
      */
-    protected static ExecutorService createThreadPoolWihtoutSpans(
-            String threadNamePrefix, int _corePoolSize, int maxPoolSize) {
-        return PTExecutors.newFixedThreadPoolWithoutSpan(maxPoolSize, threadNamePrefix);
+    protected static ExecutorService createThreadPoolWithoutSpans(
+            TaggedMetricRegistry registry, String name, int _corePoolSize, int maxPoolSize) {
+        return MetricRegistries.executor()
+                .registry(registry)
+                .name(name)
+                .executor(PTExecutors.newFixedThreadPoolWithoutSpan(maxPoolSize, name))
+                .build();
     }
 
     @Override

--- a/changelog/@unreleased/pr-6490.v2.yml
+++ b/changelog/@unreleased/pr-6490.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Executors created using `PTExecutors` don't produce metrics by default.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6490


### PR DESCRIPTION
**Before this PR**:

We were seeing high GC in an internal service while handling some very read-heavy requests.

Looking at the JFR, `Timer$Context` was the the second largest allocated class by far.

![Screenshot 2023-03-30 at 3 21 01 PM](https://user-images.githubusercontent.com/5273164/228977949-bde4f466-fe10-4c51-b353-88624a2f2fce.png)

Looking at the executor metrics for some of our larger services, the largest contributors were `timed-runner` and `atlas_cassanda_kvs`.

![Screenshot 2023-03-30 at 3 38 22 PM](https://user-images.githubusercontent.com/5273164/228979332-fea1083c-5ca8-488c-b85c-c88552717010.png)

AtlasDB creates a ton of executors and the majority of them probably don't need to be instrumented. Executors like `timed-runner` are very high volume and produce very low-signal metrics.

We should be judicious where we add instrumentation - instrumentation has both a performance cost and monetary cost.

**After this PR**:

Executors created using `PTExecutors` don't produce metrics by default. Callers can opt-in to metrics by using the facilities provided by Tritium.