### PR TITLE
Avoid boxing for Cassandra known port checks

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
@@ -17,7 +17,6 @@ package com.palantir.atlasdb.keyvalue.cassandra.pool;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableRangeMap;
@@ -62,13 +61,13 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.PrimitiveIterator.OfInt;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -77,6 +76,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.cassandra.thrift.EndpointDetails;
 import org.apache.cassandra.thrift.TokenRange;
@@ -306,16 +306,16 @@ public class CassandraService implements AutoCloseable {
     }
 
     private int getKnownPort() throws UnknownHostException {
-        // explicitly not using streams due to allocation overhead
-        return onlyPort(FluentIterable.concat(
-                        FluentIterable.from(currentPools.keySet()).transform(CassandraServer::proxy),
-                        getServersSocketAddressesFromConfig())
-                .transform(InetSocketAddress::getPort));
+        // Avoid allocations and intermediate collection as this is on hot path
+        return only(Stream.concat(
+                        currentPools.keySet().stream().map(CassandraServer::proxy),
+                        getServersSocketAddressesFromConfig().stream())
+                .mapToInt(InetSocketAddress::getPort));
     }
 
     @VisibleForTesting
-    static int onlyPort(Iterable<? extends Integer> iterable) throws UnknownHostException {
-        Iterator<? extends Integer> iterator = iterable.iterator();
+    static int only(IntStream intStream) throws UnknownHostException {
+        OfInt iterator = intStream.iterator();
         if (!iterator.hasNext()) {
             throw new UnknownHostException("No single known port");
         }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
@@ -33,7 +33,6 @@ import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.refreshable.Refreshable;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
@@ -272,12 +271,10 @@ public class CassandraServiceTest {
 
     @Test
     public void ports() throws Exception {
-        assertThat(CassandraService.onlyPort(List.of(1, 1, 1))).isEqualTo(1);
-        assertThat(IntStream.generate(() -> 4224).boxed().limit(15).collect(Collectors.toList()))
-                .hasSize(15)
-                .satisfies(cluster ->
-                        assertThat(CassandraService.onlyPort(cluster)).isEqualTo(4224));
-        assertThatThrownBy(() -> CassandraService.onlyPort(List.of(1, 2, 1)))
+        assertThat(CassandraService.only(IntStream.of(1, 1, 1))).isEqualTo(1);
+        assertThat(CassandraService.only(IntStream.generate(() -> 4224).limit(15)))
+                .isEqualTo(4224);
+        assertThatThrownBy(() -> CassandraService.only(IntStream.of(1, 2, 1)))
                 .isInstanceOf(UnknownHostException.class)
                 .hasMessageContaining("No single known port");
     }

--- a/changelog/@unreleased/pr-6562.v2.yml
+++ b/changelog/@unreleased/pr-6562.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Avoid boxing for Cassandra known port checks
+  links:
+  - https://github.com/palantir/atlasdb/pull/6562


### PR DESCRIPTION
## General
**Before this PR**:

We're allocating a lot of boxed `Integer` via `com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraService.onlyPort(Iterable):324`

![image](https://user-images.githubusercontent.com/54594/236499491-d1d409cb-5b54-4c2f-9f53-d4157fb7a048.png)


**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Avoid boxing for Cassandra known port checks
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
