### PR TITLE
[CBT] Run build with 2xlarge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     docker:
       - image: cimg/openjdk:11.0.10-node
-    resource_class: xlarge
+    resource_class: 2xlarge
     environment:
       GRADLE_OPTS: -Dorg.gradle.console=plain -Dorg.gradle.internal.launcher.welcomeMessageEnabled=false
       _JAVA_OPTIONS: "-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Xlog:class+unload=off -Xlog:gc:build-%t-%p.gc.log"

--- a/changelog/@unreleased/pr-6540.v2.yml
+++ b/changelog/@unreleased/pr-6540.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '[CBT] Run build with 2xlarge'
+  links:
+  - https://github.com/palantir/atlasdb/pull/6540


### PR DESCRIPTION
Build jobs will run 15% faster, and do not run into DaemonDisappearedException