### PR TITLE
Improve DB KVS default config

### DIFF
--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
@@ -58,7 +58,10 @@ public abstract class ConnectionConfig {
 
     public abstract String getDriverClass();
 
-    public abstract String getTestQuery();
+    @Value.Default
+    public String getTestQuery() {
+        return "";
+    }
 
     @JsonIgnore
     @Value.Derived

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
@@ -132,7 +132,7 @@ public abstract class ConnectionConfig {
 
     @Value.Default
     public boolean testConnectionBeforeHandout() {
-        return true;
+        return false;
     }
 
     /**
@@ -182,7 +182,7 @@ public abstract class ConnectionConfig {
 
         initializeFailTimeoutMillis().ifPresent(config::setInitializationFailTimeout);
 
-        if (getTestQuery() != null && !getTestQuery().isEmpty()) {
+        if (!getTestQuery().isEmpty()) {
             config.setConnectionTestQuery(getTestQuery());
         }
 

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/H2ConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/H2ConnectionConfig.java
@@ -51,12 +51,6 @@ public abstract class H2ConnectionConfig extends ConnectionConfig {
     }
 
     @Override
-    @Value.Default
-    public String getTestQuery() {
-        return "SELECT 1";
-    }
-
-    @Override
     public final DBType getDbType() {
         return DBType.H2_MEMORY;
     }

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/OracleConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/OracleConnectionConfig.java
@@ -88,12 +88,6 @@ public abstract class OracleConnectionConfig extends ConnectionConfig {
         return "oracle.jdbc.driver.OracleDriver";
     }
 
-    @Override
-    @Value.Default
-    public String getTestQuery() {
-        return "SELECT 1 FROM DUAL";
-    }
-
     public abstract Optional<String> getSid();
 
     public abstract Optional<ServiceNameConfiguration> serviceNameConfiguration();

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/OracleConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/OracleConnectionConfig.java
@@ -91,7 +91,7 @@ public abstract class OracleConnectionConfig extends ConnectionConfig {
     @Override
     @Value.Default
     public String getTestQuery() {
-        return "";
+        return "SELECT 1 FROM DUAL";
     }
 
     public abstract Optional<String> getSid();

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/PostgresConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/PostgresConnectionConfig.java
@@ -66,12 +66,6 @@ public abstract class PostgresConnectionConfig extends ConnectionConfig {
         return "org.postgresql.Driver";
     }
 
-    @Override
-    @Value.Default
-    public String getTestQuery() {
-        return "SELECT 1";
-    }
-
     public abstract String getDbName();
 
     @Override

--- a/changelog/@unreleased/pr-6499.v2.yml
+++ b/changelog/@unreleased/pr-6499.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Disable AtlasDB DB connection testing by default in favor of relying
+    on Hikari's connection testing.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6499


### PR DESCRIPTION
_See https://github.com/palantir/atlasdb/pull/2301 and https://github.com/palantir/atlasdb/pull/6018 for prior context_

- Disable AtlasDB connection testing by default

    Hikari has it's own connection testing, so performing our own connection tests is mostly redundant.

    The Oracle driver bugs that prompted this feature are from a much older version of the Oracle driver. I'm assuming that connection corruption is rare and that Hikari's connection testing should be sufficient.

- ~Set the Oracle test query to `SELECT 1 from DUAL`~

    ~This reverts a change from https://github.com/palantir/atlasdb/pull/6018.~

    ~Without this configuration set, we call `isValid` with a timeout. The Oracle driver implements `isValid` using a `SELECT 'x' FROM DUAL` query. Because we specified a timeout, the driver spawns a new thread for this query. In practice this means we are spawning a thread every time we acquire a connection from the connection pool.~

- Use `isValid` for connection tests by default

   We originally did this in https://github.com/palantir/atlasdb/pull/4602 but then reverted it in https://github.com/palantir/atlasdb/pull/4617 was because of bugs in the Oracle driver.

    But then we effectively (accidentally?) brought this back in https://github.com/palantir/atlasdb/pull/6018, after which we use `isValid` to test connections when using Oracle.