### PR TITLE
Optimize TimestampMapping::leader to avoid stream overhead

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampMapping.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampMapping.java
@@ -16,12 +16,17 @@
 
 package com.palantir.atlasdb.keyvalue.api.watch;
 
-import com.google.common.collect.MoreCollectors;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Collections2;
 import com.google.common.collect.Range;
 import com.palantir.lock.watch.LockWatchVersion;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.Iterator;
 import java.util.LongSummaryStatistics;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import org.immutables.value.Value;
 
@@ -44,10 +49,8 @@ interface TimestampMapping {
 
     @Value.Derived
     default UUID leader() {
-        return timestampMapping().values().stream()
-                .map(LockWatchVersion::id)
-                .distinct()
-                .collect(MoreCollectors.onlyElement());
+        // explicitly avoiding stream and distinct collection copy when all IDs should be identical
+        return identicalElement(Collections2.transform(timestampMapping().values(), LockWatchVersion::id));
     }
 
     @Value.Check
@@ -57,5 +60,21 @@ interface TimestampMapping {
 
     static ImmutableTimestampMapping.Builder builder() {
         return ImmutableTimestampMapping.builder();
+    }
+
+    @VisibleForTesting
+    static <T> T identicalElement(Iterable<? extends T> iterable) {
+        Iterator<? extends T> iterator = iterable.iterator();
+        T element = iterator.next();
+        while (iterator.hasNext()) {
+            T next = iterator.next();
+            if (!Objects.equals(element, next)) {
+                throw new SafeIllegalArgumentException(
+                        "Input contains multiple distinct elements",
+                        SafeArg.of("element", element),
+                        SafeArg.of("next", next));
+            }
+        }
+        return element;
     }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampMappingTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampMappingTest.java
@@ -1,0 +1,92 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.api.watch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.collect.Iterables;
+import com.palantir.lock.watch.LockWatchVersion;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import org.junit.Test;
+
+public class TimestampMappingTest {
+    @Test
+    public void singleLeaderMappingIsValid() {
+        UUID id = UUID.randomUUID();
+        ImmutableTimestampMapping timestampMapping = TimestampMapping.builder()
+                .putTimestampMapping(1L, LockWatchVersion.of(id, 1))
+                .build();
+        assertThat(timestampMapping.leader()).isEqualTo(id);
+    }
+
+    @Test
+    public void singleDistinctLeaderMappingIsValid() {
+        UUID id = UUID.randomUUID();
+        ImmutableTimestampMapping timestampMapping = TimestampMapping.builder()
+                .putTimestampMapping(1L, LockWatchVersion.of(id, 1))
+                .putTimestampMapping(2L, LockWatchVersion.of(id, 1))
+                .build();
+        assertThat(timestampMapping.leader()).isEqualTo(id);
+    }
+
+    @Test
+    public void conflictingLeaderMappingIsInvalid() {
+        ImmutableTimestampMapping.Builder builder = TimestampMapping.builder()
+                .putTimestampMapping(1L, LockWatchVersion.of(UUID.randomUUID(), 1))
+                .putTimestampMapping(2L, LockWatchVersion.of(UUID.randomUUID(), 1));
+
+        assertThatThrownBy(builder::build)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Input contains multiple distinct elements");
+    }
+
+    @Test
+    public void emptyMappingIsInvalid() {
+        assertThatThrownBy(() -> TimestampMapping.builder().build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid range");
+    }
+
+    @Test
+    public void onlyIdenticalElements() {
+        assertThat(TimestampMapping.identicalElement(List.of("test"))).isEqualTo("test");
+        assertThat(TimestampMapping.identicalElement(Iterables.limit(Iterables.cycle("test"), 1000)))
+                .isEqualTo("test");
+        assertThat(TimestampMapping.identicalElement(Iterables.limit(Iterables.cycle(42L), 1000)))
+                .isEqualTo(42L);
+    }
+
+    @Test
+    public void emptyDistinctElements() {
+        assertThatThrownBy(() -> TimestampMapping.identicalElement(List.of()))
+                .isInstanceOf(NoSuchElementException.class);
+    }
+
+    @Test
+    public void multipleDistinctElements() {
+        assertThatThrownBy(() -> TimestampMapping.identicalElement(List.of("a", "b", "a")))
+                .isInstanceOf(SafeIllegalArgumentException.class)
+                .hasMessageContaining("Input contains multiple distinct elements");
+        assertThatThrownBy(() -> TimestampMapping.identicalElement(List.of("a", "a", "b")))
+                .isInstanceOf(SafeIllegalArgumentException.class)
+                .hasMessageContaining("Input contains multiple distinct elements");
+    }
+}

--- a/changelog/@unreleased/pr-6506.v2.yml
+++ b/changelog/@unreleased/pr-6506.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Optimize TimestampMapping::leader to avoid stream overhead
+  links:
+  - https://github.com/palantir/atlasdb/pull/6506


### PR DESCRIPTION
## General
**Before this PR**:

`com.palantir.atlasdb.keyvalue.api.watch.TimestampMapping.leader():50` is on a hot path finding the distinct leader for given `LockWatchVersion`s and could be optimized

![image](https://user-images.githubusercontent.com/54594/229944709-f995f515-952b-43fc-ac8c-17ebdae84b8f.png)


**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Optimize TimestampMapping::leader to avoid stream overhead
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
