### PR TITLE
Fix bug in workload server when failing to fetch commit timestamp due to network errors

### DIFF
--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/store/AtlasDbTransactionStore.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/store/AtlasDbTransactionStore.java
@@ -16,12 +16,14 @@
 
 package com.palantir.atlasdb.workload.store;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Suppliers;
 import com.google.common.primitives.Ints;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.transaction.api.PreCommitCondition;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
-import com.palantir.atlasdb.transaction.service.TransactionStatus;
 import com.palantir.atlasdb.workload.transaction.DeleteTransactionAction;
 import com.palantir.atlasdb.workload.transaction.ReadTransactionAction;
 import com.palantir.atlasdb.workload.transaction.TransactionAction;
@@ -33,6 +35,7 @@ import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedTransactionA
 import com.palantir.atlasdb.workload.util.AtlasDbUtils;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.util.List;
@@ -41,7 +44,9 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import javax.annotation.concurrent.NotThreadSafe;
 import one.util.streamex.EntryStream;
 
 public final class AtlasDbTransactionStore implements TransactionStore {
@@ -70,8 +75,10 @@ public final class AtlasDbTransactionStore implements TransactionStore {
     public Optional<WitnessedTransaction> readWrite(List<TransactionAction> actions) {
         AtomicReference<Long> startTimestampReference = new AtomicReference<>();
         AtomicReference<List<WitnessedTransactionAction>> witnessedActionsReference = new AtomicReference<>();
+        Supplier<CommitTimestampProvider> commitTimestampProvider =
+                Suppliers.memoize(() -> new CommitTimestampProvider());
         try {
-            transactionManager.runTaskWithRetry(txn -> {
+            transactionManager.runTaskWithConditionWithRetry(commitTimestampProvider, (txn, _condition) -> {
                 AtlasDbTransactionActionVisitor visitor = new AtlasDbTransactionActionVisitor(txn);
                 startTimestampReference.set(txn.getTimestamp());
                 witnessedActionsReference.set(actions.stream()
@@ -80,15 +87,11 @@ public final class AtlasDbTransactionStore implements TransactionStore {
                         .collect(Collectors.toList()));
                 return null;
             });
-
-            TransactionStatus status =
-                    transactionManager.getTransactionService().getV2(startTimestampReference.get());
-
-            Optional<Long> commitTimestamp = TransactionStatus.getCommitTimestamp(status);
-
             return Optional.of(ImmutableWitnessedTransaction.builder()
                     .startTimestamp(startTimestampReference.get())
-                    .commitTimestamp(commitTimestamp)
+                    .commitTimestamp(commitTimestampProvider
+                            .get()
+                            .getCommitTimestampOrThrowIfMaybeNotCommitted(startTimestampReference.get()))
                     .actions(witnessedActionsReference.get())
                     .build());
         } catch (SafeIllegalArgumentException e) {
@@ -157,5 +160,28 @@ public final class AtlasDbTransactionStore implements TransactionStore {
                 .mapToEntry(TableReference::getTableName, Function.identity())
                 .toMap();
         return new AtlasDbTransactionStore(transactionManager, tableMapping);
+    }
+
+    @VisibleForTesting
+    @NotThreadSafe
+    static final class CommitTimestampProvider implements PreCommitCondition {
+
+        private Optional<Long> maybeCommitOrStartTimestamp = Optional.empty();
+
+        @Override
+        public void throwIfConditionInvalid(long timestamp) {
+            maybeCommitOrStartTimestamp = Optional.of(timestamp);
+        }
+
+        public Optional<Long> getCommitTimestampOrThrowIfMaybeNotCommitted(long startTimestamp) {
+            long commitOrStartTimestamp = maybeCommitOrStartTimestamp.orElseThrow(() -> new SafeIllegalStateException(
+                    "Timestamp has not been set, which means the pre commit condition has never been executed,"
+                            + " thus the transaction never committed."));
+            if (startTimestamp == commitOrStartTimestamp) {
+                return Optional.empty();
+            }
+
+            return Optional.of(commitOrStartTimestamp);
+        }
     }
 }

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/store/AtlasDbTransactionStoreTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/store/AtlasDbTransactionStoreTest.java
@@ -27,13 +27,17 @@ import static com.palantir.atlasdb.workload.transaction.WorkloadTestHelpers.WORK
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Iterables;
 import com.palantir.atlasdb.factory.TransactionManagers;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
+import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.atlasdb.workload.store.AtlasDbTransactionStore.CommitTimestampProvider;
 import com.palantir.atlasdb.workload.transaction.DeleteTransactionAction;
@@ -51,6 +55,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Test;
@@ -60,6 +65,12 @@ public final class AtlasDbTransactionStoreTest {
     private static final long START_TS = 1;
     private static final long COMMIT_TS = 2;
 
+    private static final Map<TableReference, byte[]> TABLES = Map.of(
+            TABLE_REFERENCE,
+            AtlasDbUtils.tableMetadata(ConflictHandler.SERIALIZABLE),
+            INDEX_REFERENCE,
+            AtlasDbUtils.indexMetadata(ConflictHandler.SERIALIZABLE));
+
     private TransactionManager manager;
 
     private AtlasDbTransactionStore store;
@@ -67,13 +78,7 @@ public final class AtlasDbTransactionStoreTest {
     @Before
     public void before() {
         manager = TransactionManagers.createInMemory(Set.of());
-        store = AtlasDbTransactionStore.create(
-                manager,
-                Map.of(
-                        TABLE_REFERENCE,
-                        AtlasDbUtils.tableMetadata(ConflictHandler.SERIALIZABLE),
-                        INDEX_REFERENCE,
-                        AtlasDbUtils.indexMetadata(ConflictHandler.SERIALIZABLE)));
+        store = AtlasDbTransactionStore.create(manager, TABLES);
     }
 
     @Test
@@ -149,6 +154,17 @@ public final class AtlasDbTransactionStoreTest {
                 store.readWrite(List.of(ReadTransactionAction.of(TABLE_1, WORKLOAD_CELL_ONE)));
         assertThat(witnessedTransaction).isPresent();
         assertThat(witnessedTransaction.get().commitTimestamp()).isEmpty();
+    }
+
+    @Test
+    public void abortedTransactionsReturnEmpty() {
+        TransactionManager onlyAbortsManager = spy(manager);
+        Transaction abortedTransaction = mock(Transaction.class);
+        when(abortedTransaction.isAborted()).thenReturn(true);
+        doReturn(abortedTransaction).when(onlyAbortsManager).runTaskWithConditionWithRetry(any(Supplier.class), any());
+        AtlasDbTransactionStore onlyAbortsStore = AtlasDbTransactionStore.create(onlyAbortsManager, TABLES);
+        assertThat(onlyAbortsStore.readWrite(List.of(ReadTransactionAction.of(TABLE_1, WORKLOAD_CELL_ONE))))
+                .isEmpty();
     }
 
     @Test


### PR DESCRIPTION
## General
**Before this PR**:
If any network errors occurs _after_ we've successfully ran a transaction when obtaining the commit timestamp, we fail, and as result do not track a witnessed transaction! 

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Obtain commit timestamp from the transaction itself to be resilient to network failures after a transaction has been witnessed. 
==COMMIT_MSG==

**Priority**:
P0

**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
