### PR TITLE
Eliminate duplicate executor instrumentation

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -115,3 +115,9 @@ acceptedBreaks:
     - code: "java.class.removed"
       old: "interface com.palantir.atlasdb.transaction.api.expectations.ExpectationsAwareTransaction"
       justification: "moving out of API"
+  "0.824.0":
+    com.palantir.atlasdb:atlasdb-cassandra:
+    - code: "java.method.removed"
+      old: "method java.util.concurrent.ExecutorService com.palantir.atlasdb.keyvalue.impl.AbstractKeyValueService::createThreadPoolWihtoutSpans(java.lang.String,\
+        \ int, int) @ com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServiceImpl"
+      justification: "Protected method"

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -108,8 +108,6 @@ import com.palantir.common.streams.KeyedStream;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.refreshable.Refreshable;
-import com.palantir.tracing.Tracers;
-import com.palantir.tritium.metrics.MetricRegistries;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import com.palantir.util.Pair;
 import com.palantir.util.paging.AbstractPagingIterable;
@@ -485,10 +483,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             int numberOfThriftHosts = serversConfig.numberOfThriftHosts();
             int corePoolSize = poolSize * numberOfThriftHosts;
             int maxPoolSize = maxConnectionBurstSize * numberOfThriftHosts;
-            return Tracers.wrap(MetricRegistries.instrument(
-                    registry,
-                    createThreadPoolWihtoutSpans("Atlas Cassandra KVS", corePoolSize, maxPoolSize),
-                    "Atlas Cassandra KVS"));
+            return createThreadPoolWithoutSpans("Atlas Cassandra KVS", corePoolSize, maxPoolSize);
         };
     }
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueService.java
@@ -70,38 +70,37 @@ public abstract class AbstractKeyValueService implements KeyValueService {
     /**
      * Creates a fixed thread pool.
      *
-     * @param threadNamePrefix thread name prefix
+     * @param name thread name prefix
      * @param corePoolSize size of the core pool
      * @return a new fixed size thread pool with a keep alive time of 1 minute
      */
-    protected static ExecutorService createFixedThreadPool(String threadNamePrefix, int corePoolSize) {
-        return createThreadPool(threadNamePrefix, corePoolSize, corePoolSize);
+    protected static ExecutorService createFixedThreadPool(String name, int corePoolSize) {
+        return createThreadPool(name, corePoolSize, corePoolSize);
     }
 
     /**
      * Creates a thread pool with number of threads between {@code _corePoolSize} and {@code maxPoolSize}.
      *
-     * @param threadNamePrefix thread name prefix
+     * @param name thread name prefix
      * @param _corePoolSize size of the core pool
      * @param maxPoolSize maximum size of the pool
      * @return a new fixed size thread pool with a keep alive time of 1 minute
      */
-    protected static ExecutorService createThreadPool(String threadNamePrefix, int _corePoolSize, int maxPoolSize) {
-        return PTExecutors.newFixedThreadPool(maxPoolSize, threadNamePrefix);
+    protected static ExecutorService createThreadPool(String name, int _corePoolSize, int maxPoolSize) {
+        return PTExecutors.newFixedThreadPool(maxPoolSize, name);
     }
 
     /**
      * Creates a thread pool with number of threads between {@code _corePoolSize} and {@code maxPoolSize}.
      * It does not create a span.
      *
-     * @param threadNamePrefix thread name prefix
+     * @param name thread name prefix
      * @param _corePoolSize size of the core pool
      * @param maxPoolSize maximum size of the pool
      * @return a new fixed size thread pool with a keep alive time of 1 minute
      */
-    protected static ExecutorService createThreadPoolWihtoutSpans(
-            String threadNamePrefix, int _corePoolSize, int maxPoolSize) {
-        return PTExecutors.newFixedThreadPoolWithoutSpan(maxPoolSize, threadNamePrefix);
+    protected static ExecutorService createThreadPoolWithoutSpans(String name, int _corePoolSize, int maxPoolSize) {
+        return PTExecutors.newFixedThreadPoolWithoutSpan(maxPoolSize, name);
     }
 
     @Override

--- a/commons-executors/src/main/java/com/palantir/common/concurrent/PTExecutors.java
+++ b/commons-executors/src/main/java/com/palantir/common/concurrent/PTExecutors.java
@@ -295,10 +295,12 @@ public final class PTExecutors {
      * @throws IllegalArgumentException if <tt>numThreads &lt;= 0</tt>
      */
     public static ExecutorService newFixedThreadPool(int numThreads, String name) {
-        return MetricRegistries.instrument(
-                SharedTaggedMetricRegistries.getSingleton(),
-                PTExecutors.wrap(name, getViewExecutor(name, numThreads, Integer.MAX_VALUE, SHARED_EXECUTOR.get())),
-                name);
+        return MetricRegistries.executor()
+                .registry(SharedTaggedMetricRegistries.getSingleton())
+                .name(name)
+                .executor(PTExecutors.wrap(
+                        name, getViewExecutor(name, numThreads, Integer.MAX_VALUE, SHARED_EXECUTOR.get())))
+                .build();
     }
 
     /**
@@ -316,11 +318,12 @@ public final class PTExecutors {
      * @throws IllegalArgumentException if <tt>numThreads &lt;= 0</tt>
      */
     public static ExecutorService newFixedThreadPoolWithoutSpan(int numThreads, String name) {
-        return MetricRegistries.instrument(
-                SharedTaggedMetricRegistries.getSingleton(),
-                PTExecutors.wrapWithoutSpan(
-                        getViewExecutor(name, numThreads, Integer.MAX_VALUE, SHARED_EXECUTOR.get())),
-                name);
+        return MetricRegistries.executor()
+                .registry(SharedTaggedMetricRegistries.getSingleton())
+                .name(name)
+                .executor(PTExecutors.wrapWithoutSpan(
+                        getViewExecutor(name, numThreads, Integer.MAX_VALUE, SHARED_EXECUTOR.get())))
+                .build();
     }
 
     public static ExecutorService getViewExecutor(


### PR DESCRIPTION
A less disruptive version of https://github.com/palantir/atlasdb/pull/6490 that doesn't change the behavior of `PTExecutors` but just removes the duplicate instrumentation.