### PR TITLE
[PDS-350703 and Others | i like trains] Part 4: The Meaning of What 'Is' Is / Hotfix Boolean Serialization

### DIFF
--- a/changelog/@unreleased/pr-6563.v2.yml
+++ b/changelog/@unreleased/pr-6563.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fixed a serialization issue for users of `LockServerOptions` and `LockState`
+    endpoints in the legacy lock service.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6563

--- a/lock-api/build.gradle
+++ b/lock-api/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     testImplementation 'com.palantir.common:streams'
     testImplementation 'io.dropwizard.metrics:metrics-core'
     testImplementation 'org.slf4j:slf4j-api'
+    testImplementation project(':lock-api-objects')
     testImplementation project(':lock-conjure-api:lock-conjure-api-objects')
     testImplementation project(':timelock-api:timelock-api-objects')
 

--- a/lock-api/src/main/java/com/palantir/lock/LockServerOptions.java
+++ b/lock-api/src/main/java/com/palantir/lock/LockServerOptions.java
@@ -184,8 +184,7 @@ public class LockServerOptions implements Serializable {
         return new Builder();
     }
 
-    public static final class Builder extends ImmutableLockServerOptions.Builder {
-    }
+    public static final class Builder extends ImmutableLockServerOptions.Builder {}
 
     static class SerializationProxy implements Serializable {
         private static final long serialVersionUID = 4043798817916565364L;

--- a/lock-api/src/main/java/com/palantir/lock/LockServerOptions.java
+++ b/lock-api/src/main/java/com/palantir/lock/LockServerOptions.java
@@ -48,6 +48,7 @@ public class LockServerOptions implements Serializable {
      * client accessing it.
      */
     @Value.Default
+    @JsonProperty("isStandaloneServer")
     public boolean isStandaloneServer() {
         return true;
     }
@@ -183,7 +184,8 @@ public class LockServerOptions implements Serializable {
         return new Builder();
     }
 
-    public static final class Builder extends ImmutableLockServerOptions.Builder {}
+    public static final class Builder extends ImmutableLockServerOptions.Builder {
+    }
 
     static class SerializationProxy implements Serializable {
         private static final long serialVersionUID = 4043798817916565364L;

--- a/lock-api/src/main/java/com/palantir/lock/LockState.java
+++ b/lock-api/src/main/java/com/palantir/lock/LockState.java
@@ -16,6 +16,7 @@
 
 package com.palantir.lock;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
@@ -26,8 +27,10 @@ import org.immutables.value.Value;
 @JsonSerialize(as = ImmutableLockState.class)
 @JsonDeserialize(as = ImmutableLockState.class)
 public interface LockState {
+    @JsonProperty("isWriteLocked")
     boolean isWriteLocked();
 
+    @JsonProperty("isFrozen")
     boolean isFrozen();
 
     List<LockClient> exactCurrentLockHolders();

--- a/lock-api/src/test/java/com/palantir/lock/LockServerOptionsTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/LockServerOptionsTest.java
@@ -1,0 +1,81 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.palantir.conjure.java.serialization.ObjectMappers;
+import com.palantir.lock.v2.IdentifiedTimeLockRequest;
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+
+public class LockServerOptionsTest {
+    private static final File LOCK_SERVER_OPTIONS_JSON = new File(IdentifiedTimeLockRequest.class
+            .getResource("/lock-server-options.json")
+            .getPath());
+    private static final LockServerOptions NON_STANDALONE_OPTIONS =
+            LockServerOptions.builder().isStandaloneServer(false).build();
+
+    private final ObjectMapper serverMapper = ObjectMappers.newServerObjectMapper();
+    private final ObjectMapper clientMapper = ObjectMappers.newClientObjectMapper();
+
+    @Test
+    public void serializationContainsIsStandaloneServerExplicitly() throws Exception {
+        assertThat(serverMapper.writeValueAsString(NON_STANDALONE_OPTIONS))
+                .isNotEmpty()
+                .contains("\"isStandaloneServer\":false");
+        assertThat(serverMapper.writeValueAsString(LockServerOptions.DEFAULT))
+                .isNotEmpty()
+                .contains("\"isStandaloneServer\":true");
+    }
+
+    @Test
+    public void serializationIsInverseOfDeserialization() throws JsonProcessingException {
+        assertSerializationIsInverseOfDeserialization(NON_STANDALONE_OPTIONS);
+        assertSerializationIsInverseOfDeserialization(LockServerOptions.DEFAULT);
+    }
+
+    @Test
+    public void existingOptionsCanBeDeserialized() throws IOException {
+        LockServerOptions lockServerOptions = LockServerOptions.builder()
+                .maxAllowedLockTimeout(SimpleTimeDuration.of(1, TimeUnit.MILLISECONDS))
+                .maxAllowedClockDrift(SimpleTimeDuration.of(2, TimeUnit.SECONDS))
+                .maxAllowedBlockingDuration(SimpleTimeDuration.of(3, TimeUnit.MINUTES))
+                .maxNormalLockAge(SimpleTimeDuration.of(4, TimeUnit.HOURS))
+                .randomBitCount(32)
+                .stuckTransactionTimeout(SimpleTimeDuration.of(5, TimeUnit.DAYS))
+                .slowLogTriggerMillis(12345)
+                .isStandaloneServer(false)
+                .build();
+
+        assertThat(clientMapper.readValue(LOCK_SERVER_OPTIONS_JSON, LockServerOptions.class))
+                .isEqualTo(lockServerOptions);
+        assertThat(serverMapper.readValue(LOCK_SERVER_OPTIONS_JSON, LockServerOptions.class))
+                .isEqualTo(lockServerOptions);
+    }
+
+    private void assertSerializationIsInverseOfDeserialization(LockServerOptions options)
+            throws JsonProcessingException {
+        String json = serverMapper.writeValueAsString(options);
+        assertThat(clientMapper.readValue(json, LockServerOptions.class)).isEqualTo(options);
+        assertThat(serverMapper.readValue(json, LockServerOptions.class)).isEqualTo(options);
+    }
+}

--- a/lock-api/src/test/java/com/palantir/lock/LockServerOptionsTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/LockServerOptionsTest.java
@@ -42,7 +42,7 @@ public class LockServerOptionsTest {
         assertThat(serverMapper.writeValueAsString(NON_STANDALONE_OPTIONS))
                 .isNotEmpty()
                 .contains("\"isStandaloneServer\":false");
-        assertThat(serverMapper.writeValueAsString(LockServerOptions.DEFAULT))
+        assertThat(serverMapper.writeValueAsString(LockServerOptions.builder().build()))
                 .isNotEmpty()
                 .contains("\"isStandaloneServer\":true");
     }
@@ -50,10 +50,11 @@ public class LockServerOptionsTest {
     @Test
     public void serializationIsInverseOfDeserialization() throws JsonProcessingException {
         assertSerializationIsInverseOfDeserialization(NON_STANDALONE_OPTIONS);
-        assertSerializationIsInverseOfDeserialization(LockServerOptions.DEFAULT);
+        assertSerializationIsInverseOfDeserialization(LockServerOptions.builder().build());
     }
 
     @Test
+    @SuppressWarnings("deprecation") // These are actual fields users might set that we still support...
     public void existingOptionsCanBeDeserialized() throws IOException {
         LockServerOptions lockServerOptions = LockServerOptions.builder()
                 .maxAllowedLockTimeout(SimpleTimeDuration.of(1, TimeUnit.MILLISECONDS))

--- a/lock-api/src/test/java/com/palantir/lock/LockServerOptionsTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/LockServerOptionsTest.java
@@ -50,7 +50,8 @@ public class LockServerOptionsTest {
     @Test
     public void serializationIsInverseOfDeserialization() throws JsonProcessingException {
         assertSerializationIsInverseOfDeserialization(NON_STANDALONE_OPTIONS);
-        assertSerializationIsInverseOfDeserialization(LockServerOptions.builder().build());
+        assertSerializationIsInverseOfDeserialization(
+                LockServerOptions.builder().build());
     }
 
     @Test

--- a/lock-api/src/test/resources/lock-server-options.json
+++ b/lock-api/src/test/resources/lock-server-options.json
@@ -1,0 +1,1 @@
+{"maxAllowedLockTimeout":{"time":1,"unit":"MILLISECONDS"},"maxAllowedClockDrift":{"time":2,"unit":"SECONDS"},"maxAllowedBlockingDuration":{"time":3,"unit":"MINUTES"},"maxNormalLockAge":{"time":4,"unit":"HOURS"},"randomBitCount":32,"stuckTransactionTimeout":{"time":5,"unit":"DAYS"},"slowLogTriggerMillis":12345,"isStandaloneServer":false}


### PR DESCRIPTION
## General
**Before this PR**:
At Undertow deployments, #6518 switches the implementation of the ObjectMapper to use one provided by our internal server architecture as opposed to the ObjectMappers we normally create (e.g. through `ObjectMappers.newServerObjectMapper()`). However, the implementation we switched to breaks serialization, in that a `boolean` field of the form `isX` is serialized as (for instance) `X: false`. We need to preserve the legacy behaviour.

This was reported in `LockServerOptions`, but also exists in `LockState`.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixed a serialization issue for users of `LockServerOptions` and `LockState` endpoints in the legacy lock service.
==COMMIT_MSG==

**Priority**: dev P0

**Concerns / possible downsides (what feedback would you like?)**: 
- Did I miss anything? As with many PRs, the difficult part of this review is in what is **not** included.

**Is documentation needed?**: No.

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: Well, this fixes a break, and in doing so breaks the broken state.

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: Yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: No

**Does this PR need a schema migration?** No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: Not much

**What was existing testing like? What have you done to improve it?**: The additional tests will be added on the internal timelock repository. Including a simple undertow server in OSS AtlasDB would be nice, but is a bit out of scope.

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: Nothing too weird here

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: N/A

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: Not having 500s

**Has the safety of all log arguments been decided correctly?**: No args

**Will this change significantly affect our spending on metrics or logs?**: No

**How would I tell that this PR does not work in production? (monitors, etc.)**: 500s

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: Rollback

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**: No

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**: No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**: I don't think so?

## Development Process
**Where should we start reviewing?**: LockServerOptions

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: N/A

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
