### PR TITLE
DO NOT MERGE: Introducing bug in order to check if Antithesis can detect it: dont check for immutableT lock on thorough swept tables

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/SweepStrategy.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/SweepStrategy.java
@@ -30,7 +30,7 @@ public final class SweepStrategy {
 
     public static final SweepStrategy CONSERVATIVE =
             new SweepStrategy(Optional.of(SweeperStrategy.CONSERVATIVE), false);
-    public static final SweepStrategy THOROUGH = new SweepStrategy(Optional.of(SweeperStrategy.THOROUGH), true);
+    public static final SweepStrategy THOROUGH = new SweepStrategy(Optional.of(SweeperStrategy.THOROUGH), false);
 
     private final Optional<SweeperStrategy> sweeperStrategy;
     private final boolean mustCheckImmutableLockAfterReads;

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/SweepStrategy.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/SweepStrategy.java
@@ -69,10 +69,9 @@ public final class SweepStrategy {
         switch (strategy) {
             case CONSERVATIVE:
             case NOTHING:
-                return false;
             case THOROUGH_MIGRATION:
             case THOROUGH:
-                return true;
+                return false;
         }
         throw new SafeIllegalStateException("Unknown case", SafeArg.of("strategy", strategy));
     }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/transaction/impl/ReadTransactionShould.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/transaction/impl/ReadTransactionShould.java
@@ -30,7 +30,6 @@ import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
 import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.table.description.SweepStrategy;
-import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.junit.Before;
@@ -103,9 +102,5 @@ public class ReadTransactionShould {
             assertThat(e.getMessage()).contains(errorMessage);
             verifyNoMoreInteractions(delegateTransaction);
         }
-    }
-
-    private boolean hasExpectedParameterCount(Method method) {
-        return simpleGets.get(method.getName()).length == method.getParameterCount();
     }
 }

--- a/atlasdb-workload-server-antithesis/var/docker-compose.yml
+++ b/atlasdb-workload-server-antithesis/var/docker-compose.yml
@@ -15,8 +15,6 @@ services:
       - LOCAL_JMX=no
       - CASSANDRA_HINTED_HANDOFF_ENABLED=false
     container_name: cassandra1
-    volumes:
-      - /opt/config/volumes/cassandra1:/var/lib/cassandra
     networks:
       antithesis-net:
         ipv4_address: 10.20.20.2
@@ -35,8 +33,6 @@ services:
       - LOCAL_JMX=no
       - CASSANDRA_HINTED_HANDOFF_ENABLED=false
     container_name: cassandra2
-    volumes:
-      - /opt/config/volumes/cassandra2:/var/lib/cassandra
     networks:
       antithesis-net:
         ipv4_address: 10.20.20.3
@@ -55,8 +51,6 @@ services:
       - LOCAL_JMX=no
       - CASSANDRA_HINTED_HANDOFF_ENABLED=false
     container_name: cassandra3
-    volumes:
-      - /opt/config/volumes/cassandra3:/var/lib/cassandra
     networks:
       antithesis-net:
         ipv4_address: 10.20.20.4

--- a/atlasdb-workload-server-distribution/src/main/java/com/palantir/atlasdb/workload/WorkloadServerLauncher.java
+++ b/atlasdb-workload-server-distribution/src/main/java/com/palantir/atlasdb/workload/WorkloadServerLauncher.java
@@ -134,6 +134,8 @@ public class WorkloadServerLauncher extends Application<WorkloadServerConfigurat
                 Refreshable.only(configuration.runtime().atlas()),
                 USER_AGENT,
                 metricsManager);
+        SingleBusyCellReadsNoTouchWorkflowConfiguration singleBusyCellReadNoTouchWorkflowConfiguration =
+                configuration.install().singleBusyCellReadsNoTouchConfig();
         SingleRowTwoCellsWorkflowConfiguration singleRowTwoCellsConfig =
                 configuration.install().singleRowTwoCellsConfig();
         RingWorkflowConfiguration ringWorkflowConfiguration =
@@ -144,13 +146,15 @@ public class WorkloadServerLauncher extends Application<WorkloadServerConfigurat
                 configuration.install().singleBusyCellConfig();
         RandomWorkflowConfiguration randomWorkflowConfig =
                 configuration.install().randomConfig();
-        SingleBusyCellReadsNoTouchWorkflowConfiguration singleBusyCellReadNoTouchWorkflowConfiguration =
-                configuration.install().singleBusyCellReadsNoTouchConfig();
 
         waitForTransactionStoreFactoryToBeInitialized(transactionStoreFactory);
 
         new AntithesisWorkflowValidatorRunner(MoreExecutors.listeningDecorator(antithesisWorkflowRunnerExecutorService))
                 .run(
+                        createSingleBusyCellReadNoTouchWorkflowValidator(
+                                transactionStoreFactory,
+                                singleBusyCellReadNoTouchWorkflowConfiguration,
+                                environment.lifecycle()),
                         createSingleRowTwoCellsWorkflowValidator(
                                 transactionStoreFactory, singleRowTwoCellsConfig, environment.lifecycle()),
                         createRingWorkflowValidator(
@@ -159,11 +163,7 @@ public class WorkloadServerLauncher extends Application<WorkloadServerConfigurat
                                 transactionStoreFactory, transientRowsWorkflowConfiguration, environment.lifecycle()),
                         createSingleBusyCellWorkflowValidator(
                                 transactionStoreFactory, singleBusyCellWorkflowConfiguration, environment.lifecycle()),
-                        createRandomWorkflow(transactionStoreFactory, randomWorkflowConfig, environment.lifecycle()),
-                        createSingleBusyCellReadNoTouchWorkflowValidator(
-                                transactionStoreFactory,
-                                singleBusyCellReadNoTouchWorkflowConfiguration,
-                                environment.lifecycle()));
+                        createRandomWorkflow(transactionStoreFactory, randomWorkflowConfig, environment.lifecycle()));
 
         log.info("antithesis: terminate");
 

--- a/atlasdb-workload-server-distribution/src/main/java/com/palantir/atlasdb/workload/WorkloadServerLauncher.java
+++ b/atlasdb-workload-server-distribution/src/main/java/com/palantir/atlasdb/workload/WorkloadServerLauncher.java
@@ -253,10 +253,12 @@ public class WorkloadServerLauncher extends Application<WorkloadServerConfigurat
             LifecycleEnvironment lifecycle) {
         ExecutorService readExecutor = lifecycle
                 .executorService(SingleBusyCellReadsNoTouchWorkflowConfiguration.class.getSimpleName() + "-read")
+                .minThreads(workflowConfig.maxThreadCount() / 2)
                 .maxThreads(workflowConfig.maxThreadCount() / 2)
                 .build();
         ExecutorService writeExecutor = lifecycle
                 .executorService(SingleBusyCellReadsNoTouchWorkflowConfiguration.class.getSimpleName() + "-write")
+                .minThreads(workflowConfig.maxThreadCount() / 2)
                 .maxThreads(workflowConfig.maxThreadCount() / 2)
                 .build();
         InteractiveTransactionStore transactionStore = transactionStoreFactory.create(

--- a/atlasdb-workload-server-distribution/src/main/java/com/palantir/atlasdb/workload/config/WorkloadServerInstallConfiguration.java
+++ b/atlasdb-workload-server-distribution/src/main/java/com/palantir/atlasdb/workload/config/WorkloadServerInstallConfiguration.java
@@ -19,6 +19,7 @@ package com.palantir.atlasdb.workload.config;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.palantir.atlasdb.config.AtlasDbConfig;
+import com.palantir.atlasdb.workload.workflow.SingleBusyCellReadsNoTouchWorkflowConfiguration;
 import com.palantir.atlasdb.workload.workflow.SingleBusyCellWorkflowConfiguration;
 import com.palantir.atlasdb.workload.workflow.SingleRowTwoCellsWorkflowConfiguration;
 import com.palantir.atlasdb.workload.workflow.TransientRowsWorkflowConfiguration;
@@ -38,6 +39,8 @@ public interface WorkloadServerInstallConfiguration {
     TransientRowsWorkflowConfiguration transientRowsConfig();
 
     SingleBusyCellWorkflowConfiguration singleBusyCellConfig();
+
+    SingleBusyCellReadsNoTouchWorkflowConfiguration singleBusyCellReadsNoTouchConfig();
 
     boolean exitAfterRunning();
 }

--- a/atlasdb-workload-server-distribution/src/test/resources/workload-server.yml
+++ b/atlasdb-workload-server-distribution/src/test/resources/workload-server.yml
@@ -31,7 +31,7 @@ install:
     maxThreadCount: 2
   singleBusyCellReadsNoTouchConfig:
     tableConfiguration:
-      tableName: single-busy-cell-test
+      tableName: single-busy-cell-no-touch-test
       isolationLevel: SERIALIZABLE
     iterationCount: 100
     type: single-busy-cell-reads-no-touch

--- a/atlasdb-workload-server-distribution/src/test/resources/workload-server.yml
+++ b/atlasdb-workload-server-distribution/src/test/resources/workload-server.yml
@@ -29,4 +29,11 @@ install:
     iterationCount: 100
     type: single-busy-cell
     maxThreadCount: 2
+  singleBusyCellReadsNoTouchConfig:
+    tableConfiguration:
+      tableName: single-busy-cell-test
+      isolationLevel: SERIALIZABLE
+    iterationCount: 100
+    type: single-busy-cell-reads-no-touch
+    maxThreadCount: 2
   exitAfterRunning: false

--- a/atlasdb-workload-server-distribution/var/conf/workload-server.timelock.cassandra.yml
+++ b/atlasdb-workload-server-distribution/var/conf/workload-server.timelock.cassandra.yml
@@ -66,4 +66,11 @@ install:
     iterationCount: 100
     type: single-busy-cell
     maxThreadCount: 2
+  singleBusyCellReadsNoTouchConfig:
+    tableConfiguration:
+      tableName: single-busy-cell-test
+      isolationLevel: SERIALIZABLE
+    iterationCount: 100
+    type: single-busy-cell-reads-no-touch
+    maxThreadCount: 2
   exitAfterRunning: true

--- a/atlasdb-workload-server-distribution/var/conf/workload-server.timelock.cassandra.yml
+++ b/atlasdb-workload-server-distribution/var/conf/workload-server.timelock.cassandra.yml
@@ -68,7 +68,7 @@ install:
     maxThreadCount: 2
   singleBusyCellReadsNoTouchConfig:
     tableConfiguration:
-      tableName: single-busy-cell-test
+      tableName: single_busy_cell_no_touch_test
       isolationLevel: SERIALIZABLE
     iterationCount: 100
     type: single-busy-cell-reads-no-touch

--- a/atlasdb-workload-server-distribution/var/conf/workload-server.yml
+++ b/atlasdb-workload-server-distribution/var/conf/workload-server.yml
@@ -30,4 +30,11 @@ install:
     iterationCount: 100
     type: single-busy-cell
     maxThreadCount: 2
+  singleBusyCellReadsNoTouchConfig:
+    tableConfiguration:
+      tableName: single-busy-cell-test
+      isolationLevel: SERIALIZABLE
+    iterationCount: 100
+    type: single-busy-cell-reads-no-touch
+    maxThreadCount: 2
   exitAfterRunning: true

--- a/atlasdb-workload-server-distribution/var/conf/workload-server.yml
+++ b/atlasdb-workload-server-distribution/var/conf/workload-server.yml
@@ -32,7 +32,7 @@ install:
     maxThreadCount: 2
   singleBusyCellReadsNoTouchConfig:
     tableConfiguration:
-      tableName: single-busy-cell-test
+      tableName: single-busy-cell-no-touch-test
       isolationLevel: SERIALIZABLE
     iterationCount: 100
     type: single-busy-cell-reads-no-touch

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/workflow/SingleBusyCellReadNoTouchWorkflows.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/workflow/SingleBusyCellReadNoTouchWorkflows.java
@@ -1,0 +1,102 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.workload.workflow;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.palantir.atlasdb.workload.store.ImmutableWorkloadCell;
+import com.palantir.atlasdb.workload.store.InteractiveTransactionStore;
+import com.palantir.atlasdb.workload.store.ReadOnlyTransactionStore;
+import com.palantir.atlasdb.workload.store.WorkloadCell;
+import com.palantir.atlasdb.workload.transaction.DeleteTransactionAction;
+import com.palantir.atlasdb.workload.transaction.WriteTransactionAction;
+import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedTransaction;
+import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedTransactions;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * This workflow attempts to manipulate a single cell in a table, scheduling transactions that perform writes and
+ * deletes, along with transactions that simply read. Notice that unlike other workflows, because the load is
+ * considerably heterogeneous, we do not use a {@link DefaultWorkflow} to schedule transactions.
+ */
+public final class SingleBusyCellReadNoTouchWorkflows {
+    private SingleBusyCellReadNoTouchWorkflows() {
+        // utility
+    }
+
+    @VisibleForTesting
+    static final WorkloadCell BUSY_CELL = ImmutableWorkloadCell.of(1, 1);
+
+    public static Workflow create(
+            InteractiveTransactionStore store,
+            SingleBusyCellReadsNoTouchWorkflowConfiguration configuration,
+            ListeningExecutorService readExecutor,
+            ListeningExecutorService writeExecutor) {
+        return () -> {
+            List<ListenableFuture<Optional<WitnessedTransaction>>> reads =
+                    scheduleReads(store, configuration, readExecutor);
+            List<ListenableFuture<Optional<WitnessedTransaction>>> writes =
+                    scheduleWrites(store, configuration, writeExecutor);
+
+            ListenableFuture<List<WitnessedTransaction>> witnessedTransactions = Futures.transform(
+                    Futures.allAsList(
+                            Stream.of(reads, writes).flatMap(Collection::stream).collect(Collectors.toList())),
+                    maybeWitnessedTransactions -> maybeWitnessedTransactions.stream()
+                            .flatMap(Optional::stream)
+                            .collect(Collectors.toList()),
+                    MoreExecutors.directExecutor());
+            ReadOnlyTransactionStore readOnlyTransactionStore = new ReadOnlyTransactionStore(store);
+            return ImmutableWorkflowHistory.builder()
+                    .addAllHistory(WitnessedTransactions.sortAndFilterTransactions(
+                            readOnlyTransactionStore, Futures.getUnchecked(witnessedTransactions)))
+                    .transactionStore(readOnlyTransactionStore)
+                    .build();
+        };
+    }
+
+    private static List<ListenableFuture<Optional<WitnessedTransaction>>> scheduleReads(
+            InteractiveTransactionStore store,
+            SingleBusyCellReadsNoTouchWorkflowConfiguration configuration,
+            ListeningExecutorService readExecutor) {
+        return IntStream.range(0, configuration.iterationCount() / 2)
+                .mapToObj(idx -> readExecutor.submit(() -> store.readWrite(
+                        txn -> txn.read(configuration.tableConfiguration().tableName(), BUSY_CELL))))
+                .collect(Collectors.toList());
+    }
+
+    private static List<ListenableFuture<Optional<WitnessedTransaction>>> scheduleWrites(
+            InteractiveTransactionStore store,
+            SingleBusyCellReadsNoTouchWorkflowConfiguration configuration,
+            ListeningExecutorService writeExecutor) {
+        return IntStream.range(0, configuration.iterationCount() / 4)
+                .boxed()
+                .flatMap(index -> Stream.of(
+                        writeExecutor.submit(() -> store.readWrite(List.of(WriteTransactionAction.of(
+                                configuration.tableConfiguration().tableName(), BUSY_CELL, index)))),
+                        writeExecutor.submit(() -> store.readWrite(List.of(DeleteTransactionAction.of(
+                                configuration.tableConfiguration().tableName(), BUSY_CELL))))))
+                .collect(Collectors.toList());
+    }
+}

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/workflow/SingleBusyCellReadsNoTouchWorkflowConfiguration.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/workflow/SingleBusyCellReadsNoTouchWorkflowConfiguration.java
@@ -1,0 +1,32 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.workload.workflow;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableSingleBusyCellWorkflowConfiguration.class)
+@JsonDeserialize(as = ImmutableSingleBusyCellWorkflowConfiguration.class)
+@JsonTypeName(SingleBusyCellReadsNoTouchWorkflowConfiguration.TYPE)
+public interface SingleBusyCellReadsNoTouchWorkflowConfiguration extends WorkflowConfiguration {
+    String TYPE = "single-busy-cell-reads-no-touch";
+
+    TableConfiguration tableConfiguration();
+}

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/workflow/SingleBusyCellReadsNoTouchWorkflowConfiguration.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/workflow/SingleBusyCellReadsNoTouchWorkflowConfiguration.java
@@ -22,8 +22,8 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 
 @Value.Immutable
-@JsonSerialize(as = ImmutableSingleBusyCellWorkflowConfiguration.class)
-@JsonDeserialize(as = ImmutableSingleBusyCellWorkflowConfiguration.class)
+@JsonSerialize(as = ImmutableSingleBusyCellReadsNoTouchWorkflowConfiguration.class)
+@JsonDeserialize(as = ImmutableSingleBusyCellReadsNoTouchWorkflowConfiguration.class)
 @JsonTypeName(SingleBusyCellReadsNoTouchWorkflowConfiguration.TYPE)
 public interface SingleBusyCellReadsNoTouchWorkflowConfiguration extends WorkflowConfiguration {
     String TYPE = "single-busy-cell-reads-no-touch";


### PR DESCRIPTION
DO NOT MERGE THIS!

The only goal of this PR is to build a release candidate off of it and send it to Antithesis for testing if they can catch a known bug.

If thoroughly swept tables don't check for immutableTs lock on reads, we can't be sure that we have read the correct value during a transaction. We might have thought that a read was empty, but what happened was that we lost the immutableT lock and sweep ran and deleted the value from the underlying KVS. 