### PR TITLE
[LockV1] Add async thread info snapshotting (disabled by default)

### DIFF
--- a/lock-api-objects/src/main/java/com/palantir/lock/LockClientAndThread.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/LockClientAndThread.java
@@ -19,18 +19,18 @@ package com.palantir.lock;
 import org.immutables.value.Value;
 
 @Value.Immutable
-public interface ThreadAwareLockClient {
-    ThreadAwareLockClient UNKNOWN = ThreadAwareLockClient.of(LockClient.ANONYMOUS, "unknown-thread");
+public interface LockClientAndThread {
+    LockClientAndThread UNKNOWN = LockClientAndThread.of(LockClient.ANONYMOUS, "unknown-thread");
 
     LockClient client();
 
     String thread();
 
-    static ImmutableThreadAwareLockClient.Builder builder() {
-        return ImmutableThreadAwareLockClient.builder();
+    static ImmutableLockClientAndThread.Builder builder() {
+        return ImmutableLockClientAndThread.builder();
     }
 
-    static ThreadAwareLockClient of(LockClient client, String requestingThread) {
+    static LockClientAndThread of(LockClient client, String requestingThread) {
         return builder().client(client).thread(requestingThread).build();
     }
 }

--- a/lock-api-objects/src/main/java/com/palantir/lock/ThreadAwareLockClient.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/ThreadAwareLockClient.java
@@ -1,0 +1,36 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface ThreadAwareLockClient {
+    ThreadAwareLockClient UNKNOWN = ThreadAwareLockClient.of(LockClient.ANONYMOUS, "unknown-thread");
+
+    LockClient client();
+
+    String thread();
+
+    static ImmutableThreadAwareLockClient.Builder builder() {
+        return ImmutableThreadAwareLockClient.builder();
+    }
+
+    static ThreadAwareLockClient of(LockClient client, String requestingThread) {
+        return builder().client(client).thread(requestingThread).build();
+    }
+}

--- a/lock-api/src/main/java/com/palantir/lock/DebugThreadInfoConfiguration.java
+++ b/lock-api/src/main/java/com/palantir/lock/DebugThreadInfoConfiguration.java
@@ -1,0 +1,33 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface DebugThreadInfoConfiguration {
+
+    @Value.Default
+    default boolean recordThreadInfo() {
+        return false;
+    }
+
+    @Value.Default
+    default long threadInfoSnapshotIntervalMillis() {
+        return 5000L;
+    }
+}

--- a/lock-api/src/main/java/com/palantir/lock/LockServerOptions.java
+++ b/lock-api/src/main/java/com/palantir/lock/LockServerOptions.java
@@ -16,6 +16,7 @@
 package com.palantir.lock;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.MoreObjects;
@@ -126,6 +127,15 @@ public class LockServerOptions implements Serializable {
         return 10000L;
     }
 
+    /**
+     * Runtime configuration relating to thread info recording (which lock is held by which client-thread).
+     */
+    @JsonIgnore
+    @Value.Default
+    public DebugThreadInfoConfiguration threadInfoConfiguration() {
+        return ImmutableDebugThreadInfoConfiguration.builder().build();
+    }
+
     @Override
     public boolean equals(@Nullable Object obj) {
         if (this == obj) {
@@ -142,7 +152,8 @@ public class LockServerOptions implements Serializable {
                 && Objects.equals(getMaxAllowedClockDrift(), other.getMaxAllowedClockDrift())
                 && Objects.equals(getMaxAllowedBlockingDuration(), other.getMaxAllowedBlockingDuration())
                 && Objects.equals(getMaxNormalLockAge(), other.getMaxNormalLockAge())
-                && Objects.equals(getStuckTransactionTimeout(), other.getStuckTransactionTimeout());
+                && Objects.equals(getStuckTransactionTimeout(), other.getStuckTransactionTimeout())
+                && Objects.equals(threadInfoConfiguration(), other.threadInfoConfiguration());
     }
 
     @Override
@@ -155,7 +166,8 @@ public class LockServerOptions implements Serializable {
                 getMaxNormalLockAge(),
                 getRandomBitCount(),
                 getStuckTransactionTimeout(),
-                slowLogTriggerMillis());
+                slowLogTriggerMillis(),
+                threadInfoConfiguration());
     }
 
     @Override
@@ -169,6 +181,7 @@ public class LockServerOptions implements Serializable {
                 .add("randomBitCount", getRandomBitCount())
                 .add("stuckTransactionTimeout", getStuckTransactionTimeout())
                 .add("slowLogTriggerMillis", slowLogTriggerMillis())
+                .add("threadInfoConfiguration", threadInfoConfiguration())
                 .toString();
     }
 

--- a/lock-impl/build.gradle
+++ b/lock-impl/build.gradle
@@ -13,7 +13,6 @@ dependencies {
   implementation 'com.palantir.safe-logging:preconditions'
   implementation 'com.palantir.safe-logging:safe-logging'
   implementation 'joda-time:joda-time'
-  implementation 'one.util:streamex'
   implementation 'org.eclipse.collections:eclipse-collections'
   implementation 'org.eclipse.collections:eclipse-collections-api'
   implementation 'org.slf4j:slf4j-api'

--- a/lock-impl/build.gradle
+++ b/lock-impl/build.gradle
@@ -13,6 +13,7 @@ dependencies {
   implementation 'com.palantir.safe-logging:preconditions'
   implementation 'com.palantir.safe-logging:safe-logging'
   implementation 'joda-time:joda-time'
+  implementation 'one.util:streamex'
   implementation 'org.eclipse.collections:eclipse-collections'
   implementation 'org.eclipse.collections:eclipse-collections-api'
   implementation 'org.slf4j:slf4j-api'
@@ -22,6 +23,7 @@ dependencies {
   implementation project(':lock-api-objects')
   implementation project(':timestamp-api')
 
+  testImplementation 'org.awaitility:awaitility'
   testImplementation 'com.fasterxml.jackson.core:jackson-databind'
   testImplementation 'com.google.guava:guava'
   testImplementation 'com.palantir.safe-logging:preconditions'

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
@@ -1234,7 +1234,7 @@ public final class LockServiceImpl
     }
 
     public LockThreadInfoSnapshotManager getSnapshotManager() {
-        return this.threadInfoSnapshotManager;
+        return threadInfoSnapshotManager;
     }
 
     private static String updateThreadName(LockRequest request) {

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockThreadInfoSnapshotManager.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockThreadInfoSnapshotManager.java
@@ -70,12 +70,12 @@ public class LockThreadInfoSnapshotManager implements AutoCloseable {
 
     @VisibleForTesting
     Map<LockDescriptor, LockClientAndThread> getLastKnownThreadInfoSnapshot() {
-        return this.lastKnownThreadInfoSnapshot;
+        return lastKnownThreadInfoSnapshot;
     }
 
     @VisibleForTesting
     void takeSnapshot() {
-        this.lastKnownThreadInfoSnapshot = tokenMapSupplier.get().keySet().stream()
+        lastKnownThreadInfoSnapshot = tokenMapSupplier.get().keySet().stream()
                 .flatMap(token -> {
                     LockClientAndThread clientThread = LockClientAndThread.of(
                             Objects.requireNonNullElse(token.getClient(), LockClientAndThread.UNKNOWN.client()),

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockThreadInfoSnapshotManager.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockThreadInfoSnapshotManager.java
@@ -39,7 +39,7 @@ public class LockThreadInfoSnapshotManager implements AutoCloseable {
 
     private Supplier<ConcurrentMap<HeldLocksToken, HeldLocks<HeldLocksToken>>> tokenMapSupplier;
 
-    private Map<LockDescriptor, LockClientAndThread> lastKnownThreadInfoSnapshot;
+    private volatile Map<LockDescriptor, LockClientAndThread> lastKnownThreadInfoSnapshot;
 
     private ScheduledExecutorService scheduledExecutorService = PTExecutors.newSingleThreadScheduledExecutor();
 

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockThreadInfoSnapshotManager.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockThreadInfoSnapshotManager.java
@@ -17,7 +17,7 @@
 package com.palantir.lock.impl;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Strings;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.lock.DebugThreadInfoConfiguration;
@@ -84,10 +84,10 @@ public class LockThreadInfoSnapshotManager implements AutoCloseable {
     void takeSnapshot() {
         this.lastKnownThreadInfoSnapshot = tokenMapSupplier.get().keySet().stream()
                 .flatMap(token -> {
-                    LockClientAndThread clientThread =
-                            token.getClient() == null || Strings.isNullOrEmpty(token.getRequestingThread())
-                                    ? LockClientAndThread.UNKNOWN
-                                    : LockClientAndThread.of(token.getClient(), token.getRequestingThread());
+                    LockClientAndThread clientThread = LockClientAndThread.of(
+                            MoreObjects.firstNonNull(token.getClient(), LockClientAndThread.UNKNOWN.client()),
+                            MoreObjects.firstNonNull(
+                                    token.getRequestingThread(), LockClientAndThread.UNKNOWN.thread()));
                     return token.getLockDescriptors().stream()
                             .map(lockDescriptor -> Map.entry(lockDescriptor, clientThread));
                 })

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockThreadInfoSnapshotManager.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockThreadInfoSnapshotManager.java
@@ -27,7 +27,6 @@ import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.impl.LockServiceImpl.HeldLocks;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -69,15 +68,9 @@ public class LockThreadInfoSnapshotManager implements AutoCloseable {
         }
     }
 
-    /**
-     * Returns a consistent snapshot of thread information restricted to the given lock descriptors
-     */
-    public Map<LockDescriptor, LockClientAndThread> getLastKnownThreadInfoSnapshot(
-            Set<LockDescriptor> lockDescriptors) {
-        final Map<LockDescriptor, LockClientAndThread> currentSnapshot = this.lastKnownThreadInfoSnapshot;
-        return lockDescriptors.stream()
-                .filter(currentSnapshot::containsKey)
-                .collect(Collectors.toMap(lock -> lock, currentSnapshot::get));
+    @VisibleForTesting
+    Map<LockDescriptor, LockClientAndThread> getLastKnownThreadInfoSnapshot() {
+        return this.lastKnownThreadInfoSnapshot;
     }
 
     @VisibleForTesting

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockThreadInfoSnapshotManager.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockThreadInfoSnapshotManager.java
@@ -1,0 +1,94 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.impl;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+import com.palantir.common.concurrent.PTExecutors;
+import com.palantir.lock.DebugThreadInfoConfiguration;
+import com.palantir.lock.HeldLocksToken;
+import com.palantir.lock.LockDescriptor;
+import com.palantir.lock.ThreadAwareLockClient;
+import com.palantir.lock.impl.LockServiceImpl.HeldLocks;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+public class LockThreadInfoSnapshotManager {
+
+    private DebugThreadInfoConfiguration threadInfoConfiguration;
+
+    private Supplier<ConcurrentMap<HeldLocksToken, HeldLocks<HeldLocksToken>>> tokenMapSupplier;
+
+    private Map<LockDescriptor, ThreadAwareLockClient> lastKnownThreadInfoSnapshot;
+
+    private ScheduledExecutorService scheduledExecutorService = PTExecutors.newSingleThreadScheduledExecutor();
+
+    public LockThreadInfoSnapshotManager(
+            DebugThreadInfoConfiguration threadInfoConfiguration,
+            Supplier<ConcurrentMap<HeldLocksToken, HeldLocks<HeldLocksToken>>> mapSupplier) {
+        this.threadInfoConfiguration = threadInfoConfiguration;
+        this.tokenMapSupplier = mapSupplier;
+        this.lastKnownThreadInfoSnapshot = ImmutableMap.of();
+
+        scheduleSnapshotting();
+    }
+
+    private void scheduleSnapshotting() {
+        if (threadInfoConfiguration.recordThreadInfo()) {
+            scheduledExecutorService.schedule(
+                    this::takeSnapshot,
+                    threadInfoConfiguration.threadInfoSnapshotIntervalMillis(),
+                    TimeUnit.MILLISECONDS);
+        }
+    }
+
+    /**
+     * Returns a consistent snapshot of tread information restricted to the given lock descriptors
+     */
+    public Map<LockDescriptor, ThreadAwareLockClient> getLastKnownThreadInfoSnapshot(
+            Set<LockDescriptor> lockDescriptors) {
+        final Map<LockDescriptor, ThreadAwareLockClient> currentSnapshot = this.lastKnownThreadInfoSnapshot;
+        return lockDescriptors.stream()
+                .filter(currentSnapshot::containsKey)
+                .collect(Collectors.toMap(lock -> lock, currentSnapshot::get));
+    }
+
+    @VisibleForTesting
+    void takeSnapshot() {
+        this.lastKnownThreadInfoSnapshot = tokenMapSupplier.get().keySet().stream()
+                .flatMap(token -> {
+                    ThreadAwareLockClient threadAwareLockClient =
+                            token.getClient() == null || Strings.isNullOrEmpty(token.getRequestingThread())
+                                    ? ThreadAwareLockClient.UNKNOWN
+                                    : ThreadAwareLockClient.of(token.getClient(), token.getRequestingThread());
+                    return token.getLockDescriptors().stream()
+                            .map(lockDescriptor -> Map.entry(lockDescriptor, threadAwareLockClient));
+                })
+                // Although a lock can be held by multiple clients/threads, we only remember one to save space
+                .collect(Collectors.toMap(Entry::getKey, Entry::getValue, (existing, replacement) -> existing));
+
+        // schedule next snapshot so this can be enabled/disabled at runtime
+        scheduleSnapshotting();
+    }
+}

--- a/lock-impl/src/test/java/com/palantir/lock/impl/ThreadAwareLockServiceImplTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/impl/ThreadAwareLockServiceImplTest.java
@@ -1,0 +1,315 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableSortedMap;
+import com.palantir.common.concurrent.PTExecutors;
+import com.palantir.lock.ImmutableDebugThreadInfoConfiguration;
+import com.palantir.lock.LockClient;
+import com.palantir.lock.LockDescriptor;
+import com.palantir.lock.LockMode;
+import com.palantir.lock.LockRequest;
+import com.palantir.lock.LockResponse;
+import com.palantir.lock.LockServerOptions;
+import com.palantir.lock.SimpleTimeDuration;
+import com.palantir.lock.StringLockDescriptor;
+import com.palantir.lock.ThreadAwareLockClient;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.Test;
+
+public class ThreadAwareLockServiceImplTest {
+
+    // Disable background snapshotting, invoke explicitly instead
+    private final LockServiceImpl lockService = LockServiceImpl.create(LockServerOptions.builder()
+            .isStandaloneServer(false)
+            .threadInfoConfiguration(ImmutableDebugThreadInfoConfiguration.builder()
+                    .recordThreadInfo(false)
+                    .build())
+            .build());
+
+    private final LockThreadInfoSnapshotManager snapshotRunner = lockService.createSnapshotManager();
+
+    private final ExecutorService executor =
+            PTExecutors.newCachedThreadPool(ThreadAwareLockServiceImplTest.class.getName());
+
+    private static final LockDescriptor TEST_LOCK_1 = StringLockDescriptor.of("lock-1");
+    private static final LockDescriptor TEST_LOCK_2 = StringLockDescriptor.of("lock-2");
+    private static final LockDescriptor TEST_LOCK_3 = StringLockDescriptor.of("lock-3");
+
+    private static final String TEST_THREAD_1 = "thread-1";
+    private static final String TEST_THREAD_2 = "thread-2";
+    private static final String TEST_THREAD_3 = "thread-3";
+
+    private static final LockRequest LOCK_1_THREAD_1_WRITE_REQUEST = LockRequest.builder(
+                    ImmutableSortedMap.of(TEST_LOCK_1, LockMode.WRITE))
+            .withCreatingThreadName(TEST_THREAD_1)
+            .build();
+
+    @Test
+    public void initialThreadInfoIsEmpty() {
+        snapshotRunner.takeSnapshot();
+        assertThat(getLatestThreadInfoForLock(TEST_LOCK_1)).isNull();
+        assertThat(getLatestThreadInfoForLock(TEST_LOCK_2)).isNull();
+        assertThat(getLatestThreadInfoForLock(TEST_LOCK_3)).isNull();
+    }
+
+    @Test
+    public void recordsThreadInfo_singleLock() throws InterruptedException {
+        lockService.lockWithFullLockResponse(LockClient.ANONYMOUS, LOCK_1_THREAD_1_WRITE_REQUEST);
+        snapshotRunner.takeSnapshot();
+
+        assertThat(getLatestThreadInfoForLock(TEST_LOCK_1))
+                .isEqualTo(ThreadAwareLockClient.of(LockClient.ANONYMOUS, TEST_THREAD_1));
+    }
+
+    @Test
+    public void recordsThreadInfo_multipleUniqueLocks_fromDifferentThreads() throws InterruptedException {
+        final int numThreads = 10;
+        final int numLocksPerThread = 10;
+
+        List<String> threadNames =
+                IntStream.range(0, numThreads).mapToObj(i -> "test-thread-" + i).collect(Collectors.toList());
+        Map<String, List<LockDescriptor>> locksPerThread = new HashMap<>();
+        for (String threadName : threadNames) {
+            List<LockDescriptor> locks = IntStream.range(0, numLocksPerThread)
+                    .mapToObj(i -> StringLockDescriptor.of("test-lock-" + i + "-from-thread-" + threadName))
+                    .collect(Collectors.toList());
+            locksPerThread.put(threadName, locks);
+        }
+
+        for (String threadName : threadNames) {
+            LockRequest lockRequest = LockRequest.builder(
+                            ImmutableSortedMap.copyOf(locksPerThread.get(threadName).stream()
+                                    .collect(Collectors.toMap(lock -> lock, lock -> LockMode.WRITE))))
+                    .withCreatingThreadName(threadName)
+                    .build();
+            lockService.lockWithFullLockResponse(LockClient.ANONYMOUS, lockRequest);
+        }
+
+        snapshotRunner.takeSnapshot();
+
+        Map<LockDescriptor, ThreadAwareLockClient> expected = locksPerThread.keySet().stream()
+                .flatMap(threadName -> locksPerThread.get(threadName).stream()
+                        .map(lock -> Map.entry(lock, ThreadAwareLockClient.of(LockClient.ANONYMOUS, threadName))))
+                .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+
+        expected.forEach((lock, clientThread) -> {
+            assertThat(getLatestThreadInfoForLock(lock)).isEqualTo(clientThread);
+        });
+    }
+
+    @Test
+    public void recordsThreadInfo_sharedLock_fromDifferentThreads() throws InterruptedException {
+        LockRequest lockRequest1 = LockRequest.builder(ImmutableSortedMap.of(TEST_LOCK_1, LockMode.READ))
+                .withCreatingThreadName(TEST_THREAD_1)
+                .build();
+        LockRequest lockRequest2 = LockRequest.builder(ImmutableSortedMap.of(TEST_LOCK_1, LockMode.READ))
+                .doNotBlock()
+                .lockAsManyAsPossible()
+                .withCreatingThreadName(TEST_THREAD_2)
+                .build();
+
+        lockService.lockWithFullLockResponse(LockClient.ANONYMOUS, lockRequest1);
+        lockService.lockWithFullLockResponse(LockClient.ANONYMOUS, lockRequest2);
+        snapshotRunner.takeSnapshot();
+
+        assertThat(getLatestThreadInfoForLock(TEST_LOCK_1))
+                .isIn(
+                        ThreadAwareLockClient.of(LockClient.ANONYMOUS, TEST_THREAD_1),
+                        ThreadAwareLockClient.of(LockClient.ANONYMOUS, TEST_THREAD_2));
+    }
+
+    @Test
+    public void doesNotRecordDroppedLocksWithLockAllOrNone() throws InterruptedException {
+        // T2 cannot get lock 1 -> grouping behavior LOCK_ALL_OR_NONE will release lock 2, even though it could have
+        // been locked
+        LockRequest lockRequest2 = LockRequest.builder(
+                        ImmutableSortedMap.of(TEST_LOCK_1, LockMode.READ, TEST_LOCK_2, LockMode.READ))
+                .doNotBlock()
+                .withCreatingThreadName(TEST_THREAD_2)
+                .build();
+
+        lockService.lockWithFullLockResponse(LockClient.ANONYMOUS, LOCK_1_THREAD_1_WRITE_REQUEST);
+        lockService.lockWithFullLockResponse(LockClient.ANONYMOUS, lockRequest2);
+        snapshotRunner.takeSnapshot();
+
+        assertThat(getLatestThreadInfoForLock(TEST_LOCK_1))
+                .isEqualTo(ThreadAwareLockClient.of(LockClient.ANONYMOUS, TEST_THREAD_1));
+    }
+
+    @Test
+    public void doesNotRecordFailedLocks() throws InterruptedException {
+        LockRequest lockRequest2 = LockRequest.builder(ImmutableSortedMap.of(TEST_LOCK_1, LockMode.WRITE))
+                .doNotBlock()
+                .lockAsManyAsPossible()
+                .withCreatingThreadName(TEST_THREAD_2)
+                .build();
+
+        lockService.lockWithFullLockResponse(LockClient.ANONYMOUS, LOCK_1_THREAD_1_WRITE_REQUEST);
+        lockService.lockWithFullLockResponse(LockClient.ANONYMOUS, lockRequest2);
+        snapshotRunner.takeSnapshot();
+
+        assertThat(getLatestThreadInfoForLock(TEST_LOCK_1))
+                .isEqualTo(ThreadAwareLockClient.of(LockClient.ANONYMOUS, TEST_THREAD_1));
+    }
+
+    @Test
+    public void recordsUnlockWriteLock() throws InterruptedException {
+        LockResponse response =
+                lockService.lockWithFullLockResponse(LockClient.ANONYMOUS, LOCK_1_THREAD_1_WRITE_REQUEST);
+
+        lockService.unlock(response.getToken());
+        snapshotRunner.takeSnapshot();
+
+        assertThat(getLatestThreadInfoForLock(TEST_LOCK_1)).isNull();
+    }
+
+    @Test
+    public void recordsUnlockAndFreezeForNonAnonymousClient() throws InterruptedException {
+        LockResponse response = lockService.lockWithFullLockResponse(
+                LockClient.of("non-anonymous-client"), LOCK_1_THREAD_1_WRITE_REQUEST);
+        lockService.unlockAndFreeze(response.getToken());
+        snapshotRunner.takeSnapshot();
+
+        assertThat(getLatestThreadInfoForLock(TEST_LOCK_1)).isNull();
+    }
+
+    @Test
+    public void recordsCorrectStateAfterMultipleOperations() throws Exception {
+        final CyclicBarrier barrier = new CyclicBarrier(2);
+
+        // T1 locks 1 exclusively and locks 2 in shared mode
+        LockResponse response1 = lockService.lockWithFullLockResponse(
+                LockClient.ANONYMOUS,
+                LockRequest.builder(ImmutableSortedMap.of(TEST_LOCK_1, LockMode.WRITE, TEST_LOCK_2, LockMode.READ))
+                        .doNotBlock()
+                        .lockAsManyAsPossible()
+                        .withCreatingThreadName(TEST_THREAD_1)
+                        .build());
+
+        // T2 shouldn't get 1, but locks 3 in exclusive mode,
+        LockResponse response2 = lockService.lockWithFullLockResponse(
+                LockClient.ANONYMOUS,
+                LockRequest.builder(ImmutableSortedMap.of(TEST_LOCK_1, LockMode.READ, TEST_LOCK_3, LockMode.WRITE))
+                        .doNotBlock()
+                        .lockAsManyAsPossible()
+                        .withCreatingThreadName(TEST_THREAD_2)
+                        .build());
+
+        Future<LockResponse> response3 = executor.submit(() -> {
+
+            // T3 will wait at most 5 seconds to lock 1 in exclusive mode and lock 2 in shared mode
+            LockResponse response = lockService.lockWithFullLockResponse(
+                    LockClient.ANONYMOUS,
+                    LockRequest.builder(ImmutableSortedMap.of(TEST_LOCK_1, LockMode.WRITE, TEST_LOCK_2, LockMode.READ))
+                            .blockForAtMost(SimpleTimeDuration.of(5, TimeUnit.SECONDS))
+                            .lockAsManyAsPossible()
+                            .withCreatingThreadName(TEST_THREAD_3)
+                            .build());
+            barrier.await();
+            return response;
+        });
+        lockService.unlock(response1.getToken());
+        barrier.await();
+        snapshotRunner.takeSnapshot();
+
+        // T1 should hold nothing, T2 holds 3 in exclusive mode, T3 holds 1 in exclusive and 2 in shared mode
+        assertThat(getLatestThreadInfoForLock(TEST_LOCK_1))
+                .isEqualTo(ThreadAwareLockClient.of(LockClient.ANONYMOUS, TEST_THREAD_3));
+        assertThat(getLatestThreadInfoForLock(TEST_LOCK_2))
+                .isEqualTo(ThreadAwareLockClient.of(LockClient.ANONYMOUS, TEST_THREAD_3));
+        assertThat(getLatestThreadInfoForLock(TEST_LOCK_3))
+                .isEqualTo(ThreadAwareLockClient.of(LockClient.ANONYMOUS, TEST_THREAD_2));
+
+        lockService.unlock(response2.getToken());
+        snapshotRunner.takeSnapshot();
+
+        // Only T3 should hold locks
+        assertThat(getLatestThreadInfoForLock(TEST_LOCK_1))
+                .isEqualTo(ThreadAwareLockClient.of(LockClient.ANONYMOUS, TEST_THREAD_3));
+        assertThat(getLatestThreadInfoForLock(TEST_LOCK_2))
+                .isEqualTo(ThreadAwareLockClient.of(LockClient.ANONYMOUS, TEST_THREAD_3));
+        assertThat(getLatestThreadInfoForLock(TEST_LOCK_3)).isNull();
+
+        lockService.unlock(response3.get().getToken());
+        snapshotRunner.takeSnapshot();
+
+        assertThat(getLatestThreadInfoForLock(TEST_LOCK_1)).isNull();
+        // Lock 2 is a shared lock
+        assertThat(getLatestThreadInfoForLock(TEST_LOCK_2)).isNull();
+        assertThat(getLatestThreadInfoForLock(TEST_LOCK_3)).isNull();
+    }
+
+    @Test
+    public void refreshDoesNotChangeSnapshot() throws InterruptedException {
+        LockResponse response =
+                lockService.lockWithFullLockResponse(LockClient.ANONYMOUS, LOCK_1_THREAD_1_WRITE_REQUEST);
+        lockService.refreshTokens(List.of(response.getToken()));
+        snapshotRunner.takeSnapshot();
+
+        assertThat(getLatestThreadInfoForLock(TEST_LOCK_1))
+                .isEqualTo(ThreadAwareLockClient.of(LockClient.ANONYMOUS, TEST_THREAD_1));
+    }
+
+    @Test(timeout = 500L)
+    public void backgroundSnapshotRunnerWorks() throws InterruptedException {
+        final LockServiceImpl lockServiceWithBackgroundRunner = LockServiceImpl.create(LockServerOptions.builder()
+                .isStandaloneServer(false)
+                .threadInfoConfiguration(ImmutableDebugThreadInfoConfiguration.builder()
+                        .recordThreadInfo(true)
+                        .threadInfoSnapshotIntervalMillis(10L)
+                        .build())
+                .build());
+        LockThreadInfoSnapshotManager backgroundSnapshotRunner =
+                lockServiceWithBackgroundRunner.createSnapshotManager();
+
+        LockResponse response = lockServiceWithBackgroundRunner.lockWithFullLockResponse(
+                LockClient.ANONYMOUS, LOCK_1_THREAD_1_WRITE_REQUEST);
+
+        Thread.sleep(50L);
+
+        assertThat(backgroundSnapshotRunner
+                        .getLastKnownThreadInfoSnapshot(Set.of(TEST_LOCK_1))
+                        .get(TEST_LOCK_1))
+                .isEqualTo(ThreadAwareLockClient.of(LockClient.ANONYMOUS, TEST_THREAD_1));
+
+        lockServiceWithBackgroundRunner.unlock(response.getToken());
+
+        Thread.sleep(50L);
+
+        assertThat(backgroundSnapshotRunner
+                        .getLastKnownThreadInfoSnapshot(Set.of(TEST_LOCK_1))
+                        .get(TEST_LOCK_1))
+                .isNull();
+    }
+
+    private ThreadAwareLockClient getLatestThreadInfoForLock(LockDescriptor lock) {
+        return snapshotRunner.getLastKnownThreadInfoSnapshot(Set.of(lock)).get(lock);
+    }
+}

--- a/lock-impl/src/test/java/com/palantir/lock/impl/ThreadInfoLockServiceImplTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/impl/ThreadInfoLockServiceImplTest.java
@@ -42,9 +42,6 @@ import java.util.stream.IntStream;
 import org.junit.Test;
 
 public class ThreadInfoLockServiceImplTest {
-    private final ExecutorService executor =
-            PTExecutors.newCachedThreadPool(ThreadInfoLockServiceImplTest.class.getName());
-
     private static final LockDescriptor TEST_LOCK_1 = StringLockDescriptor.of("lock-1");
     private static final LockDescriptor TEST_LOCK_2 = StringLockDescriptor.of("lock-2");
     private static final LockDescriptor TEST_LOCK_3 = StringLockDescriptor.of("lock-3");
@@ -57,6 +54,9 @@ public class ThreadInfoLockServiceImplTest {
                     ImmutableSortedMap.of(TEST_LOCK_1, LockMode.WRITE))
             .withCreatingThreadName(TEST_THREAD_1)
             .build();
+
+    private final ExecutorService executor =
+            PTExecutors.newCachedThreadPool(ThreadInfoLockServiceImplTest.class.getName());
 
     // Disable background snapshotting, invoke explicitly instead
     private final LockServiceImpl lockService = LockServiceImpl.create(LockServerOptions.builder()

--- a/lock-impl/src/test/java/com/palantir/lock/impl/ThreadInfoLockServiceImplTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/impl/ThreadInfoLockServiceImplTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableSortedMap;
 import com.palantir.common.concurrent.PTExecutors;
+import com.palantir.common.streams.KeyedStream;
 import com.palantir.lock.ImmutableDebugThreadInfoConfiguration;
 import com.palantir.lock.LockClient;
 import com.palantir.lock.LockClientAndThread;
@@ -40,8 +41,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import one.util.streamex.IntStreamEx;
-import one.util.streamex.StreamEx;
 import org.awaitility.Awaitility;
 import org.junit.Test;
 
@@ -111,11 +110,11 @@ public class ThreadInfoLockServiceImplTest {
         List<String> threadNames =
                 IntStream.range(0, numThreads).mapToObj(i -> "test-thread-" + i).collect(Collectors.toList());
 
-        Map<String, Set<LockDescriptor>> locksPerThread = StreamEx.of(threadNames)
-                .mapToEntry(threadName -> IntStreamEx.range(0, numLocksPerThread)
+        Map<String, Set<LockDescriptor>> locksPerThread = KeyedStream.of(threadNames)
+                .map(threadName -> IntStream.range(0, numLocksPerThread)
                         .mapToObj(i -> StringLockDescriptor.of("test-lock-" + i + "-from-thread-" + threadName))
-                        .toSet())
-                .toMap();
+                        .collect(Collectors.toSet()))
+                .collectToMap();
 
         for (Map.Entry<String, Set<LockDescriptor>> entry : locksPerThread.entrySet()) {
             LockRequest lockRequest = LockRequest.builder(ImmutableSortedMap.copyOf(
@@ -286,19 +285,19 @@ public class ThreadInfoLockServiceImplTest {
         LockResponse response = lockServiceWithBackgroundRunner.lockWithFullLockResponse(
                 LockClient.ANONYMOUS, LOCK_1_THREAD_1_WRITE_REQUEST);
 
-        Awaitility.waitAtMost(200, TimeUnit.MILLISECONDS)
-                .untilAsserted(() -> assertThat(backgroundSnapshotRunner.getLastKnownThreadInfoSnapshot())
-                        .containsExactly(Map.entry(TEST_LOCK_1, ANONYMOUS_TEST_THREAD_1)));
+        Awaitility.await().atMost(200, TimeUnit.MILLISECONDS).untilAsserted(() -> assertThat(
+                        backgroundSnapshotRunner.getLastKnownThreadInfoSnapshot())
+                .containsExactly(Map.entry(TEST_LOCK_1, ANONYMOUS_TEST_THREAD_1)));
 
         lockServiceWithBackgroundRunner.unlock(response.getToken());
 
-        Awaitility.waitAtMost(200, TimeUnit.MILLISECONDS)
-                .untilAsserted(() -> assertThat(backgroundSnapshotRunner.getLastKnownThreadInfoSnapshot())
-                        .doesNotContainKey(TEST_LOCK_1));
+        Awaitility.await().atMost(200, TimeUnit.MILLISECONDS).untilAsserted(() -> assertThat(
+                        backgroundSnapshotRunner.getLastKnownThreadInfoSnapshot())
+                .doesNotContainKey(TEST_LOCK_1));
     }
 
     private void forceSnapshot() {
-        this.lockService.getSnapshotManager().takeSnapshot();
+        lockService.getSnapshotManager().takeSnapshot();
     }
 
     private Optional<LockClientAndThread> getLatestThreadInfoForLock(LockDescriptor lock) {


### PR DESCRIPTION
This PR concerns LockV1 only !
## General
**Before this PR**:

**After this PR**:
Add `LockThreadInfoSnapshotManager`, which maintains a background task that periodically collects that periodically collects information about which lock is currently owned by which client thread by traversing the currently known lock tokens. 
LockServiceImpl holds a reference to a snapshot manager.
In this PR, the background runner is disabled by default.

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
[LockV1] Add async thread info snapshotting (disabled by default)
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
This PR assumes that heldLockTokensMap is an up-to-date representation of the current lock ownership
**What was existing testing like? What have you done to improve it?**:
I have added a new suite of unit tests to verify the collection works using basic locking/unlocking workflows.
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

heldLocksTokenMap is a concurrent map, so traversal of it in a background task is safe.

Likewise, the thread info snapshot is stored in a volatile member

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
No locks are acquired
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Cannot be enabled in production
**Has the safety of all log arguments been decided correctly?**:
N/A
**Will this change significantly affect our spending on metrics or logs?**:
No
**How would I tell that this PR does not work in production? (monitors, etc.)**:
N/A
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
N/A
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
Once the background runner can be enabled and there are a lot of locks held concurrently, taking a snapshot can become expensive. Also, snapshots are short-lived, which can negatively affect GC behavior.
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
If the number of concurrently held locks reaches into the many millions, takin a snapshot of the current lock state is not feasible. 
## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
