### PR TITLE
Remove DefaultLocale override

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,8 +113,7 @@ allprojects {
                 'Slf4jLogsafeArgs',
                 'StaticAssignmentInConstructor',
                 'StrictUnusedVariable'
-        options.errorprone.error 'DefaultLocale',
-                'SafeLoggingPropagation'
+        options.errorprone.error 'SafeLoggingPropagation'
     }
 }
 


### PR DESCRIPTION
This is being replaced by the standard `StringCaseLocaleUsage` check.

https://github.com/palantir/gradle-baseline/pull/2589