### PR TITLE
improvement: Replace most Iterable uses with Collection on Transaction and KeyValueService classes

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -69,7 +69,7 @@ public interface KeyValueService extends AutoCloseable, AsyncKeyValueService {
     @Idempotent
     @Timed
     Map<Cell, Value> getRows(
-            TableReference tableRef, Iterable<byte[]> rows, ColumnSelection columnSelection, long timestamp);
+            TableReference tableRef, Collection<byte[]> rows, ColumnSelection columnSelection, long timestamp);
 
     /**
      * Gets values from the key-value store for the specified rows and column range
@@ -89,14 +89,14 @@ public interface KeyValueService extends AutoCloseable, AsyncKeyValueService {
     @Timed
     Map<byte[], RowColumnRangeIterator> getRowsColumnRange(
             TableReference tableRef,
-            Iterable<byte[]> rows,
+            Collection<byte[]> rows,
             BatchColumnRangeSelection batchColumnRangeSelection,
             long timestamp);
 
     /**
      * Gets values from the key-value store for the specified rows and column range as a single iterator. This method
      * should be at least as performant as
-     * {@link #getRowsColumnRange(TableReference, Iterable, BatchColumnRangeSelection, long)}, and may be more
+     * {@link #getRowsColumnRange(TableReference, Collection, BatchColumnRangeSelection, long)}, and may be more
      * performant in some cases. Note that rows and columns must be non-empty: behaviour is undefined when
      * any of the rows or any of the columns in the column selection are the empty byte array.
      *
@@ -116,7 +116,7 @@ public interface KeyValueService extends AutoCloseable, AsyncKeyValueService {
     @Timed
     RowColumnRangeIterator getRowsColumnRange(
             TableReference tableRef,
-            Iterable<byte[]> rows,
+            Collection<byte[]> rows,
             ColumnRangeSelection columnRangeSelection,
             int cellBatchHint,
             long timestamp);
@@ -395,7 +395,7 @@ public interface KeyValueService extends AutoCloseable, AsyncKeyValueService {
      */
     @Idempotent
     @Timed
-    void deleteRows(TableReference tableRef, Iterable<byte[]> rows);
+    void deleteRows(TableReference tableRef, Collection<byte[]> rows);
 
     /**
      * For each cell, deletes all timestamps prior to the associated maximum timestamp. If this
@@ -516,7 +516,7 @@ public interface KeyValueService extends AutoCloseable, AsyncKeyValueService {
     @Idempotent
     @Timed
     Map<RangeRequest, TokenBackedBasicResultsPage<RowResult<Value>, byte[]>> getFirstBatchForRanges(
-            TableReference tableRef, Iterable<RangeRequest> rangeRequests, long timestamp);
+            TableReference tableRef, Collection<RangeRequest> rangeRequests, long timestamp);
 
     ////////////////////////////////////////////////////////////
     // TABLE CREATION AND METADATA
@@ -601,7 +601,7 @@ public interface KeyValueService extends AutoCloseable, AsyncKeyValueService {
      */
     @Idempotent
     @Timed
-    void addGarbageCollectionSentinelValues(TableReference tableRef, Iterable<Cell> cells);
+    void addGarbageCollectionSentinelValues(TableReference tableRef, Collection<Cell> cells);
 
     /**
      * Gets timestamp values from the key-value store. For each cell, this returns all associated

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/NoOpTransactionScopedCache.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/NoOpTransactionScopedCache.java
@@ -25,6 +25,7 @@ import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.lock.watch.CommitUpdate;
+import java.util.Collection;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Set;
@@ -62,10 +63,10 @@ public final class NoOpTransactionScopedCache implements TransactionScopedCache 
     @Override
     public NavigableMap<byte[], RowResult<byte[]>> getRows(
             TableReference tableRef,
-            Iterable<byte[]> rows,
+            Collection<byte[]> rows,
             ColumnSelection columnSelection,
             Function<Set<Cell>, Map<Cell, byte[]>> cellLoader,
-            Function<Iterable<byte[]>, NavigableMap<byte[], RowResult<byte[]>>> rowLoader) {
+            Function<Collection<byte[]>, NavigableMap<byte[], RowResult<byte[]>>> rowLoader) {
         return rowLoader.apply(rows);
     }
 

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ReadOnlyTransactionScopedCache.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ReadOnlyTransactionScopedCache.java
@@ -22,6 +22,7 @@ import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.lock.watch.CommitUpdate;
+import java.util.Collection;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Set;
@@ -67,10 +68,10 @@ public final class ReadOnlyTransactionScopedCache implements TransactionScopedCa
     @Override
     public NavigableMap<byte[], RowResult<byte[]>> getRows(
             TableReference tableRef,
-            Iterable<byte[]> rows,
+            Collection<byte[]> rows,
             ColumnSelection columnSelection,
             Function<Set<Cell>, Map<Cell, byte[]>> cellLoader,
-            Function<Iterable<byte[]>, NavigableMap<byte[], RowResult<byte[]>>> rowLoader) {
+            Function<Collection<byte[]>, NavigableMap<byte[], RowResult<byte[]>>> rowLoader) {
         return delegate.getRows(tableRef, rows, columnSelection, cellLoader, rowLoader);
     }
 

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/TransactionScopedCache.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/TransactionScopedCache.java
@@ -23,6 +23,7 @@ import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.lock.watch.CommitUpdate;
+import java.util.Collection;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Set;
@@ -77,10 +78,10 @@ public interface TransactionScopedCache {
      */
     NavigableMap<byte[], RowResult<byte[]>> getRows(
             TableReference tableRef,
-            Iterable<byte[]> rows,
+            Collection<byte[]> rows,
             ColumnSelection columnSelection,
             Function<Set<Cell>, Map<Cell, byte[]>> cellLoader,
-            Function<Iterable<byte[]>, NavigableMap<byte[], RowResult<byte[]>>> rowLoader);
+            Function<Collection<byte[]>, NavigableMap<byte[], RowResult<byte[]>>> rowLoader);
 
     /**
      * This method should be called before retrieving the value or hit digest, as it guarantees that no more reads or

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/ConstraintCheckingTransaction.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/ConstraintCheckingTransaction.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.transaction.api;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
@@ -31,5 +32,5 @@ public interface ConstraintCheckingTransaction extends Transaction {
     /**
      * Returns the row result values in the key-value service, ignoring the cache of local writes.
      */
-    SortedMap<byte[], RowResult<byte[]>> getRowsIgnoringLocalWrites(TableReference tableRef, Iterable<byte[]> rows);
+    SortedMap<byte[], RowResult<byte[]>> getRowsIgnoringLocalWrites(TableReference tableRef, Collection<byte[]> rows);
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
@@ -27,6 +27,7 @@ import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.common.annotation.Idempotent;
 import com.palantir.common.base.BatchingVisitable;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -71,7 +72,7 @@ public interface Transaction {
      */
     @Idempotent
     NavigableMap<byte[], RowResult<byte[]>> getRows(
-            TableReference tableRef, Iterable<byte[]> rows, ColumnSelection columnSelection);
+            TableReference tableRef, Collection<byte[]> rows, ColumnSelection columnSelection);
 
     /**
      * Returns a mapping of requested {@code rows} to corresponding columns from the queried table.
@@ -93,7 +94,7 @@ public interface Transaction {
      */
     @Idempotent
     Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> getRowsColumnRange(
-            TableReference tableRef, Iterable<byte[]> rows, BatchColumnRangeSelection columnRangeSelection);
+            TableReference tableRef, Collection<byte[]> rows, BatchColumnRangeSelection columnRangeSelection);
 
     /**
      * Returns a single iterator over the cell-value pairs in {@code tableRef} for the specified {@code rows}, where the
@@ -140,7 +141,7 @@ public interface Transaction {
      */
     @Idempotent
     Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> getRowsColumnRangeIterator(
-            TableReference tableRef, Iterable<byte[]> rows, BatchColumnRangeSelection columnRangeSelection);
+            TableReference tableRef, Collection<byte[]> rows, BatchColumnRangeSelection columnRangeSelection);
 
     /**
      * Returns an iterator over cell-value pairs within {@code tableRef} for the specified {@code rows}, where the

--- a/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/ReadOnlyTransactionScopedCacheTest.java
+++ b/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/ReadOnlyTransactionScopedCacheTest.java
@@ -28,6 +28,7 @@ import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.lock.watch.CommitUpdate;
+import java.util.Collection;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Set;
@@ -56,7 +57,7 @@ public final class ReadOnlyTransactionScopedCacheTest {
     public Function<Set<Cell>, Map<Cell, byte[]>> immediateValueLoader;
 
     @Mock
-    public Function<Iterable<byte[]>, NavigableMap<byte[], RowResult<byte[]>>> rowLoader;
+    public Function<Collection<byte[]>, NavigableMap<byte[], RowResult<byte[]>>> rowLoader;
 
     @Test
     public void nonReadMethodsThrow() {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueService.java
@@ -178,7 +178,7 @@ public abstract class AbstractKeyValueService implements KeyValueService {
     }
 
     @Override
-    public void deleteRows(TableReference tableRef, Iterable<byte[]> rows) {
+    public void deleteRows(TableReference tableRef, Collection<byte[]> rows) {
         rows.forEach(row -> deleteRange(tableRef, RangeRequests.ofSingleRow(row)));
     }
 
@@ -222,7 +222,7 @@ public abstract class AbstractKeyValueService implements KeyValueService {
     @Override
     public Map<byte[], RowColumnRangeIterator> getRowsColumnRange(
             TableReference tableRef,
-            Iterable<byte[]> rows,
+            Collection<byte[]> rows,
             BatchColumnRangeSelection batchColumnRangeSelection,
             long timestamp) {
         return KeyValueServices.filterGetRowsToColumnRange(this, tableRef, rows, batchColumnRangeSelection, timestamp);
@@ -231,7 +231,7 @@ public abstract class AbstractKeyValueService implements KeyValueService {
     @Override
     public RowColumnRangeIterator getRowsColumnRange(
             TableReference tableRef,
-            Iterable<byte[]> rows,
+            Collection<byte[]> rows,
             ColumnRangeSelection columnRangeSelection,
             int cellBatchHint,
             long timestamp) {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DualWriteKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DualWriteKeyValueService.java
@@ -73,7 +73,7 @@ public class DualWriteKeyValueService implements KeyValueService {
 
     @Override
     public Map<Cell, Value> getRows(
-            TableReference tableRef, Iterable<byte[]> rows, ColumnSelection columnSelection, long timestamp) {
+            TableReference tableRef, Collection<byte[]> rows, ColumnSelection columnSelection, long timestamp) {
         return delegate1.getRows(tableRef, rows, columnSelection, timestamp);
     }
 
@@ -143,7 +143,7 @@ public class DualWriteKeyValueService implements KeyValueService {
     }
 
     @Override
-    public void deleteRows(TableReference tableRef, Iterable<byte[]> rows) {
+    public void deleteRows(TableReference tableRef, Collection<byte[]> rows) {
         delegate1.deleteRows(tableRef, rows);
         delegate2.deleteRows(tableRef, rows);
     }
@@ -175,7 +175,7 @@ public class DualWriteKeyValueService implements KeyValueService {
 
     @Override
     public Map<RangeRequest, TokenBackedBasicResultsPage<RowResult<Value>, byte[]>> getFirstBatchForRanges(
-            TableReference tableRef, Iterable<RangeRequest> rangeRequests, long timestamp) {
+            TableReference tableRef, Collection<RangeRequest> rangeRequests, long timestamp) {
         return delegate1.getFirstBatchForRanges(tableRef, rangeRequests, timestamp);
     }
 
@@ -221,7 +221,7 @@ public class DualWriteKeyValueService implements KeyValueService {
     }
 
     @Override
-    public void addGarbageCollectionSentinelValues(TableReference tableRef, Iterable<Cell> cells) {
+    public void addGarbageCollectionSentinelValues(TableReference tableRef, Collection<Cell> cells) {
         delegate1.addGarbageCollectionSentinelValues(tableRef, cells);
         delegate2.addGarbageCollectionSentinelValues(tableRef, cells);
     }
@@ -282,7 +282,7 @@ public class DualWriteKeyValueService implements KeyValueService {
     @Override
     public Map<byte[], RowColumnRangeIterator> getRowsColumnRange(
             TableReference tableRef,
-            Iterable<byte[]> rows,
+            Collection<byte[]> rows,
             BatchColumnRangeSelection batchColumnRangeSelection,
             long timestamp) {
         return delegate1.getRowsColumnRange(tableRef, rows, batchColumnRangeSelection, timestamp);
@@ -291,7 +291,7 @@ public class DualWriteKeyValueService implements KeyValueService {
     @Override
     public RowColumnRangeIterator getRowsColumnRange(
             TableReference tableRef,
-            Iterable<byte[]> rows,
+            Collection<byte[]> rows,
             ColumnRangeSelection columnRangeSelection,
             int cellBatchHint,
             long timestamp) {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/InMemoryKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/InMemoryKeyValueService.java
@@ -111,7 +111,7 @@ public class InMemoryKeyValueService extends AbstractKeyValueService {
     @Override
     @SuppressWarnings({"CheckReturnValue"}) // Consume all remaining values of iterator.
     public Map<Cell, Value> getRows(
-            TableReference tableRef, Iterable<byte[]> rows, ColumnSelection columnSelection, long timestamp) {
+            TableReference tableRef, Collection<byte[]> rows, ColumnSelection columnSelection, long timestamp) {
         Map<Cell, Value> result = new HashMap<>();
         ConcurrentNavigableMap<Key, byte[]> table = getTableMap(tableRef).entries;
         for (byte[] row : rows) {
@@ -176,7 +176,7 @@ public class InMemoryKeyValueService extends AbstractKeyValueService {
 
     @Override
     public Map<RangeRequest, TokenBackedBasicResultsPage<RowResult<Value>, byte[]>> getFirstBatchForRanges(
-            TableReference tableRef, Iterable<RangeRequest> rangeRequests, long timestamp) {
+            TableReference tableRef, Collection<RangeRequest> rangeRequests, long timestamp) {
         return KeyValueServices.getFirstBatchForRangesUsingGetRange(this, tableRef, rangeRequests, timestamp);
     }
 
@@ -314,7 +314,7 @@ public class InMemoryKeyValueService extends AbstractKeyValueService {
     @Override
     public Map<byte[], RowColumnRangeIterator> getRowsColumnRange(
             TableReference tableRef,
-            Iterable<byte[]> rows,
+            Collection<byte[]> rows,
             BatchColumnRangeSelection batchColumnRangeSelection,
             long timestamp) {
         IdentityHashMap<byte[], RowColumnRangeIterator> result = new IdentityHashMap<>();
@@ -332,7 +332,7 @@ public class InMemoryKeyValueService extends AbstractKeyValueService {
     @Override
     public RowColumnRangeIterator getRowsColumnRange(
             TableReference tableRef,
-            Iterable<byte[]> rows,
+            Collection<byte[]> rows,
             ColumnRangeSelection columnRangeSelection,
             int cellBatchHint,
             long timestamp) {
@@ -686,7 +686,7 @@ public class InMemoryKeyValueService extends AbstractKeyValueService {
     }
 
     @Override
-    public void addGarbageCollectionSentinelValues(TableReference tableRef, Iterable<Cell> cells) {
+    public void addGarbageCollectionSentinelValues(TableReference tableRef, Collection<Cell> cells) {
         runWithLockForWrites(tableRef, table -> {
             for (Cell cell : cells) {
                 table.put(new Key(cell, Value.INVALID_VALUE_TIMESTAMP), ArrayUtils.EMPTY_BYTE_ARRAY);

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/KeyValueServices.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/KeyValueServices.java
@@ -56,6 +56,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
 
 public final class KeyValueServices {
@@ -147,7 +148,7 @@ public final class KeyValueServices {
     public static Map<byte[], RowColumnRangeIterator> filterGetRowsToColumnRange(
             KeyValueService kvs,
             TableReference tableRef,
-            Iterable<byte[]> rows,
+            Collection<byte[]> rows,
             BatchColumnRangeSelection columnRangeSelection,
             long timestamp) {
         log.warn("Using inefficient postfiltering for getRowsColumnRange because the KVS doesn't support it natively. "
@@ -195,7 +196,7 @@ public final class KeyValueServices {
     public static RowColumnRangeIterator mergeGetRowsColumnRangeIntoSingleIterator(
             KeyValueService kvs,
             TableReference tableRef,
-            Iterable<byte[]> rows,
+            Collection<byte[]> rows,
             ColumnRangeSelection columnRangeSelection,
             int batchHint,
             long timestamp) {
@@ -208,7 +209,8 @@ public final class KeyValueServices {
         Map<byte[], RowColumnRangeIterator> rowsColumnRanges =
                 kvs.getRowsColumnRange(tableRef, rows, batchColumnRangeSelection, timestamp);
         // Return results in the same order as the provided rows.
-        Iterable<RowColumnRangeIterator> orderedRanges = Iterables.transform(rows, rowsColumnRanges::get);
+        Iterable<RowColumnRangeIterator> orderedRanges =
+                rows.stream().map(rowsColumnRanges::get).collect(Collectors.toList());
         return new LocalRowColumnRangeIterator(Iterators.concat(orderedRanges.iterator()));
     }
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
@@ -158,7 +158,7 @@ public final class ProfilingKeyValueService implements KeyValueService {
     }
 
     @Override
-    public void addGarbageCollectionSentinelValues(TableReference tableRef, Iterable<Cell> cells) {
+    public void addGarbageCollectionSentinelValues(TableReference tableRef, Collection<Cell> cells) {
         long startTime = System.currentTimeMillis();
         maybeLog(
                 () -> delegate.addGarbageCollectionSentinelValues(tableRef, cells),
@@ -197,7 +197,7 @@ public final class ProfilingKeyValueService implements KeyValueService {
     }
 
     @Override
-    public void deleteRows(TableReference tableRef, Iterable<byte[]> rows) {
+    public void deleteRows(TableReference tableRef, Collection<byte[]> rows) {
         maybeLog(() -> delegate.deleteRows(tableRef, rows), logTimeAndTableRows("deleteRows", tableRef, rows));
     }
 
@@ -251,7 +251,7 @@ public final class ProfilingKeyValueService implements KeyValueService {
 
     @Override
     public Map<RangeRequest, TokenBackedBasicResultsPage<RowResult<Value>, byte[]>> getFirstBatchForRanges(
-            TableReference tableRef, Iterable<RangeRequest> rangeRequests, long timestamp) {
+            TableReference tableRef, Collection<RangeRequest> rangeRequests, long timestamp) {
         return maybeLog(
                 () -> delegate.getFirstBatchForRanges(tableRef, rangeRequests, timestamp),
                 logTimeAndTable("getFirstBatchForRanges", tableRef));
@@ -306,7 +306,7 @@ public final class ProfilingKeyValueService implements KeyValueService {
 
     @Override
     public Map<Cell, Value> getRows(
-            TableReference tableRef, Iterable<byte[]> rows, ColumnSelection columnSelection, long timestamp) {
+            TableReference tableRef, Collection<byte[]> rows, ColumnSelection columnSelection, long timestamp) {
         long startTime = System.currentTimeMillis();
         return KvsProfilingLogger.maybeLog(
                 () -> delegate.getRows(tableRef, rows, columnSelection, timestamp),
@@ -463,7 +463,7 @@ public final class ProfilingKeyValueService implements KeyValueService {
     @Override
     public Map<byte[], RowColumnRangeIterator> getRowsColumnRange(
             TableReference tableRef,
-            Iterable<byte[]> rows,
+            Collection<byte[]> rows,
             BatchColumnRangeSelection batchColumnRangeSelection,
             long timestamp) {
         long startTime = System.currentTimeMillis();
@@ -481,7 +481,7 @@ public final class ProfilingKeyValueService implements KeyValueService {
     @Override
     public RowColumnRangeIterator getRowsColumnRange(
             TableReference tableRef,
-            Iterable<byte[]> rows,
+            Collection<byte[]> rows,
             ColumnRangeSelection columnRangeSelection,
             int cellBatchHint,
             long timestamp) {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/StatsTrackingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/StatsTrackingKeyValueService.java
@@ -30,6 +30,7 @@ import com.palantir.common.base.ClosableIterator;
 import com.palantir.common.base.ForwardingClosableIterator;
 import com.palantir.common.collect.MapEntries;
 import java.io.PrintWriter;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -166,7 +167,7 @@ public class StatsTrackingKeyValueService extends ForwardingKeyValueService {
 
     @Override
     public Map<Cell, Value> getRows(
-            TableReference tableRef, Iterable<byte[]> rows, ColumnSelection columnSelection, long timestamp) {
+            TableReference tableRef, Collection<byte[]> rows, ColumnSelection columnSelection, long timestamp) {
         long start = System.currentTimeMillis();
         Map<Cell, Value> r = super.getRows(tableRef, rows, columnSelection, timestamp);
         long finish = System.currentTimeMillis();

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueService.java
@@ -91,7 +91,7 @@ public final class TracingKeyValueService extends ForwardingObject implements Ke
     }
 
     @Override
-    public void addGarbageCollectionSentinelValues(TableReference tableRef, Iterable<Cell> cells) {
+    public void addGarbageCollectionSentinelValues(TableReference tableRef, Collection<Cell> cells) {
         //noinspection unused - try-with-resources closes trace
         try (CloseableTracer trace = startLocalTrace("atlasdb-kvs.addGarbageCollectionSentinelValues", sink -> {
             sink.tableRef(tableRef);
@@ -191,7 +191,7 @@ public final class TracingKeyValueService extends ForwardingObject implements Ke
     }
 
     @Override
-    public void deleteRows(TableReference tableRef, Iterable<byte[]> rows) {
+    public void deleteRows(TableReference tableRef, Collection<byte[]> rows) {
         //noinspection unused - try-with-resources closes trace
         try (CloseableTracer trace = startLocalTrace("atlasdb-kvs.deleteRows", tableRef)) {
             delegate().deleteRows(tableRef, rows);
@@ -264,7 +264,7 @@ public final class TracingKeyValueService extends ForwardingObject implements Ke
 
     @Override
     public Map<RangeRequest, TokenBackedBasicResultsPage<RowResult<Value>, byte[]>> getFirstBatchForRanges(
-            TableReference tableRef, Iterable<RangeRequest> rangeRequests, long timestamp) {
+            TableReference tableRef, Collection<RangeRequest> rangeRequests, long timestamp) {
         //noinspection unused - try-with-resources closes trace
         try (CloseableTracer trace = startLocalTrace("atlasdb-kvs.getFirstBatchForRanges", sink -> {
             sink.tableRef(tableRef);
@@ -356,7 +356,7 @@ public final class TracingKeyValueService extends ForwardingObject implements Ke
 
     @Override
     public Map<Cell, Value> getRows(
-            TableReference tableRef, Iterable<byte[]> rows, ColumnSelection columnSelection, long timestamp) {
+            TableReference tableRef, Collection<byte[]> rows, ColumnSelection columnSelection, long timestamp) {
         //noinspection unused - try-with-resources closes trace
         try (CloseableTracer trace = startLocalTrace("atlasdb-kvs.getRows", sink -> {
             sink.tableRef(tableRef);
@@ -370,7 +370,7 @@ public final class TracingKeyValueService extends ForwardingObject implements Ke
     @Override
     public Map<byte[], RowColumnRangeIterator> getRowsColumnRange(
             TableReference tableRef,
-            Iterable<byte[]> rows,
+            Collection<byte[]> rows,
             BatchColumnRangeSelection columnRangeSelection,
             long timestamp) {
         TraceStatistic original = TraceStatistics.getCurrentAndClear();
@@ -389,7 +389,7 @@ public final class TracingKeyValueService extends ForwardingObject implements Ke
     @Override
     public RowColumnRangeIterator getRowsColumnRange(
             TableReference tableRef,
-            Iterable<byte[]> rows,
+            Collection<byte[]> rows,
             ColumnRangeSelection columnRangeSelection,
             int cellBatchHint,
             long timestamp) {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ValidatingQueryRewritingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ValidatingQueryRewritingKeyValueService.java
@@ -159,7 +159,7 @@ public class ValidatingQueryRewritingKeyValueService extends ForwardingKeyValueS
 
     @Override
     public Map<RangeRequest, TokenBackedBasicResultsPage<RowResult<Value>, byte[]>> getFirstBatchForRanges(
-            TableReference tableRef, Iterable<RangeRequest> rangeRequests, long timestamp) {
+            TableReference tableRef, Collection<RangeRequest> rangeRequests, long timestamp) {
         if (Iterables.isEmpty(rangeRequests)) {
             return ImmutableMap.of();
         }
@@ -176,7 +176,7 @@ public class ValidatingQueryRewritingKeyValueService extends ForwardingKeyValueS
 
     @Override
     public Map<Cell, Value> getRows(
-            TableReference tableRef, Iterable<byte[]> rows, ColumnSelection columnSelection, long timestamp) {
+            TableReference tableRef, Collection<byte[]> rows, ColumnSelection columnSelection, long timestamp) {
         if (Iterables.isEmpty(rows) || columnSelection.noColumnsSelected()) {
             return ImmutableMap.of();
         }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/CachingTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/CachingTransaction.java
@@ -77,7 +77,7 @@ public class CachingTransaction extends ForwardingTransaction {
 
     @Override
     public NavigableMap<byte[], RowResult<byte[]>> getRows(
-            TableReference tableRef, Iterable<byte[]> rows, ColumnSelection columnSelection) {
+            TableReference tableRef, Collection<byte[]> rows, ColumnSelection columnSelection) {
         if (Iterables.isEmpty(rows)) {
             return AbstractTransaction.EMPTY_SORTED_ROWS;
         }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransaction.java
@@ -31,6 +31,7 @@ import com.palantir.atlasdb.transaction.api.TransactionFailedException;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.common.base.BatchingVisitable;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -50,19 +51,19 @@ public abstract class ForwardingTransaction extends ForwardingObject implements 
 
     @Override
     public NavigableMap<byte[], RowResult<byte[]>> getRows(
-            TableReference tableRef, Iterable<byte[]> rows, ColumnSelection columnSelection) {
+            TableReference tableRef, Collection<byte[]> rows, ColumnSelection columnSelection) {
         return delegate().getRows(tableRef, rows, columnSelection);
     }
 
     @Override
     public Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> getRowsColumnRange(
-            TableReference tableRef, Iterable<byte[]> rows, BatchColumnRangeSelection columnRangeSelection) {
+            TableReference tableRef, Collection<byte[]> rows, BatchColumnRangeSelection columnRangeSelection) {
         return delegate().getRowsColumnRange(tableRef, rows, columnRangeSelection);
     }
 
     @Override
     public Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> getRowsColumnRangeIterator(
-            TableReference tableRef, Iterable<byte[]> rows, BatchColumnRangeSelection columnRangeSelection) {
+            TableReference tableRef, Collection<byte[]> rows, BatchColumnRangeSelection columnRangeSelection) {
         return delegate().getRowsColumnRangeIterator(tableRef, rows, columnRangeSelection);
     }
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ReadTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ReadTransaction.java
@@ -29,6 +29,7 @@ import com.palantir.atlasdb.transaction.api.GetRangesQuery;
 import com.palantir.common.base.BatchingVisitable;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -52,7 +53,7 @@ public class ReadTransaction extends ForwardingCallbackAwareTransaction {
 
     @Override
     public NavigableMap<byte[], RowResult<byte[]>> getRows(
-            TableReference tableRef, Iterable<byte[]> rows, ColumnSelection columnSelection) {
+            TableReference tableRef, Collection<byte[]> rows, ColumnSelection columnSelection) {
         checkTableName(tableRef);
         return delegate().getRows(tableRef, rows, columnSelection);
     }
@@ -109,14 +110,14 @@ public class ReadTransaction extends ForwardingCallbackAwareTransaction {
 
     @Override
     public Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> getRowsColumnRange(
-            TableReference tableRef, Iterable<byte[]> rows, BatchColumnRangeSelection columnRangeSelection) {
+            TableReference tableRef, Collection<byte[]> rows, BatchColumnRangeSelection columnRangeSelection) {
         checkTableName(tableRef);
         return delegate().getRowsColumnRange(tableRef, rows, columnRangeSelection);
     }
 
     @Override
     public Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> getRowsColumnRangeIterator(
-            TableReference tableRef, Iterable<byte[]> rows, BatchColumnRangeSelection columnRangeSelection) {
+            TableReference tableRef, Collection<byte[]> rows, BatchColumnRangeSelection columnRangeSelection) {
         checkTableName(tableRef);
         return delegate().getRowsColumnRangeIterator(tableRef, rows, columnRangeSelection);
     }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/AbstractSchemaApiTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/AbstractSchemaApiTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.google.common.primitives.UnsignedBytes;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.Cell;
@@ -43,7 +42,9 @@ import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.impl.AbstractTransaction;
 import com.palantir.common.base.BatchingVisitableFromIterable;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -121,7 +122,7 @@ public abstract class AbstractSchemaApiTest {
         long value = getSingleRowFirstColumn(transaction, TEST_ROW_KEY);
 
         assertThat(value).isEqualTo(TEST_VALUE_LONG);
-        ArgumentCaptor<Iterable<byte[]>> argument = ArgumentCaptor.forClass(Iterable.class);
+        ArgumentCaptor<Collection<byte[]>> argument = ArgumentCaptor.forClass(Collection.class);
         verify(transaction, times(1)).getRows(eq(tableRef), argument.capture(), eq(FIRST_COLUMN_SELECTION));
 
         Iterable<byte[]> argumentRows = argument.getValue();
@@ -144,10 +145,10 @@ public abstract class AbstractSchemaApiTest {
         assertThat(result)
                 .containsExactlyInAnyOrderEntriesOf(
                         ImmutableMap.of(TEST_ROW_KEY, TEST_VALUE_LONG, TEST_ROW_KEY2, TEST_VALUE_LONG2));
-        ArgumentCaptor<Iterable<byte[]>> argument = ArgumentCaptor.forClass(Iterable.class);
+        ArgumentCaptor<Collection<byte[]>> argument = ArgumentCaptor.forClass(Collection.class);
         verify(transaction, times(1)).getRows(eq(tableRef), argument.capture(), eq(FIRST_COLUMN_SELECTION));
 
-        List<byte[]> argumentRows = Lists.newArrayList(argument.getValue());
+        List<byte[]> argumentRows = new ArrayList<>(argument.getValue());
         assertThat(argumentRows).hasSize(2);
         assertThat(argumentRows.get(0))
                 .usingComparator(UnsignedBytes.lexicographicalComparator())

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
@@ -314,7 +314,7 @@ public final class DbKvs extends AbstractKeyValueService implements DbKeyValueSe
 
     @Override
     public Map<Cell, Value> getRows(
-            TableReference tableRef, Iterable<byte[]> rows, ColumnSelection columnSelection, long timestamp) {
+            TableReference tableRef, Collection<byte[]> rows, ColumnSelection columnSelection, long timestamp) {
         return getRowsBatching(tableRef, rows, columnSelection, timestamp);
     }
 
@@ -653,7 +653,7 @@ public final class DbKvs extends AbstractKeyValueService implements DbKeyValueSe
 
     @Override
     public Map<RangeRequest, TokenBackedBasicResultsPage<RowResult<Value>, byte[]>> getFirstBatchForRanges(
-            TableReference tableRef, Iterable<RangeRequest> rangeRequests, long timestamp) {
+            TableReference tableRef, Collection<RangeRequest> rangeRequests, long timestamp) {
         return new DbKvsGetRanges(this, dbTables.getDbType(), connections, dbTables.getPrefixedTableNames())
                 .getFirstBatchForRanges(tableRef, rangeRequests, timestamp);
     }
@@ -812,7 +812,7 @@ public final class DbKvs extends AbstractKeyValueService implements DbKeyValueSe
     @Override
     public Map<byte[], RowColumnRangeIterator> getRowsColumnRange(
             TableReference tableRef,
-            Iterable<byte[]> rows,
+            Collection<byte[]> rows,
             BatchColumnRangeSelection batchColumnRangeSelection,
             long timestamp) {
         List<byte[]> rowList = ImmutableList.copyOf(rows);
@@ -846,7 +846,7 @@ public final class DbKvs extends AbstractKeyValueService implements DbKeyValueSe
     @Override
     public RowColumnRangeIterator getRowsColumnRange(
             TableReference tableRef,
-            Iterable<byte[]> rows,
+            Collection<byte[]> rows,
             ColumnRangeSelection columnRangeSelection,
             int cellBatchHint,
             long timestamp) {
@@ -1219,7 +1219,7 @@ public final class DbKvs extends AbstractKeyValueService implements DbKeyValueSe
     }
 
     @Override
-    public void addGarbageCollectionSentinelValues(TableReference tableRef, Iterable<Cell> cells) {
+    public void addGarbageCollectionSentinelValues(TableReference tableRef, Collection<Cell> cells) {
         runWrite(tableRef, (Function<DbWriteTable, Void>) table -> {
             table.putSentinels(cells);
             return null;

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/RowsColumnRangeBatchRequest.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/RowsColumnRangeBatchRequest.java
@@ -25,8 +25,7 @@ import javax.annotation.Nullable;
 import org.immutables.value.Value;
 
 /**
- * Represents a batch to load in {@link com.palantir.atlasdb.keyvalue.api.KeyValueService#getRowsColumnRange(
- * com.palantir.atlasdb.keyvalue.api.TableReference, Iterable, ColumnRangeSelection, int, long)}. The overall iteration
+ * Represents a batch to load in {@link com.palantir.atlasdb.keyvalue.api.KeyValueService#getRowsColumnRange(com.palantir.atlasdb.keyvalue.api.TableReference, java.util.Collection, ColumnRangeSelection, int, long)}. The overall iteration
  * order returns all requested columns for the first row, followed by all requested columns for the second row, and so
  * forth. Hence, a single batch consists of some contiguous group of rows to fully load, plus optionally a first row
  * that has a different starting column and optionally a last row where we load a number of columns less than the total.

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/TransactionScopedCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/TransactionScopedCacheImpl.java
@@ -34,6 +34,7 @@ import com.palantir.atlasdb.transaction.api.TransactionLockWatchFailedException;
 import com.palantir.common.streams.KeyedStream;
 import com.palantir.lock.watch.CommitUpdate;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -108,10 +109,10 @@ final class TransactionScopedCacheImpl implements TransactionScopedCache {
     @Override
     public NavigableMap<byte[], RowResult<byte[]>> getRows(
             TableReference tableRef,
-            Iterable<byte[]> rows,
+            Collection<byte[]> rows,
             ColumnSelection columnSelection,
             Function<Set<Cell>, Map<Cell, byte[]>> cellLoader,
-            Function<Iterable<byte[]>, NavigableMap<byte[], RowResult<byte[]>>> rowLoader) {
+            Function<Collection<byte[]>, NavigableMap<byte[], RowResult<byte[]>>> rowLoader) {
         ensureNotFinalised();
 
         if (!valueStore.isWatched(tableRef)) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ValidatingTransactionScopedCache.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ValidatingTransactionScopedCache.java
@@ -38,6 +38,7 @@ import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.NavigableSet;
@@ -117,10 +118,10 @@ final class ValidatingTransactionScopedCache implements TransactionScopedCache {
     @Override
     public NavigableMap<byte[], RowResult<byte[]>> getRows(
             TableReference tableRef,
-            Iterable<byte[]> rows,
+            Collection<byte[]> rows,
             ColumnSelection columnSelection,
             Function<Set<Cell>, Map<Cell, byte[]>> cellLoader,
-            Function<Iterable<byte[]>, NavigableMap<byte[], RowResult<byte[]>>> rowLoader) {
+            Function<Collection<byte[]>, NavigableMap<byte[], RowResult<byte[]>>> rowLoader) {
         if (shouldValidate()) {
             NavigableMap<byte[], RowResult<byte[]>> remoteReads = rowLoader.apply(rows);
             NavigableMap<byte[], RowResult<byte[]>> cacheReads = delegate.getRows(

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableRemappingKeyValueService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableRemappingKeyValueService.java
@@ -68,7 +68,7 @@ public final class TableRemappingKeyValueService extends ForwardingObject implem
     }
 
     @Override
-    public void addGarbageCollectionSentinelValues(TableReference tableRef, Iterable<Cell> cells) {
+    public void addGarbageCollectionSentinelValues(TableReference tableRef, Collection<Cell> cells) {
         try {
             delegate().addGarbageCollectionSentinelValues(tableMapper.getMappedTableName(tableRef), cells);
         } catch (TableMappingNotFoundException e) {
@@ -116,7 +116,7 @@ public final class TableRemappingKeyValueService extends ForwardingObject implem
     }
 
     @Override
-    public void deleteRows(TableReference tableRef, Iterable<byte[]> rows) {
+    public void deleteRows(TableReference tableRef, Collection<byte[]> rows) {
         try {
             delegate().deleteRows(tableMapper.getMappedTableName(tableRef), rows);
         } catch (TableMappingNotFoundException e) {
@@ -193,7 +193,7 @@ public final class TableRemappingKeyValueService extends ForwardingObject implem
 
     @Override
     public Map<RangeRequest, TokenBackedBasicResultsPage<RowResult<Value>, byte[]>> getFirstBatchForRanges(
-            TableReference tableRef, Iterable<RangeRequest> rangeRequests, long timestamp) {
+            TableReference tableRef, Collection<RangeRequest> rangeRequests, long timestamp) {
         try {
             return delegate()
                     .getFirstBatchForRanges(tableMapper.getMappedTableName(tableRef), rangeRequests, timestamp);
@@ -268,7 +268,7 @@ public final class TableRemappingKeyValueService extends ForwardingObject implem
 
     @Override
     public Map<Cell, Value> getRows(
-            TableReference tableRef, Iterable<byte[]> rows, ColumnSelection columnSelection, long timestamp) {
+            TableReference tableRef, Collection<byte[]> rows, ColumnSelection columnSelection, long timestamp) {
         try {
             return delegate().getRows(tableMapper.getMappedTableName(tableRef), rows, columnSelection, timestamp);
         } catch (TableMappingNotFoundException e) {
@@ -279,7 +279,7 @@ public final class TableRemappingKeyValueService extends ForwardingObject implem
     @Override
     public Map<byte[], RowColumnRangeIterator> getRowsColumnRange(
             TableReference tableRef,
-            Iterable<byte[]> rows,
+            Collection<byte[]> rows,
             BatchColumnRangeSelection columnRangeSelection,
             long timestamp) {
         try {
@@ -294,7 +294,7 @@ public final class TableRemappingKeyValueService extends ForwardingObject implem
     @Override
     public RowColumnRangeIterator getRowsColumnRange(
             TableReference tableRef,
-            Iterable<byte[]> rows,
+            Collection<byte[]> rows,
             ColumnRangeSelection columnRangeSelection,
             int cellBatchHint,
             long timestamp) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableSplittingKeyValueService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableSplittingKeyValueService.java
@@ -97,7 +97,7 @@ public final class TableSplittingKeyValueService implements KeyValueService {
     }
 
     @Override
-    public void addGarbageCollectionSentinelValues(TableReference tableRef, Iterable<Cell> cells) {
+    public void addGarbageCollectionSentinelValues(TableReference tableRef, Collection<Cell> cells) {
         getDelegate(tableRef).addGarbageCollectionSentinelValues(tableRef, cells);
     }
 
@@ -143,7 +143,7 @@ public final class TableSplittingKeyValueService implements KeyValueService {
     }
 
     @Override
-    public void deleteRows(TableReference tableRef, Iterable<byte[]> rows) {
+    public void deleteRows(TableReference tableRef, Collection<byte[]> rows) {
         getDelegate(tableRef).deleteRows(tableRef, rows);
     }
 
@@ -227,7 +227,7 @@ public final class TableSplittingKeyValueService implements KeyValueService {
 
     @Override
     public Map<RangeRequest, TokenBackedBasicResultsPage<RowResult<Value>, byte[]>> getFirstBatchForRanges(
-            TableReference tableRef, Iterable<RangeRequest> rangeRequests, long timestamp) {
+            TableReference tableRef, Collection<RangeRequest> rangeRequests, long timestamp) {
         return getDelegate(tableRef).getFirstBatchForRanges(tableRef, rangeRequests, timestamp);
     }
 
@@ -273,14 +273,14 @@ public final class TableSplittingKeyValueService implements KeyValueService {
 
     @Override
     public Map<Cell, Value> getRows(
-            TableReference tableRef, Iterable<byte[]> rows, ColumnSelection columnSelection, long timestamp) {
+            TableReference tableRef, Collection<byte[]> rows, ColumnSelection columnSelection, long timestamp) {
         return getDelegate(tableRef).getRows(tableRef, rows, columnSelection, timestamp);
     }
 
     @Override
     public Map<byte[], RowColumnRangeIterator> getRowsColumnRange(
             TableReference tableRef,
-            Iterable<byte[]> rows,
+            Collection<byte[]> rows,
             BatchColumnRangeSelection batchColumnRangeSelection,
             long timestamp) {
         return getDelegate(tableRef).getRowsColumnRange(tableRef, rows, batchColumnRangeSelection, timestamp);
@@ -289,7 +289,7 @@ public final class TableSplittingKeyValueService implements KeyValueService {
     @Override
     public RowColumnRangeIterator getRowsColumnRange(
             TableReference tableRef,
-            Iterable<byte[]> rows,
+            Collection<byte[]> rows,
             ColumnRangeSelection columnRangeSelection,
             int cellBatchHint,
             long timestamp) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueTable.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueTable.java
@@ -25,6 +25,7 @@ import com.palantir.atlasdb.keyvalue.api.RowColumnRangeIterator;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.impl.LocalRowColumnRangeIterator;
 import com.palantir.atlasdb.sweep.metrics.TargetedSweepMetrics;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -123,7 +124,7 @@ public abstract class SweepQueueTable {
                 .stream();
     }
 
-    void deleteRows(Iterable<byte[]> rows) {
+    void deleteRows(Collection<byte[]> rows) {
         kvs.deleteRows(tableRef, rows);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -85,6 +85,7 @@ import com.palantir.logsafe.logger.SafeLoggerFactory;
 import com.palantir.util.Pair;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -195,7 +196,7 @@ public class SerializableTransaction extends SnapshotTransaction {
     @Override
     @Idempotent
     public NavigableMap<byte[], RowResult<byte[]>> getRows(
-            TableReference tableRef, Iterable<byte[]> rows, ColumnSelection columnSelection) {
+            TableReference tableRef, Collection<byte[]> rows, ColumnSelection columnSelection) {
         NavigableMap<byte[], RowResult<byte[]>> ret = super.getRows(tableRef, rows, columnSelection);
         markRowsRead(tableRef, rows, columnSelection, ret.values());
         return ret;
@@ -203,7 +204,7 @@ public class SerializableTransaction extends SnapshotTransaction {
 
     @Override
     public Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> getRowsColumnRange(
-            TableReference tableRef, Iterable<byte[]> rows, BatchColumnRangeSelection columnRangeSelection) {
+            TableReference tableRef, Collection<byte[]> rows, BatchColumnRangeSelection columnRangeSelection) {
         Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> ret =
                 super.getRowsColumnRange(tableRef, rows, columnRangeSelection);
         return KeyedStream.stream(ret)
@@ -222,7 +223,7 @@ public class SerializableTransaction extends SnapshotTransaction {
 
     @Override
     public Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> getRowsColumnRangeIterator(
-            TableReference tableRef, Iterable<byte[]> rows, BatchColumnRangeSelection columnRangeSelection) {
+            TableReference tableRef, Collection<byte[]> rows, BatchColumnRangeSelection columnRangeSelection) {
         Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> ret =
                 super.getRowsColumnRangeIterator(tableRef, rows, columnRangeSelection);
         return KeyedStream.stream(ret)

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/expectations/TrackingKeyValueServiceImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/expectations/TrackingKeyValueServiceImpl.java
@@ -43,6 +43,7 @@ import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
 import java.lang.reflect.Array;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -87,7 +88,7 @@ public final class TrackingKeyValueServiceImpl extends ForwardingKeyValueService
 
     @Override
     public Map<Cell, Value> getRows(
-            TableReference tableRef, Iterable<byte[]> rows, ColumnSelection columnSelection, long timestamp) {
+            TableReference tableRef, Collection<byte[]> rows, ColumnSelection columnSelection, long timestamp) {
         Map<Cell, Value> result = delegate.getRows(tableRef, rows, columnSelection, timestamp);
         tracker.recordReadForTable(tableRef, "getRows", MeasuringUtils.sizeOf(result));
         return result;
@@ -96,7 +97,7 @@ public final class TrackingKeyValueServiceImpl extends ForwardingKeyValueService
     @Override
     public Map<byte[], RowColumnRangeIterator> getRowsColumnRange(
             TableReference tableRef,
-            Iterable<byte[]> rows,
+            Collection<byte[]> rows,
             BatchColumnRangeSelection batchColumnRangeSelection,
             long timestamp) {
         Map<byte[], RowColumnRangeIterator> result =
@@ -114,7 +115,7 @@ public final class TrackingKeyValueServiceImpl extends ForwardingKeyValueService
     @Override
     public RowColumnRangeIterator getRowsColumnRange(
             TableReference tableRef,
-            Iterable<byte[]> rows,
+            Collection<byte[]> rows,
             ColumnRangeSelection columnRangeSelection,
             int cellBatchHint,
             long timestamp) {
@@ -166,7 +167,7 @@ public final class TrackingKeyValueServiceImpl extends ForwardingKeyValueService
 
     @Override
     public Map<RangeRequest, TokenBackedBasicResultsPage<RowResult<Value>, byte[]>> getFirstBatchForRanges(
-            TableReference tableRef, Iterable<RangeRequest> rangeRequests, long timestamp) {
+            TableReference tableRef, Collection<RangeRequest> rangeRequests, long timestamp) {
         Map<RangeRequest, TokenBackedBasicResultsPage<RowResult<Value>, byte[]>> result =
                 delegate.getFirstBatchForRanges(tableRef, rangeRequests, timestamp);
         tracker.recordReadForTable(

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/ValidatingTransactionScopedCacheTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/ValidatingTransactionScopedCacheTest.java
@@ -43,6 +43,7 @@ import com.palantir.common.streams.KeyedStream;
 import com.palantir.lock.watch.CommitUpdate;
 import io.vavr.collection.HashMap;
 import io.vavr.collection.HashSet;
+import java.util.Collection;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Optional;
@@ -150,7 +151,7 @@ public final class ValidatingTransactionScopedCacheTest {
         ColumnSelection columns = ColumnSelection.create(rowsAndCols);
 
         Function<Set<Cell>, Map<Cell, byte[]>> cellLoader = mock(Function.class);
-        Function<Iterable<byte[]>, NavigableMap<byte[], RowResult<byte[]>>> rowLoader = mock(Function.class);
+        Function<Collection<byte[]>, NavigableMap<byte[], RowResult<byte[]>>> rowLoader = mock(Function.class);
 
         // set up mock
         NavigableMap<byte[], RowResult<byte[]>> resultMap = new TreeMap<>(UnsignedBytes.lexicographicalComparator());
@@ -179,7 +180,7 @@ public final class ValidatingTransactionScopedCacheTest {
         ColumnSelection columns = ColumnSelection.create(rowsAndCols);
 
         Function<Set<Cell>, Map<Cell, byte[]>> cellLoader = mock(Function.class);
-        Function<Iterable<byte[]>, NavigableMap<byte[], RowResult<byte[]>>> rowLoader = mock(Function.class);
+        Function<Collection<byte[]>, NavigableMap<byte[], RowResult<byte[]>>> rowLoader = mock(Function.class);
 
         when(rowLoader.apply(any())).thenReturn(new TreeMap<>(UnsignedBytes.lexicographicalComparator()));
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/expectations/TrackingKeyValueServiceForwardingTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/expectations/TrackingKeyValueServiceForwardingTest.java
@@ -47,6 +47,7 @@ import com.palantir.common.base.ClosableIterators;
 import com.palantir.common.streams.KeyedStream;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
 import java.util.AbstractMap.SimpleEntry;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -258,7 +259,7 @@ public final class TrackingKeyValueServiceForwardingTest {
 
     @Test
     public void getFirstBatchForRangesForwardsDelegateResult() {
-        Iterable<RangeRequest> rangeRequests = mock(Iterable.class);
+        Collection<RangeRequest> rangeRequests = mock(Collection.class);
         Map<RangeRequest, TokenBackedBasicResultsPage<RowResult<Value>, byte[]>> batchForRangesMap = mock(Map.class);
         when(delegate.getFirstBatchForRanges(tableReference, rangeRequests, TIMESTAMP))
                 .thenReturn(batchForRangesMap);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/expectations/TrackingKeyValueServiceReadInfoTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/expectations/TrackingKeyValueServiceReadInfoTest.java
@@ -43,6 +43,7 @@ import com.palantir.atlasdb.transaction.api.expectations.ImmutableTransactionRea
 import com.palantir.atlasdb.transaction.api.expectations.TransactionReadInfo;
 import com.palantir.common.base.ClosableIterators;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -259,7 +260,7 @@ public final class TrackingKeyValueServiceReadInfoTest {
 
     @Test
     public void readInfoIsCorrectAfterGetFirstBatchForRangesCall() {
-        Iterable<RangeRequest> rangeRequests = mock(Iterable.class);
+        Collection<RangeRequest> rangeRequests = mock(Collection.class);
         Map<RangeRequest, TokenBackedBasicResultsPage<RowResult<Value>, byte[]>> pageByRangeRequestMapOfSize =
                 TrackingKeyValueServiceTestUtils.createPageByRangeRequestMapWithSize(size);
 

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsGetRangeBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsGetRangeBenchmarks.java
@@ -26,6 +26,7 @@ import com.palantir.atlasdb.performance.benchmarks.table.ConsecutiveNarrowTable;
 import com.palantir.common.base.ClosableIterator;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -62,7 +63,7 @@ public class KvsGetRangeBenchmarks {
     }
 
     private Object getMultiRangeInner(ConsecutiveNarrowTable table) {
-        Iterable<RangeRequest> requests = table.getRangeRequests(1000, 1, false);
+        Collection<RangeRequest> requests = table.getRangeRequests(1000, 1, false);
         Map<RangeRequest, TokenBackedBasicResultsPage<RowResult<Value>, byte[]>> results =
                 table.getKvs().getFirstBatchForRanges(table.getTableRef(), requests, Long.MAX_VALUE);
 

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/ConsecutiveNarrowTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/ConsecutiveNarrowTable.java
@@ -28,6 +28,7 @@ import com.palantir.atlasdb.performance.benchmarks.Benchmarks;
 import com.palantir.atlasdb.services.AtlasDbServices;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -188,7 +189,7 @@ public abstract class ConsecutiveNarrowTable {
                 .collect(Collectors.toSet());
     }
 
-    public Iterable<RangeRequest> getRangeRequests(int numRequests, int sliceSize, boolean allColumns) {
+    public Collection<RangeRequest> getRangeRequests(int numRequests, int sliceSize, boolean allColumns) {
         List<RangeRequest> requests = new ArrayList<>();
         Set<Integer> used = new HashSet<>();
         for (int i = 0; i < numRequests; i++) {

--- a/atlasdb-service/src/main/java/com/palantir/atlasdb/api/TableRowSelection.java
+++ b/atlasdb-service/src/main/java/com/palantir/atlasdb/api/TableRowSelection.java
@@ -17,6 +17,7 @@ package com.palantir.atlasdb.api;
 
 import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
 import com.palantir.logsafe.Preconditions;
+import java.util.Collection;
 
 /**
  * <pre>
@@ -32,10 +33,10 @@ import com.palantir.logsafe.Preconditions;
  */
 public class TableRowSelection {
     private final String tableName;
-    private final Iterable<byte[]> rows;
+    private final Collection<byte[]> rows;
     private final ColumnSelection columnSelection;
 
-    public TableRowSelection(String tableName, Iterable<byte[]> rows, ColumnSelection columnSelection) {
+    public TableRowSelection(String tableName, Collection<byte[]> rows, ColumnSelection columnSelection) {
         this.tableName = Preconditions.checkNotNull(tableName, "tableName must not be null!");
         this.rows = Preconditions.checkNotNull(rows, "rows must not be null!");
         this.columnSelection = columnSelection;
@@ -45,7 +46,7 @@ public class TableRowSelection {
         return tableName;
     }
 
-    public Iterable<byte[]> getRows() {
+    public Collection<byte[]> getRows() {
         return rows;
     }
 

--- a/atlasdb-service/src/main/java/com/palantir/atlasdb/jackson/TableRowSelectionDeserializer.java
+++ b/atlasdb-service/src/main/java/com/palantir/atlasdb/jackson/TableRowSelectionDeserializer.java
@@ -25,6 +25,8 @@ import com.palantir.atlasdb.impl.TableMetadataCache;
 import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
 import com.palantir.atlasdb.table.description.TableMetadata;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
 
 public class TableRowSelectionDeserializer extends StdDeserializer<TableRowSelection> {
     private static final long serialVersionUID = 1L;
@@ -42,10 +44,19 @@ public class TableRowSelectionDeserializer extends StdDeserializer<TableRowSelec
         TableMetadata metadata = metadataCache.getMetadata(tableName);
         Iterable<byte[]> rows = AtlasDeserializers.deserializeRows(metadata.getRowMetadata(), node.get("rows"));
         Iterable<byte[]> columns = AtlasDeserializers.deserializeNamedCols(metadata.getColumns(), node.get("cols"));
+        Collection<byte[]> rowCollection = iterableToCollection(rows);
         if (Iterables.isEmpty(columns)) {
-            return new TableRowSelection(tableName, rows, ColumnSelection.all());
+            return new TableRowSelection(tableName, rowCollection, ColumnSelection.all());
         } else {
-            return new TableRowSelection(tableName, rows, ColumnSelection.create(columns));
+            return new TableRowSelection(tableName, rowCollection, ColumnSelection.create(columns));
         }
+    }
+
+    private static <T> Collection<T> iterableToCollection(Iterable<T> iterable) {
+        Collection<T> collection = new ArrayList<T>();
+        for (T item : iterable) {
+            collection.add(item);
+        }
+        return collection;
     }
 }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TrackingKeyValueService.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TrackingKeyValueService.java
@@ -28,6 +28,7 @@ import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.common.base.ClosableIterator;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -54,7 +55,7 @@ public class TrackingKeyValueService extends ForwardingKeyValueService {
 
     @Override
     public Map<Cell, Value> getRows(
-            TableReference tableRef, Iterable<byte[]> rows, ColumnSelection columnSelection, long timestamp) {
+            TableReference tableRef, Collection<byte[]> rows, ColumnSelection columnSelection, long timestamp) {
         tablesReadFrom.add(tableRef);
         return super.getRows(tableRef, rows, columnSelection, timestamp);
     }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -479,14 +479,18 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
         for (int i = 0; i < totalPuts; i++) {
             putDirect("row" + i, "col1", "v1", 0);
         }
-
+        List<RangeRequest> requests = IntStream.range(0, 100)
+                .boxed()
+                .map(_x -> RangeRequest.builder().batchHint(1000).build())
+                .collect(Collectors.toList());
         Map<RangeRequest, TokenBackedBasicResultsPage<RowResult<Value>, byte[]>> ranges =
                 keyValueService.getFirstBatchForRanges(
                         TEST_TABLE,
-                        Iterables.limit(
-                                Iterables.cycle(
-                                        RangeRequest.builder().batchHint(1000).build()),
-                                100),
+                        requests,
+                        //                        Iterables.limit(
+                        //                                Iterables.cycle(
+                        //                                        RangeRequest.builder().batchHint(1000).build()),
+                        //                                100),
                         1);
         assertThat(ranges.keySet()).hasSize(1);
         assertThat(ranges.values().iterator().next().getResults()).hasSize(totalPuts);
@@ -502,15 +506,12 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
             putDirect("row" + i, "col1", "v1", 0);
         }
 
+        List<RangeRequest> requests = IntStream.range(0, 100)
+                .boxed()
+                .map(_x -> RangeRequest.builder().batchHint(1000).build())
+                .collect(Collectors.toList());
         Map<RangeRequest, TokenBackedBasicResultsPage<RowResult<Value>, byte[]>> ranges =
-                keyValueService.getFirstBatchForRanges(
-                        TEST_TABLE,
-                        Iterables.limit(
-                                Iterables.cycle(RangeRequest.reverseBuilder()
-                                        .batchHint(1000)
-                                        .build()),
-                                100),
-                        1);
+                keyValueService.getFirstBatchForRanges(TEST_TABLE, requests, 1);
         assertThat(ranges.keySet()).hasSize(1);
         assertThat(ranges.values().iterator().next().getResults()).hasSize(totalPuts);
     }
@@ -523,9 +524,10 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
         }
 
         RangeRequest rangeRequest = RangeRequest.builder().batchHint(1).build();
+        List<RangeRequest> requests =
+                IntStream.range(0, 100).boxed().map(_x -> rangeRequest).collect(Collectors.toList());
         Map<RangeRequest, TokenBackedBasicResultsPage<RowResult<Value>, byte[]>> ranges =
-                keyValueService.getFirstBatchForRanges(
-                        TEST_TABLE, Iterables.limit(Iterables.cycle(rangeRequest), 100), 1);
+                keyValueService.getFirstBatchForRanges(TEST_TABLE, requests, 1);
         assertThat(ranges.keySet()).hasSize(1);
         assertThat(ranges.values().iterator().next().getResults()).hasSize(1);
         assertThat(PtBytes.toString(ranges.values()
@@ -549,9 +551,10 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
         }
 
         RangeRequest rangeRequest = RangeRequest.reverseBuilder().batchHint(1).build();
+        List<RangeRequest> requests =
+                IntStream.range(0, 100).boxed().map(_x -> rangeRequest).collect(Collectors.toList());
         Map<RangeRequest, TokenBackedBasicResultsPage<RowResult<Value>, byte[]>> ranges =
-                keyValueService.getFirstBatchForRanges(
-                        TEST_TABLE, Iterables.limit(Iterables.cycle(rangeRequest), 100), 1);
+                keyValueService.getFirstBatchForRanges(TEST_TABLE, requests, 1);
         assertThat(ranges.keySet()).hasSize(1);
         assertThat(ranges.values().iterator().next().getResults()).hasSize(1);
         assertThat(PtBytes.toString(ranges.values()

--- a/changelog/@unreleased/pr-6597.v2.yml
+++ b/changelog/@unreleased/pr-6597.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Transaction and KeyValueServices methods changed to received rows as
+    Collections instead of Iterables, except when originally returning iterators or
+    streams.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6597


### PR DESCRIPTION
## General
**Before this PR**:

Almost all the methods on Transaction and KeyValueService received their `rows` parameters as `Iterable<byte[]>` , but that in practice we were mostly passing around actual collections.

This lead to cases [like this](https://github.com/palantir/atlasdb/blob/bf6890433442e3e1661fb64a5ec87a7ffee50c23/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java#L410-L426) where we were using Iterables as if they were Collections, when that is not guaranteed by the type. Iterables don't need to be backed by collections and can be backed by just iterators, which can be exhausted once iterated, leaving the Iterable empty. In many places throughout the codebase, we didn't take that into consideration and were trying to double consuming iterators leading to potentially subtle bugs (or at least hard to reason about code).

So, in order to make things easier to reason about and actually match most of the use we actually have, I'm changing all of our method signatures that didn't return iterators or streams to received Collections instead of Iterables.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Transaction and KeyValueServices methods changed to received rows as Collections instead of Iterables, except when originally returning iterators or streams.
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
