### PR TITLE
Remove potential case for large recursion in read path

### DIFF
--- a/atlasdb-tests-shared/build.gradle
+++ b/atlasdb-tests-shared/build.gradle
@@ -50,6 +50,7 @@ dependencies {
   testImplementation 'com.google.protobuf:protobuf-java'
   testImplementation 'com.palantir.common:streams'
   testImplementation 'com.palantir.safe-logging:safe-logging'
+  testImplementation 'com.palantir.safe-logging:preconditions-assertj'
   testImplementation 'com.palantir.tracing:tracing-api'
   testImplementation 'com.palantir.tritium:tritium-registry'
   testImplementation 'commons-io:commons-io'

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
@@ -77,11 +77,16 @@ public class AtlasDbTestCase {
 
     protected TransactionKnowledgeComponents knowledge;
 
+    protected ExecutorService deleteExecutor;
+
     @Rule
     public InMemoryTimeLockRule inMemoryTimeLockRule = new InMemoryTimeLockRule(CLIENT);
 
+    // Needed for preventing runnables from being executed by an executor service
+    @SuppressWarnings("DoNotMock")
     @Before
     public void setUp() throws Exception {
+        deleteExecutor = spy(MoreExecutors.newDirectExecutorService());
         lockClient = LockClient.of(CLIENT);
         lockService = inMemoryTimeLockRule.getLockService();
         timelockService = inMemoryTimeLockRule.getLegacyTimelockService();

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
@@ -86,7 +86,7 @@ public class AtlasDbTestCase {
     @SuppressWarnings("DoNotMock")
     @Before
     public void setUp() throws Exception {
-        deleteExecutor = spy(MoreExecutors.newDirectExecutorService());
+        deleteExecutor = MoreExecutors.newDirectExecutorService();
         lockClient = LockClient.of(CLIENT);
         lockService = inMemoryTimeLockRule.getLockService();
         timelockService = inMemoryTimeLockRule.getLegacyTimelockService();

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
@@ -52,6 +52,7 @@ import com.palantir.timestamp.TimestampService;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -82,11 +83,9 @@ public class AtlasDbTestCase {
     @Rule
     public InMemoryTimeLockRule inMemoryTimeLockRule = new InMemoryTimeLockRule(CLIENT);
 
-    // Needed for preventing runnables from being executed by an executor service
-    @SuppressWarnings("DoNotMock")
     @Before
     public void setUp() throws Exception {
-        deleteExecutor = MoreExecutors.newDirectExecutorService();
+        deleteExecutor = Executors.newSingleThreadExecutor();
         lockClient = LockClient.of(CLIENT);
         lockService = inMemoryTimeLockRule.getLockService();
         timelockService = inMemoryTimeLockRule.getLegacyTimelockService();

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
@@ -52,7 +52,6 @@ import com.palantir.timestamp.TimestampService;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -85,7 +84,7 @@ public class AtlasDbTestCase {
 
     @Before
     public void setUp() throws Exception {
-        deleteExecutor = Executors.newSingleThreadExecutor();
+        deleteExecutor = MoreExecutors.newDirectExecutorService();
         lockClient = LockClient.of(CLIENT);
         lockService = inMemoryTimeLockRule.getLockService();
         timelockService = inMemoryTimeLockRule.getLegacyTimelockService();

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -2458,6 +2459,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 .hasExactlyArgs(
                         SafeArg.of("table", TABLE_NO_SWEEP),
                         SafeArg.of("maxIterations", SnapshotTransaction.MAX_POST_FILTERING_ITERATIONS));
+        doCallRealMethod().when(deleteExecutor).execute(any());
+        txManager.getKeyValueService().truncateTable(TABLE_NO_SWEEP);
     }
 
     private void verifyPrefetchValidations(

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -2448,6 +2448,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                     return null;
                 });
             } catch (TransactionFailedRetriableException _t) {
+                // Expected, as we want to create a large row with only aborted values.
             }
         }
         assertThatLoggableExceptionThrownBy(

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -24,8 +24,6 @@ import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doCallRealMethod;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -153,6 +151,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
@@ -2437,31 +2436,36 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
         assertThat(commitLockInfo.rowCommitLocksRequested()).isEqualTo(1 + 1);
     }
 
-    // @Test
-    // public void exceptionThrownWhenTooManyPostFilterIterationsOccur() {
-    //     // Need to block deleter executor from deleting aborted values to help bloat the row.
-    //     doNothing().when(deleteExecutor).execute(any());
-    //
-    //     for (int idx = 0; idx < SnapshotTransaction.MAX_POST_FILTERING_ITERATIONS; idx++) {
-    //         try {
-    //             txManager.runTaskWithConditionThrowOnConflict(ALWAYS_FAILS_CONDITION, (txn, _c) -> {
-    //                 txn.put(TABLE_NO_SWEEP, ImmutableMap.of(TEST_CELL, TEST_VALUE));
-    //                 return null;
-    //             });
-    //         } catch (TransactionFailedRetriableException _t) {
-    //             // Expected, as we want to create a large row with only aborted values.
-    //         }
-    //     }
-    //     assertThatLoggableExceptionThrownBy(
-    //                     () -> txManager.runTaskThrowOnConflict(txn -> txn.get(TABLE_NO_SWEEP, Set.of(TEST_CELL))))
-    //             .isInstanceOf(SafeIllegalStateException.class)
-    //             .hasMessageStartingWith("Unable to filter cells")
-    //             .hasExactlyArgs(
-    //                     SafeArg.of("table", TABLE_NO_SWEEP),
-    //                     SafeArg.of("maxIterations", SnapshotTransaction.MAX_POST_FILTERING_ITERATIONS));
-    //     doCallRealMethod().when(deleteExecutor).execute(any());
-    //     txManager.getKeyValueService().truncateTable(TABLE_NO_SWEEP);
-    // }
+    @Test
+    public void exceptionThrownWhenTooManyPostFilterIterationsOccur() {
+        // Need to block deleter executor from deleting aborted values to help bloat the row.
+        Future<?> future = deleteExecutor.submit(() -> {
+            try {
+                new Semaphore(0).acquire();
+            } catch (InterruptedException e) {
+                // Do nothing, we should stop.
+            }
+        });
+
+        for (int idx = 0; idx < SnapshotTransaction.MAX_POST_FILTERING_ITERATIONS; idx++) {
+            try {
+                txManager.runTaskWithConditionThrowOnConflict(ALWAYS_FAILS_CONDITION, (txn, _c) -> {
+                    txn.put(TABLE_NO_SWEEP, ImmutableMap.of(TEST_CELL, TEST_VALUE));
+                    return null;
+                });
+            } catch (TransactionFailedRetriableException _t) {
+                // Expected, as we want to create a large row with only aborted values.
+            }
+        }
+        assertThatLoggableExceptionThrownBy(
+                        () -> txManager.runTaskThrowOnConflict(txn -> txn.get(TABLE_NO_SWEEP, Set.of(TEST_CELL))))
+                .isInstanceOf(SafeIllegalStateException.class)
+                .hasMessageStartingWith("Unable to filter cells")
+                .hasExactlyArgs(
+                        SafeArg.of("table", TABLE_NO_SWEEP),
+                        SafeArg.of("maxIterations", SnapshotTransaction.MAX_POST_FILTERING_ITERATIONS));
+        future.cancel(true);
+    }
 
     private void verifyPrefetchValidations(
             List<byte[]> rows,

--- a/changelog/@unreleased/pr-6630.v2.yml
+++ b/changelog/@unreleased/pr-6630.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Remove recursive loop when filtering out cells that are not applicable
+    to our transaction.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6630

--- a/scripts/circle-ci/run-circle-tests.sh
+++ b/scripts/circle-ci/run-circle-tests.sh
@@ -77,6 +77,8 @@ JAVA_GC_LOGGING_OPTIONS="${JAVA_GC_LOGGING_OPTIONS} -Xlog:gc:build-%t-%p.gc.log"
 # External builds have a 16gb limit.
 if [ "$test_suite_index" -eq "14" ]; then
     export _JAVA_OPTIONS="-Xms2g -Xmx4g -XX:ActiveProcessorCount=8 ${JAVA_GC_LOGGING_OPTIONS}"
+elif [ "$test_suite_index" -eq "4" ]; then
+    export _JAVA_OPTIONS="-Xms8g -Xmx8g -XX:ActiveProcessorCount=8 ${JAVA_GC_LOGGING_OPTIONS}"
 elif [ "$test_suite_index" -eq "3" ]; then
     export _JAVA_OPTIONS="-Xms8g -Xmx8g -XX:ActiveProcessorCount=8 ${JAVA_GC_LOGGING_OPTIONS}"
     BASE_GRADLE_ARGS+=" --scan --parallel"


### PR DESCRIPTION
## General
**Before this PR**:
Consider the case where, someone is running a transaction writing to some cell X, and then purposefully aborts _themselves_. They do this for a very long time, say for 1_000_000 cells, with never actually committing a value. When we go to read this cell, we will have to read through *every* aborted copy of this cell to determine, that, it is in fact empty. The good news is we should ideally try to do this "only once", as we attempt to delete aborted values as we read them (although there is still the case of parallel reads which if they are identical in position/performance, will perform the same amount of work). Sweep will also progress in the background and try to delete these cells, but can fall behind. 

Now let's say sweep did fall behind, and we somehow tried to read this value (probably during a range scan); we will need to go through all 1_000_000 (aborted/not committed) cells to determine that is empty! Normally this would be ok, but we chain futures in a way which results in a recursive call. This recursive call will effectively result in 1_000_000 iterations, eventually exceeding our call stack, leading to `StackOverflowError`. Yikes.  


**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Remove recursive loop when filtering out cells that are not applicable to our transaction.
==COMMIT_MSG==

**Priority**:
P0

**Concerns / possible downsides (what feedback would you like?)**:
Test suppressions are ugly, and is also ugly that we're spying an executor service. 


**Is documentation needed?**:
No

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
Nope

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No

**Does this PR need a schema migration?**
No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
200 is unreasonable iteration length. We will find out after a transaction retires 10x, and eventually fails with this log line.

**What was existing testing like? What have you done to improve it?**:
Added a test to actually reproduce this condition/case, and verify that we throw. 

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: Logs

**Has the safety of all log arguments been decided correctly?**: Yes

**Will this change significantly affect our spending on metrics or logs?**: No

**How would I tell that this PR does not work in production? (monitors, etc.)**:
Logs

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Just revert

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No, only 200 calls rather than 173 prior.

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
