### PR TITLE
[CBT] Reorganize test job parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           paths: [ . ]
 
   test:
-    parallelism: 13
+    parallelism: 14
     machine:
       image: ubuntu-2004:202111-02
     resource_class: xlarge

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           paths: [ . ]
 
   test:
-    parallelism: 12
+    parallelism: 13
     machine:
       image: ubuntu-2004:202111-02
     resource_class: xlarge

--- a/atlasdb-cassandra-integration-tests/build.gradle
+++ b/atlasdb-cassandra-integration-tests/build.gradle
@@ -56,6 +56,24 @@ test {
     exclude '**/CassandraKeyValueServiceSweepTaskRunnerIntegrationTest.class'
 }
 
+task testSubset1(type: Test) {
+    include '**/CassandraKeyValueServiceTableCreationIntegrationTest.class'
+    include '**/CassandraKeyValueServiceTableManipulationIntegrationTest.class'
+    include '**/CassandraKeyValueServiceTransactionIntegrationTest.class'
+    include '**/CassandraKvsAsyncFallbackMechanismsTests.class'
+    include '**/CassandraKvsSerializableTransactionTest.class'
+}
+
+task testSubset2(type: Test) {
+    include '**/*Test.class'
+    include '**/*Tests.class'
+    exclude '**/CassandraKeyValueServiceTableCreationIntegrationTest.class'
+    exclude '**/CassandraKeyValueServiceTableManipulationIntegrationTest.class'
+    exclude '**/CassandraKeyValueServiceTransactionIntegrationTest.class'
+    exclude '**/CassandraKvsAsyncFallbackMechanismsTests.class'
+    exclude '**/CassandraKvsSerializableTransactionTest.class'
+}
+
 tasks.withType(Test) {
     testLogging {
         // set options for log level LIFECYCLE

--- a/changelog/@unreleased/pr-6548.v2.yml
+++ b/changelog/@unreleased/pr-6548.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '[CBT] Reorganize test job parallelism'
+  links:
+  - https://github.com/palantir/atlasdb/pull/6548

--- a/scripts/circle-ci/run-circle-tests.sh
+++ b/scripts/circle-ci/run-circle-tests.sh
@@ -19,7 +19,7 @@ CONTAINER_2=(':atlasdb-ete-tests:check')
 
 CONTAINER_3=(':atlasdb-dbkvs:check' ':atlasdb-cassandra:check' ':timelock-server:integTest')
 
-CONTAINER_4=(':atlasdb-cassandra-multinode-tests:check' ':atlasdb-impl-shared:check' ':atlasdb-tests-shared:check' ':atlasdb-perf:check' ':atlasdb-ete-tests:dbkvsTest')
+CONTAINER_4=(':atlasdb-cassandra-multinode-tests:check' ':atlasdb-tests-shared:check' ':atlasdb-perf:check' ':atlasdb-ete-tests:dbkvsTest')
 
 CONTAINER_5=(':lock-impl:check' ':atlasdb-dbkvs-tests:postgresTest' ':atlasdb-ete-test-utils:check' ':atlasdb-ete-tests:longTest')
 
@@ -33,10 +33,12 @@ CONTAINER_9=(':atlasdb-ete-tests:oracleTest')
 
 CONTAINER_10=('atlasdb-dbkvs-tests:oracleTest')
 
-CONTAINER_11=('compileJava' 'compileTestJava')
+CONTAINER_11=(':atlasdb-impl-shared:check' )
+
+CONTAINER_12=('compileJava' 'compileTestJava')
 
 # Container 0 - runs tasks not found in the below containers
-CONTAINER_0_EXCLUDE=("${CONTAINER_1[@]}" "${CONTAINER_2[@]}" "${CONTAINER_3[@]}" "${CONTAINER_4[@]}" "${CONTAINER_5[@]}" "${CONTAINER_6[@]}" "${CONTAINER_7[@]}" "${CONTAINER_8[@]}" "${CONTAINER_9[@]}" "${CONTAINER_10[@]}")
+CONTAINER_0_EXCLUDE=("${CONTAINER_1[@]}" "${CONTAINER_2[@]}" "${CONTAINER_3[@]}" "${CONTAINER_4[@]}" "${CONTAINER_5[@]}" "${CONTAINER_6[@]}" "${CONTAINER_7[@]}" "${CONTAINER_8[@]}" "${CONTAINER_9[@]}" "${CONTAINER_10[@]}" "${CONTAINER_11[@]}")
 
 for task in "${CONTAINER_0_EXCLUDE[@]}"
 do
@@ -64,7 +66,7 @@ JAVA_GC_LOGGING_OPTIONS="${JAVA_GC_LOGGING_OPTIONS} -Xlog:class+unload=off"
 JAVA_GC_LOGGING_OPTIONS="${JAVA_GC_LOGGING_OPTIONS} -Xlog:gc:build-%t-%p.gc.log"
 
 # External builds have a 16gb limit.
-if [ "$CIRCLE_NODE_INDEX" -eq "11" ]; then
+if [ "$CIRCLE_NODE_INDEX" -eq "12" ]; then
     export _JAVA_OPTIONS="-Xms2g -Xmx4g -XX:ActiveProcessorCount=8 ${JAVA_GC_LOGGING_OPTIONS}"
 else
     export _JAVA_OPTIONS="-Xmx4g ${JAVA_GC_LOGGING_OPTIONS}"
@@ -85,5 +87,6 @@ case $CIRCLE_NODE_INDEX in
     8) ./gradlew $BASE_GRADLE_ARGS ${CONTAINER_8[@]} ;;
     9) ./gradlew $BASE_GRADLE_ARGS ${CONTAINER_9[@]} ;;
     10) ./gradlew $BASE_GRADLE_ARGS ${CONTAINER_10[@]} ;;
-    11) ./gradlew $BASE_GRADLE_ARGS ${CONTAINER_11[@]} --stacktrace -PenableErrorProne=true && checkDocsBuild ;;
+    10) ./gradlew $BASE_GRADLE_ARGS ${CONTAINER_11[@]} ;;
+    11) ./gradlew $BASE_GRADLE_ARGS ${CONTAINER_12[@]} --stacktrace -PenableErrorProne=true && checkDocsBuild ;;
 esac

--- a/scripts/circle-ci/run-circle-tests.sh
+++ b/scripts/circle-ci/run-circle-tests.sh
@@ -13,7 +13,7 @@ function checkDocsBuild {
      make html
 }
 
-CONTAINER_1=(':atlasdb-cassandra-integration-tests:check')
+CONTAINER_1=(':atlasdb-cassandra-integration-tests:testSubset1')
 
 CONTAINER_2=(':atlasdb-ete-tests:check')
 
@@ -35,10 +35,15 @@ CONTAINER_10=('atlasdb-dbkvs-tests:oracleTest')
 
 CONTAINER_11=(':atlasdb-impl-shared:check' )
 
-CONTAINER_12=('compileJava' 'compileTestJava')
+CONTAINER_12=(':atlasdb-cassandra-integration-tests:testSubset2')
+
+CONTAINER_13=('compileJava' 'compileTestJava')
+
+# Excluded as it is split into two subsets
+EXCLUDED=(':atlasdb-cassandra-integration-tests:check')
 
 # Container 0 - runs tasks not found in the below containers
-CONTAINER_0_EXCLUDE=("${CONTAINER_1[@]}" "${CONTAINER_2[@]}" "${CONTAINER_3[@]}" "${CONTAINER_4[@]}" "${CONTAINER_5[@]}" "${CONTAINER_6[@]}" "${CONTAINER_7[@]}" "${CONTAINER_8[@]}" "${CONTAINER_9[@]}" "${CONTAINER_10[@]}" "${CONTAINER_11[@]}")
+CONTAINER_0_EXCLUDE=("${CONTAINER_1[@]}" "${CONTAINER_2[@]}" "${CONTAINER_3[@]}" "${CONTAINER_4[@]}" "${CONTAINER_5[@]}" "${CONTAINER_6[@]}" "${CONTAINER_7[@]}" "${CONTAINER_8[@]}" "${CONTAINER_9[@]}" "${CONTAINER_10[@]}" "${CONTAINER_11[@]}" "${CONTAINER_12[@]}" "${EXCLUDED[@]}")
 
 for task in "${CONTAINER_0_EXCLUDE[@]}"
 do
@@ -66,7 +71,7 @@ JAVA_GC_LOGGING_OPTIONS="${JAVA_GC_LOGGING_OPTIONS} -Xlog:class+unload=off"
 JAVA_GC_LOGGING_OPTIONS="${JAVA_GC_LOGGING_OPTIONS} -Xlog:gc:build-%t-%p.gc.log"
 
 # External builds have a 16gb limit.
-if [ "$CIRCLE_NODE_INDEX" -eq "12" ]; then
+if [ "$CIRCLE_NODE_INDEX" -eq "13" ]; then
     export _JAVA_OPTIONS="-Xms2g -Xmx4g -XX:ActiveProcessorCount=8 ${JAVA_GC_LOGGING_OPTIONS}"
 else
     export _JAVA_OPTIONS="-Xmx4g ${JAVA_GC_LOGGING_OPTIONS}"
@@ -87,6 +92,7 @@ case $CIRCLE_NODE_INDEX in
     8) ./gradlew $BASE_GRADLE_ARGS ${CONTAINER_8[@]} ;;
     9) ./gradlew $BASE_GRADLE_ARGS ${CONTAINER_9[@]} ;;
     10) ./gradlew $BASE_GRADLE_ARGS ${CONTAINER_10[@]} ;;
-    10) ./gradlew $BASE_GRADLE_ARGS ${CONTAINER_11[@]} ;;
-    11) ./gradlew $BASE_GRADLE_ARGS ${CONTAINER_12[@]} --stacktrace -PenableErrorProne=true && checkDocsBuild ;;
+    11) ./gradlew $BASE_GRADLE_ARGS ${CONTAINER_11[@]} ;;
+    12) ./gradlew $BASE_GRADLE_ARGS ${CONTAINER_12[@]} ;;
+    13) ./gradlew $BASE_GRADLE_ARGS ${CONTAINER_13[@]} --stacktrace -PenableErrorProne=true && checkDocsBuild ;;
 esac


### PR DESCRIPTION
Splitting tests differently (increased parallelism) now results in all containers (except the one running `timeLockMigrationTest`) finishing with a runtime around 8 minutes.

`timeLockMigrationTest` will be moved to only run when we make a release.