### PR TITLE
[LockV1] Maintain thread info with every request (off by default)

### DIFF
--- a/lock-api-objects/src/main/java/com/palantir/lock/ThreadAwareLockClient.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/ThreadAwareLockClient.java
@@ -1,0 +1,37 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock;
+
+import javax.annotation.Nullable;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface ThreadAwareLockClient {
+
+    @Nullable
+    LockClient client();
+
+    String thread();
+
+    static ImmutableThreadAwareLockClient.Builder builder() {
+        return ImmutableThreadAwareLockClient.builder();
+    }
+
+    static ThreadAwareLockClient of(LockClient client, String requestingThread) {
+        return builder().client(client).thread(requestingThread).build();
+    }
+}

--- a/lock-api/src/main/java/com/palantir/lock/DebugThreadInfoConfiguration.java
+++ b/lock-api/src/main/java/com/palantir/lock/DebugThreadInfoConfiguration.java
@@ -1,0 +1,28 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface DebugThreadInfoConfiguration {
+
+    @Value.Default
+    default boolean recordThreadInfo() {
+        return false;
+    }
+}

--- a/lock-api/src/main/java/com/palantir/lock/LockServerOptions.java
+++ b/lock-api/src/main/java/com/palantir/lock/LockServerOptions.java
@@ -16,6 +16,7 @@
 package com.palantir.lock;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.MoreObjects;
@@ -126,6 +127,17 @@ public class LockServerOptions implements Serializable {
         return 10000L;
     }
 
+    /**
+     * Runtime configuration relating the thread info recording
+     * (which lock is held by which client-thread).
+     */
+    @JsonProperty("threadInfoConfiguration")
+    @JsonIgnore
+    @Value.Default
+    public DebugThreadInfoConfiguration threadInfoConfiguration() {
+        return ImmutableDebugThreadInfoConfiguration.builder().build();
+    }
+
     @Override
     public boolean equals(@Nullable Object obj) {
         if (this == obj) {
@@ -142,7 +154,8 @@ public class LockServerOptions implements Serializable {
                 && Objects.equals(getMaxAllowedClockDrift(), other.getMaxAllowedClockDrift())
                 && Objects.equals(getMaxAllowedBlockingDuration(), other.getMaxAllowedBlockingDuration())
                 && Objects.equals(getMaxNormalLockAge(), other.getMaxNormalLockAge())
-                && Objects.equals(getStuckTransactionTimeout(), other.getStuckTransactionTimeout());
+                && Objects.equals(getStuckTransactionTimeout(), other.getStuckTransactionTimeout())
+                && Objects.equals(threadInfoConfiguration(), other.threadInfoConfiguration());
     }
 
     @Override
@@ -155,7 +168,8 @@ public class LockServerOptions implements Serializable {
                 getMaxNormalLockAge(),
                 getRandomBitCount(),
                 getStuckTransactionTimeout(),
-                slowLogTriggerMillis());
+                slowLogTriggerMillis(),
+                threadInfoConfiguration());
     }
 
     @Override
@@ -169,6 +183,7 @@ public class LockServerOptions implements Serializable {
                 .add("randomBitCount", getRandomBitCount())
                 .add("stuckTransactionTimeout", getStuckTransactionTimeout())
                 .add("slowLogTriggerMillis", slowLogTriggerMillis())
+                .add("threadInfoConfiguration", threadInfoConfiguration())
                 .toString();
     }
 

--- a/lock-api/src/main/java/com/palantir/lock/ThreadAwareCloseableLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/ThreadAwareCloseableLockService.java
@@ -1,0 +1,28 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock;
+
+public interface ThreadAwareCloseableLockService extends CloseableLockService {
+
+    /**
+     * This is a debugging-only method providing best-effort information about which client-thread last successfully
+     * acquired a lock. This does not guarantee that the lock is still held by that thread as unlock operations are
+     * not recorded.
+     * Returns null if we have not recorded a thread acquisition for this lock yet.
+     */
+    ThreadAwareLockClient getLastAcquiringThread(LockDescriptor lock);
+}

--- a/lock-impl/src/test/java/com/palantir/lock/impl/ThreadAwareLockServiceImplTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/impl/ThreadAwareLockServiceImplTest.java
@@ -1,0 +1,244 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableSortedMap;
+import com.palantir.common.concurrent.PTExecutors;
+import com.palantir.lock.ImmutableDebugThreadInfoConfiguration;
+import com.palantir.lock.LockClient;
+import com.palantir.lock.LockDescriptor;
+import com.palantir.lock.LockMode;
+import com.palantir.lock.LockRequest;
+import com.palantir.lock.LockResponse;
+import com.palantir.lock.LockServerOptions;
+import com.palantir.lock.SimpleTimeDuration;
+import com.palantir.lock.StringLockDescriptor;
+import com.palantir.lock.ThreadAwareLockClient;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.Test;
+
+public class ThreadAwareLockServiceImplTest {
+
+    // Disable background thread info collection by default, it will be invoked manually instead
+    private final LockServiceImpl lockService = LockServiceImpl.create(LockServerOptions.builder()
+            .isStandaloneServer(false)
+            .threadInfoConfiguration(ImmutableDebugThreadInfoConfiguration.builder()
+                    .recordThreadInfo(true)
+                    .build())
+            .build());
+
+    // default for thread info configuration
+    private final LockServiceImpl defaultLockService = LockServiceImpl.create(
+            LockServerOptions.builder().isStandaloneServer(false).build());
+
+    private final ExecutorService executor =
+            PTExecutors.newCachedThreadPool(ThreadAwareLockServiceImplTest.class.getName());
+
+    private static final LockDescriptor TEST_LOCK_1 = StringLockDescriptor.of("lock-1");
+    private static final LockDescriptor TEST_LOCK_2 = StringLockDescriptor.of("lock-2");
+    private static final LockDescriptor TEST_LOCK_3 = StringLockDescriptor.of("lock-3");
+
+    private static final String TEST_THREAD_1 = "thread-1";
+    private static final String TEST_THREAD_2 = "thread-2";
+    private static final String TEST_THREAD_3 = "thread-3";
+
+    private static final LockClient TEST_LOCK_CLIENT = LockClient.ANONYMOUS;
+
+    @Test
+    public void initialThreadInfoIsEmpty() {
+        assertThat(lockService.getLastAcquiringThread(TEST_LOCK_1)).isNull();
+        assertThat(lockService.getLastAcquiringThread(TEST_LOCK_2)).isNull();
+        assertThat(lockService.getLastAcquiringThread(TEST_LOCK_3)).isNull();
+    }
+
+    @Test
+    public void recordsThreadInfo_singleLock() throws InterruptedException {
+        LockRequest lockRequest = LockRequest.builder(ImmutableSortedMap.of(TEST_LOCK_1, LockMode.WRITE))
+                .withCreatingThreadName(TEST_THREAD_1)
+                .build();
+
+        lockService.lockWithFullLockResponse(TEST_LOCK_CLIENT, lockRequest);
+
+        assertThat(lockService.getLastAcquiringThread(TEST_LOCK_1))
+                .isEqualTo(ThreadAwareLockClient.of(TEST_LOCK_CLIENT, TEST_THREAD_1));
+    }
+
+    @Test
+    public void doesNotRecordThreadInfoByDefault() throws InterruptedException {
+        LockRequest lockRequest = LockRequest.builder(ImmutableSortedMap.of(TEST_LOCK_1, LockMode.WRITE))
+                .withCreatingThreadName(TEST_THREAD_1)
+                .build();
+
+        defaultLockService.lockWithFullLockResponse(TEST_LOCK_CLIENT, lockRequest);
+
+        assertThat(defaultLockService.getLastAcquiringThread(TEST_LOCK_1)).isNull();
+    }
+
+    @Test
+    public void recordsThreadInfo_multipleUniqueLocks_fromDifferentThreads() throws InterruptedException {
+        final int numThreads = 10;
+        final int numLocksPerThread = 10;
+
+        List<String> threadNames =
+                IntStream.range(0, numThreads).mapToObj(i -> "test-thread-" + i).collect(Collectors.toList());
+        Map<String, List<LockDescriptor>> locksPerThread = new HashMap<>();
+        for (String threadName : threadNames) {
+            List<LockDescriptor> locks = IntStream.range(0, numLocksPerThread)
+                    .mapToObj(i -> StringLockDescriptor.of("test-lock-" + i + "-from-thread-" + threadName))
+                    .collect(Collectors.toList());
+            locksPerThread.put(threadName, locks);
+        }
+
+        for (String threadName : threadNames) {
+            LockRequest lockRequest = LockRequest.builder(
+                            ImmutableSortedMap.copyOf(locksPerThread.get(threadName).stream()
+                                    .collect(Collectors.toMap(lock -> lock, lock -> LockMode.WRITE))))
+                    .withCreatingThreadName(threadName)
+                    .build();
+            lockService.lockWithFullLockResponse(TEST_LOCK_CLIENT, lockRequest);
+        }
+
+        Map<LockDescriptor, ThreadAwareLockClient> expected = locksPerThread.keySet().stream()
+                .flatMap(threadName -> locksPerThread.get(threadName).stream()
+                        .map(lock -> Map.entry(lock, ThreadAwareLockClient.of(TEST_LOCK_CLIENT, threadName))))
+                .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+
+        expected.forEach((lock, clientThread) -> {
+            assertThat(lockService.getLastAcquiringThread(lock)).isEqualTo(clientThread);
+        });
+    }
+
+    @Test
+    public void recordsThreadInfo_sharedLock_fromDifferentThreads() throws InterruptedException {
+        LockRequest lockRequest1 = LockRequest.builder(ImmutableSortedMap.of(TEST_LOCK_1, LockMode.READ))
+                .withCreatingThreadName(TEST_THREAD_1)
+                .build();
+        LockRequest lockRequest2 = LockRequest.builder(ImmutableSortedMap.of(TEST_LOCK_1, LockMode.READ))
+                .doNotBlock()
+                .lockAsManyAsPossible()
+                .withCreatingThreadName(TEST_THREAD_2)
+                .build();
+
+        lockService.lockWithFullLockResponse(TEST_LOCK_CLIENT, lockRequest1);
+        lockService.lockWithFullLockResponse(TEST_LOCK_CLIENT, lockRequest2);
+
+        assertThat(lockService.getLastAcquiringThread(TEST_LOCK_1))
+                .isIn(
+                        ThreadAwareLockClient.of(TEST_LOCK_CLIENT, TEST_THREAD_1),
+                        ThreadAwareLockClient.of(TEST_LOCK_CLIENT, TEST_THREAD_2));
+    }
+
+    @Test
+    public void doesNotRecordDroppedLocksWithLockAllOrNone() throws InterruptedException {
+        LockRequest lockRequest1 = LockRequest.builder(ImmutableSortedMap.of(TEST_LOCK_1, LockMode.WRITE))
+                .withCreatingThreadName(TEST_THREAD_1)
+                .build();
+
+        // T2 cannot get lock 1 -> grouping behavior LOCK_ALL_OR_NONE will release lock 2, even though it could have
+        // been locked
+        LockRequest lockRequest2 = LockRequest.builder(
+                        ImmutableSortedMap.of(TEST_LOCK_1, LockMode.READ, TEST_LOCK_2, LockMode.READ))
+                .doNotBlock()
+                .withCreatingThreadName(TEST_THREAD_2)
+                .build();
+
+        lockService.lockWithFullLockResponse(TEST_LOCK_CLIENT, lockRequest1);
+        lockService.lockWithFullLockResponse(TEST_LOCK_CLIENT, lockRequest2);
+
+        assertThat(lockService.getLastAcquiringThread(TEST_LOCK_1))
+                .isEqualTo(ThreadAwareLockClient.of(TEST_LOCK_CLIENT, TEST_THREAD_1));
+    }
+
+    @Test
+    public void doesNotRecordFailedLocks() throws InterruptedException {
+        LockRequest lockRequest1 = LockRequest.builder(ImmutableSortedMap.of(TEST_LOCK_1, LockMode.WRITE))
+                .withCreatingThreadName(TEST_THREAD_1)
+                .build();
+        LockRequest lockRequest2 = LockRequest.builder(ImmutableSortedMap.of(TEST_LOCK_1, LockMode.WRITE))
+                .doNotBlock()
+                .lockAsManyAsPossible()
+                .withCreatingThreadName(TEST_THREAD_2)
+                .build();
+
+        LockResponse response = lockService.lockWithFullLockResponse(TEST_LOCK_CLIENT, lockRequest1);
+        // should fail to acquire lock
+        lockService.lockWithFullLockResponse(TEST_LOCK_CLIENT, lockRequest2);
+        // After unlocking locks of T1, no more locks should be held by any thread
+        lockService.unlock(response.getLockRefreshToken());
+
+        assertThat(lockService.getLastAcquiringThread(TEST_LOCK_1))
+                .isEqualTo(ThreadAwareLockClient.of(TEST_LOCK_CLIENT, TEST_THREAD_1));
+    }
+
+    @Test
+    public void recordsCorrectStateAfterMultipleOperations() throws Exception {
+        final CyclicBarrier barrier = new CyclicBarrier(2);
+
+        // T1 locks 1 exclusively and locks 2 in shared mode
+        LockResponse response1 = lockService.lockWithFullLockResponse(
+                TEST_LOCK_CLIENT,
+                LockRequest.builder(ImmutableSortedMap.of(TEST_LOCK_1, LockMode.WRITE, TEST_LOCK_2, LockMode.READ))
+                        .doNotBlock()
+                        .lockAsManyAsPossible()
+                        .withCreatingThreadName(TEST_THREAD_1)
+                        .build());
+
+        // T2 won't get lock 1, but locks 3 in exclusive mode,
+        LockResponse response2 = lockService.lockWithFullLockResponse(
+                TEST_LOCK_CLIENT,
+                LockRequest.builder(ImmutableSortedMap.of(TEST_LOCK_1, LockMode.READ, TEST_LOCK_3, LockMode.WRITE))
+                        .doNotBlock()
+                        .lockAsManyAsPossible()
+                        .withCreatingThreadName(TEST_THREAD_2)
+                        .build());
+
+        executor.submit((Callable<Void>) () -> {
+
+            // T3 will wait 5 seconds to lock 1 in exclusive mode and lock 2 in shared mode
+            LockResponse response3 = lockService.lockWithFullLockResponse(
+                    TEST_LOCK_CLIENT,
+                    LockRequest.builder(ImmutableSortedMap.of(TEST_LOCK_1, LockMode.WRITE, TEST_LOCK_2, LockMode.READ))
+                            .blockForAtMost(SimpleTimeDuration.of(5, TimeUnit.SECONDS))
+                            .lockAsManyAsPossible()
+                            .withCreatingThreadName(TEST_THREAD_3)
+                            .build());
+            barrier.await();
+            return null;
+        });
+        lockService.unlock(response1.getLockRefreshToken());
+        barrier.await();
+
+        // Now T1 should hold nothing, T2 holds 3 in exclusive mode, T3 holds 1 in exclusive and 2 in shared mode
+        assertThat(lockService.getLastAcquiringThread(TEST_LOCK_1))
+                .isEqualTo(ThreadAwareLockClient.of(TEST_LOCK_CLIENT, TEST_THREAD_3));
+        assertThat(lockService.getLastAcquiringThread(TEST_LOCK_2))
+                .isEqualTo(ThreadAwareLockClient.of(TEST_LOCK_CLIENT, TEST_THREAD_3));
+        assertThat(lockService.getLastAcquiringThread(TEST_LOCK_3))
+                .isEqualTo(ThreadAwareLockClient.of(TEST_LOCK_CLIENT, TEST_THREAD_2));
+    }
+}


### PR DESCRIPTION
## General
**Before this PR**:

**After this PR**:
If it was enabled, calls to `createHeldLocksToken` or `createHeldGrantsToken` (which are transitively invoked by `lock `and `convertToGrant`) also create a lock-to-threadinfo (client + requesting thread) mapping in a Caffeine.Cache data structure.
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
[LockV1] Record thread info with every request (off by default)
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:
Due to behavior of Caffeine.Cache, recording unlocks leads to race conditions. However, recording unlocks is really not that important since unlocked locks are usually not a problem.
Of course, if enabled, recording thread info with every request will incur some overhead, hence why this feature is off by default and will be configurable in the future.

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
all held locks are eventually recorded by invoking createHeldLocksToken
**What was existing testing like? What have you done to improve it?**:
I have added multiple unit tests to verify the expected recording behavior.
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution

**Changes from this PR do not yet lead to logs/metrics (coming soon)**

**How would I tell this PR works in production? (Metrics, logs, etc.)**:
N/A
**Has the safety of all log arguments been decided correctly?**:
N/A
**Will this change significantly affect our spending on metrics or logs?**:
N/A
**How would I tell that this PR does not work in production? (monitors, etc.)**:
N/A
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
N/A
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
If thread info recording is enabled in the future, this PR adds some slight overhead to lock, convertToGrant and similar calls and adds a mapping for every lock descriptor. With Caffeine.Cache, we can limit the maximum number of values in the cache and set a time-based eviction policy for written values.
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
N/A
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
If it is common to request millions of locks with every request and this feature is enabled by default (for some reason), the overhead of updating the mappings is rather expensive. Also, if the number of concurrent locks managed by timelock rises and/or locks are held for significantly longer times, we should reconsider the parameters for the Caffeine.Cache instance.
## Development Process
**Where should we start reviewing?**:
LockServiceImpl
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:


<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
