### PR TITLE
Add current pool size metric 

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -366,9 +366,9 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
         Preconditions.checkState(
                 !getCurrentPools().isEmpty() || serversToAdd.isEmpty(),
                 "No servers were successfully added to the pool. This means we could not come to a consensus on"
-                        + " cluster topology, and the client cannot connect as there are no valid hosts. This state should"
-                        + " be transient (<5 minutes), and if it is not, indicates that the user may have accidentally"
-                        + " configured AltasDB to use two separate Cassandra clusters (i.e., user-led split brain).",
+                    + " cluster topology, and the client cannot connect as there are no valid hosts. This state should"
+                    + " be transient (<5 minutes), and if it is not, indicates that the user may have accidentally"
+                    + " configured AltasDB to use two separate Cassandra clusters (i.e., user-led split brain).",
                 SafeArg.of("serversToAdd", CassandraLogHelper.collectionOfHosts(serversToAdd.keySet())));
 
         logRefreshedHosts(validatedServersToAdd, serversToShutdown, absentServers);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -361,12 +361,14 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
             cassandra.refreshTokenRangesAndGetServers();
         }
 
+        metrics.recordPoolSize(getCurrentPools().size());
+
         Preconditions.checkState(
                 !getCurrentPools().isEmpty() || serversToAdd.isEmpty(),
                 "No servers were successfully added to the pool. This means we could not come to a consensus on"
-                    + " cluster topology, and the client cannot connect as there are no valid hosts. This state should"
-                    + " be transient (<5 minutes), and if it is not, indicates that the user may have accidentally"
-                    + " configured AltasDB to use two separate Cassandra clusters (i.e., user-led split brain).",
+                        + " cluster topology, and the client cannot connect as there are no valid hosts. This state should"
+                        + " be transient (<5 minutes), and if it is not, indicates that the user may have accidentally"
+                        + " configured AltasDB to use two separate Cassandra clusters (i.e., user-led split brain).",
                 SafeArg.of("serversToAdd", CassandraLogHelper.collectionOfHosts(serversToAdd.keySet())));
 
         logRefreshedHosts(validatedServersToAdd, serversToShutdown, absentServers);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -359,16 +359,15 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
 
         if (!(validatedServersToAdd.isEmpty() && absentServers.isEmpty())) { // if we made any changes
             cassandra.refreshTokenRangesAndGetServers();
+            metrics.recordPoolSize(getCurrentPools().size());
         }
-
-        metrics.recordPoolSize(getCurrentPools().size());
 
         Preconditions.checkState(
                 !getCurrentPools().isEmpty() || serversToAdd.isEmpty(),
                 "No servers were successfully added to the pool. This means we could not come to a consensus on"
-                    + " cluster topology, and the client cannot connect as there are no valid hosts. This state should"
-                    + " be transient (<5 minutes), and if it is not, indicates that the user may have accidentally"
-                    + " configured AltasDB to use two separate Cassandra clusters (i.e., user-led split brain).",
+                        + " cluster topology, and the client cannot connect as there are no valid hosts. This state should"
+                        + " be transient (<5 minutes), and if it is not, indicates that the user may have accidentally"
+                        + " configured AltasDB to use two separate Cassandra clusters (i.e., user-led split brain).",
                 SafeArg.of("serversToAdd", CassandraLogHelper.collectionOfHosts(serversToAdd.keySet())));
 
         logRefreshedHosts(validatedServersToAdd, serversToShutdown, absentServers);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -365,9 +365,9 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
         Preconditions.checkState(
                 !getCurrentPools().isEmpty() || serversToAdd.isEmpty(),
                 "No servers were successfully added to the pool. This means we could not come to a consensus on"
-                        + " cluster topology, and the client cannot connect as there are no valid hosts. This state should"
-                        + " be transient (<5 minutes), and if it is not, indicates that the user may have accidentally"
-                        + " configured AltasDB to use two separate Cassandra clusters (i.e., user-led split brain).",
+                    + " cluster topology, and the client cannot connect as there are no valid hosts. This state should"
+                    + " be transient (<5 minutes), and if it is not, indicates that the user may have accidentally"
+                    + " configured AltasDB to use two separate Cassandra clusters (i.e., user-led split brain).",
                 SafeArg.of("serversToAdd", CassandraLogHelper.collectionOfHosts(serversToAdd.keySet())));
 
         logRefreshedHosts(validatedServersToAdd, serversToShutdown, absentServers);

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraClientPoolMetricsTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraClientPoolMetricsTest.java
@@ -33,6 +33,8 @@ public class CassandraClientPoolMetricsTest {
     private final MetricsManager metricsManager =
             MetricsManagers.of(new MetricRegistry(), new DefaultTaggedMetricRegistry(), Refreshable.only(true));
 
+    private final CassandraClientPoolMetrics metrics = new CassandraClientPoolMetrics(metricsManager);
+
     @Test
     public void metricsAreProducedAndFiltered() {
         CassandraClientPoolMetrics metrics = new CassandraClientPoolMetrics(metricsManager);
@@ -55,6 +57,18 @@ public class CassandraClientPoolMetricsTest {
                 .doesNotContainKey(createMeanActiveTimeMillisMetric("pool2"))
                 .containsKey(createMeanActiveTimeMillisMetric("pool3"))
                 .containsKey(createMeanActiveTimeMillisMetric("mean"));
+    }
+
+    @Test
+    public void recordPoolSizeSetsSizeToLastReportedValue() {
+        metrics.recordPoolSize(100);
+        assertThat(metrics.getPoolSize()).isEqualTo(100);
+        metrics.recordPoolSize(-13);
+        assertThat(metrics.getPoolSize()).isEqualTo(-13);
+        metrics.recordPoolSize(25);
+        assertThat(metrics.getPoolSize()).isEqualTo(25);
+        metrics.recordPoolSize(0);
+        assertThat(metrics.getPoolSize()).isEqualTo(0);
     }
 
     private static MetricName createMeanActiveTimeMillisMetric(String pool) {

--- a/changelog/@unreleased/pr-6554.v2.yml
+++ b/changelog/@unreleased/pr-6554.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Adds metric for tracking the size of the cassandra client pool
+  links:
+  - https://github.com/palantir/atlasdb/pull/6554


### PR DESCRIPTION
## General
**Before this PR**:

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Adds metric for tracking the size of the cassandra client pool
==COMMIT_MSG==

**Priority**:
P2

**Concerns / possible downsides (what feedback would you like?)**:
N/A

**Is documentation needed?**:
N/A

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No

**Does this PR need a schema migration?**
No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
N/A

**What was existing testing like? What have you done to improve it?**:
Added tests!

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Metric will not produce! 

**Has the safety of all log arguments been decided correctly?**:
N/A

**Will this change significantly affect our spending on metrics or logs?**:
N/A

**How would I tell that this PR does not work in production? (monitors, etc.)**:
Metric will be visible

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Just rollback

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
NO

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
