### PR TITLE
Add background runner to periodically collect thread info snapshots

### DIFF
--- a/lock-api-objects/src/main/java/com/palantir/lock/ThreadAwareLockClient.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/ThreadAwareLockClient.java
@@ -1,0 +1,40 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock;
+
+import javax.annotation.Nullable;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@SuppressWarnings("ClassInitializationDeadlock")
+public interface ThreadAwareLockClient {
+
+    ThreadAwareLockClient UNKNOWN = ThreadAwareLockClient.of(LockClient.ANONYMOUS, "");
+
+    @Nullable
+    LockClient client();
+
+    String requestingThread();
+
+    static ImmutableThreadAwareLockClient.Builder builder() {
+        return ImmutableThreadAwareLockClient.builder();
+    }
+
+    static ThreadAwareLockClient of(LockClient client, String requestingThread) {
+        return builder().client(client).requestingThread(requestingThread).build();
+    }
+}

--- a/lock-api/src/main/java/com/palantir/lock/ThreadAwareCloseableLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/ThreadAwareCloseableLockService.java
@@ -1,0 +1,32 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock;
+
+import java.util.Map;
+
+public interface ThreadAwareCloseableLockService extends CloseableLockService {
+
+    /**
+     * This is a debugging-only method providing a good-effort guess for which lock is currently held
+     * by which client thread.
+     * This guess is likely based on significantly out-of-date information (as old as a few seconds).
+     * Lock descriptors without a mapping (or mapped to null) are assumed to be free at the moment.
+     * The {@link ThreadAwareLockClient#UNKNOWN} sentinel value signals that we cannot provide any information about
+     * which thread currently owns the lock.
+     */
+    Map<LockDescriptor, ThreadAwareLockClient> getLastKnownThreadInfoSnapshot();
+}

--- a/lock-impl/build.gradle
+++ b/lock-impl/build.gradle
@@ -22,6 +22,7 @@ dependencies {
   implementation project(':lock-api-objects')
   implementation project(':timestamp-api')
 
+  testImplementation 'org.awaitility:awaitility'
   testImplementation 'com.fasterxml.jackson.core:jackson-databind'
   testImplementation 'com.google.guava:guava'
   testImplementation 'com.palantir.safe-logging:preconditions'

--- a/lock-impl/src/test/java/com/palantir/lock/impl/ThreadAwareLockServiceImplTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/impl/ThreadAwareLockServiceImplTest.java
@@ -1,0 +1,273 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
+import com.palantir.common.concurrent.PTExecutors;
+import com.palantir.lock.LockClient;
+import com.palantir.lock.LockDescriptor;
+import com.palantir.lock.LockMode;
+import com.palantir.lock.LockRequest;
+import com.palantir.lock.LockResponse;
+import com.palantir.lock.LockServerOptions;
+import com.palantir.lock.SimpleTimeDuration;
+import com.palantir.lock.StringLockDescriptor;
+import com.palantir.lock.ThreadAwareLockClient;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.awaitility.Awaitility;
+import org.junit.Test;
+
+public class ThreadAwareLockServiceImplTest {
+
+    // Disable background thread info collection by default, it will be invoked manually instead
+    private final LockServiceImpl lockService = LockServiceImpl.create(
+            LockServerOptions.builder().isStandaloneServer(false).build());
+
+    private final ExecutorService executor =
+            PTExecutors.newCachedThreadPool(ThreadAwareLockServiceImplTest.class.getName());
+
+    private static final LockDescriptor TEST_LOCK_1 = StringLockDescriptor.of("lock-1");
+    private static final LockDescriptor TEST_LOCK_2 = StringLockDescriptor.of("lock-2");
+    private static final LockDescriptor TEST_LOCK_3 = StringLockDescriptor.of("lock-3");
+
+    private static final String TEST_THREAD_1 = "thread-1";
+    private static final String TEST_THREAD_2 = "thread-2";
+    private static final String TEST_THREAD_3 = "thread-3";
+
+    private static final LockClient TEST_LOCK_CLIENT = LockClient.ANONYMOUS;
+
+    @Test
+    public void initialSnapShotIsEmpty() {
+        lockService.updateThreadInfoSnapshot();
+        assertThat(lockService.getLastKnownThreadInfoSnapshot()).isEmpty();
+    }
+
+    @Test
+    public void collectsHeldLocks_singleLock() throws InterruptedException {
+        LockRequest lockRequest = LockRequest.builder(ImmutableSortedMap.of(TEST_LOCK_1, LockMode.WRITE))
+                .withCreatingThreadName(TEST_THREAD_1)
+                .build();
+
+        lockService.lockWithFullLockResponse(TEST_LOCK_CLIENT, lockRequest);
+        lockService.updateThreadInfoSnapshot();
+
+        assertThat(lockService.getLastKnownThreadInfoSnapshot())
+                .containsExactly(Map.entry(TEST_LOCK_1, ThreadAwareLockClient.of(TEST_LOCK_CLIENT, TEST_THREAD_1)));
+    }
+
+    @Test
+    public void collectsHeldLocks_multipleUniqueLocks_fromDifferentThreads() throws InterruptedException {
+        final int numThreads = 10;
+        final int numLocksPerThread = 10;
+
+        List<String> threadNames =
+                IntStream.range(0, numThreads).mapToObj(i -> "test-thread-" + i).collect(Collectors.toList());
+        Map<String, List<LockDescriptor>> locksPerThread = new HashMap<>();
+        for (String threadName : threadNames) {
+            List<LockDescriptor> locks = IntStream.range(0, numLocksPerThread)
+                    .mapToObj(i -> StringLockDescriptor.of("test-lock-" + i + "-from-thread-" + threadName))
+                    .collect(Collectors.toList());
+            locksPerThread.put(threadName, locks);
+        }
+
+        for (String threadName : threadNames) {
+            LockRequest lockRequest = LockRequest.builder(
+                            ImmutableSortedMap.copyOf(locksPerThread.get(threadName).stream()
+                                    .collect(Collectors.toMap(lock -> lock, lock -> LockMode.WRITE))))
+                    .withCreatingThreadName(threadName)
+                    .build();
+            lockService.lockWithFullLockResponse(TEST_LOCK_CLIENT, lockRequest);
+        }
+        lockService.updateThreadInfoSnapshot();
+
+        Map<LockDescriptor, ThreadAwareLockClient> expected = locksPerThread.keySet().stream()
+                .flatMap(threadName -> locksPerThread.get(threadName).stream()
+                        .map(lock -> Map.entry(lock, ThreadAwareLockClient.of(TEST_LOCK_CLIENT, threadName))))
+                .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+        assertThat(lockService.getLastKnownThreadInfoSnapshot()).containsExactlyInAnyOrderEntriesOf(expected);
+    }
+
+    @Test
+    public void collectsHeldLocks_sharedLock_fromDifferentThreads() throws InterruptedException {
+        LockRequest lockRequest1 = LockRequest.builder(ImmutableSortedMap.of(TEST_LOCK_1, LockMode.READ))
+                .withCreatingThreadName(TEST_THREAD_1)
+                .build();
+        LockRequest lockRequest2 = LockRequest.builder(ImmutableSortedMap.of(TEST_LOCK_1, LockMode.READ))
+                .doNotBlock()
+                .lockAsManyAsPossible()
+                .withCreatingThreadName(TEST_THREAD_2)
+                .build();
+
+        lockService.lockWithFullLockResponse(TEST_LOCK_CLIENT, lockRequest1);
+        lockService.lockWithFullLockResponse(TEST_LOCK_CLIENT, lockRequest2);
+        lockService.updateThreadInfoSnapshot();
+
+        assertThat(lockService.getLastKnownThreadInfoSnapshot())
+                .hasSize(1)
+                .containsAnyOf(
+                        Map.entry(TEST_LOCK_1, ThreadAwareLockClient.of(TEST_LOCK_CLIENT, TEST_THREAD_1)),
+                        Map.entry(TEST_LOCK_1, ThreadAwareLockClient.of(TEST_LOCK_CLIENT, TEST_THREAD_2)));
+    }
+
+    @Test
+    public void doesNotCollectDroppedLocksWithLockAllOrNone() throws InterruptedException {
+        LockRequest lockRequest1 = LockRequest.builder(ImmutableSortedMap.of(TEST_LOCK_1, LockMode.WRITE))
+                .withCreatingThreadName(TEST_THREAD_1)
+                .build();
+
+        // T2 cannot get lock 1 -> grouping behavior LOCK_ALL_OR_NONE will release lock 2, even though it could have
+        // been locked
+        LockRequest lockRequest2 = LockRequest.builder(
+                        ImmutableSortedMap.of(TEST_LOCK_1, LockMode.READ, TEST_LOCK_2, LockMode.READ))
+                .doNotBlock()
+                .withCreatingThreadName(TEST_THREAD_2)
+                .build();
+
+        lockService.lockWithFullLockResponse(TEST_LOCK_CLIENT, lockRequest1);
+        lockService.lockWithFullLockResponse(TEST_LOCK_CLIENT, lockRequest2);
+        lockService.updateThreadInfoSnapshot();
+
+        assertThat(lockService.getLastKnownThreadInfoSnapshot())
+                .containsExactly(Map.entry(TEST_LOCK_1, ThreadAwareLockClient.of(TEST_LOCK_CLIENT, TEST_THREAD_1)));
+    }
+
+    @Test
+    public void doesNotCollectUnlockedLocks() throws InterruptedException {
+        LockRequest lockRequest = LockRequest.builder(ImmutableSortedMap.of(TEST_LOCK_1, LockMode.WRITE))
+                .withCreatingThreadName(TEST_THREAD_1)
+                .build();
+
+        LockResponse response = lockService.lockWithFullLockResponse(TEST_LOCK_CLIENT, lockRequest);
+        lockService.unlock(response.getLockRefreshToken());
+        lockService.updateThreadInfoSnapshot();
+
+        assertThat(lockService.getLastKnownThreadInfoSnapshot()).isEmpty();
+    }
+
+    @Test
+    public void doesNotCollectFailedLocks() throws InterruptedException {
+        LockRequest lockRequest1 = LockRequest.builder(ImmutableSortedMap.of(TEST_LOCK_1, LockMode.WRITE))
+                .withCreatingThreadName(TEST_THREAD_1)
+                .build();
+        LockRequest lockRequest2 = LockRequest.builder(ImmutableSortedMap.of(TEST_LOCK_1, LockMode.WRITE))
+                .doNotBlock()
+                .lockAsManyAsPossible()
+                .withCreatingThreadName(TEST_THREAD_2)
+                .build();
+
+        LockResponse response = lockService.lockWithFullLockResponse(TEST_LOCK_CLIENT, lockRequest1);
+        // should fail to acquire lock
+        lockService.lockWithFullLockResponse(TEST_LOCK_CLIENT, lockRequest2);
+        // After unlocking locks of T1, no more locks should be held by any thread
+        lockService.unlock(response.getLockRefreshToken());
+        lockService.updateThreadInfoSnapshot();
+
+        assertThat(lockService.getLastKnownThreadInfoSnapshot()).isEmpty();
+    }
+
+    @Test
+    public void collectsCorrectStateAfterMultipleOperations() throws Exception {
+        final CyclicBarrier barrier = new CyclicBarrier(2);
+
+        // T1 locks 1 exclusively and locks 2 in shared mode
+        LockResponse response1 = lockService.lockWithFullLockResponse(
+                TEST_LOCK_CLIENT,
+                LockRequest.builder(ImmutableSortedMap.of(TEST_LOCK_1, LockMode.WRITE, TEST_LOCK_2, LockMode.READ))
+                        .doNotBlock()
+                        .lockAsManyAsPossible()
+                        .withCreatingThreadName(TEST_THREAD_1)
+                        .build());
+
+        // T2 won't get lock 1, but locks 3 in exclusive mode,
+        LockResponse response2 = lockService.lockWithFullLockResponse(
+                TEST_LOCK_CLIENT,
+                LockRequest.builder(ImmutableSortedMap.of(TEST_LOCK_1, LockMode.READ, TEST_LOCK_3, LockMode.WRITE))
+                        .doNotBlock()
+                        .lockAsManyAsPossible()
+                        .withCreatingThreadName(TEST_THREAD_2)
+                        .build());
+
+        executor.submit((Callable<Void>) () -> {
+
+            // T3 will wait 5 seconds to lock 1 in exclusive mode and lock 2 in shared mode
+            LockResponse response3 = lockService.lockWithFullLockResponse(
+                    TEST_LOCK_CLIENT,
+                    LockRequest.builder(ImmutableSortedMap.of(TEST_LOCK_1, LockMode.WRITE, TEST_LOCK_2, LockMode.READ))
+                            .blockForAtMost(SimpleTimeDuration.of(5, TimeUnit.SECONDS))
+                            .lockAsManyAsPossible()
+                            .withCreatingThreadName(TEST_THREAD_3)
+                            .build());
+            barrier.await();
+            return null;
+        });
+        lockService.unlock(response1.getLockRefreshToken());
+        barrier.await();
+
+        lockService.updateThreadInfoSnapshot();
+
+        // Now T1 should hold nothing, T2 holds 3 in exclusive mode, T3 holds 1 in exclusive and 2 in shared mode
+        Map<LockDescriptor, ThreadAwareLockClient> expected = ImmutableMap.of(
+                TEST_LOCK_1,
+                ThreadAwareLockClient.of(TEST_LOCK_CLIENT, TEST_THREAD_3),
+                TEST_LOCK_2,
+                ThreadAwareLockClient.of(TEST_LOCK_CLIENT, TEST_THREAD_3),
+                TEST_LOCK_3,
+                ThreadAwareLockClient.of(TEST_LOCK_CLIENT, TEST_THREAD_2));
+
+        assertThat(lockService.getLastKnownThreadInfoSnapshot()).containsExactlyInAnyOrderEntriesOf(expected);
+    }
+
+    @Test
+    public void backgroundCollectionWorks() throws InterruptedException {
+        // TODO this simulates the running background snapshotting task and should be replaced with the creation of a
+        // properly configured LockServiceImpl once everything has been wired together
+        Future<Void> future = executor.submit(() -> {
+            while (true) {
+                lockService.updateThreadInfoSnapshot();
+                Thread.sleep(100);
+            }
+        });
+
+        LockRequest lockRequest = LockRequest.builder(ImmutableSortedMap.of(TEST_LOCK_1, LockMode.WRITE))
+                .withCreatingThreadName(TEST_THREAD_1)
+                .build();
+        lockService.lockWithFullLockResponse(TEST_LOCK_CLIENT, lockRequest);
+
+        Awaitility.await("wait for background runner to take a snapshot")
+                .atMost(500, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertThat(lockService.getLastKnownThreadInfoSnapshot())
+                            .containsExactly(
+                                    Map.entry(TEST_LOCK_1, ThreadAwareLockClient.of(TEST_LOCK_CLIENT, TEST_THREAD_1)));
+                });
+
+        future.cancel(true);
+    }
+}


### PR DESCRIPTION
## General
**Before this PR**:

**After this PR**:

LockServiceImpl contains a background task that periodically collects information about which lock is currently owned by which client thread by traversing the currently known lock tokens.

In this PR, the background runner is disabled by default.

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add background runner to periodically collect thread info snapshots
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:
Although ScheduledExecutorService is a much better fit for this kind of task, I use Thread.sleep() to simulate an interval. I consider it important to reuse the passed executor for any sort of background work (like LockReapRunner does). However, changing the executor that is passed to a ScheduledExecutorService is non-trivial and the underlying thread-pool behavior would likely differ, which I'd rather avoid.

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
This PR assumes that heldLockTokensMap is an up-to-date representation of the current lock ownership
**What was existing testing like? What have you done to improve it?**:
I have added a new suite of unit tests to verify the collection works using basic locking/unlocking workflows.
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

heldLocksTokenMap is a concurrent map, so traversal of it in a background task is safe.

Likewise, the thread info snapshot is stored in a volatile member

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
No locks are acquired
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Cannot be enabled in production
**Has the safety of all log arguments been decided correctly?**:
N/A
**Will this change significantly affect our spending on metrics or logs?**:
No
**How would I tell that this PR does not work in production? (monitors, etc.)**:
N/A
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
N/A
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
Once the background runner can be enabled and there are a lot of locks held concurrently, taking a snapshot can become expensive. Also, snapshots are short-lived, which can negatively affect GC behavior.
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
If the number of concurrently held locks reaches into the many millions, takin a snapshot of the current lock state is not feasible. 
## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
