### PR TITLE
[LockV1] Add lock service JMH benchmark

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ buildscript {
         classpath 'gradle.plugin.org.inferred:gradle-processors:3.7.0'
         classpath 'org.unbroken-dome.gradle-plugins:gradle-testsets-plugin:4.0.0'
         classpath 'com.palantir.gradle.revapi:gradle-revapi:1.7.0'
+        classpath 'me.champeau.jmh:jmh-gradle-plugin:0.6.6'
     }
 }
 

--- a/lock-benchmark/build.gradle
+++ b/lock-benchmark/build.gradle
@@ -1,0 +1,22 @@
+apply from: "../gradle/shared.gradle"
+apply plugin: 'me.champeau.jmh'
+
+dependencies {
+    jmhImplementation project(path: ':lock-impl')
+    jmhImplementation project(path: ':lock-api')
+
+    jmhAnnotationProcessor 'org.immutables:value'
+    jmhAnnotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess'
+
+    compileOnly 'org.openjdk.jmh:jmh-generator-annprocess'
+}
+
+jmh {
+    profilers = ["gc"]
+    jvmArgs = ["-XX:+UseShenandoahGC"]
+}
+
+tasks.jmhCompileGeneratedClasses {
+    options.annotationProcessorPath = configurations.errorprone
+    options.errorprone.enabled = true
+}

--- a/lock-benchmark/build.gradle
+++ b/lock-benchmark/build.gradle
@@ -11,6 +11,8 @@ dependencies {
 }
 
 jmh {
+    resultsFile = project.file("${project.buildDir}/reports/jmh/results.txt")
+    resultFormat = 'CSV'
     profilers = ["gc"]
     jvmArgs = ["-XX:+UseShenandoahGC"]
 }

--- a/lock-benchmark/build.gradle
+++ b/lock-benchmark/build.gradle
@@ -5,7 +5,6 @@ dependencies {
     jmhImplementation project(path: ':lock-impl')
     jmhImplementation project(path: ':lock-api')
 
-    jmhAnnotationProcessor 'org.immutables:value'
     jmhAnnotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess'
 
     compileOnly 'org.openjdk.jmh:jmh-generator-annprocess'

--- a/lock-benchmark/src/jmh/java/com/palantir/atlasdb/LockServiceBenchmark.java
+++ b/lock-benchmark/src/jmh/java/com/palantir/atlasdb/LockServiceBenchmark.java
@@ -1,0 +1,76 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.atlasdb.state.LockServiceBenchmarkState;
+import com.palantir.atlasdb.state.ThreadIndex;
+import com.palantir.lock.LockClient;
+import com.palantir.lock.LockRequest;
+import com.palantir.lock.LockResponse;
+import com.palantir.lock.LockService;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@Measurement(iterations = 2)
+@Warmup(iterations = 1)
+@Fork(2)
+public class LockServiceBenchmark {
+
+    /**
+     * Simulate a very simple interaction with TimeLock.
+     * A client sends a lock request, does something with the obtained locks (and maybe refreshes them),
+     * and eventually unlocks them again.
+     */
+    @BenchmarkMode(Mode.Throughput)
+    @Benchmark
+    @Threads(20)
+    public int lockSleepRefreshUnlockMultiThreaded(LockServiceBenchmarkState state, ThreadIndex threadIndex) {
+        final LockClient client = LockClient.of("Benchmark Client " + threadIndex.getThreadId());
+        final LockService lockService = state.getLockService();
+        final LockRequest lockRequest = state.generateLockRequest();
+        try {
+            // acquire some locks
+            LockResponse lockResponse = lockService.lockWithFullLockResponse(client, lockRequest);
+
+            // pretend we are doing something with them ...
+            for (int i = 0; i < state.refreshCount + 1; i++) {
+                if (state.sleepMs > 0) {
+                    Thread.sleep(state.sleepMs);
+                }
+                // maybe refresh as well
+                if (i < state.refreshCount && lockResponse.getLockRefreshToken() != null) {
+                    lockService.refreshLockRefreshTokens(ImmutableList.of(lockResponse.getLockRefreshToken()));
+                }
+            }
+
+            // give them back
+            if (lockResponse.getLockRefreshToken() != null) {
+                lockService.unlock(lockResponse.getLockRefreshToken());
+            }
+
+            return lockResponse.getLocks().size();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/lock-benchmark/src/jmh/java/com/palantir/atlasdb/LockServiceBenchmark.java
+++ b/lock-benchmark/src/jmh/java/com/palantir/atlasdb/LockServiceBenchmark.java
@@ -43,7 +43,7 @@ public class LockServiceBenchmark {
      */
     @BenchmarkMode(Mode.Throughput)
     @Benchmark
-    @Threads(20)
+    @Threads(4)
     public int lockSleepRefreshUnlockMultiThreaded(LockServiceBenchmarkState state, ThreadIndex threadIndex) {
         final LockClient client = LockClient.of("Benchmark Client " + threadIndex.getThreadId());
         final LockService lockService = state.getLockService();

--- a/lock-benchmark/src/jmh/java/com/palantir/atlasdb/state/LockServiceBenchmarkState.java
+++ b/lock-benchmark/src/jmh/java/com/palantir/atlasdb/state/LockServiceBenchmarkState.java
@@ -1,0 +1,156 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.state;
+
+import com.palantir.lock.ImmutableDebugThreadInfoConfiguration;
+import com.palantir.lock.LockClient;
+import com.palantir.lock.LockDescriptor;
+import com.palantir.lock.LockMode;
+import com.palantir.lock.LockRequest;
+import com.palantir.lock.LockServerOptions;
+import com.palantir.lock.SimpleTimeDuration;
+import com.palantir.lock.StringLockDescriptor;
+import com.palantir.lock.ThreadAwareCloseableLockService;
+import com.palantir.lock.impl.LockServiceImpl;
+import java.util.List;
+import java.util.Random;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class LockServiceBenchmarkState {
+    @Param({"true", "false"})
+    public boolean recordThreadInfo;
+
+    @Param({"20", "1000"})
+    public int locksPerRequest;
+
+    @Param({"5", "0"})
+    public int sleepMs;
+
+    @Param({"0"})
+    public int refreshCount;
+
+    @Param({"10000"})
+    public int numHeldLocksAtBeginning;
+
+    @Param("10000")
+    public int numAvailableLocks;
+
+    @Param({"nonBlocking_asManyAsPossible"})
+    public String requestSupplierMethodName;
+
+    private ThreadAwareCloseableLockService lockService;
+    private Supplier<LockRequest> lockRequestSupplier;
+    private final int maxBlockingDurationMillis = 100;
+    private final Random rand = new Random();
+    private List<LockDescriptor> heldLocksAtBeginning;
+    private List<LockDescriptor> availableLocks;
+
+    private LockRequest nonBlocking_asManyAsPossible_randomMode() {
+        SortedMap<LockDescriptor, LockMode> locks = new TreeMap<>();
+        for (int i = 0; i < locksPerRequest; i++) {
+            locks.put(
+                    availableLocks.get(rand.nextInt(getAvailableLocks().size())),
+                    rand.nextBoolean() ? LockMode.READ : LockMode.WRITE);
+        }
+        return LockRequest.builder(locks).lockAsManyAsPossible().doNotBlock().build();
+    }
+
+    private LockRequest allRandom() {
+        SortedMap<LockDescriptor, LockMode> locks = new TreeMap<>();
+        final int numLocks = Math.max(1, rand.nextInt(locksPerRequest));
+        for (int i = 0; i < numLocks; i++) {
+            locks.put(
+                    availableLocks.get(rand.nextInt(getAvailableLocks().size())),
+                    rand.nextBoolean() ? LockMode.READ : LockMode.WRITE);
+        }
+        LockRequest.Builder builder = LockRequest.builder(locks);
+        if (rand.nextBoolean()) {
+            builder.lockAsManyAsPossible();
+        }
+        // Never choose BLOCK_INDEFINITELY since it is incompatible with LOCK_AS_MANY_AS_POSSIBLE
+        if (rand.nextBoolean()) {
+            builder.doNotBlock();
+        } else {
+            builder.blockForAtMost(
+                    SimpleTimeDuration.of(rand.nextInt(maxBlockingDurationMillis), TimeUnit.MILLISECONDS));
+        }
+        return builder.build();
+    }
+
+    @Setup
+    public void setup() {
+        this.heldLocksAtBeginning = IntStream.range(0, numHeldLocksAtBeginning)
+                .mapToObj(i -> StringLockDescriptor.of(Integer.toString(i)))
+                .collect(Collectors.toList());
+        this.availableLocks = IntStream.range(0, numAvailableLocks)
+                .mapToObj(i -> StringLockDescriptor.of(Integer.toString(i)))
+                .collect(Collectors.toUnmodifiableList());
+
+        this.lockRequestSupplier = getRequestSupplierFromName(this.requestSupplierMethodName);
+        this.lockService = LockServiceImpl.create(LockServerOptions.builder()
+                .threadInfoConfiguration(ImmutableDebugThreadInfoConfiguration.builder()
+                        .recordThreadInfo(recordThreadInfo)
+                        .build())
+                .isStandaloneServer(false)
+                .build());
+
+        SortedMap<LockDescriptor, LockMode> locks = new TreeMap<>();
+        for (LockDescriptor lock : heldLocksAtBeginning) {
+            locks.put(lock, LockMode.WRITE);
+        }
+        LockRequest lockRequest =
+                LockRequest.builder(locks).lockAsManyAsPossible().doNotBlock().build();
+        try {
+            lockService.lockWithFullLockResponse(LockClient.ANONYMOUS, lockRequest);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public ThreadAwareCloseableLockService getLockService() {
+        return this.lockService;
+    }
+
+    public List<LockDescriptor> getAvailableLocks() {
+        return this.availableLocks;
+    }
+
+    public LockRequest generateLockRequest() {
+        return this.lockRequestSupplier.get();
+    }
+
+    private Supplier<LockRequest> getRequestSupplierFromName(String name) {
+        switch (this.requestSupplierMethodName) {
+            case "nonBlocking_asManyAsPossible":
+                return this::nonBlocking_asManyAsPossible_randomMode;
+            case "allRandom":
+                return this::allRandom;
+            default:
+                throw new IllegalArgumentException(name + " is not a known request supplier");
+        }
+    }
+}

--- a/lock-benchmark/src/jmh/java/com/palantir/atlasdb/state/LockServiceBenchmarkState.java
+++ b/lock-benchmark/src/jmh/java/com/palantir/atlasdb/state/LockServiceBenchmarkState.java
@@ -44,7 +44,7 @@ public class LockServiceBenchmarkState {
     @Param({"true", "false"})
     public boolean recordThreadInfo;
 
-    @Param({"20", "1000"})
+    @Param({"20", "10000"})
     public int locksPerRequest;
 
     @Param({"5", "0"})
@@ -56,7 +56,7 @@ public class LockServiceBenchmarkState {
     @Param({"10000"})
     public int numHeldLocksAtBeginning;
 
-    @Param("10000")
+    @Param("1000000")
     public int numAvailableLocks;
 
     @Param({"nonBlocking_asManyAsPossible"})

--- a/lock-benchmark/src/jmh/java/com/palantir/atlasdb/state/ThreadIndex.java
+++ b/lock-benchmark/src/jmh/java/com/palantir/atlasdb/state/ThreadIndex.java
@@ -1,0 +1,31 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.state;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Thread)
+public class ThreadIndex {
+    private static final AtomicInteger THREAD_INDEX = new AtomicInteger(0);
+    private final int id = THREAD_INDEX.getAndIncrement();
+
+    public int getThreadId() {
+        return this.id;
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -54,6 +54,7 @@ include ":leader-election-api-protobufs"
 include ":leader-election-impl"
 include ":lock-api"
 include ":lock-api-objects"
+include ":lock-benchmark"
 include ":lock-conjure-api"
 include ":lock-conjure-api:lock-conjure-api-undertow"
 include ":lock-conjure-api:lock-conjure-api-jersey"
@@ -94,3 +95,4 @@ gradleEnterprise {
         uploadInBackground = !isCiServer
     }
 }
+


### PR DESCRIPTION
Benchmark results will follow in a separate document.

## General
**Before this PR**:

**After this PR**:
A microbenchmark for a simple lock service interaction exists, written with JMH.

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add microbenchmark for lock service
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:
is the benchmark even remotely testing a typical workflow?
**Is documentation needed?**:
Possibly, if we plan on adding more benchmarks like this.
## Compatibility
This PR is test-only code

## Testing and Correctness
This PR introduces a lock service microbenchmark written with JMH that is highly configurable, but based on a simple interaction with timelock: 
- lock()
- sleep (do something with the lock) & refresh()
- unlock()

## Execution
This PR does not affect production.

## Scale
If anything, this PR can help us detect changes that are problematic at scale.

## Development Process
**Where should we start reviewing?**:
LockServiceBenchmark
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
