### PR TITLE
[LockV1] Pass refreshable thread info configuration

### DIFF
--- a/changelog/@unreleased/pr-6626.v2.yml
+++ b/changelog/@unreleased/pr-6626.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '[LockV1] Pass refreshable thread info configuration'
+  links:
+  - https://github.com/palantir/atlasdb/pull/6626

--- a/lock-api/src/main/java/com/palantir/lock/DebugThreadInfoConfiguration.java
+++ b/lock-api/src/main/java/com/palantir/lock/DebugThreadInfoConfiguration.java
@@ -16,16 +16,23 @@
 
 package com.palantir.lock;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 
+@JsonDeserialize(as = ImmutableDebugThreadInfoConfiguration.class)
+@JsonSerialize(as = ImmutableDebugThreadInfoConfiguration.class)
 @Value.Immutable
 public interface DebugThreadInfoConfiguration {
 
+    @JsonProperty("record-thread-info")
     @Value.Default
     default boolean recordThreadInfo() {
         return false;
     }
 
+    @JsonProperty("thread-info-snapshot-interval-millis")
     @Value.Default
     default long threadInfoSnapshotIntervalMillis() {
         return 5000L;

--- a/lock-api/src/main/java/com/palantir/lock/DebugThreadInfoConfiguration.java
+++ b/lock-api/src/main/java/com/palantir/lock/DebugThreadInfoConfiguration.java
@@ -35,6 +35,6 @@ public interface DebugThreadInfoConfiguration {
     @JsonProperty("thread-info-snapshot-interval-millis")
     @Value.Default
     default long threadInfoSnapshotIntervalMillis() {
-        return 5000L;
+        return 300000L;
     }
 }

--- a/lock-api/src/main/java/com/palantir/lock/LockServerConfigs.java
+++ b/lock-api/src/main/java/com/palantir/lock/LockServerConfigs.java
@@ -20,4 +20,7 @@ public final class LockServerConfigs {
     private LockServerConfigs() {}
 
     public static final LockServerOptions DEFAULT = LockServerOptions.builder().build();
+
+    public static final DebugThreadInfoConfiguration DEFAULT_THREAD_INFO_CONFIG =
+            ImmutableDebugThreadInfoConfiguration.builder().build();
 }

--- a/lock-api/src/main/java/com/palantir/lock/LockServerOptions.java
+++ b/lock-api/src/main/java/com/palantir/lock/LockServerOptions.java
@@ -16,6 +16,7 @@
 package com.palantir.lock;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.MoreObjects;
@@ -126,6 +127,15 @@ public class LockServerOptions implements Serializable {
         return 10000L;
     }
 
+    /**
+     * Runtime configuration relating to thread info recording (which lock is held by which client-thread).
+     */
+    @JsonIgnore
+    @Value.Default
+    public DebugThreadInfoConfiguration threadInfoConfiguration() {
+        return ImmutableDebugThreadInfoConfiguration.builder().build();
+    }
+
     @Override
     public boolean equals(@Nullable Object obj) {
         if (this == obj) {
@@ -142,7 +152,8 @@ public class LockServerOptions implements Serializable {
                 && Objects.equals(getMaxAllowedClockDrift(), other.getMaxAllowedClockDrift())
                 && Objects.equals(getMaxAllowedBlockingDuration(), other.getMaxAllowedBlockingDuration())
                 && Objects.equals(getMaxNormalLockAge(), other.getMaxNormalLockAge())
-                && Objects.equals(getStuckTransactionTimeout(), other.getStuckTransactionTimeout());
+                && Objects.equals(getStuckTransactionTimeout(), other.getStuckTransactionTimeout())
+                && Objects.equals(threadInfoConfiguration(), other.threadInfoConfiguration());
     }
 
     @Override
@@ -155,7 +166,8 @@ public class LockServerOptions implements Serializable {
                 getMaxNormalLockAge(),
                 getRandomBitCount(),
                 getStuckTransactionTimeout(),
-                slowLogTriggerMillis());
+                slowLogTriggerMillis(),
+                threadInfoConfiguration());
     }
 
     @Override
@@ -169,6 +181,7 @@ public class LockServerOptions implements Serializable {
                 .add("randomBitCount", getRandomBitCount())
                 .add("stuckTransactionTimeout", getStuckTransactionTimeout())
                 .add("slowLogTriggerMillis", slowLogTriggerMillis())
+                .add("threadInfoConfiguration", threadInfoConfiguration())
                 .toString();
     }
 

--- a/lock-api/src/main/java/com/palantir/lock/LockServerOptions.java
+++ b/lock-api/src/main/java/com/palantir/lock/LockServerOptions.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.MoreObjects;
+import com.palantir.refreshable.Refreshable;
 import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
@@ -132,8 +133,8 @@ public class LockServerOptions implements Serializable {
      */
     @JsonIgnore
     @Value.Default
-    public DebugThreadInfoConfiguration threadInfoConfiguration() {
-        return ImmutableDebugThreadInfoConfiguration.builder().build();
+    public Refreshable<DebugThreadInfoConfiguration> threadInfoConfiguration() {
+        return Refreshable.only(ImmutableDebugThreadInfoConfiguration.builder().build());
     }
 
     @Override
@@ -153,7 +154,9 @@ public class LockServerOptions implements Serializable {
                 && Objects.equals(getMaxAllowedBlockingDuration(), other.getMaxAllowedBlockingDuration())
                 && Objects.equals(getMaxNormalLockAge(), other.getMaxNormalLockAge())
                 && Objects.equals(getStuckTransactionTimeout(), other.getStuckTransactionTimeout())
-                && Objects.equals(threadInfoConfiguration(), other.threadInfoConfiguration());
+                && Objects.equals(
+                        threadInfoConfiguration().current(),
+                        other.threadInfoConfiguration().current());
     }
 
     @Override

--- a/lock-api/src/main/java/com/palantir/lock/LockServerOptions.java
+++ b/lock-api/src/main/java/com/palantir/lock/LockServerOptions.java
@@ -170,7 +170,7 @@ public class LockServerOptions implements Serializable {
                 getRandomBitCount(),
                 getStuckTransactionTimeout(),
                 slowLogTriggerMillis(),
-                threadInfoConfiguration());
+                threadInfoConfiguration().current());
     }
 
     @Override
@@ -184,7 +184,7 @@ public class LockServerOptions implements Serializable {
                 .add("randomBitCount", getRandomBitCount())
                 .add("stuckTransactionTimeout", getStuckTransactionTimeout())
                 .add("slowLogTriggerMillis", slowLogTriggerMillis())
-                .add("threadInfoConfiguration", threadInfoConfiguration())
+                .add("threadInfoConfiguration", threadInfoConfiguration().current())
                 .toString();
     }
 

--- a/lock-api/src/main/java/com/palantir/lock/LockServerOptions.java
+++ b/lock-api/src/main/java/com/palantir/lock/LockServerOptions.java
@@ -16,11 +16,9 @@
 package com.palantir.lock;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.MoreObjects;
-import com.palantir.refreshable.Refreshable;
 import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
@@ -128,15 +126,6 @@ public class LockServerOptions implements Serializable {
         return 10000L;
     }
 
-    /**
-     * Runtime configuration relating to thread info recording (which lock is held by which client-thread).
-     */
-    @JsonIgnore
-    @Value.Default
-    public Refreshable<DebugThreadInfoConfiguration> threadInfoConfiguration() {
-        return Refreshable.only(ImmutableDebugThreadInfoConfiguration.builder().build());
-    }
-
     @Override
     public boolean equals(@Nullable Object obj) {
         if (this == obj) {
@@ -153,10 +142,7 @@ public class LockServerOptions implements Serializable {
                 && Objects.equals(getMaxAllowedClockDrift(), other.getMaxAllowedClockDrift())
                 && Objects.equals(getMaxAllowedBlockingDuration(), other.getMaxAllowedBlockingDuration())
                 && Objects.equals(getMaxNormalLockAge(), other.getMaxNormalLockAge())
-                && Objects.equals(getStuckTransactionTimeout(), other.getStuckTransactionTimeout())
-                && Objects.equals(
-                        threadInfoConfiguration().current(),
-                        other.threadInfoConfiguration().current());
+                && Objects.equals(getStuckTransactionTimeout(), other.getStuckTransactionTimeout());
     }
 
     @Override
@@ -169,8 +155,7 @@ public class LockServerOptions implements Serializable {
                 getMaxNormalLockAge(),
                 getRandomBitCount(),
                 getStuckTransactionTimeout(),
-                slowLogTriggerMillis(),
-                threadInfoConfiguration().current());
+                slowLogTriggerMillis());
     }
 
     @Override
@@ -184,7 +169,6 @@ public class LockServerOptions implements Serializable {
                 .add("randomBitCount", getRandomBitCount())
                 .add("stuckTransactionTimeout", getStuckTransactionTimeout())
                 .add("slowLogTriggerMillis", slowLogTriggerMillis())
-                .add("threadInfoConfiguration", threadInfoConfiguration().current())
                 .toString();
     }
 

--- a/lock-impl/build.gradle
+++ b/lock-impl/build.gradle
@@ -10,6 +10,7 @@ dependencies {
   implementation 'com.google.guava:guava'
   implementation 'com.palantir.common:streams'
   implementation 'com.palantir.nylon:nylon-threads'
+  implementation 'com.palantir.refreshable:refreshable'
   implementation 'com.palantir.safe-logging:preconditions'
   implementation 'com.palantir.safe-logging:safe-logging'
   implementation 'joda-time:joda-time'

--- a/lock-impl/src/main/java/com/palantir/lock/impl/AdjustableBackgroundTask.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/AdjustableBackgroundTask.java
@@ -34,7 +34,7 @@ public final class AdjustableBackgroundTask implements Closeable {
      * This is to prevent having a blocking thread in the background that does nothing.
      */
     @VisibleForTesting
-    static final Duration MINIMUM_DELAY_IF_NOT_RUNNING = Duration.ofSeconds(1);
+    static final Duration MINIMUM_INTERVAL_IF_NOT_RUNNING = Duration.ofSeconds(1);
 
     private static final SafeLogger log = SafeLoggerFactory.get(AdjustableBackgroundTask.class);
 
@@ -80,7 +80,7 @@ public final class AdjustableBackgroundTask implements Closeable {
             long intervalMillis = intervalSupplier.get().toMillis();
             scheduledExecutor.schedule(
                     this::run,
-                    shouldRun ? intervalMillis : Math.max(MINIMUM_DELAY_IF_NOT_RUNNING.toMillis(), intervalMillis),
+                    shouldRun ? intervalMillis : Math.max(MINIMUM_INTERVAL_IF_NOT_RUNNING.toMillis(), intervalMillis),
                     TimeUnit.MILLISECONDS);
         } catch (RejectedExecutionException e) {
             // that's ok, we were probably closed

--- a/lock-impl/src/main/java/com/palantir/lock/impl/AdjustableBackgroundTask.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/AdjustableBackgroundTask.java
@@ -1,0 +1,77 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.impl;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.palantir.common.concurrent.PTExecutors;
+import com.palantir.lock.SimpleTimeDuration;
+import com.palantir.lock.TimeDuration;
+import java.io.Closeable;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+public final class AdjustableBackgroundTask implements Closeable {
+    /** A minimum duration between invocations if the task is not actually enabled.
+     * This is to prevent having a blocking thread in the background that does nothing.
+     */
+    @VisibleForTesting
+    static final TimeDuration MINIMUM_DELAY_IF_NOT_RUNNING = SimpleTimeDuration.of(1, TimeUnit.SECONDS);
+
+    private final ScheduledExecutorService scheduledExecutor;
+    private final Supplier<Boolean> shouldRunSupplier;
+    private final Supplier<TimeDuration> intervalSupplier;
+    private final Runnable task;
+
+    public static AdjustableBackgroundTask create(
+            Supplier<Boolean> shouldRunSupplier, Supplier<TimeDuration> delaySupplier, Runnable task) {
+        return new AdjustableBackgroundTask(
+                shouldRunSupplier, delaySupplier, task, PTExecutors.newSingleThreadScheduledExecutor());
+    }
+
+    @VisibleForTesting
+    AdjustableBackgroundTask(
+            Supplier<Boolean> shouldRunSupplier,
+            Supplier<TimeDuration> intervalSupplier,
+            Runnable task,
+            ScheduledExecutorService scheduledExecutor) {
+        this.shouldRunSupplier = shouldRunSupplier;
+        this.intervalSupplier = intervalSupplier;
+        this.task = task;
+        this.scheduledExecutor = scheduledExecutor;
+        run();
+    }
+
+    private synchronized void run() {
+        if (shouldRunSupplier.get()) {
+            task.run();
+        }
+        if (!scheduledExecutor.isShutdown()) {
+            scheduledExecutor.schedule(
+                    this::run,
+                    Math.max(
+                            MINIMUM_DELAY_IF_NOT_RUNNING.toMillis(),
+                            intervalSupplier.get().toMillis()),
+                    TimeUnit.MILLISECONDS);
+        }
+    }
+
+    @Override
+    public synchronized void close() {
+        scheduledExecutor.shutdown();
+    }
+}

--- a/lock-impl/src/main/java/com/palantir/lock/impl/AdjustableBackgroundTask.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/AdjustableBackgroundTask.java
@@ -26,11 +26,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 public final class AdjustableBackgroundTask implements Closeable {
-    /** A minimum duration between invocations if the task is not actually enabled.
+
+    /**
+     * A minimum duration between invocations if the task is not actually enabled.
      * This is to prevent having a blocking thread in the background that does nothing.
      */
-    @VisibleForTesting
-    static final TimeDuration MINIMUM_DELAY_IF_NOT_RUNNING = SimpleTimeDuration.of(1, TimeUnit.SECONDS);
+    private static final TimeDuration MINIMUM_DELAY_IF_NOT_RUNNING = SimpleTimeDuration.of(1, TimeUnit.SECONDS);
 
     private final ScheduledExecutorService scheduledExecutor;
     private final Supplier<Boolean> shouldRunSupplier;

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
@@ -275,7 +275,6 @@ public final class LockServiceImpl
         this.slowLogTriggerMillis = currentOptions.slowLogTriggerMillis();
         this.threadInfoSnapshotManager = new LockThreadInfoSnapshotManager(
                 options.map(LockServerOptions::threadInfoConfiguration), () -> heldLocksTokenMap);
-        threadInfoSnapshotManager.start();
     }
 
     private HeldLocksToken createHeldLocksToken(

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
@@ -1231,6 +1231,7 @@ public final class LockServiceImpl
     public void close() {
         if (isShutDown.compareAndSet(false, true)) {
             lockReapRunner.close();
+            threadInfoSnapshotManager.close();
             blockingThreads.forEach(Thread::interrupt);
             callOnClose.run();
         }

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockThreadInfoSnapshotManager.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockThreadInfoSnapshotManager.java
@@ -45,13 +45,13 @@ import javax.annotation.concurrent.GuardedBy;
 
 public class LockThreadInfoSnapshotManager implements AutoCloseable {
     private static final SafeLogger log = SafeLoggerFactory.get(LockThreadInfoSnapshotManager.class);
-    private Refreshable<DebugThreadInfoConfiguration> threadInfoConfiguration;
+    private final Refreshable<DebugThreadInfoConfiguration> threadInfoConfiguration;
 
-    private Supplier<ConcurrentMap<HeldLocksToken, HeldLocks<HeldLocksToken>>> tokenMapSupplier;
+    private final Supplier<ConcurrentMap<HeldLocksToken, HeldLocks<HeldLocksToken>>> tokenMapSupplier;
 
     private volatile Map<LockDescriptor, LockClientAndThread> lastKnownThreadInfoSnapshot = ImmutableMap.of();
 
-    private ScheduledExecutorService scheduledExecutorService = PTExecutors.newSingleThreadScheduledExecutor();
+    private final ScheduledExecutorService scheduledExecutorService = PTExecutors.newSingleThreadScheduledExecutor();
 
     private Optional<Disposable> disposable;
 
@@ -82,9 +82,11 @@ public class LockThreadInfoSnapshotManager implements AutoCloseable {
     private void run() {
         takeSnapshot();
         log.info(
-                "Took lock thread info snapshot of size {}. Next snapshot due in {}",
+                "Took thread info snapshot of {} locks. Next snapshot due in {}ms",
                 SafeArg.of("snapshotSize", lastKnownThreadInfoSnapshot.size()),
-                SafeArg.of("snapshotInterval", threadInfoConfiguration.current().threadInfoSnapshotIntervalMillis()));
+                SafeArg.of(
+                        "snapshotIntervalMillis",
+                        threadInfoConfiguration.current().threadInfoSnapshotIntervalMillis()));
         scheduleRun();
     }
 
@@ -102,7 +104,7 @@ public class LockThreadInfoSnapshotManager implements AutoCloseable {
                 log.info(
                         "Starting to take lock thread info snapshots in the background",
                         SafeArg.of(
-                                "snapshotInterval",
+                                "snapshotIntervalMillis",
                                 threadInfoConfiguration.current().threadInfoSnapshotIntervalMillis()));
                 isRunning = true;
             }

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockThreadInfoSnapshotManager.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockThreadInfoSnapshotManager.java
@@ -22,13 +22,13 @@ import com.palantir.lock.DebugThreadInfoConfiguration;
 import com.palantir.lock.HeldLocksToken;
 import com.palantir.lock.LockClientAndThread;
 import com.palantir.lock.LockDescriptor;
-import com.palantir.lock.SimpleTimeDuration;
 import com.palantir.lock.impl.LockServiceImpl.HeldLocks;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import com.palantir.refreshable.Refreshable;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -36,7 +36,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -57,8 +56,7 @@ public class LockThreadInfoSnapshotManager implements AutoCloseable {
         this.tokenMapSupplier = mapSupplier;
         this.backgroundTask = AdjustableBackgroundTask.create(
                 threadInfoConfiguration.map(DebugThreadInfoConfiguration::recordThreadInfo),
-                threadInfoConfiguration.map(config ->
-                        SimpleTimeDuration.of(config.threadInfoSnapshotIntervalMillis(), TimeUnit.MILLISECONDS)),
+                threadInfoConfiguration.map(config -> Duration.ofMillis(config.threadInfoSnapshotIntervalMillis())),
                 this::takeSnapshot);
     }
 

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockThreadInfoSnapshotManager.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockThreadInfoSnapshotManager.java
@@ -18,17 +18,16 @@ package com.palantir.lock.impl;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
-import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.lock.DebugThreadInfoConfiguration;
 import com.palantir.lock.HeldLocksToken;
 import com.palantir.lock.LockClientAndThread;
 import com.palantir.lock.LockDescriptor;
+import com.palantir.lock.SimpleTimeDuration;
 import com.palantir.lock.impl.LockServiceImpl.HeldLocks;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
-import com.palantir.refreshable.Disposable;
 import com.palantir.refreshable.Refreshable;
 import java.util.HashMap;
 import java.util.Map;
@@ -37,11 +36,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import javax.annotation.concurrent.GuardedBy;
 
 public class LockThreadInfoSnapshotManager implements AutoCloseable {
     private static final SafeLogger log = SafeLoggerFactory.get(LockThreadInfoSnapshotManager.class);
@@ -51,71 +48,18 @@ public class LockThreadInfoSnapshotManager implements AutoCloseable {
 
     private volatile Map<LockDescriptor, LockClientAndThread> lastKnownThreadInfoSnapshot = ImmutableMap.of();
 
-    private final ScheduledExecutorService scheduledExecutorService = PTExecutors.newSingleThreadScheduledExecutor();
-
-    private Optional<Disposable> disposable;
-
-    @GuardedBy("this")
-    private boolean isRunning = false;
+    private final AdjustableBackgroundTask backgroundTask;
 
     public LockThreadInfoSnapshotManager(
             Refreshable<DebugThreadInfoConfiguration> threadInfoConfiguration,
             Supplier<ConcurrentMap<HeldLocksToken, HeldLocks<HeldLocksToken>>> mapSupplier) {
         this.threadInfoConfiguration = threadInfoConfiguration;
         this.tokenMapSupplier = mapSupplier;
-    }
-
-    public synchronized void start() {
-        if (isRunning || isClosed()) {
-            return;
-        }
-        scheduleRun();
-        disposable = Optional.of(threadInfoConfiguration.subscribe(newThreadInfoConfiguration -> {
-            synchronized (this) {
-                if (!isRunning) {
-                    scheduleRun();
-                }
-            }
-        }));
-    }
-
-    private void run() {
-        takeSnapshot();
-        log.info(
-                "Took thread info snapshot of {} locks. Next snapshot due in {}ms",
-                SafeArg.of("snapshotSize", lastKnownThreadInfoSnapshot.size()),
-                SafeArg.of(
-                        "snapshotIntervalMillis",
-                        threadInfoConfiguration.current().threadInfoSnapshotIntervalMillis()));
-        scheduleRun();
-    }
-
-    @VisibleForTesting
-    synchronized boolean isRunning() {
-        return isRunning;
-    }
-
-    private synchronized void scheduleRun() {
-        if (isClosed()) {
-            return;
-        }
-        if (threadInfoConfiguration.current().recordThreadInfo()) {
-            if (!isRunning) {
-                log.info(
-                        "Starting to take lock thread info snapshots in the background",
-                        SafeArg.of(
-                                "snapshotIntervalMillis",
-                                threadInfoConfiguration.current().threadInfoSnapshotIntervalMillis()));
-                isRunning = true;
-            }
-            scheduledExecutorService.schedule(
-                    this::run,
-                    threadInfoConfiguration.current().threadInfoSnapshotIntervalMillis(),
-                    TimeUnit.MILLISECONDS);
-        } else {
-            log.info("Stopping background lock thread info snapshots");
-            isRunning = false;
-        }
+        this.backgroundTask = AdjustableBackgroundTask.create(
+                threadInfoConfiguration.map(DebugThreadInfoConfiguration::recordThreadInfo),
+                threadInfoConfiguration.map(config ->
+                        SimpleTimeDuration.of(config.threadInfoSnapshotIntervalMillis(), TimeUnit.MILLISECONDS)),
+                this::takeSnapshot);
     }
 
     @VisibleForTesting
@@ -154,16 +98,17 @@ public class LockThreadInfoSnapshotManager implements AutoCloseable {
                 })
                 // Although a lock can be held by multiple clients/threads, we only remember one to save space
                 .collect(Collectors.toMap(Entry::getKey, Entry::getValue, (existing, replacement) -> existing));
-    }
 
-    @VisibleForTesting
-    boolean isClosed() {
-        return scheduledExecutorService.isShutdown();
+        log.info(
+                "Took thread info snapshot of {} locks. Next snapshot due in {}ms",
+                SafeArg.of("snapshotSize", lastKnownThreadInfoSnapshot.size()),
+                SafeArg.of(
+                        "snapshotIntervalMillis",
+                        threadInfoConfiguration.current().threadInfoSnapshotIntervalMillis()));
     }
 
     @Override
-    public synchronized void close() {
-        scheduledExecutorService.shutdown();
-        disposable.ifPresent(Disposable::dispose);
+    public void close() {
+        backgroundTask.close();
     }
 }

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockThreadInfoSnapshotManager.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockThreadInfoSnapshotManager.java
@@ -54,7 +54,8 @@ public class LockThreadInfoSnapshotManager implements AutoCloseable {
 
     private Disposable disposable;
 
-    private boolean isRunning = false;
+    @VisibleForTesting
+    boolean isRunning = false;
 
     public LockThreadInfoSnapshotManager(
             Refreshable<DebugThreadInfoConfiguration> threadInfoConfiguration,
@@ -81,11 +82,6 @@ public class LockThreadInfoSnapshotManager implements AutoCloseable {
                 SafeArg.of("snapshotSize", lastKnownThreadInfoSnapshot.size()),
                 SafeArg.of("snapshotInterval", threadInfoConfiguration.current().threadInfoSnapshotIntervalMillis()));
         scheduleRun();
-    }
-
-    @VisibleForTesting
-    synchronized boolean isRunning() {
-        return isRunning;
     }
 
     private synchronized void scheduleRun() {

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockThreadInfoSnapshotManager.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockThreadInfoSnapshotManager.java
@@ -73,6 +73,8 @@ public class LockThreadInfoSnapshotManager implements AutoCloseable {
             Set<LockDescriptor> lockDescriptors) {
         String argName = "presumedClientThreadHoldersIfEnabled";
         if (!threadInfoConfiguration.current().recordThreadInfo()) {
+            // Avoids keeping the value alive even though we are never returning it
+            lastKnownThreadInfoSnapshot = Map.of();
             return UnsafeArg.of(argName, Optional.empty());
         }
         Map<LockDescriptor, LockClientAndThread> latestSnapshot = lastKnownThreadInfoSnapshot;

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockThreadInfoSnapshotManager.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockThreadInfoSnapshotManager.java
@@ -149,12 +149,10 @@ public class LockThreadInfoSnapshotManager implements AutoCloseable {
     }
 
     @Override
-    public void close() {
+    public synchronized void close() {
         scheduledExecutorService.shutdown();
-        synchronized (this) {
-            // To prevent scheduling of future tasks, which will throw an exception
-            isRunning = true;
-        }
+        // To prevent scheduling of future tasks, which will throw an exception
+        isRunning = true;
         disposable.dispose();
     }
 }

--- a/lock-impl/src/test/java/com/palantir/lock/impl/AdjustableBackgroundTaskTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/impl/AdjustableBackgroundTaskTest.java
@@ -34,7 +34,7 @@ public class AdjustableBackgroundTaskTest {
      * Dummy deterministic scheduled executor service that cannot be shut down.
      * The default {@link DeterministicScheduler} throws an exception when calling {@link ExecutorService#isShutdown()}.
      */
-    static class NeverShutdownDeterministicScheduler extends DeterministicScheduler {
+    private static class NeverShutdownDeterministicScheduler extends DeterministicScheduler {
         @Override
         public boolean isShutdown() {
             return false;
@@ -44,15 +44,10 @@ public class AdjustableBackgroundTaskTest {
     // We have to ensure all of our delays are higher than MINIMUM_DELAY_IF_NOT_RUNNING
     // so it doesn't interfere with our tests
     private static final TimeDuration DEFAULT_DELAY = SimpleTimeDuration.of(10, TimeUnit.SECONDS);
-
     private final AtomicInteger field = new AtomicInteger(0);
-
     private final SettableRefreshable<Boolean> shouldRun = Refreshable.create(false);
-
     private final SettableRefreshable<TimeDuration> interval = Refreshable.create(DEFAULT_DELAY);
-
     private final NeverShutdownDeterministicScheduler scheduledExecutor = new NeverShutdownDeterministicScheduler();
-
     private final AdjustableBackgroundTask adjustableBackgroundTask =
             new AdjustableBackgroundTask(shouldRun, interval, field::incrementAndGet, scheduledExecutor);
 

--- a/lock-impl/src/test/java/com/palantir/lock/impl/AdjustableBackgroundTaskTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/impl/AdjustableBackgroundTaskTest.java
@@ -22,6 +22,7 @@ import com.palantir.lock.SimpleTimeDuration;
 import com.palantir.lock.TimeDuration;
 import com.palantir.refreshable.Refreshable;
 import com.palantir.refreshable.SettableRefreshable;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.jmock.lib.concurrent.DeterministicScheduler;
@@ -29,6 +30,10 @@ import org.junit.Test;
 
 public class AdjustableBackgroundTaskTest {
 
+    /**
+     * Dummy deterministic scheduled executor service that cannot be shut down.
+     * The default {@link DeterministicScheduler} throws an exception when calling {@link ExecutorService#isShutdown()}.
+     */
     static class NeverShutdownDeterministicScheduler extends DeterministicScheduler {
         @Override
         public boolean isShutdown() {
@@ -36,10 +41,8 @@ public class AdjustableBackgroundTaskTest {
         }
     }
 
-    /** We have to ensure all of our delays are higher than
-     * {@link com.palantir.lock.impl.AdjustableBackgroundTask#MINIMUM_DELAY_IF_NOT_RUNNING}
-     * so it doesn't interfere.
-     */
+    // We have to ensure all of our delays are higher than MINIMUM_DELAY_IF_NOT_RUNNING
+    // so it doesn't interfere with our tests
     private static final TimeDuration DEFAULT_DELAY = SimpleTimeDuration.of(10, TimeUnit.SECONDS);
 
     private final AtomicInteger field = new AtomicInteger(0);

--- a/lock-impl/src/test/java/com/palantir/lock/impl/AdjustableBackgroundTaskTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/impl/AdjustableBackgroundTaskTest.java
@@ -34,7 +34,7 @@ public class AdjustableBackgroundTaskTest {
      * Dummy deterministic scheduled executor service that cannot be shut down.
      * The default {@link DeterministicScheduler} throws an exception when calling {@link ExecutorService#isShutdown()}.
      */
-    private static class NeverShutdownDeterministicScheduler extends DeterministicScheduler {
+    private static final class NeverShutdownDeterministicScheduler extends DeterministicScheduler {
         @Override
         public boolean isShutdown() {
             return false;

--- a/lock-impl/src/test/java/com/palantir/lock/impl/AdjustableBackgroundTaskTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/impl/AdjustableBackgroundTaskTest.java
@@ -1,0 +1,98 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.lock.SimpleTimeDuration;
+import com.palantir.lock.TimeDuration;
+import com.palantir.refreshable.Refreshable;
+import com.palantir.refreshable.SettableRefreshable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.jmock.lib.concurrent.DeterministicScheduler;
+import org.junit.Test;
+
+public class AdjustableBackgroundTaskTest {
+
+    static class NeverShutdownDeterministicScheduler extends DeterministicScheduler {
+        @Override
+        public boolean isShutdown() {
+            return false;
+        }
+    }
+
+    /** We have to ensure all of our delays are higher than
+     * {@link com.palantir.lock.impl.AdjustableBackgroundTask#MINIMUM_DELAY_IF_NOT_RUNNING}
+     * so it doesn't interfere.
+     */
+    private static final TimeDuration DEFAULT_DELAY = SimpleTimeDuration.of(10, TimeUnit.SECONDS);
+
+    private final AtomicInteger field = new AtomicInteger(0);
+
+    private final SettableRefreshable<Boolean> shouldRun = Refreshable.create(false);
+
+    private final SettableRefreshable<TimeDuration> interval = Refreshable.create(DEFAULT_DELAY);
+
+    private final NeverShutdownDeterministicScheduler scheduledExecutor = new NeverShutdownDeterministicScheduler();
+
+    private final AdjustableBackgroundTask adjustableBackgroundTask =
+            new AdjustableBackgroundTask(shouldRun, interval, field::incrementAndGet, scheduledExecutor);
+
+    @Test
+    public void doesNotRunTaskDuringConstruction() {
+        assertThat(field.get()).isEqualTo(0);
+    }
+
+    @Test
+    public void doesNotRunTaskByDefault() {
+        int before = field.get();
+        tick(DEFAULT_DELAY);
+        assertThat(field.get()).isEqualTo(before);
+    }
+
+    @Test
+    public void canBeEnabledDisabledAndReEnabled() {
+        int before = field.get();
+        shouldRun.update(true);
+        tick(DEFAULT_DELAY);
+        int after = field.get();
+        assertThat(after).isEqualTo(before + 1);
+
+        shouldRun.update(false);
+        tick(DEFAULT_DELAY);
+        assertThat(field.get()).isEqualTo(after);
+
+        shouldRun.update(true);
+        tick(DEFAULT_DELAY);
+        assertThat(field.get()).isEqualTo(after + 1);
+    }
+
+    @Test
+    public void canAdjustDuration() {
+        int before = field.get();
+        TimeDuration newInterval = SimpleTimeDuration.of(42, TimeUnit.SECONDS);
+        interval.update(newInterval);
+        shouldRun.update(true);
+        tick(SimpleTimeDuration.of(10 * newInterval.toMillis(), TimeUnit.MILLISECONDS));
+        assertThat(field.get()).isEqualTo(before + 10);
+    }
+
+    private void tick(TimeDuration duration) {
+        scheduledExecutor.tick(duration.toMillis(), TimeUnit.MILLISECONDS);
+    }
+}

--- a/lock-impl/src/test/java/com/palantir/lock/impl/ThreadInfoLockServiceImplTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/impl/ThreadInfoLockServiceImplTest.java
@@ -363,7 +363,7 @@ public class ThreadInfoLockServiceImplTest {
                 .threadInfoSnapshotIntervalMillis(50L)
                 .build());
 
-        Awaitility.await().until(() -> !backgroundSnapshotRunner.isRunning());
+        Awaitility.await().until(() -> !backgroundSnapshotRunner.isRunning);
 
         lockServiceWithBackgroundRunner.unlock(lockResponse.getToken());
 

--- a/lock-impl/src/test/java/com/palantir/lock/impl/ThreadInfoLockServiceImplTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/impl/ThreadInfoLockServiceImplTest.java
@@ -49,10 +49,6 @@ import org.awaitility.Awaitility;
 import org.junit.Test;
 
 public class ThreadInfoLockServiceImplTest {
-
-    private static final ExecutorService LOCK_SERVICE_IMPL_EXECUTOR =
-            PTExecutors.newCachedThreadPool(LockServiceImpl.class.getName());
-
     private static final LockDescriptor TEST_LOCK_1 = StringLockDescriptor.of("lock-1");
     private static final LockDescriptor TEST_LOCK_2 = StringLockDescriptor.of("lock-2");
     private static final LockDescriptor TEST_LOCK_3 = StringLockDescriptor.of("lock-3");
@@ -73,12 +69,12 @@ public class ThreadInfoLockServiceImplTest {
             PTExecutors.newCachedThreadPool(ThreadInfoLockServiceImplTest.class.getName());
 
     // Disable background snapshotting, invoke explicitly instead
-    private final LockServiceImpl lockService = LockServiceImpl.create(
-            LockServerOptions.builder().isStandaloneServer(false).build(),
-            LOCK_SERVICE_IMPL_EXECUTOR,
-            Refreshable.only(ImmutableDebugThreadInfoConfiguration.builder()
+    private final LockServiceImpl lockService = LockServiceImpl.create(LockServerOptions.builder()
+            .isStandaloneServer(false)
+            .threadInfoConfiguration(ImmutableDebugThreadInfoConfiguration.builder()
                     .recordThreadInfo(false)
-                    .build()));
+                    .build())
+            .build());
 
     @Test
     public void initialThreadInfoIsEmpty() {
@@ -281,13 +277,13 @@ public class ThreadInfoLockServiceImplTest {
 
     @Test
     public void backgroundSnapshotRunnerWorks() throws InterruptedException {
-        LockServiceImpl lockServiceWithBackgroundRunner = LockServiceImpl.create(
-                LockServerOptions.builder().isStandaloneServer(false).build(),
-                LOCK_SERVICE_IMPL_EXECUTOR,
-                Refreshable.only(ImmutableDebugThreadInfoConfiguration.builder()
+        LockServiceImpl lockServiceWithBackgroundRunner = LockServiceImpl.create(LockServerOptions.builder()
+                .isStandaloneServer(false)
+                .threadInfoConfiguration(ImmutableDebugThreadInfoConfiguration.builder()
                         .recordThreadInfo(true)
                         .threadInfoSnapshotIntervalMillis(50L)
-                        .build()));
+                        .build())
+                .build());
         LockThreadInfoSnapshotManager backgroundSnapshotRunner = lockServiceWithBackgroundRunner.getSnapshotManager();
 
         LockResponse response = lockServiceWithBackgroundRunner.lockWithFullLockResponse(
@@ -314,13 +310,13 @@ public class ThreadInfoLockServiceImplTest {
 
     @Test
     public void logArgIsUnsafeAndContainsRestrictedSnapshotIfRecordingThreadInfo() throws InterruptedException {
-        LockServiceImpl lockServiceWithBackgroundRunner = LockServiceImpl.create(
-                LockServerOptions.builder().isStandaloneServer(false).build(),
-                LOCK_SERVICE_IMPL_EXECUTOR,
-                Refreshable.only(ImmutableDebugThreadInfoConfiguration.builder()
+        LockServiceImpl lockServiceWithBackgroundRunner = LockServiceImpl.create(LockServerOptions.builder()
+                .isStandaloneServer(false)
+                .threadInfoConfiguration(ImmutableDebugThreadInfoConfiguration.builder()
                         .recordThreadInfo(true)
                         .threadInfoSnapshotIntervalMillis(50L)
-                        .build()));
+                        .build())
+                .build());
         LockRequest lockRequest2 = LockRequest.builder(
                         ImmutableSortedMap.of(TEST_LOCK_1, LockMode.READ, TEST_LOCK_2, LockMode.READ))
                 .doNotBlock()
@@ -348,9 +344,11 @@ public class ThreadInfoLockServiceImplTest {
                         .threadInfoSnapshotIntervalMillis(50L)
                         .build());
         LockServiceImpl lockServiceWithBackgroundRunner = LockServiceImpl.create(
-                LockServerOptions.builder().isStandaloneServer(false).build(),
-                LOCK_SERVICE_IMPL_EXECUTOR,
-                refreshableThreadInfoConfiguration);
+                refreshableThreadInfoConfiguration.map(threadInfoConfig -> LockServerOptions.builder()
+                        .isStandaloneServer(false)
+                        .threadInfoConfiguration(threadInfoConfig)
+                        .build()),
+                executor);
         LockThreadInfoSnapshotManager backgroundSnapshotRunner = lockServiceWithBackgroundRunner.getSnapshotManager();
 
         LockResponse lockResponse = lockServiceWithBackgroundRunner.lockWithFullLockResponse(

--- a/lock-impl/src/test/java/com/palantir/lock/impl/ThreadInfoLockServiceImplTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/impl/ThreadInfoLockServiceImplTest.java
@@ -386,6 +386,12 @@ public class ThreadInfoLockServiceImplTest {
                 .doesNotContainKey(TEST_LOCK_1));
     }
 
+    @Test
+    public void closesWithLockService() {
+        lockService.close();
+        assertThat(lockService.getSnapshotManager().isClosed()).isTrue();
+    }
+
     private void forceSnapshot() {
         lockService.getSnapshotManager().takeSnapshot();
     }

--- a/lock-impl/src/test/java/com/palantir/lock/impl/ThreadInfoLockServiceImplTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/impl/ThreadInfoLockServiceImplTest.java
@@ -363,7 +363,7 @@ public class ThreadInfoLockServiceImplTest {
                 .threadInfoSnapshotIntervalMillis(50L)
                 .build());
 
-        Awaitility.await().until(() -> !backgroundSnapshotRunner.isRunning);
+        Awaitility.await().until(() -> !backgroundSnapshotRunner.isRunning());
 
         lockServiceWithBackgroundRunner.unlock(lockResponse.getToken());
 

--- a/lock-impl/src/test/java/com/palantir/lock/impl/ThreadInfoLockServiceImplTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/impl/ThreadInfoLockServiceImplTest.java
@@ -363,7 +363,7 @@ public class ThreadInfoLockServiceImplTest {
                 .threadInfoSnapshotIntervalMillis(50L)
                 .build());
 
-        Awaitility.await().until(() -> !backgroundSnapshotRunner.isScheduled());
+        Awaitility.await().until(() -> !backgroundSnapshotRunner.isRunning());
 
         lockServiceWithBackgroundRunner.unlock(lockResponse.getToken());
 

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/RestrictedTimeLockRuntimeConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/RestrictedTimeLockRuntimeConfiguration.java
@@ -16,6 +16,7 @@
 
 package com.palantir.timelock.config;
 
+import com.palantir.lock.DebugThreadInfoConfiguration;
 import java.util.Optional;
 
 public class RestrictedTimeLockRuntimeConfiguration extends TimeLockRuntimeConfiguration {
@@ -53,5 +54,10 @@ public class RestrictedTimeLockRuntimeConfiguration extends TimeLockRuntimeConfi
     @Override
     public Optional<TsBoundPersisterRuntimeConfiguration> timestampBoundPersistence() {
         return runtime.timestampBoundPersistence();
+    }
+
+    @Override
+    public DebugThreadInfoConfiguration threadInfoConfiguration() {
+        return runtime.threadInfoConfiguration();
     }
 }

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockRuntimeConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockRuntimeConfiguration.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Preconditions;
+import com.palantir.lock.DebugThreadInfoConfiguration;
+import com.palantir.lock.ImmutableDebugThreadInfoConfiguration;
 import com.palantir.logsafe.DoNotLog;
 import java.util.Optional;
 import org.immutables.value.Value;
@@ -77,6 +79,12 @@ public abstract class TimeLockRuntimeConfiguration {
 
     @JsonProperty("timestamp-bound-persistence")
     public abstract Optional<TsBoundPersisterRuntimeConfiguration> timestampBoundPersistence();
+
+    @JsonProperty("debug-thread-info-config")
+    @Value.Default
+    public DebugThreadInfoConfiguration threadInfoConfiguration() {
+        return ImmutableDebugThreadInfoConfiguration.builder().build();
+    }
 
     @Value.Check
     public void check() {

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/LockCreator.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/LockCreator.java
@@ -21,18 +21,18 @@ import com.palantir.lock.CloseableLockService;
 import com.palantir.lock.LockServerOptions;
 import com.palantir.lock.impl.LockServiceImpl;
 import com.palantir.lock.impl.ThreadPooledLockService;
+import com.palantir.refreshable.Refreshable;
 import com.palantir.timelock.config.TimeLockRuntimeConfiguration;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Semaphore;
-import java.util.function.Supplier;
 
 public class LockCreator {
-    private final Supplier<TimeLockRuntimeConfiguration> runtime;
+    private final Refreshable<TimeLockRuntimeConfiguration> runtime;
     private final long blockingTimeoutMs;
     private final Semaphore sharedThreadPool;
     private final ExecutorService sharedExecutor = PTExecutors.newCachedThreadPool(LockServiceImpl.class.getName());
 
-    public LockCreator(Supplier<TimeLockRuntimeConfiguration> runtime, int threadPoolSize, long blockingTimeoutMs) {
+    public LockCreator(Refreshable<TimeLockRuntimeConfiguration> runtime, int threadPoolSize, long blockingTimeoutMs) {
         this.runtime = runtime;
         this.sharedThreadPool = new Semaphore(threadPoolSize);
         this.blockingTimeoutMs = blockingTimeoutMs;
@@ -41,6 +41,7 @@ public class LockCreator {
     public CloseableLockService createThreadPoolingLockService() {
         LockServerOptions lockServerOptions = LockServerOptions.builder()
                 .slowLogTriggerMillis(runtime.get().slowLockLogTriggerMillis())
+                .threadInfoConfiguration(runtime.map(TimeLockRuntimeConfiguration::threadInfoConfiguration))
                 .build();
 
         LockServiceImpl rawLockService = LockServiceImpl.create(lockServerOptions, sharedExecutor);

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/LockCreator.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/LockCreator.java
@@ -39,12 +39,12 @@ public class LockCreator {
     }
 
     public CloseableLockService createThreadPoolingLockService() {
-        LockServerOptions lockServerOptions = LockServerOptions.builder()
-                .slowLogTriggerMillis(runtime.get().slowLockLogTriggerMillis())
-                .build();
+        Refreshable<LockServerOptions> lockServerOptions = runtime.map(rt -> LockServerOptions.builder()
+                .slowLogTriggerMillis(rt.slowLockLogTriggerMillis())
+                .threadInfoConfiguration(rt.threadInfoConfiguration())
+                .build());
 
-        LockServiceImpl rawLockService = LockServiceImpl.create(
-                lockServerOptions, sharedExecutor, runtime.map(TimeLockRuntimeConfiguration::threadInfoConfiguration));
+        LockServiceImpl rawLockService = LockServiceImpl.create(lockServerOptions, sharedExecutor);
         CloseableLockService lockService = BlockingTimeLimitedLockService.create(
                 rawLockService, blockingTimeoutMs, rawLockService.getSnapshotManager());
 

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/LockCreator.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/LockCreator.java
@@ -41,10 +41,10 @@ public class LockCreator {
     public CloseableLockService createThreadPoolingLockService() {
         LockServerOptions lockServerOptions = LockServerOptions.builder()
                 .slowLogTriggerMillis(runtime.get().slowLockLogTriggerMillis())
-                .threadInfoConfiguration(runtime.map(TimeLockRuntimeConfiguration::threadInfoConfiguration))
                 .build();
 
-        LockServiceImpl rawLockService = LockServiceImpl.create(lockServerOptions, sharedExecutor);
+        LockServiceImpl rawLockService = LockServiceImpl.create(
+                lockServerOptions, sharedExecutor, runtime.map(TimeLockRuntimeConfiguration::threadInfoConfiguration));
         CloseableLockService lockService = BlockingTimeLimitedLockService.create(
                 rawLockService, blockingTimeoutMs, rawLockService.getSnapshotManager());
 


### PR DESCRIPTION
## General
**Before this PR**:
The logic for capturing and logging thread info snapshot is in place, but cannot be enabled/configured at runtime.

**After this PR**:
Thread info debugging can be configured at runtime by updating the runtime configuration.
Under the hood, the configuration is stored as `Refreshable<DebugThreadInfoConfiguration>`.

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
[LockV1] Pass refreshable thread info configuration
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:
Are JSON field names reasonable?
Is the synchronization sufficient to prevent scheduling of two snapshots at the same time.

**Is documentation needed?**:
We should add documentation once we have verified that this works in a dev stack.

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
This PR adds optional (!) fields to the timelock runtime configuration
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
This PR assumes relies on the refreshable runtime configuration being piped to LockCreator.
**What was existing testing like? What have you done to improve it?**:
I have added a test to verify that the background snapshotting task can be enabled/disabled at runtime.
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
To enable thread info debugging at runtime, we need to subscribe to a refreshable and potentially schedule the (indefinite) snapshotting in the background.
However, we need to watch out for the case that the config is changed frequently, maybe multiple times while taking a snapshot. To ensure that no two snapshotting tasks are scheduled simultaneously, we add a new member `isRunning` to `LockThreadInfoSnapshotManager` that signals whether a background task is currently running or not. All access to this field are synchronized and we ensured that `isRunning` is true after we have scheduled a task. Analogously, we only set it to false in case we naturally stop our background task.
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
This PR involves only synchronized blocks that are non-blocking
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
After adding `"debug-thread-info-config" : { "record-thread-info" : true, "thread-info-snapshot-interval-millis" : 300000 }` to the timelock runtime config JSON, one should see logs involving actual thread info.
**Has the safety of all log arguments been decided correctly?**:
Yes, only longs are logged as safe arguments
**Will this change significantly affect our spending on metrics or logs?**:
Existing locks could grow significantly, see #6623. 
The additional logs when starting/stopping the background service and taking snapshots are negligible.
**How would I tell that this PR does not work in production? (monitors, etc.)**:
No logs of said kind are present after enabling
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
rollback is sufficient
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No
## Development Process
**Where should we start reviewing?**:
LockThreadInfoSnapshotManager
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
