### PR TITLE
Add metrics for number of requested cell/row-level commit locks

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/expectations/TransactionCommitLockInfo.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/expectations/TransactionCommitLockInfo.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.atlasdb.transaction.impl.expectations;
+package com.palantir.atlasdb.transaction.api.expectations;
 
 import org.immutables.value.Value;
 
@@ -24,7 +24,14 @@ import org.immutables.value.Value;
 @Value.Immutable
 public interface TransactionCommitLockInfo {
 
+    /**
+     * The number of cell-level locks requested as part of the commit protocol (excluding any user-defined locking).
+     */
     long cellCommitLocksRequested();
 
+    /**
+     * The number of row-level locks requested as part of the commit protocol (excluding any user-defined locking).
+     * For write transactions, this includes the single row lock that is requested for the transaction table itself.
+     */
     long rowCommitLocksRequested();
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/expectations/TransactionCommitLockInfo.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/expectations/TransactionCommitLockInfo.java
@@ -1,0 +1,30 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.api.expectations;
+
+import org.immutables.value.Value;
+
+/**
+ * Data about the amount of commit locks requested by a transaction.
+ */
+@Value.Immutable
+public interface TransactionCommitLockInfo {
+
+    long cellCommitLocksRequested();
+
+    long rowCommitLocksRequested();
+}

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ExpectationsAwareTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ExpectationsAwareTransaction.java
@@ -17,6 +17,7 @@
 package com.palantir.atlasdb.transaction.impl;
 
 import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.atlasdb.transaction.api.expectations.TransactionCommitLockInfo;
 import com.palantir.atlasdb.transaction.api.expectations.TransactionReadInfo;
 
 /**
@@ -31,6 +32,11 @@ public interface ExpectationsAwareTransaction extends Transaction {
      * Returns a point-in-time snapshot of transaction read information.
      */
     TransactionReadInfo getReadInfo();
+
+    /**
+     * Returns transaction commit lock information.
+     */
+    TransactionCommitLockInfo getCommitLockInfo();
 
     /**
      * Update TEX data collection metrics for (post-mortem) transactions.

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingExpectationsAwareTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingExpectationsAwareTransaction.java
@@ -16,6 +16,7 @@
 
 package com.palantir.atlasdb.transaction.impl;
 
+import com.palantir.atlasdb.transaction.api.expectations.TransactionCommitLockInfo;
 import com.palantir.atlasdb.transaction.api.expectations.TransactionReadInfo;
 
 public abstract class ForwardingExpectationsAwareTransaction extends ForwardingTransaction
@@ -32,6 +33,11 @@ public abstract class ForwardingExpectationsAwareTransaction extends ForwardingT
     @Override
     public TransactionReadInfo getReadInfo() {
         return delegate().getReadInfo();
+    }
+
+    @Override
+    public TransactionCommitLockInfo getCommitLockInfo() {
+        return delegate().getCommitLockInfo();
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -97,12 +97,12 @@ import com.palantir.atlasdb.transaction.api.TransactionFailedRetriableException;
 import com.palantir.atlasdb.transaction.api.TransactionLockAcquisitionTimeoutException;
 import com.palantir.atlasdb.transaction.api.TransactionLockTimeoutException;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
-import com.palantir.atlasdb.transaction.api.expectations.ImmutableTransactionCommitLockInfo;
-import com.palantir.atlasdb.transaction.api.expectations.TransactionCommitLockInfo;
 import com.palantir.atlasdb.transaction.api.expectations.TransactionReadInfo;
 import com.palantir.atlasdb.transaction.expectations.ExpectationsMetrics;
+import com.palantir.atlasdb.transaction.impl.expectations.ImmutableTransactionCommitLockInfo;
 import com.palantir.atlasdb.transaction.impl.expectations.TrackingKeyValueService;
 import com.palantir.atlasdb.transaction.impl.expectations.TrackingKeyValueServiceImpl;
+import com.palantir.atlasdb.transaction.impl.expectations.TransactionCommitLockInfo;
 import com.palantir.atlasdb.transaction.impl.metrics.TableLevelMetricsController;
 import com.palantir.atlasdb.transaction.impl.metrics.TransactionOutcomeMetrics;
 import com.palantir.atlasdb.transaction.knowledge.TransactionKnowledgeComponents;
@@ -186,7 +186,6 @@ import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.tuple.Pair;
-import org.checkerframework.checker.units.qual.A;
 
 /**
  * This implements snapshot isolation for transactions.

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/expectations/TransactionCommitLockInfo.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/expectations/TransactionCommitLockInfo.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.atlasdb.transaction.api.expectations;
+package com.palantir.atlasdb.transaction.impl.expectations;
 
 import org.immutables.value.Value;
 

--- a/atlasdb-impl-shared/src/main/metrics/expectations.yml
+++ b/atlasdb-impl-shared/src/main/metrics/expectations.yml
@@ -18,8 +18,8 @@ namespaces:
         docs: Most bytes read by a transaction in one Atlas kvs read call
         type: histogram
       cellCommitLocksRequested:
-        docs: Number of cell-level commit locks requested at the beginning of the commit protocol
+        docs: Number of cell-level commit locks requested as part of the commit protocol
         type: histogram
       rowCommitLocksRequested:
-        docs: Number of row-level commit locks requested at the beginning of the commit protocol
+        docs: Number of row-level commit locks requested as part of the commit protocol
         type: histogram

--- a/atlasdb-impl-shared/src/main/metrics/expectations.yml
+++ b/atlasdb-impl-shared/src/main/metrics/expectations.yml
@@ -17,3 +17,9 @@ namespaces:
       mostKvsBytesReadInSingleCall:
         docs: Most bytes read by a transaction in one Atlas kvs read call
         type: histogram
+      cellCommitLocksRequested:
+        docs: Number of cell-level commit locks requested at the beginning of the commit protocol
+        type: histogram
+      rowCommitLocksRequested:
+        docs: Number of row-level commit locks requested at the beginning of the commit protocol
+        type: histogram

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/ExpectationsMetricsReportingTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/ExpectationsMetricsReportingTest.java
@@ -19,10 +19,10 @@ package com.palantir.atlasdb.transaction.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.palantir.atlasdb.transaction.api.expectations.ImmutableKvsCallReadInfo;
-import com.palantir.atlasdb.transaction.api.expectations.ImmutableTransactionCommitLockInfo;
 import com.palantir.atlasdb.transaction.api.expectations.ImmutableTransactionReadInfo;
 import com.palantir.atlasdb.transaction.api.expectations.TransactionReadInfo;
 import com.palantir.atlasdb.transaction.expectations.ExpectationsMetrics;
+import com.palantir.atlasdb.transaction.impl.expectations.ImmutableTransactionCommitLockInfo;
 import com.palantir.atlasdb.util.MetricsManagers;
 import org.junit.Before;
 import org.junit.Test;

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
@@ -240,7 +240,9 @@ public class SnapshotTransactionManagerTest {
                 .contains(FINISH_TASK_METRIC_NAME)
                 .contains("expectations.bytesRead")
                 .contains("expectations.kvsReads")
-                .contains("expectations.ageMillis");
+                .contains("expectations.ageMillis")
+                .contains("expectations.cellCommitLocksRequested")
+                .contains("expectations.rowCommitLocksRequested");
         assertThat(registry.timer(MetricName.builder()
                                 .safeName(SETUP_TASK_METRIC_NAME)
                                 .build())

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -2428,19 +2428,6 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
         assertThat(commitLockInfo.rowCommitLocksRequested()).isEqualTo(1 + 1);
     }
 
-    @Test
-    public void setsRequestedCommitLocksCountCorrectly_readOnlyTransaction() {
-        SnapshotTransaction txn = unwrapSnapshotTransaction(txManager.createNewTransaction());
-        txn.get(TABLE, ImmutableSet.of(TEST_CELL));
-        txn.commit();
-
-        TransactionCommitLockInfo commitLockInfo = txn.getCommitLockInfo();
-
-        assertThat(commitLockInfo.cellCommitLocksRequested()).isEqualTo(0);
-        // Since this is a read-only transaction, we should not even lock a row in the transaction table itself
-        assertThat(commitLockInfo.rowCommitLocksRequested()).isEqualTo(0);
-    }
-
     private void verifyPrefetchValidations(
             List<byte[]> rows,
             List<Cell> cells,

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -2375,7 +2375,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                         eq(AtlasDbConstraintCheckingMode.FULL_CONSTRAINT_CHECKING_THROWS_EXCEPTIONS));
     }
 
-    private void assertCellCommitLocksCountEquals(long expected) {
+    private void assertCellCommitLocksMetricEquals(long expected) {
         assertThat(metricsManager.getTaggedRegistry().getMetrics())
                 .anySatisfy((MetricName metricName, Metric metric) -> {
                     assertThat(metricName.safeName()).isEqualTo("expectations.cellCommitLocksRequested");
@@ -2384,7 +2384,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 });
     }
 
-    private void assertRowCommitLocksCountEquals(long expected) {
+    private void assertRowCommitLocksMetricEquals(long expected) {
         assertThat(metricsManager.getTaggedRegistry().getMetrics())
                 .anySatisfy((MetricName metricName, Metric metric) -> {
                     assertThat(metricName.safeName()).isEqualTo("expectations.rowCommitLocksRequested");
@@ -2394,7 +2394,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
     }
 
     @Test
-    public void setsRequestedCommitLocksCountCorrectly_serializableCell() {
+    public void reportsRequestedCommitLocksCountCorrectly_serializableCell() {
         // Will request commit locks for cells, but not rows
         overrideConflictHandlerForTable(TABLE, ConflictHandler.SERIALIZABLE_CELL);
 
@@ -2403,12 +2403,12 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
             return null;
         });
 
-        assertCellCommitLocksCountEquals(1);
-        assertRowCommitLocksCountEquals(0);
+        assertCellCommitLocksMetricEquals(1);
+        assertRowCommitLocksMetricEquals(0);
     }
 
     @Test
-    public void setsRequestedCommitLocksCountCorrectly_serializable() {
+    public void reportsRequestedCommitLocksCountCorrectly_serializable() {
         // Will request commit locks for rows, but not cells
         overrideConflictHandlerForTable(TABLE, ConflictHandler.SERIALIZABLE);
 
@@ -2417,12 +2417,12 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
             return null;
         });
 
-        assertCellCommitLocksCountEquals(0);
-        assertRowCommitLocksCountEquals(1);
+        assertCellCommitLocksMetricEquals(0);
+        assertRowCommitLocksMetricEquals(1);
     }
 
     @Test
-    public void setsRequestedCommitLocksCountCorrectly_serializableLockLevelMigration_sameRow() {
+    public void reportsRequestedCommitLocksCountCorrectly_serializableLockLevelMigration_sameRow() {
         // Will request commit locks for cells and rows
         overrideConflictHandlerForTable(TABLE, ConflictHandler.SERIALIZABLE_LOCK_LEVEL_MIGRATION);
 
@@ -2445,8 +2445,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
             return null;
         });
 
-        assertCellCommitLocksCountEquals(2);
-        assertRowCommitLocksCountEquals(1);
+        assertCellCommitLocksMetricEquals(2);
+        assertRowCommitLocksMetricEquals(1);
     }
 
     private void verifyPrefetchValidations(

--- a/changelog/@unreleased/pr-6602.v2.yml
+++ b/changelog/@unreleased/pr-6602.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add metrics for number of requested cell/row-level commit locks
+  links:
+  - https://github.com/palantir/atlasdb/pull/6602


### PR DESCRIPTION
## General
**Before this PR**:
There is no metric for the number of commit locks (cell/row-level) requested per transaction.
**After this PR**:
The metrics exist.
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add metrics for number of requested cell/row-level commit locks
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:
Is it advisable to wrap commit lock request counts in their own value class (like I did)?
Since the rest of transaction expectations is part of the transaction API, should we make the commit lock info public as well?
Is it wrong to report the commit lock metrics together with other transaction expectation metrics?
Is the unit test case naming understandable?

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
N/A
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
The unit test rely on metric schema code generation behavior, specifically, the `safeName` generated for each metric. Also, the unit tests use the cell/row-level locking behavior of certain conflict handlers.
**What was existing testing like? What have you done to improve it?**:
- Added new metrics to expectation metrics test
- Added unit tests to run transactions and check the state of metrics afterwards

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
`expectations.cellCommitLocksRequested` and `expectations.rowCommitLocksRequested` metrics exist
**Has the safety of all log arguments been decided correctly?**:
N/A
**Will this change significantly affect our spending on metrics or logs?**:
It introduces two new metrics which are reported for every transaction. Still, the effect on overall metrics spending should be insignificant.
**How would I tell that this PR does not work in production? (monitors, etc.)**:
The aforementioned metrics do not exist.
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
If this PR does not work, the implementation is most likely at fault and should be patched.
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
Since other similar metrics are already working at scale, I do not expect this to pose a scalability issue.
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
Since the metrics are reported for every transaction, one would have to measure the overhead of reporting these metrics in comparison to the total transaction runtime.
## Development Process
**Where should we start reviewing?**:
TransactionCommitLockInfo
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
N/A
**Please tag any other people who should be aware of this PR**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
