### PR TITLE
Add metric for number of commit lock acquisition failures

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -2412,6 +2412,7 @@ public class SnapshotTransaction extends AbstractTransaction
                                 lockDescriptors, currentTransactionConfig, stackTraceSnapshot))
                         .build());
         if (!lockResponse.wasSuccessful()) {
+            transactionOutcomeMetrics.markLockAcquisitionFailed();
             log.error(
                     "Timed out waiting while acquiring commit locks. Timeout was {} ms. "
                             + "First ten required locks were {}.",

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -2412,7 +2412,7 @@ public class SnapshotTransaction extends AbstractTransaction
                                 lockDescriptors, currentTransactionConfig, stackTraceSnapshot))
                         .build());
         if (!lockResponse.wasSuccessful()) {
-            transactionOutcomeMetrics.markLockAcquisitionFailed();
+            transactionOutcomeMetrics.markCommitLockAcquisitionFailed();
             log.error(
                     "Timed out waiting while acquiring commit locks. Timeout was {} ms. "
                             + "First ten required locks were {}.",

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/metrics/TransactionOutcome.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/metrics/TransactionOutcome.java
@@ -62,5 +62,10 @@ public enum TransactionOutcome {
      * that started before our start timestamp and hasn't committed). This will be logged at most once for a given
      * transaction being rolled back, even if multiple transactions aim to rollback the same transaction.
      */
-    ROLLBACK_OTHER
+    ROLLBACK_OTHER,
+
+    /**
+     * The transaction failed to acquire write locks at the beginning of the commit protocol.
+     */
+    LOCK_ACQUISITION_FAILED,
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/metrics/TransactionOutcome.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/metrics/TransactionOutcome.java
@@ -65,7 +65,7 @@ public enum TransactionOutcome {
     ROLLBACK_OTHER,
 
     /**
-     * The transaction failed to acquire write locks at the beginning of the commit protocol.
+     * The transaction failed to acquire commit locks at the beginning of the AtlasDB commit protocol.
      */
-    LOCK_ACQUISITION_FAILED,
+    COMMIT_LOCK_ACQUISITION_FAILED,
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/metrics/TransactionOutcomeMetrics.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/metrics/TransactionOutcomeMetrics.java
@@ -85,6 +85,10 @@ public class TransactionOutcomeMetrics {
         getMeter(TransactionOutcome.ROLLBACK_OTHER).mark();
     }
 
+    public void markLockAcquisitionFailed() {
+        getMeter(TransactionOutcome.LOCK_ACQUISITION_FAILED).mark();
+    }
+
     @VisibleForTesting
     Meter getMeter(TransactionOutcome outcome) {
         return getMeter(outcome, ImmutableMap.of());

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/metrics/TransactionOutcomeMetrics.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/metrics/TransactionOutcomeMetrics.java
@@ -85,8 +85,8 @@ public class TransactionOutcomeMetrics {
         getMeter(TransactionOutcome.ROLLBACK_OTHER).mark();
     }
 
-    public void markLockAcquisitionFailed() {
-        getMeter(TransactionOutcome.LOCK_ACQUISITION_FAILED).mark();
+    public void markCommitLockAcquisitionFailed() {
+        getMeter(TransactionOutcome.COMMIT_LOCK_ACQUISITION_FAILED).mark();
     }
 
     @VisibleForTesting

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/metrics/TransactionOutcomeMetricsAssert.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/metrics/TransactionOutcomeMetricsAssert.java
@@ -59,6 +59,11 @@ public class TransactionOutcomeMetricsAssert
         return this;
     }
 
+    public TransactionOutcomeMetricsAssert hasLocksAcquisitionFailures(long count) {
+        checkPresentAndCheckCount(TransactionOutcome.LOCK_ACQUISITION_FAILED, count);
+        return this;
+    }
+
     public TransactionOutcomeMetricsAssert hasLocksExpired(long count) {
         checkPresentAndCheckCount(TransactionOutcome.LOCKS_EXPIRED, count);
         return this;

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/metrics/TransactionOutcomeMetricsAssert.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/metrics/TransactionOutcomeMetricsAssert.java
@@ -59,7 +59,7 @@ public class TransactionOutcomeMetricsAssert
         return this;
     }
 
-    public TransactionOutcomeMetricsAssert hasLocksAcquisitionFailures(long count) {
+    public TransactionOutcomeMetricsAssert hasLockAcquisitionFailures(long count) {
         checkPresentAndCheckCount(TransactionOutcome.LOCK_ACQUISITION_FAILED, count);
         return this;
     }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/metrics/TransactionOutcomeMetricsAssert.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/metrics/TransactionOutcomeMetricsAssert.java
@@ -59,8 +59,8 @@ public class TransactionOutcomeMetricsAssert
         return this;
     }
 
-    public TransactionOutcomeMetricsAssert hasLockAcquisitionFailures(long count) {
-        checkPresentAndCheckCount(TransactionOutcome.LOCK_ACQUISITION_FAILED, count);
+    public TransactionOutcomeMetricsAssert hasCommitLockAcquisitionFailures(long count) {
+        checkPresentAndCheckCount(TransactionOutcome.COMMIT_LOCK_ACQUISITION_FAILED, count);
         return this;
     }
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -1487,7 +1487,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
     }
 
     @Test
-    public void commitThrowsIfLocksAcquisitionFails() {
+    public void commitThrowsIfLockAcquisitionFails() {
         final Cell cell = Cell.create(PtBytes.toBytes("row1"), PtBytes.toBytes("column1"));
 
         TimelockService timelockServiceMock = mock(TimelockService.class);
@@ -1498,18 +1498,18 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
         LockImmutableTimestampResponse res = conjureResponse.getImmutableTimestamp();
         long transactionTs = conjureResponse.getTimestamps().start();
 
-        Transaction snapshot = getSnapshotTransactionWith(timelockServiceMock, () -> transactionTs, res, unused -> {
-        });
+        Transaction snapshot = getSnapshotTransactionWith(timelockServiceMock, () -> transactionTs, res, unused -> {});
 
         // Need a writer to trigger writer commit protocol
         snapshot.put(TABLE, ImmutableMap.of(cell, PtBytes.toBytes("value")));
 
         // Lock acquisition should fail and be marked as time out
-        assertThatExceptionOfType(TransactionLockAcquisitionTimeoutException.class).isThrownBy(snapshot::commit);
+        assertThatExceptionOfType(TransactionLockAcquisitionTimeoutException.class)
+                .isThrownBy(snapshot::commit);
 
         TransactionOutcomeMetricsAssert.assertThat(transactionOutcomeMetrics)
                 .hasFailedCommits(1)
-                .hasLocksAcquisitionFailures(1);
+                .hasLockAcquisitionFailures(1);
     }
 
     @Test

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/metrics/TransactionOutcomeMetricsTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/metrics/TransactionOutcomeMetricsTest.java
@@ -72,7 +72,7 @@ public class TransactionOutcomeMetricsTest {
                 .put(4, transactionOutcomeMetrics::markPutUnlessExistsFailed)
                 .put(5, transactionOutcomeMetrics::markRollbackOtherTransaction)
                 .put(6, transactionOutcomeMetrics::markPreCommitCheckFailed)
-                .put(7, transactionOutcomeMetrics::markLockAcquisitionFailed)
+                .put(7, transactionOutcomeMetrics::markCommitLockAcquisitionFailed)
                 .buildOrThrow();
 
         tasks.entrySet().forEach(entry -> IntStream.range(0, entry.getKey())
@@ -85,7 +85,7 @@ public class TransactionOutcomeMetricsTest {
                 .hasPutUnlessExistsFailures(4)
                 .hasRollbackOther(5)
                 .hasPreCommitCheckFailures(6)
-                .hasLockAcquisitionFailures(7);
+                .hasCommitLockAcquisitionFailures(7);
     }
 
     @Test

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/metrics/TransactionOutcomeMetricsTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/metrics/TransactionOutcomeMetricsTest.java
@@ -85,7 +85,7 @@ public class TransactionOutcomeMetricsTest {
                 .hasPutUnlessExistsFailures(4)
                 .hasRollbackOther(5)
                 .hasPreCommitCheckFailures(6)
-                .hasLocksAcquisitionFailures(7);
+                .hasLockAcquisitionFailures(7);
     }
 
     @Test

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/metrics/TransactionOutcomeMetricsTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/metrics/TransactionOutcomeMetricsTest.java
@@ -72,6 +72,7 @@ public class TransactionOutcomeMetricsTest {
                 .put(4, transactionOutcomeMetrics::markPutUnlessExistsFailed)
                 .put(5, transactionOutcomeMetrics::markRollbackOtherTransaction)
                 .put(6, transactionOutcomeMetrics::markPreCommitCheckFailed)
+                .put(7, transactionOutcomeMetrics::markLockAcquisitionFailed)
                 .buildOrThrow();
 
         tasks.entrySet().forEach(entry -> IntStream.range(0, entry.getKey())
@@ -83,7 +84,8 @@ public class TransactionOutcomeMetricsTest {
                 .hasLocksExpired(3)
                 .hasPutUnlessExistsFailures(4)
                 .hasRollbackOther(5)
-                .hasPreCommitCheckFailures(6);
+                .hasPreCommitCheckFailures(6)
+                .hasLocksAcquisitionFailures(7);
     }
 
     @Test

--- a/changelog/@unreleased/pr-6598.v2.yml
+++ b/changelog/@unreleased/pr-6598.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add metric for number of commit lock acquisition failures
+  links:
+  - https://github.com/palantir/atlasdb/pull/6598


### PR DESCRIPTION
Adds a new transaction outcome metric LOCK_ACQUISITION_FAILURES that is incremented whenever a transaction fails to acquire the necessary write locks at the beginning of the AtlasDB commit protocol.

This PR also provides unit testing to verify the desired behavior.

## General
**Before this PR**:

There was no metric to track the number of lock acquisition failures.

**After this PR**:

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add metric for number of commit lock acquisition failures
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:
Are there additional changes necessary to actually export the metric (to Datadog)?
Since it's my first PR: Does it fit in with the existing code style?

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

No

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

No

**Does this PR need a schema migration?**

No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

It is assumed that all metrics tracked in TransactionOutcome are automatically persisted, without any more manual intervention.

**What was existing testing like? What have you done to improve it?**:

There is an existing test to validate  basic functionality of the metric counters, I added the new metric to verify it is also incremented.

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

N/A

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

The metric should be exported to Datadog.

**Has the safety of all log arguments been decided correctly?**:
N/A

**Will this change significantly affect our spending on metrics or logs?**:

It  will affect the number of transmitted metrics, but merely represents an insignificant amount.

**How would I tell that this PR does not work in production? (monitors, etc.)**:

There is no metric for the number of lock acquisition failures in Datadog.

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

Since this is a new metric, rollback would not help. Instead, the implementation needs to be reviewed and patched.

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

Since other similar metrics are already working at scale, I do not expect this to pose a scalability issue.

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

If lock acquisition can fail repeatedly (in a hot loop), incrementing this metric every time could represent an unwanted overhead.

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@Sam-Kramer 

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
