### PR TITLE
Lock state logging handles multiple mappings

### DIFF
--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockServerLock.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockServerLock.java
@@ -20,6 +20,7 @@ import com.palantir.lock.LockClient;
 import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.LockMode;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
@@ -71,6 +72,7 @@ public class LockServerLock implements ClientAwareReadWriteLock {
                 .toString();
     }
 
+    @Safe
     public String toSanitizedString() {
         return MoreObjects.toStringHelper(getClass().getSimpleName())
                 .add("sync", sync)

--- a/lock-impl/src/main/java/com/palantir/lock/logger/LockDescriptorMapper.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/LockDescriptorMapper.java
@@ -15,11 +15,11 @@
  */
 package com.palantir.lock.logger;
 
+import com.google.common.collect.ImmutableMap;
 import com.palantir.lock.LockDescriptor;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 
 /**
  * Lock descriptors may contain obfuscated sensitive information. We want to make it impossible to get a real descriptor,
@@ -31,8 +31,8 @@ class LockDescriptorMapper {
 
     private static final String LOCK_PREFIX = "Lock-";
 
-    private Map<LockDescriptor, ObfuscatedLockDescriptor> mapper = new ConcurrentHashMap<>();
-    private AtomicInteger lockCounter = new AtomicInteger();
+    private final Map<LockDescriptor, ObfuscatedLockDescriptor> mapper = new ConcurrentHashMap<>();
+    private final AtomicInteger lockCounter = new AtomicInteger();
 
     ObfuscatedLockDescriptor getDescriptorMapping(LockDescriptor descriptor) {
         return mapper.computeIfAbsent(
@@ -44,6 +44,6 @@ class LockDescriptorMapper {
      * @return map from mapping to real descriptor.
      */
     Map<ObfuscatedLockDescriptor, LockDescriptor> getReversedMapper() {
-        return mapper.entrySet().stream().collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
+        return mapper.entrySet().stream().collect(ImmutableMap.toImmutableMap(Map.Entry::getValue, Map.Entry::getKey));
     }
 }

--- a/lock-impl/src/main/java/com/palantir/lock/logger/LogState.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/LogState.java
@@ -16,7 +16,8 @@
 
 package com.palantir.lock.logger;
 
-import com.google.common.collect.Multimap;
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.SetMultimap;
 import com.palantir.lock.LockDescriptor;
 import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
@@ -34,13 +35,13 @@ public interface LogState {
     List<SimpleLockRequestsWithSameDescriptor> getOutstandingRequests();
 
     @Safe
-    Multimap<ObfuscatedLockDescriptor, SimpleTokenInfo> getHeldLocks();
+    SetMultimap<ObfuscatedLockDescriptor, SimpleTokenInfo> getHeldLocks();
 
     @Safe
     Map<ObfuscatedLockDescriptor, String> getSyncState();
 
     @Safe
-    Map<ClientId, List<SanitizedLockRequestProgress>> getSynthesizedRequestState();
+    ListMultimap<ClientId, SanitizedLockRequestProgress> getSynthesizedRequestState();
 
     @Unsafe
     Map<ObfuscatedLockDescriptor, LockDescriptor> getLockDescriptorMapping();

--- a/lock-impl/src/main/java/com/palantir/lock/logger/SanitizedLockRequestProgress.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/SanitizedLockRequestProgress.java
@@ -19,11 +19,13 @@ package com.palantir.lock.logger;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.palantir.lock.impl.LockServiceStateDebugger;
+import com.palantir.logsafe.Safe;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.immutables.value.Value;
 
+@Safe
 @Value.Immutable
 @JsonSerialize(as = ImmutableSanitizedLockRequestProgress.class)
 @JsonDeserialize(as = ImmutableSanitizedLockRequestProgress.class)

--- a/lock-impl/src/test/java/com/palantir/lock/logger/LockServiceStateLoggerTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/logger/LockServiceStateLoggerTest.java
@@ -160,7 +160,7 @@ public class LockServiceStateLoggerTest {
 
     @Test
     public void testSynthesizedRequestState() {
-        assertThat(loggedState.getSynthesizedRequestState()).hasSameSizeAs(getSyncStateDescriptors());
+        assertThat(loggedState.getSynthesizedRequestState().asMap()).hasSameSizeAs(getSyncStateDescriptors());
     }
 
     private static void assertDescriptorsNotPresentInString(String serialized) {


### PR DESCRIPTION
## General
**Before this PR**:
Builds on #6576 to avoid other potential edge cases where there are multiple mappings for a given lock element.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Lock state logging handles multiple mappings
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
