### PR TITLE
[Antithesis] Single Busy Cell Workflow aka "Bouncing Value"

### DIFF
--- a/atlasdb-workload-server-distribution/src/main/java/com/palantir/atlasdb/workload/WorkloadServerLauncher.java
+++ b/atlasdb-workload-server-distribution/src/main/java/com/palantir/atlasdb/workload/WorkloadServerLauncher.java
@@ -31,6 +31,8 @@ import com.palantir.atlasdb.workload.runner.AntithesisWorkflowValidatorRunner;
 import com.palantir.atlasdb.workload.store.AtlasDbTransactionStoreFactory;
 import com.palantir.atlasdb.workload.store.InteractiveTransactionStore;
 import com.palantir.atlasdb.workload.store.TransactionStore;
+import com.palantir.atlasdb.workload.workflow.SingleBusyCellWorkflowConfiguration;
+import com.palantir.atlasdb.workload.workflow.SingleBusyCellWorkflows;
 import com.palantir.atlasdb.workload.workflow.SingleRowTwoCellsWorkflowConfiguration;
 import com.palantir.atlasdb.workload.workflow.SingleRowTwoCellsWorkflows;
 import com.palantir.atlasdb.workload.workflow.Workflow;
@@ -102,13 +104,17 @@ public class WorkloadServerLauncher extends Application<WorkloadServerConfigurat
                 configuration.install().singleRowTwoCellsConfig();
         RingWorkflowConfiguration ringWorkflowConfiguration =
                 configuration.install().ringConfig();
+        SingleBusyCellWorkflowConfiguration singleBusyCellWorkflowConfiguration =
+                configuration.install().singleBusyCellConfig();
 
         new AntithesisWorkflowValidatorRunner(MoreExecutors.listeningDecorator(antithesisWorkflowRunnerExecutorService))
                 .run(
                         createSingleRowTwoCellsWorkflowValidator(
                                 transactionStoreFactory, singleRowTwoCellsConfig, environment.lifecycle()),
                         createRingWorkflowValidator(
-                                transactionStoreFactory, ringWorkflowConfiguration, environment.lifecycle()));
+                                transactionStoreFactory, ringWorkflowConfiguration, environment.lifecycle()),
+                        createSingleBusyCellWorkflowValidator(
+                                transactionStoreFactory, singleBusyCellWorkflowConfiguration, environment.lifecycle()));
 
         log.info("antithesis: terminate");
 
@@ -117,6 +123,34 @@ public class WorkloadServerLauncher extends Application<WorkloadServerConfigurat
         if (configuration.install().exitAfterRunning()) {
             System.exit(0);
         }
+    }
+
+    private WorkflowAndInvariants<Workflow> createSingleBusyCellWorkflowValidator(
+            AtlasDbTransactionStoreFactory transactionStoreFactory,
+            SingleBusyCellWorkflowConfiguration workflowConfig,
+            LifecycleEnvironment lifecycle) {
+        ExecutorService readExecutor = lifecycle
+                .executorService(SingleBusyCellWorkflowConfiguration.class.getSimpleName() + "-read")
+                .maxThreads(workflowConfig.maxThreadCount() / 2)
+                .build();
+        ExecutorService writeExecutor = lifecycle
+                .executorService(SingleBusyCellWorkflowConfiguration.class.getSimpleName() + "-write")
+                .maxThreads(workflowConfig.maxThreadCount() / 2)
+                .build();
+        InteractiveTransactionStore transactionStore = transactionStoreFactory.create(
+                Map.of(
+                        workflowConfig.tableConfiguration().tableName(),
+                        workflowConfig.tableConfiguration().isolationLevel()),
+                Set.of());
+        return WorkflowAndInvariants.of(
+                SingleBusyCellWorkflows.create(
+                        transactionStore,
+                        workflowConfig,
+                        MoreExecutors.listeningDecorator(readExecutor),
+                        MoreExecutors.listeningDecorator(writeExecutor)),
+                new DurableWritesInvariantMetricReporter(
+                        SingleBusyCellWorkflows.class.getSimpleName(), DurableWritesMetrics.of(taggedMetricRegistry)),
+                SerializableInvariantLogReporter.INSTANCE);
     }
 
     private WorkflowAndInvariants<Workflow> createRingWorkflowValidator(

--- a/atlasdb-workload-server-distribution/src/main/java/com/palantir/atlasdb/workload/config/WorkloadServerInstallConfiguration.java
+++ b/atlasdb-workload-server-distribution/src/main/java/com/palantir/atlasdb/workload/config/WorkloadServerInstallConfiguration.java
@@ -19,6 +19,7 @@ package com.palantir.atlasdb.workload.config;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.palantir.atlasdb.config.AtlasDbConfig;
+import com.palantir.atlasdb.workload.workflow.SingleBusyCellWorkflowConfiguration;
 import com.palantir.atlasdb.workload.workflow.SingleRowTwoCellsWorkflowConfiguration;
 import com.palantir.atlasdb.workload.workflow.ring.RingWorkflowConfiguration;
 import org.immutables.value.Value;
@@ -32,6 +33,8 @@ public interface WorkloadServerInstallConfiguration {
     SingleRowTwoCellsWorkflowConfiguration singleRowTwoCellsConfig();
 
     RingWorkflowConfiguration ringConfig();
+
+    SingleBusyCellWorkflowConfiguration singleBusyCellConfig();
 
     boolean exitAfterRunning();
 }

--- a/atlasdb-workload-server-distribution/src/test/resources/workload-server.yml
+++ b/atlasdb-workload-server-distribution/src/test/resources/workload-server.yml
@@ -16,4 +16,11 @@ install:
       isolationLevel: SERIALIZABLE
     iterationCount: 100
     type: ring
+  singleBusyCellConfig:
+    tableConfiguration:
+      tableName: single-busy-cell-test
+      isolationLevel: SERIALIZABLE
+    iterationCount: 100
+    type: single-busy-cell
+    maxThreadCount: 2
   exitAfterRunning: false

--- a/atlasdb-workload-server-distribution/var/conf/workload-server.timelock.cassandra.yml
+++ b/atlasdb-workload-server-distribution/var/conf/workload-server.timelock.cassandra.yml
@@ -51,4 +51,11 @@ install:
       isolationLevel: SERIALIZABLE
     iterationCount: 100
     type: ring
+  singleBusyCellConfig:
+    tableConfiguration:
+      tableName: single-busy-cell-test
+      isolationLevel: SERIALIZABLE
+    iterationCount: 100
+    type: single-busy-cell
+    maxThreadCount: 2
   exitAfterRunning: true

--- a/atlasdb-workload-server-distribution/var/conf/workload-server.yml
+++ b/atlasdb-workload-server-distribution/var/conf/workload-server.yml
@@ -16,4 +16,11 @@ install:
       isolationLevel: SERIALIZABLE
     iterationCount: 100
     type: ring
+  singleBusyCellConfig:
+    tableConfiguration:
+      tableName: single-busy-cell-test
+      isolationLevel: SERIALIZABLE
+    iterationCount: 100
+    type: single-busy-cell
+    maxThreadCount: 2
   exitAfterRunning: true

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/transaction/witnessed/WitnessedTransactions.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/transaction/witnessed/WitnessedTransactions.java
@@ -1,0 +1,45 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.workload.transaction.witnessed;
+
+import com.palantir.atlasdb.workload.store.ReadOnlyTransactionStore;
+import java.util.Comparator;
+import java.util.List;
+import one.util.streamex.StreamEx;
+
+public final class WitnessedTransactions {
+    private WitnessedTransactions() {
+        // utility
+    }
+
+    /**
+     * Sorts transactions by their effective timestamp and filters out transactions that are not fully committed.
+     */
+    public static List<FullyWitnessedTransaction> sortAndFilterTransactions(
+            ReadOnlyTransactionStore readOnlyTransactionStore, List<WitnessedTransaction> unorderedTransactions) {
+        OnlyCommittedWitnessedTransactionVisitor visitor =
+                new OnlyCommittedWitnessedTransactionVisitor(readOnlyTransactionStore);
+        return StreamEx.of(unorderedTransactions)
+                .mapPartial(transaction -> transaction.accept(visitor))
+                .sorted(Comparator.comparingLong(WitnessedTransactions::effectiveTimestamp))
+                .toList();
+    }
+
+    private static long effectiveTimestamp(WitnessedTransaction witnessedTransaction) {
+        return witnessedTransaction.commitTimestamp().orElseGet(witnessedTransaction::startTimestamp);
+    }
+}

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/workflow/DefaultWorkflow.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/workflow/DefaultWorkflow.java
@@ -16,19 +16,15 @@
 
 package com.palantir.atlasdb.workload.workflow;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.palantir.atlasdb.workload.store.ReadOnlyTransactionStore;
 import com.palantir.atlasdb.workload.store.TransactionStore;
-import com.palantir.atlasdb.workload.transaction.witnessed.FullyWitnessedTransaction;
-import com.palantir.atlasdb.workload.transaction.witnessed.OnlyCommittedWitnessedTransactionVisitor;
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedTransaction;
+import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedTransactions;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
-import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import one.util.streamex.StreamEx;
 
 public final class DefaultWorkflow<T extends TransactionStore> implements Workflow {
     private final ConcurrentTransactionRunner<T> concurrentTransactionRunner;
@@ -62,7 +58,8 @@ public final class DefaultWorkflow<T extends TransactionStore> implements Workfl
     @Override
     public WorkflowHistory run() {
         return ImmutableWorkflowHistory.builder()
-                .history(sortAndFilterTransactions(runTransactionTask()))
+                .history(
+                        WitnessedTransactions.sortAndFilterTransactions(readOnlyTransactionStore, runTransactionTask()))
                 .transactionStore(readOnlyTransactionStore)
                 .build();
     }
@@ -79,22 +76,5 @@ public final class DefaultWorkflow<T extends TransactionStore> implements Workfl
         } catch (ExecutionException e) {
             throw new SafeRuntimeException("Error when running workflow task", e.getCause());
         }
-    }
-
-    /**
-     * Sorts transactions by their effective timestamp and filters out transactions that are not fully committed.
-     */
-    @VisibleForTesting
-    List<FullyWitnessedTransaction> sortAndFilterTransactions(List<WitnessedTransaction> unorderedTransactions) {
-        OnlyCommittedWitnessedTransactionVisitor visitor =
-                new OnlyCommittedWitnessedTransactionVisitor(readOnlyTransactionStore);
-        return StreamEx.of(unorderedTransactions)
-                .mapPartial(transaction -> transaction.accept(visitor))
-                .sorted(Comparator.comparingLong(DefaultWorkflow::effectiveTimestamp))
-                .toList();
-    }
-
-    private static long effectiveTimestamp(WitnessedTransaction witnessedTransaction) {
-        return witnessedTransaction.commitTimestamp().orElseGet(witnessedTransaction::startTimestamp);
     }
 }

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/workflow/SingleBusyCellWorkflowConfiguration.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/workflow/SingleBusyCellWorkflowConfiguration.java
@@ -1,0 +1,32 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.workload.workflow;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableSingleBusyCellWorkflowConfiguration.class)
+@JsonDeserialize(as = ImmutableSingleBusyCellWorkflowConfiguration.class)
+@JsonTypeName(SingleBusyCellWorkflowConfiguration.TYPE)
+public interface SingleBusyCellWorkflowConfiguration extends WorkflowConfiguration {
+    String TYPE = "single-busy-cell";
+
+    TableConfiguration tableConfiguration();
+}

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/workflow/SingleBusyCellWorkflows.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/workflow/SingleBusyCellWorkflows.java
@@ -1,0 +1,110 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.workload.workflow;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.palantir.atlasdb.workload.store.ImmutableWorkloadCell;
+import com.palantir.atlasdb.workload.store.InteractiveTransactionStore;
+import com.palantir.atlasdb.workload.store.ReadOnlyTransactionStore;
+import com.palantir.atlasdb.workload.store.WorkloadCell;
+import com.palantir.atlasdb.workload.transaction.DeleteTransactionAction;
+import com.palantir.atlasdb.workload.transaction.WriteTransactionAction;
+import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedTransaction;
+import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedTransactions;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * This workflow attempts to manipulate a single cell in a table, scheduling transactions that perform writes and
+ * deletes, along with transactions that simply read. Notice that unlike other workflows, because the load is
+ * considerably heterogeneous, we do not use a {@link DefaultWorkflow} to schedule transactions.
+ */
+public final class SingleBusyCellWorkflows {
+    private SingleBusyCellWorkflows() {
+        // utility
+    }
+
+    @VisibleForTesting
+    static final WorkloadCell BUSY_CELL = ImmutableWorkloadCell.of(1, 1);
+
+    public static Workflow create(
+            InteractiveTransactionStore store,
+            SingleBusyCellWorkflowConfiguration configuration,
+            ListeningExecutorService readExecutor,
+            ListeningExecutorService writeExecutor) {
+        return () -> {
+            List<ListenableFuture<Optional<WitnessedTransaction>>> reads =
+                    scheduleReadsAndTouches(store, configuration, readExecutor);
+            List<ListenableFuture<Optional<WitnessedTransaction>>> writes =
+                    scheduleWrites(store, configuration, writeExecutor);
+
+            ListenableFuture<List<WitnessedTransaction>> witnessedTransactions = Futures.transform(
+                    Futures.allAsList(
+                            Stream.of(reads, writes).flatMap(Collection::stream).collect(Collectors.toList())),
+                    maybeWitnessedTransactions -> maybeWitnessedTransactions.stream()
+                            .flatMap(Optional::stream)
+                            .collect(Collectors.toList()),
+                    MoreExecutors.directExecutor());
+            ReadOnlyTransactionStore readOnlyTransactionStore = new ReadOnlyTransactionStore(store);
+            return ImmutableWorkflowHistory.builder()
+                    .addAllHistory(WitnessedTransactions.sortAndFilterTransactions(
+                            readOnlyTransactionStore, Futures.getUnchecked(witnessedTransactions)))
+                    .transactionStore(readOnlyTransactionStore)
+                    .build();
+        };
+    }
+
+    @NotNull
+    private static List<ListenableFuture<Optional<WitnessedTransaction>>> scheduleReadsAndTouches(
+            InteractiveTransactionStore store,
+            SingleBusyCellWorkflowConfiguration configuration,
+            ListeningExecutorService readExecutor) {
+        return IntStream.range(0, configuration.iterationCount() / 2)
+                .mapToObj(idx -> readExecutor.submit(() -> store.readWrite(txn -> {
+                    Optional<Integer> value =
+                            txn.read(configuration.tableConfiguration().tableName(), BUSY_CELL);
+                    txn.write(configuration.tableConfiguration().tableName(), BUSY_CELL, value.orElse(-1));
+                })))
+                .collect(Collectors.toList());
+    }
+
+    @NotNull
+    private static List<ListenableFuture<Optional<WitnessedTransaction>>> scheduleWrites(
+            InteractiveTransactionStore store,
+            SingleBusyCellWorkflowConfiguration configuration,
+            ListeningExecutorService writeExecutor) {
+        List<ListenableFuture<Optional<WitnessedTransaction>>> writes = new ArrayList<>();
+        for (int index = 0; index < configuration.iterationCount() / 4; index++) {
+            int stableIndex = index;
+            writes.add(writeExecutor.submit(() -> store.readWrite(List.of(WriteTransactionAction.of(
+                    configuration.tableConfiguration().tableName(), BUSY_CELL, stableIndex)))));
+            writes.add(writeExecutor.submit(() -> store.readWrite(List.of(DeleteTransactionAction.of(
+                    configuration.tableConfiguration().tableName(), BUSY_CELL)))));
+        }
+        return writes;
+    }
+}

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/transaction/witnessed/WitnessedTransactionsTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/transaction/witnessed/WitnessedTransactionsTest.java
@@ -24,8 +24,11 @@ import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.workload.store.ReadOnlyTransactionStore;
 import java.util.List;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
+@RunWith(MockitoJUnitRunner.class)
 public class WitnessedTransactionsTest {
     @Mock
     private ReadOnlyTransactionStore readOnlyTransactionStore;
@@ -36,10 +39,10 @@ public class WitnessedTransactionsTest {
         FullyWitnessedTransaction readOnlyAtFive = createReadOnlyWitnessedTransactionWithoutActions(5);
 
         assertThat(WitnessedTransactions.sortAndFilterTransactions(
-                        readOnlyTransactionStore, ImmutableList.of(twoToEight)))
+                readOnlyTransactionStore, ImmutableList.of(twoToEight)))
                 .containsExactly(twoToEight);
         assertThat(WitnessedTransactions.sortAndFilterTransactions(
-                        readOnlyTransactionStore, ImmutableList.of(readOnlyAtFive)))
+                readOnlyTransactionStore, ImmutableList.of(readOnlyAtFive)))
                 .containsExactly(readOnlyAtFive);
     }
 
@@ -50,7 +53,7 @@ public class WitnessedTransactionsTest {
         FullyWitnessedTransaction fourToSix = createWitnessedTransactionWithoutActions(4, 6);
 
         assertThat(WitnessedTransactions.sortAndFilterTransactions(
-                        readOnlyTransactionStore, ImmutableList.of(twoToEight, threeToSeven, fourToSix)))
+                readOnlyTransactionStore, ImmutableList.of(twoToEight, threeToSeven, fourToSix)))
                 .containsExactly(fourToSix, threeToSeven, twoToEight);
     }
 
@@ -61,8 +64,8 @@ public class WitnessedTransactionsTest {
         FullyWitnessedTransaction readOnlyAtFortyTwo = createReadOnlyWitnessedTransactionWithoutActions(42);
 
         assertThat(WitnessedTransactions.sortAndFilterTransactions(
-                        readOnlyTransactionStore,
-                        ImmutableList.of(readOnlyAtSeven, readOnlyAtFortyTwo, readOnlyAtThree)))
+                readOnlyTransactionStore,
+                ImmutableList.of(readOnlyAtSeven, readOnlyAtFortyTwo, readOnlyAtThree)))
                 .containsExactly(readOnlyAtThree, readOnlyAtSeven, readOnlyAtFortyTwo);
     }
 
@@ -77,14 +80,14 @@ public class WitnessedTransactionsTest {
         FullyWitnessedTransaction readOnlyAtNine = createReadOnlyWitnessedTransactionWithoutActions(9);
 
         assertThat(WitnessedTransactions.sortAndFilterTransactions(
-                        readOnlyTransactionStore,
-                        ImmutableList.of(
-                                twoToEight,
-                                readOnlyAtNine,
-                                fourToSix,
-                                readOnlyAtFive,
-                                readOnlyAtThree,
-                                readOnlyAtSeven)))
+                readOnlyTransactionStore,
+                ImmutableList.of(
+                        twoToEight,
+                        readOnlyAtNine,
+                        fourToSix,
+                        readOnlyAtFive,
+                        readOnlyAtThree,
+                        readOnlyAtSeven)))
                 .containsExactly(
                         readOnlyAtThree, readOnlyAtFive, fourToSix, readOnlyAtSeven, twoToEight, readOnlyAtNine);
     }
@@ -97,12 +100,12 @@ public class WitnessedTransactionsTest {
         FullyWitnessedTransaction readOnlyAtFive = createReadOnlyWitnessedTransactionWithoutActions(5);
         FullyWitnessedTransaction fourToSix = createWitnessedTransactionWithoutActions(4, 6);
         assertThat(WitnessedTransactions.sortAndFilterTransactions(
-                        readOnlyTransactionStore,
-                        List.of(
-                                committedMaybeWitnessedTransaction,
-                                notCommittedTransaction,
-                                readOnlyAtFive,
-                                fourToSix)))
+                readOnlyTransactionStore,
+                List.of(
+                        committedMaybeWitnessedTransaction,
+                        notCommittedTransaction,
+                        readOnlyAtFive,
+                        fourToSix)))
                 .containsExactly(committedMaybeWitnessedTransaction.toFullyWitnessed(), readOnlyAtFive, fourToSix);
     }
 

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/transaction/witnessed/WitnessedTransactionsTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/transaction/witnessed/WitnessedTransactionsTest.java
@@ -1,0 +1,128 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.workload.transaction.witnessed;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.atlasdb.workload.store.ReadOnlyTransactionStore;
+import java.util.List;
+import org.junit.Test;
+import org.mockito.Mock;
+
+public class WitnessedTransactionsTest {
+    @Mock
+    private ReadOnlyTransactionStore readOnlyTransactionStore;
+
+    @Test
+    public void returnsUnderlyingWitnessedTransactions() {
+        FullyWitnessedTransaction twoToEight = createWitnessedTransactionWithoutActions(2, 8);
+        FullyWitnessedTransaction readOnlyAtFive = createReadOnlyWitnessedTransactionWithoutActions(5);
+
+        assertThat(WitnessedTransactions.sortAndFilterTransactions(
+                        readOnlyTransactionStore, ImmutableList.of(twoToEight)))
+                .containsExactly(twoToEight);
+        assertThat(WitnessedTransactions.sortAndFilterTransactions(
+                        readOnlyTransactionStore, ImmutableList.of(readOnlyAtFive)))
+                .containsExactly(readOnlyAtFive);
+    }
+
+    @Test
+    public void sortsResultsOfWriteTransactionsByCommitTimestamp() {
+        FullyWitnessedTransaction twoToEight = createWitnessedTransactionWithoutActions(2, 8);
+        FullyWitnessedTransaction threeToSeven = createWitnessedTransactionWithoutActions(3, 7);
+        FullyWitnessedTransaction fourToSix = createWitnessedTransactionWithoutActions(4, 6);
+
+        assertThat(WitnessedTransactions.sortAndFilterTransactions(
+                        readOnlyTransactionStore, ImmutableList.of(twoToEight, threeToSeven, fourToSix)))
+                .containsExactly(fourToSix, threeToSeven, twoToEight);
+    }
+
+    @Test
+    public void sortsReadOnlyTransactionsByStartTimestamp() {
+        FullyWitnessedTransaction readOnlyAtThree = createReadOnlyWitnessedTransactionWithoutActions(3);
+        FullyWitnessedTransaction readOnlyAtSeven = createReadOnlyWitnessedTransactionWithoutActions(7);
+        FullyWitnessedTransaction readOnlyAtFortyTwo = createReadOnlyWitnessedTransactionWithoutActions(42);
+
+        assertThat(WitnessedTransactions.sortAndFilterTransactions(
+                        readOnlyTransactionStore,
+                        ImmutableList.of(readOnlyAtSeven, readOnlyAtFortyTwo, readOnlyAtThree)))
+                .containsExactly(readOnlyAtThree, readOnlyAtSeven, readOnlyAtFortyTwo);
+    }
+
+    @Test
+    public void sortsReadAndWriteTransactionsByEffectiveTimestamp() {
+        FullyWitnessedTransaction twoToEight = createWitnessedTransactionWithoutActions(2, 8);
+        FullyWitnessedTransaction fourToSix = createWitnessedTransactionWithoutActions(4, 6);
+
+        FullyWitnessedTransaction readOnlyAtThree = createReadOnlyWitnessedTransactionWithoutActions(3);
+        FullyWitnessedTransaction readOnlyAtFive = createReadOnlyWitnessedTransactionWithoutActions(5);
+        FullyWitnessedTransaction readOnlyAtSeven = createReadOnlyWitnessedTransactionWithoutActions(7);
+        FullyWitnessedTransaction readOnlyAtNine = createReadOnlyWitnessedTransactionWithoutActions(9);
+
+        assertThat(WitnessedTransactions.sortAndFilterTransactions(
+                        readOnlyTransactionStore,
+                        ImmutableList.of(
+                                twoToEight,
+                                readOnlyAtNine,
+                                fourToSix,
+                                readOnlyAtFive,
+                                readOnlyAtThree,
+                                readOnlyAtSeven)))
+                .containsExactly(
+                        readOnlyAtThree, readOnlyAtFive, fourToSix, readOnlyAtSeven, twoToEight, readOnlyAtNine);
+    }
+
+    @Test
+    public void filterRemovesUncommittedTransactions() {
+        MaybeWitnessedTransaction committedMaybeWitnessedTransaction =
+                createMaybeWitnessedTransactionWithoutActions(1, 3, true);
+        MaybeWitnessedTransaction notCommittedTransaction = createMaybeWitnessedTransactionWithoutActions(2, 8, false);
+        FullyWitnessedTransaction readOnlyAtFive = createReadOnlyWitnessedTransactionWithoutActions(5);
+        FullyWitnessedTransaction fourToSix = createWitnessedTransactionWithoutActions(4, 6);
+        assertThat(WitnessedTransactions.sortAndFilterTransactions(
+                        readOnlyTransactionStore,
+                        List.of(
+                                committedMaybeWitnessedTransaction,
+                                notCommittedTransaction,
+                                readOnlyAtFive,
+                                fourToSix)))
+                .containsExactly(committedMaybeWitnessedTransaction.toFullyWitnessed(), readOnlyAtFive, fourToSix);
+    }
+
+    private MaybeWitnessedTransaction createMaybeWitnessedTransactionWithoutActions(
+            long start, long commit, boolean committed) {
+        when(readOnlyTransactionStore.isCommitted(eq(start))).thenReturn(committed);
+        return MaybeWitnessedTransaction.builder()
+                .startTimestamp(start)
+                .commitTimestamp(commit)
+                .build();
+    }
+
+    private static FullyWitnessedTransaction createReadOnlyWitnessedTransactionWithoutActions(long start) {
+        return FullyWitnessedTransaction.builder().startTimestamp(start).build();
+    }
+
+    private static FullyWitnessedTransaction createWitnessedTransactionWithoutActions(long start, long commit) {
+        return FullyWitnessedTransaction.builder()
+                .startTimestamp(start)
+                .commitTimestamp(commit)
+                .build();
+    }
+}

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/transaction/witnessed/WitnessedTransactionsTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/transaction/witnessed/WitnessedTransactionsTest.java
@@ -39,10 +39,10 @@ public class WitnessedTransactionsTest {
         FullyWitnessedTransaction readOnlyAtFive = createReadOnlyWitnessedTransactionWithoutActions(5);
 
         assertThat(WitnessedTransactions.sortAndFilterTransactions(
-                readOnlyTransactionStore, ImmutableList.of(twoToEight)))
+                        readOnlyTransactionStore, ImmutableList.of(twoToEight)))
                 .containsExactly(twoToEight);
         assertThat(WitnessedTransactions.sortAndFilterTransactions(
-                readOnlyTransactionStore, ImmutableList.of(readOnlyAtFive)))
+                        readOnlyTransactionStore, ImmutableList.of(readOnlyAtFive)))
                 .containsExactly(readOnlyAtFive);
     }
 
@@ -53,7 +53,7 @@ public class WitnessedTransactionsTest {
         FullyWitnessedTransaction fourToSix = createWitnessedTransactionWithoutActions(4, 6);
 
         assertThat(WitnessedTransactions.sortAndFilterTransactions(
-                readOnlyTransactionStore, ImmutableList.of(twoToEight, threeToSeven, fourToSix)))
+                        readOnlyTransactionStore, ImmutableList.of(twoToEight, threeToSeven, fourToSix)))
                 .containsExactly(fourToSix, threeToSeven, twoToEight);
     }
 
@@ -64,8 +64,8 @@ public class WitnessedTransactionsTest {
         FullyWitnessedTransaction readOnlyAtFortyTwo = createReadOnlyWitnessedTransactionWithoutActions(42);
 
         assertThat(WitnessedTransactions.sortAndFilterTransactions(
-                readOnlyTransactionStore,
-                ImmutableList.of(readOnlyAtSeven, readOnlyAtFortyTwo, readOnlyAtThree)))
+                        readOnlyTransactionStore,
+                        ImmutableList.of(readOnlyAtSeven, readOnlyAtFortyTwo, readOnlyAtThree)))
                 .containsExactly(readOnlyAtThree, readOnlyAtSeven, readOnlyAtFortyTwo);
     }
 
@@ -80,14 +80,14 @@ public class WitnessedTransactionsTest {
         FullyWitnessedTransaction readOnlyAtNine = createReadOnlyWitnessedTransactionWithoutActions(9);
 
         assertThat(WitnessedTransactions.sortAndFilterTransactions(
-                readOnlyTransactionStore,
-                ImmutableList.of(
-                        twoToEight,
-                        readOnlyAtNine,
-                        fourToSix,
-                        readOnlyAtFive,
-                        readOnlyAtThree,
-                        readOnlyAtSeven)))
+                        readOnlyTransactionStore,
+                        ImmutableList.of(
+                                twoToEight,
+                                readOnlyAtNine,
+                                fourToSix,
+                                readOnlyAtFive,
+                                readOnlyAtThree,
+                                readOnlyAtSeven)))
                 .containsExactly(
                         readOnlyAtThree, readOnlyAtFive, fourToSix, readOnlyAtSeven, twoToEight, readOnlyAtNine);
     }
@@ -100,12 +100,12 @@ public class WitnessedTransactionsTest {
         FullyWitnessedTransaction readOnlyAtFive = createReadOnlyWitnessedTransactionWithoutActions(5);
         FullyWitnessedTransaction fourToSix = createWitnessedTransactionWithoutActions(4, 6);
         assertThat(WitnessedTransactions.sortAndFilterTransactions(
-                readOnlyTransactionStore,
-                List.of(
-                        committedMaybeWitnessedTransaction,
-                        notCommittedTransaction,
-                        readOnlyAtFive,
-                        fourToSix)))
+                        readOnlyTransactionStore,
+                        List.of(
+                                committedMaybeWitnessedTransaction,
+                                notCommittedTransaction,
+                                readOnlyAtFive,
+                                fourToSix)))
                 .containsExactly(committedMaybeWitnessedTransaction.toFullyWitnessed(), readOnlyAtFive, fourToSix);
     }
 

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/DefaultWorkflowTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/DefaultWorkflowTest.java
@@ -16,21 +16,16 @@
 
 package com.palantir.atlasdb.workload.workflow;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.atlasdb.workload.store.TransactionStore;
-import com.palantir.atlasdb.workload.transaction.witnessed.FullyWitnessedTransaction;
-import com.palantir.atlasdb.workload.transaction.witnessed.MaybeWitnessedTransaction;
 import com.palantir.common.concurrent.PTExecutors;
-import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import org.junit.Test;
 
@@ -54,66 +49,6 @@ public class DefaultWorkflowTest {
                 .hasCause(transactionException);
     }
 
-    @Test
-    public void returnsUnderlyingWitnessedTransactions() {
-        FullyWitnessedTransaction twoToEight = createWitnessedTransactionWithoutActions(2, 8);
-        FullyWitnessedTransaction readOnlyAtFive = createReadOnlyWitnessedTransactionWithoutActions(5);
-
-        assertThat(workflow.sortAndFilterTransactions(ImmutableList.of(twoToEight)))
-                .containsExactly(twoToEight);
-        assertThat(workflow.sortAndFilterTransactions(ImmutableList.of(readOnlyAtFive)))
-                .containsExactly(readOnlyAtFive);
-    }
-
-    @Test
-    public void sortsResultsOfWriteTransactionsByCommitTimestamp() {
-        FullyWitnessedTransaction twoToEight = createWitnessedTransactionWithoutActions(2, 8);
-        FullyWitnessedTransaction threeToSeven = createWitnessedTransactionWithoutActions(3, 7);
-        FullyWitnessedTransaction fourToSix = createWitnessedTransactionWithoutActions(4, 6);
-
-        assertThat(workflow.sortAndFilterTransactions(ImmutableList.of(twoToEight, threeToSeven, fourToSix)))
-                .containsExactly(fourToSix, threeToSeven, twoToEight);
-    }
-
-    @Test
-    public void sortsReadOnlyTransactionsByStartTimestamp() {
-        FullyWitnessedTransaction readOnlyAtThree = createReadOnlyWitnessedTransactionWithoutActions(3);
-        FullyWitnessedTransaction readOnlyAtSeven = createReadOnlyWitnessedTransactionWithoutActions(7);
-        FullyWitnessedTransaction readOnlyAtFortyTwo = createReadOnlyWitnessedTransactionWithoutActions(42);
-
-        assertThat(workflow.sortAndFilterTransactions(
-                        ImmutableList.of(readOnlyAtSeven, readOnlyAtFortyTwo, readOnlyAtThree)))
-                .containsExactly(readOnlyAtThree, readOnlyAtSeven, readOnlyAtFortyTwo);
-    }
-
-    @Test
-    public void sortsReadAndWriteTransactionsByEffectiveTimestamp() {
-        FullyWitnessedTransaction twoToEight = createWitnessedTransactionWithoutActions(2, 8);
-        FullyWitnessedTransaction fourToSix = createWitnessedTransactionWithoutActions(4, 6);
-
-        FullyWitnessedTransaction readOnlyAtThree = createReadOnlyWitnessedTransactionWithoutActions(3);
-        FullyWitnessedTransaction readOnlyAtFive = createReadOnlyWitnessedTransactionWithoutActions(5);
-        FullyWitnessedTransaction readOnlyAtSeven = createReadOnlyWitnessedTransactionWithoutActions(7);
-        FullyWitnessedTransaction readOnlyAtNine = createReadOnlyWitnessedTransactionWithoutActions(9);
-
-        assertThat(workflow.sortAndFilterTransactions(ImmutableList.of(
-                        twoToEight, readOnlyAtNine, fourToSix, readOnlyAtFive, readOnlyAtThree, readOnlyAtSeven)))
-                .containsExactly(
-                        readOnlyAtThree, readOnlyAtFive, fourToSix, readOnlyAtSeven, twoToEight, readOnlyAtNine);
-    }
-
-    @Test
-    public void filterRemovesUncommittedTransactions() {
-        MaybeWitnessedTransaction committedMaybeWitnessedTransaction =
-                createMaybeWitnessedTransactionWithoutActions(1, 3, true);
-        MaybeWitnessedTransaction notCommittedTransaction = createMaybeWitnessedTransactionWithoutActions(2, 8, false);
-        FullyWitnessedTransaction readOnlyAtFive = createReadOnlyWitnessedTransactionWithoutActions(5);
-        FullyWitnessedTransaction fourToSix = createWitnessedTransactionWithoutActions(4, 6);
-        assertThat(workflow.sortAndFilterTransactions(List.of(
-                        committedMaybeWitnessedTransaction, notCommittedTransaction, readOnlyAtFive, fourToSix)))
-                .containsExactly(committedMaybeWitnessedTransaction.toFullyWitnessed(), readOnlyAtFive, fourToSix);
-    }
-
     private WorkflowConfiguration createWorkflowConfiguration(int iterationCount) {
         return new WorkflowConfiguration() {
             @Override
@@ -121,25 +56,5 @@ public class DefaultWorkflowTest {
                 return iterationCount;
             }
         };
-    }
-
-    private MaybeWitnessedTransaction createMaybeWitnessedTransactionWithoutActions(
-            long start, long commit, boolean committed) {
-        when(store.isCommitted(eq(start))).thenReturn(committed);
-        return MaybeWitnessedTransaction.builder()
-                .startTimestamp(start)
-                .commitTimestamp(commit)
-                .build();
-    }
-
-    private static FullyWitnessedTransaction createReadOnlyWitnessedTransactionWithoutActions(long start) {
-        return FullyWitnessedTransaction.builder().startTimestamp(start).build();
-    }
-
-    private static FullyWitnessedTransaction createWitnessedTransactionWithoutActions(long start, long commit) {
-        return FullyWitnessedTransaction.builder()
-                .startTimestamp(start)
-                .commitTimestamp(commit)
-                .build();
     }
 }

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/SingleBusyCellWorkflowsTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/SingleBusyCellWorkflowsTest.java
@@ -59,8 +59,8 @@ public class SingleBusyCellWorkflowsTest {
     private final Workflow workflow = SingleBusyCellWorkflows.create(
             transactionStore,
             CONFIGURATION,
-            MoreExecutors.listeningDecorator(PTExecutors.newSingleThreadExecutor()),
-            MoreExecutors.listeningDecorator(PTExecutors.newSingleThreadExecutor()));
+            MoreExecutors.listeningDecorator(PTExecutors.newFixedThreadPool(4)),
+            MoreExecutors.listeningDecorator(PTExecutors.newFixedThreadPool(4)));
 
     @Test
     public void workflowHistoryTransactionStoreShouldBeReadOnly() {
@@ -94,8 +94,8 @@ public class SingleBusyCellWorkflowsTest {
                 .map(WitnessedTransaction::actions)
                 .flatMap(Collection::stream)
                 .collect(Collectors.toList());
-        assertThat(witnessedTransactionActions).anyMatch(action -> action instanceof WitnessedReadTransactionAction);
-        assertThat(witnessedTransactionActions).anyMatch(action -> action instanceof WitnessedWriteTransactionAction);
-        assertThat(witnessedTransactionActions).anyMatch(action -> action instanceof WitnessedDeleteTransactionAction);
+        assertThat(witnessedTransactionActions).anyMatch(WitnessedReadTransactionAction.class::isInstance);
+        assertThat(witnessedTransactionActions).anyMatch(WitnessedWriteTransactionAction.class::isInstance);
+        assertThat(witnessedTransactionActions).anyMatch(WitnessedDeleteTransactionAction.class::isInstance);
     }
 }

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/SingleBusyCellWorkflowsTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/SingleBusyCellWorkflowsTest.java
@@ -1,0 +1,101 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.workload.workflow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.palantir.atlasdb.factory.TransactionManagers;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.workload.store.AtlasDbTransactionStore;
+import com.palantir.atlasdb.workload.store.InteractiveTransactionStore;
+import com.palantir.atlasdb.workload.store.IsolationLevel;
+import com.palantir.atlasdb.workload.store.ReadOnlyTransactionStore;
+import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedDeleteTransactionAction;
+import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedReadTransactionAction;
+import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedTransaction;
+import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedTransactionAction;
+import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedWriteTransactionAction;
+import com.palantir.atlasdb.workload.util.AtlasDbUtils;
+import com.palantir.common.concurrent.PTExecutors;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Test;
+
+public class SingleBusyCellWorkflowsTest {
+    private static final String TABLE_NAME = "busy.cell";
+    private static final int ITERATION_COUNT = 1_000;
+    private static final SingleBusyCellWorkflowConfiguration CONFIGURATION =
+            ImmutableSingleBusyCellWorkflowConfiguration.builder()
+                    .tableConfiguration(ImmutableTableConfiguration.builder()
+                            .tableName(TABLE_NAME)
+                            .isolationLevel(IsolationLevel.SERIALIZABLE)
+                            .build())
+                    .iterationCount(ITERATION_COUNT)
+                    .build();
+
+    private final InteractiveTransactionStore transactionStore = AtlasDbTransactionStore.create(
+            TransactionManagers.createInMemory(ImmutableSet.of()),
+            ImmutableMap.of(
+                    TableReference.createWithEmptyNamespace(TABLE_NAME),
+                    AtlasDbUtils.tableMetadata(IsolationLevel.SERIALIZABLE)));
+    private final Workflow workflow = SingleBusyCellWorkflows.create(
+            transactionStore,
+            CONFIGURATION,
+            MoreExecutors.listeningDecorator(PTExecutors.newSingleThreadExecutor()),
+            MoreExecutors.listeningDecorator(PTExecutors.newSingleThreadExecutor()));
+
+    @Test
+    public void workflowHistoryTransactionStoreShouldBeReadOnly() {
+        WorkflowHistory history = workflow.run();
+        assertThat(history.transactionStore()).isInstanceOf(ReadOnlyTransactionStore.class);
+    }
+
+    @Test
+    public void transactionsDoNotConflictExcessively() {
+        WorkflowHistory workflowHistory = workflow.run();
+        assertThat(workflowHistory.history()).hasSizeBetween(ITERATION_COUNT / 2, ITERATION_COUNT);
+    }
+
+    @Test
+    public void successfulTransactionsOnlyReadOrModifyTheTargetCell() {
+        WorkflowHistory workflowHistory = workflow.run();
+        List<WitnessedTransactionAction> witnessedTransactionActions = workflowHistory.history().stream()
+                .map(WitnessedTransaction::actions)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+        assertThat(witnessedTransactionActions)
+                .allMatch(action -> action.table().equals(TABLE_NAME));
+        assertThat(witnessedTransactionActions)
+                .allMatch(action -> action.cell().equals(SingleBusyCellWorkflows.BUSY_CELL));
+    }
+
+    @Test
+    public void targetCellIsReadModifiedAndDeleted() {
+        WorkflowHistory workflowHistory = workflow.run();
+        List<WitnessedTransactionAction> witnessedTransactionActions = workflowHistory.history().stream()
+                .map(WitnessedTransaction::actions)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+        assertThat(witnessedTransactionActions).anyMatch(action -> action instanceof WitnessedReadTransactionAction);
+        assertThat(witnessedTransactionActions).anyMatch(action -> action instanceof WitnessedWriteTransactionAction);
+        assertThat(witnessedTransactionActions).anyMatch(action -> action instanceof WitnessedDeleteTransactionAction);
+    }
+}


### PR DESCRIPTION
## General
**Before this PR**:
Existing workflows modify a single cell or a token ring, but might not expose a sweep bug under certain circumstances- see #6537.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
A workflow that aggressively reads, writes and deletes a single cell exists.
==COMMIT_MSG==

**Priority**: P1

**Concerns / possible downsides (what feedback would you like?)**: Not much

**Is documentation needed?**: No

## Compatibility
Workload not deployed in production

## Testing and Correctness
**What was existing testing like? What have you done to improve it?**: Yep the new stuff is tested

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: No

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: No

## Execution
Workload not deployed in production

## Scale
Workload not deployed in production

## Development Process
**Where should we start reviewing?**: The refactor to WitnessedTransactions.

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: The diff looks larger than it actually is because I had to move some tests around to expose the sorting mechanism for transactions, as we don't really want to use DefaultWorkflow since transaction tasks are heterogeneous (explained in comments)

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
