### PR TITLE
[Antithesis | Range Queries] Part 1: Explicitly Identify Existing Actions As Single-Cell

### DIFF
--- a/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/DeleteTransactionAction.java
+++ b/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/DeleteTransactionAction.java
@@ -22,7 +22,7 @@ import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedDeleteTransa
 import org.immutables.value.Value;
 
 @Value.Immutable(builder = false)
-public interface DeleteTransactionAction extends TransactionAction {
+public interface DeleteTransactionAction extends SingleCellTransactionAction {
 
     default WitnessedDeleteTransactionAction witness() {
         return ImmutableWitnessedDeleteTransactionAction.of(table(), cell());

--- a/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/ReadTransactionAction.java
+++ b/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/ReadTransactionAction.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 import org.immutables.value.Value;
 
 @Value.Immutable(builder = false)
-public interface ReadTransactionAction extends TransactionAction {
+public interface ReadTransactionAction extends SingleCellTransactionAction {
 
     default WitnessedReadTransactionAction witness(Optional<Integer> value) {
         return ImmutableWitnessedReadTransactionAction.of(table(), cell(), value);

--- a/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/SingleCellTransactionAction.java
+++ b/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/SingleCellTransactionAction.java
@@ -14,8 +14,17 @@
  * limitations under the License.
  */
 
-package com.palantir.atlasdb.workload.transaction.witnessed;
+package com.palantir.atlasdb.workload.transaction;
 
-public interface WitnessedTransactionAction {
-    <T> T accept(WitnessedTransactionActionVisitor<T> visitor);
+import com.palantir.atlasdb.workload.store.WorkloadCell;
+import org.immutables.value.Value;
+
+public interface SingleCellTransactionAction extends TransactionAction {
+    /** Table to apply transaction to. */
+    @Value.Parameter
+    String table();
+
+    /** Cell (Key, Column) to apply the action to. */
+    @Value.Parameter
+    WorkloadCell cell();
 }

--- a/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/TransactionAction.java
+++ b/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/TransactionAction.java
@@ -16,18 +16,6 @@
 
 package com.palantir.atlasdb.workload.transaction;
 
-import com.palantir.atlasdb.workload.store.WorkloadCell;
-import org.immutables.value.Value;
-
 public interface TransactionAction {
-
-    /** Table to apply transaction to. */
-    @Value.Parameter
-    String table();
-
-    /** Cell (Key, Column) to apply the action to. */
-    @Value.Parameter
-    WorkloadCell cell();
-
     <T> T accept(TransactionActionVisitor<T> visitor);
 }

--- a/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/WriteTransactionAction.java
+++ b/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/WriteTransactionAction.java
@@ -22,7 +22,7 @@ import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedWriteTransac
 import org.immutables.value.Value;
 
 @Value.Immutable
-public interface WriteTransactionAction extends TransactionAction {
+public interface WriteTransactionAction extends SingleCellTransactionAction {
 
     @Override
     @Value.Parameter

--- a/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/witnessed/InvalidWitnessedSingleCellTransactionAction.java
+++ b/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/witnessed/InvalidWitnessedSingleCellTransactionAction.java
@@ -16,6 +16,19 @@
 
 package com.palantir.atlasdb.workload.transaction.witnessed;
 
-public interface WitnessedTransactionAction {
-    <T> T accept(WitnessedTransactionActionVisitor<T> visitor);
+import com.palantir.atlasdb.workload.invariant.MismatchedValue;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface InvalidWitnessedSingleCellTransactionAction extends InvalidWitnessedTransactionAction {
+    @Value.Parameter
+    WitnessedSingleCellTransactionAction action();
+
+    @Value.Parameter
+    MismatchedValue mismatchedValue();
+
+    static InvalidWitnessedSingleCellTransactionAction of(
+            WitnessedSingleCellTransactionAction action, MismatchedValue mismatchedValue) {
+        return ImmutableInvalidWitnessedSingleCellTransactionAction.of(action, mismatchedValue);
+    }
 }

--- a/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/witnessed/InvalidWitnessedTransactionAction.java
+++ b/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/witnessed/InvalidWitnessedTransactionAction.java
@@ -16,18 +16,4 @@
 
 package com.palantir.atlasdb.workload.transaction.witnessed;
 
-import com.palantir.atlasdb.workload.invariant.MismatchedValue;
-import org.immutables.value.Value;
-
-@Value.Immutable
-public interface InvalidWitnessedTransactionAction {
-    @Value.Parameter
-    WitnessedTransactionAction action();
-
-    @Value.Parameter
-    MismatchedValue mismatchedValue();
-
-    static InvalidWitnessedTransactionAction of(WitnessedTransactionAction action, MismatchedValue mismatchedValue) {
-        return ImmutableInvalidWitnessedTransactionAction.of(action, mismatchedValue);
-    }
-}
+public interface InvalidWitnessedTransactionAction {}

--- a/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/witnessed/WitnessedDeleteTransactionAction.java
+++ b/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/witnessed/WitnessedDeleteTransactionAction.java
@@ -20,7 +20,7 @@ import com.palantir.atlasdb.workload.store.WorkloadCell;
 import org.immutables.value.Value;
 
 @Value.Immutable(builder = false)
-public interface WitnessedDeleteTransactionAction extends WitnessedTransactionAction {
+public interface WitnessedDeleteTransactionAction extends WitnessedSingleCellTransactionAction {
 
     @Override
     default <T> T accept(WitnessedTransactionActionVisitor<T> visitor) {

--- a/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/witnessed/WitnessedReadTransactionAction.java
+++ b/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/witnessed/WitnessedReadTransactionAction.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 import org.immutables.value.Value;
 
 @Value.Immutable(builder = false)
-public interface WitnessedReadTransactionAction extends WitnessedTransactionAction {
+public interface WitnessedReadTransactionAction extends WitnessedSingleCellTransactionAction {
 
     @Override
     @Value.Parameter

--- a/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/witnessed/WitnessedSingleCellTransactionAction.java
+++ b/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/witnessed/WitnessedSingleCellTransactionAction.java
@@ -16,6 +16,15 @@
 
 package com.palantir.atlasdb.workload.transaction.witnessed;
 
-public interface WitnessedTransactionAction {
-    <T> T accept(WitnessedTransactionActionVisitor<T> visitor);
+import com.palantir.atlasdb.workload.store.WorkloadCell;
+import org.immutables.value.Value;
+
+public interface WitnessedSingleCellTransactionAction extends WitnessedTransactionAction {
+    /** Table action was applied to. */
+    @Value.Parameter
+    String table();
+
+    /** Cell (Key, Column) the action applied to. */
+    @Value.Parameter
+    WorkloadCell cell();
 }

--- a/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/witnessed/WitnessedWriteTransactionAction.java
+++ b/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/witnessed/WitnessedWriteTransactionAction.java
@@ -20,7 +20,7 @@ import com.palantir.atlasdb.workload.store.WorkloadCell;
 import org.immutables.value.Value;
 
 @Value.Immutable
-public interface WitnessedWriteTransactionAction extends WitnessedTransactionAction {
+public interface WitnessedWriteTransactionAction extends WitnessedSingleCellTransactionAction {
 
     @Override
     @Value.Parameter

--- a/atlasdb-workload-server-api/src/test/java/com/palantir/atlasdb/workload/transaction/witnessed/MaybeWitnessedTransactionTest.java
+++ b/atlasdb-workload-server-api/src/test/java/com/palantir/atlasdb/workload/transaction/witnessed/MaybeWitnessedTransactionTest.java
@@ -54,7 +54,7 @@ public class MaybeWitnessedTransactionTest {
     public void toFullyWitnessedCopiesArgumentsCorrectly() {
         WitnessedWriteTransactionAction writeTransactionAction = mock(WitnessedWriteTransactionAction.class);
         WitnessedReadTransactionAction readTransactionAction = mock(WitnessedReadTransactionAction.class);
-        List<WitnessedTransactionAction> actions = List.of(readTransactionAction, writeTransactionAction);
+        List<WitnessedSingleCellTransactionAction> actions = List.of(readTransactionAction, writeTransactionAction);
         FullyWitnessedTransaction fullyWitnessedTransaction = MaybeWitnessedTransaction.builder()
                 .startTimestamp(START_TIMESTAMP)
                 .commitTimestamp(COMMIT_TIMESTAMP)

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/invariant/SerializableInvariant.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/invariant/SerializableInvariant.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.workload.invariant;
 
 import com.palantir.atlasdb.workload.store.TableAndWorkloadCell;
 import com.palantir.atlasdb.workload.transaction.InMemoryTransactionReplayer;
+import com.palantir.atlasdb.workload.transaction.witnessed.InvalidWitnessedSingleCellTransactionAction;
 import com.palantir.atlasdb.workload.transaction.witnessed.InvalidWitnessedTransaction;
 import com.palantir.atlasdb.workload.transaction.witnessed.InvalidWitnessedTransactionAction;
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedDeleteTransactionAction;
@@ -68,7 +69,7 @@ public enum SerializableInvariant implements TransactionInvariant {
                     .orElseGet(Optional::empty);
 
             if (!expectedValue.equals(readTransactionAction.value())) {
-                return Optional.of(InvalidWitnessedTransactionAction.of(
+                return Optional.of(InvalidWitnessedSingleCellTransactionAction.of(
                         readTransactionAction, MismatchedValue.of(readTransactionAction.value(), expectedValue)));
             }
 

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/invariant/SnapshotInvariantVisitor.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/invariant/SnapshotInvariantVisitor.java
@@ -19,6 +19,7 @@ package com.palantir.atlasdb.workload.invariant;
 import com.palantir.atlasdb.keyvalue.api.cache.StructureHolder;
 import com.palantir.atlasdb.workload.store.TableAndWorkloadCell;
 import com.palantir.atlasdb.workload.store.WorkloadCell;
+import com.palantir.atlasdb.workload.transaction.witnessed.InvalidWitnessedSingleCellTransactionAction;
 import com.palantir.atlasdb.workload.transaction.witnessed.InvalidWitnessedTransactionAction;
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedDeleteTransactionAction;
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedReadTransactionAction;
@@ -29,10 +30,10 @@ import java.util.Optional;
 
 /**
  * Replays transactions and validates for conflicts on the latest and read view.
- *
+ * <p>
  * The latest view will be a view of the database at the commit timestamp, while the read view will be the view of
  * the database at the start timestamp.
- *
+ * <p>
  * Objects created from this class should only be used within a scope of a single transaction.
  */
 final class SnapshotInvariantVisitor
@@ -57,7 +58,7 @@ final class SnapshotInvariantVisitor
                         readTransactionAction.table(), readTransactionAction.cell(), readView)
                 .value();
         if (!expected.equals(readTransactionAction.value())) {
-            return Optional.of(InvalidWitnessedTransactionAction.of(
+            return Optional.of(InvalidWitnessedSingleCellTransactionAction.of(
                     readTransactionAction, MismatchedValue.of(readTransactionAction.value(), expected)));
         }
         return Optional.empty();
@@ -67,7 +68,8 @@ final class SnapshotInvariantVisitor
     public Optional<InvalidWitnessedTransactionAction> visit(WitnessedWriteTransactionAction writeTransactionAction) {
         Optional<InvalidWitnessedTransactionAction> invalidAction = checkForWriteWriteConflicts(
                         writeTransactionAction.table(), writeTransactionAction.cell())
-                .map(mismatchedValue -> InvalidWitnessedTransactionAction.of(writeTransactionAction, mismatchedValue));
+                .map(mismatchedValue ->
+                        InvalidWitnessedSingleCellTransactionAction.of(writeTransactionAction, mismatchedValue));
 
         applyWrites(
                 writeTransactionAction.table(),
@@ -80,7 +82,8 @@ final class SnapshotInvariantVisitor
     public Optional<InvalidWitnessedTransactionAction> visit(WitnessedDeleteTransactionAction deleteTransactionAction) {
         Optional<InvalidWitnessedTransactionAction> invalidAction = checkForWriteWriteConflicts(
                         deleteTransactionAction.table(), deleteTransactionAction.cell())
-                .map(mismatchedValue -> InvalidWitnessedTransactionAction.of(deleteTransactionAction, mismatchedValue));
+                .map(mismatchedValue ->
+                        InvalidWitnessedSingleCellTransactionAction.of(deleteTransactionAction, mismatchedValue));
 
         applyWrites(deleteTransactionAction.table(), deleteTransactionAction.cell(), Optional.empty());
         return invalidAction;


### PR DESCRIPTION
## General
**Before this PR**: Existing transaction actions operate on only a single cell. Thus, concepts like having a `Cell` be a concept at the `TransactionAction` level, or similarly a `MismatchedValue` at the `InvalidWitnessedTransactionAction` level made sense. However, for range queries this is not sufficiently expressive (for example, a read might return extra cells, insufficient cells, or even the correct cells but not in the correct order).

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Workload server transaction actions are now generic; existing actions now implement a sub-interface that allows them to be identified and, where applicable, verified through the existing methods (notice the relative paucity of changes in e.g. the invariants).
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**: Not much

**Is documentation needed?**: No

## Compatibility
Antithesis Workload Server.

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: Not much.

**What was existing testing like? What have you done to improve it?**: I'm relying on the existing tests not breaking.

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: N/A

## Execution
Antithesis Workload Server.

## Scale
Antithesis Workload Server.

## Development Process
**Where should we start reviewing?**: SingleCellTransactionAction/TransactionAction changes

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: It's not

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
