### PR TITLE
Make test query optional

### DIFF
--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/HikariCPConnectionManager.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/HikariCPConnectionManager.java
@@ -246,19 +246,20 @@ public class HikariCPConnectionManager extends BaseConnectionManager {
      * @throws SQLException if connection is invalid and cannot be used.
      */
     private void testConnection(Connection connection) throws SQLException {
-        if (connConfig.getTestQuery().isEmpty()) {
-            if (!connection.isValid(connConfig.getSocketTimeoutSeconds())) {
-                throw new SQLException(String.format("Connection %s is not valid", connection));
-            }
-        } else {
-            try (PreparedStatement stmt = connection.prepareStatement(connConfig.getTestQuery())) {
+        if (connConfig.getTestQuery().isPresent()) {
+            try (PreparedStatement stmt =
+                    connection.prepareStatement(connConfig.getTestQuery().get())) {
                 stmt.setFetchSize(1); // only need first row result
                 ResultSet rs = stmt.executeQuery();
                 if (!rs.next()) {
                     throw new SQLException(String.format(
                             "Connection %s could not be validated as it did not return any results for test query %s",
-                            connection, connConfig.getTestQuery()));
+                            connection, connConfig.getTestQuery().get()));
                 }
+            }
+        } else {
+            if (!connection.isValid(connConfig.getSocketTimeoutSeconds())) {
+                throw new SQLException(String.format("Connection %s is not valid", connection));
             }
         }
     }

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
@@ -58,10 +58,7 @@ public abstract class ConnectionConfig {
 
     public abstract String getDriverClass();
 
-    @Value.Default
-    public String getTestQuery() {
-        return "";
-    }
+    public abstract Optional<String> getTestQuery();
 
     @JsonIgnore
     @Value.Derived
@@ -185,8 +182,8 @@ public abstract class ConnectionConfig {
 
         initializeFailTimeoutMillis().ifPresent(config::setInitializationFailTimeout);
 
-        if (!getTestQuery().isEmpty()) {
-            config.setConnectionTestQuery(getTestQuery());
+        if (getTestQuery().isPresent()) {
+            config.setConnectionTestQuery(getTestQuery().get());
         }
 
         if (getSqlExceptionOverrideClass().isPresent()) {


### PR DESCRIPTION
Small FLUP to https://github.com/palantir/atlasdb/pull/6499 that more accurately represents the intention of the test query config by using `Optional` rather than an empty string to indicate no test query.