### PR TITLE
Run gradle with build scans

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           key: gradle-cache-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}
 
       - run: git tag -l | xargs git tag -d && git fetch -t # ensure all tags are fetched and up-to-date
-      - run: ./gradlew --profile --parallel --stacktrace classes testClasses
+      - run: ./gradlew --scan --profile --parallel --stacktrace classes testClasses
 
       - save_cache:
           key: gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
@@ -95,7 +95,7 @@ jobs:
       CIRCLE_ARTIFACTS: /tmp/artifacts
     steps:
       - attach_workspace: { at: . }
-      - run: ./gradlew --profile --stacktrace --continue publishToMavenLocal
+      - run: ./gradlew --scan --profile --stacktrace --continue publishToMavenLocal
 
   deploy:
     docker:
@@ -118,7 +118,7 @@ jobs:
             # hack - notion of "owners" isn't supported in Circle 2
             if [ $CIRCLE_PROJECT_USERNAME = 'palantir' ] && [ -z $CIRCLE_PR_NUMBER ]; then
               git status
-              ./gradlew --profile --stacktrace --continue publish
+              ./gradlew --scan --profile --stacktrace --continue publish
             fi
       - run:
           command: |

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,9 @@
+plugins {
+    id "com.gradle.enterprise" version "3.12.6"
+}
+
 rootProject.name = 'atlasdb'
+
 include ":atlasdb-api"
 include ":atlasdb-autobatch"
 include ":atlasdb-cassandra"
@@ -78,5 +83,13 @@ boolean isCiServer = System.getenv().containsKey('CI')
 buildCache {
     local {
         enabled = !isCiServer
+    }
+}
+
+gradleEnterprise {
+    buildScan {
+        termsOfServiceUrl = "https://gradle.com/terms-of-service"
+        termsOfServiceAgree = "yes"
+        uploadInBackground = !isCiServer
     }
 }


### PR DESCRIPTION
Add some scan data to collect more information about runs in CircleCI for performance analysis. This won't enable scans by default when run locally on workstations.