### PR TITLE
[Antithesis] Test Run: Bouncing Value Workflow

### DIFF
--- a/atlasdb-workload-server-distribution/src/main/java/com/palantir/atlasdb/workload/WorkloadServerLauncher.java
+++ b/atlasdb-workload-server-distribution/src/main/java/com/palantir/atlasdb/workload/WorkloadServerLauncher.java
@@ -28,6 +28,7 @@ import com.palantir.atlasdb.workload.invariant.DurableWritesInvariantMetricRepor
 import com.palantir.atlasdb.workload.invariant.SerializableInvariantLogReporter;
 import com.palantir.atlasdb.workload.runner.AntithesisWorkflowRunner;
 import com.palantir.atlasdb.workload.store.AtlasDbTransactionStoreFactory;
+import com.palantir.atlasdb.workload.store.IsolationLevel;
 import com.palantir.atlasdb.workload.workflow.BouncingValueWorkflow;
 import com.palantir.atlasdb.workload.workflow.SingleRowTwoCellsWorkflowConfiguration;
 import com.palantir.atlasdb.workload.workflow.SingleRowTwoCellsWorkflows;
@@ -99,8 +100,8 @@ public class WorkloadServerLauncher extends Application<WorkloadServerConfigurat
         AntithesisWorkflowRunner.INSTANCE.run(
                 BouncingValueWorkflow.createBouncingValue(transactionStoreFactory.create(
                         Map.of(
-                                workflowConfig.tableConfiguration().tableName(),
-                                workflowConfig.tableConfiguration().isolationLevel()),
+                                BouncingValueWorkflow.TEST_TABLE,
+                                IsolationLevel.SERIALIZABLE),
                         Set.of())),
                 //                SingleRowTwoCellsWorkflows.createSingleRowTwoCell(
                 //                        transactionStoreFactory.create(

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/store/AtlasDbTransactionStoreFactory.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/store/AtlasDbTransactionStoreFactory.java
@@ -50,7 +50,7 @@ public final class AtlasDbTransactionStoreFactory implements TransactionStoreFac
     }
 
     @Override
-    public TransactionStore create(Map<String, IsolationLevel> tables, Set<IndexTable> indexes) {
+    public InteractiveTransactionStore create(Map<String, IsolationLevel> tables, Set<IndexTable> indexes) {
         return AtlasDbTransactionStore.create(transactionManager, toAtlasTables(tables, indexes));
     }
 

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/workflow/BouncingValueWorkflow.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/workflow/BouncingValueWorkflow.java
@@ -41,7 +41,7 @@ import java.util.stream.Stream;
 import one.util.streamex.StreamEx;
 
 public class BouncingValueWorkflow {
-    private static final String TEST_TABLE = "bouncingValue";
+    public static final String TEST_TABLE = "bouncingValue";
     private static final WorkloadCell BUSY_CELL = ImmutableWorkloadCell.of(1, 1);
 
     public static Workflow createBouncingValue(InteractiveTransactionStore store) {

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/workflow/BouncingValueWorkflow.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/workflow/BouncingValueWorkflow.java
@@ -1,0 +1,104 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.workload.workflow;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.palantir.atlasdb.workload.store.ImmutableWorkloadCell;
+import com.palantir.atlasdb.workload.store.InteractiveTransactionStore;
+import com.palantir.atlasdb.workload.store.ReadOnlyTransactionStore;
+import com.palantir.atlasdb.workload.store.WorkloadCell;
+import com.palantir.atlasdb.workload.transaction.DeleteTransactionAction;
+import com.palantir.atlasdb.workload.transaction.WriteTransactionAction;
+import com.palantir.atlasdb.workload.transaction.witnessed.FullyWitnessedTransaction;
+import com.palantir.atlasdb.workload.transaction.witnessed.OnlyCommittedWitnessedTransactionVisitor;
+import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedTransaction;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import one.util.streamex.StreamEx;
+
+public class BouncingValueWorkflow {
+    private static final String TEST_TABLE = "bouncingValue";
+    private static final WorkloadCell BUSY_CELL = ImmutableWorkloadCell.of(1, 1);
+
+    public static Workflow createBouncingValue(InteractiveTransactionStore store) {
+        return new Workflow() {
+            @Override
+            public WorkflowHistory run() {
+                ListeningExecutorService readExecutor =
+                        MoreExecutors.listeningDecorator(Executors.newSingleThreadExecutor());
+                ListeningExecutorService writeExecutor =
+                        MoreExecutors.listeningDecorator(Executors.newSingleThreadExecutor());
+                List<ListenableFuture<Optional<WitnessedTransaction>>> reads = IntStream.range(0, 1_000)
+                        .mapToObj(idx -> readExecutor.submit(() -> {
+                            return store.readWrite(txn -> {
+                                Optional<Integer> value = txn.read(TEST_TABLE, BUSY_CELL);
+                                txn.write(TEST_TABLE, BUSY_CELL, value.orElse(-1));
+                            });
+                        }))
+                        .collect(Collectors.toList());
+
+                List<ListenableFuture<Optional<WitnessedTransaction>>> writes = new ArrayList<>();
+                for (int i = 0; i < 500; i++) {
+                    int stableI = i;
+                    writes.add(writeExecutor.submit(
+                            () -> store.readWrite(List.of(WriteTransactionAction.of(TEST_TABLE, BUSY_CELL, stableI)))));
+                    writes.add(writeExecutor.submit(
+                            () -> store.readWrite(List.of(DeleteTransactionAction.of(TEST_TABLE, BUSY_CELL)))));
+                }
+                ListenableFuture<List<WitnessedTransaction>> witnessedTransactions = Futures.transform(
+                        Futures.allAsList(Stream.of(reads, writes)
+                                .flatMap(Collection::stream)
+                                .collect(Collectors.toList())),
+                        maybeWitnessedTransactions -> maybeWitnessedTransactions.stream()
+                                .flatMap(Optional::stream)
+                                .collect(Collectors.toList()),
+                        MoreExecutors.directExecutor());
+                ReadOnlyTransactionStore readOnlyTransactionStore = new ReadOnlyTransactionStore(store);
+                return ImmutableWorkflowHistory.builder()
+                        .addAllHistory(sortAndFilterTransactions(
+                                readOnlyTransactionStore, Futures.getUnchecked(witnessedTransactions)))
+                        .transactionStore(readOnlyTransactionStore)
+                        .build();
+            }
+        };
+    }
+
+    // Naughty
+    static List<FullyWitnessedTransaction> sortAndFilterTransactions(
+            ReadOnlyTransactionStore readOnlyTransactionStore, List<WitnessedTransaction> unorderedTransactions) {
+        OnlyCommittedWitnessedTransactionVisitor visitor =
+                new OnlyCommittedWitnessedTransactionVisitor(readOnlyTransactionStore);
+        return StreamEx.of(unorderedTransactions)
+                .mapPartial(transaction -> transaction.accept(visitor))
+                .sorted(Comparator.comparingLong(BouncingValueWorkflow::effectiveTimestamp))
+                .toList();
+    }
+
+    private static long effectiveTimestamp(WitnessedTransaction witnessedTransaction) {
+        return witnessedTransaction.commitTimestamp().orElseGet(witnessedTransaction::startTimestamp);
+    }
+}


### PR DESCRIPTION
Introduces a new workflow. This maintains two threads:
- the **writer thread** consistently alternates between writing a value `V` to a cell `C`, and deleting the value from the cell `C`
- the **reader thread** consistently reads `C`, and writes to some random cell `D`.

We also introduce a bug:
- we now perform read write conflict checks only **after** we check our immutable timestamp and commit locks.
- I added some buggifying logic to hopefully make flushing this out easier.

The nature of how exactly this produces a serializable invariant violation is left as an exercise to the reader. 😅 