### PR TITLE
[Antithesis | Range Queries] Part 9: Row Range Scan Support

### DIFF
--- a/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/store/RowResult.java
+++ b/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/store/RowResult.java
@@ -14,25 +14,18 @@
  * limitations under the License.
  */
 
-package com.palantir.atlasdb.workload.transaction.witnessed;
+package com.palantir.atlasdb.workload.store;
 
-import com.palantir.atlasdb.workload.store.RowResult;
-import com.palantir.atlasdb.workload.transaction.RowRangeReadTransactionAction;
-import java.util.List;
+import java.util.Set;
 import org.immutables.value.Value;
 
 @Value.Immutable
-public interface WitnessedRowRangeReadTransactionAction extends WitnessedTransactionAction {
-    RowRangeReadTransactionAction originalQuery();
+public interface RowResult {
+    int row();
 
-    List<RowResult> results();
+    Set<ColumnValue> columns();
 
-    @Override
-    default <T> T accept(WitnessedTransactionActionVisitor<T> visitor) {
-        return visitor.visit(this);
-    }
-
-    static ImmutableWitnessedRowRangeReadTransactionAction.Builder builder() {
-        return ImmutableWitnessedRowRangeReadTransactionAction.builder();
+    static ImmutableRowResult.Builder builder() {
+        return ImmutableRowResult.builder();
     }
 }

--- a/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/ColumnRangeSelection.java
+++ b/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/ColumnRangeSelection.java
@@ -43,10 +43,14 @@ public final class ColumnRangeSelection {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        ColumnRangeSelection that = (ColumnRangeSelection) o;
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        ColumnRangeSelection that = (ColumnRangeSelection) other;
         return Objects.equals(rangeSlice, that.rangeSlice);
     }
 
@@ -55,6 +59,7 @@ public final class ColumnRangeSelection {
         return Objects.hashCode(rangeSlice);
     }
 
+    @SuppressWarnings({"HiddenField"}) // Should be reasonable for builder classes
     public static final class Builder {
         private Optional<Integer> startColumnInclusive = Optional.empty();
         private Optional<Integer> endColumnExclusive = Optional.empty();

--- a/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/ColumnRangeSelection.java
+++ b/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/ColumnRangeSelection.java
@@ -16,6 +16,7 @@
 
 package com.palantir.atlasdb.workload.transaction;
 
+import java.util.Objects;
 import java.util.Optional;
 
 public final class ColumnRangeSelection {
@@ -39,6 +40,19 @@ public final class ColumnRangeSelection {
 
     public static ColumnRangeSelection.Builder builder() {
         return new Builder();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ColumnRangeSelection that = (ColumnRangeSelection) o;
+        return Objects.equals(rangeSlice, that.rangeSlice);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(rangeSlice);
     }
 
     public static final class Builder {

--- a/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/InteractiveTransaction.java
+++ b/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/InteractiveTransaction.java
@@ -17,10 +17,12 @@
 package com.palantir.atlasdb.workload.transaction;
 
 import com.palantir.atlasdb.workload.store.ColumnValue;
+import com.palantir.atlasdb.workload.store.RowResult;
 import com.palantir.atlasdb.workload.store.WorkloadCell;
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedTransactionAction;
 import java.util.List;
 import java.util.Optional;
+import java.util.SortedSet;
 
 /**
  * Allows for convenient interaction with a transactional store.
@@ -33,6 +35,8 @@ public interface InteractiveTransaction {
     void delete(String table, WorkloadCell workloadCell);
 
     List<ColumnValue> getRowColumnRange(String table, Integer row, ColumnRangeSelection columnRangeSelection);
+
+    List<RowResult> getRange(String table, RangeSlice rowsToRead, SortedSet<Integer> columns, boolean reverse);
 
     List<WitnessedTransactionAction> witness();
 }

--- a/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/InteractiveTransaction.java
+++ b/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/InteractiveTransaction.java
@@ -36,7 +36,7 @@ public interface InteractiveTransaction {
 
     List<ColumnValue> getRowColumnRange(String table, Integer row, ColumnRangeSelection columnRangeSelection);
 
-    List<RowResult> getRange(String table, RangeSlice rowsToRead, SortedSet<Integer> columns, boolean reverse);
+    List<RowResult> getRange(String table, RangeSlice rowsToRead, SortedSet<Integer> columns);
 
     List<WitnessedTransactionAction> witness();
 }

--- a/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/RangeSlice.java
+++ b/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/RangeSlice.java
@@ -43,8 +43,7 @@ public interface RangeSlice {
             if (endExclusive().isEmpty()) {
                 return Range.atLeast(startInclusive().get());
             } else {
-                return Range.closedOpen(
-                        startInclusive().get(), endExclusive().get());
+                return Range.closedOpen(startInclusive().get(), endExclusive().get());
             }
         }
     }

--- a/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/RangeSlice.java
+++ b/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/RangeSlice.java
@@ -1,0 +1,66 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.workload.transaction;
+
+import com.google.common.collect.Range;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import java.util.Optional;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface RangeSlice {
+    Optional<Integer> startInclusive();
+
+    Optional<Integer> endExclusive();
+
+    default boolean contains(int column) {
+        return asGuavaRange().contains(column);
+    }
+
+    default Range<Integer> asGuavaRange() {
+        if (startInclusive().isEmpty()) {
+            if (endExclusive().isEmpty()) {
+                return Range.all();
+            } else {
+                return Range.lessThan(endExclusive().get());
+            }
+        } else {
+            if (endExclusive().isEmpty()) {
+                return Range.atLeast(startInclusive().get());
+            } else {
+                return Range.closedOpen(
+                        startInclusive().get(), endExclusive().get());
+            }
+        }
+    }
+
+    @Value.Check
+    default void check() {
+        Preconditions.checkState(
+                startInclusive().isEmpty()
+                        || endExclusive().isEmpty()
+                        || startInclusive().get() <= endExclusive().get(),
+                "Start must be less than or equal to end",
+                SafeArg.of("startInclusive", startInclusive()),
+                SafeArg.of("endExclusive", endExclusive()));
+    }
+
+    static ImmutableRangeSlice.Builder builder() {
+        return ImmutableRangeSlice.builder();
+    }
+}

--- a/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/RowRangeReadTransactionAction.java
+++ b/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/RowRangeReadTransactionAction.java
@@ -25,6 +25,9 @@ import org.immutables.value.Value;
  * In the interest of implementation simplicity, one significant simplification is made: values read from getRanges
  * are accessed in batches through a live iterator, while for purposes of gathering a witness, we immediately drain the
  * iterator and use the set of cells read as the witness to this action.
+ * <p>
+ * We also do not currently support reversed ranges: this is also not currently supported in SnapshotTransaction, even
+ * though the API permits it.
  */
 @Value.Immutable
 public interface RowRangeReadTransactionAction extends TransactionAction {
@@ -33,8 +36,6 @@ public interface RowRangeReadTransactionAction extends TransactionAction {
     RangeSlice rowsToRead();
 
     SortedSet<Integer> columns();
-
-    boolean reverse();
 
     @Override
     default <T> T accept(TransactionActionVisitor<T> visitor) {

--- a/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/RowRangeReadTransactionAction.java
+++ b/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/RowRangeReadTransactionAction.java
@@ -16,7 +16,6 @@
 
 package com.palantir.atlasdb.workload.transaction;
 
-import java.util.Optional;
 import java.util.SortedSet;
 import org.immutables.value.Value;
 
@@ -37,9 +36,12 @@ public interface RowRangeReadTransactionAction extends TransactionAction {
 
     boolean reverse();
 
-
     @Override
     default <T> T accept(TransactionActionVisitor<T> visitor) {
         return visitor.visit(this);
+    }
+
+    static ImmutableRowRangeReadTransactionAction.Builder builder() {
+        return ImmutableRowRangeReadTransactionAction.builder();
     }
 }

--- a/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/RowRangeReadTransactionAction.java
+++ b/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/RowRangeReadTransactionAction.java
@@ -1,0 +1,45 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.workload.transaction;
+
+import java.util.Optional;
+import java.util.SortedSet;
+import org.immutables.value.Value;
+
+/**
+ * This transaction action models a row range scan in AtlasDB ("getRange" in the AtlasDB API).
+ * <p>
+ * In the interest of implementation simplicity, one significant simplification is made: values read from getRanges
+ * are accessed in batches through a live iterator, while for purposes of gathering a witness, we immediately drain the
+ * iterator and use the set of cells read as the witness to this action.
+ */
+@Value.Immutable
+public interface RowRangeReadTransactionAction extends TransactionAction {
+    String table();
+
+    RangeSlice rowsToRead();
+
+    SortedSet<Integer> columns();
+
+    boolean reverse();
+
+
+    @Override
+    default <T> T accept(TransactionActionVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+}

--- a/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/TransactionActionVisitor.java
+++ b/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/TransactionActionVisitor.java
@@ -24,4 +24,6 @@ public interface TransactionActionVisitor<T> {
     T visit(DeleteTransactionAction deleteTransactionAction);
 
     T visit(RowColumnRangeReadTransactionAction rowColumnRangeReadTransactionAction);
+
+    T visit(RowRangeReadTransactionAction rowRangeReadTransactionAction);
 }

--- a/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/witnessed/WitnessedRowRangeReadTransactionAction.java
+++ b/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/witnessed/WitnessedRowRangeReadTransactionAction.java
@@ -1,0 +1,38 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.workload.transaction.witnessed;
+
+import com.google.common.collect.Multimap;
+import com.palantir.atlasdb.workload.store.ColumnValue;
+import com.palantir.atlasdb.workload.transaction.RowRangeReadTransactionAction;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface WitnessedRowRangeReadTransactionAction extends WitnessedTransactionAction {
+    RowRangeReadTransactionAction originalQuery();
+
+    Multimap<Integer, ColumnValue> result();
+
+    @Override
+    default <T> T accept(WitnessedTransactionActionVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+
+//    static ImmutableWitnessedRowReadTransactionAction.Builder builder() {
+//        return ImmutableWitnessedRowReadTransactionAction.builder();
+//    }
+}

--- a/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/witnessed/WitnessedTransactionActionVisitor.java
+++ b/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/transaction/witnessed/WitnessedTransactionActionVisitor.java
@@ -24,4 +24,6 @@ public interface WitnessedTransactionActionVisitor<T> {
     T visit(WitnessedDeleteTransactionAction deleteTransactionAction);
 
     T visit(WitnessedRowColumnRangeReadTransactionAction rowColumnRangeReadTransactionAction);
+
+    T visit(WitnessedRowRangeReadTransactionAction rowReadTransactionAction);
 }

--- a/atlasdb-workload-server-api/src/test/java/com/palantir/atlasdb/workload/transaction/RangeSliceTest.java
+++ b/atlasdb-workload-server-api/src/test/java/com/palantir/atlasdb/workload/transaction/RangeSliceTest.java
@@ -27,23 +27,18 @@ import org.junit.Test;
 public class RangeSliceTest {
     @Test
     public void cannotCreateRangeWithStartColumnGreaterThanEndColumn() {
-        assertThatLoggableExceptionThrownBy(() -> RangeSlice.builder()
-                .startInclusive(5)
-                .endExclusive(4)
-                .build())
+        assertThatLoggableExceptionThrownBy(() ->
+                        RangeSlice.builder().startInclusive(5).endExclusive(4).build())
                 .isInstanceOf(SafeIllegalStateException.class)
                 .hasMessageContaining("Start must be less than or equal to end")
                 .hasExactlyArgs(
-                        SafeArg.of("startInclusive", Optional.of(5)),
-                        SafeArg.of("endExclusive", Optional.of(4)));
+                        SafeArg.of("startInclusive", Optional.of(5)), SafeArg.of("endExclusive", Optional.of(4)));
     }
 
     @Test
     public void emptyRangeDoesNotContainAnyElements() {
-        RangeSlice emptyRange = RangeSlice.builder()
-                .startInclusive(6)
-                .endExclusive(6)
-                .build();
+        RangeSlice emptyRange =
+                RangeSlice.builder().startInclusive(6).endExclusive(6).build();
         assertThat(emptyRange.contains(5)).isFalse();
         assertThat(emptyRange.contains(6)).isFalse();
         assertThat(emptyRange.contains(7)).isFalse();
@@ -53,10 +48,8 @@ public class RangeSliceTest {
 
     @Test
     public void singleElementRangeContainsJustItself() {
-        RangeSlice justSeven = RangeSlice.builder()
-                .startInclusive(7)
-                .endExclusive(8)
-                .build();
+        RangeSlice justSeven =
+                RangeSlice.builder().startInclusive(7).endExclusive(8).build();
         assertThat(justSeven.contains(6)).isFalse();
         assertThat(justSeven.contains(7)).isTrue();
         assertThat(justSeven.contains(8)).isFalse();
@@ -76,8 +69,7 @@ public class RangeSliceTest {
 
     @Test
     public void lowerBoundedRangesContainCorrectElements() {
-        RangeSlice fiveOrGreater =
-                RangeSlice.builder().startInclusive(5).build();
+        RangeSlice fiveOrGreater = RangeSlice.builder().startInclusive(5).build();
         assertThat(fiveOrGreater.contains(4)).isFalse();
         assertThat(fiveOrGreater.contains(5)).isTrue();
         assertThat(fiveOrGreater.contains(6)).isTrue();
@@ -87,8 +79,7 @@ public class RangeSliceTest {
 
     @Test
     public void upperBoundedRangesContainCorrectElements() {
-        RangeSlice lessThanFive =
-                RangeSlice.builder().endExclusive(5).build();
+        RangeSlice lessThanFive = RangeSlice.builder().endExclusive(5).build();
         assertThat(lessThanFive.contains(4)).isTrue();
         assertThat(lessThanFive.contains(5)).isFalse();
         assertThat(lessThanFive.contains(6)).isFalse();

--- a/atlasdb-workload-server-api/src/test/java/com/palantir/atlasdb/workload/transaction/RangeSliceTest.java
+++ b/atlasdb-workload-server-api/src/test/java/com/palantir/atlasdb/workload/transaction/RangeSliceTest.java
@@ -24,25 +24,25 @@ import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.Optional;
 import org.junit.Test;
 
-public class ColumnRangeSelectionTest {
+public class RangeSliceTest {
     @Test
     public void cannotCreateRangeWithStartColumnGreaterThanEndColumn() {
-        assertThatLoggableExceptionThrownBy(() -> ColumnRangeSelection.builder()
-                        .startColumnInclusive(5)
-                        .endColumnExclusive(4)
-                        .build())
+        assertThatLoggableExceptionThrownBy(() -> RangeSlice.builder()
+                .startInclusive(5)
+                .endExclusive(4)
+                .build())
                 .isInstanceOf(SafeIllegalStateException.class)
-                .hasMessageContaining("Start column must be less than or equal to end column")
+                .hasMessageContaining("Start must be less than or equal to end")
                 .hasExactlyArgs(
-                        SafeArg.of("startColumnInclusive", Optional.of(5)),
-                        SafeArg.of("endColumnExclusive", Optional.of(4)));
+                        SafeArg.of("startInclusive", Optional.of(5)),
+                        SafeArg.of("endExclusive", Optional.of(4)));
     }
 
     @Test
     public void emptyRangeDoesNotContainAnyElements() {
-        ColumnRangeSelection emptyRange = ColumnRangeSelection.builder()
-                .startColumnInclusive(6)
-                .endColumnExclusive(6)
+        RangeSlice emptyRange = RangeSlice.builder()
+                .startInclusive(6)
+                .endExclusive(6)
                 .build();
         assertThat(emptyRange.contains(5)).isFalse();
         assertThat(emptyRange.contains(6)).isFalse();
@@ -53,9 +53,9 @@ public class ColumnRangeSelectionTest {
 
     @Test
     public void singleElementRangeContainsJustItself() {
-        ColumnRangeSelection justSeven = ColumnRangeSelection.builder()
-                .startColumnInclusive(7)
-                .endColumnExclusive(8)
+        RangeSlice justSeven = RangeSlice.builder()
+                .startInclusive(7)
+                .endExclusive(8)
                 .build();
         assertThat(justSeven.contains(6)).isFalse();
         assertThat(justSeven.contains(7)).isTrue();
@@ -66,7 +66,7 @@ public class ColumnRangeSelectionTest {
 
     @Test
     public void universalRangeContainsEverything() {
-        ColumnRangeSelection universal = ColumnRangeSelection.builder().build();
+        RangeSlice universal = RangeSlice.builder().build();
         assertThat(universal.contains(10241024)).isTrue();
         assertThat(universal.contains(-20482048)).isTrue();
         assertThat(universal.contains(40924092)).isTrue();
@@ -76,23 +76,23 @@ public class ColumnRangeSelectionTest {
 
     @Test
     public void lowerBoundedRangesContainCorrectElements() {
-        ColumnRangeSelection universal =
-                ColumnRangeSelection.builder().startColumnInclusive(5).build();
-        assertThat(universal.contains(4)).isFalse();
-        assertThat(universal.contains(5)).isTrue();
-        assertThat(universal.contains(6)).isTrue();
-        assertThat(universal.contains(Integer.MIN_VALUE)).isFalse();
-        assertThat(universal.contains(Integer.MAX_VALUE)).isTrue();
+        RangeSlice fiveOrGreater =
+                RangeSlice.builder().startInclusive(5).build();
+        assertThat(fiveOrGreater.contains(4)).isFalse();
+        assertThat(fiveOrGreater.contains(5)).isTrue();
+        assertThat(fiveOrGreater.contains(6)).isTrue();
+        assertThat(fiveOrGreater.contains(Integer.MIN_VALUE)).isFalse();
+        assertThat(fiveOrGreater.contains(Integer.MAX_VALUE)).isTrue();
     }
 
     @Test
     public void upperBoundedRangesContainCorrectElements() {
-        ColumnRangeSelection universal =
-                ColumnRangeSelection.builder().endColumnExclusive(5).build();
-        assertThat(universal.contains(4)).isTrue();
-        assertThat(universal.contains(5)).isFalse();
-        assertThat(universal.contains(6)).isFalse();
-        assertThat(universal.contains(Integer.MIN_VALUE)).isTrue();
-        assertThat(universal.contains(Integer.MAX_VALUE)).isFalse();
+        RangeSlice lessThanFive =
+                RangeSlice.builder().endExclusive(5).build();
+        assertThat(lessThanFive.contains(4)).isTrue();
+        assertThat(lessThanFive.contains(5)).isFalse();
+        assertThat(lessThanFive.contains(6)).isFalse();
+        assertThat(lessThanFive.contains(Integer.MIN_VALUE)).isTrue();
+        assertThat(lessThanFive.contains(Integer.MAX_VALUE)).isFalse();
     }
 }

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/invariant/SerializableInvariant.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/invariant/SerializableInvariant.java
@@ -27,6 +27,7 @@ import com.palantir.atlasdb.workload.transaction.witnessed.InvalidWitnessedTrans
 import com.palantir.atlasdb.workload.transaction.witnessed.InvalidWitnessedTransactionAction;
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedDeleteTransactionAction;
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedRowColumnRangeReadTransactionAction;
+import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedRowRangeReadTransactionAction;
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedSingleCellReadTransactionAction;
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedTransactionActionVisitor;
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedWriteTransactionAction;
@@ -108,6 +109,13 @@ public enum SerializableInvariant implements TransactionInvariant {
                         .expectedColumnsAndValues(expectedReads)
                         .build());
             }
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<InvalidWitnessedTransactionAction> visit(
+                WitnessedRowRangeReadTransactionAction rowReadTransactionAction) {
+            // TODO (jkong): Not implemented yet!
             return Optional.empty();
         }
     }

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/invariant/SnapshotInvariantVisitor.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/invariant/SnapshotInvariantVisitor.java
@@ -26,6 +26,7 @@ import com.palantir.atlasdb.workload.transaction.witnessed.InvalidWitnessedSingl
 import com.palantir.atlasdb.workload.transaction.witnessed.InvalidWitnessedTransactionAction;
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedDeleteTransactionAction;
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedRowColumnRangeReadTransactionAction;
+import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedRowRangeReadTransactionAction;
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedSingleCellReadTransactionAction;
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedTransactionActionVisitor;
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedWriteTransactionAction;
@@ -106,6 +107,13 @@ final class SnapshotInvariantVisitor
                     .expectedColumnsAndValues(expectedReads)
                     .build());
         }
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<InvalidWitnessedTransactionAction> visit(
+            WitnessedRowRangeReadTransactionAction rowReadTransactionAction) {
+        // TODO (jkong): Not implemented yet!
         return Optional.empty();
     }
 

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/store/AtlasDbTransactionStore.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/store/AtlasDbTransactionStore.java
@@ -27,6 +27,7 @@ import com.palantir.atlasdb.transaction.service.TransactionStatus;
 import com.palantir.atlasdb.workload.transaction.DeleteTransactionAction;
 import com.palantir.atlasdb.workload.transaction.InteractiveTransaction;
 import com.palantir.atlasdb.workload.transaction.RowColumnRangeReadTransactionAction;
+import com.palantir.atlasdb.workload.transaction.RowRangeReadTransactionAction;
 import com.palantir.atlasdb.workload.transaction.SingleCellReadTransactionAction;
 import com.palantir.atlasdb.workload.transaction.TransactionAction;
 import com.palantir.atlasdb.workload.transaction.TransactionActionVisitor;
@@ -167,6 +168,12 @@ public final class AtlasDbTransactionStore implements InteractiveTransactionStor
                     rowColumnRangeReadTransactionAction.table(),
                     rowColumnRangeReadTransactionAction.row(),
                     rowColumnRangeReadTransactionAction.columnRangeSelection());
+            return null;
+        }
+
+        @Override
+        public Void visit(RowRangeReadTransactionAction rowRangeReadTransactionAction) {
+            // TODO (jkong): Not implemented yet!
             return null;
         }
     }

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/store/AtlasDbTransactionStore.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/store/AtlasDbTransactionStore.java
@@ -173,7 +173,11 @@ public final class AtlasDbTransactionStore implements InteractiveTransactionStor
 
         @Override
         public Void visit(RowRangeReadTransactionAction rowRangeReadTransactionAction) {
-            // TODO (jkong): Not implemented yet!
+            transaction.getRange(
+                    rowRangeReadTransactionAction.table(),
+                    rowRangeReadTransactionAction.rowsToRead(),
+                    rowRangeReadTransactionAction.columns(),
+                    rowRangeReadTransactionAction.reverse());
             return null;
         }
     }

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/store/AtlasDbTransactionStore.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/store/AtlasDbTransactionStore.java
@@ -176,8 +176,7 @@ public final class AtlasDbTransactionStore implements InteractiveTransactionStor
             transaction.getRange(
                     rowRangeReadTransactionAction.table(),
                     rowRangeReadTransactionAction.rowsToRead(),
-                    rowRangeReadTransactionAction.columns(),
-                    rowRangeReadTransactionAction.reverse());
+                    rowRangeReadTransactionAction.columns());
             return null;
         }
     }

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/transaction/InMemoryTransactionReplayer.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/transaction/InMemoryTransactionReplayer.java
@@ -20,6 +20,7 @@ import com.palantir.atlasdb.keyvalue.api.cache.StructureHolder;
 import com.palantir.atlasdb.workload.store.TableAndWorkloadCell;
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedDeleteTransactionAction;
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedRowColumnRangeReadTransactionAction;
+import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedRowRangeReadTransactionAction;
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedSingleCellReadTransactionAction;
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedTransactionActionVisitor;
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedWriteTransactionAction;
@@ -58,6 +59,11 @@ public final class InMemoryTransactionReplayer implements WitnessedTransactionAc
 
     @Override
     public Void visit(WitnessedRowColumnRangeReadTransactionAction rowColumnRangeReadTransactionAction) {
+        return null;
+    }
+
+    @Override
+    public Void visit(WitnessedRowRangeReadTransactionAction rowReadTransactionAction) {
         return null;
     }
 

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/transaction/WitnessToActionVisitor.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/transaction/WitnessToActionVisitor.java
@@ -18,8 +18,8 @@ package com.palantir.atlasdb.workload.transaction;
 
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedDeleteTransactionAction;
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedRowColumnRangeReadTransactionAction;
-import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedSingleCellReadTransactionAction;
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedRowRangeReadTransactionAction;
+import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedSingleCellReadTransactionAction;
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedTransactionActionVisitor;
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedWriteTransactionAction;
 
@@ -43,7 +43,8 @@ public enum WitnessToActionVisitor implements WitnessedTransactionActionVisitor<
     }
 
     @Override
-    public RowColumnRangeReadTransactionAction visit(WitnessedRowColumnRangeReadTransactionAction rowColumnRangeReadTransactionAction) {
+    public RowColumnRangeReadTransactionAction visit(
+            WitnessedRowColumnRangeReadTransactionAction rowColumnRangeReadTransactionAction) {
         return rowColumnRangeReadTransactionAction.originalQuery();
     }
 

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/transaction/WitnessToActionVisitor.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/transaction/WitnessToActionVisitor.java
@@ -19,6 +19,7 @@ package com.palantir.atlasdb.workload.transaction;
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedDeleteTransactionAction;
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedRowColumnRangeReadTransactionAction;
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedSingleCellReadTransactionAction;
+import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedRowRangeReadTransactionAction;
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedTransactionActionVisitor;
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedWriteTransactionAction;
 
@@ -42,7 +43,12 @@ public enum WitnessToActionVisitor implements WitnessedTransactionActionVisitor<
     }
 
     @Override
-    public TransactionAction visit(WitnessedRowColumnRangeReadTransactionAction rowColumnRangeReadTransactionAction) {
+    public RowColumnRangeReadTransactionAction visit(WitnessedRowColumnRangeReadTransactionAction rowColumnRangeReadTransactionAction) {
         return rowColumnRangeReadTransactionAction.originalQuery();
+    }
+
+    @Override
+    public RowRangeReadTransactionAction visit(WitnessedRowRangeReadTransactionAction rowReadTransactionAction) {
+        return rowReadTransactionAction.originalQuery();
     }
 }

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/util/AtlasDbUtils.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/util/AtlasDbUtils.java
@@ -129,8 +129,8 @@ public final class AtlasDbUtils {
                         .orElse(null));
     }
 
-    public static RangeRequest toAtlasRangeRequest(RangeSlice rowsToRead, SortedSet<Integer> columns, boolean reverse) {
-        RangeRequest.Builder builder = RangeRequest.builder(reverse)
+    public static RangeRequest toAtlasRangeRequest(RangeSlice rowsToRead, SortedSet<Integer> columns) {
+        RangeRequest.Builder builder = RangeRequest.builder()
                 .retainColumns(ColumnSelection.create(
                         columns.stream().map(AtlasDbUtils::toAtlasKey).collect(Collectors.toSet())))
                 .batchHint(2);


### PR DESCRIPTION
## General
**Before this PR**:
We can do `getRowsColumnRange`, but not `getRange` in the workload server.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
`getRange` is now supported in the workload server.
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**:
- The RangeSlice refactor means we lose a bit of detail on what goes wrong if a user provides an invalid column range scan. I think this is fine as it only comes up in internal usage.
- The simplifying assumptions (not implementing reverse and draining the iterator) may be a bit dramatic, but these make things a lot simpler.

**Is documentation needed?**: No

## Compatibility
Antithesis workload server change.

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: Nothing in particular.

**What was existing testing like? What have you done to improve it?**: New code should be tested.

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: N/A

## Execution
Antithesis workload server change.

## Scale
Antithesis workload server change.

## Development Process
**Where should we start reviewing?**: RowRangeReadTransactionAction

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: I could, though this PR is analogous to #6606 plus #6607, and reviewing the former without the latter might be a bit tricky.

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
