### PR TITLE
[Antithesis] Transient Rows Workflow: Fix Inconsistent Reads

### DIFF
--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/workflow/TransientRowsWorkflows.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/workflow/TransientRowsWorkflows.java
@@ -38,6 +38,7 @@ import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -141,10 +142,12 @@ public final class TransientRowsWorkflows {
                 .orElseThrow(() -> new SafeIllegalStateException(
                         "Expected to find a read of the summary row", SafeArg.of("actions", actions)));
         WitnessedReadTransactionAction normalRowRead = readTransactionActions.stream()
-                .filter(action -> action.cell().key() != SUMMARY_ROW)
+                .filter(action -> Objects.equals(
+                                action.cell().key(), summaryRowRead.cell().column())
+                        && action.cell().column() == COLUMN)
                 .findAny()
                 .orElseThrow(() -> new SafeIllegalStateException(
-                        "Expected to find a read of a normal row", SafeArg.of("actions", actions)));
+                        "Expected to find a read of a corresponding normal row", SafeArg.of("actions", actions)));
         if (!summaryRowRead.value().equals(normalRowRead.value())) {
             return Stream.of(CrossCellInconsistency.builder()
                     .putInconsistentValues(

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/TransientRowsWorkflowsTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/TransientRowsWorkflowsTest.java
@@ -49,7 +49,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
-import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
 public class TransientRowsWorkflowsTest {
@@ -199,8 +198,7 @@ public class TransientRowsWorkflowsTest {
         WitnessedReadTransactionAction readWitness = WitnessedReadTransactionAction.of(
                 TABLE_NAME, ImmutableWorkloadCell.of(5, TransientRowsWorkflows.COLUMN), Optional.empty());
         WorkflowHistory history = getWorkflowHistory(ImmutableList.of(readWitness));
-        assertThatLoggableExceptionThrownBy(() -> invariant.accept(history, inconsistencies -> {
-        }))
+        assertThatLoggableExceptionThrownBy(() -> invariant.accept(history, inconsistencies -> {}))
                 .isInstanceOf(SafeIllegalStateException.class)
                 .hasMessageContaining("Expected to find a read of the summary row")
                 .hasExactlyArgs(SafeArg.of("actions", ImmutableList.of(readWitness)));
@@ -214,8 +212,7 @@ public class TransientRowsWorkflowsTest {
                 WitnessedReadTransactionAction.of(
                         TABLE_NAME, ImmutableWorkloadCell.of(2, TransientRowsWorkflows.COLUMN), Optional.empty()));
         WorkflowHistory history = getWorkflowHistory(actions);
-        assertThatLoggableExceptionThrownBy(() -> invariant.accept(history, inconsistencies -> {
-        }))
+        assertThatLoggableExceptionThrownBy(() -> invariant.accept(history, inconsistencies -> {}))
                 .isInstanceOf(SafeIllegalStateException.class)
                 .hasMessageContaining("Expected to find a read of a corresponding normal row")
                 .hasExactlyArgs(SafeArg.of("actions", actions));


### PR DESCRIPTION
## General
**Before this PR**:
The transient rows workflow might check the summary cell with a different cell that was read by the same transaction.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
The transient rows workflow now only checks the summary cell with the correctly corresponding cell.
==COMMIT_MSG==

**Priority**: P1

**Concerns / possible downsides (what feedback would you like?)**: Nothing in particular

**Is documentation needed?**: No

## Compatibility
This pertains to the antithesis workflow server.

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: Nothing much

**What was existing testing like? What have you done to improve it?**: Added new tests

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: N/A

## Execution
Antithesis-only PR.

## Scale
Antithesis-only PR.

## Development Process
**Where should we start reviewing?**: TransientRowsWorkflows?

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
